### PR TITLE
feat: CLI v1 foundation — prowl target + command service scaffold

### DIFF
--- a/supacode/CLIService/CLICommandRouter.swift
+++ b/supacode/CLIService/CLICommandRouter.swift
@@ -1,0 +1,62 @@
+// supacode/CLIService/CLICommandRouter.swift
+// Routes incoming command envelopes to the appropriate handler.
+
+import Foundation
+
+@MainActor
+final class CLICommandRouter {
+  private let openHandler: any CommandHandler
+  private let listHandler: any CommandHandler
+  private let focusHandler: any CommandHandler
+  private let sendHandler: any CommandHandler
+  private let keyHandler: any CommandHandler
+  private let readHandler: any CommandHandler
+
+  init(
+    openHandler: any CommandHandler = StubCommandHandler(command: "open"),
+    listHandler: any CommandHandler = StubCommandHandler(command: "list"),
+    focusHandler: any CommandHandler = StubCommandHandler(command: "focus"),
+    sendHandler: any CommandHandler = StubCommandHandler(command: "send"),
+    keyHandler: any CommandHandler = StubCommandHandler(command: "key"),
+    readHandler: any CommandHandler = StubCommandHandler(command: "read")
+  ) {
+    self.openHandler = openHandler
+    self.listHandler = listHandler
+    self.focusHandler = focusHandler
+    self.sendHandler = sendHandler
+    self.keyHandler = keyHandler
+    self.readHandler = readHandler
+  }
+
+  func route(_ envelope: CommandEnvelope) async -> CommandResponse {
+    let handler: any CommandHandler
+    switch envelope.command {
+    case .open: handler = openHandler
+    case .list: handler = listHandler
+    case .focus: handler = focusHandler
+    case .send: handler = sendHandler
+    case .key: handler = keyHandler
+    case .read: handler = readHandler
+    }
+    return await handler.handle(envelope: envelope)
+  }
+}
+
+// MARK: - Stub handler (placeholder until real handlers are implemented)
+
+struct StubCommandHandler: CommandHandler {
+  let command: String
+
+  // swiftlint:disable:next async_without_await
+  func handle(envelope: CommandEnvelope) async -> CommandResponse {
+    CommandResponse(
+      ok: false,
+      command: command,
+      schemaVersion: "prowl.cli.\(command).v1",
+      error: CommandError(
+        code: "NOT_IMPLEMENTED",
+        message: "Command '\(command)' is not yet implemented."
+      )
+    )
+  }
+}

