### PR TITLE
feat: add Git Log viewer window

### DIFF
--- a/supacode/App/AppShortcuts.swift
+++ b/supacode/App/AppShortcuts.swift
@@ -90,6 +90,7 @@ enum AppShortcuts {
   static let stopRunScript = AppShortcut(key: ".", modifiers: .command)
   static let checkForUpdates = AppShortcut(key: "u", modifiers: .command)
   static let showDiff = AppShortcut(key: "]", modifiers: .command)
+  static let showGitLog = AppShortcut(key: "l", modifiers: [.command, .shift])
   static let toggleCanvas = AppShortcut(
     keyEquivalent: .return, ghosttyKeyName: "return", modifiers: [.command, .option]
   )
@@ -147,6 +148,7 @@ enum AppShortcuts {
     stopRunScript,
     checkForUpdates,
     showDiff,
+    showGitLog,
     toggleCanvas,
     archivedWorktrees,
     selectNextWorktree,

--- a/supacode/Clients/Git/GitClient.swift
+++ b/supacode/Clients/Git/GitClient.swift
@@ -22,6 +22,9 @@ enum GitOperation: String {
   case untrackedFilePaths = "untracked_file_paths"
   case showFile = "show_file"
   case remoteInfo = "remote_info"
+  case commitLog = "commit_log"
+  case commitShow = "commit_show"
+  case commitDiffNameStatus = "commit_diff_name_status"
 }
 
 enum GitClientError: LocalizedError {
@@ -528,6 +531,60 @@ struct GitClient {
       }
     }
     return nil
+  }
+
+  nonisolated func commitLog(
+    at worktreeURL: URL,
+    skip: Int = 0,
+    count: Int = 50
+  ) async throws -> String {
+    let path = worktreeURL.path(percentEncoded: false)
+    return try await runGit(
+      operation: .commitLog,
+      arguments: [
+        "-C", path,
+        "log",
+        "--format=\(GitLogCommit.logFormat)",
+        "--skip=\(skip)",
+        "-n", "\(count)",
+      ]
+    )
+  }
+
+  nonisolated func showFileAtCommit(
+    _ relativePath: String,
+    commit: String,
+    in worktreeURL: URL
+  ) async -> String? {
+    let path = worktreeURL.path(percentEncoded: false)
+    do {
+      return try await runGit(
+        operation: .commitShow,
+        arguments: ["-C", path, "show", "\(commit):\(relativePath)"]
+      )
+    } catch {
+      return nil
+    }
+  }
+
+  nonisolated func commitDiffNameStatus(
+    commit: String,
+    at worktreeURL: URL
+  ) async -> String {
+    let path = worktreeURL.path(percentEncoded: false)
+    do {
+      return try await runGit(
+        operation: .commitDiffNameStatus,
+        arguments: [
+          "-C", path,
+          "-c", "core.quotePath=false",
+          "diff-tree", "--no-commit-id", "-r", "-m", "--first-parent",
+          "--name-status", commit,
+        ]
+      )
+    } catch {
+      return ""
+    }
   }
 
   nonisolated func removeWorktree(_ worktree: Worktree, deleteBranch: Bool) async throws -> URL {

--- a/supacode/Commands/SidebarCommands.swift
+++ b/supacode/Commands/SidebarCommands.swift
@@ -40,6 +40,22 @@ struct SidebarCommands: Commands {
       )
       .help("Show Diff (\(AppShortcuts.showDiff.display))")
       .disabled(store.repositories.selectedWorktreeID == nil)
+      Button("Git Log") {
+        let repos = store.repositories
+        guard let worktreeID = repos.selectedWorktreeID,
+          let worktree = repos.worktree(for: worktreeID)
+        else { return }
+        GitLogWindowManager.shared.show(
+          worktreeURL: worktree.workingDirectory,
+          branchName: worktree.name,
+        )
+      }
+      .keyboardShortcut(
+        AppShortcuts.showGitLog.keyEquivalent,
+        modifiers: AppShortcuts.showGitLog.modifiers
+      )
+      .help("Git Log (\(AppShortcuts.showGitLog.display))")
+      .disabled(store.repositories.selectedWorktreeID == nil)
     }
   }
 }

