### PR TITLE
Fix terminal layout restore for plain folders and clear-then-quit

### DIFF
--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -53,6 +53,7 @@ final class SupacodeAppDelegate: NSObject, NSApplicationDelegate {
 
   func applicationWillTerminate(_ notification: Notification) {
     guard appStore?.state.settings.restoreTerminalLayoutOnLaunch == true else { return }
+    guard appStore?.state.suppressLayoutSaveUntilRelaunch != true else { return }
     terminalManager?.persistLayoutSnapshotSync()
   }
 

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -51,6 +51,7 @@ struct AppFeature {
     var notificationIndicatorCount: Int = 0
     var lastKnownSystemNotificationsEnabled: Bool
     var launchRestoreMode: LaunchRestoreMode
+    var suppressLayoutSaveUntilRelaunch = false
     @Presents var alert: AlertState<Alert>?
 
     init(
@@ -189,7 +190,7 @@ struct AppFeature {
           )
         case .inactive, .background:
           var effects: [Effect<Action>] = [.cancel(id: CancelID.periodicRefresh)]
-          if state.settings.restoreTerminalLayoutOnLaunch {
+          if state.settings.restoreTerminalLayoutOnLaunch, !state.suppressLayoutSaveUntilRelaunch {
             appLogger.info("[LayoutRestore] scenePhase=\(String(describing: phase)), saving layout snapshot")
             effects.append(.run { _ in await terminalClient.send(.saveLayoutSnapshot) })
           }
@@ -469,6 +470,7 @@ struct AppFeature {
 
       case .settings(.delegate(.terminalLayoutSnapshotCleared(let success))):
         if success {
+          state.suppressLayoutSaveUntilRelaunch = true
           return .send(.repositories(.showToast(.success("Saved terminal layout cleared"))))
         }
         return .send(
@@ -928,6 +930,12 @@ struct AppFeature {
       case .terminalEvent(.layoutRestored(let selectedWorktreeID)):
         appLogger.info("[LayoutRestore] layoutRestored: selectedWorktreeID=\(selectedWorktreeID ?? "nil")")
         if let selectedWorktreeID {
+          // Plain folders use .repository selection, not .worktree
+          if let repo = state.repositories.repositories[id: selectedWorktreeID],
+            repo.kind == .plain
+          {
+            return .send(.repositories(.selectRepository(selectedWorktreeID)))
+          }
           return .send(.repositories(.selectWorktree(selectedWorktreeID)))
         }
         return .none

--- a/supacodeTests/AppFeatureTerminalLayoutRestoreTests.swift
+++ b/supacodeTests/AppFeatureTerminalLayoutRestoreTests.swift
@@ -129,6 +129,20 @@ struct AppFeatureTerminalLayoutRestoreTests {
     await store.receive(\.repositories.selectWorktree)
   }
 
+  @Test(.dependencies) func layoutRestoredEventSelectsRepositoryForPlainFolder() async {
+    let plainRepo = makePlainRepository()
+    let repositoriesState = RepositoriesFeature.State(repositories: [plainRepo])
+    let store = TestStore(
+      initialState: AppFeature.State(repositories: repositoriesState)
+    ) {
+      AppFeature()
+    }
+    store.exhaustivity = .off
+
+    await store.send(.terminalEvent(.layoutRestored(selectedWorktreeID: plainRepo.id)))
+    await store.receive(\.repositories.selectRepository)
+  }
+
   @Test(.dependencies) func scenePhaseInactiveSavesLayoutSnapshot() async {
     let sentCommands = LockIsolated<[TerminalClient.Command]>([])
     var settings = SettingsFeature.State()
@@ -164,6 +178,64 @@ struct AppFeatureTerminalLayoutRestoreTests {
 
     #expect(!sentCommands.value.contains(.saveLayoutSnapshot))
   }
+
+  @Test(.dependencies) func clearLayoutSuppressesSaveOnScenePhaseInactive() async {
+    let sentCommands = LockIsolated<[TerminalClient.Command]>([])
+    var settings = SettingsFeature.State()
+    settings.restoreTerminalLayoutOnLaunch = true
+    let store = TestStore(initialState: AppFeature.State(settings: settings)) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in
+        sentCommands.withValue { $0.append(command) }
+      }
+      $0.terminalLayoutPersistence.clearSnapshot = { true }
+    }
+    store.exhaustivity = .off
+
+    // Clear the layout
+    await store.send(.settings(.delegate(.terminalLayoutSnapshotCleared(success: true)))) {
+      $0.suppressLayoutSaveUntilRelaunch = true
+    }
+    await store.finish()
+
+    sentCommands.withValue { $0.removeAll() }
+
+    // Scene phase inactive should NOT save because layout was cleared
+    await store.send(.scenePhaseChanged(.inactive))
+    await store.finish()
+
+    #expect(!sentCommands.value.contains(.saveLayoutSnapshot))
+  }
+
+  @Test(.dependencies) func suppressLayoutSavePersistsAcrossMultipleScenePhaseChanges() async {
+    let sentCommands = LockIsolated<[TerminalClient.Command]>([])
+    var settings = SettingsFeature.State()
+    settings.restoreTerminalLayoutOnLaunch = true
+    let store = TestStore(initialState: AppFeature.State(settings: settings)) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in
+        sentCommands.withValue { $0.append(command) }
+      }
+      $0.terminalLayoutPersistence.clearSnapshot = { true }
+    }
+    store.exhaustivity = .off
+
+    // Clear the layout
+    await store.send(.settings(.delegate(.terminalLayoutSnapshotCleared(success: true)))) {
+      $0.suppressLayoutSaveUntilRelaunch = true
+    }
+    await store.finish()
+
+    // Multiple inactive/active cycles should all skip saving
+    for _ in 0..<3 {
+      sentCommands.withValue { $0.removeAll() }
+      await store.send(.scenePhaseChanged(.inactive))
+      await store.finish()
+      #expect(!sentCommands.value.contains(.saveLayoutSnapshot))
+    }
+  }
 }
 
 private func makeWorktree() -> Worktree {
@@ -182,5 +254,15 @@ private func makeRepository(worktrees: [Worktree]) -> Repository {
     rootURL: URL(fileURLWithPath: "/tmp/repo"),
     name: "repo",
     worktrees: IdentifiedArray(uniqueElements: worktrees)
+  )
+}
+
+private func makePlainRepository() -> Repository {
+  Repository(
+    id: "/tmp/plain-folder",
+    rootURL: URL(fileURLWithPath: "/tmp/plain-folder"),
+    name: "plain-folder",
+    kind: .plain,
+    worktrees: IdentifiedArray()
   )
 }


### PR DESCRIPTION
## Summary
- Plain folders now correctly restore terminal layout on relaunch by routing through `selectRepository` instead of `selectWorktree`
- Clicking "Clear saved terminal layout" now actually prevents re-saving on quit via a `suppressLayoutSaveUntilRelaunch` flag that gates both the async (`scenePhaseChanged`) and sync (`applicationWillTerminate`) save paths

## Test plan
- [x] `layoutRestoredEventSelectsRepositoryForPlainFolder` — verifies plain folders dispatch `selectRepository`
- [x] `clearLayoutSuppressesSaveOnScenePhaseInactive` — verifies save is suppressed after clear
- [x] `suppressLayoutSavePersistsAcrossMultipleScenePhaseChanges` — verifies suppression persists across multiple background/foreground cycles
- [x] Manual: open app with a plain folder, create tabs/splits, quit, relaunch → layout restored
- [x] Manual: click "Clear saved terminal layout", quit, relaunch → default empty layout