### PR TITLE
Add scroll jump diagnostic logging

### DIFF
--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
@@ -1625,6 +1625,8 @@ final class GhosttySurfaceScrollView: NSView {
   private let documentView: NSView
   private let surfaceView: GhosttySurfaceView
   private var observers: [NSObjectProtocol] = []
+  private static let logger = SupaLogger("ScrollView")
+
   private var isLiveScrolling = false
   private var lastSentRow: Int?
   private var scrollbar: ScrollbarState?
@@ -1774,9 +1776,22 @@ final class GhosttySurfaceScrollView: NSView {
     if !isLiveScrolling {
       let cellHeight = surfaceView.currentCellSize().height
       if cellHeight > 0, let scrollbar {
-        let offsetY =
+        // Log when a scrollbar update would jump the viewport significantly,
+        // which is the suspected auto-scroll-to-bottom symptom.
+        let visibleRect = scrollView.contentView.documentVisibleRect
+        let currentY = visibleRect.origin.y
+        let targetY =
           CGFloat(scrollbar.total - scrollbar.offset - scrollbar.length) * cellHeight
-        scrollView.contentView.scroll(to: CGPoint(x: 0, y: offsetY))
+        let jump = abs(targetY - currentY)
+        if jump > cellHeight * 2 {
+          Self.logger.warning(
+            "Scroll jump detected: currentY=\(currentY) targetY=\(targetY) "
+              + "jump=\(jump) scrollbar=(total:\(scrollbar.total) offset:\(scrollbar.offset) "
+              + "length:\(scrollbar.length))"
+          )
+        }
+
+        scrollView.contentView.scroll(to: CGPoint(x: 0, y: targetY))
         lastSentRow = Int(scrollbar.offset)
       }
     }


### PR DESCRIPTION
## Summary

- Add a warning log in `synchronizeScrollView` when the viewport would jump more than 2 cell heights, to help diagnose the intermittent issue where the terminal snaps to bottom while the user is reading scrollback
- Logs `currentY`, `targetY`, jump distance, and full scrollbar state (`total`, `offset`, `length`)
- Uses `SupaLogger` so the log is available in both debug (`print`) and release (`os.Logger.warning`) builds
- View with `make log-stream` or `log stream --predicate 'subsystem == "com.onevcat.prowl"'`

## Context

PR #47 proposed a fix for auto-scroll-to-bottom during scrollback reading, but we cannot reliably reproduce the issue. This logging will capture the exact scrollbar state when a jump occurs, helping us understand the root cause before merging a fix.

## Test plan

- [x] `make build-app` passes
- [x] Run `make log-stream`, then scroll up in a terminal with active output — no log should appear (normal behavior)
- [x] If the snap-to-bottom issue occurs, a `[ScrollView] Scroll jump detected` warning should appear in the log stream