--- a/supacode/Features/GitLog/GitLogCommit.swift
+++ b/supacode/Features/GitLog/GitLogCommit.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+nonisolated struct GitLogCommit: Identifiable, Hashable, Sendable {
+  let hash: String
+  let shortHash: String
+  let authorName: String
+  let authorDate: Date
+  let subject: String
+  let body: String
+
+  var id: String { hash }
+
+  static let fieldSeparator = "\u{1F}"
+  static let recordSeparator = "\u{1E}"
+
+  static let logFormat: String = [
+    "%H", "%h", "%an", "%aI", "%s", "%B",
+  ].joined(separator: fieldSeparator) + recordSeparator
+
+  static func parse(_ output: String) -> [GitLogCommit] {
+    let trimmed = output.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return [] }
+    return trimmed.split(separator: Character(recordSeparator)).compactMap { record in
+      let fields = record.split(
+        separator: Character(fieldSeparator),
+        maxSplits: 5,
+        omittingEmptySubsequences: false
+      )
+      guard fields.count >= 6 else { return nil }
+      let hash = String(fields[0])
+      let shortHash = String(fields[1])
+      let authorName = String(fields[2])
+      let dateString = String(fields[3])
+      let subject = String(fields[4])
+      let body = String(fields[5]).trimmingCharacters(in: .whitespacesAndNewlines)
+      let date = ISO8601DateFormatter().date(from: dateString) ?? .distantPast
+      return GitLogCommit(
+        hash: hash,
+        shortHash: shortHash,
+        authorName: authorName,
+        authorDate: date,
+        subject: subject,
+        body: body,
+      )
+    }
+  }
+}

