### PR TITLE
Preload last focused repository on startup

### DIFF
--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -82,27 +82,20 @@ struct SupacodeApp: App {
   @State private var commandKeyObserver: CommandKeyObserver
   @State private var store: StoreOf<AppFeature>
 
-  private static let startupLogger = SupaLogger("Startup")
-
   @MainActor init() {
-    let initStart = ContinuousClock.now
-
     NSWindow.allowsAutomaticWindowTabbing = false
     UserDefaults.standard.set(200, forKey: "NSInitialToolTipDelay")
     @Shared(.settingsFile) var settingsFile
     let initialSettings = settingsFile.global
     #if !DEBUG
       if initialSettings.crashReportsEnabled {
-        let t = ContinuousClock.now
         SentrySDK.start { options in
           options.dsn = "__SENTRY_DSN__"
           options.tracesSampleRate = 1.0
           options.enableAppHangTracking = false
         }
-        Self.startupLogger.info("[Benchmark] Sentry init: \(t.duration(to: .now))")
       }
       if initialSettings.analyticsEnabled {
-        let t = ContinuousClock.now
         let posthogAPIKey = "__POSTHOG_API_KEY__"
         let posthogHost = "__POSTHOG_HOST__"
         let config = PostHogConfig(apiKey: posthogAPIKey, host: posthogHost)
@@ -111,11 +104,8 @@ struct SupacodeApp: App {
         if let hardwareUUID = HardwareInfo.uuid {
           PostHogSDK.shared.identify(hardwareUUID)
         }
-        Self.startupLogger.info("[Benchmark] PostHog init: \(t.duration(to: .now))")
       }
     #endif
-
-    var t = ContinuousClock.now
     if let resourceURL = Bundle.main.resourceURL?.appendingPathComponent("ghostty") {
       setenv("GHOSTTY_RESOURCES_DIR", resourceURL.path, 1)
     }
@@ -126,9 +116,6 @@ struct SupacodeApp: App {
         preconditionFailure("ghostty_init failed")
       }
     }
-    Self.startupLogger.info("[Benchmark] ghostty_init: \(t.duration(to: .now))")
-
-    t = ContinuousClock.now
     let runtime = GhosttyRuntime()
     _ghostty = State(initialValue: runtime)
     let shortcuts = GhosttyShortcutManager(runtime: runtime)
@@ -139,9 +126,6 @@ struct SupacodeApp: App {
     _worktreeInfoWatcher = State(initialValue: worktreeInfoWatcher)
     let keyObserver = CommandKeyObserver()
     _commandKeyObserver = State(initialValue: keyObserver)
-    Self.startupLogger.info("[Benchmark] runtime + managers: \(t.duration(to: .now))")
-
-    t = ContinuousClock.now
     let appStore = Store(
       initialState: AppFeature.State(settings: SettingsFeature.State(settings: initialSettings))
     ) {
@@ -175,8 +159,6 @@ struct SupacodeApp: App {
       ghosttyShortcuts: shortcuts,
       commandKeyObserver: keyObserver
     )
-    Self.startupLogger.info("[Benchmark] TCA store: \(t.duration(to: .now))")
-    Self.startupLogger.info("[Benchmark] init() total: \(initStart.duration(to: .now))")
   }
 
   var body: some Scene {

--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -82,20 +82,27 @@ struct SupacodeApp: App {
   @State private var commandKeyObserver: CommandKeyObserver
   @State private var store: StoreOf<AppFeature>
 
+  private static let startupLogger = SupaLogger("Startup")
+
   @MainActor init() {
+    let initStart = ContinuousClock.now
+
     NSWindow.allowsAutomaticWindowTabbing = false
     UserDefaults.standard.set(200, forKey: "NSInitialToolTipDelay")
     @Shared(.settingsFile) var settingsFile
     let initialSettings = settingsFile.global
     #if !DEBUG
       if initialSettings.crashReportsEnabled {
+        let t = ContinuousClock.now
         SentrySDK.start { options in
           options.dsn = "__SENTRY_DSN__"
           options.tracesSampleRate = 1.0
           options.enableAppHangTracking = false
         }
+        Self.startupLogger.info("[Benchmark] Sentry init: \(t.duration(to: .now))")
       }
       if initialSettings.analyticsEnabled {
+        let t = ContinuousClock.now
         let posthogAPIKey = "__POSTHOG_API_KEY__"
         let posthogHost = "__POSTHOG_HOST__"
         let config = PostHogConfig(apiKey: posthogAPIKey, host: posthogHost)
@@ -104,8 +111,11 @@ struct SupacodeApp: App {
         if let hardwareUUID = HardwareInfo.uuid {
           PostHogSDK.shared.identify(hardwareUUID)
         }
+        Self.startupLogger.info("[Benchmark] PostHog init: \(t.duration(to: .now))")
       }
     #endif
+
+    var t = ContinuousClock.now
     if let resourceURL = Bundle.main.resourceURL?.appendingPathComponent("ghostty") {
       setenv("GHOSTTY_RESOURCES_DIR", resourceURL.path, 1)
     }
@@ -116,6 +126,9 @@ struct SupacodeApp: App {
         preconditionFailure("ghostty_init failed")
       }
     }
+    Self.startupLogger.info("[Benchmark] ghostty_init: \(t.duration(to: .now))")
+
+    t = ContinuousClock.now
     let runtime = GhosttyRuntime()
     _ghostty = State(initialValue: runtime)
     let shortcuts = GhosttyShortcutManager(runtime: runtime)
@@ -126,6 +139,9 @@ struct SupacodeApp: App {
     _worktreeInfoWatcher = State(initialValue: worktreeInfoWatcher)
     let keyObserver = CommandKeyObserver()
     _commandKeyObserver = State(initialValue: keyObserver)
+    Self.startupLogger.info("[Benchmark] runtime + managers: \(t.duration(to: .now))")
+
+    t = ContinuousClock.now
     let appStore = Store(
       initialState: AppFeature.State(settings: SettingsFeature.State(settings: initialSettings))
     ) {
@@ -159,6 +175,8 @@ struct SupacodeApp: App {
       ghosttyShortcuts: shortcuts,
       commandKeyObserver: keyObserver
     )
+    Self.startupLogger.info("[Benchmark] TCA store: \(t.duration(to: .now))")
+    Self.startupLogger.info("[Benchmark] init() total: \(initStart.duration(to: .now))")
   }
 
   var body: some Scene {

--- a/supacode/Clients/Git/GitClient.swift
+++ b/supacode/Clients/Git/GitClient.swift
@@ -59,17 +59,18 @@ struct GitClient {
   nonisolated func repoRoot(for path: URL) async throws -> URL {
     let normalizedPath = Self.directoryURL(for: path)
     let wtURL = try wtScriptURL()
-    let output = try await runLoginShellProcess(
+    let output = try await runBundledWtProcess(
       operation: .repoRoot,
       executableURL: wtURL,
       arguments: ["root"],
       currentDirectoryURL: normalizedPath
     )
-    if output.isEmpty {
+    let trimmed = output.trimmingCharacters(in: .whitespacesAndNewlines)
+    if trimmed.isEmpty {
       let command = "\(wtURL.lastPathComponent) root"
       throw GitClientError.commandFailed(command: command, message: "Empty output")
     }
-    return URL(fileURLWithPath: output).standardizedFileURL
+    return URL(fileURLWithPath: trimmed).standardizedFileURL
   }
 
   nonisolated func worktrees(for repoRoot: URL) async throws -> [Worktree] {
@@ -689,7 +690,7 @@ struct GitClient {
   nonisolated private func runWtList(repoRoot: URL) async throws -> String {
     let wtURL = try wtScriptURL()
     let arguments = ["ls", "--json"]
-    return try await runLoginShellProcess(
+    return try await runBundledWtProcess(
       operation: .worktreeList,
       executableURL: wtURL,
       arguments: arguments,
@@ -702,6 +703,28 @@ struct GitClient {
       fatalError("Bundled wt script not found")
     }
     return url
+  }
+
+  nonisolated private func runBundledWtProcess(
+    operation: GitOperation,
+    executableURL: URL,
+    arguments: [String],
+    currentDirectoryURL: URL?
+  ) async throws -> String {
+    let command = ([executableURL.path(percentEncoded: false)] + arguments).joined(separator: " ")
+    do {
+      return try await shell.run(executableURL, arguments, currentDirectoryURL).stdout
+    } catch {
+      guard shouldFallbackToLoginShell(error) else {
+        throw wrapShellError(error, operation: operation, command: command)
+      }
+      gitLogger.info("Falling back to login shell for \(operation.rawValue)")
+      do {
+        return try await shell.runLogin(executableURL, arguments, currentDirectoryURL).stdout
+      } catch {
+        throw wrapShellError(error, operation: operation, command: command)
+      }
+    }
   }
 
   nonisolated private func runLoginShellProcess(
@@ -845,6 +868,17 @@ struct GitClient {
 }
 
 private nonisolated let gitLogger = SupaLogger("Git")
+
+nonisolated private func shouldFallbackToLoginShell(_ error: Error) -> Bool {
+  guard let shellError = error as? ShellClientError else {
+    return false
+  }
+  if shellError.exitCode == 127 {
+    return true
+  }
+  let output = "\(shellError.stderr)\n\(shellError.stdout)".lowercased()
+  return output.contains("command not found")
+}
 
 nonisolated private func wrapShellError(
   _ error: Error,

--- a/supacode/Clients/Repositories/RepositoryPersistenceClient.swift
+++ b/supacode/Clients/Repositories/RepositoryPersistenceClient.swift
@@ -15,6 +15,8 @@ struct RepositoryPersistenceClient {
   var saveWorktreeOrderByRepository: @Sendable ([Repository.ID: [Worktree.ID]]) async -> Void
   var loadLastFocusedWorktreeID: @Sendable () async -> Worktree.ID?
   var saveLastFocusedWorktreeID: @Sendable (Worktree.ID?) async -> Void
+  var loadLastFocusedRepositoryID: @Sendable () async -> Repository.ID?
+  var saveLastFocusedRepositoryID: @Sendable (Repository.ID?) async -> Void
 }
 
 extension RepositoryPersistenceClient: DependencyKey {
@@ -82,6 +84,18 @@ extension RepositoryPersistenceClient: DependencyKey {
         $sharedLastFocused.withLock {
           $0 = id
         }
+      },
+      loadLastFocusedRepositoryID: {
+        @Shared(.appStorage("lastFocusedRepositoryID")) var repositoryID: Repository.ID?
+        guard let repositoryID else { return nil }
+        return RepositoryOrderNormalizer.normalizeRepositoryIDs([repositoryID]).first
+      },
+      saveLastFocusedRepositoryID: { id in
+        @Shared(.appStorage("lastFocusedRepositoryID")) var sharedRepositoryID: Repository.ID?
+        let normalized = id.flatMap { RepositoryOrderNormalizer.normalizeRepositoryIDs([$0]).first }
+        $sharedRepositoryID.withLock {
+          $0 = normalized
+        }
       }
     )
   }()
@@ -97,7 +111,9 @@ extension RepositoryPersistenceClient: DependencyKey {
     loadWorktreeOrderByRepository: { [:] },
     saveWorktreeOrderByRepository: { _ in },
     loadLastFocusedWorktreeID: { nil },
-    saveLastFocusedWorktreeID: { _ in }
+    saveLastFocusedWorktreeID: { _ in },
+    loadLastFocusedRepositoryID: { nil },
+    saveLastFocusedRepositoryID: { _ in }
   )
 }
 

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -130,6 +130,7 @@ struct AppFeature {
 
       case .repositories(.delegate(.selectedWorktreeChanged(let worktree))):
         let lastFocusedWorktreeID = worktree?.id
+        let lastFocusedRepositoryID = worktree?.repositoryRootURL.path(percentEncoded: false)
         let repositoryPersistence = repositoryPersistence
         guard let worktree else {
           state.openActionSelection = .finder
@@ -149,6 +150,7 @@ struct AppFeature {
             effects.insert(
               .run { _ in
                 await repositoryPersistence.saveLastFocusedWorktreeID(lastFocusedWorktreeID)
+                await repositoryPersistence.saveLastFocusedRepositoryID(lastFocusedRepositoryID)
               },
               at: 0
             )
@@ -174,6 +176,7 @@ struct AppFeature {
         return .merge(
           .run { _ in
             await repositoryPersistence.saveLastFocusedWorktreeID(lastFocusedWorktreeID)
+            await repositoryPersistence.saveLastFocusedRepositoryID(lastFocusedRepositoryID)
           },
           .run { _ in
             await terminalClient.send(.setSelectedWorktreeID(worktree.id))

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -83,14 +83,10 @@ struct AppFeature {
   @Dependency(TerminalClient.self) private var terminalClient
   @Dependency(WorktreeInfoWatcherClient.self) private var worktreeInfoWatcher
 
-  private let startupLogger = SupaLogger("Startup")
-  static let appLaunchTime = ContinuousClock.now
-
   var body: some Reducer<State, Action> {
     let core = Reduce<State, Action> { state, action in
       switch action {
       case .appLaunched:
-        startupLogger.info("[Benchmark] appLaunched received: \(Self.appLaunchTime.duration(to: .now))")
         return .merge(
           .send(.repositories(.task)),
           .send(.settings(.task)),

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -83,10 +83,14 @@ struct AppFeature {
   @Dependency(TerminalClient.self) private var terminalClient
   @Dependency(WorktreeInfoWatcherClient.self) private var worktreeInfoWatcher
 
+  private let startupLogger = SupaLogger("Startup")
+  static let appLaunchTime = ContinuousClock.now
+
   var body: some Reducer<State, Action> {
     let core = Reduce<State, Action> { state, action in
       switch action {
       case .appLaunched:
+        startupLogger.info("[Benchmark] appLaunched received: \(Self.appLaunchTime.duration(to: .now))")
         return .merge(
           .send(.repositories(.task)),
           .send(.settings(.task)),

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -1889,7 +1889,7 @@ struct RepositoriesFeature {
         var effects: [Effect<Action>] = [
           .run { _ in
             await repositoryPersistence.savePinnedWorktreeIDs(pinnedWorktreeIDs)
-          },
+          }
         ]
         if didUpdateWorktreeOrder {
           let worktreeOrderByRepository = state.worktreeOrderByRepository
@@ -1916,7 +1916,7 @@ struct RepositoriesFeature {
         var effects: [Effect<Action>] = [
           .run { _ in
             await repositoryPersistence.savePinnedWorktreeIDs(pinnedWorktreeIDs)
-          },
+          }
         ]
         if didUpdateWorktreeOrder {
           let worktreeOrderByRepository = state.worktreeOrderByRepository

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -356,6 +356,13 @@ struct RepositoriesFeature {
           let rootPaths = RepositoryPathNormalizer.normalize(loadedPaths)
           let roots = rootPaths.map { URL(fileURLWithPath: $0) }
 
+          // Priority loading: load the last-focused repo first so the UI can appear
+          // immediately with the selected worktree, then load remaining repos in the
+          // background. The second `repositoriesLoaded` includes the priority repo again
+          // because `applyRepositories` performs a full replacement — omitting it would
+          // remove the already-visible repo from state. The priority repo is NOT re-fetched
+          // from disk; its in-memory result is simply included in the combined list.
+          // `applyRepositories` is idempotent, so processing it twice is harmless.
           if let lastFocused {
             var priorityRoot: URL?
             var remainingRoots: [URL] = []

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -262,6 +262,12 @@ struct RepositoriesFeature {
     let didPruneArchivedWorktreeIDs: Bool
   }
 
+  private struct RepositoryLoadBatch {
+    let repositories: [Repository]
+    let failures: [LoadFailure]
+    let didLoadPriorityRepository: Bool
+  }
+
   enum StatusToast: Equatable {
     case inProgress(String)
     case success(String)
@@ -356,57 +362,39 @@ struct RepositoriesFeature {
           let rootPaths = RepositoryPathNormalizer.normalize(loadedPaths)
           let roots = rootPaths.map { URL(fileURLWithPath: $0) }
 
-          // Priority loading: load the last-focused repo first so the UI can appear
-          // immediately with the selected worktree, then load remaining repos in the
-          // background. The second `repositoriesLoaded` includes the priority repo again
-          // because `applyRepositories` performs a full replacement — omitting it would
-          // remove the already-visible repo from state. The priority repo is NOT re-fetched
-          // from disk; its in-memory result is simply included in the combined list.
-          // `applyRepositories` is idempotent, so processing it twice is harmless.
+          // Priority loading: emit the repository that actually contains the last-focused
+          // worktree as soon as that fetch completes, then apply the final full snapshot
+          // in root order. Matching on fetched worktree IDs is robust even when linked
+          // worktrees live outside the repository root.
+          let batch: RepositoryLoadBatch
           if let lastFocused {
-            var priorityRoot: URL?
-            var remainingRoots: [URL] = []
-            for root in roots {
-              let rootPath = root.path(percentEncoded: false)
-              let prefix = rootPath.hasSuffix("/") ? rootPath : rootPath + "/"
-              if priorityRoot == nil,
-                lastFocused.hasPrefix(prefix) || lastFocused == rootPath
-              {
-                priorityRoot = root
-              } else {
-                remainingRoots.append(root)
-              }
-            }
-            if let priorityRoot {
-              let (priorityRepos, priorityFailures) = await loadRepositoriesData([priorityRoot])
+            batch = await loadRepositoriesData(
+              roots,
+              prioritizeWorktreeID: lastFocused
+            ) { priorityRepository in
               await send(
                 .repositoriesLoaded(
-                  priorityRepos,
-                  failures: priorityFailures,
+                  [priorityRepository],
+                  failures: [],
                   roots: roots,
                   animated: false
                 )
               )
-              if !remainingRoots.isEmpty {
-                let (remainingRepos, remainingFailures) = await loadRepositoriesData(remainingRoots)
-                await send(
-                  .repositoriesLoaded(
-                    priorityRepos + remainingRepos,
-                    failures: priorityFailures + remainingFailures,
-                    roots: roots,
-                    animated: false
-                  )
-                )
-              }
+            }
+            if batch.didLoadPriorityRepository,
+              batch.repositories.count == 1,
+              batch.failures.isEmpty
+            {
               return
             }
+          } else {
+            batch = await loadRepositoriesData(roots)
           }
 
-          let (repositories, failures) = await loadRepositoriesData(roots)
           await send(
             .repositoriesLoaded(
-              repositories,
-              failures: failures,
+              batch.repositories,
+              failures: batch.failures,
               roots: roots,
               animated: false
             )
@@ -494,8 +482,8 @@ struct RepositoriesFeature {
         analyticsClient.capture("repository_added", ["count": urls.count])
         state.alert = nil
         return .run { send in
-          let loadedPaths = await repositoryPersistence.loadRoots()
-          let existingRootPaths = RepositoryPathNormalizer.normalize(loadedPaths)
+      let loadedPaths = await repositoryPersistence.loadRoots()
+      let existingRootPaths = RepositoryPathNormalizer.normalize(loadedPaths)
           var resolvedRoots: [URL] = []
           var invalidRoots: [String] = []
           for url in urls {
@@ -512,11 +500,11 @@ struct RepositoriesFeature {
           let mergedPaths = RepositoryPathNormalizer.normalize(existingRootPaths + resolvedRootPaths)
           let mergedRoots = mergedPaths.map { URL(fileURLWithPath: $0) }
           await repositoryPersistence.saveRoots(mergedPaths)
-          let (repositories, failures) = await loadRepositoriesData(mergedRoots)
+          let batch = await loadRepositoriesData(mergedRoots)
           await send(
             .openRepositoriesFinished(
-              repositories,
-              failures: failures,
+              batch.repositories,
+              failures: batch.failures,
               invalidRoots: invalidRoots,
               roots: mergedRoots
             )
@@ -1790,11 +1778,11 @@ struct RepositoriesFeature {
           let remaining = rootPaths.filter { $0 != repositoryID }
           await repositoryPersistence.saveRoots(remaining)
           let roots = remaining.map { URL(fileURLWithPath: $0) }
-          let (repositories, failures) = await loadRepositoriesData(roots)
+          let batch = await loadRepositoriesData(roots)
           await send(
             .repositoriesLoaded(
-              repositories,
-              failures: failures,
+              batch.repositories,
+              failures: batch.failures,
               roots: roots,
               animated: true
             )
@@ -1834,11 +1822,11 @@ struct RepositoriesFeature {
             let remaining = rootPaths.filter { $0 != repositoryID }
             await repositoryPersistence.saveRoots(remaining)
             let roots = remaining.map { URL(fileURLWithPath: $0) }
-            let (repositories, failures) = await loadRepositoriesData(roots)
+            let batch = await loadRepositoriesData(roots)
             await send(
               .repositoriesLoaded(
-                repositories,
-                failures: failures,
+                batch.repositories,
+                failures: batch.failures,
                 roots: roots,
                 animated: true
               )
@@ -2638,11 +2626,11 @@ struct RepositoriesFeature {
       for root in roots {
         _ = try? await gitClient.pruneWorktrees(root)
       }
-      let (repositories, failures) = await loadRepositoriesData(roots)
+      let batch = await loadRepositoriesData(roots)
       await send(
         .repositoriesLoaded(
-          repositories,
-          failures: failures,
+          batch.repositories,
+          failures: batch.failures,
           roots: roots,
           animated: animated
         )
@@ -2652,51 +2640,109 @@ struct RepositoriesFeature {
   }
 
   private enum WorktreesFetchResult: Sendable {
-    case loaded(root: URL, worktrees: [Worktree])
-    case failed(root: URL, message: String)
+    case loaded(index: Int, root: URL, worktrees: [Worktree])
+    case failed(index: Int, root: URL, message: String)
+
+    var index: Int {
+      switch self {
+      case .loaded(let index, _, _), .failed(let index, _, _):
+        return index
+      }
+    }
+
+    func contains(worktreeID: Worktree.ID) -> Bool {
+      switch self {
+      case .loaded(_, _, let worktrees):
+        worktrees.contains { $0.id == worktreeID }
+      case .failed:
+        false
+      }
+    }
+
+    var repository: Repository? {
+      switch self {
+      case .loaded(_, let root, let worktrees):
+        let normalizedRoot = root.standardizedFileURL
+        let rootID = normalizedRoot.path(percentEncoded: false)
+        let name = Repository.name(for: normalizedRoot)
+        return Repository(
+          id: rootID,
+          rootURL: normalizedRoot,
+          name: name,
+          worktrees: IdentifiedArray(uniqueElements: worktrees),
+        )
+      case .failed:
+        return nil
+      }
+    }
+
+    var failure: LoadFailure? {
+      switch self {
+      case .failed(_, let root, let message):
+        let rootID = root.standardizedFileURL.path(percentEncoded: false)
+        return LoadFailure(rootID: rootID, message: message)
+      case .loaded:
+        return nil
+      }
+    }
   }
 
-  private func loadRepositoriesData(_ roots: [URL]) async -> ([Repository], [LoadFailure]) {
+  private func loadRepositoriesData(
+    _ roots: [URL],
+    prioritizeWorktreeID: Worktree.ID? = nil,
+    onPriorityRepositoryLoaded: (@Sendable (Repository) async -> Void)? = nil
+  ) async -> RepositoryLoadBatch {
     let gitClient = self.gitClient
     let fetchResults = await withTaskGroup(of: WorktreesFetchResult.self) { group in
-      for root in roots {
+      for (index, root) in roots.enumerated() {
         group.addTask {
           do {
             let worktrees = try await gitClient.worktrees(root)
-            return .loaded(root: root, worktrees: worktrees)
+            return .loaded(index: index, root: root, worktrees: worktrees)
           } catch {
-            return .failed(root: root, message: error.localizedDescription)
+            return .failed(index: index, root: root, message: error.localizedDescription)
           }
         }
       }
       var collected: [WorktreesFetchResult] = []
+      var didSendPriorityRepository = false
       for await result in group {
+        if !didSendPriorityRepository,
+          let prioritizeWorktreeID,
+          result.contains(worktreeID: prioritizeWorktreeID),
+          let priorityRepository = result.repository
+        {
+          didSendPriorityRepository = true
+          await onPriorityRepositoryLoaded?(priorityRepository)
+        }
         collected.append(result)
       }
       return collected
     }
-    var loaded: [Repository] = []
+    let orderedResults = fetchResults.sorted { $0.index < $1.index }
+    var repositories: [Repository] = []
     var failures: [LoadFailure] = []
-    for result in fetchResults {
-      switch result {
-      case .loaded(let root, let worktrees):
-        let normalizedRoot = root.standardizedFileURL
-        let rootID = normalizedRoot.path(percentEncoded: false)
-        let name = Repository.name(for: normalizedRoot)
-        loaded.append(
-          Repository(
-            id: rootID,
-            rootURL: normalizedRoot,
-            name: name,
-            worktrees: IdentifiedArray(uniqueElements: worktrees),
-          )
-        )
-      case .failed(let root, let message):
-        let rootID = root.standardizedFileURL.path(percentEncoded: false)
-        failures.append(LoadFailure(rootID: rootID, message: message))
+    for result in orderedResults {
+      if let repository = result.repository {
+        repositories.append(repository)
+      }
+      if let failure = result.failure {
+        failures.append(failure)
       }
     }
-    return (loaded, failures)
+    let didLoadPriorityRepository: Bool
+    if let prioritizeWorktreeID {
+      didLoadPriorityRepository = orderedResults.contains {
+        $0.contains(worktreeID: prioritizeWorktreeID)
+      }
+    } else {
+      didLoadPriorityRepository = false
+    }
+    return RepositoryLoadBatch(
+      repositories: repositories,
+      failures: failures,
+      didLoadPriorityRepository: didLoadPriorityRepository
+    )
   }
 
   private func applyRepositories(

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -294,8 +294,6 @@ struct RepositoriesFeature {
     case worktreeCreated(Worktree)
   }
 
-  private let startupLogger = SupaLogger("Startup")
-
   @Dependency(TerminalClient.self) private var terminalClient
   @Dependency(AnalyticsClient.self) private var analyticsClient
   @Dependency(GitClientDependency.self) private var gitClient
@@ -310,14 +308,12 @@ struct RepositoriesFeature {
       switch action {
       case .task:
         return .run { send in
-          let t = ContinuousClock.now
           let pinned = await repositoryPersistence.loadPinnedWorktreeIDs()
           let archived = await repositoryPersistence.loadArchivedWorktreeIDs()
           let lastFocused = await repositoryPersistence.loadLastFocusedWorktreeID()
           let repositoryOrderIDs = await repositoryPersistence.loadRepositoryOrderIDs()
           let worktreeOrderByRepository =
             await repositoryPersistence.loadWorktreeOrderByRepository()
-          startupLogger.info("[Benchmark] persistence load: \(t.duration(to: .now))")
           await send(.pinnedWorktreeIDsLoaded(pinned))
           await send(.archivedWorktreeIDsLoaded(archived))
           await send(.repositoryOrderIDsLoaded(repositoryOrderIDs))
@@ -423,11 +419,6 @@ struct RepositoriesFeature {
         return loadRepositories(roots, animated: animated)
 
       case .repositoriesLoaded(let repositories, let failures, let roots, let animated):
-        if !state.isInitialLoadComplete {
-          startupLogger.info(
-            "[Benchmark] initial load complete (end-to-end since AppFeature init): \(AppFeature.appLaunchTime.duration(to: .now))"
-          )
-        }
         state.isRefreshingWorktrees = false
         let previousSelection = state.selectedWorktreeID
         let previousSelectedWorktree = state.worktree(for: previousSelection)
@@ -2658,23 +2649,14 @@ struct RepositoriesFeature {
   }
 
   private func loadRepositoriesData(_ roots: [URL]) async -> ([Repository], [LoadFailure]) {
-    let total = ContinuousClock.now
     let gitClient = self.gitClient
-    let startupLogger = self.startupLogger
     let fetchResults = await withTaskGroup(of: WorktreesFetchResult.self) { group in
       for root in roots {
         group.addTask {
-          let t = ContinuousClock.now
-          let normalizedRoot = root.standardizedFileURL
-          let rootID = normalizedRoot.path(percentEncoded: false)
           do {
             let worktrees = try await gitClient.worktrees(root)
-            startupLogger.info(
-              "[Benchmark] worktrees(\(rootID)): \(t.duration(to: .now)) (\(worktrees.count) worktrees)"
-            )
             return WorktreesFetchResult(root: root, worktrees: worktrees, errorMessage: nil)
           } catch {
-            startupLogger.warning("[Benchmark] worktrees(\(rootID)) failed: \(t.duration(to: .now))")
             return WorktreesFetchResult(root: root, worktrees: nil, errorMessage: error.localizedDescription)
           }
         }
@@ -2704,9 +2686,6 @@ struct RepositoriesFeature {
         failures.append(LoadFailure(rootID: rootID, message: result.errorMessage ?? "Unknown error"))
       }
     }
-    startupLogger.info(
-      "[Benchmark] loadRepositoriesData total: \(total.duration(to: .now)) (\(roots.count) repos)"
-    )
     return (loaded, failures)
   }
 

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -482,8 +482,8 @@ struct RepositoriesFeature {
         analyticsClient.capture("repository_added", ["count": urls.count])
         state.alert = nil
         return .run { send in
-      let loadedPaths = await repositoryPersistence.loadRoots()
-      let existingRootPaths = RepositoryPathNormalizer.normalize(loadedPaths)
+          let loadedPaths = await repositoryPersistence.loadRoots()
+          let existingRootPaths = RepositoryPathNormalizer.normalize(loadedPaths)
           var resolvedRoots: [URL] = []
           var invalidRoots: [String] = []
           for url in urls {

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -83,6 +83,7 @@ struct RepositoriesFeature {
     var automaticallyArchiveMergedWorktrees = false
     var moveNotifiedWorktreeToTop = true
     var lastFocusedWorktreeID: Worktree.ID?
+    var lastFocusedRepositoryID: Repository.ID?
     var preCanvasWorktreeID: Worktree.ID?
     var shouldRestoreLastFocusedWorktree = false
     var shouldSelectFirstAfterReload = false
@@ -130,6 +131,7 @@ struct RepositoriesFeature {
     case repositoryOrderIDsLoaded([Repository.ID])
     case worktreeOrderByRepositoryLoaded([Repository.ID: [Worktree.ID]])
     case lastFocusedWorktreeIDLoaded(Worktree.ID?)
+    case lastFocusedRepositoryIDLoaded(Repository.ID?)
     case refreshWorktrees
     case reloadRepositories(animated: Bool)
     case repositoriesLoaded([Repository], failures: [LoadFailure], roots: [URL], animated: Bool)
@@ -318,6 +320,7 @@ struct RepositoriesFeature {
           let archived = await repositoryPersistence.loadArchivedWorktreeIDs()
           let lastFocused = await repositoryPersistence.loadLastFocusedWorktreeID()
           let repositoryOrderIDs = await repositoryPersistence.loadRepositoryOrderIDs()
+          let lastFocusedRepositoryID = await repositoryPersistence.loadLastFocusedRepositoryID()
           let worktreeOrderByRepository =
             await repositoryPersistence.loadWorktreeOrderByRepository()
           await send(.pinnedWorktreeIDsLoaded(pinned))
@@ -326,6 +329,7 @@ struct RepositoriesFeature {
           await send(.worktreeOrderByRepositoryLoaded(worktreeOrderByRepository))
           await send(.lastFocusedWorktreeIDLoaded(lastFocused))
           await send(.loadPersistedRepositories)
+          await send(.lastFocusedRepositoryIDLoaded(lastFocusedRepositoryID))
         }
 
       case .pinnedWorktreeIDsLoaded(let pinnedWorktreeIDs):
@@ -350,6 +354,10 @@ struct RepositoriesFeature {
         return .none
 
       case .setOpenPanelPresented(let isPresented):
+      case .lastFocusedRepositoryIDLoaded(let lastFocusedRepositoryID):
+        state.lastFocusedRepositoryID = lastFocusedRepositoryID
+        return .none
+
         state.isOpenPanelPresented = isPresented
         return .none
 
@@ -359,13 +367,51 @@ struct RepositoriesFeature {
         let lastFocused = state.lastFocusedWorktreeID
         return .run { send in
           let loadedPaths = await repositoryPersistence.loadRoots()
+        let lastFocusedRepositoryID = state.lastFocusedRepositoryID
           let rootPaths = RepositoryPathNormalizer.normalize(loadedPaths)
           let roots = rootPaths.map { URL(fileURLWithPath: $0) }
 
-          // Priority loading: emit the repository that actually contains the last-focused
-          // worktree as soon as that fetch completes, then apply the final full snapshot
-          // in root order. Matching on fetched worktree IDs is robust even when linked
-          // worktrees live outside the repository root.
+          if let priorityRoot = roots.first(where: {
+            $0.standardizedFileURL.path(percentEncoded: false) == lastFocusedRepositoryID
+          }) {
+            let priorityBatch = await loadRepositoriesData([priorityRoot])
+            if !priorityBatch.repositories.isEmpty || !priorityBatch.failures.isEmpty {
+              await send(
+                .repositoriesLoaded(
+                  priorityBatch.repositories,
+                  failures: priorityBatch.failures,
+                  roots: roots,
+                  animated: false
+                )
+              )
+            }
+
+            let remainingRoots = roots.filter {
+              $0.standardizedFileURL.path(percentEncoded: false)
+                != priorityRoot.standardizedFileURL.path(percentEncoded: false)
+            }
+            guard !remainingRoots.isEmpty else { return }
+
+            let remainingBatch = await loadRepositoriesData(remainingRoots)
+            let fullBatch = Self.mergeRepositoryLoadBatches(
+              priorityBatch,
+              remainingBatch,
+              roots: roots
+            )
+            await send(
+              .repositoriesLoaded(
+                fullBatch.repositories,
+                failures: fullBatch.failures,
+                roots: roots,
+                animated: false
+              )
+            )
+            return
+          }
+
+          // Fallback path for users who do not yet have a persisted last-focused
+          // repository root. Matching on fetched worktree IDs is robust even when
+          // linked worktrees live outside the repository root.
           let batch: RepositoryLoadBatch
           if let lastFocused {
             batch = await loadRepositoriesData(
@@ -2751,6 +2797,27 @@ struct RepositoriesFeature {
     shouldPruneArchivedWorktreeIDs: Bool,
     state: inout State,
     animated: Bool
+  private nonisolated static func mergeRepositoryLoadBatches(
+    _ lhs: RepositoryLoadBatch,
+    _ rhs: RepositoryLoadBatch,
+    roots: [URL]
+  ) -> RepositoryLoadBatch {
+    let repositoriesByID = Dictionary(
+      uniqueKeysWithValues: (lhs.repositories + rhs.repositories).map { ($0.id, $0) }
+    )
+    let failuresByID = Dictionary(
+      uniqueKeysWithValues: (lhs.failures + rhs.failures).map { ($0.rootID, $0) }
+    )
+    let orderedRootIDs = roots.map { $0.standardizedFileURL.path(percentEncoded: false) }
+    let repositories = orderedRootIDs.compactMap { repositoriesByID[$0] }
+    let failures = orderedRootIDs.compactMap { failuresByID[$0] }
+    return RepositoryLoadBatch(
+      repositories: repositories,
+      failures: failures,
+      didLoadPriorityRepository: lhs.didLoadPriorityRepository || rhs.didLoadPriorityRepository
+    )
+  }
+
   ) -> ApplyRepositoriesResult {
     let previousCounts = Dictionary(
       uniqueKeysWithValues: state.repositories.map { ($0.id, $0.worktrees.count) }

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -360,8 +360,10 @@ struct RepositoriesFeature {
             var priorityRoot: URL?
             var remainingRoots: [URL] = []
             for root in roots {
+              let rootPath = root.path(percentEncoded: false)
+              let prefix = rootPath.hasSuffix("/") ? rootPath : rootPath + "/"
               if priorityRoot == nil,
-                lastFocused.hasPrefix(root.path(percentEncoded: false))
+                lastFocused.hasPrefix(prefix) || lastFocused == rootPath
               {
                 priorityRoot = root
               } else {
@@ -2642,10 +2644,9 @@ struct RepositoriesFeature {
     .cancellable(id: CancelID.load, cancelInFlight: true)
   }
 
-  private struct WorktreesFetchResult: Sendable {
-    let root: URL
-    let worktrees: [Worktree]?
-    let errorMessage: String?
+  private enum WorktreesFetchResult: Sendable {
+    case loaded(root: URL, worktrees: [Worktree])
+    case failed(root: URL, message: String)
   }
 
   private func loadRepositoriesData(_ roots: [URL]) async -> ([Repository], [LoadFailure]) {
@@ -2655,9 +2656,9 @@ struct RepositoriesFeature {
         group.addTask {
           do {
             let worktrees = try await gitClient.worktrees(root)
-            return WorktreesFetchResult(root: root, worktrees: worktrees, errorMessage: nil)
+            return .loaded(root: root, worktrees: worktrees)
           } catch {
-            return WorktreesFetchResult(root: root, worktrees: nil, errorMessage: error.localizedDescription)
+            return .failed(root: root, message: error.localizedDescription)
           }
         }
       }
@@ -2670,9 +2671,10 @@ struct RepositoriesFeature {
     var loaded: [Repository] = []
     var failures: [LoadFailure] = []
     for result in fetchResults {
-      let normalizedRoot = result.root.standardizedFileURL
-      let rootID = normalizedRoot.path(percentEncoded: false)
-      if let worktrees = result.worktrees {
+      switch result {
+      case .loaded(let root, let worktrees):
+        let normalizedRoot = root.standardizedFileURL
+        let rootID = normalizedRoot.path(percentEncoded: false)
         let name = Repository.name(for: normalizedRoot)
         loaded.append(
           Repository(
@@ -2682,8 +2684,9 @@ struct RepositoriesFeature {
             worktrees: IdentifiedArray(uniqueElements: worktrees),
           )
         )
-      } else {
-        failures.append(LoadFailure(rootID: rootID, message: result.errorMessage ?? "Unknown error"))
+      case .failed(let root, let message):
+        let rootID = root.standardizedFileURL.path(percentEncoded: false)
+        failures.append(LoadFailure(rootID: rootID, message: message))
       }
     }
     return (loaded, failures)

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -294,6 +294,8 @@ struct RepositoriesFeature {
     case worktreeCreated(Worktree)
   }
 
+  private let startupLogger = SupaLogger("Startup")
+
   @Dependency(TerminalClient.self) private var terminalClient
   @Dependency(AnalyticsClient.self) private var analyticsClient
   @Dependency(GitClientDependency.self) private var gitClient
@@ -308,12 +310,14 @@ struct RepositoriesFeature {
       switch action {
       case .task:
         return .run { send in
+          let t = ContinuousClock.now
           let pinned = await repositoryPersistence.loadPinnedWorktreeIDs()
           let archived = await repositoryPersistence.loadArchivedWorktreeIDs()
           let lastFocused = await repositoryPersistence.loadLastFocusedWorktreeID()
           let repositoryOrderIDs = await repositoryPersistence.loadRepositoryOrderIDs()
           let worktreeOrderByRepository =
             await repositoryPersistence.loadWorktreeOrderByRepository()
+          startupLogger.info("[Benchmark] persistence load: \(t.duration(to: .now))")
           await send(.pinnedWorktreeIDsLoaded(pinned))
           await send(.archivedWorktreeIDsLoaded(archived))
           await send(.repositoryOrderIDsLoaded(repositoryOrderIDs))
@@ -350,10 +354,49 @@ struct RepositoriesFeature {
       case .loadPersistedRepositories:
         state.alert = nil
         state.isRefreshingWorktrees = false
+        let lastFocused = state.lastFocusedWorktreeID
         return .run { send in
           let loadedPaths = await repositoryPersistence.loadRoots()
           let rootPaths = RepositoryPathNormalizer.normalize(loadedPaths)
           let roots = rootPaths.map { URL(fileURLWithPath: $0) }
+
+          if let lastFocused {
+            var priorityRoot: URL?
+            var remainingRoots: [URL] = []
+            for root in roots {
+              if priorityRoot == nil,
+                lastFocused.hasPrefix(root.path(percentEncoded: false))
+              {
+                priorityRoot = root
+              } else {
+                remainingRoots.append(root)
+              }
+            }
+            if let priorityRoot {
+              let (priorityRepos, priorityFailures) = await loadRepositoriesData([priorityRoot])
+              await send(
+                .repositoriesLoaded(
+                  priorityRepos,
+                  failures: priorityFailures,
+                  roots: roots,
+                  animated: false
+                )
+              )
+              if !remainingRoots.isEmpty {
+                let (remainingRepos, remainingFailures) = await loadRepositoriesData(remainingRoots)
+                await send(
+                  .repositoriesLoaded(
+                    priorityRepos + remainingRepos,
+                    failures: priorityFailures + remainingFailures,
+                    roots: roots,
+                    animated: false
+                  )
+                )
+              }
+              return
+            }
+          }
+
           let (repositories, failures) = await loadRepositoriesData(roots)
           await send(
             .repositoriesLoaded(
@@ -380,6 +423,11 @@ struct RepositoriesFeature {
         return loadRepositories(roots, animated: animated)
 
       case .repositoriesLoaded(let repositories, let failures, let roots, let animated):
+        if !state.isInitialLoadComplete {
+          startupLogger.info(
+            "[Benchmark] initial load complete (end-to-end since AppFeature init): \(AppFeature.appLaunchTime.duration(to: .now))"
+          )
+        }
         state.isRefreshingWorktrees = false
         let previousSelection = state.selectedWorktreeID
         let previousSelectedWorktree = state.worktree(for: previousSelection)
@@ -2603,26 +2651,62 @@ struct RepositoriesFeature {
     .cancellable(id: CancelID.load, cancelInFlight: true)
   }
 
+  private struct WorktreesFetchResult: Sendable {
+    let root: URL
+    let worktrees: [Worktree]?
+    let errorMessage: String?
+  }
+
   private func loadRepositoriesData(_ roots: [URL]) async -> ([Repository], [LoadFailure]) {
+    let total = ContinuousClock.now
+    let gitClient = self.gitClient
+    let startupLogger = self.startupLogger
+    let fetchResults = await withTaskGroup(of: WorktreesFetchResult.self) { group in
+      for root in roots {
+        group.addTask {
+          let t = ContinuousClock.now
+          let normalizedRoot = root.standardizedFileURL
+          let rootID = normalizedRoot.path(percentEncoded: false)
+          do {
+            let worktrees = try await gitClient.worktrees(root)
+            startupLogger.info(
+              "[Benchmark] worktrees(\(rootID)): \(t.duration(to: .now)) (\(worktrees.count) worktrees)"
+            )
+            return WorktreesFetchResult(root: root, worktrees: worktrees, errorMessage: nil)
+          } catch {
+            startupLogger.warning("[Benchmark] worktrees(\(rootID)) failed: \(t.duration(to: .now))")
+            return WorktreesFetchResult(root: root, worktrees: nil, errorMessage: error.localizedDescription)
+          }
+        }
+      }
+      var collected: [WorktreesFetchResult] = []
+      for await result in group {
+        collected.append(result)
+      }
+      return collected
+    }
     var loaded: [Repository] = []
     var failures: [LoadFailure] = []
-    for root in roots {
-      let normalizedRoot = root.standardizedFileURL
+    for result in fetchResults {
+      let normalizedRoot = result.root.standardizedFileURL
       let rootID = normalizedRoot.path(percentEncoded: false)
-      do {
-        let worktrees = try await gitClient.worktrees(root)
+      if let worktrees = result.worktrees {
         let name = Repository.name(for: normalizedRoot)
-        let repository = Repository(
-          id: rootID,
-          rootURL: normalizedRoot,
-          name: name,
-          worktrees: IdentifiedArray(uniqueElements: worktrees)
+        loaded.append(
+          Repository(
+            id: rootID,
+            rootURL: normalizedRoot,
+            name: name,
+            worktrees: IdentifiedArray(uniqueElements: worktrees),
+          )
         )
-        loaded.append(repository)
-      } catch {
-        failures.append(LoadFailure(rootID: rootID, message: error.localizedDescription))
+      } else {
+        failures.append(LoadFailure(rootID: rootID, message: result.errorMessage ?? "Unknown error"))
       }
     }
+    startupLogger.info(
+      "[Benchmark] loadRepositoriesData total: \(total.duration(to: .now)) (\(roots.count) repos)"
+    )
     return (loaded, failures)
   }
 

--- a/supacodeTests/AppFeatureArchivedSelectionTests.swift
+++ b/supacodeTests/AppFeatureArchivedSelectionTests.swift
@@ -37,6 +37,7 @@ struct AppFeatureArchivedSelectionTests {
       $0.repositoryPersistence.saveLastFocusedWorktreeID = { id in
         saved.withValue { $0.append(id) }
       }
+      $0.repositoryPersistence.saveLastFocusedRepositoryID = { _ in }
       $0.terminalClient.send = { _ in }
       $0.worktreeInfoWatcher.send = { _ in }
     }

--- a/supacodeTests/AppFeatureDefaultEditorTests.swift
+++ b/supacodeTests/AppFeatureDefaultEditorTests.swift
@@ -100,6 +100,8 @@ struct AppFeatureDefaultEditorTests {
     let repositoriesState = makeRepositoriesState(worktree: worktree)
     let expectedOpenActionSelection = OpenWorktreeAction.preferredDefault()
     let watcherCommands = LockIsolated<[WorktreeInfoWatcherClient.Command]>([])
+    let savedWorktreeIDs = LockIsolated<[Worktree.ID?]>([])
+    let savedRepositoryIDs = LockIsolated<[Repository.ID?]>([])
     let storage = SettingsTestStorage()
     let settingsFileURL = URL(
       fileURLWithPath: "/tmp/supacode-settings-\(UUID().uuidString).json"
@@ -112,7 +114,12 @@ struct AppFeatureDefaultEditorTests {
     ) {
       AppFeature()
     } withDependencies: {
-      $0.repositoryPersistence.saveLastFocusedWorktreeID = { _ in }
+      $0.repositoryPersistence.saveLastFocusedWorktreeID = { id in
+        savedWorktreeIDs.withValue { $0.append(id) }
+      }
+      $0.repositoryPersistence.saveLastFocusedRepositoryID = { id in
+        savedRepositoryIDs.withValue { $0.append(id) }
+      }
       $0.terminalClient.send = { _ in }
       $0.worktreeInfoWatcher.send = { command in
         watcherCommands.withValue { $0.append(command) }
@@ -129,6 +136,8 @@ struct AppFeatureDefaultEditorTests {
     await store.finish()
 
     #expect(watcherCommands.value == [.setSelectedWorktreeID(worktree.id)])
+    #expect(savedWorktreeIDs.value == [worktree.id])
+    #expect(savedRepositoryIDs.value == [worktree.repositoryRootURL.path(percentEncoded: false)])
   }
 
   private func makeWorktree() -> Worktree {

--- a/supacodeTests/GitClientWorktreeDiscoveryTests.swift
+++ b/supacodeTests/GitClientWorktreeDiscoveryTests.swift
@@ -1,0 +1,185 @@
+import Foundation
+import Testing
+
+@testable import supacode
+
+nonisolated final class GitWorktreeDiscoveryRecorder: @unchecked Sendable {
+  struct Invocation: Equatable {
+    let executablePath: String
+    let arguments: [String]
+    let currentDirectoryPath: String?
+  }
+
+  private let lock = NSLock()
+  private var runInvocationsValue: [Invocation] = []
+  private var loginInvocationsValue: [Invocation] = []
+
+  func recordRun(executableURL: URL, arguments: [String], currentDirectoryURL: URL?) {
+    lock.lock()
+    runInvocationsValue.append(
+      Invocation(
+        executablePath: executableURL.path(percentEncoded: false),
+        arguments: arguments,
+        currentDirectoryPath: currentDirectoryURL?.path(percentEncoded: false)
+      )
+    )
+    lock.unlock()
+  }
+
+  func recordLogin(executableURL: URL, arguments: [String], currentDirectoryURL: URL?) {
+    lock.lock()
+    loginInvocationsValue.append(
+      Invocation(
+        executablePath: executableURL.path(percentEncoded: false),
+        arguments: arguments,
+        currentDirectoryPath: currentDirectoryURL?.path(percentEncoded: false)
+      )
+    )
+    lock.unlock()
+  }
+
+  func runInvocations() -> [Invocation] {
+    lock.lock()
+    let value = runInvocationsValue
+    lock.unlock()
+    return value
+  }
+
+  func loginInvocations() -> [Invocation] {
+    lock.lock()
+    let value = loginInvocationsValue
+    lock.unlock()
+    return value
+  }
+}
+
+struct GitClientWorktreeDiscoveryTests {
+  @Test func repoRootUsesDirectBundledWtExecution() async throws {
+    let recorder = GitWorktreeDiscoveryRecorder()
+    let shell = ShellClient(
+      run: { executableURL, arguments, currentDirectoryURL in
+        recorder.recordRun(
+          executableURL: executableURL,
+          arguments: arguments,
+          currentDirectoryURL: currentDirectoryURL
+        )
+        return ShellOutput(stdout: "/tmp/repo\n", stderr: "", exitCode: 0)
+      },
+      runLoginImpl: { executableURL, arguments, currentDirectoryURL, _ in
+        recorder.recordLogin(
+          executableURL: executableURL,
+          arguments: arguments,
+          currentDirectoryURL: currentDirectoryURL
+        )
+        Issue.record("repoRoot should not use runLogin when direct execution succeeds")
+        return ShellOutput(stdout: "", stderr: "", exitCode: 0)
+      }
+    )
+    let client = GitClient(shell: shell)
+    let worktreeURL = URL(fileURLWithPath: "/tmp/repo/worktree")
+
+    let root = try await client.repoRoot(for: worktreeURL)
+
+    #expect(root.standardizedFileURL.path(percentEncoded: false).trimmingCharacters(in: CharacterSet(charactersIn: "/")) == "tmp/repo")
+    let runs = recorder.runInvocations()
+    #expect(runs.count == 1)
+    if let invocation = runs.first {
+      #expect(invocation.arguments == ["root"])
+      let normalizedPath = URL(fileURLWithPath: invocation.currentDirectoryPath ?? "")
+        .standardizedFileURL
+        .path(percentEncoded: false)
+      #expect(normalizedPath.trimmingCharacters(in: CharacterSet(charactersIn: "/")) == "tmp/repo")
+    } else {
+      Issue.record("Expected one direct bundled wt invocation for repoRoot")
+    }
+    #expect(recorder.loginInvocations().isEmpty)
+  }
+
+  @Test func worktreesUseDirectBundledWtExecution() async throws {
+    let recorder = GitWorktreeDiscoveryRecorder()
+    let output = """
+      [
+        {"branch":"main","path":"/tmp/repo","head":"abc","is_bare":false},
+        {"branch":"feature","path":"/tmp/repo/.worktrees/feature","head":"def","is_bare":false}
+      ]
+      """
+    let shell = ShellClient(
+      run: { executableURL, arguments, currentDirectoryURL in
+        recorder.recordRun(
+          executableURL: executableURL,
+          arguments: arguments,
+          currentDirectoryURL: currentDirectoryURL
+        )
+        return ShellOutput(stdout: output, stderr: "", exitCode: 0)
+      },
+      runLoginImpl: { executableURL, arguments, currentDirectoryURL, _ in
+        recorder.recordLogin(
+          executableURL: executableURL,
+          arguments: arguments,
+          currentDirectoryURL: currentDirectoryURL
+        )
+        Issue.record("worktrees should not use runLogin when direct execution succeeds")
+        return ShellOutput(stdout: "", stderr: "", exitCode: 0)
+      }
+    )
+    let client = GitClient(shell: shell)
+    let repoRoot = URL(fileURLWithPath: "/tmp/repo")
+
+    let worktrees = try await client.worktrees(for: repoRoot)
+
+    #expect(worktrees.map(\.id) == ["/tmp/repo", "/tmp/repo/.worktrees/feature"])
+    let runs = recorder.runInvocations()
+    #expect(runs.count == 1)
+    if let invocation = runs.first {
+      #expect(invocation.arguments == ["ls", "--json"])
+      #expect(invocation.currentDirectoryPath == "/tmp/repo")
+    } else {
+      Issue.record("Expected one direct bundled wt invocation for worktree discovery")
+    }
+    #expect(recorder.loginInvocations().isEmpty)
+  }
+
+  @Test func worktreesFallbackToLoginShellWhenDirectExecutionCannotResolveGit() async throws {
+    let recorder = GitWorktreeDiscoveryRecorder()
+    let shell = ShellClient(
+      run: { executableURL, arguments, currentDirectoryURL in
+        recorder.recordRun(
+          executableURL: executableURL,
+          arguments: arguments,
+          currentDirectoryURL: currentDirectoryURL
+        )
+        throw ShellClientError(
+          command: "wt ls --json",
+          stdout: "",
+          stderr: "git: command not found",
+          exitCode: 127
+        )
+      },
+      runLoginImpl: { executableURL, arguments, currentDirectoryURL, _ in
+        recorder.recordLogin(
+          executableURL: executableURL,
+          arguments: arguments,
+          currentDirectoryURL: currentDirectoryURL
+        )
+        return ShellOutput(
+          stdout: #"[{"branch":"main","path":"/tmp/repo","head":"abc","is_bare":false}]"#,
+          stderr: "",
+          exitCode: 0
+        )
+      }
+    )
+    let client = GitClient(shell: shell)
+    let repoRoot = URL(fileURLWithPath: "/tmp/repo")
+
+    let worktrees = try await client.worktrees(for: repoRoot)
+
+    #expect(worktrees.map(\.id) == ["/tmp/repo"])
+    #expect(recorder.runInvocations().count == 1)
+    #expect(recorder.loginInvocations().count == 1)
+    if let invocation = recorder.loginInvocations().first {
+      #expect(invocation.arguments == ["ls", "--json"])
+    } else {
+      Issue.record("Expected login-shell fallback invocation for worktree discovery")
+    }
+  }
+}

--- a/supacodeTests/RepositoriesFeaturePersistenceTests.swift
+++ b/supacodeTests/RepositoriesFeaturePersistenceTests.swift
@@ -45,7 +45,12 @@ struct RepositoriesFeaturePersistenceTests {
           calls.withValue { $0.append("loadLastFocusedWorktreeID") }
           return nil
         },
-        saveLastFocusedWorktreeID: { _ in }
+        saveLastFocusedWorktreeID: { _ in },
+        loadLastFocusedRepositoryID: {
+          calls.withValue { $0.append("loadLastFocusedRepositoryID") }
+          return nil
+        },
+        saveLastFocusedRepositoryID: { _ in }
       )
     }
 
@@ -57,6 +62,7 @@ struct RepositoriesFeaturePersistenceTests {
         "loadPinnedWorktreeIDs",
         "loadArchivedWorktreeIDs",
         "loadLastFocusedWorktreeID",
+        "loadLastFocusedRepositoryID",
         "loadRepositoryOrderIDs",
         "loadWorktreeOrderByRepository",
         "loadRoots",

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -700,7 +700,7 @@ struct RepositoriesFeatureTests {
         id: pendingID,
         repositoryID: repository.id,
         progress: WorktreeCreationProgress(stage: .loadingLocalBranches)
-      ),
+      )
     ]
     let store = TestStore(initialState: state) {
       RepositoriesFeature()
@@ -737,7 +737,7 @@ struct RepositoriesFeatureTests {
           stage: .checkingRepositoryMode,
           worktreeName: "swift-otter"
         )
-      ),
+      )
     ]
     let store = TestStore(initialState: state) {
       RepositoriesFeature()
@@ -928,7 +928,7 @@ struct RepositoriesFeatureTests {
         addedLines: nil,
         removedLines: nil,
         pullRequest: makePullRequest(state: "MERGED")
-      ),
+      )
     ]
     let store = TestStore(initialState: state) {
       RepositoriesFeature()
@@ -1610,7 +1610,7 @@ struct RepositoriesFeatureTests {
         id: removedWorktree.id,
         repositoryID: repository.id,
         progress: WorktreeCreationProgress(stage: .choosingWorktreeName)
-      ),
+      )
     ]
     initialState.pinnedWorktreeIDs = [removedWorktree.id]
     initialState.worktreeInfoByID = [
@@ -1693,7 +1693,7 @@ struct RepositoriesFeatureTests {
         id: pendingID,
         repositoryID: repository.id,
         progress: WorktreeCreationProgress(stage: .loadingLocalBranches)
-      ),
+      )
     ]
     initialState.selection = .worktree(pendingID)
     initialState.sidebarSelectedWorktreeIDs = [existingWorktree.id, pendingID]

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -2561,9 +2561,12 @@ struct RepositoriesFeatureTests {
     let roots = [repoRootA, repoRootB]
     let rootURLs = roots.map { URL(fileURLWithPath: $0) }
     let gate = AsyncGate()
+    let phase = LockIsolated("priority")
+    let worktreeCalls = LockIsolated<[String]>([])
 
     var state = RepositoriesFeature.State()
     state.lastFocusedWorktreeID = worktreeB.id
+    state.lastFocusedRepositoryID = repoRootB
     state.shouldRestoreLastFocusedWorktree = true
 
     let store = TestStore(initialState: state) {
@@ -2571,8 +2574,12 @@ struct RepositoriesFeatureTests {
     } withDependencies: {
       $0.repositoryPersistence.loadRoots = { roots }
       $0.gitClient.worktrees = { root in
+        worktreeCalls.withValue { $0.append(root.path(percentEncoded: false)) }
         switch root.path(percentEncoded: false) {
         case repoRootA:
+          if phase.value == "priority" {
+            Issue.record("Non-priority root started before priority load completed")
+          }
           await gate.wait()
           return [worktreeA]
         case repoRootB:
@@ -2594,13 +2601,16 @@ struct RepositoriesFeatureTests {
     }
     await store.receive(\.delegate.repositoriesChanged)
     await store.receive(\.delegate.selectedWorktreeChanged)
+    #expect(worktreeCalls.value == [repoRootB])
 
+    phase.withValue { $0 = "remaining" }
     await gate.resume()
 
     await store.receive(\.repositoriesLoaded) {
       $0.repositories = IdentifiedArray(uniqueElements: [repoA, repoB])
     }
     await store.receive(\.delegate.repositoriesChanged)
+    #expect(worktreeCalls.value == [repoRootB, repoRootA])
     await store.finish()
   }
 

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -9,6 +9,7 @@ import Testing
 
 @testable import supacode
 
+@Suite(.serialized)
 @MainActor
 struct RepositoriesFeatureTests {
   @Test func refreshWorktreesSetsRefreshingStateUntilLoadCompletes() async {
@@ -2447,11 +2448,15 @@ struct RepositoriesFeatureTests {
     )
   }
 
-  private func makeRepository(id: String, worktrees: [Worktree]) -> Repository {
+  private func makeRepository(
+    id: String,
+    name: String = "repo",
+    worktrees: [Worktree]
+  ) -> Repository {
     Repository(
       id: id,
       rootURL: URL(fileURLWithPath: id),
-      name: "repo",
+      name: name,
       worktrees: IdentifiedArray(uniqueElements: worktrees)
     )
   }
@@ -2466,7 +2471,6 @@ struct RepositoriesFeatureTests {
   // MARK: - Priority startup loading
 
   @Test func priorityLoadRestoresSelectionOnFirstRepositoriesLoaded() async {
-    let worktreeA = makeWorktree(id: "/tmp/repo-a/main", name: "main", repoRoot: "/tmp/repo-a")
     let worktreeB = makeWorktree(id: "/tmp/repo-b/main", name: "main", repoRoot: "/tmp/repo-b")
     let repoB = makeRepository(id: "/tmp/repo-b", worktrees: [worktreeB])
     let allRootURLs = ["/tmp/repo-a", "/tmp/repo-b"].map { URL(fileURLWithPath: $0) }
@@ -2531,29 +2535,211 @@ struct RepositoriesFeatureTests {
     #expect(store.state.selection == SidebarSelection.worktree(worktreeB.id))
   }
 
-  @Test func loadPersistedRepositoriesWithoutLastFocusedLoadsAllAtOnce() async {
-    let worktreeA = makeWorktree(id: "/tmp/repo-a/main", name: "main", repoRoot: "/tmp/repo-a")
-    let worktreeB = makeWorktree(id: "/tmp/repo-b/main", name: "main", repoRoot: "/tmp/repo-b")
-    let roots = ["/tmp/repo-a", "/tmp/repo-b"]
+  @Test func loadPersistedRepositoriesPrioritizesLinkedLastFocusedWorktree() async {
+    let testID = UUID().uuidString
+    let repoRootA = "/tmp/\(testID)-repo-a"
+    let repoRootB = "/tmp/\(testID)-repo-b"
+    let worktreeA = makeWorktree(
+      id: "/tmp/worktrees/\(testID)-repo-a/feature-a",
+      name: "feature-a",
+      repoRoot: repoRootA
+    )
+    let worktreeB = makeWorktree(
+      id: "/tmp/worktrees/\(testID)-repo-b/feature-b",
+      name: "feature-b",
+      repoRoot: repoRootB
+    )
+    let repoA = makeRepository(
+      id: repoRootA,
+      name: URL(fileURLWithPath: repoRootA).lastPathComponent,
+      worktrees: [worktreeA]
+    )
+    let repoB = makeRepository(
+      id: repoRootB,
+      name: URL(fileURLWithPath: repoRootB).lastPathComponent,
+      worktrees: [worktreeB]
+    )
+    let roots = [repoRootA, repoRootB]
+    let rootURLs = roots.map { URL(fileURLWithPath: $0) }
+    let gate = AsyncGate()
+
+    var state = RepositoriesFeature.State()
+    state.lastFocusedWorktreeID = worktreeB.id
+    state.shouldRestoreLastFocusedWorktree = true
+
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.repositoryPersistence.loadRoots = { roots }
+      $0.gitClient.worktrees = { root in
+        switch root.path(percentEncoded: false) {
+        case repoRootA:
+          await gate.wait()
+          return [worktreeA]
+        case repoRootB:
+          return [worktreeB]
+        default:
+          return []
+        }
+      }
+    }
+
+    await store.send(.loadPersistedRepositories)
+
+    await store.receive(\.repositoriesLoaded) {
+      $0.isInitialLoadComplete = true
+      $0.repositories = IdentifiedArray(uniqueElements: [repoB])
+      $0.repositoryRoots = rootURLs
+      $0.shouldRestoreLastFocusedWorktree = false
+      $0.selection = .worktree(worktreeB.id)
+    }
+    await store.receive(\.delegate.repositoriesChanged)
+    await store.receive(\.delegate.selectedWorktreeChanged)
+
+    await gate.resume()
+
+    await store.receive(\.repositoriesLoaded) {
+      $0.repositories = IdentifiedArray(uniqueElements: [repoA, repoB])
+    }
+    await store.receive(\.delegate.repositoriesChanged)
+    await store.finish()
+  }
+
+  @Test func loadPersistedRepositoriesPreservesRootOrderWhenLoadsFinishOutOfOrder() async {
+    let testID = UUID().uuidString
+    let repoRootA = "/tmp/\(testID)-repo-a"
+    let repoRootB = "/tmp/\(testID)-repo-b"
+    let worktreeA = makeWorktree(id: "\(repoRootA)/main", name: "main", repoRoot: repoRootA)
+    let worktreeB = makeWorktree(id: "\(repoRootB)/main", name: "main", repoRoot: repoRootB)
+    let repoA = makeRepository(
+      id: repoRootA,
+      name: URL(fileURLWithPath: repoRootA).lastPathComponent,
+      worktrees: [worktreeA]
+    )
+    let repoB = makeRepository(
+      id: repoRootB,
+      name: URL(fileURLWithPath: repoRootB).lastPathComponent,
+      worktrees: [worktreeB]
+    )
+    let roots = [repoRootA, repoRootB]
+    let rootURLs = roots.map { URL(fileURLWithPath: $0) }
+    let gate = AsyncGate()
 
     let store = TestStore(initialState: RepositoriesFeature.State()) {
       RepositoriesFeature()
     } withDependencies: {
       $0.repositoryPersistence.loadRoots = { roots }
       $0.gitClient.worktrees = { root in
-        let path = root.path(percentEncoded: false)
-        if path.hasPrefix("/tmp/repo-a") { return [worktreeA] }
-        if path.hasPrefix("/tmp/repo-b") { return [worktreeB] }
-        return []
+        switch root.path(percentEncoded: false) {
+        case repoRootA:
+          await gate.wait()
+          return [worktreeA]
+        case repoRootB:
+          return [worktreeB]
+        default:
+          return []
+        }
       }
     }
-    store.exhaustivity = .off
 
     await store.send(.loadPersistedRepositories)
+    await gate.resume()
 
-    // No lastFocusedWorktreeID — single repositoriesLoaded with all repos
     await store.receive(\.repositoriesLoaded) {
       $0.isInitialLoadComplete = true
+      $0.repositories = IdentifiedArray(uniqueElements: [repoA, repoB])
+      $0.repositoryRoots = rootURLs
+    }
+    await store.receive(\.delegate.repositoriesChanged)
+    await store.finish()
+  }
+
+  @Test func repositoryRemovedSelectsFirstRemainingWorktreeInRootOrder() async {
+    let testID = UUID().uuidString
+    let removedRoot = "/tmp/\(testID)-repo-removed"
+    let repoRootA = "/tmp/\(testID)-repo-a"
+    let repoRootB = "/tmp/\(testID)-repo-b"
+    let removedWorktree = makeWorktree(id: removedRoot, name: "main", repoRoot: removedRoot)
+    let worktreeA = makeWorktree(id: "\(repoRootA)/main", name: "main", repoRoot: repoRootA)
+    let worktreeB = makeWorktree(id: "\(repoRootB)/main", name: "main", repoRoot: repoRootB)
+    let removedRepo = makeRepository(
+      id: removedRoot,
+      name: URL(fileURLWithPath: removedRoot).lastPathComponent,
+      worktrees: [removedWorktree]
+    )
+    let repoA = makeRepository(
+      id: repoRootA,
+      name: URL(fileURLWithPath: repoRootA).lastPathComponent,
+      worktrees: [worktreeA]
+    )
+    let repoB = makeRepository(
+      id: repoRootB,
+      name: URL(fileURLWithPath: repoRootB).lastPathComponent,
+      worktrees: [worktreeB]
+    )
+    let gate = AsyncGate()
+
+    var state = makeState(repositories: [removedRepo, repoA, repoB])
+    state.selection = .worktree(removedWorktree.id)
+    state.removingRepositoryIDs = [removedRepo.id]
+
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.repositoryPersistence.loadRoots = { [removedRoot, repoRootA, repoRootB] }
+      $0.repositoryPersistence.saveRoots = { _ in }
+      $0.gitClient.worktrees = { root in
+        switch root.path(percentEncoded: false) {
+        case repoRootA:
+          await gate.wait()
+          return [worktreeA]
+        case repoRootB:
+          return [worktreeB]
+        default:
+          return []
+        }
+      }
+    }
+
+    await store.send(.repositoryRemoved(removedRepo.id, selectionWasRemoved: true)) {
+      $0.removingRepositoryIDs = []
+      $0.selection = nil
+      $0.shouldSelectFirstAfterReload = true
+    }
+    await store.receive(\.delegate.selectedWorktreeChanged)
+
+    await gate.resume()
+
+    await store.receive(\.repositoriesLoaded) {
+      $0.isInitialLoadComplete = true
+      $0.repositories = IdentifiedArray(uniqueElements: [repoA, repoB])
+      $0.repositoryRoots = [URL(fileURLWithPath: repoRootA), URL(fileURLWithPath: repoRootB)]
+      $0.selection = .worktree(worktreeA.id)
+      $0.shouldSelectFirstAfterReload = false
+    }
+    await store.receive(\.delegate.repositoriesChanged)
+    await store.receive(\.delegate.selectedWorktreeChanged)
+    await store.finish()
+  }
+
+  private actor AsyncGate {
+    var continuation: CheckedContinuation<Void, Never>?
+    var isOpen = false
+
+    func wait() async {
+      guard !isOpen else { return }
+      await withCheckedContinuation { continuation in
+        self.continuation = continuation
+      }
+    }
+
+    func resume() {
+      if let continuation {
+        continuation.resume()
+        self.continuation = nil
+      } else {
+        isOpen = true
+      }
     }
   }
 }

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -9,7 +9,6 @@ import Testing
 
 @testable import supacode
 
-@Suite(.serialized)
 @MainActor
 struct RepositoriesFeatureTests {
   @Test func refreshWorktreesSetsRefreshingStateUntilLoadCompletes() async {

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -2462,4 +2462,98 @@ struct RepositoriesFeatureTests {
     state.repositoryRoots = repositories.map(\.rootURL)
     return state
   }
+
+  // MARK: - Priority startup loading
+
+  @Test func priorityLoadRestoresSelectionOnFirstRepositoriesLoaded() async {
+    let worktreeA = makeWorktree(id: "/tmp/repo-a/main", name: "main", repoRoot: "/tmp/repo-a")
+    let worktreeB = makeWorktree(id: "/tmp/repo-b/main", name: "main", repoRoot: "/tmp/repo-b")
+    let repoB = makeRepository(id: "/tmp/repo-b", worktrees: [worktreeB])
+    let allRootURLs = ["/tmp/repo-a", "/tmp/repo-b"].map { URL(fileURLWithPath: $0) }
+
+    var state = RepositoriesFeature.State()
+    state.lastFocusedWorktreeID = "/tmp/repo-b/main"
+    state.shouldRestoreLastFocusedWorktree = true
+
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    }
+
+    // Simulate the first repositoriesLoaded from priority loading — only the
+    // last-focused repo is included. The UI should become usable immediately.
+    await store.send(
+      .repositoriesLoaded([repoB], failures: [], roots: allRootURLs, animated: false)
+    ) {
+      $0.isInitialLoadComplete = true
+      $0.repositories = IdentifiedArray(uniqueElements: [repoB])
+      $0.repositoryRoots = allRootURLs
+      $0.shouldRestoreLastFocusedWorktree = false
+      $0.selection = SidebarSelection.worktree(worktreeB.id)
+    }
+
+    await store.receive(\.delegate.repositoriesChanged)
+    await store.receive(\.delegate.selectedWorktreeChanged)
+  }
+
+  @Test func fullLoadAfterPriorityLoadPreservesSelection() async {
+    let worktreeA = makeWorktree(id: "/tmp/repo-a/main", name: "main", repoRoot: "/tmp/repo-a")
+    let worktreeB = makeWorktree(id: "/tmp/repo-b/main", name: "main", repoRoot: "/tmp/repo-b")
+    let repoA = makeRepository(id: "/tmp/repo-a", worktrees: [worktreeA])
+    let repoB = makeRepository(id: "/tmp/repo-b", worktrees: [worktreeB])
+    let allRootURLs = ["/tmp/repo-a", "/tmp/repo-b"].map { URL(fileURLWithPath: $0) }
+
+    // State after priority load has completed — repo-b is loaded and selected.
+    var state = RepositoriesFeature.State()
+    state.isInitialLoadComplete = true
+    state.repositories = IdentifiedArray(uniqueElements: [repoB])
+    state.repositoryRoots = allRootURLs
+    state.selection = SidebarSelection.worktree(worktreeB.id)
+
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    }
+
+    // Simulate the second repositoriesLoaded with all repos.
+    // Selection must remain on worktree-b.
+    await store.send(
+      .repositoriesLoaded(
+        [repoB, repoA],
+        failures: [],
+        roots: allRootURLs,
+        animated: false,
+      )
+    ) {
+      $0.repositories = IdentifiedArray(uniqueElements: [repoB, repoA])
+    }
+
+    await store.receive(\.delegate.repositoriesChanged)
+
+    #expect(store.state.selection == SidebarSelection.worktree(worktreeB.id))
+  }
+
+  @Test func loadPersistedRepositoriesWithoutLastFocusedLoadsAllAtOnce() async {
+    let worktreeA = makeWorktree(id: "/tmp/repo-a/main", name: "main", repoRoot: "/tmp/repo-a")
+    let worktreeB = makeWorktree(id: "/tmp/repo-b/main", name: "main", repoRoot: "/tmp/repo-b")
+    let roots = ["/tmp/repo-a", "/tmp/repo-b"]
+
+    let store = TestStore(initialState: RepositoriesFeature.State()) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.repositoryPersistence.loadRoots = { roots }
+      $0.gitClient.worktrees = { root in
+        let path = root.path(percentEncoded: false)
+        if path.hasPrefix("/tmp/repo-a") { return [worktreeA] }
+        if path.hasPrefix("/tmp/repo-b") { return [worktreeB] }
+        return []
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.loadPersistedRepositories)
+
+    // No lastFocusedWorktreeID — single repositoriesLoaded with all repos
+    await store.receive(\.repositoriesLoaded) {
+      $0.isInitialLoadComplete = true
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- run bundled `wt` discovery commands directly and keep a login-shell fallback for missing shell environments
- persist the last-focused repository root alongside the last-focused worktree
- preload the last-focused repository on startup before loading the remaining repositories
- add regression tests for direct `wt` execution, startup persistence ordering, and two-phase repository loading

## Testing
- `xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -only-testing:supacodeTests/GitClientWorktreeDiscoveryTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation 2>&1 | xcsift -f toon`
- `xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -only-testing:supacodeTests/RepositoriesFeatureTests/loadPersistedRepositoriesPrioritizesLinkedLastFocusedWorktree -only-testing:supacodeTests/RepositoriesFeatureTests/loadPersistedRepositoriesPreservesRootOrderWhenLoadsFinishOutOfOrder -only-testing:supacodeTests/RepositoriesFeaturePersistenceTests/taskLoadsPinnedWorktreesBeforeRepositories -only-testing:supacodeTests/AppFeatureDefaultEditorTests/selectedWorktreeChangedOnlyUpdatesWatcherSelection CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation 2>&1 | xcsift -f toon`
- `make build-app`