--- a/supacode/CLIService/Shared/CommandResponse.swift
+++ b/supacode/CLIService/Shared/CommandResponse.swift
@@ -1,0 +1,149 @@
+// ProwlShared/CommandResponse.swift
+// Structured response from app command service back to CLI.
+
+import Foundation
+
+/// Top-level response wrapper.
+/// For v1, `data` is left as raw JSON bytes so each command can define
+/// its own strongly-typed success payload without introducing `Any`.
+public struct CommandResponse: Codable, Sendable {
+  // swiftlint:disable:next identifier_name
+  public let ok: Bool
+  public let command: String
+  public let schemaVersion: String
+
+  /// Raw JSON data payload (success case). Consumers decode into
+  /// command-specific types. Nil when `ok == false`.
+  public let data: RawJSON?
+
+  /// Error payload (failure case). Nil when `ok == true`.
+  public let error: CommandError?
+
+  public init(
+    // swiftlint:disable:next identifier_name
+    ok: Bool,
+    command: String,
+    schemaVersion: String,
+    data: RawJSON? = nil,
+    error: CommandError? = nil
+  ) {
+    self.ok = ok
+    self.command = command
+    self.schemaVersion = schemaVersion
+    self.data = data
+    self.error = error
+  }
+
+  enum CodingKeys: String, CodingKey {
+    // swiftlint:disable:next identifier_name
+    case ok
+    case command
+    case schemaVersion = "schema_version"
+    case data
+    case error
+  }
+}
+
+public struct CommandError: Codable, Sendable {
+  public let code: String
+  public let message: String
+
+  public init(code: String, message: String) {
+    self.code = code
+    self.message = message
+  }
+}
+
+// MARK: - RawJSON
+
+/// A type-safe wrapper around raw JSON bytes.
+/// Preserves the original JSON without round-tripping through `Any`.
+/// Fully `Sendable` because it only holds `Data`.
+public struct RawJSON: Codable, Sendable {
+  public let bytes: Data
+
+  public init(_ bytes: Data) {
+    self.bytes = bytes
+  }
+
+  /// Create from an Encodable value.
+  public init<T: Encodable>(encoding value: T) throws {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.sortedKeys]
+    self.bytes = try encoder.encode(value)
+  }
+
+  public init(from decoder: Decoder) throws {
+    // When decoding as part of a larger structure, capture the raw JSON.
+    // This works by re-encoding the decoded JSON value container.
+    let container = try decoder.singleValueContainer()
+    // Decode as a generic JSON value, then re-encode to bytes.
+    let jsonValue = try container.decode(JSONValue.self)
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.sortedKeys]
+    self.bytes = try encoder.encode(jsonValue)
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    // Decode bytes back to JSONValue, then encode inline.
+    let decoder = JSONDecoder()
+    let jsonValue = try decoder.decode(JSONValue.self, from: bytes)
+    var container = encoder.singleValueContainer()
+    try container.encode(jsonValue)
+  }
+
+  /// Decode the raw JSON into a specific type.
+  public func decode<T: Decodable>(as type: T.Type) throws -> T {
+    try JSONDecoder().decode(type, from: bytes)
+  }
+}
+
+// MARK: - JSONValue (internal helper for RawJSON round-tripping)
+
+/// A simple recursive JSON value type that is fully Codable and Sendable.
+enum JSONValue: Codable, Sendable {
+  case null
+  case bool(Bool)
+  case int(Int)
+  case double(Double)
+  case string(String)
+  case array([JSONValue])
+  case object([String: JSONValue])
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    if container.decodeNil() {
+      self = .null
+    } else if let boolValue = try? container.decode(Bool.self) {
+      self = .bool(boolValue)
+    } else if let intValue = try? container.decode(Int.self) {
+      self = .int(intValue)
+    } else if let doubleValue = try? container.decode(Double.self) {
+      self = .double(doubleValue)
+    } else if let stringValue = try? container.decode(String.self) {
+      self = .string(stringValue)
+    } else if let arrayValue = try? container.decode([JSONValue].self) {
+      self = .array(arrayValue)
+    } else if let objectValue = try? container.decode([String: JSONValue].self) {
+      self = .object(objectValue)
+    } else {
+      throw DecodingError.dataCorruptedError(
+        in: container,
+        debugDescription: "Unsupported JSON value"
+      )
+    }
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    switch self {
+    case .null: try container.encodeNil()
+    case .bool(let boolValue): try container.encode(boolValue)
+    case .int(let intValue): try container.encode(intValue)
+    case .double(let doubleValue): try container.encode(doubleValue)
+    case .string(let stringValue): try container.encode(stringValue)
+    case .array(let arrayValue): try container.encode(arrayValue)
+    case .object(let objectValue): try container.encode(objectValue)
+    }
+  }
+}