--- a/supacode/Features/GitLog/GitLogWindowContentView.swift
+++ b/supacode/Features/GitLog/GitLogWindowContentView.swift
@@ -1,0 +1,270 @@
+import SwiftUI
+import YiTong
+
+struct GitLogWindowContentView: View {
+  var state: GitLogWindowState
+  @State private var columnVisibility: NavigationSplitViewVisibility = .automatic
+  @AppStorage("diffViewStyle") private var diffStyleRaw = DiffStyle.split.rawValue
+
+  private var diffStyle: DiffStyle {
+    DiffStyle(rawValue: diffStyleRaw) ?? .split
+  }
+
+  private var selectedCommitID: Binding<String?> {
+    Binding(
+      get: { state.selectedCommit?.id },
+      set: { id in
+        if let id, let commit = state.commits.first(where: { $0.id == id }) {
+          state.selectCommit(commit)
+        }
+      },
+    )
+  }
+
+  private var selectedFileID: Binding<String?> {
+    Binding(
+      get: { state.selectedFile?.id },
+      set: { id in
+        if let id, let file = state.commitFiles.first(where: { $0.id == id }) {
+          state.selectFile(file)
+        }
+      },
+    )
+  }
+
+  var body: some View {
+    NavigationSplitView(columnVisibility: $columnVisibility) {
+      commitListSidebar
+        .navigationSplitViewColumnWidth(min: 250, ideal: 320, max: 500)
+    } detail: {
+      commitDetail
+    }
+    .focusedSceneValue(\.toggleLeftSidebarAction, toggleSidebar)
+    .toolbar(id: "gitLogToolbar") {
+      ToolbarItem(id: "sidebarToggle", placement: .navigation) {
+        Button {
+          toggleSidebar()
+        } label: {
+          Image(systemName: "sidebar.left")
+            .accessibilityLabel("Toggle Sidebar")
+        }
+        .help("Toggle Sidebar (\(AppShortcuts.toggleLeftSidebar.display))")
+      }
+      ToolbarItem(id: "diffStyle", placement: .primaryAction) {
+        Picker("Diff Style", selection: $diffStyleRaw) {
+          Image(systemName: "square.split.2x1")
+            .accessibilityLabel("Split")
+            .tag(DiffStyle.split.rawValue)
+            .help("Split")
+          Image(systemName: "text.justify.left")
+            .accessibilityLabel("Unified")
+            .tag(DiffStyle.unified.rawValue)
+            .help("Unified")
+        }
+        .pickerStyle(.segmented)
+        .help("Diff Style")
+      }
+    }
+  }
+
+  private func toggleSidebar() {
+    withAnimation {
+      columnVisibility = columnVisibility == .detailOnly ? .automatic : .detailOnly
+    }
+  }
+
+  // MARK: - Commit List
+
+  private var commitListSidebar: some View {
+    List(selection: selectedCommitID) {
+      ForEach(state.commits) { commit in
+        CommitRowView(commit: commit)
+          .tag(commit.id)
+      }
+      if state.hasMoreCommits {
+        ProgressView()
+          .frame(maxWidth: .infinity, alignment: .center)
+          .onAppear { state.loadMore() }
+      }
+    }
+    .listStyle(.sidebar)
+    .overlay {
+      if state.isLoadingCommits && state.commits.isEmpty {
+        ProgressView()
+      } else if !state.isLoadingCommits && state.commits.isEmpty {
+        ContentUnavailableView(
+          "No Commits",
+          systemImage: "clock",
+          description: Text("No commit history found"),
+        )
+      }
+    }
+  }
+
+  // MARK: - Commit Detail
+
+  private var commitDetail: some View {
+    Group {
+      if let commit = state.selectedCommit {
+        VStack(spacing: 0) {
+          commitHeader(commit)
+          Divider()
+          commitDiffArea
+        }
+      } else if state.isLoadingCommits {
+        ProgressView()
+          .frame(maxWidth: .infinity, maxHeight: .infinity)
+      } else {
+        ContentUnavailableView(
+          "Select a Commit",
+          systemImage: "clock.arrow.trianglehead.counterclockwise.rotate.90",
+          description: Text("Choose a commit from the sidebar to view details"),
+        )
+      }
+    }
+  }
+
+  private func commitHeader(_ commit: GitLogCommit) -> some View {
+    VStack(alignment: .leading, spacing: 6) {
+      Text(commit.subject)
+        .font(.headline)
+        .lineLimit(2)
+      HStack(spacing: 8) {
+        Text(commit.shortHash)
+          .font(.caption)
+          .monospaced()
+          .foregroundStyle(.secondary)
+        Text(commit.authorName)
+          .font(.caption)
+          .foregroundStyle(.secondary)
+        Text(commit.authorDate, style: .relative)
+          .font(.caption)
+          .foregroundStyle(.tertiary)
+      }
+      if !commit.body.isEmpty, commit.body != commit.subject {
+        let bodyWithoutSubject = commit.body.hasPrefix(commit.subject)
+          ? String(commit.body.dropFirst(commit.subject.count)).trimmingCharacters(
+            in: .whitespacesAndNewlines
+          )
+          : commit.body
+        if !bodyWithoutSubject.isEmpty {
+          Text(bodyWithoutSubject)
+            .font(.callout)
+            .foregroundStyle(.secondary)
+            .lineLimit(5)
+        }
+      }
+    }
+    .padding(12)
+    .frame(maxWidth: .infinity, alignment: .leading)
+  }
+
+  @ViewBuilder
+  private var commitDiffArea: some View {
+    if state.commitFiles.isEmpty && state.isLoadingDetail {
+      ProgressView()
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    } else if state.commitFiles.isEmpty {
+      ContentUnavailableView(
+        "No Changes",
+        systemImage: "checkmark.circle",
+        description: Text("This commit has no file changes"),
+      )
+    } else {
+      HSplitView {
+        fileList
+          .frame(minWidth: 180, idealWidth: 220, maxWidth: 350)
+        diffDetail
+      }
+    }
+  }
+
+  private var fileList: some View {
+    List(selection: selectedFileID) {
+      ForEach(state.commitFiles) { file in
+        CommitFileRowView(file: file)
+          .tag(file.id)
+      }
+    }
+    .listStyle(.sidebar)
+  }
+
+  private var diffDetail: some View {
+    Group {
+      if let document = state.diffDocument {
+        DiffView(
+          document: document,
+          configuration: DiffConfiguration(
+            style: diffStyle,
+            showsFileHeaders: false,
+          ),
+        )
+      } else if state.isLoadingDetail {
+        ProgressView()
+          .frame(maxWidth: .infinity, maxHeight: .infinity)
+      } else {
+        ContentUnavailableView(
+          "Select a File",
+          systemImage: "doc.text",
+          description: Text("Choose a file to view changes"),
+        )
+      }
+    }
+  }
+}
+
+// MARK: - Commit Row
+
+private struct CommitRowView: View {
+  let commit: GitLogCommit
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 3) {
+      Text(commit.subject)
+        .font(.body)
+        .lineLimit(1)
+      HStack(spacing: 6) {
+        Text(commit.shortHash)
+          .font(.caption)
+          .monospaced()
+          .foregroundStyle(.secondary)
+        Text(commit.authorName)
+          .font(.caption)
+          .foregroundStyle(.secondary)
+        Spacer()
+        Text(commit.authorDate, style: .relative)
+          .font(.caption)
+          .foregroundStyle(.tertiary)
+      }
+    }
+    .padding(.vertical, 2)
+  }
+}
+
+// MARK: - Commit File Row
+
+private struct CommitFileRowView: View {
+  let file: DiffChangedFile
+
+  var body: some View {
+    HStack(spacing: 6) {
+      Text(file.statusSymbol)
+        .font(.caption)
+        .monospaced()
+        .foregroundStyle(file.status.color)
+        .frame(width: 14, alignment: .center)
+      VStack(alignment: .leading, spacing: 1) {
+        Text(file.displayName)
+          .font(.body)
+          .lineLimit(1)
+        if !file.directoryPath.isEmpty {
+          Text(file.directoryPath)
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .lineLimit(1)
+            .truncationMode(.head)
+        }
+      }
+    }
+  }
+}

