### PR TITLE
CLI/open: support prowl <cwd> and prowl open <cwd>

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,11 @@ run-app: build-app # Build then launch (Debug) with log streaming
 		echo "error: failed to resolve app path from build settings"; \
 		exit 1; \
 	fi; \
-	"$$build_dir/$$product/Contents/MacOS/$$exec_name"
+	app_bundle="$$build_dir/$$product"; \
+	app_exec="$$app_bundle/Contents/MacOS/$$exec_name"; \
+	echo "run-app: app bundle = $$app_bundle"; \
+	echo "run-app: executable = $$app_exec"; \
+	"$$app_exec"
 
 install-dev-build: build-app # install dev build to /Applications
 	@set -euo pipefail; \

--- a/README.md
+++ b/README.md
@@ -28,6 +28,24 @@ make test      # Run tests
 make format    # Run swift-format
 ```
 
+## Command Line (open-path entry)
+
+Prowl now ships a first-class CLI entry script at `bin/prowl`.
+
+```bash
+bin/prowl
+bin/prowl ~/Downloads
+bin/prowl .
+bin/prowl open ~/Projects/Prowl
+```
+
+Argument routing rules:
+- Reserved subcommands go to subcommand routing: `help version open list focus send key read`
+- Path-like first arguments route to open-path: `/...`, `./...`, `../...`, `~/...`, `file://...`, `.`, `..`
+- Other first arguments fail with usage error
+
+Current scope of this entrypoint is open-path (`prowl`, `prowl <path>`, `prowl open <path>`). The other reserved subcommands are intentionally reserved for upcoming first-class implementations.
+
 ## Contributing
 
 - I actual prefer a well written issue describing features/bugs u want rather than a vibe-coded PR

--- a/bin/prowl
+++ b/bin/prowl
@@ -89,6 +89,7 @@ on run argv
   set targetAlias to POSIX file targetPath
   tell application id appBundleID
     open targetAlias
+    activate
   end tell
 end run
 APPLESCRIPT

