### PR TITLE
Persist terminal font-size override in Prowl settings

### DIFF
--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -202,8 +202,7 @@ struct SupacodeApp: App {
             NSApp.activate(ignoringOtherApps: true)
           }
         }
-        .keyboardShortcut("0")
-        .help("Show main window (⌘0)")
+        .help("Show main window")
         Divider()
         Button("Minimize") {
           NSApp.keyWindow?.miniaturize(nil)

--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -124,7 +124,10 @@ struct SupacodeApp: App {
     _ghostty = State(initialValue: runtime)
     let shortcuts = GhosttyShortcutManager(runtime: runtime)
     _ghosttyShortcuts = State(initialValue: shortcuts)
-    let terminalManager = WorktreeTerminalManager(runtime: runtime)
+    let terminalManager = WorktreeTerminalManager(
+      runtime: runtime,
+      preferredFontSize: initialSettings.terminalFontSize
+    )
     _terminalManager = State(initialValue: terminalManager)
     let worktreeInfoWatcher = WorktreeInfoWatcherManager()
     _worktreeInfoWatcher = State(initialValue: worktreeInfoWatcher)

--- a/supacode/Clients/Terminal/TerminalClient.swift
+++ b/supacode/Clients/Terminal/TerminalClient.swift
@@ -38,6 +38,7 @@ struct TerminalClient {
     case runScriptStatusChanged(worktreeID: Worktree.ID, isRunning: Bool)
     case commandPaletteToggleRequested(worktreeID: Worktree.ID)
     case setupScriptConsumed(worktreeID: Worktree.ID)
+    case fontSizeChanged(Float32?)
   }
 }
 

--- a/supacode/Commands/TerminalCommands.swift
+++ b/supacode/Commands/TerminalCommands.swift
@@ -5,6 +5,9 @@ struct TerminalCommands: Commands {
   @FocusedValue(\.newTerminalAction) private var newTerminalAction
   @FocusedValue(\.closeSurfaceAction) private var closeSurfaceAction
   @FocusedValue(\.closeTabAction) private var closeTabAction
+  @FocusedValue(\.resetFontSizeAction) private var resetFontSizeAction
+  @FocusedValue(\.increaseFontSizeAction) private var increaseFontSizeAction
+  @FocusedValue(\.decreaseFontSizeAction) private var decreaseFontSizeAction
   @FocusedValue(\.startSearchAction) private var startSearchAction
   @FocusedValue(\.searchSelectionAction) private var searchSelectionAction
   @FocusedValue(\.navigateSearchNextAction) private var navigateSearchNextAction
@@ -34,6 +37,32 @@ struct TerminalCommands: Commands {
         KeyboardShortcutModifier(shortcut: ghosttyShortcuts.keyboardShortcut(for: "close_tab"))
       )
       .disabled(closeTabAction == nil)
+    }
+    CommandGroup(after: .toolbar) {
+      Divider()
+      Button("Reset Font Size", systemImage: "textformat.size") {
+        resetFontSizeAction?()
+      }
+      .modifier(
+        KeyboardShortcutModifier(shortcut: ghosttyShortcuts.keyboardShortcut(for: "reset_font_size"))
+      )
+      .disabled(resetFontSizeAction == nil)
+
+      Button("Increase Font Size", systemImage: "textformat.size.larger") {
+        increaseFontSizeAction?()
+      }
+      .modifier(
+        KeyboardShortcutModifier(shortcut: ghosttyShortcuts.keyboardShortcut(for: "increase_font_size:1"))
+      )
+      .disabled(increaseFontSizeAction == nil)
+
+      Button("Decrease Font Size", systemImage: "textformat.size.smaller") {
+        decreaseFontSizeAction?()
+      }
+      .modifier(
+        KeyboardShortcutModifier(shortcut: ghosttyShortcuts.keyboardShortcut(for: "decrease_font_size:1"))
+      )
+      .disabled(decreaseFontSizeAction == nil)
     }
     CommandGroup(after: .textEditing) {
       Button("Find...") {
@@ -113,6 +142,39 @@ extension FocusedValues {
   var closeTabAction: (() -> Void)? {
     get { self[CloseTabActionKey.self] }
     set { self[CloseTabActionKey.self] = newValue }
+  }
+}
+
+private struct ResetFontSizeActionKey: FocusedValueKey {
+  typealias Value = () -> Void
+}
+
+extension FocusedValues {
+  var resetFontSizeAction: (() -> Void)? {
+    get { self[ResetFontSizeActionKey.self] }
+    set { self[ResetFontSizeActionKey.self] = newValue }
+  }
+}
+
+private struct IncreaseFontSizeActionKey: FocusedValueKey {
+  typealias Value = () -> Void
+}
+
+extension FocusedValues {
+  var increaseFontSizeAction: (() -> Void)? {
+    get { self[IncreaseFontSizeActionKey.self] }
+    set { self[IncreaseFontSizeActionKey.self] = newValue }
+  }
+}
+
+private struct DecreaseFontSizeActionKey: FocusedValueKey {
+  typealias Value = () -> Void
+}
+
+extension FocusedValues {
+  var decreaseFontSizeAction: (() -> Void)? {
+    get { self[DecreaseFontSizeActionKey.self] }
+    set { self[DecreaseFontSizeActionKey.self] = newValue }
   }
 }
 

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -355,6 +355,9 @@ struct AppFeature {
           }
         )
 
+      case .settings(.delegate(.terminalFontSizeChanged)):
+        return .none
+
       case .openActionSelectionChanged(let action):
         state.openActionSelection = action
         guard let worktree = state.repositories.selectedTerminalWorktree else {

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -787,6 +787,9 @@ struct AppFeature {
       case .terminalEvent(.setupScriptConsumed(let worktreeID)):
         return .send(.repositories(.consumeSetupScript(worktreeID)))
 
+      case .terminalEvent(.fontSizeChanged(let fontSize)):
+        return .send(.settings(.setTerminalFontSize(fontSize)))
+
       case .terminalEvent:
         return .none
       }

--- a/supacode/Features/Repositories/Views/WorktreeDetailView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailView.swift
@@ -236,6 +236,9 @@ struct WorktreeDetailView: View {
       .focusedSceneValue(\.newTerminalAction, actions.newTerminal)
       .focusedValue(\.closeTabAction, actions.closeTab)
       .focusedValue(\.closeSurfaceAction, actions.closeSurface)
+      .focusedSceneValue(\.resetFontSizeAction, actions.resetFontSize)
+      .focusedSceneValue(\.increaseFontSizeAction, actions.increaseFontSize)
+      .focusedSceneValue(\.decreaseFontSizeAction, actions.decreaseFontSize)
       .focusedSceneValue(\.startSearchAction, actions.startSearch)
       .focusedSceneValue(\.searchSelectionAction, actions.searchSelection)
       .focusedSceneValue(\.navigateSearchNextAction, actions.navigateSearchNext)
@@ -267,11 +270,25 @@ struct WorktreeDetailView: View {
       }
     }
 
+    func fontSizeAction(_ bindingAction: String) -> (() -> Void)? {
+      if let action = canvasAction({ $0.performBindingActionOnFocusedSurface(bindingAction) }) {
+        return action
+      }
+      guard hasActiveWorktree, let selectedWorktree = repositories.selectedTerminalWorktree else { return nil }
+      return {
+        guard let state = terminalManager.stateIfExists(for: selectedWorktree.id) else { return }
+        _ = state.performBindingActionOnFocusedSurface(bindingAction)
+      }
+    }
+
     return FocusedActions(
       openSelectedWorktree: action(.openSelectedWorktree),
       newTerminal: action(.newTerminal),
       closeTab: canvasAction { $0.closeFocusedTab() } ?? action(.closeTab),
       closeSurface: canvasAction { $0.closeFocusedSurface() } ?? action(.closeSurface),
+      resetFontSize: fontSizeAction("reset_font_size"),
+      increaseFontSize: fontSizeAction("increase_font_size:1"),
+      decreaseFontSize: fontSizeAction("decrease_font_size:1"),
       startSearch: action(.startSearch),
       searchSelection: action(.searchSelection),
       navigateSearchNext: action(.navigateSearchNext),
@@ -305,6 +322,9 @@ struct WorktreeDetailView: View {
     let newTerminal: (() -> Void)?
     let closeTab: (() -> Void)?
     let closeSurface: (() -> Void)?
+    let resetFontSize: (() -> Void)?
+    let increaseFontSize: (() -> Void)?
+    let decreaseFontSize: (() -> Void)?
     let startSearch: (() -> Void)?
     let searchSelection: (() -> Void)?
     let navigateSearchNext: (() -> Void)?

--- a/supacode/Features/Settings/Models/GlobalSettings.swift
+++ b/supacode/Features/Settings/Models/GlobalSettings.swift
@@ -18,6 +18,7 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
   var automaticallyArchiveMergedWorktrees: Bool
   var promptForWorktreeCreation: Bool
   var defaultWorktreeBaseDirectoryPath: String?
+  var terminalFontSize: Float32?
 
   static let `default` = GlobalSettings(
     appearanceMode: .dark,
@@ -38,7 +39,8 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     deleteBranchOnDeleteWorktree: true,
     automaticallyArchiveMergedWorktrees: false,
     promptForWorktreeCreation: true,
-    defaultWorktreeBaseDirectoryPath: nil
+    defaultWorktreeBaseDirectoryPath: nil,
+    terminalFontSize: nil
   )
 
   init(
@@ -60,7 +62,8 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     deleteBranchOnDeleteWorktree: Bool,
     automaticallyArchiveMergedWorktrees: Bool,
     promptForWorktreeCreation: Bool,
-    defaultWorktreeBaseDirectoryPath: String? = nil
+    defaultWorktreeBaseDirectoryPath: String? = nil,
+    terminalFontSize: Float32? = nil
   ) {
     self.appearanceMode = appearanceMode
     self.defaultEditorID = defaultEditorID
@@ -81,6 +84,7 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     self.automaticallyArchiveMergedWorktrees = automaticallyArchiveMergedWorktrees
     self.promptForWorktreeCreation = promptForWorktreeCreation
     self.defaultWorktreeBaseDirectoryPath = defaultWorktreeBaseDirectoryPath
+    self.terminalFontSize = terminalFontSize
   }
 
   init(from decoder: any Decoder) throws {
@@ -136,5 +140,8 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     defaultWorktreeBaseDirectoryPath =
       try container.decodeIfPresent(String.self, forKey: .defaultWorktreeBaseDirectoryPath)
       ?? Self.default.defaultWorktreeBaseDirectoryPath
+    terminalFontSize =
+      try container.decodeIfPresent(Float32.self, forKey: .terminalFontSize)
+      ?? Self.default.terminalFontSize
   }
 }

--- a/supacode/Features/Settings/Reducer/SettingsFeature.swift
+++ b/supacode/Features/Settings/Reducer/SettingsFeature.swift
@@ -104,6 +104,7 @@ struct SettingsFeature {
   @CasePathable
   enum Delegate: Equatable {
     case settingsChanged(GlobalSettings)
+    case terminalFontSizeChanged(Float32?)
   }
 
   @Dependency(AnalyticsClient.self) private var analyticsClient
@@ -183,7 +184,10 @@ struct SettingsFeature {
       case .setTerminalFontSize(let fontSize):
         guard state.terminalFontSize != fontSize else { return .none }
         state.terminalFontSize = fontSize
-        return persist(state, captureAnalytics: false)
+        return .merge(
+          persist(state, captureAnalytics: false, emitSettingsChanged: false),
+          .send(.delegate(.terminalFontSizeChanged(fontSize)))
+        )
 
       case .showNotificationPermissionAlert(let errorMessage):
         let message: String
@@ -237,13 +241,20 @@ struct SettingsFeature {
     }
   }
 
-  private func persist(_ state: State, captureAnalytics: Bool = true) -> Effect<Action> {
+  private func persist(
+    _ state: State,
+    captureAnalytics: Bool = true,
+    emitSettingsChanged: Bool = true
+  ) -> Effect<Action> {
     let settings = state.globalSettings
     @Shared(.settingsFile) var settingsFile
     $settingsFile.withLock { $0.global = settings }
     if captureAnalytics, settings.analyticsEnabled {
       analyticsClient.capture("settings_changed", nil)
     }
-    return .send(.delegate(.settingsChanged(settings)))
+    if emitSettingsChanged {
+      return .send(.delegate(.settingsChanged(settings)))
+    }
+    return .none
   }
 }

--- a/supacode/Features/Settings/Reducer/SettingsFeature.swift
+++ b/supacode/Features/Settings/Reducer/SettingsFeature.swift
@@ -24,6 +24,7 @@ struct SettingsFeature {
     var automaticallyArchiveMergedWorktrees: Bool
     var promptForWorktreeCreation: Bool
     var defaultWorktreeBaseDirectoryPath: String
+    var terminalFontSize: Float32?
     var selection: SettingsSection? = .general
     var repositorySettings: RepositorySettingsFeature.State?
     @Presents var alert: AlertState<Alert>?
@@ -50,6 +51,7 @@ struct SettingsFeature {
       promptForWorktreeCreation = settings.promptForWorktreeCreation
       defaultWorktreeBaseDirectoryPath =
         SupacodePaths.normalizedWorktreeBaseDirectoryPath(settings.defaultWorktreeBaseDirectoryPath) ?? ""
+      terminalFontSize = settings.terminalFontSize
     }
 
     var globalSettings: GlobalSettings {
@@ -74,7 +76,8 @@ struct SettingsFeature {
         promptForWorktreeCreation: promptForWorktreeCreation,
         defaultWorktreeBaseDirectoryPath: SupacodePaths.normalizedWorktreeBaseDirectoryPath(
           defaultWorktreeBaseDirectoryPath
-        )
+        ),
+        terminalFontSize: terminalFontSize
       )
     }
   }
@@ -85,6 +88,7 @@ struct SettingsFeature {
     case setSelection(SettingsSection?)
     case setSystemNotificationsEnabled(Bool)
     case setCommandFinishedNotificationThreshold(String)
+    case setTerminalFontSize(Float32?)
     case showNotificationPermissionAlert(errorMessage: String?)
     case repositorySettings(RepositorySettingsFeature.Action)
     case alert(PresentationAction<Alert>)
@@ -149,6 +153,7 @@ struct SettingsFeature {
         state.automaticallyArchiveMergedWorktrees = normalizedSettings.automaticallyArchiveMergedWorktrees
         state.promptForWorktreeCreation = normalizedSettings.promptForWorktreeCreation
         state.defaultWorktreeBaseDirectoryPath = normalizedSettings.defaultWorktreeBaseDirectoryPath ?? ""
+        state.terminalFontSize = normalizedSettings.terminalFontSize
         state.repositorySettings?.globalDefaultWorktreeBaseDirectoryPath =
           normalizedSettings.defaultWorktreeBaseDirectoryPath
         return .send(.delegate(.settingsChanged(normalizedSettings)))
@@ -174,6 +179,11 @@ struct SettingsFeature {
         state.repositorySettings?.globalDefaultWorktreeBaseDirectoryPath =
           defaultWorktreeBaseDirectoryPath
         return persist(state)
+
+      case .setTerminalFontSize(let fontSize):
+        guard state.terminalFontSize != fontSize else { return .none }
+        state.terminalFontSize = fontSize
+        return persist(state, captureAnalytics: false)
 
       case .showNotificationPermissionAlert(let errorMessage):
         let message: String
@@ -227,11 +237,11 @@ struct SettingsFeature {
     }
   }
 
-  private func persist(_ state: State) -> Effect<Action> {
+  private func persist(_ state: State, captureAnalytics: Bool = true) -> Effect<Action> {
     let settings = state.globalSettings
     @Shared(.settingsFile) var settingsFile
     $settingsFile.withLock { $0.global = settings }
-    if settings.analyticsEnabled {
+    if captureAnalytics, settings.analyticsEnabled {
       analyticsClient.capture("settings_changed", nil)
     }
     return .send(.delegate(.settingsChanged(settings)))

--- a/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
+++ b/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
@@ -11,6 +11,8 @@ final class WorktreeTerminalManager {
   private var notificationsEnabled = true
   private var commandFinishedNotificationEnabled = true
   private var commandFinishedNotificationThreshold = 10
+  private var preferredFontSize: Float32?
+  private let baselineFontSize: Float32
   private var lastNotificationIndicatorCount: Int?
   private var eventContinuation: AsyncStream<TerminalClient.Event>.Continuation?
   private var pendingEvents: [TerminalClient.Event] = []
@@ -19,8 +21,10 @@ final class WorktreeTerminalManager {
   /// Used by toggleCanvas to know which worktree to return to.
   var canvasFocusedWorktreeID: Worktree.ID?
 
-  init(runtime: GhosttyRuntime) {
+  init(runtime: GhosttyRuntime, preferredFontSize: Float32? = nil) {
     self.runtime = runtime
+    self.preferredFontSize = preferredFontSize
+    baselineFontSize = runtime.defaultFontSize()
   }
 
   func handleCommand(_ command: TerminalClient.Command) {
@@ -152,6 +156,7 @@ final class WorktreeTerminalManager {
     runSetupScriptIfNew: () -> Bool = { false }
   ) -> WorktreeTerminalState {
     if let existing = states[worktree.id] {
+      existing.setDefaultFontSize(preferredFontSize)
       if runSetupScriptIfNew() {
         existing.enableSetupScriptIfNeeded()
       }
@@ -161,7 +166,8 @@ final class WorktreeTerminalManager {
     let state = WorktreeTerminalState(
       runtime: runtime,
       worktree: worktree,
-      runSetupScript: runSetupScript
+      runSetupScript: runSetupScript,
+      defaultFontSize: preferredFontSize
     )
     state.setNotificationsEnabled(notificationsEnabled)
     state.setCommandFinishedNotification(
@@ -197,6 +203,9 @@ final class WorktreeTerminalManager {
     }
     state.onSetupScriptConsumed = { [weak self] in
       self?.emit(.setupScriptConsumed(worktreeID: worktree.id))
+    }
+    state.onFontSizeChanged = { [weak self] fontSize in
+      self?.applyFontSize(fontSize)
     }
     states[worktree.id] = state
     terminalLogger.info("Created terminal state for worktree \(worktree.id)")
@@ -323,6 +332,25 @@ final class WorktreeTerminalManager {
 
   func surfaceBackgroundOpacity() -> Double {
     runtime.backgroundOpacity()
+  }
+
+  private func applyFontSize(_ fontSize: Float32?) {
+    let normalized = normalizedFontSize(fontSize)
+    guard preferredFontSize != normalized else { return }
+    preferredFontSize = normalized
+    for state in states.values {
+      state.setDefaultFontSize(normalized)
+    }
+    emit(.fontSizeChanged(normalized))
+  }
+
+  private func normalizedFontSize(_ fontSize: Float32?) -> Float32? {
+    guard let fontSize else { return nil }
+    let epsilon: Float32 = 0.01
+    if abs(fontSize - baselineFontSize) <= epsilon {
+      return nil
+    }
+    return fontSize
   }
 
   private func emit(_ event: TerminalClient.Event) {

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -761,9 +761,13 @@ final class WorktreeTerminalState {
   }
 
   private func handleCellSizeChange(forSurfaceID surfaceID: UUID) {
+    handleCellSizeChange(forSurfaceID: surfaceID, fontSize: fontSize(forSurfaceID: surfaceID))
+  }
+
+  func handleCellSizeChange(forSurfaceID surfaceID: UUID, fontSize: Float32?) {
     let inserted = hasInitializedCellSizeSurfaceIDs.insert(surfaceID).inserted
     guard !inserted else { return }
-    onFontSizeChanged?(fontSize(forSurfaceID: surfaceID))
+    onFontSizeChanged?(fontSize)
   }
 
   private func fontSize(forSurfaceID surfaceID: UUID) -> Float32? {

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -24,6 +24,8 @@ final class WorktreeTerminalState {
   var tabIsRunningById: [TerminalTabID: Bool] = [:]
   private var runScriptTabId: TerminalTabID?
   private var pendingSetupScript: Bool
+  private var defaultFontSize: Float32?
+  private var hasInitializedCellSizeSurfaceIDs: Set<UUID> = []
   private var isEnsuringInitialTab = false
   private var lastReportedTaskStatus: WorktreeTaskStatus?
   private var lastEmittedFocusSurfaceId: UUID?
@@ -50,11 +52,18 @@ final class WorktreeTerminalState {
   var onRunScriptStatusChanged: ((Bool) -> Void)?
   var onCommandPaletteToggle: (() -> Void)?
   var onSetupScriptConsumed: (() -> Void)?
+  var onFontSizeChanged: ((Float32?) -> Void)?
 
-  init(runtime: GhosttyRuntime, worktree: Worktree, runSetupScript: Bool = false) {
+  init(
+    runtime: GhosttyRuntime,
+    worktree: Worktree,
+    runSetupScript: Bool = false,
+    defaultFontSize: Float32? = nil
+  ) {
     self.runtime = runtime
     self.worktree = worktree
     self.pendingSetupScript = runSetupScript
+    self.defaultFontSize = defaultFontSize
     self.tabManager = TerminalTabManager()
     _repositorySettings = SharedReader(
       wrappedValue: RepositorySettings.default,
@@ -99,6 +108,10 @@ final class WorktreeTerminalState {
 
   var isRunScriptRunning: Bool {
     runScriptTabId != nil
+  }
+
+  func setDefaultFontSize(_ fontSize: Float32?) {
+    defaultFontSize = fontSize
   }
 
   func ensureInitialTab(focusing: Bool) {
@@ -441,6 +454,7 @@ final class WorktreeTerminalState {
       } catch {
         newSurface.closeSurface()
         surfaces.removeValue(forKey: newSurface.id)
+        hasInitializedCellSizeSurfaceIDs.remove(newSurface.id)
         return false
       }
 
@@ -533,6 +547,7 @@ final class WorktreeTerminalState {
       surface.closeSurface()
     }
     surfaces.removeAll()
+    hasInitializedCellSizeSurfaceIDs.removeAll()
     trees.removeAll()
     focusedSurfaceIdByTab.removeAll()
     tabIsRunningById.removeAll()
@@ -640,7 +655,7 @@ final class WorktreeTerminalState {
       runtime: runtime,
       workingDirectory: inherited.workingDirectory ?? worktree.workingDirectory,
       initialInput: initialInput,
-      fontSize: inherited.fontSize,
+      fontSize: inherited.fontSize ?? defaultFontSize,
       context: context
     )
     view.bridge.onTitleChange = { [weak self, weak view] title in
@@ -674,6 +689,10 @@ final class WorktreeTerminalState {
     view.bridge.onProgressReport = { [weak self] _ in
       guard let self else { return }
       self.updateRunningState(for: tabId)
+    }
+    view.bridge.onCellSizeChange = { [weak self, weak view] in
+      guard let self, let view else { return }
+      self.handleCellSizeChange(forSurfaceID: view.id)
     }
     view.bridge.onDesktopNotification = { [weak self, weak view] title, body in
       guard let self, let view else { return }
@@ -739,6 +758,16 @@ final class WorktreeTerminalState {
   private func currentFocusedSurfaceId() -> UUID? {
     guard let selectedTabId = tabManager.selectedTabId else { return nil }
     return focusedSurfaceIdByTab[selectedTabId]
+  }
+
+  private func handleCellSizeChange(forSurfaceID surfaceID: UUID) {
+    let inserted = hasInitializedCellSizeSurfaceIDs.insert(surfaceID).inserted
+    guard !inserted else { return }
+    onFontSizeChanged?(fontSize(forSurfaceID: surfaceID))
+  }
+
+  private func fontSize(forSurfaceID surfaceID: UUID) -> Float32? {
+    inheritedSurfaceConfig(fromSurfaceId: surfaceID, context: GHOSTTY_SURFACE_CONTEXT_TAB).fontSize
   }
 
   private func handlePromptTitle(
@@ -891,6 +920,7 @@ final class WorktreeTerminalState {
     for surface in tree.leaves() {
       surface.closeSurface()
       surfaces.removeValue(forKey: surface.id)
+      hasInitializedCellSizeSurfaceIDs.remove(surface.id)
     }
     focusedSurfaceIdByTab.removeValue(forKey: tabId)
     tabIsRunningById.removeValue(forKey: tabId)
@@ -1006,11 +1036,13 @@ final class WorktreeTerminalState {
     guard let tabId = tabId(containing: view.id), let tree = trees[tabId] else {
       view.closeSurface()
       surfaces.removeValue(forKey: view.id)
+      hasInitializedCellSizeSurfaceIDs.remove(view.id)
       return
     }
     guard let node = tree.find(id: view.id) else {
       view.closeSurface()
       surfaces.removeValue(forKey: view.id)
+      hasInitializedCellSizeSurfaceIDs.remove(view.id)
       return
     }
     let nextSurface =
@@ -1020,6 +1052,7 @@ final class WorktreeTerminalState {
     let newTree = tree.removing(node)
     view.closeSurface()
     surfaces.removeValue(forKey: view.id)
+    hasInitializedCellSizeSurfaceIDs.remove(view.id)
     if newTree.isEmpty {
       trees.removeValue(forKey: tabId)
       focusedSurfaceIdByTab.removeValue(forKey: tabId)

--- a/supacode/Infrastructure/Ghostty/GhosttyRuntime.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttyRuntime.swift
@@ -492,6 +492,16 @@ final class GhosttyRuntime {
     return Self.keyboardShortcut(for: trigger)
   }
 
+  func defaultFontSize() -> Float32 {
+    guard let config else { return 0 }
+    var value: Double = 0
+    let key = "font-size"
+    guard ghostty_config_get(config, &value, key, UInt(key.lengthOfBytes(using: .utf8))) else {
+      return 0
+    }
+    return Float32(value)
+  }
+
   func commandPaletteEntries() -> [GhosttyCommand] {
     guard let config else { return [] }
     var value = ghostty_config_command_list_s()

--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceBridge.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceBridge.swift
@@ -16,6 +16,7 @@ final class GhosttySurfaceBridge {
   var onMoveTab: ((ghostty_action_move_tab_s) -> Bool)?
   var onCommandPaletteToggle: (() -> Bool)?
   var onProgressReport: ((ghostty_action_progress_report_state_e) -> Void)?
+  var onCellSizeChange: (() -> Void)?
   var onDesktopNotification: ((String, String) -> Void)?
   var onCommandFinished: ((Int?, UInt64) -> Void)?
   var onPromptTitle: ((ghostty_action_prompt_title_e) -> Void)?
@@ -370,6 +371,7 @@ final class GhosttySurfaceBridge {
     case GHOSTTY_ACTION_CELL_SIZE:
       let cell = action.action.cell_size
       surfaceView?.updateCellSize(width: cell.width, height: cell.height)
+      onCellSizeChange?()
       return true
 
     case GHOSTTY_ACTION_RESET_WINDOW_SIZE:

--- a/supacodeTests/AppFeatureSettingsChangedTests.swift
+++ b/supacodeTests/AppFeatureSettingsChangedTests.swift
@@ -30,4 +30,29 @@ struct AppFeatureSettingsChangedTests {
     }
     await store.finish()
   }
+
+  @Test(.dependencies) func terminalFontSizeEventDoesNotFanOutGlobalSettingsEffects() async {
+    let sentTerminalCommands = LockIsolated<[TerminalClient.Command]>([])
+    let watcherCommands = LockIsolated<[WorktreeInfoWatcherClient.Command]>([])
+    let store = TestStore(initialState: AppFeature.State()) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in
+        sentTerminalCommands.withValue { $0.append(command) }
+      }
+      $0.worktreeInfoWatcher.send = { command in
+        watcherCommands.withValue { $0.append(command) }
+      }
+    }
+
+    await store.send(.terminalEvent(.fontSizeChanged(18)))
+    await store.receive(\.settings.setTerminalFontSize) {
+      $0.settings.terminalFontSize = 18
+    }
+    await store.receive(\.settings.delegate.terminalFontSizeChanged)
+    await store.finish()
+
+    #expect(sentTerminalCommands.value.isEmpty)
+    #expect(watcherCommands.value.isEmpty)
+  }
 }

--- a/supacodeTests/SettingsFeatureTests.swift
+++ b/supacodeTests/SettingsFeatureTests.swift
@@ -253,4 +253,53 @@ struct SettingsFeatureTests {
     #expect(store.state.repositorySettings?.globalDefaultWorktreeBaseDirectoryPath == expectedPath)
     #expect(settingsFile.global.defaultWorktreeBaseDirectoryPath == expectedPath)
   }
+
+  @Test(.dependencies) func setTerminalFontSizePersistsWithoutAnalyticsOrGlobalFanout() async {
+    var initialSettings = GlobalSettings.default
+    initialSettings.analyticsEnabled = true
+    initialSettings.terminalFontSize = nil
+    @Shared(.settingsFile) var settingsFile
+    $settingsFile.withLock { $0.global = initialSettings }
+    let capturedEvents = LockIsolated<[String]>([])
+
+    let store = TestStore(initialState: SettingsFeature.State(settings: initialSettings)) {
+      SettingsFeature()
+    } withDependencies: {
+      $0.analyticsClient.capture = { event, _ in
+        capturedEvents.withValue { $0.append(event) }
+      }
+    }
+
+    await store.send(.setTerminalFontSize(18)) {
+      $0.terminalFontSize = 18
+    }
+    await store.receive(\.delegate.terminalFontSizeChanged)
+    await store.finish()
+
+    #expect(settingsFile.global.terminalFontSize == 18)
+    #expect(capturedEvents.value.isEmpty)
+  }
+
+  @Test(.dependencies) func setTerminalFontSizeIgnoresDuplicateValue() async {
+    var initialSettings = GlobalSettings.default
+    initialSettings.analyticsEnabled = true
+    initialSettings.terminalFontSize = 18
+    @Shared(.settingsFile) var settingsFile
+    $settingsFile.withLock { $0.global = initialSettings }
+    let capturedEvents = LockIsolated<[String]>([])
+
+    let store = TestStore(initialState: SettingsFeature.State(settings: initialSettings)) {
+      SettingsFeature()
+    } withDependencies: {
+      $0.analyticsClient.capture = { event, _ in
+        capturedEvents.withValue { $0.append(event) }
+      }
+    }
+
+    await store.send(.setTerminalFontSize(18))
+    await store.finish()
+
+    #expect(settingsFile.global.terminalFontSize == 18)
+    #expect(capturedEvents.value.isEmpty)
+  }
 }

--- a/supacodeTests/WorktreeTerminalManagerTests.swift
+++ b/supacodeTests/WorktreeTerminalManagerTests.swift
@@ -44,6 +44,74 @@ struct WorktreeTerminalManagerTests {
     #expect(event == .setupScriptConsumed(worktreeID: worktree.id))
   }
 
+  @Test func fontSizeResetToBaselineEmitsNilOverride() async {
+    let runtime = GhosttyRuntime()
+    let baseline = runtime.defaultFontSize()
+    let manager = WorktreeTerminalManager(runtime: runtime, preferredFontSize: baseline + 1)
+    let worktree = makeWorktree()
+    let state = manager.state(for: worktree)
+    let stream = manager.eventStream()
+    var iterator = stream.makeAsyncIterator()
+
+    state.onFontSizeChanged?(baseline)
+
+    var event: TerminalClient.Event?
+    while let next = await iterator.next() {
+      if case .fontSizeChanged = next {
+        event = next
+        break
+      }
+    }
+
+    #expect(event == .fontSizeChanged(nil))
+  }
+
+  @Test func duplicateFontSizeChangeIsDeduplicated() async {
+    let runtime = GhosttyRuntime()
+    let baseline = runtime.defaultFontSize()
+    let firstSize = baseline + 2
+    let secondSize = baseline + 3
+    let manager = WorktreeTerminalManager(runtime: runtime)
+    let worktree = makeWorktree()
+    let state = manager.state(for: worktree)
+    let stream = manager.eventStream()
+    var iterator = stream.makeAsyncIterator()
+
+    state.onFontSizeChanged?(firstSize)
+    state.onFontSizeChanged?(firstSize)
+    state.onFontSizeChanged?(secondSize)
+
+    var fontSizeEvents: [TerminalClient.Event] = []
+    while let next = await iterator.next() {
+      if case .fontSizeChanged = next {
+        fontSizeEvents.append(next)
+      }
+      if fontSizeEvents.count == 2 {
+        break
+      }
+    }
+
+    #expect(fontSizeEvents == [.fontSizeChanged(firstSize), .fontSizeChanged(secondSize)])
+  }
+
+  @Test func cellSizeChangeSkipsFirstEventPerSurface() {
+    let state = WorktreeTerminalState(runtime: GhosttyRuntime(), worktree: makeWorktree())
+    var captured: [Float32?] = []
+    let firstSurface = UUID()
+    let secondSurface = UUID()
+
+    state.onFontSizeChanged = { fontSize in
+      captured.append(fontSize)
+    }
+
+    state.handleCellSizeChange(forSurfaceID: firstSurface, fontSize: 13)
+    state.handleCellSizeChange(forSurfaceID: firstSurface, fontSize: 14)
+    state.handleCellSizeChange(forSurfaceID: secondSurface, fontSize: 15)
+    state.handleCellSizeChange(forSurfaceID: secondSurface, fontSize: 16)
+
+    #expect(captured == [14, 16])
+  }
+
   @Test func notificationIndicatorUsesCurrentCountOnStreamStart() async {
     let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
     let worktree = makeWorktree()


### PR DESCRIPTION
## Summary
- persist terminal font-size as a Prowl-local setting (`global.terminalFontSize`) instead of writing Ghostty config
- restore the saved font size when creating new terminal surfaces/tabs after app launch
- observe Ghostty cell-size changes to detect font-size adjustments and sync the setting automatically
- normalize saved value against Ghostty default `font-size` so reset-to-default clears the Prowl override

## Implementation details
- added `terminalFontSize` to `GlobalSettings` + `SettingsFeature` persistence flow
- initialized `WorktreeTerminalManager` with the saved setting at app boot
- propagated a new terminal event (`fontSizeChanged`) to update settings state
- wired a new `GhosttySurfaceBridge.onCellSizeChange` callback and handled it in `WorktreeTerminalState`

## Validation
- `xcodebuild build -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation 2>&1 | xcsift -f toon` ✅
- `xcodebuild build-for-testing -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation 2>&1 | xcsift -f toon` ✅
- `xcodebuild test ...` could not run on this host because test target requires macOS 26.1 while host is 26.0

## Scope
This PR intentionally covers only font-size persistence. Tab/pane layout persistence is out of scope for now.
