### PR TITLE
Fix blank surface when exiting canvas via toggle shortcut

### DIFF
--- a/supacode/Features/Canvas/Views/CanvasView.swift
+++ b/supacode/Features/Canvas/Views/CanvasView.swift
@@ -467,14 +467,11 @@ struct CanvasView: View {
 
   private func deactivateCanvas() {
     focusedTabID = nil
-    for state in terminalManager.activeWorktreeStates {
-      for tab in state.tabManager.tabs {
-        for surface in state.splitTree(for: tab.id).leaves() {
-          surface.setOcclusion(false)
-          surface.focusDidChange(false)
-        }
-      }
-    }
+    // Don't occlude surfaces here. In SwiftUI's if/else view swap,
+    // onAppear fires before onDisappear, so occluding here would undo
+    // WorktreeTerminalTabsView.onAppear's syncFocus() and cause blank
+    // surfaces. Cleanup of non-selected worktrees is handled by
+    // setSelectedWorktreeID in the async exit flow.
   }
 }
 

--- a/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
+++ b/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
@@ -115,6 +115,11 @@ final class WorktreeTerminalManager {
       guard id != selectedWorktreeID else { return }
       if let previousID = selectedWorktreeID, let previousState = states[previousID] {
         previousState.setAllSurfacesOccluded()
+      } else if selectedWorktreeID == nil {
+        // Leaving canvas mode: occlude all worktrees except the newly selected one.
+        for (wid, state) in states where wid != id {
+          state.setAllSurfacesOccluded()
+        }
       }
       selectedWorktreeID = id
       terminalLogger.info("Selected worktree \(id ?? "nil")")


### PR DESCRIPTION
## Summary

- When exiting canvas (⌥⌘↩), the selected tab showed a blank surface because `deactivateCanvas()` (in `onDisappear`) occluded all surfaces *after* `syncFocus()` (in `onAppear`) had already un-occluded them.
- Removed surface occluding from `deactivateCanvas()` to avoid the SwiftUI `onAppear`/`onDisappear` ordering race.
- Added canvas-exit cleanup in `setSelectedWorktreeID`: when `selectedWorktreeID` is nil (leaving canvas), occlude all non-selected worktrees to reclaim resources.

## Root Cause

Introduced by `ff4f7c6` (Clear worktree selection when entering canvas mode). Before that commit, `selectedWorktreeID` was never cleared, so `setSelectedWorktreeID` was a no-op on exit (guard: same ID). After, the nil→ID transition passed the guard but had no compensating un-occlude.

## Test plan

- [x] Open multiple worktrees, enter Canvas (⌥⌘↩)
- [x] Click a card in Canvas, then exit Canvas (⌥⌘↩) → surface content should be visible immediately
- [x] Enter Canvas without clicking any card, exit → should return to the previous worktree with content visible
- [x] Switch worktrees normally (no canvas) → verify no regression
