### PR TITLE
ci: preserve cask stanza spacing when updating tap

### DIFF
--- a/.github/workflows/release-homebrew-cask.yml
+++ b/.github/workflows/release-homebrew-cask.yml
@@ -94,9 +94,9 @@ jobs:
             print("Created tap/Casks/prowl.rb")
           else:
             text = path.read_text()
-            text = re.sub(r'^\s*desc\s+\".*\"\s*$', '  desc "Coding agent orchestrator"', text, flags=re.M)
-            text = re.sub(r'^\s*version\s+\".*\"\s*$', f'  version \"{version}\"', text, flags=re.M)
-            text = re.sub(r'^\s*sha256\s+\".*\"\s*$', f'  sha256 \"{sha}\"', text, flags=re.M)
+            text = re.sub(r'^[ \t]*desc[ \t]+\".*\"[ \t]*$', '  desc "Coding agent orchestrator"', text, flags=re.M)
+            text = re.sub(r'^[ \t]*version[ \t]+\".*\"[ \t]*$', f'  version "{version}"', text, flags=re.M)
+            text = re.sub(r'^[ \t]*sha256[ \t]+\".*\"[ \t]*$', f'  sha256 "{sha}"', text, flags=re.M)
             path.write_text(text)
             print("Updated tap/Casks/prowl.rb")
           PY


### PR DESCRIPTION
## Why
`release-homebrew-cask` used broad `\s*` regexes when replacing `version`, `sha256`, and `desc`.
That can consume the trailing newline/blank line after those stanzas, which triggered `Cask/StanzaGrouping` failures in Homebrew `test-bot`.

## What
- Update regexes to match only within the line (`[ \t]*..."` + `$`) so blank lines are preserved.
- Keep the existing generated cask style stable for subsequent `brew test-bot` checks.

## Validation
- This is a narrow workflow-only change with no app code impact.
- It addresses the exact diff seen in PR #19 (`1 deletion` removing one blank line) and should prevent repeated test-bot failures when updating the same file.
