### PR TITLE
fix: show unescaped chinese/unicode filenames in git diff

### DIFF
--- a/supacode/Clients/Git/GitClient.swift
+++ b/supacode/Clients/Git/GitClient.swift
@@ -456,7 +456,7 @@ struct GitClient {
     do {
       return try await runGit(
         operation: .diffNameStatus,
-        arguments: ["-C", path, "diff", "HEAD", "--name-status"]
+        arguments: ["-C", path, "-c", "core.quotePath=false", "diff", "HEAD", "--name-status"]
       )
     } catch {
       return ""
@@ -468,7 +468,7 @@ struct GitClient {
     do {
       let output = try await runGit(
         operation: .untrackedFilePaths,
-        arguments: ["-C", path, "ls-files", "--others", "--exclude-standard"]
+        arguments: ["-C", path, "-c", "core.quotePath=false", "ls-files", "--others", "--exclude-standard"]
       )
       return
         output

--- a/supacodeTests/GitClientDiffPathEncodingTests.swift
+++ b/supacodeTests/GitClientDiffPathEncodingTests.swift
@@ -1,0 +1,63 @@
+import Foundation
+import Testing
+
+@testable import supacode
+
+actor DiffPathShellCallStore {
+  private(set) var calls: [[String]] = []
+
+  func record(_ arguments: [String]) {
+    calls.append(arguments)
+  }
+}
+
+struct GitClientDiffPathEncodingTests {
+  @Test func diffNameStatusDisablesQuotePath() async {
+    let store = DiffPathShellCallStore()
+    let shell = ShellClient(
+      run: { _, arguments, _ in
+        await store.record(arguments)
+        return ShellOutput(stdout: "M\t中文文件.md\n", stderr: "", exitCode: 0)
+      },
+      runLoginImpl: { _, _, _, _ in ShellOutput(stdout: "", stderr: "", exitCode: 0) }
+    )
+    let client = GitClient(shell: shell)
+
+    let output = await client.diffNameStatus(at: URL(fileURLWithPath: "/tmp/repo"))
+
+    #expect(output.contains("中文文件.md"))
+    let calls = await store.calls
+    #expect(calls.count == 1)
+    let args = calls[0]
+    #expect(args.first == "git")
+    #expect(args.contains("-c"))
+    #expect(args.contains("core.quotePath=false"))
+    #expect(args.contains("diff"))
+    #expect(args.contains("--name-status"))
+  }
+
+  @Test func untrackedFilePathsDisablesQuotePath() async {
+    let store = DiffPathShellCallStore()
+    let shell = ShellClient(
+      run: { _, arguments, _ in
+        await store.record(arguments)
+        return ShellOutput(stdout: "中文文件.md\n", stderr: "", exitCode: 0)
+      },
+      runLoginImpl: { _, _, _, _ in ShellOutput(stdout: "", stderr: "", exitCode: 0) }
+    )
+    let client = GitClient(shell: shell)
+
+    let paths = await client.untrackedFilePaths(at: URL(fileURLWithPath: "/tmp/repo"))
+
+    #expect(paths == ["中文文件.md"])
+    let calls = await store.calls
+    #expect(calls.count == 1)
+    let args = calls[0]
+    #expect(args.first == "git")
+    #expect(args.contains("-c"))
+    #expect(args.contains("core.quotePath=false"))
+    #expect(args.contains("ls-files"))
+    #expect(args.contains("--others"))
+    #expect(args.contains("--exclude-standard"))
+  }
+}


### PR DESCRIPTION
## Fix

Git's default `core.quotePath=true` escapes non-ASCII paths (e.g. `\346\226\207\344\273\245`), making Chinese filenames invisible in the diff UI.

**Changes:**
- Pass `-c core.quotePath=false` to `git diff HEAD --name-status` (`diffNameStatus`)
- Pass `-c core.quotePath=false` to `git ls-files --others` (`untrackedFilePaths`)
- Added unit tests for both

**Before:** Chinese filenames show as empty in diff view
**After:** Chinese filenames display correctly

Closes #9