--- a/supacode/Features/GitLog/GitLogWindowManager.swift
+++ b/supacode/Features/GitLog/GitLogWindowManager.swift
@@ -1,0 +1,63 @@
+import AppKit
+import SwiftUI
+
+@MainActor
+final class GitLogWindowManager {
+  static let shared = GitLogWindowManager()
+
+  let state = GitLogWindowState()
+  private var window: NSWindow?
+  private var localEventMonitor: Any?
+
+  private init() {}
+
+  func show(worktreeURL: URL, branchName: String) {
+    state.load(worktreeURL: worktreeURL, branchName: branchName)
+
+    if let existingWindow = window {
+      existingWindow.title = windowTitle(branchName: branchName)
+      if existingWindow.isMiniaturized {
+        existingWindow.deminiaturize(nil)
+      }
+      existingWindow.makeKeyAndOrderFront(nil)
+      return
+    }
+
+    let contentView = GitLogWindowContentView(state: state)
+    let hostingController = NSHostingController(rootView: contentView)
+
+    let newWindow = NSWindow(contentViewController: hostingController)
+    newWindow.title = windowTitle(branchName: branchName)
+    newWindow.identifier = NSUserInterfaceItemIdentifier("gitlog")
+    newWindow.styleMask = [.titled, .closable, .miniaturizable, .resizable]
+    newWindow.tabbingMode = .disallowed
+    newWindow.toolbarStyle = .unified
+    newWindow.toolbar = NSToolbar(identifier: "GitLogToolbar")
+    newWindow.isReleasedWhenClosed = false
+    newWindow.minSize = NSSize(width: 700, height: 500)
+    let hasSavedFrame = UserDefaults.standard.string(forKey: "NSWindow Frame GitLogWindow") != nil
+    newWindow.setFrameAutosaveName("GitLogWindow")
+    if !hasSavedFrame {
+      newWindow.setContentSize(NSSize(width: 1100, height: 750))
+      newWindow.center()
+    }
+    newWindow.makeKeyAndOrderFront(nil)
+
+    window = newWindow
+
+    localEventMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+      guard let self, let window = self.window, window == event.window else { return event }
+      if event.modifierFlags.intersection(.deviceIndependentFlagsMask) == .command,
+        event.charactersIgnoringModifiers == "w"
+      {
+        window.performClose(nil)
+        return nil
+      }
+      return event
+    }
+  }
+
+  private func windowTitle(branchName: String) -> String {
+    "Git Log — \(branchName)"
+  }
+}

