### PR TITLE
Fix migration: copy instead of move to preserve ~/.supacode

### DIFF
--- a/supacode/Support/SupacodePaths.swift
+++ b/supacode/Support/SupacodePaths.swift
@@ -9,7 +9,7 @@ nonisolated enum SupacodePaths {
     if !FileManager.default.fileExists(atPath: prowlDir.path(percentEncoded: false)),
       FileManager.default.fileExists(atPath: legacyDir.path(percentEncoded: false))
     {
-      try? FileManager.default.moveItem(at: legacyDir, to: prowlDir)
+      try? FileManager.default.copyItem(at: legacyDir, to: prowlDir)
     }
     return prowlDir
   }


### PR DESCRIPTION
## Summary
- Change `moveItem` to `copyItem` in `SupacodePaths.baseDirectory` migration
- Prevents Prowl from deleting `~/.supacode` on first launch, so a co-installed Supacode keeps its data

Closes #16

## Test plan
- [x] Install both Supacode and Prowl, launch Prowl — verify `~/.supacode` still exists with original content
- [x] Verify `~/.prowl` is created with a full copy of the data