--- a/supacodeTests/CLICommandEnvelopeTests.swift
+++ b/supacodeTests/CLICommandEnvelopeTests.swift
@@ -1,0 +1,122 @@
+// supacodeTests/CLICommandEnvelopeTests.swift
+// Contract tests for CommandEnvelope, CommandResponse, and shared types.
+
+import Foundation
+import Testing
+
+@testable import supacode
+
+struct CLICommandEnvelopeTests {
+
+  // MARK: - CommandEnvelope encoding stability
+
+  @Test func envelopeOpenEncodesCorrectly() throws {
+    let envelope = CommandEnvelope(
+      output: .json,
+      command: .open(OpenInput(path: "/Users/test/project"))
+    )
+    let data = try JSONEncoder().encode(envelope)
+    let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+    #expect(json["output"] as? String == "json")
+    let command = try #require(json["command"] as? [String: Any])
+    let open = try #require(command["open"] as? [String: Any])
+    #expect(open["path"] as? String == "/Users/test/project")
+  }
+
+  @Test func envelopeListEncodesCorrectly() throws {
+    let envelope = CommandEnvelope(
+      output: .text,
+      command: .list(ListInput())
+    )
+    let data = try JSONEncoder().encode(envelope)
+    let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    #expect(json["output"] as? String == "text")
+    #expect(json["command"] != nil)
+  }
+
+  @Test func envelopeSendWithSelectorEncodesCorrectly() throws {
+    let envelope = CommandEnvelope(
+      output: .json,
+      command: .send(SendInput(
+        selector: .pane("abc-123"),
+        text: "hello world",
+        trailingEnter: false
+      ))
+    )
+    let data = try JSONEncoder().encode(envelope)
+    let decoded = try JSONDecoder().decode(CommandEnvelope.self, from: data)
+    if case .send(let input) = decoded.command {
+      #expect(input.text == "hello world")
+      #expect(input.trailingEnter == false)
+      #expect(input.selector == .pane("abc-123"))
+    } else {
+      Issue.record("Expected .send command")
+    }
+  }
+
+  @Test func envelopeKeyWithRepeatRoundTrips() throws {
+    let envelope = CommandEnvelope(
+      output: .text,
+      command: .key(KeyInput(
+        selector: .tab("tab-1"),
+        token: "enter",
+        repeatCount: 5
+      ))
+    )
+    let data = try JSONEncoder().encode(envelope)
+    let decoded = try JSONDecoder().decode(CommandEnvelope.self, from: data)
+    if case .key(let input) = decoded.command {
+      #expect(input.token == "enter")
+      #expect(input.repeatCount == 5)
+      #expect(input.selector == .tab("tab-1"))
+    } else {
+      Issue.record("Expected .key command")
+    }
+  }
+
+  @Test func envelopeReadWithLastRoundTrips() throws {
+    let envelope = CommandEnvelope(
+      output: .json,
+      command: .read(ReadInput(selector: .worktree("wt-main"), last: 50))
+    )
+    let data = try JSONEncoder().encode(envelope)
+    let decoded = try JSONDecoder().decode(CommandEnvelope.self, from: data)
+    if case .read(let input) = decoded.command {
+      #expect(input.last == 50)
+      #expect(input.selector == .worktree("wt-main"))
+    } else {
+      Issue.record("Expected .read command")
+    }
+  }
+
+  @Test func envelopeFocusNoSelectorRoundTrips() throws {
+    let envelope = CommandEnvelope(
+      output: .text,
+      command: .focus(FocusInput(selector: .none))
+    )
+    let data = try JSONEncoder().encode(envelope)
+    let decoded = try JSONDecoder().decode(CommandEnvelope.self, from: data)
+    if case .focus(let input) = decoded.command {
+      #expect(input.selector == .none)
+    } else {
+      Issue.record("Expected .focus command")
+    }
+  }
+
+  // MARK: - Command name
+
+  @Test func commandNameReturnsCorrectStrings() {
+    let commands: [(Command, String)] = [
+      (.open(OpenInput(path: nil)), "open"),
+      (.list(ListInput()), "list"),
+      (.focus(FocusInput()), "focus"),
+      (.send(SendInput(text: "x")), "send"),
+      (.key(KeyInput(token: "tab")), "key"),
+      (.read(ReadInput()), "read"),
+    ]
+    for (command, expected) in commands {
+      #expect(command.name == expected)
+    }
+  }
+}

