### PR TITLE
Filter duplicate Ghostty commands from command palette

### DIFF
--- a/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
+++ b/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
@@ -589,8 +589,15 @@ private func pullRequestDelegateAction(
   }
 }
 
+/// Ghostty actions that Prowl handles natively and should not appear as
+/// duplicates from the Ghostty command palette entries.
+private let filteredGhosttyActions: Set<String> = [
+  "check_for_updates",
+]
+
 private func ghosttyCommandItems(_ commands: [GhosttyCommand]) -> [CommandPaletteItem] {
-  commands.map { command in
+  commands.compactMap { command in
+    guard !filteredGhosttyActions.contains(command.action) else { return nil }
     let subtitle = command.description.trimmingCharacters(in: .whitespacesAndNewlines)
     return CommandPaletteItem(
       id: CommandPaletteItemID.ghosttyCommand(command),


### PR DESCRIPTION
## Summary
- Ghostty exposes `check_for_updates` as a command palette entry, but Prowl already has its own native implementation backed by Sparkle
- Added a `filteredGhosttyActions` set in `CommandPaletteFeature` to strip out Ghostty actions that the app handles natively
- Prevents duplicate "Check for Updates" entries in the command palette

## Test plan
- [x] Open the command palette and verify only one "Check for Updates" entry appears
- [x] Verify "Check for Updates" triggers the Sparkle updater (not a no-op Ghostty action)
- [x] Verify other Ghostty commands still appear normally in the palette
