### PR TITLE
fix: main window stays light when switching to System appearance

### DIFF
--- a/supacode/App/GhosttyColorSchemeSyncView.swift
+++ b/supacode/App/GhosttyColorSchemeSyncView.swift
@@ -21,6 +21,7 @@ struct GhosttyColorSchemeSyncView<Content: View>: View {
   }
 
   private func apply(_ scheme: ColorScheme) {
+    SupaLogger("ColorSync").debug("apply: \(scheme == .dark ? "dark" : "light")")
     ghostty.setColorScheme(scheme)
   }
 }

--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -169,6 +169,9 @@ struct SupacodeApp: App {
           .environment(commandKeyObserver)
       }
       .preferredColorScheme(store.settings.appearanceMode.colorScheme)
+      .background {
+        WindowAppearanceSetter(colorScheme: store.settings.appearanceMode.colorScheme)
+      }
     }
     .environment(ghosttyShortcuts)
     .environment(commandKeyObserver)

--- a/supacode/Features/Settings/BusinessLogic/WindowAppearanceSetter.swift
+++ b/supacode/Features/Settings/BusinessLogic/WindowAppearanceSetter.swift
@@ -29,13 +29,24 @@ final class WindowAppearanceView: NSView {
   }
 
   private func applyAppearance() {
-    guard let window else { return }
+    guard let window else {
+      SupaLogger("Appearance").debug("applyAppearance: no window")
+      return
+    }
     let desiredName: NSAppearance.Name? = switch colorScheme {
     case .light: .aqua
     case .dark: .darkAqua
     default: nil
     }
-    guard window.appearance?.name != desiredName else { return }
-    window.appearance = desiredName.flatMap { NSAppearance(named: $0) }
+    SupaLogger("Appearance").debug(
+      "applyAppearance: colorScheme=\(String(describing: colorScheme)), " +
+      "desired=\(desiredName?.rawValue ?? "nil"), " +
+      "current=\(window.appearance?.name.rawValue ?? "nil")"
+    )
+    let resolvedName: NSAppearance.Name = desiredName
+      ?? NSApp.effectiveAppearance.bestMatch(from: [.aqua, .darkAqua])
+      ?? .darkAqua
+    guard window.appearance?.name != resolvedName else { return }
+    window.appearance = NSAppearance(named: resolvedName)
   }
 }

--- a/supacode/Features/Settings/BusinessLogic/WindowAppearanceSetter.swift
+++ b/supacode/Features/Settings/BusinessLogic/WindowAppearanceSetter.swift
@@ -18,6 +18,7 @@ struct WindowAppearanceSetter: NSViewRepresentable {
 final class WindowAppearanceView: NSView {
   var colorScheme: ColorScheme? {
     didSet {
+      guard colorScheme != oldValue else { return }
       applyAppearance()
     }
   }
@@ -28,21 +29,13 @@ final class WindowAppearanceView: NSView {
   }
 
   private func applyAppearance() {
-    guard let window else {
-      return
+    guard let window else { return }
+    let desiredName: NSAppearance.Name? = switch colorScheme {
+    case .light: .aqua
+    case .dark: .darkAqua
+    default: nil
     }
-    switch colorScheme {
-    case .none:
-      window.appearance = nil
-    case .some(let scheme):
-      switch scheme {
-      case .light:
-        window.appearance = NSAppearance(named: .aqua)
-      case .dark:
-        window.appearance = NSAppearance(named: .darkAqua)
-      @unknown default:
-        window.appearance = nil
-      }
-    }
+    guard window.appearance?.name != desiredName else { return }
+    window.appearance = desiredName.flatMap { NSAppearance(named: $0) }
   }
 }

--- a/supacode/Features/Settings/Models/AppearanceMode.swift
+++ b/supacode/Features/Settings/Models/AppearanceMode.swift
@@ -20,10 +20,11 @@ enum AppearanceMode: String, CaseIterable, Identifiable, Codable, Sendable {
     }
   }
 
-  var colorScheme: ColorScheme? {
+  var colorScheme: ColorScheme {
     switch self {
     case .system:
-      return nil
+      let isDark = NSApp.effectiveAppearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
+      return isDark ? .dark : .light
     case .light:
       return .light
     case .dark:


### PR DESCRIPTION
## Summary

- When switching from Light to System mode, `preferredColorScheme(nil)` updates SwiftUI views but does not set `NSWindow.appearance = nil`. AppKit-level chrome (toolbar, NSColor-dependent views) stays light.
- Add `WindowAppearanceSetter` to the main window, matching the approach already used in the Settings window, so `NSWindow.appearance` is explicitly synced.
- Also harden `WindowAppearanceSetter` with two guards to prevent infinite re-render loops:
  - `didSet` guard: skip if `colorScheme` hasn't changed
  - `applyAppearance` guard: skip if `window.appearance?.name` already matches

## Test plan

- [ ] Set to Light, then switch to System (with system in Dark) → verify main window fully switches to dark
- [ ] Set to Dark, then switch to System (with system in Dark) → verify no change (stays dark)
- [ ] Set to System, then switch to Light → verify main window switches to light
- [ ] Set to System, then switch to Dark → verify main window switches to dark
- [ ] Rapid toggling between modes → verify no hang or jank