--- a/supacodeTests/CLICommandResponseTests.swift
+++ b/supacodeTests/CLICommandResponseTests.swift
@@ -1,0 +1,120 @@
+// supacodeTests/CLICommandResponseTests.swift
+// Contract tests for CommandResponse and RawJSON encoding/decoding.
+
+import Foundation
+import Testing
+
+@testable import supacode
+
+struct CLICommandResponseTests {
+
+  // MARK: - CommandResponse JSON key stability
+
+  @Test func successResponseHasStableKeys() throws {
+    let payload = ["items": [1, 2, 3]]
+    let rawData = try JSONSerialization.data(withJSONObject: payload)
+    let response = CommandResponse(
+      ok: true,
+      command: "list",
+      schemaVersion: "prowl.cli.list.v1",
+      data: RawJSON(rawData)
+    )
+    let encoded = try JSONEncoder().encode(response)
+    let json = try #require(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+
+    #expect(json["ok"] as? Bool == true)
+    #expect(json["command"] as? String == "list")
+    #expect(json["schema_version"] as? String == "prowl.cli.list.v1")
+    #expect(json["data"] != nil)
+    #expect(json["error"] == nil)
+  }
+
+  @Test func errorResponseHasStableKeys() throws {
+    let response = CommandResponse(
+      ok: false,
+      command: "open",
+      schemaVersion: "prowl.cli.open.v1",
+      error: CommandError(code: "PATH_NOT_FOUND", message: "Path not found: ~/nope")
+    )
+    let encoded = try JSONEncoder().encode(response)
+    let json = try #require(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+
+    #expect(json["ok"] as? Bool == false)
+    #expect(json["command"] as? String == "open")
+    #expect(json["schema_version"] as? String == "prowl.cli.open.v1")
+    #expect(json["data"] == nil)
+    let error = try #require(json["error"] as? [String: Any])
+    #expect(error["code"] as? String == "PATH_NOT_FOUND")
+    #expect(error["message"] as? String == "Path not found: ~/nope")
+  }
+
+  @Test func responseRoundTrips() throws {
+    let original = CommandResponse(
+      ok: false,
+      command: "send",
+      schemaVersion: "prowl.cli.send.v1",
+      error: CommandError(code: "EMPTY_INPUT", message: "No input provided.")
+    )
+    let data = try JSONEncoder().encode(original)
+    let decoded = try JSONDecoder().decode(CommandResponse.self, from: data)
+    #expect(decoded.ok == false)
+    #expect(decoded.command == "send")
+    #expect(decoded.schemaVersion == "prowl.cli.send.v1")
+    #expect(decoded.error?.code == "EMPTY_INPUT")
+  }
+
+  // MARK: - RawJSON round-tripping
+
+  @Test func rawJSONFromEncodableRoundTrips() throws {
+    struct Payload: Codable, Equatable {
+      let count: Int
+      let name: String
+    }
+    let original = Payload(count: 42, name: "test")
+    let raw = try RawJSON(encoding: original)
+    let decoded = try raw.decode(as: Payload.self)
+    #expect(decoded == original)
+  }
+
+  @Test func rawJSONPreservesNestedStructure() throws {
+    let nested: [String: Any] = [
+      "items": [
+        ["id": "a", "value": 1],
+        ["id": "b", "value": 2],
+      ],
+    ]
+    let rawData = try JSONSerialization.data(withJSONObject: nested)
+    let raw = RawJSON(rawData)
+
+    // Embed in response and round-trip
+    let response = CommandResponse(
+      ok: true,
+      command: "list",
+      schemaVersion: "prowl.cli.list.v1",
+      data: raw
+    )
+    let encoded = try JSONEncoder().encode(response)
+    let decoded = try JSONDecoder().decode(CommandResponse.self, from: encoded)
+    #expect(decoded.data != nil)
+
+    // Verify nested data survived
+    let decodedPayload = try JSONSerialization.jsonObject(with: decoded.data!.bytes)
+    let dict = try #require(decodedPayload as? [String: Any])
+    let items = try #require(dict["items"] as? [[String: Any]])
+    #expect(items.count == 2)
+  }
+
+  // MARK: - Error codes constants
+
+  @Test func errorCodeConstantsAreDefined() {
+    #expect(CLIErrorCode.appNotRunning == "APP_NOT_RUNNING")
+    #expect(CLIErrorCode.invalidArgument == "INVALID_ARGUMENT")
+    #expect(CLIErrorCode.targetNotFound == "TARGET_NOT_FOUND")
+    #expect(CLIErrorCode.emptyInput == "EMPTY_INPUT")
+    #expect(CLIErrorCode.invalidRepeat == "INVALID_REPEAT")
+    #expect(CLIErrorCode.transportFailed == "TRANSPORT_FAILED")
+    #expect(CLIErrorCode.timeout == "TIMEOUT")
+    #expect(CLIErrorCode.pathNotFound == "PATH_NOT_FOUND")
+    #expect(CLIErrorCode.pathNotDirectory == "PATH_NOT_DIRECTORY")
+  }
+}

