### PR TITLE
Restore Cmd-W handling in canvas

### DIFF
--- a/supacode/Features/Repositories/Views/WorktreeDetailView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailView.swift
@@ -112,6 +112,7 @@ struct WorktreeDetailView: View {
       }
     }
     let actions = makeFocusedActions(
+      repositories: repositories,
       hasActiveWorktree: hasActiveTerminalTarget,
       runScriptEnabled: runScriptEnabled,
       runScriptIsRunning: runScriptIsRunning
@@ -245,6 +246,7 @@ struct WorktreeDetailView: View {
   }
 
   private func makeFocusedActions(
+    repositories: RepositoriesFeature.State,
     hasActiveWorktree: Bool,
     runScriptEnabled: Bool,
     runScriptIsRunning: Bool
@@ -252,11 +254,24 @@ struct WorktreeDetailView: View {
     func action(_ appAction: AppFeature.Action) -> (() -> Void)? {
       hasActiveWorktree ? { store.send(appAction) } : nil
     }
+
+    func canvasAction(_ perform: @escaping (WorktreeTerminalState) -> Bool) -> (() -> Void)? {
+      guard repositories.isShowingCanvas else { return nil }
+      return {
+        guard let worktreeID = terminalManager.canvasFocusedWorktreeID,
+          let state = terminalManager.stateIfExists(for: worktreeID)
+        else {
+          return
+        }
+        _ = perform(state)
+      }
+    }
+
     return FocusedActions(
       openSelectedWorktree: action(.openSelectedWorktree),
       newTerminal: action(.newTerminal),
-      closeTab: action(.closeTab),
-      closeSurface: action(.closeSurface),
+      closeTab: canvasAction { $0.closeFocusedTab() } ?? action(.closeTab),
+      closeSurface: canvasAction { $0.closeFocusedSurface() } ?? action(.closeSurface),
       startSearch: action(.startSearch),
       searchSelection: action(.searchSelection),
       navigateSearchNext: action(.navigateSearchNext),


### PR DESCRIPTION
## Summary
- restore Canvas-specific close-surface / close-tab focused actions while preserving upstream Close Window behavior
- route Canvas `Cmd+W` through the currently focused canvas worktree instead of letting Window menu close the whole app window
- keep main terminal view behavior unchanged

## Why
Upstream commit `b78042c` added a `Close Window` command on `Cmd+W`. That is correct for the main app, but in Canvas we rely on terminal close-surface semantics:
- close the focused split pane when a split exists
- otherwise close the focused card/tab

Canvas was not exposing a non-nil `closeSurfaceAction`, so the Window command won the shortcut overlap and closed the whole window.

## Testing
- `xcodebuild -project supacode.xcodeproj -scheme supacode -configuration Debug build -skipMacroValidation -clonedSourcePackagesDirPath /tmp/supacode-spm-cache/SourcePackages CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY='' 2>&1 | mise exec -- xcsift -qw --format toon` ✅
- `xcodebuild build-for-testing -project supacode.xcodeproj -scheme supacode -destination 'generic/platform=macOS' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY='' -skipMacroValidation 2>&1 | mise exec -- xcsift -qw --format toon` ✅
- full `xcodebuild test` still cannot run on this host because `supacodeTests` requires macOS 26.1 while this machine is on macOS 26.0

## Manual verification
1. Open Canvas.
2. Focus a card with a single pane, press `Cmd+W`.
   - Expected: close that card/tab, not the whole window.
3. Open a split inside a Canvas card and focus one pane, press `Cmd+W`.
   - Expected: close only the focused pane.
4. In the normal non-Canvas terminal view, press `Cmd+W`.
   - Expected: existing main-view behavior remains unchanged.