--- a/supacode/Features/GitLog/GitLogWindowState.swift
+++ b/supacode/Features/GitLog/GitLogWindowState.swift
@@ -1,0 +1,188 @@
+import Foundation
+import YiTong
+
+@Observable
+@MainActor
+final class GitLogWindowState {
+  var worktreeURL: URL?
+  var branchName: String = ""
+
+  var commits: [GitLogCommit] = []
+  var isLoadingCommits = false
+  var hasMoreCommits = true
+
+  var selectedCommit: GitLogCommit?
+  var commitFiles: [DiffChangedFile] = []
+  var isLoadingDetail = false
+
+  var selectedFile: DiffChangedFile?
+  var diffDocument: DiffDocument?
+
+  private var loadedCount = 0
+  private var documentCache: [String: DiffDocument] = [:]
+  private var loadTask: Task<Void, Never>?
+  private var detailTask: Task<Void, Never>?
+
+  private static let pageSize = 50
+
+  func load(worktreeURL: URL, branchName: String) {
+    self.worktreeURL = worktreeURL
+    self.branchName = branchName
+    commits = []
+    selectedCommit = nil
+    commitFiles = []
+    selectedFile = nil
+    diffDocument = nil
+    documentCache = [:]
+    loadedCount = 0
+    hasMoreCommits = true
+    loadTask?.cancel()
+    detailTask?.cancel()
+    loadTask = Task { await loadCommits(worktreeURL: worktreeURL, skip: 0) }
+  }
+
+  func loadMore() {
+    guard !isLoadingCommits, hasMoreCommits, let worktreeURL else { return }
+    loadTask?.cancel()
+    loadTask = Task { await loadCommits(worktreeURL: worktreeURL, skip: loadedCount) }
+  }
+
+  func selectCommit(_ commit: GitLogCommit) {
+    guard selectedCommit != commit else { return }
+    selectedCommit = commit
+    commitFiles = []
+    selectedFile = nil
+    diffDocument = nil
+    documentCache = [:]
+    detailTask?.cancel()
+    guard let worktreeURL else { return }
+    detailTask = Task { await loadCommitDetail(commit: commit, worktreeURL: worktreeURL) }
+  }
+
+  func selectFile(_ file: DiffChangedFile) {
+    guard selectedFile != file else { return }
+    selectedFile = file
+    diffDocument = documentCache[file.id]
+  }
+
+  // MARK: - Private
+
+  private func loadCommits(worktreeURL: URL, skip: Int) async {
+    isLoadingCommits = true
+    do {
+      let output = try await GitClient().commitLog(
+        at: worktreeURL,
+        skip: skip,
+        count: Self.pageSize
+      )
+      guard !Task.isCancelled else { return }
+      let newCommits = GitLogCommit.parse(output)
+      commits.append(contentsOf: newCommits)
+      loadedCount = commits.count
+      hasMoreCommits = newCommits.count >= Self.pageSize
+    } catch {
+      hasMoreCommits = false
+    }
+    isLoadingCommits = false
+
+    if selectedCommit == nil, let first = commits.first {
+      selectCommit(first)
+    }
+  }
+
+  private func loadCommitDetail(commit: GitLogCommit, worktreeURL: URL) async {
+    isLoadingDetail = true
+    let output = await GitClient().commitDiffNameStatus(
+      commit: commit.hash,
+      at: worktreeURL
+    )
+    guard !Task.isCancelled else { return }
+    let files = DiffChangedFile.parseNameStatus(output)
+    commitFiles = files
+
+    let documents = await Self.loadAllDocuments(
+      files: files,
+      commit: commit.hash,
+      worktreeURL: worktreeURL
+    )
+    guard !Task.isCancelled else { return }
+    documentCache = documents
+    isLoadingDetail = false
+
+    if let selectedFile, documents[selectedFile.id] != nil {
+      diffDocument = documents[selectedFile.id]
+    } else if let first = files.first {
+      selectedFile = first
+      diffDocument = documents[first.id]
+    } else {
+      selectedFile = nil
+      diffDocument = nil
+    }
+  }
+
+  private nonisolated static func loadAllDocuments(
+    files: [DiffChangedFile],
+    commit: String,
+    worktreeURL: URL
+  ) async -> [String: DiffDocument] {
+    await withTaskGroup(of: (String, DiffDocument).self) { group in
+      for file in files {
+        group.addTask {
+          let doc = await loadDocument(for: file, commit: commit, worktreeURL: worktreeURL)
+          return (file.id, doc)
+        }
+      }
+      var result: [String: DiffDocument] = [:]
+      for await (id, doc) in group {
+        result[id] = doc
+      }
+      return result
+    }
+  }
+
+  private nonisolated static func loadDocument(
+    for file: DiffChangedFile,
+    commit: String,
+    worktreeURL: URL
+  ) async -> DiffDocument {
+    let gitClient = GitClient()
+    let oldContents: String
+    let newContents: String
+
+    switch file.status {
+    case .added:
+      oldContents = ""
+      newContents = await gitClient.showFileAtCommit(
+        file.displayPath, commit: commit, in: worktreeURL
+      ) ?? ""
+    case .deleted:
+      oldContents = await gitClient.showFileAtCommit(
+        file.oldPath ?? "", commit: "\(commit)~1", in: worktreeURL
+      ) ?? ""
+      newContents = ""
+    case .renamed:
+      oldContents = await gitClient.showFileAtCommit(
+        file.oldPath ?? "", commit: "\(commit)~1", in: worktreeURL
+      ) ?? ""
+      newContents = await gitClient.showFileAtCommit(
+        file.newPath ?? "", commit: commit, in: worktreeURL
+      ) ?? ""
+    default:
+      let path = file.displayPath
+      oldContents = await gitClient.showFileAtCommit(
+        path, commit: "\(commit)~1", in: worktreeURL
+      ) ?? ""
+      newContents = await gitClient.showFileAtCommit(
+        path, commit: commit, in: worktreeURL
+      ) ?? ""
+    }
+
+    let diffFile = DiffFile(
+      oldPath: file.oldPath,
+      newPath: file.newPath,
+      oldContents: oldContents,
+      newContents: newContents,
+    )
+    return DiffDocument(files: [diffFile], title: file.displayName)
+  }
+}