--- a/supacodeTests/CLICommandRouterTests.swift
+++ b/supacodeTests/CLICommandRouterTests.swift
@@ -1,0 +1,129 @@
+// supacodeTests/CLICommandRouterTests.swift
+// Unit tests for CLICommandRouter and StubCommandHandler.
+
+import Foundation
+import Testing
+
+@testable import supacode
+
+struct CLICommandRouterTests {
+
+  // MARK: - Stub handler returns NOT_IMPLEMENTED
+
+  @MainActor
+  @Test func stubHandlerReturnsNotImplemented() async {
+    let router = CLICommandRouter()
+    let envelope = CommandEnvelope(output: .json, command: .list(ListInput()))
+    let response = await router.route(envelope)
+    #expect(response.ok == false)
+    #expect(response.error?.code == "NOT_IMPLEMENTED")
+    #expect(response.command == "list")
+  }
+
+  @MainActor
+  @Test func routerDispatchesOpenToOpenHandler() async {
+    let router = CLICommandRouter()
+    let envelope = CommandEnvelope(
+      output: .text,
+      command: .open(OpenInput(path: "/tmp/test"))
+    )
+    let response = await router.route(envelope)
+    #expect(response.command == "open")
+    #expect(response.error?.code == "NOT_IMPLEMENTED")
+  }
+
+  @MainActor
+  @Test func routerDispatchesSendToSendHandler() async {
+    let router = CLICommandRouter()
+    let envelope = CommandEnvelope(
+      output: .json,
+      command: .send(SendInput(text: "hello"))
+    )
+    let response = await router.route(envelope)
+    #expect(response.command == "send")
+    #expect(response.error?.code == "NOT_IMPLEMENTED")
+  }
+
+  @MainActor
+  @Test func routerDispatchesFocusToFocusHandler() async {
+    let router = CLICommandRouter()
+    let envelope = CommandEnvelope(
+      output: .text,
+      command: .focus(FocusInput(selector: .pane("p1")))
+    )
+    let response = await router.route(envelope)
+    #expect(response.command == "focus")
+  }
+
+  @MainActor
+  @Test func routerDispatchesKeyToKeyHandler() async {
+    let router = CLICommandRouter()
+    let envelope = CommandEnvelope(
+      output: .json,
+      command: .key(KeyInput(token: "enter", repeatCount: 3))
+    )
+    let response = await router.route(envelope)
+    #expect(response.command == "key")
+  }
+
+  @MainActor
+  @Test func routerDispatchesReadToReadHandler() async {
+    let router = CLICommandRouter()
+    let envelope = CommandEnvelope(
+      output: .text,
+      command: .read(ReadInput(last: 10))
+    )
+    let response = await router.route(envelope)
+    #expect(response.command == "read")
+  }
+
+  // MARK: - Custom handler injection
+
+  @MainActor
+  @Test func routerUsesInjectedHandler() async {
+    let customHandler = MockCommandHandler(
+      response: CommandResponse(
+        ok: true,
+        command: "list",
+        schemaVersion: "prowl.cli.list.v1"
+      )
+    )
+    let router = CLICommandRouter(listHandler: customHandler)
+    let envelope = CommandEnvelope(output: .json, command: .list(ListInput()))
+    let response = await router.route(envelope)
+    #expect(response.ok == true)
+    #expect(response.command == "list")
+  }
+
+  // MARK: - Schema version format
+
+  @MainActor
+  @Test func stubSchemaVersionFollowsConvention() async {
+    let commands: [Command] = [
+      .open(OpenInput()),
+      .list(ListInput()),
+      .focus(FocusInput()),
+      .send(SendInput(text: "x")),
+      .key(KeyInput(token: "tab")),
+      .read(ReadInput()),
+    ]
+    let router = CLICommandRouter()
+    for cmd in commands {
+      let envelope = CommandEnvelope(output: .json, command: cmd)
+      let response = await router.route(envelope)
+      #expect(response.schemaVersion.hasPrefix("prowl.cli."))
+      #expect(response.schemaVersion.hasSuffix(".v1"))
+    }
+  }
+}
+
+// MARK: - Test helpers
+
+private struct MockCommandHandler: CommandHandler {
+  let response: CommandResponse
+
+  // swiftlint:disable:next async_without_await
+  func handle(envelope: CommandEnvelope) async -> CommandResponse {
+    response
+  }
+}

