### PR TITLE
feat: filter unsupported Ghostty actions from command palette

### DIFF
--- a/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
+++ b/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
@@ -600,6 +600,7 @@ private let filteredGhosttyActionKeys: Set<String> = [
   "close_all_windows",
   "goto_window",
   "toggle_tab_overview",
+  "toggle_window_decorations",
   "inspector",
   "show_gtk_inspector",
   "show_on_screen_keyboard",


### PR DESCRIPTION
## Summary

- Hide Ghostty command palette actions that are unsupported or redundant in Prowl's single-window architecture
- Filtered actions:
  - `check_for_updates` — Prowl has its own Sparkle-based update mechanism
  - `new_window` / `close_all_windows` / `goto_window` — single-window app
  - `toggle_tab_overview` — not applicable to Prowl's custom tab bar
  - `toggle_window_decorations` — not applicable to single-window app
  - `inspector` / `show_gtk_inspector` — Ghostty debug tools
  - `show_on_screen_keyboard` — iOS-only

Closes #21 (together with already-merged #26, #31 and pending #27)

## Test plan

- [x] Open command palette → verify filtered actions do not appear
- [x] Verify remaining Ghostty commands still work as expected