### PR TITLE
feat: add embedded browser as split pane

### DIFF
--- a/supacode/Features/Canvas/Views/CanvasCardView.swift
+++ b/supacode/Features/Canvas/Views/CanvasCardView.swift
@@ -4,7 +4,7 @@ import SwiftUI
 struct CanvasCardView: View {
   let repositoryName: String
   let worktreeName: String
-  let tree: SplitTree<GhosttySurfaceView>
+  let tree: SplitTree<SurfaceView>
   let isFocused: Bool
   let hasUnseenNotification: Bool
   let cardSize: CGSize

--- a/supacode/Features/Canvas/Views/CanvasView.swift
+++ b/supacode/Features/Canvas/Views/CanvasView.swift
@@ -46,49 +46,7 @@ struct CanvasView: View {
         // reaching the NSView, keeping terminal grid stable during zoom.
         ForEach(activeStates, id: \.worktreeID) { state in
           ForEach(state.tabManager.tabs) { tab in
-            if state.surfaceView(for: tab.id) != nil {
-              let tree = state.splitTree(for: tab.id)
-              let cardKey = tab.id.rawValue.uuidString
-              let baseLayout = layoutStore.cardLayouts[cardKey] ?? CanvasCardLayout(position: .zero)
-              let resized = resizedFrame(for: tab.id, baseLayout: baseLayout)
-              let screenCenter = screenPosition(for: resized.center)
-              let cardTotalHeight = resized.size.height + titleBarHeight
-
-              CanvasCardView(
-                repositoryName: Repository.name(for: state.repositoryRootURL),
-                worktreeName: tab.title,
-                tree: tree,
-                isFocused: focusedTabID == tab.id,
-                hasUnseenNotification: state.hasUnseenNotification(for: tab.id),
-                cardSize: resized.size,
-                canvasScale: canvasScale,
-                onTap: {
-                  if let activeSurface = state.surfaceView(for: tab.id) {
-                    focusCard(tab.id, surfaceView: activeSurface, states: activeStates)
-                  }
-                },
-                onDragCommit: { translation in commitDrag(for: cardKey, translation: translation) },
-                onResize: { edge, translation in
-                  activeResize[tab.id] = ActiveResize(
-                    edge: edge,
-                    translation: CGSize(
-                      width: translation.width / canvasScale,
-                      height: translation.height / canvasScale
-                    )
-                  )
-                },
-                onResizeEnd: { commitResize(for: tab.id, cardKey: cardKey, surfaces: tree.leaves()) },
-                onSplitOperation: { operation in
-                  state.performSplitOperation(operation, in: tab.id)
-                }
-              )
-              .scaleEffect(canvasScale, anchor: .center)
-              .offset(
-                x: screenCenter.x - resized.size.width / 2,
-                y: screenCenter.y - cardTotalHeight / 2
-              )
-              .zIndex(focusedTabID == tab.id ? 1 : 0)
-            }
+            canvasCard(for: tab, state: state, activeStates: activeStates)
           }
         }
       }
@@ -113,6 +71,57 @@ struct CanvasView: View {
     }
     .task { activateCanvas() }
     .onDisappear { deactivateCanvas() }
+  }
+
+  @ViewBuilder
+  private func canvasCard(
+    for tab: TerminalTabItem,
+    state: WorktreeTerminalState,
+    activeStates: [WorktreeTerminalState]
+  ) -> some View {
+    if state.surfaceView(for: tab.id) != nil {
+      let tree = state.splitTree(for: tab.id)
+      let cardKey = tab.id.rawValue.uuidString
+      let baseLayout = layoutStore.cardLayouts[cardKey] ?? CanvasCardLayout(position: .zero)
+      let resized = resizedFrame(for: tab.id, baseLayout: baseLayout)
+      let screenCenter = screenPosition(for: resized.center)
+      let cardTotalHeight = resized.size.height + titleBarHeight
+
+      CanvasCardView(
+        repositoryName: Repository.name(for: state.repositoryRootURL),
+        worktreeName: tab.title,
+        tree: tree,
+        isFocused: focusedTabID == tab.id,
+        hasUnseenNotification: state.hasUnseenNotification(for: tab.id),
+        cardSize: resized.size,
+        canvasScale: canvasScale,
+        onTap: {
+          if let activeSurface = state.surfaceView(for: tab.id) {
+            focusCard(tab.id, surfaceView: activeSurface, states: activeStates)
+          }
+        },
+        onDragCommit: { translation in commitDrag(for: cardKey, translation: translation) },
+        onResize: { edge, translation in
+          activeResize[tab.id] = ActiveResize(
+            edge: edge,
+            translation: CGSize(
+              width: translation.width / canvasScale,
+              height: translation.height / canvasScale
+            )
+          )
+        },
+        onResizeEnd: { commitResize(for: tab.id, cardKey: cardKey, surfaces: tree.leaves()) },
+        onSplitOperation: { operation in
+          state.performSplitOperation(operation, in: tab.id)
+        }
+      )
+      .scaleEffect(canvasScale, anchor: .center)
+      .offset(
+        x: screenCenter.x - resized.size.width / 2,
+        y: screenCenter.y - cardTotalHeight / 2
+      )
+      .zIndex(focusedTabID == tab.id ? 1 : 0)
+    }
   }
 
   // MARK: - Canvas Gestures