--- a/supacodeTests/CLITargetSelectorTests.swift
+++ b/supacodeTests/CLITargetSelectorTests.swift
@@ -1,0 +1,53 @@
+// supacodeTests/CLITargetSelectorTests.swift
+// Tests for TargetSelector mutual exclusivity and encoding.
+
+import Foundation
+import Testing
+
+@testable import supacode
+
+struct CLITargetSelectorTests {
+
+  // MARK: - Encoding stability
+
+  @Test func selectorNoneRoundTrips() throws {
+    let selector = TargetSelector.none
+    let data = try JSONEncoder().encode(selector)
+    let decoded = try JSONDecoder().decode(TargetSelector.self, from: data)
+    #expect(decoded == .none)
+  }
+
+  @Test func selectorWorktreeRoundTrips() throws {
+    let selector = TargetSelector.worktree("my-project")
+    let data = try JSONEncoder().encode(selector)
+    let decoded = try JSONDecoder().decode(TargetSelector.self, from: data)
+    #expect(decoded == .worktree("my-project"))
+  }
+
+  @Test func selectorTabRoundTrips() throws {
+    let selector = TargetSelector.tab("tab-uuid-123")
+    let data = try JSONEncoder().encode(selector)
+    let decoded = try JSONDecoder().decode(TargetSelector.self, from: data)
+    #expect(decoded == .tab("tab-uuid-123"))
+  }
+
+  @Test func selectorPaneRoundTrips() throws {
+    let selector = TargetSelector.pane("pane-0")
+    let data = try JSONEncoder().encode(selector)
+    let decoded = try JSONDecoder().decode(TargetSelector.self, from: data)
+    #expect(decoded == .pane("pane-0"))
+  }
+
+  // MARK: - Equality
+
+  @Test func differentSelectorsAreNotEqual() {
+    #expect(TargetSelector.worktree("a") != TargetSelector.tab("a"))
+    #expect(TargetSelector.tab("a") != TargetSelector.pane("a"))
+    #expect(TargetSelector.none != TargetSelector.worktree(""))
+  }
+
+  @Test func sameSelectorsAreEqual() {
+    #expect(TargetSelector.worktree("x") == TargetSelector.worktree("x"))
+    #expect(TargetSelector.none == TargetSelector.none)
+  }
+}

