### PR TITLE
fix: show opened tab count for plain folder in repo header

### DIFF
--- a/supacode/Features/Repositories/Views/RepositorySectionView.swift
+++ b/supacode/Features/Repositories/Views/RepositorySectionView.swift
@@ -40,9 +40,10 @@ struct RepositorySectionView: View {
       RepoHeaderRow(
         name: repository.name,
         isRemoving: isRemovingRepository,
-        tabCount: repository.worktrees.reduce(0) { count, worktree in
-          count + (terminalManager.stateIfExists(for: worktree.id)?.tabManager.tabs.count ?? 0)
-        }
+        tabCount: Self.openTabCount(
+          for: repository,
+          terminalManager: terminalManager
+        )
       )
       .frame(maxWidth: .infinity, alignment: .leading)
       .background {
@@ -213,5 +214,17 @@ struct RepositorySectionView: View {
 
   private var headerCellHeight: CGFloat {
     34
+  }
+
+  static func openTabCount(
+    for repository: Repository,
+    terminalManager: WorktreeTerminalManager
+  ) -> Int {
+    if repository.capabilities.supportsWorktrees {
+      return repository.worktrees.reduce(0) { count, worktree in
+        count + (terminalManager.stateIfExists(for: worktree.id)?.tabManager.tabs.count ?? 0)
+      }
+    }
+    return terminalManager.stateIfExists(for: repository.id)?.tabManager.tabs.count ?? 0
   }
 }

--- a/supacodeTests/RepositorySectionViewTests.swift
+++ b/supacodeTests/RepositorySectionViewTests.swift
@@ -1,0 +1,73 @@
+import Foundation
+import IdentifiedCollections
+import Testing
+
+@testable import supacode
+
+@MainActor
+struct RepositorySectionViewTests {
+  @Test func openTabCountForGitRepositorySumsAllWorktrees() {
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    let repositoryRootURL = URL(fileURLWithPath: "/tmp/repo")
+    let mainWorktree = Worktree(
+      id: "/tmp/repo/main",
+      name: "main",
+      detail: "main",
+      workingDirectory: URL(fileURLWithPath: "/tmp/repo/main"),
+      repositoryRootURL: repositoryRootURL
+    )
+    let featureWorktree = Worktree(
+      id: "/tmp/repo/feature",
+      name: "feature",
+      detail: "feature",
+      workingDirectory: URL(fileURLWithPath: "/tmp/repo/feature"),
+      repositoryRootURL: repositoryRootURL
+    )
+    let repository = Repository(
+      id: "/tmp/repo",
+      rootURL: repositoryRootURL,
+      name: "repo",
+      kind: .git,
+      worktrees: IdentifiedArray(uniqueElements: [mainWorktree, featureWorktree])
+    )
+
+    let mainState = manager.state(for: mainWorktree)
+    let featureState = manager.state(for: featureWorktree)
+    _ = mainState.tabManager.createTab(title: "main 1", icon: nil)
+    _ = mainState.tabManager.createTab(title: "main 2", icon: nil)
+    _ = featureState.tabManager.createTab(title: "feature 1", icon: nil)
+
+    #expect(
+      RepositorySectionView.openTabCount(for: repository, terminalManager: manager)
+        == 3
+    )
+  }
+
+  @Test func openTabCountForPlainFolderUsesRepositoryIDTerminalState() {
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    let repositoryRootURL = URL(fileURLWithPath: "/tmp/folder")
+    let repository = Repository(
+      id: "/tmp/folder",
+      rootURL: repositoryRootURL,
+      name: "folder",
+      kind: .plain,
+      worktrees: []
+    )
+    let terminalTarget = Worktree(
+      id: repository.id,
+      name: repository.name,
+      detail: repository.rootURL.path(percentEncoded: false),
+      workingDirectory: repository.rootURL,
+      repositoryRootURL: repository.rootURL
+    )
+
+    let state = manager.state(for: terminalTarget)
+    _ = state.tabManager.createTab(title: "folder 1", icon: nil)
+    _ = state.tabManager.createTab(title: "folder 2", icon: nil)
+
+    #expect(
+      RepositorySectionView.openTabCount(for: repository, terminalManager: manager)
+        == 2
+    )
+  }
+}


### PR DESCRIPTION
## Summary
- fix repo header tab count for plain folders by counting the terminal state keyed by `repository.id`
- keep existing worktree aggregation for git repositories
- extract counting logic into `RepositorySectionView.openTabCount` for reuse and testability
- add tests covering both git and plain folder counting paths

## Testing
- xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -only-testing:supacodeTests/RepositorySectionViewTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation
- make build-app
