### PR TITLE
feat: filter unsupported Ghostty actions from command palette

### DIFF
--- a/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
+++ b/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
@@ -589,15 +589,25 @@ private func pullRequestDelegateAction(
   }
 }
 
-/// Ghostty actions that Prowl handles natively and should not appear as
-/// duplicates from the Ghostty command palette entries.
-private let filteredGhosttyActions: Set<String> = [
+/// Ghostty action keys that should be hidden from Prowl's command palette.
+///
+/// Includes:
+/// - actions Prowl already exposes natively (`check_for_updates`)
+/// - Ghostty actions intentionally unsupported by Prowl's architecture/platform
+private let filteredGhosttyActionKeys: Set<String> = [
   "check_for_updates",
+  "new_window",
+  "close_all_windows",
+  "goto_window",
+  "toggle_tab_overview",
+  "inspector",
+  "show_gtk_inspector",
+  "show_on_screen_keyboard",
 ]
 
 private func ghosttyCommandItems(_ commands: [GhosttyCommand]) -> [CommandPaletteItem] {
   commands.compactMap { command in
-    guard !filteredGhosttyActions.contains(command.action) else { return nil }
+    guard !filteredGhosttyActionKeys.contains(command.actionKey) else { return nil }
     let subtitle = command.description.trimmingCharacters(in: .whitespacesAndNewlines)
     return CommandPaletteItem(
       id: CommandPaletteItemID.ghosttyCommand(command),

--- a/supacodeTests/CommandPaletteFeatureTests.swift
+++ b/supacodeTests/CommandPaletteFeatureTests.swift
@@ -88,6 +88,56 @@ struct CommandPaletteFeatureTests {
     #expect(ghosttyItem?.subtitle == "Focus the split to the right.")
   }
 
+  @Test func commandPaletteItems_filtersUnsupportedGhosttyCommands() {
+    let rootPath = "/tmp/repo"
+    let worktree = makeWorktree(id: rootPath, name: "repo", repoRoot: rootPath)
+    let repository = makeRepository(rootPath: rootPath, name: "Repo", worktrees: [worktree])
+    var state = RepositoriesFeature.State(repositories: [repository])
+    state.selection = .worktree(worktree.id)
+
+    let items = CommandPaletteFeature.commandPaletteItems(
+      from: state,
+      ghosttyCommands: [
+        GhosttyCommand(
+          title: "New Window",
+          description: "Create a new window",
+          action: "new_window",
+          actionKey: "new_window"
+        ),
+        GhosttyCommand(
+          title: "Next Window",
+          description: "Go to next window",
+          action: "goto_window:next",
+          actionKey: "goto_window"
+        ),
+        GhosttyCommand(
+          title: "Inspector",
+          description: "Open inspector",
+          action: "inspector",
+          actionKey: "inspector"
+        ),
+        GhosttyCommand(
+          title: "Focus Split Right",
+          description: "Focus the split to the right.",
+          action: "goto_split:right",
+          actionKey: "goto_split"
+        ),
+      ]
+    )
+
+    let ghosttyActions = items.compactMap { item -> String? in
+      if case .ghosttyCommand(let action) = item.kind {
+        return action
+      }
+      return nil
+    }
+
+    #expect(ghosttyActions.contains("new_window") == false)
+    #expect(ghosttyActions.contains("goto_window:next") == false)
+    #expect(ghosttyActions.contains("inspector") == false)
+    #expect(ghosttyActions.contains("goto_split:right"))
+  }
+
   @Test func commandPaletteItems_omitGhosttyCommandsWithoutSelectedWorktree() {
     let items = CommandPaletteFeature.commandPaletteItems(
       from: RepositoriesFeature.State(),


### PR DESCRIPTION
## Summary

- Hide Ghostty command palette actions that are unsupported or redundant in Prowl's single-window architecture
- Filtered actions:
  - `check_for_updates` — Prowl has its own Sparkle-based update mechanism
  - `new_window` / `close_all_windows` / `goto_window` — Prowl is a single-window app
  - `toggle_tab_overview` — not applicable to Prowl's custom tab bar
  - `inspector` / `show_gtk_inspector` — Ghostty debug tools, not relevant
  - `show_on_screen_keyboard` — iOS-only action

## Test plan

- [x] Open command palette → verify filtered actions do not appear
- [x] Verify remaining Ghostty commands still work as expected