### PR TITLE
Make canvas notification dot per-tab instead of per-worktree

### DIFF
--- a/supacode/Features/Canvas/Views/CanvasView.swift
+++ b/supacode/Features/Canvas/Views/CanvasView.swift
@@ -59,7 +59,7 @@ struct CanvasView: View {
                 worktreeName: tab.title,
                 tree: tree,
                 isFocused: focusedTabID == tab.id,
-                hasUnseenNotification: state.hasUnseenNotification,
+                hasUnseenNotification: state.hasUnseenNotification(for: tab.id),
                 cardSize: resized.size,
                 canvasScale: canvasScale,
                 onTap: {

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -32,6 +32,11 @@ final class WorktreeTerminalState {
   var hasUnseenNotification: Bool {
     notifications.contains { !$0.isRead }
   }
+
+  func hasUnseenNotification(for tabId: TerminalTabID) -> Bool {
+    let surfaceIds = trees[tabId]?.leaves().map(\.id) ?? []
+    return notifications.contains { !$0.isRead && surfaceIds.contains($0.surfaceId) }
+  }
   var isSelected: () -> Bool = { false }
   var onNotificationReceived: ((String, String) -> Void)?
   var onNotificationIndicatorChanged: (() -> Void)?


### PR DESCRIPTION
## Summary
- Canvas card notification dots were previously driven by worktree-level `hasUnseenNotification`, causing all tab cards within a worktree to light up when any single tab received a notification
- Added `hasUnseenNotification(for:)` to `WorktreeTerminalState` that filters notifications by surfaces belonging to the specific tab
- Updated `CanvasView` to use the per-tab query

## Test plan
- [x] Open a worktree with multiple tabs in canvas view
- [x] Trigger a notification in one tab (e.g. a terminal bell or desktop notification)
- [x] Verify only the card for that tab shows the orange dot, not sibling tabs