### PR TITLE
Fix canvas sidebar button hit area to cover full row

### DIFF
--- a/supacode/Features/Canvas/Views/CanvasSidebarButton.swift
+++ b/supacode/Features/Canvas/Views/CanvasSidebarButton.swift
@@ -21,10 +21,11 @@ struct CanvasSidebarButton: View {
           ShortcutHintView(text: shortcut, color: .secondary)
         }
       }
+      .padding(.horizontal, 12)
+      .padding(.vertical, 6)
+      .contentShape(.rect)
     }
     .buttonStyle(.plain)
-    .padding(.horizontal, 12)
-    .padding(.vertical, 6)
     .background(isSelected ? Color.accentColor.opacity(0.15) : .clear, in: .rect(cornerRadius: 6))
     .help(
       AppShortcuts.helpText(


### PR DESCRIPTION
## Summary
- The Canvas button in the sidebar only responded to clicks on the icon and text, ignoring the surrounding padding area
- Moved `.padding()` and `.contentShape(.rect)` inside the Button label so `.buttonStyle(.plain)` treats the entire padded row as the tap target

## Test plan
- [ ] Click on the empty space to the right of the "Canvas" label — should now select Canvas
- [ ] Click on the padding area above/below the label — should also work
- [ ] Verify the selection highlight (`.background`) still renders correctly across the full row
- [ ] Hold ⌘ to verify the shortcut hint still appears correctly