--- a/supacodeTests/CLITransportProtocolTests.swift
+++ b/supacodeTests/CLITransportProtocolTests.swift
@@ -1,0 +1,121 @@
+// supacodeTests/CLITransportProtocolTests.swift
+// Tests for the length-prefixed JSON transport encoding/decoding.
+
+import Foundation
+import Testing
+
+@testable import supacode
+
+struct CLITransportProtocolTests {
+
+  // MARK: - Length-prefix encoding
+
+  @Test func lengthPrefixEncodesCorrectly() throws {
+    let envelope = CommandEnvelope(
+      output: .json,
+      command: .list(ListInput())
+    )
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.sortedKeys]
+    let payload = try encoder.encode(envelope)
+
+    // Build length-prefixed message
+    var length = UInt32(payload.count).bigEndian
+    var message = Data()
+    withUnsafeBytes(of: &length) { message.append(contentsOf: $0) }
+    message.append(payload)
+
+    // Verify: first 4 bytes are big-endian length
+    #expect(message.count == 4 + payload.count)
+    let decodedLength = message.withUnsafeBytes { ptr -> UInt32 in
+      UInt32(bigEndian: ptr.load(as: UInt32.self))
+    }
+    #expect(decodedLength == UInt32(payload.count))
+
+    // Verify: remaining bytes decode back to envelope
+    let payloadSlice = message.suffix(from: 4)
+    let decoded = try JSONDecoder().decode(CommandEnvelope.self, from: payloadSlice)
+    #expect(decoded.output == .json)
+    if case .list = decoded.command {
+      // expected
+    } else {
+      Issue.record("Expected .list command")
+    }
+  }
+
+  @Test func responseLengthPrefixRoundTrips() throws {
+    let response = CommandResponse(
+      ok: true,
+      command: "list",
+      schemaVersion: "prowl.cli.list.v1"
+    )
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.sortedKeys]
+    let payload = try encoder.encode(response)
+
+    var length = UInt32(payload.count).bigEndian
+    var message = Data()
+    withUnsafeBytes(of: &length) { message.append(contentsOf: $0) }
+    message.append(payload)
+
+    // Parse back
+    let parsedLength = message.withUnsafeBytes { ptr -> UInt32 in
+      UInt32(bigEndian: ptr.load(as: UInt32.self))
+    }
+    let parsedPayload = message.suffix(from: 4).prefix(Int(parsedLength))
+    let decoded = try JSONDecoder().decode(CommandResponse.self, from: parsedPayload)
+    #expect(decoded.ok == true)
+    #expect(decoded.command == "list")
+  }
+
+  // MARK: - Edge cases
+
+  @Test func emptyDataPayloadLengthIsZero() {
+    let emptyPayload = Data()
+    var length = UInt32(emptyPayload.count).bigEndian
+    var message = Data()
+    withUnsafeBytes(of: &length) { message.append(contentsOf: $0) }
+    #expect(message.count == 4)
+    let decodedLength = message.withUnsafeBytes { ptr -> UInt32 in
+      UInt32(bigEndian: ptr.load(as: UInt32.self))
+    }
+    #expect(decodedLength == 0)
+  }
+
+  @Test func maxReasonablePayloadLengthEncodes() {
+    // 10MB is the max accepted by both client and server
+    let maxLength: UInt32 = 9_999_999
+    var encoded = UInt32(maxLength).bigEndian
+    var data = Data()
+    withUnsafeBytes(of: &encoded) { data.append(contentsOf: $0) }
+    let decoded = data.withUnsafeBytes { ptr -> UInt32 in
+      UInt32(bigEndian: ptr.load(as: UInt32.self))
+    }
+    #expect(decoded == maxLength)
+  }
+
+  // MARK: - All commands encode without error
+
+  @Test func allCommandTypesEncodeSuccessfully() throws {
+    let commands: [Command] = [
+      .open(OpenInput(path: "/tmp")),
+      .open(OpenInput(path: nil)),
+      .list(ListInput()),
+      .focus(FocusInput(selector: .worktree("wt"))),
+      .focus(FocusInput(selector: .none)),
+      .send(SendInput(selector: .tab("t1"), text: "cmd", trailingEnter: true)),
+      .key(KeyInput(selector: .pane("p1"), token: "ctrl-c", repeatCount: 100)),
+      .read(ReadInput(selector: .none, last: nil)),
+      .read(ReadInput(selector: .worktree("w"), last: 1)),
+    ]
+    let encoder = JSONEncoder()
+    for cmd in commands {
+      let envelope = CommandEnvelope(output: .json, command: cmd)
+      let data = try encoder.encode(envelope)
+      #expect(data.count > 0)
+      // Verify it decodes back
+      let decoded = try JSONDecoder().decode(CommandEnvelope.self, from: data)
+      #expect(decoded.command.name == cmd.name)
+    }
+  }
+}


