### PR TITLE
Update YiTong to 0.2.0

### DIFF
--- a/supacode.xcodeproj/project.pbxproj
+++ b/supacode.xcodeproj/project.pbxproj
@@ -665,8 +665,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/onevcat/YiTong.git";
 			requirement = {
-				branch = master;
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.2.0;
 			};
 		};
 		D6D054262F2E3EB300D70ED5 /* XCRemoteSwiftPackageReference "posthog-ios" */ = {

--- a/supacode.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/supacode.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -159,8 +159,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/onevcat/YiTong.git",
       "state" : {
-        "branch" : "master",
-        "revision" : "03208b0e59f01dcb9662e10aa02f4af99306d6e9"
+        "revision" : "9fe06046fc894440c664406ec1585995c6f08906",
+        "version" : "0.2.0"
       }
     }
   ],


### PR DESCRIPTION
## Summary

- Update YiTong dependency from branch-tracking (`master`) to semver pinning (`upToNextMajorVersion: 0.2.0`)
- YiTong 0.2.0 ships an optimized web bundle with significantly reduced asset size

## Size comparison (release archive build)

| Metric | v2026.3.23 (before) | With YiTong 0.2.0 | Delta |
|--------|--------------------|--------------------|-------|
| **YiTong bundle** | 9.3 MB | 2.7 MB | **-6.6 MB (-71%)** |
| **.app** | 58 MB | 51 MB | **-7 MB** |
| **.dmg** | 23.5 MB | 22 MB | **-1.5 MB (-6.4%)** |
| Prowl binary | 40.3 MB | 40.3 MB | unchanged |

## Test plan

- [x] Clean archive build succeeds
- [x] DMG created and size verified
- [x] App launches and diff view works correctly