### PR TITLE
ci: align generated prowl cask desc with tap rules

### DIFF
--- a/.github/workflows/release-homebrew-cask.yml
+++ b/.github/workflows/release-homebrew-cask.yml
@@ -72,7 +72,7 @@ jobs:
 
                 url \"https://github.com/onevcat/Prowl/releases/download/v#{{version}}/Prowl.dmg\"
                 name \"Prowl\"
-                desc \"Native macOS coding agent orchestrator\"
+                desc \"Coding agent orchestrator\"
                 homepage \"https://github.com/onevcat/Prowl\"
 
                 auto_updates true
@@ -94,6 +94,7 @@ jobs:
             print("Created tap/Casks/prowl.rb")
           else:
             text = path.read_text()
+            text = re.sub(r'^\s*desc\s+\".*\"\s*$', '  desc "Coding agent orchestrator"', text, flags=re.M)
             text = re.sub(r'^\s*version\s+\".*\"\s*$', f'  version \"{version}\"', text, flags=re.M)
             text = re.sub(r'^\s*sha256\s+\".*\"\s*$', f'  sha256 \"{sha}\"', text, flags=re.M)
             path.write_text(text)


### PR DESCRIPTION
## Why
- The cask style in `onevcat/homebrew-tap` forbids platform names in `desc`.
- `release-homebrew-cask.yml` was still generating a `desc` with `macOS`, which can reintroduce that lint issue on future automated updates.

## What changed
- Update the cask template in `.github/workflows/release-homebrew-cask.yml` to use `Coding agent orchestrator`.
- Also normalize the existing `desc` line to the same value when updating an existing `tap/Casks/prowl.rb`, so future runs stay compliant.