--- a/bin/prowl
+++ b/bin/prowl
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 APP_NAME="${PROWL_APP_NAME:-Prowl}"
+APP_BUNDLE_ID="${PROWL_APP_BUNDLE_ID:-com.onevcat.prowl}"
 
 usage() {
   cat <<'EOF'
@@ -61,9 +62,37 @@ PY
 launch_prowl() {
   if (($# == 0)); then
     open -a "$APP_NAME"
-  else
-    open -a "$APP_NAME" "$1"
+    return
   fi
+
+  local target_path="$1"
+  if app_is_running && open_path_in_running_app "$target_path"; then
+    return
+  fi
+
+  open -a "$APP_NAME" "$target_path"
+}
+
+app_is_running() {
+  local result
+  result="$(osascript -e "application id \"$APP_BUNDLE_ID\" is running" 2>/dev/null || true)"
+  [[ "$result" == "true" ]]
+}
+
+open_path_in_running_app() {
+  local target_path="$1"
+  osascript - "$APP_BUNDLE_ID" "$target_path" <<'APPLESCRIPT' >/dev/null 2>&1
+on run argv
+  if (count of argv) is not 2 then error "invalid argument count"
+  set appBundleID to item 1 of argv
+  set targetPath to item 2 of argv
+  set targetAlias to POSIX file targetPath
+  tell application id appBundleID
+    open targetAlias
+    activate
+  end tell
+end run
+APPLESCRIPT
 }
 
 print_version() {

--- a/bin/prowl
+++ b/bin/prowl
@@ -88,7 +88,9 @@ on run argv
   set targetPath to item 2 of argv
   set targetAlias to POSIX file targetPath
   tell application id appBundleID
-    open targetAlias
+    ignoring application responses
+      open targetAlias
+    end ignoring
   end tell
 end run
 APPLESCRIPT

--- a/bin/prowl
+++ b/bin/prowl
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_NAME="${PROWL_APP_NAME:-Prowl}"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  prowl
+  prowl <path>
+  prowl open <path>
+  prowl help
+  prowl version
+
+Reserved subcommands:
+  help version open list focus send key read
+
+Notes:
+  - <path> must look like a path: /... ./... ../... ~/... file://... . ..
+  - list/focus/send/key/read are reserved but not implemented in this build
+EOF
+}
+
+error() {
+  echo "prowl: $*" >&2
+}
+
+is_reserved_subcommand() {
+  case "$1" in
+    help | version | open | list | focus | send | key | read) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+is_path_like() {
+  case "$1" in
+    / | /* | ./* | ../* | ~ | ~/* | . | .. | file://*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+resolve_path() {
+  python3 - "$1" <<'PY'
+import os
+import sys
+import urllib.parse
+
+raw = sys.argv[1]
+if raw.startswith("file://"):
+    parsed = urllib.parse.urlparse(raw)
+    path = urllib.parse.unquote(parsed.path)
+else:
+    path = raw
+path = os.path.expanduser(path)
+if not os.path.isabs(path):
+    path = os.path.abspath(path)
+print(os.path.normpath(path))
+PY
+}
+
+launch_prowl() {
+  if (($# == 0)); then
+    open -a "$APP_NAME"
+  else
+    open -a "$APP_NAME" "$1"
+  fi
+}
+
+print_version() {
+  local app_path="/Applications/${APP_NAME}.app"
+  if [[ -d "$app_path" ]]; then
+    defaults read "$app_path/Contents/Info" CFBundleShortVersionString 2>/dev/null || echo "unknown"
+  else
+    echo "unknown"
+  fi
+}
+
+run_open() {
+  if (($# > 1)); then
+    error "too many arguments for open"
+    exit 64
+  fi
+
+  if (($# == 0)); then
+    launch_prowl
+    exit 0
+  fi
+
+  local raw_path="$1"
+  if ! is_path_like "$raw_path"; then
+    error "invalid path argument: $raw_path"
+    exit 64
+  fi
+
+  local resolved_path
+  resolved_path="$(resolve_path "$raw_path")"
+  if [[ ! -d "$resolved_path" ]]; then
+    error "directory not found: $resolved_path"
+    exit 66
+  fi
+
+  launch_prowl "$resolved_path"
+}
+
+if (($# == 0)); then
+  launch_prowl
+  exit 0
+fi
+
+first_arg="$1"
+shift
+
+if is_reserved_subcommand "$first_arg"; then
+  case "$first_arg" in
+    help)
+      usage
+      ;;
+    version)
+      print_version
+      ;;
+    open)
+      run_open "$@"
+      ;;
+    list | focus | send | key | read)
+      error "subcommand '$first_arg' is reserved but not implemented yet"
+      exit 2
+      ;;
+  esac
+  exit 0
+fi
+
+if is_path_like "$first_arg"; then
+  if (($# > 0)); then
+    error "unexpected extra arguments after path"
+    exit 64
+  fi
+  run_open "$first_arg"
+  exit 0
+fi
+
+error "unknown subcommand or invalid path: $first_arg"
+usage >&2
+exit 64

--- a/bin/prowl
+++ b/bin/prowl
@@ -89,7 +89,6 @@ on run argv
   set targetAlias to POSIX file targetPath
   tell application id appBundleID
     open targetAlias
-    activate
   end tell
 end run
 APPLESCRIPT

--- a/supacode/App/KeybindingSchema.swift
+++ b/supacode/App/KeybindingSchema.swift
@@ -133,24 +133,6 @@ nonisolated struct KeybindingCommandSchema: Codable, Equatable, Sendable {
   var allowUserOverride: Bool
   var conflictPolicy: KeybindingConflictPolicy
   var defaultBinding: Keybinding?
-
-  init(
-    id: String,
-    title: String,
-    scope: KeybindingScope,
-    platform: KeybindingPlatform,
-    allowUserOverride: Bool,
-    conflictPolicy: KeybindingConflictPolicy,
-    defaultBinding: Keybinding?
-  ) {
-    self.id = id
-    self.title = title
-    self.scope = scope
-    self.platform = platform
-    self.allowUserOverride = allowUserOverride
-    self.conflictPolicy = conflictPolicy
-    self.defaultBinding = defaultBinding
-  }
 }
 
 nonisolated struct KeybindingUserOverrideStore: Codable, Equatable, Sendable {

--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -14,7 +14,7 @@ import Sentry
 import Sharing
 import SwiftUI
 
-private let appOpenLogger = SupaLogger("AppOpen")
+private let cliLogger = SupaLogger("CLI")
 
 private enum GhosttyCLI {
   static let argv: [UnsafeMutablePointer<CChar>?] = {
@@ -81,7 +81,7 @@ final class SupacodeAppDelegate: NSObject, NSApplicationDelegate {
       return normalizedURL
     }
     guard !directoryURLs.isEmpty else { return }
-    appOpenLogger.info(
+    cliLogger.info(
       """
       handleExternalOpen received \(directoryURLs.count) directories. \
       hasStore=\(appStore != nil), launched=\(hasFinishedLaunching), \
@@ -91,16 +91,16 @@ final class SupacodeAppDelegate: NSObject, NSApplicationDelegate {
 
     if let appStore, hasFinishedLaunching {
       for directoryURL in directoryURLs {
-        appOpenLogger.info("Dispatch .openPath immediately: \(directoryURL.path(percentEncoded: false))")
+        cliLogger.info("Dispatch .openPath immediately: \(directoryURL.path(percentEncoded: false))")
         appStore.send(.repositories(.openPath(directoryURL)))
       }
     } else {
       pendingExternalOpenURLs.append(contentsOf: directoryURLs)
-      appOpenLogger.info("Queue external open URLs. pending=\(pendingExternalOpenURLs.count)")
+      cliLogger.info("Queue external open URLs. pending=\(pendingExternalOpenURLs.count)")
     }
 
     if shouldBringMainWindowToFront(from: application) {
-      appOpenLogger.info("Bring main window to front for external open.")
+      cliLogger.info("Bring main window to front for external open.")
       _ = showMainWindow(from: application)
     }
   }
@@ -111,9 +111,9 @@ final class SupacodeAppDelegate: NSObject, NSApplicationDelegate {
     guard let appStore else { return }
     let pendingURLs = pendingExternalOpenURLs
     pendingExternalOpenURLs.removeAll()
-    appOpenLogger.info("Flush pending external opens: \(pendingURLs.count)")
+    cliLogger.info("Flush pending external opens: \(pendingURLs.count)")
     for pendingURL in pendingURLs {
-      appOpenLogger.info("Dispatch pending .openPath: \(pendingURL.path(percentEncoded: false))")
+      cliLogger.info("Dispatch pending .openPath: \(pendingURL.path(percentEncoded: false))")
       appStore.send(.repositories(.openPath(pendingURL)))
     }
   }

--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -29,7 +29,12 @@ private enum GhosttyCLI {
 
 @MainActor
 final class SupacodeAppDelegate: NSObject, NSApplicationDelegate {
-  var appStore: StoreOf<AppFeature>?
+  var appStore: StoreOf<AppFeature>? {
+    didSet {
+      flushPendingExternalOpens()
+    }
+  }
+  private var pendingExternalOpenURLs: [URL] = []
 
   func applicationDidFinishLaunching(_ notification: Notification) {
     // Disable press-and-hold accent menu so that key repeat works in the terminal.
@@ -37,6 +42,17 @@ final class SupacodeAppDelegate: NSObject, NSApplicationDelegate {
       "ApplePressAndHoldEnabled": false,
     ])
     appStore?.send(.appLaunched)
+    flushPendingExternalOpens()
+  }
+
+  func application(_ application: NSApplication, open urls: [URL]) {
+    handleExternalOpen(urls: urls, application: application)
+  }
+
+  func application(_ sender: NSApplication, openFiles filenames: [String]) {
+    let urls = filenames.map { URL(fileURLWithPath: $0, isDirectory: true) }
+    handleExternalOpen(urls: urls, application: sender)
+    sender.reply(toOpenOrPrint: .success)
   }
 
   func applicationDidBecomeActive(_ notification: Notification) {
@@ -52,6 +68,43 @@ final class SupacodeAppDelegate: NSObject, NSApplicationDelegate {
 
   func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
     false
+  }
+
+  private func handleExternalOpen(urls: [URL], application: NSApplication) {
+    let directoryURLs = urls.compactMap { url -> URL? in
+      let normalizedURL = url.standardizedFileURL
+      guard directoryExists(at: normalizedURL) else {
+        return nil
+      }
+      return normalizedURL
+    }
+    guard !directoryURLs.isEmpty else { return }
+
+    if let appStore {
+      for directoryURL in directoryURLs {
+        appStore.send(.repositories(.openPath(directoryURL)))
+      }
+    } else {
+      pendingExternalOpenURLs.append(contentsOf: directoryURLs)
+    }
+
+    _ = showMainWindow(from: application)
+  }
+
+  private func flushPendingExternalOpens() {
+    guard !pendingExternalOpenURLs.isEmpty else { return }
+    guard let appStore else { return }
+    let pendingURLs = pendingExternalOpenURLs
+    pendingExternalOpenURLs.removeAll()
+    for pendingURL in pendingURLs {
+      appStore.send(.repositories(.openPath(pendingURL)))
+    }
+  }
+
+  private func directoryExists(at url: URL) -> Bool {
+    var isDirectory: ObjCBool = false
+    return FileManager.default.fileExists(atPath: url.path(percentEncoded: false), isDirectory: &isDirectory)
+      && isDirectory.boolValue
   }
 
   private func mainWindow(from sender: NSApplication) -> NSWindow? {

--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -110,10 +110,6 @@ final class SupacodeAppDelegate: NSObject, NSApplicationDelegate {
         self.pendingExternalOpenURLs.append(contentsOf: directoryURLs)
         cliLogger.info("Queue external open URLs. pending=\(self.pendingExternalOpenURLs.count)")
       }
-      if self.shouldBringMainWindowToFront(from: application) {
-        cliLogger.info("Show main window for external open.")
-        _ = self.showMainWindow(from: application)
-      }
     }
 
     if shouldActivateFirst {
@@ -142,10 +138,6 @@ final class SupacodeAppDelegate: NSObject, NSApplicationDelegate {
     var isDirectory: ObjCBool = false
     return FileManager.default.fileExists(atPath: url.path(percentEncoded: false), isDirectory: &isDirectory)
       && isDirectory.boolValue
-  }
-
-  private func shouldBringMainWindowToFront(from application: NSApplication) -> Bool {
-    return !application.windows.contains(where: \.isVisible)
   }
 
   private func mainWindow(from sender: NSApplication) -> NSWindow? {

--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -89,14 +89,35 @@ final class SupacodeAppDelegate: NSObject, NSApplicationDelegate {
       """
     )
 
-    if let appStore, hasFinishedLaunching {
-      for directoryURL in directoryURLs {
-        cliLogger.info("Dispatch .openPath: \(directoryURL.path(percentEncoded: false))")
-        appStore.send(.repositories(.openPath(directoryURL)))
+    let shouldActivateFirst = !application.isActive
+    if !application.isActive {
+      cliLogger.info("Activate app for external open.")
+      let activated = NSRunningApplication.current.activate(options: [
+        .activateIgnoringOtherApps,
+        .activateAllWindows,
+      ])
+      cliLogger.info("External open activate result: \(activated)")
+    }
+
+    let dispatchOpenPaths = { [weak self] in
+      guard let self else { return }
+      if let appStore = self.appStore, self.hasFinishedLaunching {
+        for directoryURL in directoryURLs {
+          cliLogger.info("Dispatch .openPath: \(directoryURL.path(percentEncoded: false))")
+          appStore.send(.repositories(.openPath(directoryURL)))
+        }
+      } else {
+        self.pendingExternalOpenURLs.append(contentsOf: directoryURLs)
+        cliLogger.info("Queue external open URLs. pending=\(self.pendingExternalOpenURLs.count)")
+      }
+    }
+
+    if shouldActivateFirst {
+      DispatchQueue.main.async {
+        dispatchOpenPaths()
       }
     } else {
-      pendingExternalOpenURLs.append(contentsOf: directoryURLs)
-      cliLogger.info("Queue external open URLs. pending=\(pendingExternalOpenURLs.count)")
+      dispatchOpenPaths()
     }
   }
 

--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -89,16 +89,7 @@ final class SupacodeAppDelegate: NSObject, NSApplicationDelegate {
       """
     )
 
-    if let appStore, hasFinishedLaunching {
-      for directoryURL in directoryURLs {
-        cliLogger.info("Dispatch .openPath immediately: \(directoryURL.path(percentEncoded: false))")
-        appStore.send(.repositories(.openPath(directoryURL)))
-      }
-    } else {
-      pendingExternalOpenURLs.append(contentsOf: directoryURLs)
-      cliLogger.info("Queue external open URLs. pending=\(pendingExternalOpenURLs.count)")
-    }
-
+    let shouldActivateFirst = !application.isActive
     if !application.isActive {
       cliLogger.info("Activate app for external open.")
       let activated = NSRunningApplication.current.activate(options: [
@@ -106,11 +97,31 @@ final class SupacodeAppDelegate: NSObject, NSApplicationDelegate {
         .activateAllWindows,
       ])
       cliLogger.info("External open activate result: \(activated)")
-      return
     }
-    if shouldBringMainWindowToFront(from: application) {
-      cliLogger.info("Show main window for external open (app already active).")
-      _ = showMainWindow(from: application)
+
+    let dispatchOpenPaths = { [weak self] in
+      guard let self else { return }
+      if let appStore = self.appStore, self.hasFinishedLaunching {
+        for directoryURL in directoryURLs {
+          cliLogger.info("Dispatch .openPath: \(directoryURL.path(percentEncoded: false))")
+          appStore.send(.repositories(.openPath(directoryURL)))
+        }
+      } else {
+        self.pendingExternalOpenURLs.append(contentsOf: directoryURLs)
+        cliLogger.info("Queue external open URLs. pending=\(self.pendingExternalOpenURLs.count)")
+      }
+      if self.shouldBringMainWindowToFront(from: application) {
+        cliLogger.info("Show main window for external open.")
+        _ = self.showMainWindow(from: application)
+      }
+    }
+
+    if shouldActivateFirst {
+      DispatchQueue.main.async {
+        dispatchOpenPaths()
+      }
+    } else {
+      dispatchOpenPaths()
     }
   }
 

--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -14,6 +14,8 @@ import Sentry
 import Sharing
 import SwiftUI
 
+private let appOpenLogger = SupaLogger("AppOpen")
+
 private enum GhosttyCLI {
   static let argv: [UnsafeMutablePointer<CChar>?] = {
     var args: [UnsafeMutablePointer<CChar>?] = []
@@ -29,20 +31,20 @@ private enum GhosttyCLI {
 
 @MainActor
 final class SupacodeAppDelegate: NSObject, NSApplicationDelegate {
-  var appStore: StoreOf<AppFeature>? {
-    didSet {
-      flushPendingExternalOpens()
-    }
-  }
+  var appStore: StoreOf<AppFeature>?
   private var pendingExternalOpenURLs: [URL] = []
+  private var hasFinishedLaunching = false
 
   func applicationDidFinishLaunching(_ notification: Notification) {
     // Disable press-and-hold accent menu so that key repeat works in the terminal.
     UserDefaults.standard.register(defaults: [
       "ApplePressAndHoldEnabled": false
     ])
+    hasFinishedLaunching = true
     appStore?.send(.appLaunched)
-    flushPendingExternalOpens()
+    DispatchQueue.main.async { [weak self] in
+      self?.flushPendingExternalOpens()
+    }
   }
 
   func application(_ application: NSApplication, open urls: [URL]) {
@@ -79,26 +81,39 @@ final class SupacodeAppDelegate: NSObject, NSApplicationDelegate {
       return normalizedURL
     }
     guard !directoryURLs.isEmpty else { return }
+    appOpenLogger.info(
+      """
+      handleExternalOpen received \(directoryURLs.count) directories. \
+      hasStore=\(appStore != nil), launched=\(hasFinishedLaunching), \
+      appActive=\(application.isActive), visibleWindows=\(application.windows.filter(\.isVisible).count)
+      """
+    )
 
-    if let appStore {
+    if let appStore, hasFinishedLaunching {
       for directoryURL in directoryURLs {
+        appOpenLogger.info("Dispatch .openPath immediately: \(directoryURL.path(percentEncoded: false))")
         appStore.send(.repositories(.openPath(directoryURL)))
       }
     } else {
       pendingExternalOpenURLs.append(contentsOf: directoryURLs)
+      appOpenLogger.info("Queue external open URLs. pending=\(pendingExternalOpenURLs.count)")
     }
 
     if shouldBringMainWindowToFront(from: application) {
+      appOpenLogger.info("Bring main window to front for external open.")
       _ = showMainWindow(from: application)
     }
   }
 
   private func flushPendingExternalOpens() {
     guard !pendingExternalOpenURLs.isEmpty else { return }
+    guard hasFinishedLaunching else { return }
     guard let appStore else { return }
     let pendingURLs = pendingExternalOpenURLs
     pendingExternalOpenURLs.removeAll()
+    appOpenLogger.info("Flush pending external opens: \(pendingURLs.count)")
     for pendingURL in pendingURLs {
+      appOpenLogger.info("Dispatch pending .openPath: \(pendingURL.path(percentEncoded: false))")
       appStore.send(.repositories(.openPath(pendingURL)))
     }
   }

--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -39,7 +39,7 @@ final class SupacodeAppDelegate: NSObject, NSApplicationDelegate {
   func applicationDidFinishLaunching(_ notification: Notification) {
     // Disable press-and-hold accent menu so that key repeat works in the terminal.
     UserDefaults.standard.register(defaults: [
-      "ApplePressAndHoldEnabled": false,
+      "ApplePressAndHoldEnabled": false
     ])
     appStore?.send(.appLaunched)
     flushPendingExternalOpens()
@@ -88,7 +88,9 @@ final class SupacodeAppDelegate: NSObject, NSApplicationDelegate {
       pendingExternalOpenURLs.append(contentsOf: directoryURLs)
     }
 
-    _ = showMainWindow(from: application)
+    if shouldBringMainWindowToFront(from: application) {
+      _ = showMainWindow(from: application)
+    }
   }
 
   private func flushPendingExternalOpens() {
@@ -105,6 +107,13 @@ final class SupacodeAppDelegate: NSObject, NSApplicationDelegate {
     var isDirectory: ObjCBool = false
     return FileManager.default.fileExists(atPath: url.path(percentEncoded: false), isDirectory: &isDirectory)
       && isDirectory.boolValue
+  }
+
+  private func shouldBringMainWindowToFront(from application: NSApplication) -> Bool {
+    if !application.isActive {
+      return true
+    }
+    return !application.windows.contains(where: \.isVisible)
   }
 
   private func mainWindow(from sender: NSApplication) -> NSWindow? {

--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -89,35 +89,14 @@ final class SupacodeAppDelegate: NSObject, NSApplicationDelegate {
       """
     )
 
-    let shouldActivateFirst = !application.isActive
-    if !application.isActive {
-      cliLogger.info("Activate app for external open.")
-      let activated = NSRunningApplication.current.activate(options: [
-        .activateIgnoringOtherApps,
-        .activateAllWindows,
-      ])
-      cliLogger.info("External open activate result: \(activated)")
-    }
-
-    let dispatchOpenPaths = { [weak self] in
-      guard let self else { return }
-      if let appStore = self.appStore, self.hasFinishedLaunching {
-        for directoryURL in directoryURLs {
-          cliLogger.info("Dispatch .openPath: \(directoryURL.path(percentEncoded: false))")
-          appStore.send(.repositories(.openPath(directoryURL)))
-        }
-      } else {
-        self.pendingExternalOpenURLs.append(contentsOf: directoryURLs)
-        cliLogger.info("Queue external open URLs. pending=\(self.pendingExternalOpenURLs.count)")
-      }
-    }
-
-    if shouldActivateFirst {
-      DispatchQueue.main.async {
-        dispatchOpenPaths()
+    if let appStore, hasFinishedLaunching {
+      for directoryURL in directoryURLs {
+        cliLogger.info("Dispatch .openPath: \(directoryURL.path(percentEncoded: false))")
+        appStore.send(.repositories(.openPath(directoryURL)))
       }
     } else {
-      dispatchOpenPaths()
+      pendingExternalOpenURLs.append(contentsOf: directoryURLs)
+      cliLogger.info("Queue external open URLs. pending=\(pendingExternalOpenURLs.count)")
     }
   }
 

--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -99,9 +99,16 @@ final class SupacodeAppDelegate: NSObject, NSApplicationDelegate {
       cliLogger.info("Queue external open URLs. pending=\(pendingExternalOpenURLs.count)")
     }
 
-    if shouldBringMainWindowToFront(from: application) {
-      cliLogger.info("Bring main window to front for external open.")
-      _ = showMainWindow(from: application)
+    if !application.isActive {
+      cliLogger.info("Activate app for external open.")
+      application.activate(ignoringOtherApps: true)
+    }
+    DispatchQueue.main.async { [weak self] in
+      guard let self else { return }
+      if self.shouldBringMainWindowToFront(from: application) {
+        cliLogger.info("Show main window for external open (deferred).")
+        _ = self.showMainWindow(from: application)
+      }
     }
   }
 
@@ -125,9 +132,6 @@ final class SupacodeAppDelegate: NSObject, NSApplicationDelegate {
   }
 
   private func shouldBringMainWindowToFront(from application: NSApplication) -> Bool {
-    if !application.isActive {
-      return true
-    }
     return !application.windows.contains(where: \.isVisible)
   }
 

--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -101,14 +101,16 @@ final class SupacodeAppDelegate: NSObject, NSApplicationDelegate {
 
     if !application.isActive {
       cliLogger.info("Activate app for external open.")
-      application.activate(ignoringOtherApps: true)
+      let activated = NSRunningApplication.current.activate(options: [
+        .activateIgnoringOtherApps,
+        .activateAllWindows,
+      ])
+      cliLogger.info("External open activate result: \(activated)")
+      return
     }
-    DispatchQueue.main.async { [weak self] in
-      guard let self else { return }
-      if self.shouldBringMainWindowToFront(from: application) {
-        cliLogger.info("Show main window for external open (deferred).")
-        _ = self.showMainWindow(from: application)
-      }
+    if shouldBringMainWindowToFront(from: application) {
+      cliLogger.info("Show main window for external open (app already active).")
+      _ = showMainWindow(from: application)
     }
   }
 

--- a/supacode/Clients/Terminal/TerminalClient.swift
+++ b/supacode/Clients/Terminal/TerminalClient.swift
@@ -8,6 +8,7 @@ struct TerminalClient {
 
   enum Command: Equatable {
     case createTab(Worktree, runSetupScriptIfNew: Bool)
+    case createTabAtDirectory(Worktree, directory: URL, runSetupScriptIfNew: Bool)
     case createTabWithInput(Worktree, input: String, runSetupScriptIfNew: Bool)
     case ensureInitialTab(Worktree, runSetupScriptIfNew: Bool, focusing: Bool)
     case runScript(Worktree, script: String)

--- a/supacode/Features/Canvas/Views/CanvasView.swift
+++ b/supacode/Features/Canvas/Views/CanvasView.swift
@@ -409,10 +409,10 @@ struct CanvasView: View {
           "Broadcasting to \(selectionState.selectedTabIDs.count) cards",
           systemImage: "dot.radiowaves.left.and.right"
         )
-          .font(.callout)
-          .padding(.horizontal, 10)
-          .padding(.vertical, 6)
-          .background(.bar, in: Capsule())
+        .font(.callout)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(.bar, in: Capsule())
       }
 
       Button {

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -71,6 +71,7 @@ struct RepositoriesFeature {
     var worktreeOrderByRepository: [Repository.ID: [Worktree.ID]] = [:]
     var isOpenPanelPresented = false
     var isInitialLoadComplete = false
+    var hasCompletedInitialRepositoryLoad = true
     var pendingWorktrees: [PendingWorktree] = []
     var pendingSetupScriptWorktreeIDs: Set<Worktree.ID> = []
     var pendingTerminalFocusWorktreeIDs: Set<Worktree.ID> = []
@@ -313,6 +314,7 @@ struct RepositoriesFeature {
     Reduce { state, action in
       switch action {
       case .task:
+        state.hasCompletedInitialRepositoryLoad = false
         return .run { send in
           let pinned = await repositoryPersistence.loadPinnedWorktreeIDs()
           let archived = await repositoryPersistence.loadArchivedWorktreeIDs()
@@ -331,6 +333,11 @@ struct RepositoriesFeature {
         }
 
       case .repositorySnapshotLoaded(let repositories):
+        if state.pendingExternalOpenPath != nil,
+          !state.hasCompletedInitialRepositoryLoad
+        {
+          return .none
+        }
         guard let repositories, !repositories.isEmpty else {
           return .none
         }
@@ -424,6 +431,7 @@ struct RepositoriesFeature {
 
       case .repositoriesLoaded(let repositories, let failures, let roots, let animated):
         state.isRefreshingWorktrees = false
+        state.hasCompletedInitialRepositoryLoad = true
         let previousSelection = state.selectedWorktreeID
         let previousSelectedWorktree = state.worktree(for: previousSelection)
         let incomingRepositories = IdentifiedArray(uniqueElements: repositories)
@@ -499,8 +507,13 @@ struct RepositoriesFeature {
 
       case .openPath(let requestedURL):
         let normalizedRequestedURL = requestedURL.standardizedFileURL
-        guard state.isInitialLoadComplete else {
+        guard state.hasCompletedInitialRepositoryLoad else {
           state.pendingExternalOpenPath = normalizedRequestedURL
+          state.selection = nil
+          state.sidebarSelectedWorktreeIDs = []
+          state.pendingTerminalFocusWorktreeIDs = []
+          state.shouldRestoreLastFocusedWorktree = false
+          state.shouldSelectFirstAfterReload = false
           return .none
         }
         guard let match = state.openPathMatch(for: normalizedRequestedURL) else {
@@ -609,6 +622,7 @@ struct RepositoriesFeature {
         let pendingExternalOpenPath = state.pendingExternalOpenPath
         state.pendingExternalOpenPath = nil
         state.isRefreshingWorktrees = false
+        state.hasCompletedInitialRepositoryLoad = true
         let previousSelection = state.selectedWorktreeID
         let previousSelectedWorktree = state.worktree(for: previousSelection)
         let applyResult = applyRepositories(
@@ -2028,7 +2042,7 @@ struct RepositoriesFeature {
         var effects: [Effect<Action>] = [
           .run { _ in
             await repositoryPersistence.savePinnedWorktreeIDs(pinnedWorktreeIDs)
-          },
+          }
         ]
         if didUpdateWorktreeOrder {
           let worktreeOrderByRepository = state.worktreeOrderByRepository
@@ -2055,7 +2069,7 @@ struct RepositoriesFeature {
         var effects: [Effect<Action>] = [
           .run { _ in
             await repositoryPersistence.savePinnedWorktreeIDs(pinnedWorktreeIDs)
-          },
+          }
         ]
         if didUpdateWorktreeOrder {
           let worktreeOrderByRepository = state.worktreeOrderByRepository
@@ -3370,7 +3384,7 @@ extension RepositoriesFeature.State {
               workingDirectory: repository.rootURL,
               repositoryRootURL: repository.rootURL
             )
-          ),
+          )
         ]
       }
       return []

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -24,7 +24,7 @@ private nonisolated let githubIntegrationRecoveryInterval: Duration = .seconds(1
 private nonisolated let worktreeCreationProgressLineLimit = 200
 private nonisolated let worktreeCreationProgressUpdateStride = 20
 private nonisolated let archiveScriptProgressLineLimit = 200
-private let repositoriesOpenLogger = SupaLogger("RepoOpen")
+private let cliLogger = SupaLogger("CLI")
 
 nonisolated struct WorktreeCreationProgressUpdateThrottle {
   private let stride: Int
@@ -316,7 +316,7 @@ struct RepositoriesFeature {
       switch action {
       case .task:
         state.hasCompletedInitialRepositoryLoad = false
-        repositoriesOpenLogger.info("Initial repository load started.")
+        cliLogger.info("Initial repository load started.")
         return .run { send in
           let pinned = await repositoryPersistence.loadPinnedWorktreeIDs()
           let archived = await repositoryPersistence.loadArchivedWorktreeIDs()
@@ -338,7 +338,7 @@ struct RepositoriesFeature {
         if state.pendingExternalOpenPath != nil,
           !state.hasCompletedInitialRepositoryLoad
         {
-          repositoriesOpenLogger.info("Skip snapshot restore due to pending external open path.")
+          cliLogger.info("Skip snapshot restore due to pending external open path.")
           return .none
         }
         guard let repositories, !repositories.isEmpty else {
@@ -503,7 +503,7 @@ struct RepositoriesFeature {
           )
         }
         if let pendingExternalOpenPath = state.pendingExternalOpenPath {
-          repositoriesOpenLogger.info(
+          cliLogger.info(
             "Replay pending external open path after repositoriesLoaded: \(pendingExternalOpenPath.path(percentEncoded: false))"
           )
           state.pendingExternalOpenPath = nil
@@ -513,7 +513,7 @@ struct RepositoriesFeature {
 
       case .openPath(let requestedURL):
         let normalizedRequestedURL = requestedURL.standardizedFileURL
-        repositoriesOpenLogger.info(
+        cliLogger.info(
           "Handle .openPath: \(normalizedRequestedURL.path(percentEncoded: false)), initialLoadComplete=\(state.hasCompletedInitialRepositoryLoad)"
         )
         guard state.hasCompletedInitialRepositoryLoad else {
@@ -523,15 +523,15 @@ struct RepositoriesFeature {
           state.pendingTerminalFocusWorktreeIDs = []
           state.shouldRestoreLastFocusedWorktree = false
           state.shouldSelectFirstAfterReload = false
-          repositoriesOpenLogger.info("Queue .openPath until initial repository load completes.")
+          cliLogger.info("Queue .openPath until initial repository load completes.")
           return .none
         }
         guard let match = state.openPathMatch(for: normalizedRequestedURL) else {
           state.pendingExternalOpenPath = normalizedRequestedURL
-          repositoriesOpenLogger.info("No in-memory match for .openPath. Trigger openRepositories.")
+          cliLogger.info("No in-memory match for .openPath. Trigger openRepositories.")
           return .send(.openRepositories([normalizedRequestedURL]))
         }
-        repositoriesOpenLogger.info(
+        cliLogger.info(
           "Matched .openPath to selection=\(String(describing: match.selection)) resolution=\(String(describing: match.resolution))"
         )
 
@@ -573,7 +573,7 @@ struct RepositoriesFeature {
         return .merge(effects)
 
       case .openRepositories(let urls):
-        repositoriesOpenLogger.info("openRepositories called with \(urls.count) URL(s).")
+        cliLogger.info("openRepositories called with \(urls.count) URL(s).")
         analyticsClient.capture("repository_added", ["count": urls.count])
         state.alert = nil
         return .run { send in
@@ -634,7 +634,7 @@ struct RepositoriesFeature {
         let openFailures,
         let roots
       ):
-        repositoriesOpenLogger.info(
+        cliLogger.info(
           """
           openRepositoriesFinished repositories=\(repositories.count), failures=\(failures.count), \
           invalidRoots=\(invalidRoots.count), openFailures=\(openFailures.count)
@@ -718,7 +718,7 @@ struct RepositoriesFeature {
         if let pendingExternalOpenPath,
           state.openPathMatch(for: pendingExternalOpenPath) != nil
         {
-          repositoriesOpenLogger.info(
+          cliLogger.info(
             "Replay pending external open path after openRepositoriesFinished: \(pendingExternalOpenPath.path(percentEncoded: false))"
           )
           allEffects.append(.send(.openPath(pendingExternalOpenPath)))

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -536,13 +536,9 @@ struct RepositoriesFeature {
         )
 
         var effects: [Effect<Action>] = []
-        switch match.selection {
-        case .worktree(let worktreeID):
-          effects.append(.send(.selectWorktree(worktreeID, focusTerminal: true)))
-        case .repository(let repositoryID):
-          effects.append(.send(.selectRepository(repositoryID)))
-        }
-
+        // Prepare destination terminal state before switching selection.
+        // This avoids a transient fully-occluded frame while the destination
+        // terminal is still being created.
         switch match.resolution {
         case .exactRoot:
           effects.append(
@@ -568,6 +564,13 @@ struct RepositoriesFeature {
               )
             }
           )
+        }
+
+        switch match.selection {
+        case .worktree(let worktreeID):
+          effects.append(.send(.selectWorktree(worktreeID, focusTerminal: true)))
+        case .repository(let repositoryID):
+          effects.append(.send(.selectRepository(repositoryID)))
         }
 
         return .merge(effects)

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -24,6 +24,7 @@ private nonisolated let githubIntegrationRecoveryInterval: Duration = .seconds(1
 private nonisolated let worktreeCreationProgressLineLimit = 200
 private nonisolated let worktreeCreationProgressUpdateStride = 20
 private nonisolated let archiveScriptProgressLineLimit = 200
+private let repositoriesOpenLogger = SupaLogger("RepoOpen")
 
 nonisolated struct WorktreeCreationProgressUpdateThrottle {
   private let stride: Int
@@ -71,7 +72,7 @@ struct RepositoriesFeature {
     var worktreeOrderByRepository: [Repository.ID: [Worktree.ID]] = [:]
     var isOpenPanelPresented = false
     var isInitialLoadComplete = false
-    var hasCompletedInitialRepositoryLoad = true
+    var hasCompletedInitialRepositoryLoad = false
     var pendingWorktrees: [PendingWorktree] = []
     var pendingSetupScriptWorktreeIDs: Set<Worktree.ID> = []
     var pendingTerminalFocusWorktreeIDs: Set<Worktree.ID> = []
@@ -315,6 +316,7 @@ struct RepositoriesFeature {
       switch action {
       case .task:
         state.hasCompletedInitialRepositoryLoad = false
+        repositoriesOpenLogger.info("Initial repository load started.")
         return .run { send in
           let pinned = await repositoryPersistence.loadPinnedWorktreeIDs()
           let archived = await repositoryPersistence.loadArchivedWorktreeIDs()
@@ -336,6 +338,7 @@ struct RepositoriesFeature {
         if state.pendingExternalOpenPath != nil,
           !state.hasCompletedInitialRepositoryLoad
         {
+          repositoriesOpenLogger.info("Skip snapshot restore due to pending external open path.")
           return .none
         }
         guard let repositories, !repositories.isEmpty else {
@@ -500,6 +503,9 @@ struct RepositoriesFeature {
           )
         }
         if let pendingExternalOpenPath = state.pendingExternalOpenPath {
+          repositoriesOpenLogger.info(
+            "Replay pending external open path after repositoriesLoaded: \(pendingExternalOpenPath.path(percentEncoded: false))"
+          )
           state.pendingExternalOpenPath = nil
           allEffects.append(.send(.openPath(pendingExternalOpenPath)))
         }
@@ -507,6 +513,9 @@ struct RepositoriesFeature {
 
       case .openPath(let requestedURL):
         let normalizedRequestedURL = requestedURL.standardizedFileURL
+        repositoriesOpenLogger.info(
+          "Handle .openPath: \(normalizedRequestedURL.path(percentEncoded: false)), initialLoadComplete=\(state.hasCompletedInitialRepositoryLoad)"
+        )
         guard state.hasCompletedInitialRepositoryLoad else {
           state.pendingExternalOpenPath = normalizedRequestedURL
           state.selection = nil
@@ -514,12 +523,17 @@ struct RepositoriesFeature {
           state.pendingTerminalFocusWorktreeIDs = []
           state.shouldRestoreLastFocusedWorktree = false
           state.shouldSelectFirstAfterReload = false
+          repositoriesOpenLogger.info("Queue .openPath until initial repository load completes.")
           return .none
         }
         guard let match = state.openPathMatch(for: normalizedRequestedURL) else {
           state.pendingExternalOpenPath = normalizedRequestedURL
+          repositoriesOpenLogger.info("No in-memory match for .openPath. Trigger openRepositories.")
           return .send(.openRepositories([normalizedRequestedURL]))
         }
+        repositoriesOpenLogger.info(
+          "Matched .openPath to selection=\(String(describing: match.selection)) resolution=\(String(describing: match.resolution))"
+        )
 
         var effects: [Effect<Action>] = []
         switch match.selection {
@@ -559,6 +573,7 @@ struct RepositoriesFeature {
         return .merge(effects)
 
       case .openRepositories(let urls):
+        repositoriesOpenLogger.info("openRepositories called with \(urls.count) URL(s).")
         analyticsClient.capture("repository_added", ["count": urls.count])
         state.alert = nil
         return .run { send in
@@ -619,6 +634,12 @@ struct RepositoriesFeature {
         let openFailures,
         let roots
       ):
+        repositoriesOpenLogger.info(
+          """
+          openRepositoriesFinished repositories=\(repositories.count), failures=\(failures.count), \
+          invalidRoots=\(invalidRoots.count), openFailures=\(openFailures.count)
+          """
+        )
         let pendingExternalOpenPath = state.pendingExternalOpenPath
         state.pendingExternalOpenPath = nil
         state.isRefreshingWorktrees = false
@@ -697,6 +718,9 @@ struct RepositoriesFeature {
         if let pendingExternalOpenPath,
           state.openPathMatch(for: pendingExternalOpenPath) != nil
         {
+          repositoriesOpenLogger.info(
+            "Replay pending external open path after openRepositoriesFinished: \(pendingExternalOpenPath.path(percentEncoded: false))"
+          )
           allEffects.append(.send(.openPath(pendingExternalOpenPath)))
         }
         return .merge(allEffects)

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -394,7 +394,7 @@ struct RepositoriesFeature {
 
       case .lastFocusedWorktreeIDLoaded(let lastFocusedWorktreeID):
         state.lastFocusedWorktreeID = lastFocusedWorktreeID
-        state.shouldRestoreLastFocusedWorktree = true
+        state.shouldRestoreLastFocusedWorktree = state.pendingExternalOpenPath == nil
         return .none
 
       case .setOpenPanelPresented(let isPresented):

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -491,10 +491,18 @@ struct RepositoriesFeature {
             }
           )
         }
+        if let pendingExternalOpenPath = state.pendingExternalOpenPath {
+          state.pendingExternalOpenPath = nil
+          allEffects.append(.send(.openPath(pendingExternalOpenPath)))
+        }
         return .merge(allEffects)
 
       case .openPath(let requestedURL):
         let normalizedRequestedURL = requestedURL.standardizedFileURL
+        guard state.isInitialLoadComplete else {
+          state.pendingExternalOpenPath = normalizedRequestedURL
+          return .none
+        }
         guard let match = state.openPathMatch(for: normalizedRequestedURL) else {
           state.pendingExternalOpenPath = normalizedRequestedURL
           return .send(.openRepositories([normalizedRequestedURL]))
@@ -2825,7 +2833,7 @@ struct RepositoriesFeature {
   }
 
   private nonisolated static func isNotGitRepositoryError(_ error: any Error) -> Bool {
-    guard case let GitClientError.commandFailed(_, message) = error else {
+    guard case GitClientError.commandFailed(_, let message) = error else {
       return false
     }
     return message.localizedCaseInsensitiveContains("not a git repository")
@@ -2833,7 +2841,7 @@ struct RepositoriesFeature {
 
   private nonisolated static func openRepositoryFailureMessage(path: String, error: any Error) -> String {
     let detail: String
-    if case let GitClientError.commandFailed(_, message) = error,
+    if case GitClientError.commandFailed(_, let message) = error,
       !message.isEmpty
     {
       detail = message
@@ -2905,14 +2913,14 @@ struct RepositoriesFeature {
             return WorktreesFetchResult(
               entry: entry,
               repository: Repository(
-                  id: rootURL.path(percentEncoded: false),
-                  rootURL: rootURL,
-                  name: Repository.name(for: rootURL),
-                  kind: .plain,
-                  worktrees: IdentifiedArray()
-                ),
-                errorMessage: nil
-              )
+                id: rootURL.path(percentEncoded: false),
+                rootURL: rootURL,
+                name: Repository.name(for: rootURL),
+                kind: .plain,
+                worktrees: IdentifiedArray()
+              ),
+              errorMessage: nil
+            )
           }
         }
       }

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -88,6 +88,7 @@ struct RepositoriesFeature {
     var shouldRestoreLastFocusedWorktree = false
     var shouldSelectFirstAfterReload = false
     var isRefreshingWorktrees = false
+    var pendingExternalOpenPath: URL?
     var statusToast: StatusToast?
     var githubIntegrationAvailability: GithubIntegrationAvailability = .unknown
     var pendingPullRequestRefreshByRepositoryID: [Repository.ID: PendingPullRequestRefresh] = [:]
@@ -139,6 +140,7 @@ struct RepositoriesFeature {
     case selectCanvas
     case toggleCanvas
     case setSidebarSelectedWorktreeIDs(Set<Worktree.ID>)
+    case openPath(URL)
     case openRepositories([URL])
     case openRepositoriesFinished(
       [Repository],
@@ -491,6 +493,50 @@ struct RepositoriesFeature {
         }
         return .merge(allEffects)
 
+      case .openPath(let requestedURL):
+        let normalizedRequestedURL = requestedURL.standardizedFileURL
+        guard let match = state.openPathMatch(for: normalizedRequestedURL) else {
+          state.pendingExternalOpenPath = normalizedRequestedURL
+          return .send(.openRepositories([normalizedRequestedURL]))
+        }
+
+        var effects: [Effect<Action>] = []
+        switch match.selection {
+        case .worktree(let worktreeID):
+          effects.append(.send(.selectWorktree(worktreeID, focusTerminal: true)))
+        case .repository(let repositoryID):
+          effects.append(.send(.selectRepository(repositoryID)))
+        }
+
+        switch match.resolution {
+        case .exactRoot:
+          effects.append(
+            .run { _ in
+              await terminalClient.send(
+                .ensureInitialTab(
+                  match.worktree,
+                  runSetupScriptIfNew: false,
+                  focusing: true
+                )
+              )
+            }
+          )
+        case .insideRoot:
+          effects.append(
+            .run { _ in
+              await terminalClient.send(
+                .createTabAtDirectory(
+                  match.worktree,
+                  directory: normalizedRequestedURL,
+                  runSetupScriptIfNew: false
+                )
+              )
+            }
+          )
+        }
+
+        return .merge(effects)
+
       case .openRepositories(let urls):
         analyticsClient.capture("repository_added", ["count": urls.count])
         state.alert = nil
@@ -552,6 +598,8 @@ struct RepositoriesFeature {
         let openFailures,
         let roots
       ):
+        let pendingExternalOpenPath = state.pendingExternalOpenPath
+        state.pendingExternalOpenPath = nil
         state.isRefreshingWorktrees = false
         let previousSelection = state.selectedWorktreeID
         let previousSelectedWorktree = state.worktree(for: previousSelection)
@@ -623,6 +671,11 @@ struct RepositoriesFeature {
               await repositoryPersistence.saveRepositorySnapshot(repositories)
             }
           )
+        }
+        if let pendingExternalOpenPath,
+          state.openPathMatch(for: pendingExternalOpenPath) != nil
+        {
+          allEffects.append(.send(.openPath(pendingExternalOpenPath)))
         }
         return .merge(allEffects)
 
@@ -3253,6 +3306,78 @@ extension RepositoriesFeature.State {
     repositories[id: id]?.name
   }
 
+  func openPathMatch(for requestedURL: URL) -> OpenPathMatch? {
+    let normalizedRequestedURL = requestedURL.standardizedFileURL
+    var exactMatch: OpenPathMatch?
+    var insideMatches: [OpenPathMatch] = []
+
+    for candidate in openPathCandidates() {
+      let normalizedRootURL = candidate.worktree.workingDirectory.standardizedFileURL
+      if normalizedRootURL == normalizedRequestedURL {
+        exactMatch = OpenPathMatch(
+          resolution: .exactRoot,
+          selection: candidate.selection,
+          worktree: candidate.worktree
+        )
+        break
+      }
+      if isDescendantPath(normalizedRequestedURL, of: normalizedRootURL) {
+        insideMatches.append(
+          OpenPathMatch(
+            resolution: .insideRoot,
+            selection: candidate.selection,
+            worktree: candidate.worktree
+          )
+        )
+      }
+    }
+
+    if let exactMatch {
+      return exactMatch
+    }
+
+    return insideMatches.max { lhs, rhs in
+      lhs.worktree.workingDirectory.pathComponents.count < rhs.worktree.workingDirectory.pathComponents.count
+    }
+  }
+
+  private func openPathCandidates() -> [OpenPathCandidate] {
+    repositories.flatMap { repository in
+      if repository.capabilities.supportsWorktrees {
+        return repository.worktrees.map { worktree in
+          OpenPathCandidate(
+            selection: .worktree(worktree.id),
+            worktree: worktree
+          )
+        }
+      }
+      if repository.capabilities.supportsRunnableFolderActions {
+        return [
+          OpenPathCandidate(
+            selection: .repository(repository.id),
+            worktree: Worktree(
+              id: repository.id,
+              name: repository.name,
+              detail: repository.rootURL.path(percentEncoded: false),
+              workingDirectory: repository.rootURL,
+              repositoryRootURL: repository.rootURL
+            )
+          ),
+        ]
+      }
+      return []
+    }
+  }
+
+  private func isDescendantPath(_ path: URL, of root: URL) -> Bool {
+    let normalizedPath = path.standardizedFileURL.pathComponents
+    let normalizedRoot = root.standardizedFileURL.pathComponents
+    guard normalizedPath.count > normalizedRoot.count else {
+      return false
+    }
+    return Array(normalizedPath.prefix(normalizedRoot.count)) == normalizedRoot
+  }
+
   func orderedRepositoryRoots() -> [URL] {
     let rootsByID = Dictionary(
       uniqueKeysWithValues: repositoryRoots.map {
@@ -3471,6 +3596,27 @@ extension RepositoriesFeature.State {
       .compactMap { repositoriesByID[$0] }
       .flatMap { worktreeRows(in: $0) }
   }
+}
+
+struct OpenPathMatch: Equatable {
+  enum Resolution: Equatable {
+    case exactRoot
+    case insideRoot
+  }
+
+  let resolution: Resolution
+  let selection: OpenPathSelection
+  let worktree: Worktree
+}
+
+enum OpenPathSelection: Equatable {
+  case worktree(Worktree.ID)
+  case repository(Repository.ID)
+}
+
+private struct OpenPathCandidate: Equatable {
+  let selection: OpenPathSelection
+  let worktree: Worktree
 }
 
 struct WorktreeRowSections {

--- a/supacode/Features/Repositories/Views/WorktreeDetailView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailView.swift
@@ -121,10 +121,12 @@ struct WorktreeDetailView: View {
   }
 
   private func toolbarState(input: ToolbarStateInput) -> WorktreeToolbarState? {
-    guard let title = DetailToolbarTitle.forSelection(
-      worktree: input.selectedWorktree,
-      repository: input.repositories.selectedRepository
-    ) else {
+    guard
+      let title = DetailToolbarTitle.forSelection(
+        worktree: input.selectedWorktree,
+        repository: input.repositories.selectedRepository
+      )
+    else {
       return nil
     }
     let pullRequest = input.selectedWorktree.flatMap { input.repositories.worktreeInfo(for: $0.id)?.pullRequest }
@@ -189,9 +191,11 @@ struct WorktreeDetailView: View {
     selectedWorktreeSummaries: [MultiSelectedWorktreeSummary]
   ) -> some View {
     if repositories.isShowingCanvas {
-      CanvasView(terminalManager: terminalManager, onExitToTab: {
-        store.send(.repositories(.toggleCanvas))
-      })
+      CanvasView(
+        terminalManager: terminalManager,
+        onExitToTab: {
+          store.send(.repositories(.toggleCanvas))
+        })
     } else if repositories.isShowingArchivedWorktrees {
       ArchivedWorktreesDetailView(
         store: store.scope(state: \.repositories, action: \.repositories)

--- a/supacode/Features/Settings/BusinessLogic/RepositoryPersistenceKeys.swift
+++ b/supacode/Features/Settings/BusinessLogic/RepositoryPersistenceKeys.swift
@@ -1,5 +1,5 @@
-import Foundation
 import Dependencies
+import Foundation
 import Sharing
 
 nonisolated struct RepositoryEntriesKeyID: Hashable, Sendable {}

--- a/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
+++ b/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Observation
 import Sharing
 
@@ -44,6 +45,10 @@ final class WorktreeTerminalManager {
     switch command {
     case .createTab(let worktree, let runSetupScriptIfNew):
       Task { createTabAsync(in: worktree, runSetupScriptIfNew: runSetupScriptIfNew) }
+    case .createTabAtDirectory(let worktree, let directory, let runSetupScriptIfNew):
+      Task {
+        createTabAsync(in: worktree, workingDirectory: directory, runSetupScriptIfNew: runSetupScriptIfNew)
+      }
     case .createTabWithInput(let worktree, let input, let runSetupScriptIfNew):
       Task {
         createTabAsync(in: worktree, runSetupScriptIfNew: runSetupScriptIfNew, initialInput: input)
@@ -214,6 +219,7 @@ final class WorktreeTerminalManager {
 
   private func createTabAsync(
     in worktree: Worktree,
+    workingDirectory: URL? = nil,
     runSetupScriptIfNew: Bool,
     initialInput: String? = nil
   ) {
@@ -226,7 +232,11 @@ final class WorktreeTerminalManager {
     } else {
       setupScript = nil
     }
-    _ = state.createTab(setupScript: setupScript, initialInput: initialInput)
+    _ = state.createTab(
+      setupScript: setupScript,
+      initialInput: initialInput,
+      workingDirectory: workingDirectory
+    )
   }
 
   @discardableResult

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -139,6 +139,7 @@ final class WorktreeTerminalState {
     focusing: Bool = true,
     setupScript: String? = nil,
     initialInput: String? = nil,
+    workingDirectory: URL? = nil,
     inheritingFromSurfaceId: UUID? = nil
   ) -> TerminalTabID? {
     let context: ghostty_surface_context_e =
@@ -170,6 +171,7 @@ final class WorktreeTerminalState {
         icon: "terminal",
         isTitleLocked: false,
         initialInput: resolvedInput,
+        workingDirectory: workingDirectory,
         focusing: focusing,
         inheritingFromSurfaceId: resolvedInheritanceSurfaceId,
         context: context
@@ -193,6 +195,7 @@ final class WorktreeTerminalState {
         icon: "play.fill",
         isTitleLocked: true,
         initialInput: input,
+        workingDirectory: nil,
         focusing: true,
         inheritingFromSurfaceId: currentFocusedSurfaceId(),
         context: GHOSTTY_SURFACE_CONTEXT_TAB
@@ -214,6 +217,7 @@ final class WorktreeTerminalState {
     let icon: String?
     let isTitleLocked: Bool
     let initialInput: String?
+    let workingDirectory: URL?
     let focusing: Bool
     let inheritingFromSurfaceId: UUID?
     let context: ghostty_surface_context_e
@@ -229,6 +233,7 @@ final class WorktreeTerminalState {
       for: tabId,
       inheritingFromSurfaceId: creation.inheritingFromSurfaceId,
       initialInput: creation.initialInput,
+      workingDirectory: creation.workingDirectory,
       context: creation.context
     )
     tabIsRunningById[tabId] = false
@@ -410,6 +415,7 @@ final class WorktreeTerminalState {
     for tabId: TerminalTabID,
     inheritingFromSurfaceId: UUID? = nil,
     initialInput: String? = nil,
+    workingDirectory: URL? = nil,
     context: ghostty_surface_context_e = GHOSTTY_SURFACE_CONTEXT_TAB
   ) -> SplitTree<GhosttySurfaceView> {
     if let existing = trees[tabId] {
@@ -418,6 +424,7 @@ final class WorktreeTerminalState {
     let surface = createSurface(
       tabId: tabId,
       initialInput: initialInput,
+      workingDirectory: workingDirectory,
       inheritingFromSurfaceId: inheritingFromSurfaceId,
       context: context
     )
@@ -439,6 +446,7 @@ final class WorktreeTerminalState {
       let newSurface = createSurface(
         tabId: tabId,
         initialInput: nil,
+        workingDirectory: nil,
         inheritingFromSurfaceId: surfaceId,
         context: GHOSTTY_SURFACE_CONTEXT_SPLIT
       )
@@ -646,6 +654,7 @@ final class WorktreeTerminalState {
   private func createSurface(
     tabId: TerminalTabID,
     initialInput: String?,
+    workingDirectory: URL?,
     inheritingFromSurfaceId: UUID?,
     context: ghostty_surface_context_e
   ) -> GhosttySurfaceView {
@@ -655,9 +664,10 @@ final class WorktreeTerminalState {
       inheritedFontSize: inherited.fontSize,
       context: context
     )
+    let resolvedWorkingDirectory = workingDirectory ?? inherited.workingDirectory ?? worktree.workingDirectory
     let view = GhosttySurfaceView(
       runtime: runtime,
-      workingDirectory: inherited.workingDirectory ?? worktree.workingDirectory,
+      workingDirectory: resolvedWorkingDirectory,
       initialInput: initialInput,
       fontSize: resolvedFontSize,
       context: context

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -672,6 +672,10 @@ final class WorktreeTerminalState {
       fontSize: resolvedFontSize,
       context: context
     )
+    // Cold-start external open can create tabs before focus observers are fully
+    // attached. Start un-occluded to avoid a blank first frame; syncFocus will
+    // correct visibility immediately after view attachment.
+    view.setOcclusion(true)
     configureBridgeCallbacks(for: view, tabId: tabId)
     configureSurfaceCallbacks(for: view, tabId: tabId)
     surfaces[view.id] = view

--- a/supacode/Features/Terminal/Views/WorktreeTerminalTabsView.swift
+++ b/supacode/Features/Terminal/Views/WorktreeTerminalTabsView.swift
@@ -58,6 +58,10 @@ struct WorktreeTerminalTabsView: View {
       }
       let activity = resolvedWindowActivity
       state.syncFocus(windowIsKey: activity.isKeyWindow, windowIsVisible: activity.isVisible)
+      DispatchQueue.main.async {
+        let activity = resolvedWindowActivity
+        state.syncFocus(windowIsKey: activity.isKeyWindow, windowIsVisible: activity.isVisible)
+      }
     }
     .onChange(of: state.tabManager.selectedTabId) { _, _ in
       if shouldAutoFocusTerminal {
@@ -81,6 +85,18 @@ struct WorktreeTerminalTabsView: View {
       return WindowActivityState(
         isKeyWindow: keyWindow.isKeyWindow,
         isVisible: keyWindow.occlusionState.contains(.visible)
+      )
+    }
+    if let mainWindow = NSApp.mainWindow {
+      return WindowActivityState(
+        isKeyWindow: mainWindow.isKeyWindow,
+        isVisible: mainWindow.occlusionState.contains(.visible)
+      )
+    }
+    if let visibleWindow = NSApp.windows.first(where: { $0.occlusionState.contains(.visible) }) {
+      return WindowActivityState(
+        isKeyWindow: visibleWindow.isKeyWindow,
+        isVisible: true
       )
     }
     return windowActivity

--- a/supacode/Infrastructure/Ghostty/MirroredTerminalKey.swift
+++ b/supacode/Infrastructure/Ghostty/MirroredTerminalKey.swift
@@ -30,10 +30,10 @@ struct MirroredTerminalKey: Equatable, Sendable {
   /// Key codes allowed to pass through even with the Command modifier held.
   private static let commandAllowedKeyCodes: Set<UInt16> = [
     51,  // backspace
-    123, // arrowLeft
-    124, // arrowRight
-    125, // arrowDown
-    126, // arrowUp
+    123,  // arrowLeft
+    124,  // arrowRight
+    125,  // arrowDown
+    126,  // arrowUp
   ]
 
   init?(

--- a/supacode/Support/SupaLogger.swift
+++ b/supacode/Support/SupaLogger.swift
@@ -2,38 +2,34 @@ import OSLog
 
 nonisolated struct SupaLogger: Sendable {
   private let category: String
-  #if !DEBUG
-    private let logger: Logger
-  #endif
+  private let logger: Logger
 
   init(_ category: String) {
     self.category = category
-    #if !DEBUG
-      self.logger = Logger(subsystem: Bundle.main.bundleIdentifier!, category: category)
-    #endif
+    self.logger = Logger(
+      subsystem: Bundle.main.bundleIdentifier ?? "com.onevcat.prowl",
+      category: category
+    )
   }
 
   func debug(_ message: String) {
     #if DEBUG
       print("[\(category)] \(message)")
-    #else
-      logger.notice("\(message, privacy: .public)")
     #endif
+    logger.notice("\(message, privacy: .public)")
   }
 
   func info(_ message: String) {
     #if DEBUG
       print("[\(category)] \(message)")
-    #else
-      logger.notice("\(message, privacy: .public)")
     #endif
+    logger.notice("\(message, privacy: .public)")
   }
 
   func warning(_ message: String) {
     #if DEBUG
       print("[\(category)] \(message)")
-    #else
-      logger.warning("\(message, privacy: .public)")
     #endif
+    logger.warning("\(message, privacy: .public)")
   }
 }

--- a/supacodeTests/KeybindingSchemaTests.swift
+++ b/supacodeTests/KeybindingSchemaTests.swift
@@ -127,83 +127,83 @@ struct KeybindingSchemaTests {
 
   @Test func migrationMigratesLegacyCustomShortcutsAndCollectsUnmappedIssues() throws {
     let fixture = #"""
-    {
-      "customCommands": [
-        {
-          "id": "build",
-          "title": "Build",
-          "systemImage": "hammer",
-          "command": "swift build",
-          "execution": "shellScript",
-          "shortcut": {
-            "key": " B ",
-            "modifiers": {
-              "command": true,
-              "shift": true,
-              "option": false,
-              "control": false
+      {
+        "customCommands": [
+          {
+            "id": "build",
+            "title": "Build",
+            "systemImage": "hammer",
+            "command": "swift build",
+            "execution": "shellScript",
+            "shortcut": {
+              "key": " B ",
+              "modifiers": {
+                "command": true,
+                "shift": true,
+                "option": false,
+                "control": false
+              }
             }
-          }
-        },
-        {
-          "id": "deploy",
-          "title": "Deploy",
-          "systemImage": "rocket",
-          "command": "make release",
-          "execution": "shellScript",
-          "shortcut": {
-            "key": "d",
-            "modifiers": {
-              "command": true,
-              "shift": false,
-              "option": false,
-              "control": false
+          },
+          {
+            "id": "deploy",
+            "title": "Deploy",
+            "systemImage": "rocket",
+            "command": "make release",
+            "execution": "shellScript",
+            "shortcut": {
+              "key": "d",
+              "modifiers": {
+                "command": true,
+                "shift": false,
+                "option": false,
+                "control": false
+              }
             }
-          }
-        },
-        {
-          "id": "bad-shortcut",
-          "title": "Bad",
-          "systemImage": "xmark",
-          "command": "echo bad",
-          "execution": "shellScript",
-          "shortcut": {
-            "key": "two",
-            "modifiers": {
-              "command": true,
-              "shift": false,
-              "option": false,
-              "control": false
+          },
+          {
+            "id": "bad-shortcut",
+            "title": "Bad",
+            "systemImage": "xmark",
+            "command": "echo bad",
+            "execution": "shellScript",
+            "shortcut": {
+              "key": "two",
+              "modifiers": {
+                "command": true,
+                "shift": false,
+                "option": false,
+                "control": false
+              }
             }
-          }
-        },
-        {
-          "id": "",
-          "title": "No ID",
-          "systemImage": "questionmark",
-          "command": "echo noid",
-          "execution": "shellScript",
-          "shortcut": {
-            "key": "n",
-            "modifiers": {
-              "command": true,
-              "shift": false,
-              "option": false,
-              "control": false
+          },
+          {
+            "id": "",
+            "title": "No ID",
+            "systemImage": "questionmark",
+            "command": "echo noid",
+            "execution": "shellScript",
+            "shortcut": {
+              "key": "n",
+              "modifiers": {
+                "command": true,
+                "shift": false,
+                "option": false,
+                "control": false
+              }
             }
+          },
+          {
+            "id": "without-shortcut",
+            "title": "No Shortcut",
+            "systemImage": "ellipsis",
+            "command": "echo none",
+            "execution": "shellScript",
+            "shortcut": null
           }
-        },
-        {
-          "id": "without-shortcut",
-          "title": "No Shortcut",
-          "systemImage": "ellipsis",
-          "command": "echo none",
-          "execution": "shellScript",
-          "shortcut": null
-        }
-      ]
-    }
-    """#
+        ]
+      }
+      """#
 
     let legacySettings = try JSONDecoder().decode(
       LegacyCustomCommandShortcutFixture.self,

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -228,7 +228,7 @@ struct RepositoriesFeatureTests {
     await store.finish()
 
     let expectedSavedEntries = [
-      [PersistedRepositoryEntry(path: root, kind: .git)],
+      [PersistedRepositoryEntry(path: root, kind: .git)]
     ]
     #expect(savedEntries.value == expectedSavedEntries)
   }
@@ -317,7 +317,7 @@ struct RepositoriesFeatureTests {
     await store.finish()
 
     let expectedSavedEntries = [
-      [PersistedRepositoryEntry(path: root, kind: .plain)],
+      [PersistedRepositoryEntry(path: root, kind: .plain)]
     ]
     #expect(savedEntries.value == expectedSavedEntries)
   }
@@ -484,7 +484,7 @@ struct RepositoriesFeatureTests {
     await store.finish()
 
     let expectedSavedEntries = [
-      [PersistedRepositoryEntry(path: repoRoot, kind: .git)],
+      [PersistedRepositoryEntry(path: repoRoot, kind: .git)]
     ]
     #expect(savedEntries.value == expectedSavedEntries)
   }
@@ -3034,8 +3034,10 @@ struct RepositoriesFeatureTests {
     let worktree = makeWorktree(id: "/tmp/repo/main", name: "main", repoRoot: "/tmp/repo")
     let repository = makeRepository(id: "/tmp/repo", worktrees: [worktree])
     let sentCommands = LockIsolated<[TerminalClient.Command]>([])
+    var initialState = makeState(repositories: [repository])
+    initialState.isInitialLoadComplete = true
 
-    let store = TestStore(initialState: makeState(repositories: [repository])) {
+    let store = TestStore(initialState: initialState) {
       RepositoriesFeature()
     } withDependencies: {
       $0.terminalClient.send = { command in
@@ -3064,8 +3066,10 @@ struct RepositoriesFeatureTests {
     let repository = makeRepository(id: "/tmp/repo", worktrees: [worktree])
     let sentCommands = LockIsolated<[TerminalClient.Command]>([])
     let requestedDirectory = URL(fileURLWithPath: "/tmp/repo/main/Sources")
+    var initialState = makeState(repositories: [repository])
+    initialState.isInitialLoadComplete = true
 
-    let store = TestStore(initialState: makeState(repositories: [repository])) {
+    let store = TestStore(initialState: initialState) {
       RepositoriesFeature()
     } withDependencies: {
       $0.terminalClient.send = { command in
@@ -3097,8 +3101,10 @@ struct RepositoriesFeatureTests {
     let root = "/tmp/folder"
     let plainRepository = makeRepository(id: root, name: "folder", kind: .plain, worktrees: [])
     let sentCommands = LockIsolated<[TerminalClient.Command]>([])
+    var initialState = makeState(repositories: [plainRepository])
+    initialState.isInitialLoadComplete = true
 
-    let store = TestStore(initialState: makeState(repositories: [plainRepository])) {
+    let store = TestStore(initialState: initialState) {
       RepositoriesFeature()
     } withDependencies: {
       $0.terminalClient.send = { command in
@@ -3126,6 +3132,58 @@ struct RepositoriesFeatureTests {
             ),
             runSetupScriptIfNew: false,
             focusing: true
+          ),
+        ]
+    )
+  }
+
+  @Test func openPathBeforeInitialLoadQueuesAndRoutesAfterRepositoriesLoaded() async {
+    let requestedDirectory = URL(fileURLWithPath: "/tmp/repo/main/Sources")
+    let worktree = makeWorktree(id: "/tmp/repo/main", name: "main", repoRoot: "/tmp/repo")
+    let repository = makeRepository(id: "/tmp/repo", worktrees: [worktree])
+    let sentCommands = LockIsolated<[TerminalClient.Command]>([])
+
+    let store = TestStore(initialState: RepositoriesFeature.State()) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in
+        sentCommands.withValue { $0.append(command) }
+      }
+    }
+
+    await store.send(.openPath(requestedDirectory)) {
+      $0.pendingExternalOpenPath = requestedDirectory.standardizedFileURL
+    }
+
+    await store.send(
+      .repositoriesLoaded(
+        [repository],
+        failures: [],
+        roots: [repository.rootURL],
+        animated: false
+      )
+    ) {
+      $0.repositories = [repository]
+      $0.repositoryRoots = [repository.rootURL]
+      $0.isInitialLoadComplete = true
+      $0.pendingExternalOpenPath = nil
+    }
+    await store.receive(\.delegate.repositoriesChanged)
+    await store.receive(\.openPath)
+    await store.receive(\.selectWorktree) {
+      $0.selection = .worktree(worktree.id)
+      $0.sidebarSelectedWorktreeIDs = [worktree.id]
+      $0.pendingTerminalFocusWorktreeIDs = [worktree.id]
+    }
+    await store.receive(\.delegate.selectedWorktreeChanged)
+
+    #expect(
+      sentCommands.value
+        == [
+          .createTabAtDirectory(
+            worktree,
+            directory: requestedDirectory.standardizedFileURL,
+            runSetupScriptIfNew: false
           ),
         ]
     )

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -85,7 +85,9 @@ struct RepositoriesFeatureTests {
       }
     }
 
-    await store.send(.task)
+    await store.send(.task) {
+      $0.hasCompletedInitialRepositoryLoad = false
+    }
     await store.receive(\.pinnedWorktreeIDsLoaded)
     await store.receive(\.archivedWorktreeIDsLoaded)
     await store.receive(\.repositoryOrderIDsLoaded)
@@ -125,7 +127,9 @@ struct RepositoriesFeatureTests {
       $0.gitClient.worktrees = { _ in [worktree] }
     }
 
-    await store.send(.task)
+    await store.send(.task) {
+      $0.hasCompletedInitialRepositoryLoad = false
+    }
     await store.receive(\.pinnedWorktreeIDsLoaded)
     await store.receive(\.archivedWorktreeIDsLoaded)
     await store.receive(\.repositoryOrderIDsLoaded)
@@ -420,7 +424,7 @@ struct RepositoriesFeatureTests {
       [
         PersistedRepositoryEntry(path: repoRoot, kind: .git),
         PersistedRepositoryEntry(path: plainRoot, kind: .plain),
-      ],
+      ]
     ]
     #expect(savedEntries.value == expectedSavedEntries)
   }
@@ -1324,7 +1328,7 @@ struct RepositoriesFeatureTests {
         id: pendingID,
         repositoryID: repository.id,
         progress: WorktreeCreationProgress(stage: .loadingLocalBranches)
-      ),
+      )
     ]
     let store = TestStore(initialState: state) {
       RepositoriesFeature()
@@ -1361,7 +1365,7 @@ struct RepositoriesFeatureTests {
           stage: .checkingRepositoryMode,
           worktreeName: "swift-otter"
         )
-      ),
+      )
     ]
     let store = TestStore(initialState: state) {
       RepositoriesFeature()
@@ -1552,7 +1556,7 @@ struct RepositoriesFeatureTests {
         addedLines: nil,
         removedLines: nil,
         pullRequest: makePullRequest(state: "MERGED")
-      ),
+      )
     ]
     let store = TestStore(initialState: state) {
       RepositoriesFeature()
@@ -2234,7 +2238,7 @@ struct RepositoriesFeatureTests {
         id: removedWorktree.id,
         repositoryID: repository.id,
         progress: WorktreeCreationProgress(stage: .choosingWorktreeName)
-      ),
+      )
     ]
     initialState.pinnedWorktreeIDs = [removedWorktree.id]
     initialState.worktreeInfoByID = [
@@ -2317,7 +2321,7 @@ struct RepositoriesFeatureTests {
         id: pendingID,
         repositoryID: repository.id,
         progress: WorktreeCreationProgress(stage: .loadingLocalBranches)
-      ),
+      )
     ]
     initialState.selection = .worktree(pendingID)
     initialState.sidebarSelectedWorktreeIDs = [existingWorktree.id, pendingID]
@@ -3036,6 +3040,7 @@ struct RepositoriesFeatureTests {
     let sentCommands = LockIsolated<[TerminalClient.Command]>([])
     var initialState = makeState(repositories: [repository])
     initialState.isInitialLoadComplete = true
+    initialState.hasCompletedInitialRepositoryLoad = true
 
     let store = TestStore(initialState: initialState) {
       RepositoriesFeature()
@@ -3068,6 +3073,7 @@ struct RepositoriesFeatureTests {
     let requestedDirectory = URL(fileURLWithPath: "/tmp/repo/main/Sources")
     var initialState = makeState(repositories: [repository])
     initialState.isInitialLoadComplete = true
+    initialState.hasCompletedInitialRepositoryLoad = true
 
     let store = TestStore(initialState: initialState) {
       RepositoriesFeature()
@@ -3092,7 +3098,7 @@ struct RepositoriesFeatureTests {
             worktree,
             directory: requestedDirectory.standardizedFileURL,
             runSetupScriptIfNew: false
-          ),
+          )
         ]
     )
   }
@@ -3103,6 +3109,7 @@ struct RepositoriesFeatureTests {
     let sentCommands = LockIsolated<[TerminalClient.Command]>([])
     var initialState = makeState(repositories: [plainRepository])
     initialState.isInitialLoadComplete = true
+    initialState.hasCompletedInitialRepositoryLoad = true
 
     let store = TestStore(initialState: initialState) {
       RepositoriesFeature()
@@ -3132,7 +3139,7 @@ struct RepositoriesFeatureTests {
             ),
             runSetupScriptIfNew: false,
             focusing: true
-          ),
+          )
         ]
     )
   }
@@ -3142,8 +3149,10 @@ struct RepositoriesFeatureTests {
     let worktree = makeWorktree(id: "/tmp/repo/main", name: "main", repoRoot: "/tmp/repo")
     let repository = makeRepository(id: "/tmp/repo", worktrees: [worktree])
     let sentCommands = LockIsolated<[TerminalClient.Command]>([])
+    var initialState = RepositoriesFeature.State()
+    initialState.hasCompletedInitialRepositoryLoad = false
 
-    let store = TestStore(initialState: RepositoriesFeature.State()) {
+    let store = TestStore(initialState: initialState) {
       RepositoriesFeature()
     } withDependencies: {
       $0.terminalClient.send = { command in
@@ -3166,6 +3175,7 @@ struct RepositoriesFeatureTests {
       $0.repositories = [repository]
       $0.repositoryRoots = [repository.rootURL]
       $0.isInitialLoadComplete = true
+      $0.hasCompletedInitialRepositoryLoad = true
       $0.pendingExternalOpenPath = nil
     }
     await store.receive(\.delegate.repositoriesChanged)
@@ -3184,9 +3194,33 @@ struct RepositoriesFeatureTests {
             worktree,
             directory: requestedDirectory.standardizedFileURL,
             runSetupScriptIfNew: false
-          ),
+          )
         ]
     )
+  }
+
+  @Test func openPathBeforeInitialLoadSkipsSnapshotRestore() async {
+    let requestedDirectory = URL(fileURLWithPath: "/tmp/repo/main/Sources")
+    let worktree = makeWorktree(id: "/tmp/repo/main", name: "main", repoRoot: "/tmp/repo")
+    let repository = makeRepository(id: "/tmp/repo", worktrees: [worktree])
+    var initialState = RepositoriesFeature.State()
+    initialState.hasCompletedInitialRepositoryLoad = false
+
+    let store = TestStore(initialState: initialState) {
+      RepositoriesFeature()
+    }
+
+    await store.send(.openPath(requestedDirectory)) {
+      $0.pendingExternalOpenPath = requestedDirectory.standardizedFileURL
+      $0.shouldRestoreLastFocusedWorktree = false
+      $0.shouldSelectFirstAfterReload = false
+    }
+
+    await store.send(.repositorySnapshotLoaded([repository])) {
+      $0.pendingExternalOpenPath = requestedDirectory.standardizedFileURL
+      $0.shouldRestoreLastFocusedWorktree = false
+      $0.shouldSelectFirstAfterReload = false
+    }
   }
 
   private func makeWorktree(

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -3030,6 +3030,107 @@ struct RepositoriesFeatureTests {
     await store.receive(\.delegate.selectedWorktreeChanged)
   }
 
+  @Test func openPathFocusesExactWorktreeAndEnsuresInitialTab() async {
+    let worktree = makeWorktree(id: "/tmp/repo/main", name: "main", repoRoot: "/tmp/repo")
+    let repository = makeRepository(id: "/tmp/repo", worktrees: [worktree])
+    let sentCommands = LockIsolated<[TerminalClient.Command]>([])
+
+    let store = TestStore(initialState: makeState(repositories: [repository])) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in
+        sentCommands.withValue { $0.append(command) }
+      }
+    }
+
+    await store.send(.openPath(worktree.workingDirectory))
+    await store.receive(\.selectWorktree) {
+      $0.selection = .worktree(worktree.id)
+      $0.sidebarSelectedWorktreeIDs = [worktree.id]
+      $0.pendingTerminalFocusWorktreeIDs = [worktree.id]
+    }
+    await store.receive(\.delegate.selectedWorktreeChanged)
+
+    #expect(
+      sentCommands.value
+        == [
+          .ensureInitialTab(worktree, runSetupScriptIfNew: false, focusing: true)
+        ]
+    )
+  }
+
+  @Test func openPathInsideWorktreeCreatesTabAtRequestedDirectory() async {
+    let worktree = makeWorktree(id: "/tmp/repo/main", name: "main", repoRoot: "/tmp/repo")
+    let repository = makeRepository(id: "/tmp/repo", worktrees: [worktree])
+    let sentCommands = LockIsolated<[TerminalClient.Command]>([])
+    let requestedDirectory = URL(fileURLWithPath: "/tmp/repo/main/Sources")
+
+    let store = TestStore(initialState: makeState(repositories: [repository])) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in
+        sentCommands.withValue { $0.append(command) }
+      }
+    }
+
+    await store.send(.openPath(requestedDirectory))
+    await store.receive(\.selectWorktree) {
+      $0.selection = .worktree(worktree.id)
+      $0.sidebarSelectedWorktreeIDs = [worktree.id]
+      $0.pendingTerminalFocusWorktreeIDs = [worktree.id]
+    }
+    await store.receive(\.delegate.selectedWorktreeChanged)
+
+    #expect(
+      sentCommands.value
+        == [
+          .createTabAtDirectory(
+            worktree,
+            directory: requestedDirectory.standardizedFileURL,
+            runSetupScriptIfNew: false
+          ),
+        ]
+    )
+  }
+
+  @Test func openPathFocusesExactPlainFolderRoot() async {
+    let root = "/tmp/folder"
+    let plainRepository = makeRepository(id: root, name: "folder", kind: .plain, worktrees: [])
+    let sentCommands = LockIsolated<[TerminalClient.Command]>([])
+
+    let store = TestStore(initialState: makeState(repositories: [plainRepository])) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in
+        sentCommands.withValue { $0.append(command) }
+      }
+    }
+
+    await store.send(.openPath(URL(fileURLWithPath: root)))
+    await store.receive(\.selectRepository) {
+      $0.selection = .repository(root)
+      $0.sidebarSelectedWorktreeIDs = []
+    }
+    await store.receive(\.delegate.selectedWorktreeChanged)
+
+    #expect(
+      sentCommands.value
+        == [
+          .ensureInitialTab(
+            Worktree(
+              id: root,
+              name: "folder",
+              detail: root,
+              workingDirectory: URL(fileURLWithPath: root),
+              repositoryRootURL: URL(fileURLWithPath: root)
+            ),
+            runSetupScriptIfNew: false,
+            focusing: true
+          ),
+        ]
+    )
+  }
+
   private func makeWorktree(
     id: String,
     name: String,

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -3223,6 +3223,28 @@ struct RepositoriesFeatureTests {
     }
   }
 
+  @Test func lastFocusedWorktreeDoesNotOverridePendingExternalOpenPath() async {
+    let requestedDirectory = URL(fileURLWithPath: "/tmp/repo/main/Sources")
+    let lastFocusedWorktreeID = "/tmp/other-repo/main"
+    var initialState = RepositoriesFeature.State()
+    initialState.hasCompletedInitialRepositoryLoad = false
+
+    let store = TestStore(initialState: initialState) {
+      RepositoriesFeature()
+    }
+
+    await store.send(.openPath(requestedDirectory)) {
+      $0.pendingExternalOpenPath = requestedDirectory.standardizedFileURL
+      $0.shouldRestoreLastFocusedWorktree = false
+      $0.shouldSelectFirstAfterReload = false
+    }
+
+    await store.send(.lastFocusedWorktreeIDLoaded(lastFocusedWorktreeID)) {
+      $0.lastFocusedWorktreeID = lastFocusedWorktreeID
+      $0.shouldRestoreLastFocusedWorktree = false
+    }
+  }
+
   private func makeWorktree(
     id: String,
     name: String,


### PR DESCRIPTION
## Summary

Implement first-class command-line open-path entry and app-side directory routing for issue #64.

### What changed

- Added `bin/prowl` first-class CLI entry script with argument routing:
  - `prowl`
  - `prowl <path>` (path-like first arg)
  - `prowl open <path>`
  - reserved subcommands (`help version open list focus send key read`) with non-open ones reserved but not yet implemented.
- Added app delegate external-open handling (`openFiles` / URL open) so CLI/Finder can hand directory paths directly to app.
- Added `RepositoriesFeature.Action.openPath(URL)` for directory-open routing behavior:
  - exact match with opened worktree/plain root → focus target
  - path inside opened root → focus root + create a new tab at requested directory
  - unmanaged path → open with existing git/plain detection path, then resolve/focus
- Extended terminal command plumbing with `createTabAtDirectory` so tab creation can start at an exact directory.
- Added tests for open-path behavior in `RepositoriesFeatureTests`.
- Updated README with CLI usage and routing behavior.

## Validation

- `make build-app` ✅
- `xcodebuild build-for-testing -project supacode.xcodeproj -scheme supacode -destination "platform=macOS,arch=arm64" CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation` ✅
- `xcodebuild test ... -only-testing:supacodeTests/RepositoriesFeatureTests` ❌ blocked by local OS/runtime mismatch (`macOS 26.0` host vs test target deployment `26.1`).

Closes #64.
