### PR TITLE
docs(cli): define JSON contract for prowl key

### DIFF
--- a/doc-onevcat/contracts/cli/key.md
+++ b/doc-onevcat/contracts/cli/key.md
@@ -2,15 +2,39 @@
 
 Status: draft truth source for `#68`.
 
-This file defines the **JSON output contract** for:
+This file defines the **input/output contract** for:
 
 - `prowl key ... --json`
 
+## What changed in this revision
+
+Compared with the initial draft, this version makes `key` safer and more script-friendly:
+
+- define a strict input grammar with aliases (`return` -> `enter`, `escape` -> `esc`, `pgup` -> `pageup`, ...)
+- add `--repeat <n>` as first-class input instead of forcing shell loops
+- split `requested` vs `normalized` in output so callers can debug token normalization
+- add `delivery` counters for machine verification (`attempted` / `delivered`)
+- require `key` to target an existing pane context (no implicit tab creation)
+
 ## Contract goals
 
-- `key` must report which normalized key token was accepted and where it was delivered.
-- JSON output should be simple enough for agent loops: send key, then maybe read output.
-- The command should expose a canonical key token so scripts do not need to reverse-engineer internal AppKit details.
+- `key` should be deterministic for agent loops and TUI automation.
+- output must clearly answer:
+  - what was requested
+  - what token was actually accepted
+  - where it was delivered
+  - how many key events were delivered
+- keep key semantics separate from `send` (text input) and avoid hidden side effects.
+
+## Recommended usage
+
+- Prefer `--pane <id>` for deterministic scripting.
+- Use `--tab` / `--worktree` for human-friendly calls when exact pane ID is not needed.
+- Typical loop:
+  1) `prowl list --json`
+  2) resolve target pane
+  3) `prowl key --pane <pane-id> <token> [--repeat n]`
+  4) `prowl read --pane <pane-id> --last <n> --json`
 
 ## Supported targeting
 
@@ -19,7 +43,22 @@ This file defines the **JSON output contract** for:
 - `--pane <id>`
 - no selector, meaning current focused pane
 
-## v1 canonical key tokens
+## Input contract (v1)
+
+### Positional token
+
+```bash
+prowl key [target selectors] <token> [--repeat <n>] [--json]
+```
+
+Rules:
+
+- exactly one positional `<token>` is required
+- parsing is case-insensitive
+- surrounding spaces are ignored
+- canonical token form is lowercase kebab-case
+
+### Canonical tokens
 
 - `enter`
 - `esc`
@@ -37,6 +76,26 @@ This file defines the **JSON output contract** for:
 - `ctrl-d`
 - `ctrl-l`
 