@@ -379,7 +388,7 @@ struct CanvasView: View {
 
   // MARK: - Resize
 
-  private func commitResize(for tabID: TerminalTabID, cardKey: String, surfaces: [GhosttySurfaceView]) {
+  private func commitResize(for tabID: TerminalTabID, cardKey: String, surfaces: [SurfaceView]) {
     guard activeResize[tabID] != nil else { return }
     if var layout = layoutStore.cardLayouts[cardKey] {
       let resized = resizedFrame(for: tabID, baseLayout: layout)
@@ -398,7 +407,7 @@ struct CanvasView: View {
 
   private func focusCard(
     _ tabID: TerminalTabID,
-    surfaceView: GhosttySurfaceView,
+    surfaceView: SurfaceView,
     states: [WorktreeTerminalState]
   ) {
     let previousTabID = focusedTabID
@@ -416,12 +425,12 @@ struct CanvasView: View {
       let previousState = states.first(where: { $0.surfaceView(for: previousTabID) != nil })
     {
       for surface in previousState.splitTree(for: previousTabID).leaves() {
-        surface.focusDidChange(false)
+        surface.terminalView?.focusDidChange(false)
       }
     }
 
-    surfaceView.focusDidChange(true)
-    surfaceView.requestFocus()
+    surfaceView.terminalView?.focusDidChange(true)
+    surfaceView.terminalView?.requestFocus()
   }
 
   private func unfocusAll() {
@@ -431,7 +440,7 @@ struct CanvasView: View {
       .first(where: { $0.surfaceView(for: previousTabID) != nil })
     {
       for surface in state.splitTree(for: previousTabID).leaves() {
-        surface.focusDidChange(false)
+        surface.terminalView?.focusDidChange(false)
       }
     }
   }
@@ -459,7 +468,7 @@ struct CanvasView: View {
     for state in activeStates {
       for tab in state.tabManager.tabs {
         for surface in state.splitTree(for: tab.id).leaves() {
-          surface.setOcclusion(true)
+          surface.terminalView?.setOcclusion(true)
         }
       }
     }
@@ -470,8 +479,8 @@ struct CanvasView: View {
     for state in terminalManager.activeWorktreeStates {
       for tab in state.tabManager.tabs {
         for surface in state.splitTree(for: tab.id).leaves() {
-          surface.setOcclusion(false)
-          surface.focusDidChange(false)
+          surface.terminalView?.setOcclusion(false)
+          surface.terminalView?.focusDidChange(false)
         }
       }
     }

--- a/supacode/Features/Terminal/Models/SurfaceView.swift
+++ b/supacode/Features/Terminal/Models/SurfaceView.swift
@@ -1,0 +1,45 @@
+import AppKit
+
+/// Data container for the SplitTree. Holds either a terminal or browser surface.
+/// Not rendered directly — SwiftUI extracts the inner view via NSViewRepresentable.
+@MainActor
+final class SurfaceView: NSView, Identifiable {
+  enum Content {
+    case terminal(GhosttySurfaceView)
+    case browser(BrowserSurfaceView)
+  }
+
+  let content: Content
+
+  nonisolated var id: UUID {
+    switch content {
+    case .terminal(let view): view.id
+    case .browser(let view): view.id
+    }
+  }
+
+  var terminalView: GhosttySurfaceView? {
+    if case .terminal(let view) = content { return view }
+    return nil
+  }
+
+  var browserView: BrowserSurfaceView? {
+    if case .browser(let view) = content { return view }
+    return nil
+  }
+
+  init(terminal: GhosttySurfaceView) {
+    content = .terminal(terminal)
+    super.init(frame: .zero)
+  }
+
+  init(browser: BrowserSurfaceView) {
+    content = .browser(browser)
+    super.init(frame: .zero)
+  }
+
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) is not supported")
+  }
+}

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -18,8 +18,8 @@ final class WorktreeTerminalState {
   private let worktree: Worktree
   @ObservationIgnored
   @SharedReader private var repositorySettings: RepositorySettings
-  private var trees: [TerminalTabID: SplitTree<GhosttySurfaceView>] = [:]
-  private var surfaces: [UUID: GhosttySurfaceView] = [:]
+  private var trees: [TerminalTabID: SplitTree<SurfaceView>] = [:]
+  private var surfaces: [UUID: SurfaceView] = [:]
   private var focusedSurfaceIdByTab: [TerminalTabID: UUID] = [:]
   var tabIsRunningById: [TerminalTabID: Bool] = [:]
   private var runScriptTabId: TerminalTabID?
@@ -66,7 +66,7 @@ final class WorktreeTerminalState {
   var worktreeName: String { worktree.name }
   var repositoryRootURL: URL { worktree.repositoryRootURL }
 
-  var activeSurfaceView: GhosttySurfaceView? {
+  var activeSurfaceView: SurfaceView? {
     guard let selectedTabId = tabManager.selectedTabId,
       let surfaceId = focusedSurfaceIdByTab[selectedTabId]
     else {
@@ -75,7 +75,7 @@ final class WorktreeTerminalState {
     return surfaces[surfaceId]
   }
 
-  func surfaceView(for tabId: TerminalTabID) -> GhosttySurfaceView? {
+  func surfaceView(for tabId: TerminalTabID) -> SurfaceView? {
     guard let surfaceId = focusedSurfaceIdByTab[tabId] else { return nil }
     return surfaces[surfaceId]
   }
@@ -228,10 +228,10 @@ final class WorktreeTerminalState {
   func focusAndInsertText(_ text: String) -> Bool {
     guard let tabId = tabManager.selectedTabId,
       let focusedId = focusedSurfaceIdByTab[tabId],
-      let surface = surfaces[focusedId]
+      let terminal = surfaces[focusedId]?.terminalView
     else { return false }
-    surface.requestFocus()
-    surface.insertText(text, replacementRange: NSRange(location: 0, length: 0))
+    terminal.requestFocus()
+    terminal.insertText(text, replacementRange: NSRange(location: 0, length: 0))
     return true
   }
 
@@ -239,14 +239,14 @@ final class WorktreeTerminalState {
   func focusAndRunCommand(_ text: String) -> Bool {
     guard let tabId = tabManager.selectedTabId,
       let focusedId = focusedSurfaceIdByTab[tabId],
-      let surface = surfaces[focusedId]
+      let terminal = surfaces[focusedId]?.terminalView
     else { return false }
     let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !trimmed.isEmpty else { return false }
     let command = text.trimmingCharacters(in: .newlines)
-    surface.requestFocus()
-    surface.insertText(command, replacementRange: NSRange(location: 0, length: 0))
-    return surface.submitLine()
+    terminal.requestFocus()
+    terminal.insertText(command, replacementRange: NSRange(location: 0, length: 0))
+    return terminal.submitLine()
   }
 
   func syncFocus(windowIsKey: Bool, windowIsVisible: Bool) {
@@ -263,15 +263,22 @@ final class WorktreeTerminalState {
           focusedSurfaceID: focusedId,
           surfaceID: surface.id
         )
-        surface.setOcclusion(activity.isVisible)
-        surface.focusDidChange(activity.isFocused)
-        if activity.isFocused {
-          surfaceToFocus = surface
+        if let terminal = surface.terminalView {
+          terminal.setOcclusion(activity.isVisible)
+          terminal.focusDidChange(activity.isFocused)
+          if activity.isFocused {
+            surfaceToFocus = terminal
+          }
         }
       }
     }
-    if let surfaceToFocus, surfaceToFocus.window?.firstResponder is GhosttySurfaceView {
-      surfaceToFocus.window?.makeFirstResponder(surfaceToFocus)
+    // Only force-focus the terminal if the current first responder is also a terminal.
+    // Don't steal focus from browser panes (BrowserWebView).
+    if let surfaceToFocus {
+      let firstResponder = surfaceToFocus.window?.firstResponder
+      if firstResponder is GhosttySurfaceView || firstResponder == nil {
+        surfaceToFocus.window?.makeFirstResponder(surfaceToFocus)
+      }
     }
   }
 
@@ -310,11 +317,11 @@ final class WorktreeTerminalState {
   func closeFocusedSurface() -> Bool {
     guard let tabId = tabManager.selectedTabId,
       let focusedId = focusedSurfaceIdByTab[tabId],
-      let surface = surfaces[focusedId]
+      let terminal = surfaces[focusedId]?.terminalView
     else {
       return false
     }
-    surface.performBindingAction("close_surface")
+    terminal.performBindingAction("close_surface")
     return true
   }
 
@@ -322,11 +329,11 @@ final class WorktreeTerminalState {
   func performBindingActionOnFocusedSurface(_ action: String) -> Bool {
     guard let tabId = tabManager.selectedTabId,
       let focusedId = focusedSurfaceIdByTab[tabId],
-      let surface = surfaces[focusedId]
+      let terminal = surfaces[focusedId]?.terminalView
     else {
       return false
     }
-    surface.performBindingAction(action)
+    terminal.performBindingAction(action)
     return true
   }
 
@@ -334,11 +341,11 @@ final class WorktreeTerminalState {
   func navigateSearchOnFocusedSurface(_ direction: GhosttySearchDirection) -> Bool {
     guard let tabId = tabManager.selectedTabId,
       let focusedId = focusedSurfaceIdByTab[tabId],
-      let surface = surfaces[focusedId]
+      let terminal = surfaces[focusedId]?.terminalView
     else {
       return false
     }
-    surface.navigateSearch(direction)
+    terminal.navigateSearch(direction)
     return true
   }
 
@@ -385,7 +392,7 @@ final class WorktreeTerminalState {
     inheritingFromSurfaceId: UUID? = nil,
     initialInput: String? = nil,
     context: ghostty_surface_context_e = GHOSTTY_SURFACE_CONTEXT_TAB
-  ) -> SplitTree<GhosttySurfaceView> {
+  ) -> SplitTree<SurfaceView> {
     if let existing = trees[tabId] {
       return existing
     }
@@ -426,7 +433,7 @@ final class WorktreeTerminalState {
         focusSurface(newSurface, in: tabId)
         return true
       } catch {
-        newSurface.closeSurface()
+        newSurface.terminalView?.closeSurface()
         surfaces.removeValue(forKey: newSurface.id)
         return false
       }
@@ -509,14 +516,14 @@ final class WorktreeTerminalState {
 
   func setAllSurfacesOccluded() {
     for surface in surfaces.values {
-      surface.setOcclusion(false)
-      surface.focusDidChange(false)
+      surface.terminalView?.setOcclusion(false)
+      surface.terminalView?.focusDidChange(false)
     }
   }
 
   func closeAllSurfaces() {
     for surface in surfaces.values {
-      surface.closeSurface()
+      surface.terminalView?.closeSurface()
     }
     surfaces.removeAll()
     trees.removeAll()
@@ -620,7 +627,7 @@ final class WorktreeTerminalState {
     initialInput: String?,
     inheritingFromSurfaceId: UUID?,
     context: ghostty_surface_context_e
-  ) -> GhosttySurfaceView {
+  ) -> SurfaceView {
     let inherited = inheritedSurfaceConfig(fromSurfaceId: inheritingFromSurfaceId, context: context)
     let view = GhosttySurfaceView(
       runtime: runtime,
@@ -673,6 +680,10 @@ final class WorktreeTerminalState {
       guard let self, let view else { return }
       self.handleCloseRequest(for: view, processAlive: processAlive)
     }
+    view.bridge.onOpenUrl = { [weak self, weak view] urlString in
+      guard let self, let view, let url = URL(string: urlString) else { return }
+      self.openBrowserPane(url: url, for: view.id)
+    }
     view.bridge.onPromptTitle = { [weak self] promptType in
       guard let self else { return }
       self.handlePromptTitle(promptType, tabId: tabId)
@@ -690,8 +701,125 @@ final class WorktreeTerminalState {
       self.recordKeyInput(forSurfaceID: view.id)
       self.markNotificationsRead(forSurfaceID: view.id)
     }
-    surfaces[view.id] = view
-    return view
+    let surfaceView = SurfaceView(terminal: view)
+    surfaces[surfaceView.id] = surfaceView
+    return surfaceView
+  }
+
+  // MARK: - Browser Pane
+
+  func openBrowserPane(url: URL, for surfaceId: UUID) {
+    guard let tabId = tabId(containing: surfaceId),
+      let tree = trees[tabId],
+      let targetSurface = surfaces[surfaceId]
+    else { return }
+    let browser = BrowserSurfaceView()
+    // Route Cmd-shortcuts through app handling (Cmd+D, Cmd+W, Cmd+T)
+    browser.webView.onKeyEquivalent = { [weak self] event in
+      guard let self else { return false }
+      return self.handleBrowserKeyEquivalent(event)
+    }
+    // Track focus: when the webview becomes first responder, update focusedSurfaceIdByTab
+    browser.webView.onFocusChange = { [weak self, weak browser] focused in
+      guard let self, let browser, focused else { return }
+      if let entry = self.surfaces.first(where: { $0.value.browserView === browser }),
+        let tabId = self.tabId(containing: entry.key)
+      {
+        self.focusedSurfaceIdByTab[tabId] = entry.key
+        self.emitFocusChangedIfNeeded(entry.key)
+      }
+    }
+    browser.loadURL(url)
+    let surfaceView = SurfaceView(browser: browser)
+    surfaces[surfaceView.id] = surfaceView
+    do {
+      let newTree = try tree.inserting(
+        view: surfaceView,
+        at: targetSurface,
+        direction: .right
+      )
+      trees[tabId] = newTree
+    } catch {
+      surfaces.removeValue(forKey: surfaceView.id)
+    }
+  }
+
+  /// Creates a new terminal split next to the currently focused surface (even if it's a browser).
+  func createTerminalSplitNextToFocused(direction: SplitTree<SurfaceView>.NewDirection = .right) {
+    guard let selectedTabId = tabManager.selectedTabId,
+      let focusedId = focusedSurfaceIdByTab[selectedTabId],
+      var tree = trees[selectedTabId],
+      let targetSurface = surfaces[focusedId]
+    else { return }
+    let newSurface = createSurface(
+      tabId: selectedTabId,
+      initialInput: nil,
+      inheritingFromSurfaceId: nil,
+      context: GHOSTTY_SURFACE_CONTEXT_SPLIT
+    )
+    do {
+      let newTree = try tree.inserting(view: newSurface, at: targetSurface, direction: direction)
+      trees[selectedTabId] = newTree
+      focusSurface(newSurface, in: selectedTabId)
+    } catch {
+      newSurface.terminalView?.closeSurface()
+      surfaces.removeValue(forKey: newSurface.id)
+    }
+  }
+
+  private func handleBrowserKeyEquivalent(_ event: NSEvent) -> Bool {
+    let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+    guard let chars = event.charactersIgnoringModifiers else { return false }
+
+    // Cmd+D → new terminal split right
+    if flags == .command, chars == "d" {
+      createTerminalSplitNextToFocused(direction: .right)
+      return true
+    }
+    // Cmd+Shift+D → new terminal split down
+    if flags == [.command, .shift], chars == "d" {
+      createTerminalSplitNextToFocused(direction: .down)
+      return true
+    }
+    // Cmd+T → new tab
+    if flags == .command, chars == "t" {
+      _ = createTab()
+      return true
+    }
+    // Cmd+W → close this browser pane
+    if flags == .command, chars == "w" {
+      closeFocusedPane()
+      return true
+    }
+    return false
+  }
+
+  /// Closes the currently focused pane (terminal or browser).
+  func closeFocusedPane() {
+    guard let selectedTabId = tabManager.selectedTabId,
+      let focusedId = focusedSurfaceIdByTab[selectedTabId]
+    else { return }
+    let surface = surfaces[focusedId]
+    if surface?.terminalView != nil {
+      _ = performBindingActionOnFocusedSurface("close_surface")
+    } else if surface?.browserView != nil {
+      removeSurface(id: focusedId, tabId: selectedTabId)
+    }
+  }
+
+  private func removeSurface(id: UUID, tabId: TerminalTabID) {
+    guard var tree = trees[tabId],
+      let node = tree.find(id: id)
+    else { return }
+    let nextFocus = tree.focusTargetAfterClosing(node)
+    tree = tree.removing(node)
+    trees[tabId] = tree
+    surfaces.removeValue(forKey: id)
+    if let nextFocus {
+      focusSurface(nextFocus, in: tabId)
+    } else {
+      closeTab(tabId)
+    }
   }
 
   private struct InheritedSurfaceConfig: Equatable {
@@ -705,7 +833,7 @@ final class WorktreeTerminalState {
   ) -> InheritedSurfaceConfig {
     guard let surfaceId,
       let view = surfaces[surfaceId],
-      let sourceSurface = view.surface
+      let sourceSurface = view.terminalView?.surface
     else {
       return InheritedSurfaceConfig(workingDirectory: nil, fontSize: nil)
     }
@@ -779,7 +907,7 @@ final class WorktreeTerminalState {
   private func updateTabTitle(for tabId: TerminalTabID) {
     guard let focusedId = focusedSurfaceIdByTab[tabId],
       let surface = surfaces[focusedId],
-      let title = surface.bridge.state.title
+      let title = surface.terminalView?.bridge.state.title
     else { return }
     tabManager.updateTitle(tabId, title: title)
   }
@@ -795,14 +923,19 @@ final class WorktreeTerminalState {
     }
   }
 
-  private func focusSurface(_ surface: GhosttySurfaceView, in tabId: TerminalTabID) {
+  private func focusSurface(_ surface: SurfaceView, in tabId: TerminalTabID) {
     let previousSurface = focusedSurfaceIdByTab[tabId].flatMap { surfaces[$0] }
     focusedSurfaceIdByTab[tabId] = surface.id
     markNotificationsRead(forSurfaceID: surface.id)
     updateTabTitle(for: tabId)
     guard tabId == tabManager.selectedTabId else { return }
-    let fromSurface = (previousSurface === surface) ? nil : previousSurface
-    GhosttySurfaceView.moveFocus(to: surface, from: fromSurface)
+    switch surface.content {
+    case .terminal(let terminal):
+      let fromTerminal = (previousSurface === surface) ? nil : previousSurface?.terminalView
+      GhosttySurfaceView.moveFocus(to: terminal, from: fromTerminal)
+    case .browser(let browser):
+      browser.webView.window?.makeFirstResponder(browser.webView)
+    }
     emitFocusChangedIfNeeded(surface.id)
   }
 
@@ -875,7 +1008,7 @@ final class WorktreeTerminalState {
   private func removeTree(for tabId: TerminalTabID) {
     guard let tree = trees.removeValue(forKey: tabId) else { return }
     for surface in tree.leaves() {
-      surface.closeSurface()
+      surface.terminalView?.closeSurface()
       surfaces.removeValue(forKey: surface.id)
     }
     focusedSurfaceIdByTab.removeValue(forKey: tabId)
@@ -899,7 +1032,8 @@ final class WorktreeTerminalState {
   private func updateRunningState(for tabId: TerminalTabID) {
     guard let tree = trees[tabId] else { return }
     let isRunningNow = tree.leaves().contains { surface in
-      isRunningProgressState(surface.bridge.state.progressState)
+      guard let terminal = surface.terminalView else { return false }
+      return isRunningProgressState(terminal.bridge.state.progressState)
     }
     tabIsRunningById[tabId] = isRunningNow
     tabManager.updateDirty(tabId, isDirty: isRunningNow)
@@ -939,7 +1073,7 @@ final class WorktreeTerminalState {
   }
 
   private func mapSplitDirection(_ direction: GhosttySplitAction.NewDirection)
-    -> SplitTree<GhosttySurfaceView>.NewDirection
+    -> SplitTree<SurfaceView>.NewDirection
   {
     switch direction {
     case .left:
@@ -954,7 +1088,7 @@ final class WorktreeTerminalState {
   }
 
   private func mapFocusDirection(_ direction: GhosttySplitAction.FocusDirection)
-    -> SplitTree<GhosttySurfaceView>.FocusDirection
+    -> SplitTree<SurfaceView>.FocusDirection
   {
     switch direction {
     case .previous:
@@ -973,7 +1107,7 @@ final class WorktreeTerminalState {
   }
 
   private func mapResizeDirection(_ direction: GhosttySplitAction.ResizeDirection)
-    -> SplitTree<GhosttySurfaceView>.SpatialDirection
+    -> SplitTree<SurfaceView>.SpatialDirection
   {
     switch direction {
     case .left:
@@ -1055,7 +1189,7 @@ final class WorktreeTerminalState {
   }
 
   private func mapDropZone(_ zone: TerminalSplitTreeView.DropZone)
-    -> SplitTree<GhosttySurfaceView>.NewDirection
+    -> SplitTree<SurfaceView>.NewDirection
   {
     switch zone {
     case .top:

--- a/supacode/Features/Terminal/Views/TerminalSplitTreeView.swift
+++ b/supacode/Features/Terminal/Views/TerminalSplitTreeView.swift
@@ -3,12 +3,12 @@ import SwiftUI
 import UniformTypeIdentifiers
 
 struct TerminalSplitTreeView: View {
-  let tree: SplitTree<GhosttySurfaceView>
+  let tree: SplitTree<SurfaceView>
   var pinnedSize: CGSize?
   let action: (Operation) -> Void
 
   private static let dragType = UTType(exportedAs: "com.onevcat.prowl.ghosttySurfaceId")
-  private static func dragProvider(for surfaceView: GhosttySurfaceView) -> NSItemProvider {
+  private static func dragProvider(for surfaceView: SurfaceView) -> NSItemProvider {
     let provider = NSItemProvider()
     let data = surfaceView.id.uuidString.data(using: .utf8) ?? Data()
     provider.registerDataRepresentation(
@@ -29,13 +29,13 @@ struct TerminalSplitTreeView: View {
   }
 
   enum Operation {
-    case resize(node: SplitTree<GhosttySurfaceView>.Node, ratio: Double)
+    case resize(node: SplitTree<SurfaceView>.Node, ratio: Double)
     case drop(payloadId: UUID, destinationId: UUID, zone: DropZone)
     case equalize
   }
 
   struct SubtreeView: View {
-    let node: SplitTree<GhosttySurfaceView>.Node
+    let node: SplitTree<SurfaceView>.Node
     var isRoot: Bool = false
     var pinnedSize: CGSize?
     let action: (Operation) -> Void
@@ -79,7 +79,7 @@ struct TerminalSplitTreeView: View {
     }
 
     private func splitChildSize(
-      _ size: CGSize, ratio: Double, direction: SplitTree<GhosttySurfaceView>.Direction
+      _ size: CGSize, ratio: Double, direction: SplitTree<SurfaceView>.Direction
     ) -> CGSize {
       switch direction {
       case .horizontal:
@@ -91,7 +91,7 @@ struct TerminalSplitTreeView: View {
   }
 
   struct LeafView: View {
-    let surfaceView: GhosttySurfaceView
+    let surfaceView: SurfaceView
     let isSplit: Bool
     var pinnedSize: CGSize?
     let action: (Operation) -> Void
@@ -100,16 +100,8 @@ struct TerminalSplitTreeView: View {
 
     var body: some View {
       GeometryReader { geometry in
-        GhosttyTerminalView(surfaceView: surfaceView, pinnedSize: pinnedSize)
+        leafContent
           .frame(maxWidth: .infinity, maxHeight: .infinity)
-          .overlay(alignment: .top) {
-            GhosttySurfaceProgressOverlay(state: surfaceView.bridge.state)
-          }
-          .overlay(alignment: .topTrailing) {
-            if surfaceView.bridge.state.searchNeedle != nil {
-              GhosttySurfaceSearchOverlay(surfaceView: surfaceView)
-            }
-          }
           .overlay(alignment: .top) {
             if isSplit {
               DragHandle(surfaceView: surfaceView)
@@ -136,10 +128,27 @@ struct TerminalSplitTreeView: View {
       }
     }
 
+    @ViewBuilder
+    private var leafContent: some View {
+      switch surfaceView.content {
+      case .terminal(let terminalView):
+        GhosttyTerminalView(surfaceView: terminalView, pinnedSize: pinnedSize)
+          .overlay(alignment: .top) {
+            GhosttySurfaceProgressOverlay(state: terminalView.bridge.state)
+          }
+          .overlay(alignment: .topTrailing) {
+            if terminalView.bridge.state.searchNeedle != nil {
+              GhosttySurfaceSearchOverlay(surfaceView: terminalView)
+            }
+          }
+      case .browser(let browserView):
+        BrowserPaneView(browserView: browserView)
+      }
+    }
   }
 
   struct DragHandle: View {
-    let surfaceView: GhosttySurfaceView
+    let surfaceView: SurfaceView
     private let handleHeight: CGFloat = 10
     @State private var isHovering = false
 
@@ -298,7 +307,7 @@ struct TerminalSplitTreeView: View {
 /// Wraps the SwiftUI split tree in an AppKit view so we can expose an ordered
 /// list of terminal panes to assistive technologies.
 struct TerminalSplitTreeAXContainer: NSViewRepresentable {
-  let tree: SplitTree<GhosttySurfaceView>
+  let tree: SplitTree<SurfaceView>
   let action: (TerminalSplitTreeView.Operation) -> Void
 
   func makeNSView(context: Context) -> TerminalSplitAXContainerView {
@@ -318,11 +327,11 @@ struct TerminalSplitTreeAXContainer: NSViewRepresentable {
 @MainActor
 final class TerminalSplitAXContainerView: NSView {
   private var hostingView: NSHostingView<AnyView>?
-  private var panes: [GhosttySurfaceView] = []
+  private var panes: [SurfaceView] = []
   private var panesLabel: String = "Terminal split: 0 panes"
   private var lastPaneIDs: [UUID] = []
 
-  func update(rootView: AnyView, panes: [GhosttySurfaceView]) {
+  func update(rootView: AnyView, panes: [SurfaceView]) {
     if let hostingView {
       hostingView.rootView = rootView
     } else {
@@ -343,7 +352,7 @@ final class TerminalSplitAXContainerView: NSView {
     panesLabel = "Terminal split: \(panes.count) pane" + (panes.count == 1 ? "" : "s")
 
     for (index, pane) in panes.enumerated() {
-      pane.setAccessibilityPaneIndex(index: index + 1, total: panes.count)
+      pane.terminalView?.setAccessibilityPaneIndex(index: index + 1, total: panes.count)
       // Expose panes as direct children of this split group for predictable navigation.
       pane.setAccessibilityParent(self)
     }

--- a/supacode/Features/Terminal/Views/WorktreeTerminalTabsView.swift
+++ b/supacode/Features/Terminal/Views/WorktreeTerminalTabsView.swift
@@ -16,10 +16,14 @@ struct WorktreeTerminalTabsView: View {
         manager: state.tabManager,
         createTab: createTab,
         splitHorizontally: {
-          _ = state.performBindingActionOnFocusedSurface("new_split:down")
+          if !state.performBindingActionOnFocusedSurface("new_split:down") {
+            state.createTerminalSplitNextToFocused(direction: .down)
+          }
         },
         splitVertically: {
-          _ = state.performBindingActionOnFocusedSurface("new_split:right")
+          if !state.performBindingActionOnFocusedSurface("new_split:right") {
+            state.createTerminalSplitNextToFocused(direction: .right)
+          }
         },
         canSplit: state.tabManager.selectedTabId != nil,
         closeTab: { tabId in

--- a/supacode/Infrastructure/Browser/BrowserPaneView.swift
+++ b/supacode/Infrastructure/Browser/BrowserPaneView.swift
@@ -1,0 +1,93 @@
+import SwiftUI
+import WebKit
+
+struct BrowserPaneView: View {
+  let browserView: BrowserSurfaceView
+
+  var body: some View {
+    VStack(spacing: 0) {
+      browserToolbar
+      Divider()
+      ZStack(alignment: .top) {
+        BrowserWebViewRepresentable(webView: browserView.webView)
+        if browserView.state.isLoading {
+          ProgressView(value: browserView.state.estimatedProgress)
+            .progressViewStyle(.linear)
+        }
+      }
+    }
+  }
+
+  private var browserToolbar: some View {
+    HStack(spacing: 6) {
+      Button {
+        browserView.goBack()
+      } label: {
+        Image(systemName: "chevron.left")
+          .accessibilityLabel("Back")
+      }
+      .disabled(!browserView.state.canGoBack)
+      .help("Back")
+
+      Button {
+        browserView.goForward()
+      } label: {
+        Image(systemName: "chevron.right")
+          .accessibilityLabel("Forward")
+      }
+      .disabled(!browserView.state.canGoForward)
+      .help("Forward")
+
+      Button {
+        if browserView.state.isLoading {
+          browserView.stopLoading()
+        } else {
+          browserView.reload()
+        }
+      } label: {
+        Image(systemName: browserView.state.isLoading ? "xmark" : "arrow.clockwise")
+          .accessibilityLabel(browserView.state.isLoading ? "Stop" : "Reload")
+      }
+      .help(browserView.state.isLoading ? "Stop" : "Reload")
+
+      TextField(
+        "URL",
+        text: Binding(
+          get: { browserView.state.editableURLString },
+          set: { browserView.state.editableURLString = $0 }
+        )
+      )
+      .textFieldStyle(.roundedBorder)
+      .font(.callout)
+      .monospaced()
+      .onSubmit {
+        let input = browserView.state.editableURLString
+        if let url = urlFromInput(input) {
+          browserView.loadURL(url)
+        }
+      }
+    }
+    .buttonStyle(.borderless)
+    .padding(.horizontal, 8)
+    .padding(.vertical, 4)
+  }
+
+  private func urlFromInput(_ input: String) -> URL? {
+    let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
+    if trimmed.isEmpty { return nil }
+    if trimmed.hasPrefix("http://") || trimmed.hasPrefix("https://") {
+      return URL(string: trimmed)
+    }
+    return URL(string: "https://\(trimmed)")
+  }
+}
+
+private struct BrowserWebViewRepresentable: NSViewRepresentable {
+  let webView: BrowserWebView
+
+  func makeNSView(context: Context) -> BrowserWebView {
+    webView
+  }
+
+  func updateNSView(_ nsView: BrowserWebView, context: Context) {}
+}

--- a/supacode/Infrastructure/Browser/BrowserSurfaceState.swift
+++ b/supacode/Infrastructure/Browser/BrowserSurfaceState.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+@MainActor
+@Observable
+final class BrowserSurfaceState {
+  var currentURL: URL?
+  var title: String = ""
+  var canGoBack: Bool = false
+  var canGoForward: Bool = false
+  var isLoading: Bool = false
+  var estimatedProgress: Double = 0
+  var editableURLString: String = ""
+}

--- a/supacode/Infrastructure/Browser/BrowserSurfaceView.swift
+++ b/supacode/Infrastructure/Browser/BrowserSurfaceView.swift
@@ -1,0 +1,146 @@
+import AppKit
+import WebKit
+
+private let browserLogger = SupaLogger("Browser")
+
+/// Custom WKWebView subclass that reports focus changes and routes keyboard shortcuts.
+@MainActor
+final class BrowserWebView: WKWebView {
+  var onFocusChange: ((Bool) -> Void)?
+  var onKeyEquivalent: ((NSEvent) -> Bool)?
+
+  override var acceptsFirstResponder: Bool { true }
+
+  override func becomeFirstResponder() -> Bool {
+    let result = super.becomeFirstResponder()
+    if result {
+      onFocusChange?(true)
+    }
+    return result
+  }
+
+  override func resignFirstResponder() -> Bool {
+    let result = super.resignFirstResponder()
+    if result {
+      onFocusChange?(false)
+    }
+    return result
+  }
+
+  override func performKeyEquivalent(with event: NSEvent) -> Bool {
+    // Cmd-modified keys: check app-level shortcuts first (Cmd+D, Cmd+W, Cmd+T)
+    if event.modifierFlags.contains(.command) {
+      if let onKeyEquivalent, onKeyEquivalent(event) {
+        return true
+      }
+    }
+    return super.performKeyEquivalent(with: event)
+  }
+}
+
+@MainActor
+final class BrowserSurfaceView: NSView, Identifiable {
+  let id = UUID()
+  let state = BrowserSurfaceState()
+  let webView: BrowserWebView
+
+  private var observations: [NSKeyValueObservation] = []
+
+  override init(frame frameRect: NSRect) {
+    let config = WKWebViewConfiguration()
+    config.preferences.isElementFullscreenEnabled = true
+    webView = BrowserWebView(frame: frameRect, configuration: config)
+    super.init(frame: frameRect)
+    setup()
+  }
+
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) is not supported")
+  }
+
+  private func setup() {
+    webView.translatesAutoresizingMaskIntoConstraints = false
+    addSubview(webView)
+    NSLayoutConstraint.activate([
+      webView.topAnchor.constraint(equalTo: topAnchor),
+      webView.bottomAnchor.constraint(equalTo: bottomAnchor),
+      webView.leadingAnchor.constraint(equalTo: leadingAnchor),
+      webView.trailingAnchor.constraint(equalTo: trailingAnchor),
+    ])
+
+    webView.navigationDelegate = self
+    webView.allowsBackForwardNavigationGestures = true
+
+    observations = [
+      webView.observe(\.title) { [weak self] webView, _ in
+        MainActor.assumeIsolated {
+          self?.state.title = webView.title ?? ""
+        }
+      },
+      webView.observe(\.url) { [weak self] webView, _ in
+        MainActor.assumeIsolated {
+          self?.state.currentURL = webView.url
+          self?.state.editableURLString = webView.url?.absoluteString ?? ""
+        }
+      },
+      webView.observe(\.canGoBack) { [weak self] webView, _ in
+        MainActor.assumeIsolated {
+          self?.state.canGoBack = webView.canGoBack
+        }
+      },
+      webView.observe(\.canGoForward) { [weak self] webView, _ in
+        MainActor.assumeIsolated {
+          self?.state.canGoForward = webView.canGoForward
+        }
+      },
+      webView.observe(\.isLoading) { [weak self] webView, _ in
+        MainActor.assumeIsolated {
+          self?.state.isLoading = webView.isLoading
+        }
+      },
+      webView.observe(\.estimatedProgress) { [weak self] webView, _ in
+        MainActor.assumeIsolated {
+          self?.state.estimatedProgress = webView.estimatedProgress
+        }
+      },
+    ]
+  }
+
+  override var acceptsFirstResponder: Bool { true }
+
+  func loadURL(_ url: URL) {
+    browserLogger.info("Loading URL: \(url.absoluteString)")
+    state.editableURLString = url.absoluteString
+    webView.load(URLRequest(url: url))
+  }
+
+  func goBack() { webView.goBack() }
+  func goForward() { webView.goForward() }
+  func reload() { webView.reload() }
+  func stopLoading() { webView.stopLoading() }
+
+  deinit {
+    observations.removeAll()
+  }
+}
+
+extension BrowserSurfaceView: WKNavigationDelegate {
+  nonisolated func webView(
+    _ webView: WKWebView,
+    decidePolicyFor navigationAction: WKNavigationAction
+  ) -> WKNavigationActionPolicy {
+    .allow
+  }
+
+  nonisolated func webView(
+    _ webView: WKWebView,
+    didFailProvisionalNavigation navigation: WKNavigation!,
+    withError error: Error
+  ) {
+    let message = error.localizedDescription
+    Task { @MainActor in
+      browserLogger.warning("Navigation failed: \(message)")
+    }
+  }
+}

--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceBridge.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceBridge.swift
@@ -18,6 +18,7 @@ final class GhosttySurfaceBridge {
   var onProgressReport: ((ghostty_action_progress_report_state_e) -> Void)?
   var onDesktopNotification: ((String, String) -> Void)?
   var onCommandFinished: ((Int?, UInt64) -> Void)?
+  var onOpenUrl: ((String) -> Void)?
   var onPromptTitle: ((ghostty_action_prompt_title_e) -> Void)?
   private var progressResetTask: Task<Void, Never>?
 
@@ -28,6 +29,7 @@ final class GhosttySurfaceBridge {
   func handleAction(target: ghostty_target_s, action: ghostty_action_s) -> Bool {
     if let handled = handleAppAction(action) { return handled }
     if let handled = handleSplitAction(action) { return handled }
+    if let handled = handleOpenUrlAction(action) { return handled }
     if handleTitleAndPath(action) { return false }
     if handleCommandStatus(action) { return false }
     if handleMouseAndLink(action) { return false }
@@ -89,6 +91,17 @@ final class GhosttySurfaceBridge {
     default:
       return nil
     }
+  }
+
+  private func handleOpenUrlAction(_ action: ghostty_action_s) -> Bool? {
+    guard action.tag == GHOSTTY_ACTION_OPEN_URL, onOpenUrl != nil else { return nil }
+    let openUrl = action.action.open_url
+    state.openUrlKind = openUrl.kind
+    state.openUrl = string(from: openUrl.url, length: openUrl.len)
+    if let urlString = state.openUrl {
+      onOpenUrl?(urlString)
+    }
+    return true
   }
 
   private func handleSplitAction(_ action: ghostty_action_s) -> Bool? {


### PR DESCRIPTION
## Summary
- Add WKWebView browser pane integrated into the existing SplitTree split system
- Clicking a URL in the terminal opens a browser pane to the right (same mechanism as Cmd+D)
- `SurfaceView` wrapper allows SplitTree to hold both terminal and browser leaves
- `BrowserWebView` (custom WKWebView subclass) handles focus tracking via `becomeFirstResponder` callback
- Cmd+D/Cmd+W/Cmd+T keyboard shortcuts work when browser pane has focus
- `syncFocus` respects browser focus and won't steal it back to the terminal
- Browser toolbar: back/forward/reload/URL bar

## Test plan
- [x] `make check` passes (format + lint)
- [x] `make test` passes
- [x] Terminal URL click → browser pane opens in right split
- [x] Click browser → browser gets focus, can scroll/interact
- [x] Click terminal → terminal gets focus, Ghostty shortcuts work
- [x] Cmd+D in browser → creates terminal split
- [x] Cmd+W in browser → closes browser pane
- [x] Close terminal leaving only browser → can still create new terminal splits

🤖 Generated with [Claude Code](https://claude.com/claude-code)