### PR TITLE
fix: light mode titlebar stays dark

### DIFF
--- a/supacode/Features/Settings/BusinessLogic/WindowAppearanceSetter.swift
+++ b/supacode/Features/Settings/BusinessLogic/WindowAppearanceSetter.swift
@@ -18,6 +18,7 @@ struct WindowAppearanceSetter: NSViewRepresentable {
 final class WindowAppearanceView: NSView {
   var colorScheme: ColorScheme? {
     didSet {
+      guard colorScheme != oldValue else { return }
       applyAppearance()
     }
   }
@@ -28,21 +29,13 @@ final class WindowAppearanceView: NSView {
   }
 
   private func applyAppearance() {
-    guard let window else {
-      return
+    guard let window else { return }
+    let desiredName: NSAppearance.Name? = switch colorScheme {
+    case .light: .aqua
+    case .dark: .darkAqua
+    default: nil
     }
-    switch colorScheme {
-    case .none:
-      window.appearance = nil
-    case .some(let scheme):
-      switch scheme {
-      case .light:
-        window.appearance = NSAppearance(named: .aqua)
-      case .dark:
-        window.appearance = NSAppearance(named: .darkAqua)
-      @unknown default:
-        window.appearance = nil
-      }
-    }
+    guard window.appearance?.name != desiredName else { return }
+    window.appearance = desiredName.flatMap { NSAppearance(named: $0) }
   }
 }

--- a/supacode/Features/Terminal/TabBar/TerminalTabBarColors.swift
+++ b/supacode/Features/Terminal/TabBar/TerminalTabBarColors.swift
@@ -1,4 +1,3 @@
-import AppKit
 import SwiftUI
 
 enum TerminalTabBarColors {
@@ -19,11 +18,11 @@ enum TerminalTabBarColors {
   }
 
   static var activeText: Color {
-    Color(nsColor: .labelColor)
+    .primary
   }
 
   static var inactiveText: Color {
-    Color(nsColor: .secondaryLabelColor)
+    .secondary
   }
 
   static var separator: Color {

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabBarBackground.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabBarBackground.swift
@@ -3,12 +3,25 @@ import SwiftUI
 struct TerminalTabBarBackground: View {
   @Environment(\.controlActiveState)
   private var activeState
+  @Environment(\.colorScheme)
+  private var colorScheme
   @Environment(\.surfaceTopChromeBackgroundOpacity)
   private var surfaceTopChromeBackgroundOpacity
 
   var body: some View {
     Rectangle()
-      .fill(TerminalTabBarColors.barBackground.opacity(chromeBackgroundOpacity))
+      .fill(barBackground.opacity(chromeBackgroundOpacity))
+  }
+
+  // Use colorScheme from SwiftUI environment to resolve the right color,
+  // since Color(nsColor:) in toolbar context may not follow preferredColorScheme.
+  private var barBackground: Color {
+    let appearance = NSAppearance(named: colorScheme == .dark ? .darkAqua : .aqua)
+    var resolved: NSColor = .windowBackgroundColor
+    appearance?.performAsCurrentDrawingAppearance {
+      resolved = NSColor.windowBackgroundColor.usingColorSpace(.sRGB) ?? .windowBackgroundColor
+    }
+    return Color(nsColor: resolved)
   }
 
   private var chromeBackgroundOpacity: Double {

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabsOverflowShadow.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabsOverflowShadow.swift
@@ -7,6 +7,8 @@ struct TerminalTabsOverflowShadow: View {
 
   @Environment(\.controlActiveState)
   private var activeState
+  @Environment(\.colorScheme)
+  private var colorScheme
   @Environment(\.surfaceTopChromeBackgroundOpacity)
   private var surfaceTopChromeBackgroundOpacity
 
@@ -27,9 +29,18 @@ struct TerminalTabsOverflowShadow: View {
 
   private var gradientColors: [Color] {
     [
-      TerminalTabBarColors.barBackground.opacity(chromeBackgroundOpacity),
-      TerminalTabBarColors.barBackground.opacity(0),
+      barBackground.opacity(chromeBackgroundOpacity),
+      barBackground.opacity(0),
     ]
+  }
+
+  private var barBackground: Color {
+    let appearance = NSAppearance(named: colorScheme == .dark ? .darkAqua : .aqua)
+    var resolved: NSColor = .windowBackgroundColor
+    appearance?.performAsCurrentDrawingAppearance {
+      resolved = NSColor.windowBackgroundColor.usingColorSpace(.sRGB) ?? .windowBackgroundColor
+    }
+    return Color(nsColor: resolved)
   }
 
   private var chromeBackgroundOpacity: Double {


### PR DESCRIPTION
## Summary

- Main window titlebar/toolbar stays dark in light mode because `preferredColorScheme` only affects SwiftUI content, not AppKit-level window chrome (`NSToolbar`, system colors like `NSColor.windowBackgroundColor`)
- Add `WindowAppearanceSetter` to the main window, which explicitly sets `NSWindow.appearance` to `.aqua` or `.darkAqua` — the same approach already used in the Settings window

## Test plan

- [ ] Set appearance to Light in Prowl settings → verify titlebar and toolbar render with light colors
- [ ] Set appearance to Dark → verify titlebar remains dark
- [ ] Set appearance to Auto → verify titlebar follows system setting