### PR TITLE
Fix occlusion cache invalidation on surface reattachment

### DIFF
--- a/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
+++ b/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
@@ -113,24 +113,12 @@ final class WorktreeTerminalManager {
       }
     case .setSelectedWorktreeID(let id):
       guard id != selectedWorktreeID else { return }
-      let leavingCanvas = selectedWorktreeID == nil
       if let previousID = selectedWorktreeID, let previousState = states[previousID] {
         previousState.setAllSurfacesOccluded()
-      } else if leavingCanvas {
+      } else if selectedWorktreeID == nil {
         // Leaving canvas mode: occlude all worktrees except the newly selected one.
         for (wid, state) in states where wid != id {
           state.setAllSurfacesOccluded()
-        }
-        // During the canvas → tab view swap, surface NSViews are re-parented
-        // into a fresh hosting view. The Metal layer briefly leaves the visible
-        // layer tree, which can pause Ghostty's renderer. Because the surfaces
-        // were already marked visible in canvas (lastOcclusion == true), the
-        // setOcclusion(true) in syncFocus would be deduped and Ghostty would
-        // never learn it should resume. Refreshing the occlusion state
-        // invalidates the cache and forces the correct state to reach the
-        // C layer.
-        if let id, let state = states[id] {
-          state.refreshOcclusion()
         }
       }
       selectedWorktreeID = id

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -470,7 +470,8 @@ final class WorktreeTerminalState {
     }
   }
 
