### PR TITLE
feat: ⌥⌘↩ toggle Canvas with worktree+tab restoration

### DIFF
--- a/supacode/App/AppShortcuts.swift
+++ b/supacode/App/AppShortcuts.swift
@@ -90,6 +90,9 @@ enum AppShortcuts {
   static let stopRunScript = AppShortcut(key: ".", modifiers: .command)
   static let checkForUpdates = AppShortcut(key: "u", modifiers: .command)
   static let showDiff = AppShortcut(key: "]", modifiers: .command)
+  static let toggleCanvas = AppShortcut(
+    keyEquivalent: .return, ghosttyKeyName: "return", modifiers: [.command, .option]
+  )
   static let archivedWorktrees = AppShortcut(key: "a", modifiers: [.command, .control])
   static let selectNextWorktree = AppShortcut(
     keyEquivalent: .downArrow, ghosttyKeyName: "arrow_down", modifiers: [.command, .control]
@@ -144,6 +147,7 @@ enum AppShortcuts {
     stopRunScript,
     checkForUpdates,
     showDiff,
+    toggleCanvas,
     archivedWorktrees,
     selectNextWorktree,
     selectPreviousWorktree,

--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -174,7 +174,7 @@ struct SupacodeApp: App {
     .environment(commandKeyObserver)
     .commands {
       WorktreeCommands(store: store)
-      SidebarCommands()
+      SidebarCommands(store: store)
       TerminalCommands(ghosttyShortcuts: ghosttyShortcuts)
       CommandGroup(after: .textEditing) {
         Button("Command Palette") {

--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -138,6 +138,9 @@ struct SupacodeApp: App {
         },
         events: {
           terminalManager.eventStream()
+        },
+        canvasFocusedWorktreeID: {
+          terminalManager.canvasFocusedWorktreeID
         }
       )
       values.worktreeInfoWatcher = WorktreeInfoWatcherClient(

--- a/supacode/Clients/Terminal/TerminalClient.swift
+++ b/supacode/Clients/Terminal/TerminalClient.swift
@@ -4,6 +4,7 @@ import Foundation
 struct TerminalClient {
   var send: @MainActor @Sendable (Command) -> Void
   var events: @MainActor @Sendable () -> AsyncStream<Event>
+  var canvasFocusedWorktreeID: @MainActor @Sendable () -> Worktree.ID?
 
   enum Command: Equatable {
     case createTab(Worktree, runSetupScriptIfNew: Bool)
@@ -41,12 +42,14 @@ struct TerminalClient {
 extension TerminalClient: DependencyKey {
   static let liveValue = TerminalClient(
     send: { _ in fatalError("TerminalClient.send not configured") },
-    events: { fatalError("TerminalClient.events not configured") }
+    events: { fatalError("TerminalClient.events not configured") },
+    canvasFocusedWorktreeID: { nil }
   )
 
   static let testValue = TerminalClient(
     send: { _ in },
-    events: { AsyncStream { $0.finish() } }
+    events: { AsyncStream { $0.finish() } },
+    canvasFocusedWorktreeID: { nil }
   )
 }
 

--- a/supacode/Commands/SidebarCommands.swift
+++ b/supacode/Commands/SidebarCommands.swift
@@ -1,6 +1,8 @@
+import ComposableArchitecture
 import SwiftUI
 
 struct SidebarCommands: Commands {
+  @Bindable var store: StoreOf<AppFeature>
   @FocusedValue(\.toggleLeftSidebarAction) private var toggleLeftSidebarAction
 
   var body: some Commands {
@@ -13,6 +15,31 @@ struct SidebarCommands: Commands {
       )
       .help("Toggle Left Sidebar (\(AppShortcuts.toggleLeftSidebar.display))")
       .disabled(toggleLeftSidebarAction == nil)
+      Divider()
+      Button("Canvas") {
+        store.send(.repositories(.toggleCanvas))
+      }
+      .keyboardShortcut(
+        AppShortcuts.toggleCanvas.keyEquivalent,
+        modifiers: AppShortcuts.toggleCanvas.modifiers
+      )
+      .help("Canvas (\(AppShortcuts.toggleCanvas.display))")
+      Button("Show Diff") {
+        let repos = store.repositories
+        guard let worktreeID = repos.selectedWorktreeID,
+          let worktree = repos.worktree(for: worktreeID)
+        else { return }
+        DiffWindowManager.shared.show(
+          worktreeURL: worktree.workingDirectory,
+          branchName: worktree.name,
+        )
+      }
+      .keyboardShortcut(
+        AppShortcuts.showDiff.keyEquivalent,
+        modifiers: AppShortcuts.showDiff.modifiers
+      )
+      .help("Show Diff (\(AppShortcuts.showDiff.display))")
+      .disabled(store.repositories.selectedWorktreeID == nil)
     }
   }
 }

--- a/supacode/Commands/WorktreeCommands.swift
+++ b/supacode/Commands/WorktreeCommands.swift
@@ -96,6 +96,14 @@ struct WorktreeCommands: Commands {
       )
       .help("New Worktree (\(AppShortcuts.newWorktree.display))")
       .disabled(!repositories.canCreateWorktree)
+      Button("Canvas") {
+        store.send(.repositories(.toggleCanvas))
+      }
+      .keyboardShortcut(
+        AppShortcuts.toggleCanvas.keyEquivalent,
+        modifiers: AppShortcuts.toggleCanvas.modifiers
+      )
+      .help("Canvas (\(AppShortcuts.toggleCanvas.display))")
       Button("Archived Worktrees") {
         store.send(.repositories(.selectArchivedWorktrees))
       }

--- a/supacode/Commands/WorktreeCommands.swift
+++ b/supacode/Commands/WorktreeCommands.swift
@@ -96,14 +96,6 @@ struct WorktreeCommands: Commands {
       )
       .help("New Worktree (\(AppShortcuts.newWorktree.display))")
       .disabled(!repositories.canCreateWorktree)
-      Button("Canvas") {
-        store.send(.repositories(.toggleCanvas))
-      }
-      .keyboardShortcut(
-        AppShortcuts.toggleCanvas.keyEquivalent,
-        modifiers: AppShortcuts.toggleCanvas.modifiers
-      )
-      .help("Canvas (\(AppShortcuts.toggleCanvas.display))")
       Button("Archived Worktrees") {
         store.send(.repositories(.selectArchivedWorktrees))
       }
@@ -129,22 +121,6 @@ struct WorktreeCommands: Commands {
       .keyboardShortcut(.return, modifiers: .command)
       .help("Confirm Worktree Action (⌘↩)")
       .disabled(confirmWorktreeAction == nil)
-      Button("Show Diff") {
-        let repos = store.repositories
-        guard let worktreeID = repos.selectedWorktreeID,
-          let worktree = repos.worktree(for: worktreeID)
-        else { return }
-        DiffWindowManager.shared.show(
-          worktreeURL: worktree.workingDirectory,
-          branchName: worktree.name,
-        )
-      }
-      .keyboardShortcut(
-        AppShortcuts.showDiff.keyEquivalent,
-        modifiers: AppShortcuts.showDiff.modifiers
-      )
-      .help("Show Diff (\(AppShortcuts.showDiff.display))")
-      .disabled(!hasActiveWorktree)
       Button("Refresh Worktrees") {
         store.send(.repositories(.refreshWorktrees))
       }

--- a/supacode/Features/Canvas/Views/CanvasSidebarButton.swift
+++ b/supacode/Features/Canvas/Views/CanvasSidebarButton.swift
@@ -4,19 +4,25 @@ import SwiftUI
 struct CanvasSidebarButton: View {
   let store: StoreOf<RepositoriesFeature>
   let isSelected: Bool
+  @Environment(CommandKeyObserver.self) private var commandKeyObserver
 
   var body: some View {
     Button {
       store.send(.selectCanvas)
     } label: {
-      Label("Canvas", systemImage: "square.grid.2x2")
-        .font(.callout)
-        .frame(maxWidth: .infinity)
+      HStack(spacing: 6) {
+        Label("Canvas", systemImage: "square.grid.2x2")
+          .font(.callout)
+          .frame(maxWidth: .infinity, alignment: .leading)
+        if commandKeyObserver.isPressed {
+          ShortcutHintView(text: AppShortcuts.toggleCanvas.display, color: .secondary)
+        }
+      }
     }
     .buttonStyle(.plain)
     .padding(.horizontal, 12)
     .padding(.vertical, 6)
     .background(isSelected ? Color.accentColor.opacity(0.15) : .clear, in: .rect(cornerRadius: 6))
-    .help("Canvas")
+    .help("Canvas (\(AppShortcuts.toggleCanvas.display))")
   }
 }

--- a/supacode/Features/Canvas/Views/CanvasView.swift
+++ b/supacode/Features/Canvas/Views/CanvasView.swift
@@ -401,6 +401,13 @@ struct CanvasView: View {
     let previousTabID = focusedTabID
     focusedTabID = tabID
 
+    // Sync the tab selection on the owning worktree so that exiting canvas
+    // (via toggleCanvas → selectWorktree) will focus the correct tab.
+    if let ownerState = states.first(where: { $0.surfaceView(for: tabID) != nil }) {
+      ownerState.tabManager.selectTab(tabID)
+      terminalManager.canvasFocusedWorktreeID = ownerState.worktreeID
+    }
+
     // Unfocus all surfaces in the previous card's split tree
     if let previousTabID, previousTabID != tabID,
       let previousState = states.first(where: { $0.surfaceView(for: previousTabID) != nil })

--- a/supacode/Features/Canvas/Views/CanvasView.swift
+++ b/supacode/Features/Canvas/Views/CanvasView.swift
@@ -437,11 +437,23 @@ struct CanvasView: View {
 
   private func activateCanvas() {
     cleanStaleLayouts()
-    for state in terminalManager.activeWorktreeStates {
+
+    let activeStates = terminalManager.activeWorktreeStates
+
+    // Auto-focus the card that was active before entering canvas.
+    if let selectedID = terminalManager.selectedWorktreeID,
+      let state = activeStates.first(where: { $0.worktreeID == selectedID }),
+      let tabID = state.tabManager.selectedTabId,
+      let surface = state.surfaceView(for: tabID)
+    {
+      focusCard(tabID, surfaceView: surface, states: activeStates)
+    }
+
+    for state in activeStates {
       state.setAllSurfacesOccluded()
     }
     // Un-occlude all surfaces visible on canvas (including split panes)
-    for state in terminalManager.activeWorktreeStates {
+    for state in activeStates {
       for tab in state.tabManager.tabs {
         for surface in state.splitTree(for: tab.id).leaves() {
           surface.setOcclusion(true)

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -134,6 +134,7 @@ struct RepositoriesFeature {
     case repositoriesLoaded([Repository], failures: [LoadFailure], roots: [URL], animated: Bool)
     case selectArchivedWorktrees
     case selectCanvas
+    case toggleCanvas
     case setSidebarSelectedWorktreeIDs(Set<Worktree.ID>)
     case openRepositories([URL])
     case openRepositoriesFinished(
@@ -549,6 +550,18 @@ struct RepositoriesFeature {
         state.selection = .canvas
         state.sidebarSelectedWorktreeIDs = []
         return .none
+
+      case .toggleCanvas:
+        if state.isShowingCanvas {
+          // Exit canvas: select the last focused worktree, or the first available one.
+          let targetID = state.lastFocusedWorktreeID ?? state.orderedWorktreeRows().first?.id
+          guard let targetID else { return .none }
+          return .send(.selectWorktree(targetID, focusTerminal: true))
+        } else {
+          // Enter canvas if there are any open worktrees.
+          guard !state.orderedWorktreeRows().isEmpty else { return .none }
+          return .send(.selectCanvas)
+        }
 
       case .setSidebarSelectedWorktreeIDs(let worktreeIDs):
         let validWorktreeIDs = Set(state.orderedWorktreeRows().map(\.id))

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -83,6 +83,7 @@ struct RepositoriesFeature {
     var automaticallyArchiveMergedWorktrees = false
     var moveNotifiedWorktreeToTop = true
     var lastFocusedWorktreeID: Worktree.ID?
+    var preCanvasWorktreeID: Worktree.ID?
     var shouldRestoreLastFocusedWorktree = false
     var shouldSelectFirstAfterReload = false
     var isRefreshingWorktrees = false
@@ -293,6 +294,7 @@ struct RepositoriesFeature {
     case worktreeCreated(Worktree)
   }
 
+  @Dependency(TerminalClient.self) private var terminalClient
   @Dependency(AnalyticsClient.self) private var analyticsClient
   @Dependency(GitClientDependency.self) private var gitClient
   @Dependency(GithubCLIClient.self) private var githubCLI
@@ -547,14 +549,21 @@ struct RepositoriesFeature {
         return .send(.delegate(.selectedWorktreeChanged(nil)))
 
       case .selectCanvas:
+        // Remember the current worktree so toggleCanvas can restore it.
+        state.preCanvasWorktreeID = state.selectedWorktreeID
         state.selection = .canvas
         state.sidebarSelectedWorktreeIDs = []
         return .none
 
       case .toggleCanvas:
         if state.isShowingCanvas {
-          // Exit canvas: select the last focused worktree, or the first available one.
-          let targetID = state.lastFocusedWorktreeID ?? state.orderedWorktreeRows().first?.id
+          // Exit canvas: prefer the card focused in canvas, then the worktree
+          // we came from, then the first available worktree.
+          let targetID =
+            terminalClient.canvasFocusedWorktreeID()
+            ?? state.preCanvasWorktreeID
+            ?? state.lastFocusedWorktreeID
+            ?? state.orderedWorktreeRows().first?.id
           guard let targetID else { return .none }
           return .send(.selectWorktree(targetID, focusTerminal: true))
         } else {

--- a/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
+++ b/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
@@ -13,6 +13,9 @@ final class WorktreeTerminalManager {
   private var eventContinuation: AsyncStream<TerminalClient.Event>.Continuation?
   private var pendingEvents: [TerminalClient.Event] = []
   var selectedWorktreeID: Worktree.ID?
+  /// The worktree+tab focused in Canvas, updated by CanvasView on card tap.
+  /// Used by toggleCanvas to know which worktree to return to.
+  var canvasFocusedWorktreeID: Worktree.ID?
 
   init(runtime: GhosttyRuntime) {
     self.runtime = runtime


### PR DESCRIPTION
## Summary
- **⌥⌘↩** toggles between Canvas view and the normal worktree view
- Entering Canvas auto-focuses the card corresponding to the previously active worktree+tab
- Exiting Canvas returns to the worktree+tab that was focused in Canvas (fallback: pre-canvas → last-focused → first)
- Canvas and Show Diff menu items moved from File to **View** menu (alongside Toggle Left Sidebar)
- Sidebar Canvas button shows ⌥⌘↩ hint when Cmd is held
- Shortcut is automatically unbound in Ghostty to prevent terminal conflicts

### Data flow (TCA-compliant)
- Canvas `focusCard` → syncs `tabManager.selectTab` on the owning worktree + writes `terminalManager.canvasFocusedWorktreeID`
- Reducer `toggleCanvas` → reads `terminalClient.canvasFocusedWorktreeID()` to pick the right worktree
- `selectWorktree(focusTerminal: true)` → terminal layer naturally focuses the already-selected tab

## Test plan
- [x] Press ⌥⌘↩ → enters Canvas, previously active card is highlighted
- [x] Click a different card in Canvas, press ⌥⌘↩ → exits to that worktree+tab
- [x] Press ⌥⌘↩ with no worktrees → does nothing
- [x] Hold Cmd → sidebar Canvas button shows ⌥⌘↩ hint
- [x] View menu → Canvas (⌥⌘↩) and Show Diff (⌘]) appear under View, not File
