### PR TITLE
Harden install targets to prevent unsafe app deletion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,12 +63,21 @@ install-dev-build: build-app # install dev build to /Applications
 		echo "error: failed to resolve app path from build settings"; \
 		exit 1; \
 	fi; \
+	if [ "$$product" != "$$(basename "$$product")" ]; then \
+		echo "error: invalid product name (contains path separators): $$product"; \
+		exit 1; \
+	fi; \
 	if [[ "$$product" != *.app ]]; then \
 		echo "error: unexpected product name: $$product"; \
 		exit 1; \
 	fi; \
 	src="$$build_dir/$$product"; \
 	dst="/Applications/$$product"; \
+	dst_parent="$$(cd "$$(dirname "$$dst")" && pwd -P)"; \
+	if [ "$$dst_parent" != "/Applications" ]; then \
+		echo "error: refusing to install outside /Applications: $$dst"; \
+		exit 1; \
+	fi; \
 	if [ "$$src" = "/" ] || [ "$$dst" = "/Applications" ] || [ "$$dst" = "/Applications/" ]; then \
 		echo "error: unsafe install path (src=$$src, dst=$$dst)"; \
 		exit 1; \


### PR DESCRIPTION
## Summary
- harden `install-dev-build` path resolution and add strict guards for unsafe destinations
- enable explicit `set -euo pipefail` in run/install targets to avoid silent fallthrough
- replace destructive app replacement (`rm -rf`) with `trash` when destination exists
- keep release install target under the same `/Applications/*.app` safety constraints

## Validation
- `make build-app`