### PR DESCRIPTION
## Summary

CLI v1 foundation implementing #105. Adds the Swift `prowl` CLI target skeleton, shared types, app-side command service scaffold, and Unix domain socket transport.

## Architecture

Three new modules:

### ProwlShared/ (shared library)
Types shared between CLI and app:
- `CommandEnvelope` — the handoff contract (output mode + command)
- `Command` enum — `open/list/focus/send/key/read` with typed inputs
- `CommandResponse` — structured success/error response
- `TargetSelector` — mutually exclusive worktree/tab/pane selector
- `InputModels` — `OpenInput`, `ListInput`, `FocusInput`, `SendInput`, `KeyInput`, `ReadInput`
- `ErrorCodes` — stable error code constants matching schema.md
- `SocketConstants` — shared socket path convention

### ProwlCLI/ (executable target)
ArgumentParser-based CLI:
- `ProwlCommand` root with 6 subcommands, `--help`, `--version`
- `OpenCommand` — bare path entry (`prowl .`, `prowl ~/foo`) normalized to open; path validation (exists + is directory)
- `ListCommand`, `FocusCommand`, `SendCommand`, `KeyCommand`, `ReadCommand` — full argument parsing per input.md
- `SendCommand` handles argv vs stdin mutual exclusivity
- `KeyCommand` validates repeat range (1-100), normalizes token to lowercase
- `SelectorOptions` — shared target selector flags with mutual exclusivity check
- `GlobalOptions` — `--json` flag
- `SocketTransportClient` — Unix domain socket client (length-prefixed JSON)
- `OutputRenderer` — JSON and text mode output
- `CLIRunner` — central execution: send envelope → render response

### supacode/CLIService/ (app-side scaffold)
- `CommandHandler` protocol — async handle → CommandResponse
- `CLICommandRouter` — routes envelopes to handlers (default: stub handlers returning NOT_IMPLEMENTED)
- `CLISocketServer` — Unix domain socket server, length-prefixed JSON, concurrent client handling
- `TargetResolver` — scaffold for resolving selectors against live app state (TODO: wire to WorktreeTerminalManager)

## Transport protocol
- Unix domain socket at `$TMPDIR/prowl-cli.sock`
- Length-prefixed JSON: 4-byte big-endian length + JSON payload
- Single request / single response per connection
- App-not-running maps to `APP_NOT_RUNNING` error code

## What's not in this PR
- Xcode project file changes (adding targets + SPM dependency) — needs to be done in Xcode
- Actual command handler implementations (tracked in dedicated issues)
- Full `--json` schema validation tests (scaffold only)
- IPC error recovery / retry logic

## Matches acceptance criteria
- ✅ Parser skeleton for all 6 commands + `--help` + `--version`
- ✅ Typed command envelope for open/list/focus/send/key/read
- ✅ Local command service boundary callable from CLI path
- ✅ `--json` output path integrated
- ✅ No shell-script parser logic

Part of #105 (Xcode project integration pending local setup)

@jarvis-elevated 请帮忙 review。