### PR TITLE
Add scroll gating to prevent auto-scroll during scrollback reading

### DIFF
--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
@@ -1626,6 +1626,7 @@ final class GhosttySurfaceScrollView: NSView {
   private let surfaceView: GhosttySurfaceView
   private var observers: [NSObjectProtocol] = []
   private var isLiveScrolling = false
+  private var isUserScrolledBack = false
   private var lastSentRow: Int?
   private var scrollbar: ScrollbarState?
 
@@ -1682,6 +1683,7 @@ final class GhosttySurfaceScrollView: NSView {
       ) { [weak self] _ in
         MainActor.assumeIsolated {
           self?.isLiveScrolling = false
+          self?.updateScrollBackState()
         }
       })
 
@@ -1771,7 +1773,7 @@ final class GhosttySurfaceScrollView: NSView {
 
   private func synchronizeScrollView() {
     documentView.frame.size.height = documentHeight()
-    if !isLiveScrolling {
+    if !isLiveScrolling && !isUserScrolledBack {
       let cellHeight = surfaceView.currentCellSize().height
       if cellHeight > 0, let scrollbar {
         let offsetY =
@@ -1781,6 +1783,19 @@ final class GhosttySurfaceScrollView: NSView {
       }
     }
     scrollView.reflectScrolledClipView(scrollView.contentView)
+  }
+
+  /// Checks whether the user has scrolled away from the bottom of the terminal
+  /// output and updates `isUserScrolledBack` accordingly. When the user is scrolled
+  /// back, `synchronizeScrollView` will skip auto-scrolling so new output does not
+  /// yank the viewport away from what the user is reading.
+  private func updateScrollBackState() {
+    let cellHeight = surfaceView.currentCellSize().height
+    guard cellHeight > 0 else { return }
+    let visibleRect = scrollView.contentView.documentVisibleRect
+    let docHeight = documentView.frame.height
+    let distanceFromBottom = docHeight - visibleRect.maxY
+    isUserScrolledBack = distanceFromBottom > cellHeight / 2
   }
 
   private func handleLiveScroll() {


### PR DESCRIPTION
## Summary

- When a TUI (e.g. Claude Code) continuously outputs content, the terminal auto-scrolls to bottom on every update — even if the user has scrolled up to read earlier output
- Adds an `isUserScrolledBack` flag to `GhosttySurfaceScrollView` that tracks whether the user has scrolled away from the bottom
- While the flag is set, `synchronizeScrollView` skips auto-scrolling so the viewport stays where the user is reading
- The flag clears automatically when the user scrolls back to the bottom

## Test plan

- [ ] Open a terminal and run a command with continuous output (e.g. `yes` or a Claude Code session)
- [ ] Scroll up while output is ongoing — viewport should stay put
- [ ] Scroll back to bottom — auto-scroll should resume
- [ ] Normal usage (not scrolled up) should behave exactly as before