--- a/supacode/Features/Repositories/Views/WorktreeRowsView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeRowsView.swift
@@ -270,6 +270,12 @@ struct WorktreeRowsView: View {
       NSPasteboard.general.clearContents()
       NSPasteboard.general.setString(worktree.workingDirectory.path, forType: .string)
     }
+    Button("Git Log") {
+      GitLogWindowManager.shared.show(
+        worktreeURL: worktree.workingDirectory,
+        branchName: worktree.name,
+      )
+    }
     Button(archiveTitle) {
       archiveWorktrees(archiveTargets)
     }

--- a/supacodeTests/GitLogCommitTests.swift
+++ b/supacodeTests/GitLogCommitTests.swift
@@ -1,0 +1,88 @@
+import Foundation
+import Testing
+
+@testable import supacode
+
+struct GitLogCommitTests {
+  @Test
+  func parsesSingleCommit() {
+    let fs = GitLogCommit.fieldSeparator
+    let rs = GitLogCommit.recordSeparator
+    let output =
+      "abc1234567890\(fs)abc1234\(fs)Alice\(fs)2026-03-20T10:00:00+00:00\(fs)feat: add feature\(fs)feat: add feature\n\nSome body text\(rs)"
+
+    let commits = GitLogCommit.parse(output)
+
+    #expect(commits.count == 1)
+    #expect(commits[0].hash == "abc1234567890")
+    #expect(commits[0].shortHash == "abc1234")
+    #expect(commits[0].authorName == "Alice")
+    #expect(commits[0].subject == "feat: add feature")
+    #expect(commits[0].body.contains("Some body text"))
+  }
+
+  @Test
+  func parsesMultipleCommits() {
+    let fs = GitLogCommit.fieldSeparator
+    let rs = GitLogCommit.recordSeparator
+    let output = [
+      "hash1\(fs)h1\(fs)Alice\(fs)2026-03-20T10:00:00+00:00\(fs)first\(fs)first\(rs)",
+      "hash2\(fs)h2\(fs)Bob\(fs)2026-03-19T09:00:00+00:00\(fs)second\(fs)second\(rs)",
+    ].joined()
+
+    let commits = GitLogCommit.parse(output)
+
+    #expect(commits.count == 2)
+    #expect(commits[0].shortHash == "h1")
+    #expect(commits[1].authorName == "Bob")
+  }
+
+  @Test
+  func parsesEmptyOutput() {
+    let commits = GitLogCommit.parse("")
+    #expect(commits.isEmpty)
+  }
+
+  @Test
+  func parsesWhitespaceOnlyOutput() {
+    let commits = GitLogCommit.parse("  \n\n  ")
+    #expect(commits.isEmpty)
+  }
+
+  @Test
+  func parsesCommitWithNewlinesInBody() {
+    let fs = GitLogCommit.fieldSeparator
+    let rs = GitLogCommit.recordSeparator
+    let body = "subject line\n\nLine 1\nLine 2\nLine 3"
+    let output = "hash1\(fs)h1\(fs)Alice\(fs)2026-03-20T10:00:00+00:00\(fs)subject line\(fs)\(body)\(rs)"
+
+    let commits = GitLogCommit.parse(output)
+
+    #expect(commits.count == 1)
+    #expect(commits[0].body.contains("Line 2"))
+  }
+
+  @Test
+  func skipsIncompleteRecords() {
+    let fs = GitLogCommit.fieldSeparator
+    let rs = GitLogCommit.recordSeparator
+    let output = "onlyOneField\(rs)hash1\(fs)h1\(fs)Alice\(fs)2026-03-20T10:00:00+00:00\(fs)ok\(fs)ok\(rs)"
+
+    let commits = GitLogCommit.parse(output)
+
+    #expect(commits.count == 1)
+    #expect(commits[0].subject == "ok")
+  }
+
+  @Test
+  func parsesDateCorrectly() {
+    let fs = GitLogCommit.fieldSeparator
+    let rs = GitLogCommit.recordSeparator
+    let output = "hash1\(fs)h1\(fs)Alice\(fs)2026-03-20T10:30:00+00:00\(fs)test\(fs)test\(rs)"
+
+    let commits = GitLogCommit.parse(output)
+
+    #expect(commits.count == 1)
+    #expect(commits[0].authorDate != .distantPast)
+  }
+}


