### PR TITLE
fix(test): remove unnecessary skipInFlightEffects call

### DIFF
--- a/supacodeTests/AppFeatureSettingsChangedTests.swift
+++ b/supacodeTests/AppFeatureSettingsChangedTests.swift
@@ -111,6 +111,5 @@ struct AppFeatureSettingsChangedTests {
     await store.receive(\.repositories.showToast) {
       $0.repositories.statusToast = .success("Saved terminal layout cleared")
     }
-    await store.skipInFlightEffects()
   }
 }


### PR DESCRIPTION
## Problem

`clearTerminalLayoutSnapshotShowsSuccessToast` fails with:

> Issue recorded: There were no in-flight effects to skip.

The test calls `store.skipInFlightEffects()` after all effects have already completed. Newer TCA versions enforce that in-flight effects must exist when this method is called.

## Fix

Remove the redundant `skipInFlightEffects()` call. No effects are in flight at that point, and the test assertion (`receive(\.repositories.showToast)`) already validates the expected behavior.

## Test

522 passed / 0 failed / 0 skipped after the change.