-  func performSplitOperation(_ operation: TerminalSplitTreeView.Operation, in tabId: TerminalTabID) {
+  func performSplitOperation(_ operation: TerminalSplitTreeView.Operation, in tabId: TerminalTabID)
+  {
     guard var tree = trees[tabId] else { return }
 
     switch operation {
@@ -511,23 +512,6 @@ final class WorktreeTerminalState {
     for surface in surfaces.values {
       surface.setOcclusion(false)
       surface.focusDidChange(false)
-    }
-  }
-
-  /// Invalidate every surface's occlusion cache, then re-apply the correct
-  /// tab-view occlusion state: only the selected tab's surfaces are visible.
-  ///
-  /// Use this after the surface NSViews have been re-parented (e.g. canvas →
-  /// tab transition) to ensure Ghostty's C layer receives a fresh occlusion
-  /// signal and resumes rendering.
-  func refreshOcclusion() {
-    let selectedTabId = tabManager.selectedTabId
-    for (tabId, tree) in trees {
-      let isSelected = tabId == selectedTabId
-      for surface in tree.leaves() {
-        surface.invalidateOcclusionCache()
-        surface.setOcclusion(isSelected)
-      }
     }
   }
 

--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
@@ -5,6 +5,28 @@ import GhosttyKit
 import QuartzCore
 
 final class GhosttySurfaceView: NSView, Identifiable {
+  struct OcclusionState {
+    private(set) var desired: Bool?
+    private var applied: Bool?
+
+    mutating func prepareToApply(_ visible: Bool) -> Bool {
+      desired = visible
+      guard applied != visible else { return false }
+      applied = visible
+      return true
+    }
+
+    mutating func invalidateForAttachmentChange() -> Bool? {
+      applied = nil
+      return desired
+    }
+
+    mutating func reset() {
+      desired = nil
+      applied = nil
+    }
+  }
+
   private struct ScrollbarState {
     let total: UInt64
     let offset: UInt64
@@ -63,7 +85,7 @@ final class GhosttySurfaceView: NSView, Identifiable {
   private var keyTextAccumulator: [String]?
   private var cellSize: CGSize = .zero
   private var lastScrollbar: ScrollbarState?
-  private var lastOcclusion: Bool?
+  private var occlusionState = OcclusionState()
   private var lastSurfaceFocus: Bool?
   private var eventMonitor: Any?
   private var notificationObservers: [NSObjectProtocol] = []
@@ -223,7 +245,7 @@ final class GhosttySurfaceView: NSView, Identifiable {
       ghostty_surface_free(surface)
       self.surface = nil
       bridge.surface = nil
-      lastOcclusion = nil
+      occlusionState.reset()
       lastSurfaceFocus = nil
     }
   }
@@ -318,6 +340,12 @@ final class GhosttySurfaceView: NSView, Identifiable {
     updateContentScale()
     updateSurfaceSize()
     applyWindowBackgroundAppearance()
+    handleAttachmentChange()
+  }
+
+  override func viewDidMoveToSuperview() {
+    super.viewDidMoveToSuperview()
+    handleAttachmentChange()
   }
 
   override func viewDidChangeBackingProperties() {
@@ -665,11 +693,14 @@ final class GhosttySurfaceView: NSView, Identifiable {
   }
 
   override func otherMouseDown(with event: NSEvent) {
-    sendMouseButton(event, state: GHOSTTY_MOUSE_PRESS, button: Self.ghosttyMouseButton(from: event.buttonNumber))
+    sendMouseButton(
+      event, state: GHOSTTY_MOUSE_PRESS, button: Self.ghosttyMouseButton(from: event.buttonNumber))
   }
 
   override func otherMouseUp(with event: NSEvent) {
-    sendMouseButton(event, state: GHOSTTY_MOUSE_RELEASE, button: Self.ghosttyMouseButton(from: event.buttonNumber))
+    sendMouseButton(
+      event, state: GHOSTTY_MOUSE_RELEASE, button: Self.ghosttyMouseButton(from: event.buttonNumber)
+    )
   }
 
   private static func ghosttyMouseButton(from buttonNumber: Int) -> ghostty_input_mouse_button_e {
@@ -725,7 +756,9 @@ final class GhosttySurfaceView: NSView, Identifiable {
   override func quickLook(with event: NSEvent) {
     guard let surface else { return super.quickLook(with: event) }
     var text = ghostty_text_s()
-    guard ghostty_surface_quicklook_word(surface, &text) else { return super.quickLook(with: event) }
+    guard ghostty_surface_quicklook_word(surface, &text) else {
+      return super.quickLook(with: event)
+    }
     defer { ghostty_surface_free_text(surface, &text) }
     guard text.text_len > 0 else { return super.quickLook(with: event) }
 
@@ -861,7 +894,7 @@ final class GhosttySurfaceView: NSView, Identifiable {
     config.context = context
     surface = ghostty_surface_new(app, &config)
     bridge.surface = surface
-    lastOcclusion = nil
+    occlusionState.reset()
     lastSurfaceFocus = nil
     updateSurfaceSize()
   }
@@ -884,23 +917,24 @@ final class GhosttySurfaceView: NSView, Identifiable {
 
   func setOcclusion(_ visible: Bool) {
     guard let surface else { return }
-    if lastOcclusion == visible {
-      return
-    }
-    lastOcclusion = visible
+    guard occlusionState.prepareToApply(visible) else { return }
     ghostty_surface_set_occlusion(surface, visible)
   }
 
-  /// Clear the cached occlusion state so the next `setOcclusion` call always
-  /// reaches Ghostty, even when the desired value matches the old cache.
-  ///
-  /// This is needed when the surface's NSView is re-parented (e.g. canvas →
-  /// tab transition). During re-parenting the Metal layer briefly leaves the
-  /// visible layer tree, which can cause Ghostty's renderer to pause. Without
-  /// a fresh `ghostty_surface_set_occlusion` call, Ghostty never learns it
-  /// should resume.
-  func invalidateOcclusionCache() {
-    lastOcclusion = nil
+  private func handleAttachmentChange() {
+    // Re-parenting can temporarily detach the Metal layer from the visible
+    // tree and pause Ghostty's renderer. Invalidate the applied cache so the
+    // currently desired occlusion value is sent again after reattachment.
+    _ = occlusionState.invalidateForAttachmentChange()
+    guard superview != nil else { return }
+    DispatchQueue.main.async { [weak self] in
+      self?.reapplyOcclusionIfNeeded()
+    }
+  }
+
+  private func reapplyOcclusionIfNeeded() {
+    guard superview != nil, let desired = occlusionState.desired else { return }
+    setOcclusion(desired)
   }
 
   private func setSurfaceFocus(_ focused: Bool) {

--- a/supacodeTests/GhosttySurfaceViewTests.swift
+++ b/supacodeTests/GhosttySurfaceViewTests.swift
@@ -5,6 +5,33 @@ import Testing
 
 @MainActor
 struct GhosttySurfaceViewTests {
+  @Test func occlusionStateResendsDesiredValueAfterAttachmentChange() {
+    var state = GhosttySurfaceView.OcclusionState()
+
+    let firstApply = state.prepareToApply(true)
+    let secondApply = state.prepareToApply(true)
+
+    #expect(firstApply)
+    #expect(!secondApply)
+    let desired = state.invalidateForAttachmentChange()
+    let reapply = state.prepareToApply(true)
+
+    #expect(desired == true)
+    #expect(reapply)
+  }
+
+  @Test func occlusionStateDoesNotResendBeforeAnyDesiredValueExists() {
+    var state = GhosttySurfaceView.OcclusionState()
+
+    let desired = state.invalidateForAttachmentChange()
+    let firstApply = state.prepareToApply(false)
+    let secondApply = state.prepareToApply(false)
+
+    #expect(desired == nil)
+    #expect(firstApply)
+    #expect(!secondApply)
+  }
+
   @Test func normalizedWorkingDirectoryPathRemovesTrailingSlashForNonRootPath() {
     #expect(
       GhosttySurfaceView.normalizedWorkingDirectoryPath("/Users/onevcat/Sync/github/supacode/")


### PR DESCRIPTION
## Summary
- replace the canvas-exit-specific occlusion refresh with a general occlusion state cache that tracks desired vs applied visibility
- re-send the current occlusion state whenever a `GhosttySurfaceView` is reattached, so renderer resume is tied to real NSView lifecycle events
- add unit coverage for the new occlusion state transitions

## Testing
- xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -derivedDataPath /tmp/supacode-dd-surface-tests -only-testing:supacodeTests/GhosttySurfaceViewTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation
- xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -derivedDataPath /tmp/supacode-dd-terminal-rendering -only-testing:supacodeTests/TerminalRenderingPolicyTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation
- make build-app
