### PR TITLE
feat: show tab count badge on repo header in sidebar

### DIFF
--- a/supacode/Features/Repositories/Views/RepoHeaderRow.swift
+++ b/supacode/Features/Repositories/Views/RepoHeaderRow.swift
@@ -4,6 +4,7 @@ struct RepoHeaderRow: View {
   private static let debugHeaderLayers = false
   let name: String
   let isRemoving: Bool
+  let tabCount: Int
   var body: some View {
     HStack {
       Text(name)
@@ -12,6 +13,15 @@ struct RepoHeaderRow: View {
         Text("Removing...")
           .font(.caption)
           .foregroundStyle(.tertiary)
+      }
+      if tabCount > 0 {
+        Text("\(tabCount)")
+          .font(.caption2)
+          .monospacedDigit()
+          .foregroundStyle(.secondary)
+          .padding(.horizontal, 5)
+          .padding(.vertical, 1)
+          .background(.quaternary, in: .capsule)
       }
     }
     .background {

--- a/supacode/Features/Repositories/Views/RepositorySectionView.swift
+++ b/supacode/Features/Repositories/Views/RepositorySectionView.swift
@@ -39,7 +39,10 @@ struct RepositorySectionView: View {
     let header = HStack {
       RepoHeaderRow(
         name: repository.name,
-        isRemoving: isRemovingRepository
+        isRemoving: isRemovingRepository,
+        tabCount: repository.worktrees.reduce(0) { count, worktree in
+          count + (terminalManager.stateIfExists(for: worktree.id)?.tabManager.tabs.count ?? 0)
+        }
       )
       .frame(maxWidth: .infinity, alignment: .leading)
       .background {


### PR DESCRIPTION
## Summary
- Add a small capsule badge next to the repository name in the left sidebar, showing the total number of terminal tabs across all worktrees for that repo
- Badge only appears when tab count > 0
- Uses `.caption2` + `.monospacedDigit()` font with `.quaternary` background for a subtle look

## Test plan
- [x] Open the app, add a repo, verify no badge shows when there are 0 tabs
- [x] Open one or more tabs in different worktrees, verify badge updates with correct total
- [x] Close all tabs, verify badge disappears
- [ ] Open many tabs (10+) to verify multi-digit display looks correct