### PR TITLE
feat: implement fullscreen, maximize and background opacity toggles

### DIFF
--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceBridge.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceBridge.swift
@@ -64,6 +64,17 @@ final class GhosttySurfaceBridge {
       return onMoveTab?(action.action.move_tab) ?? false
     case GHOSTTY_ACTION_TOGGLE_COMMAND_PALETTE:
       return onCommandPaletteToggle?() ?? false
+    case GHOSTTY_ACTION_TOGGLE_FULLSCREEN:
+      surfaceView?.window?.toggleFullScreen(nil)
+      return true
+    case GHOSTTY_ACTION_TOGGLE_MAXIMIZE:
+      if let window = surfaceView?.window {
+        window.zoom(nil)
+      }
+      return true
+    case GHOSTTY_ACTION_TOGGLE_BACKGROUND_OPACITY:
+      surfaceView?.toggleBackgroundOpacity()
+      return true
     case GHOSTTY_ACTION_GOTO_WINDOW,
       GHOSTTY_ACTION_TOGGLE_QUICK_TERMINAL,
       GHOSTTY_ACTION_CLOSE_ALL_WINDOWS:

--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
@@ -68,6 +68,7 @@ final class GhosttySurfaceView: NSView, Identifiable {
   private var eventMonitor: Any?
   private var notificationObservers: [NSObjectProtocol] = []
   private var prevPressureStage: Int = 0
+  private var isBackgroundOpaqueOverride = false
   private lazy var cachedScreenContents = CachedValue<String>(duration: .milliseconds(500)) {
     [weak self] in
     self?.readScreenContents() ?? ""
@@ -353,10 +354,16 @@ final class GhosttySurfaceView: NSView, Identifiable {
     addCursorRect(bounds, cursor: currentCursor)
   }
 
+  func toggleBackgroundOpacity() {
+    guard runtime.backgroundOpacity() < 1 else { return }
+    isBackgroundOpaqueOverride.toggle()
+    applyWindowBackgroundAppearance()
+  }
+
   private func applyWindowBackgroundAppearance() {
     guard let window, window.isVisible else { return }
     let opacity = runtime.backgroundOpacity()
-    if !window.styleMask.contains(.fullScreen), opacity < 1 {
+    if !isBackgroundOpaqueOverride, !window.styleMask.contains(.fullScreen), opacity < 1 {
       window.isOpaque = false
       window.titlebarAppearsTransparent = true
       window.backgroundColor = .white.withAlphaComponent(0.001)


### PR DESCRIPTION
## Summary

- **`toggle_fullscreen`**: Uses native macOS fullscreen via `NSWindow.toggleFullScreen`. Ghostty fullscreen mode parameter (native/non-native) is accepted but Prowl always uses native fullscreen since it has its own window chrome.
- **`toggle_maximize`**: Uses `NSWindow.zoom` for standard macOS maximize/unmaximize (zoom/unzoom).
- **`toggle_background_opacity`**: Toggles between fully opaque and the configured `background-opacity` value. Only effective when `background-opacity < 1` is set in Ghostty config. Skipped in fullscreen mode (consistent with Ghostty behavior).

All three are handled as surface-level actions in `GhosttySurfaceBridge.handleAppAction`.

`toggle_window_decorations` is intentionally excluded — Prowl is a single-window app with custom chrome, so toggling window decorations would break the UI layout.

Closes #23

## Test plan

- [x] Trigger fullscreen toggle via keybinding → verify native macOS fullscreen enters/exits
- [x] Trigger maximize toggle via keybinding → verify window zooms/unzooms
- [x] Set `background-opacity = 0.8` in Ghostty config, trigger opacity toggle → verify window switches between transparent and opaque
- [x] Verify opacity toggle has no effect when `background-opacity = 1` (default)
- [x] Verify opacity toggle has no effect in fullscreen mode