### PR TITLE
Fix terminal layout restore safeguards

### DIFF
--- a/supacode/Clients/Terminal/TerminalClient.swift
+++ b/supacode/Clients/Terminal/TerminalClient.swift
@@ -42,6 +42,7 @@ struct TerminalClient {
     case setupScriptConsumed(worktreeID: Worktree.ID)
     case fontSizeChanged(Float32?)
     case layoutRestored(selectedWorktreeID: Worktree.ID?)
+    case layoutRestoreFailed(message: String)
   }
 }
 

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -940,6 +940,10 @@ struct AppFeature {
         }
         return .none
 
+      case .terminalEvent(.layoutRestoreFailed(let message)):
+        appLogger.warning("[LayoutRestore] layoutRestoreFailed: \(message)")
+        return .send(.repositories(.showToast(.warning(message))))
+
       case .terminalEvent:
         return .none
       }

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -271,6 +271,7 @@ struct RepositoriesFeature {
   enum StatusToast: Equatable {
     case inProgress(String)
     case success(String)
+    case warning(String)
   }
 
   enum SnapshotPersistencePhase: Equatable {
@@ -2035,7 +2036,7 @@ struct RepositoriesFeature {
         switch toast {
         case .inProgress:
           return .cancel(id: CancelID.toastAutoDismiss)
-        case .success:
+        case .success, .warning:
           return .run { send in
             try? await ContinuousClock().sleep(for: .seconds(2.5))
             await send(.dismissToast)

--- a/supacode/Features/Repositories/Views/ToolbarStatusView.swift
+++ b/supacode/Features/Repositories/Views/ToolbarStatusView.swift
@@ -26,6 +26,16 @@ struct ToolbarStatusView: View {
             .foregroundStyle(.secondary)
         }
         .transition(.opacity)
+      case .warning(let message):
+        HStack(spacing: 6) {
+          Image(systemName: "exclamationmark.triangle.fill")
+            .foregroundStyle(.orange)
+            .accessibilityHidden(true)
+          Text(message)
+            .font(.footnote)
+            .foregroundStyle(.secondary)
+        }
+        .transition(.opacity)
       case nil:
         if let model = PullRequestStatusModel(pullRequest: pullRequest) {
           PullRequestStatusButton(model: model)

--- a/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
+++ b/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
@@ -3,6 +3,7 @@ import Observation
 import Sharing
 
 private let terminalLogger = SupaLogger("Terminal")
+private let layoutRestoreFailureMessage = "Saved terminal layout was invalid and has been reset"
 
 @MainActor
 @Observable
@@ -440,8 +441,9 @@ final class WorktreeTerminalManager {
       )
       emit(.layoutRestored(selectedWorktreeID: payload.selectedWorktreeID))
     } else {
-      terminalLogger.info("[LayoutRestore] restore: clearing invalid snapshot")
+      terminalLogger.warning("[LayoutRestore] restore: clearing invalid snapshot and emitting failure toast")
       _ = await layoutPersistence.clearSnapshot()
+      emit(.layoutRestoreFailed(message: layoutRestoreFailureMessage))
     }
   }
 

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -1137,6 +1137,7 @@ final class WorktreeTerminalState {
       guard let ratio = snapshotNode.ratio, ratio > 0, ratio < 1 else {
         return nil
       }
+      let clampedRatio = max(0.1, min(0.9, ratio))
       guard let children = snapshotNode.children, children.count == 2 else {
         return nil
       }
@@ -1149,7 +1150,7 @@ final class WorktreeTerminalState {
       return .split(
         .init(
           direction: splitDirection(from: direction),
-          ratio: ratio,
+          ratio: clampedRatio,
           left: left,
           right: right
         )

--- a/supacodeTests/AppFeatureTerminalLayoutRestoreTests.swift
+++ b/supacodeTests/AppFeatureTerminalLayoutRestoreTests.swift
@@ -182,6 +182,20 @@ struct AppFeatureTerminalLayoutRestoreTests {
     await store.receive(\.repositories.selectRepository)
   }
 
+  @Test(.dependencies) func layoutRestoreFailedEventShowsWarningToast() async {
+    let store = TestStore(initialState: AppFeature.State()) {
+      AppFeature()
+    }
+    store.exhaustivity = .off
+
+    await store.send(
+      .terminalEvent(.layoutRestoreFailed(message: "Saved terminal layout was invalid and has been reset"))
+    )
+    await store.receive(\.repositories.showToast) {
+      $0.repositories.statusToast = .warning("Saved terminal layout was invalid and has been reset")
+    }
+  }
+
   @Test(.dependencies) func scenePhaseInactiveSavesLayoutSnapshot() async {
     let sentCommands = LockIsolated<[TerminalClient.Command]>([])
     var settings = SettingsFeature.State()

--- a/supacodeTests/TerminalLayoutSnapshotPayloadTests.swift
+++ b/supacodeTests/TerminalLayoutSnapshotPayloadTests.swift
@@ -153,6 +153,24 @@ struct TerminalLayoutSnapshotPayloadTests {
     #expect(TerminalLayoutSnapshotPayload.decodeValidated(from: data) == nil)
   }
 
+  @Test func decodeValidatedRoundTripsExtremeSplitRatioForRestoreClamping() throws {
+    let payload = makePayload(
+      splitRoot: .split(
+        direction: .horizontal,
+        ratio: 0.02,
+        children: [
+          .leaf(surfaceID: "surface-1"),
+          .leaf(surfaceID: "surface-2"),
+        ]
+      )
+    )
+    let data = try JSONEncoder().encode(payload)
+
+    let decoded = TerminalLayoutSnapshotPayload.decodeValidated(from: data)
+    #expect(decoded == payload)
+    #expect(decoded?.worktrees.first?.tabs.first?.splitRoot.ratio == 0.02)
+  }
+
   @Test func decodeValidatedRejectsTypeMismatchInFields() {
     let invalidJSON = #"""
       {

--- a/supacodeTests/WorktreeTerminalManagerTests.swift
+++ b/supacodeTests/WorktreeTerminalManagerTests.swift
@@ -251,10 +251,19 @@ struct WorktreeTerminalManagerTests {
         }
       )
     )
+    let stream = manager.eventStream()
 
     await manager.restoreLayoutSnapshot(from: [])
 
+    let event = await nextEvent(stream) { event in
+      if case .layoutRestoreFailed = event {
+        return true
+      }
+      return false
+    }
+
     #expect(clearCount.value == 1)
+    #expect(event == .layoutRestoreFailed(message: "Saved terminal layout was invalid and has been reset"))
   }
 
   @Test func persistLayoutSnapshotWithoutTabsClearsSnapshot() async {


### PR DESCRIPTION
## Summary

Implement the two missing layout-restore safeguards from #123:

- clamp restored split ratio to `[0.1, 0.9]`
- show a warning toast when layout restore fails and the snapshot is reset

## What changed

- `WorktreeTerminalState.restoreSplitNode(...)`
  - keep the existing `(0, 1)` validation
  - clamp restored ratio to `[0.1, 0.9]` to match interactive resizing behavior

- `TerminalClient`
  - add `.layoutRestoreFailed(message: String)`

- `WorktreeTerminalManager.restoreLayoutSnapshot(...)`
  - keep fail-closed cleanup behavior
  - emit a restore-failure event with user-facing copy after invalid snapshot reset

- `AppFeature`
  - route `.layoutRestoreFailed(...)` into the existing repositories toast flow

- `RepositoriesFeature.StatusToast` + `ToolbarStatusView`
  - add `warning(String)`
  - render it with a warning-style toolbar indicator
  - keep existing auto-dismiss behavior

## Tests

- add/adjust layout snapshot payload coverage for extreme ratio values
- extend restore-failure manager test to verify failure event emission
- add app-level test covering warning toast display on layout restore failure

## Notes

I could not run local Swift/Xcode build or tests in the current environment because `xcodebuild` / `swift` are unavailable here. The code and test updates are included so CI or a local macOS/Xcode environment can validate the branch.

Closes #123