### PR DESCRIPTION
## Summary
- Add Git Log viewer as an independent window showing commit history per worktree
- Commit list sidebar with pagination (50 per page, infinite scroll)
- Per-commit detail: file change list + YiTong diff visualization (split/unified)
- Entry points: `Cmd+Shift+L` shortcut, View menu item, worktree right-click context menu

## New Files
- `supacode/Features/GitLog/GitLogCommit.swift` — data model with git log parser
- `supacode/Features/GitLog/GitLogWindowState.swift` — `@Observable` state management
- `supacode/Features/GitLog/GitLogWindowManager.swift` — singleton window manager
- `supacode/Features/GitLog/GitLogWindowContentView.swift` — NavigationSplitView UI
- `supacodeTests/GitLogCommitTests.swift` — parser unit tests

## Modified Files
- `GitClient.swift` — 3 new git operations (commitLog, showFileAtCommit, commitDiffNameStatus)
- `AppShortcuts.swift` — `Cmd+Shift+L` shortcut registration
- `SidebarCommands.swift` — View menu entry
- `WorktreeRowsView.swift` — context menu entry

## Test plan
- [ ] Build app with `make build-app`
- [ ] Select a worktree, press `Cmd+Shift+L` to open Git Log window
- [ ] Verify commit list loads with correct hash, author, date, message
- [ ] Select a commit, verify file list + diff displays correctly
- [ ] Scroll to bottom, verify more commits load (pagination)
- [ ] Right-click worktree → Git Log, verify it opens
- [ ] Switch worktree and reopen, verify window updates content
- [ ] Run `GitLogCommitTests` to verify parser

🤖 Generated with [Claude Code](https://claude.com/claude-code)