+### Accepted aliases (normalized to canonical)
+
+- `return` -> `enter`
+- `escape` -> `esc`
+- `arrow-up` -> `up`
+- `arrow-down` -> `down`
+- `arrow-left` -> `left`
+- `arrow-right` -> `right`
+- `pgup` -> `pageup`
+- `pgdn` -> `pagedown`
+- `ctrl+c` -> `ctrl-c`
+- `ctrl+d` -> `ctrl-d`
+- `ctrl+l` -> `ctrl-l`
+
+### `--repeat`
+
+- optional, integer, default `1`
+- valid range in v1: `1...100`
+- repeat means “deliver the same normalized key token N times”
+
 ## Success payload
 
 ```json
@@ -45,6 +104,19 @@ This file defines the **JSON output contract** for:
   "command": "key",
   "schema_version": "prowl.cli.key.v1",
   "data": {
+    "requested": {
+      "token": "Ctrl+C",
+      "repeat": 3
+    },
+    "key": {
+      "normalized": "ctrl-c",
+      "category": "control"
+    },
+    "delivery": {
+      "attempted": 3,
+      "delivered": 3,
+      "mode": "keyDownUp"
+    },
     "target": {
       "worktree": {
         "id": "Prowl:/Users/onevcat/Projects/Prowl",
@@ -64,10 +136,6 @@ This file defines the **JSON output contract** for:
         "cwd": "/Users/onevcat/Projects/Prowl",
         "focused": true
       }
-    },
-    "key": {
-      "token": "ctrl-c",
-      "normalized": "ctrl-c"
     }
   }
 }
@@ -80,9 +148,36 @@ This file defines the **JSON output contract** for:
 - `schema_version`: string, currently `"prowl.cli.key.v1"`.
 - `data`: object.
 
-## `data.target` shape
+## `data` fields
 
-### `worktree`
+### `requested`
+
+- `token`: string
+  - raw user token after trimming
+- `repeat`: integer
+  - parsed repeat count
+
+### `key`
+
+- `normalized`: string
+  - canonical token used by runtime
+  - must be one of the canonical tokens listed above
+- `category`: `"navigation"` | `"editing"` | `"control"`
+
+### `delivery`
+
+- `attempted`: integer
+  - equals `requested.repeat`
+- `delivered`: integer
+  - number of successful key deliveries
+- `mode`: string
+  - `"keyDownUp"` for v1
+
+### `target`
+
+Same shape used by other CLI contracts:
+
+#### `worktree`
 
 - `id`: string
 - `name`: string
@@ -90,32 +185,27 @@ This file defines the **JSON output contract** for:
 - `root_path`: string, absolute path
 - `kind`: `"git"` | `"plain"`
 
-### `tab`
+#### `tab`
 
 - `id`: string, UUID text form
 - `title`: string
 - `selected`: boolean
 
-### `pane`
+#### `pane`
 
 - `id`: string, UUID text form
 - `title`: string
 - `cwd`: string or `null`
 - `focused`: boolean
 
-## `data.key` fields
-
-- `token`: string
-  - the token exactly accepted from the CLI after trimming and case normalization
-- `normalized`: string
-  - canonical token emitted by the runtime
-  - in v1, this should equal one of the tokens listed above
-
 ## Output invariants
 
-- The payload must resolve to the final pane that received the key event.
-- `normalized` exists so future aliases can still collapse to a stable form.
-- The JSON response does not need to expose low-level key codes or modifier masks.
+- payload must resolve to the final pane that received the key event(s)
+- `requested.token` may differ from `key.normalized` when an alias was used
+- `delivery.attempted == requested.repeat`
+- success requires `delivery.delivered == delivery.attempted`
+- unlike `send`, `key` must not create a new tab implicitly; no active pane means error
+- JSON should not expose low-level keycodes/modifier bitmasks in v1
 
 ## Error payload
 
@@ -138,18 +228,20 @@ This file defines the **JSON output contract** for:
 
 - `APP_NOT_RUNNING`
 - `INVALID_ARGUMENT`
+- `INVALID_REPEAT`
 - `TARGET_NOT_FOUND`
 - `TARGET_NOT_UNIQUE`
+- `NO_ACTIVE_PANE`
 - `UNSUPPORTED_KEY`
 - `KEY_DELIVERY_FAILED`
 
 ## Notes
 
-- v1 exposes command-level tokens, not a general keyboard encoding system.
-- The issue text calls out `pageup`, `pagedown`, `home`, and `end`; even if the first implementation is internally approximate, the outward token names should remain stable.
-- `key` is intentionally separate from `send`; it should never pretend that control keys are text input.
+- `key` is control/navigation input; normal text remains `send`.
+- aliases are accepted for UX, but output always returns canonical `normalized` token.
+- this contract intentionally allows future token aliases without breaking script logic.
 
-## Example: simple navigation key
+## Example: alias + repeat
 
 ```json
 {
@@ -157,6 +249,19 @@ This file defines the **JSON output contract** for:
   "command": "key",
   "schema_version": "prowl.cli.key.v1",
   "data": {
+    "requested": {
+      "token": "return",
+      "repeat": 2
+    },
+    "key": {
+      "normalized": "enter",
+      "category": "editing"
+    },
+    "delivery": {
+      "attempted": 2,
+      "delivered": 2,
+      "mode": "keyDownUp"
+    },
     "target": {
       "worktree": {
         "id": "Prowl:/Users/onevcat/Projects/Prowl",
@@ -172,14 +277,10 @@ This file defines the **JSON output contract** for:
       },
       "pane": {
         "id": "6E1A2A10-D99F-4E3F-920C-D93AA3C05764",
-        "title": "fzf",
+        "title": "zsh",
         "cwd": "/Users/onevcat/Projects/Prowl",
         "focused": true
       }
-    },
-    "key": {
-      "token": "down",
-      "normalized": "down"
     }
   }
 }


### PR DESCRIPTION
## Summary
- confirm current Prowl state for `key`: this is still **contract-first** (no CLI runtime implementation landed yet)
- refine `prowl key` from "output-only" draft to a full **input/output** contract
- add safer, script-friendly conventions:
  - strict canonical token grammar + alias normalization
  - `--repeat` input with bounded range
  - `requested` vs `normalized` in response
  - delivery counters (`attempted` / `delivered`)
  - explicit no-implicit-tab-creation rule for `key` (`NO_ACTIVE_PANE` on missing active pane)

## Why
Issue #68 is about reliable key-event delivery for TUI automation. The original draft described output shape but left ambiguity around input grammar, alias handling, and repeated delivery semantics.

This revision makes the command deterministic for agent loops and easier to validate.

## Links
- Parent issue: #70
- Related subtask: #68
