### PR TITLE
Fix blank terminal after exiting Canvas

### DIFF
--- a/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
+++ b/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
@@ -120,19 +120,29 @@ final class WorktreeTerminalManager {
       setCommandFinishedNotification(enabled: enabled, threshold: threshold)
     case .setCanvasMode(let enabled):
       if enabled {
+        terminalLogger.info("[CanvasExit] enteringCanvas previousSelectedWorktree=\(selectedWorktreeID ?? "nil")")
         selectedWorktreeID = nil
       }
     case .setSelectedWorktreeID(let id):
       guard id != selectedWorktreeID else { return }
-      if let previousID = selectedWorktreeID, let previousState = states[previousID] {
+      let previousSelectedWorktreeID = selectedWorktreeID
+      let leavingCanvas = previousSelectedWorktreeID == nil
+      if let previousID = previousSelectedWorktreeID, let previousState = states[previousID] {
         previousState.setAllSurfacesOccluded()
-      } else if selectedWorktreeID == nil {
+      } else if leavingCanvas {
         // Leaving canvas mode: occlude all worktrees except the newly selected one.
         for (wid, state) in states where wid != id {
           state.setAllSurfacesOccluded()
         }
       }
       selectedWorktreeID = id
+      terminalLogger.info(
+        "[CanvasExit] setSelectedWorktreeID previous=\(previousSelectedWorktreeID ?? "nil") "
+          + "next=\(id ?? "nil") leavingCanvas=\(leavingCanvas) states=\(states.count)"
+      )
+      if leavingCanvas, let id, let state = states[id] {
+        state.refreshSurfaceActivity(reason: "canvas-exit-selected-worktree")
+      }
       terminalLogger.info("Selected worktree \(id ?? "nil")")
     case .saveLayoutSnapshot:
       terminalLogger.info("[LayoutRestore] received saveLayoutSnapshot command")

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -289,6 +289,20 @@ final class WorktreeTerminalState {
     applySurfaceActivity()
   }
 
+  func refreshSurfaceActivity(reason: String) {
+    terminalStateLogger.info(
+      "[CanvasExit] refreshSurfaceActivity worktree=\(worktree.id) reason=\(reason) "
+        + "selectedTab=\(tabManager.selectedTabId?.rawValue.uuidString ?? "nil") "
+        + "windowKey=\(String(describing: lastWindowIsKey)) "
+        + "windowVisible=\(String(describing: lastWindowIsVisible)) "
+        + "surfaces=\(surfaces.count) tabs=\(tabManager.tabs.count)"
+    )
+    for surface in surfaces.values {
+      surface.invalidateOcclusionCache(reason: reason)
+    }
+    applySurfaceActivity()
+  }
+
   private func applySurfaceActivity() {
     let selectedTabId = tabManager.selectedTabId
     var surfaceToFocus: GhosttySurfaceView?

--- a/supacode/Features/Terminal/Views/WorktreeTerminalTabsView.swift
+++ b/supacode/Features/Terminal/Views/WorktreeTerminalTabsView.swift
@@ -1,6 +1,8 @@
 import AppKit
 import SwiftUI
 
+private let terminalTabsLogger = SupaLogger("TerminalTabs")
+
 struct WorktreeTerminalTabsView: View {
   let worktree: Worktree
   let manager: WorktreeTerminalManager
@@ -57,13 +59,25 @@ struct WorktreeTerminalTabsView: View {
         state.focusSelectedTab()
       }
       let activity = resolvedWindowActivity
+      terminalTabsLogger.info(
+        "[CanvasExit] onAppear worktree=\(worktree.id) "
+          + "selectedTab=\(state.tabManager.selectedTabId?.rawValue.uuidString ?? "nil") "
+          + "autoFocus=\(shouldAutoFocusTerminal) "
+          + "windowKey=\(activity.isKeyWindow) windowVisible=\(activity.isVisible)"
+      )
       state.syncFocus(windowIsKey: activity.isKeyWindow, windowIsVisible: activity.isVisible)
     }
-    .onChange(of: state.tabManager.selectedTabId) { _, _ in
+    .onChange(of: state.tabManager.selectedTabId) { _, newValue in
       if shouldAutoFocusTerminal {
         state.focusSelectedTab()
       }
       let activity = resolvedWindowActivity
+      terminalTabsLogger.info(
+        "[CanvasExit] selectedTabChanged worktree=\(worktree.id) "
+          + "selectedTab=\(newValue?.rawValue.uuidString ?? "nil") "
+          + "autoFocus=\(shouldAutoFocusTerminal) "
+          + "windowKey=\(activity.isKeyWindow) windowVisible=\(activity.isVisible)"
+      )
       state.syncFocus(windowIsKey: activity.isKeyWindow, windowIsVisible: activity.isVisible)
     }
   }

--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
@@ -5,6 +5,8 @@ import GhosttyKit
 import QuartzCore
 import SwiftUI
 
+private let surfaceLogger = SupaLogger("Surface")
+
 final class GhosttySurfaceView: NSView, Identifiable {
   struct OcclusionState {
     private(set) var desired: Bool?
@@ -90,6 +92,9 @@ final class GhosttySurfaceView: NSView, Identifiable {
 
   private let runtime: GhosttyRuntime
   let id = UUID()
+  private var debugID: String {
+    String(id.uuidString.prefix(8))
+  }
   let bridge: GhosttySurfaceBridge
   private(set) var surface: ghostty_surface_t?
   private var surfaceRef: GhosttyRuntime.SurfaceReference?
@@ -959,10 +964,24 @@ final class GhosttySurfaceView: NSView, Identifiable {
     ghostty_surface_set_occlusion(surface, visible)
   }
 
+  func invalidateOcclusionCache(reason: String) {
+    surfaceLogger.info(
+      "[CanvasExit] invalidateOcclusionCache surface=\(debugID) "
+        + "reason=\(reason) desired=\(String(describing: occlusionState.desired)) "
+        + "attached=\(superview != nil) window=\(window != nil)"
+    )
+    _ = occlusionState.invalidateForAttachmentChange()
+  }
+
   private func handleAttachmentChange() {
     // Re-parenting can temporarily detach the Metal layer from the visible
     // tree and pause Ghostty's renderer. Invalidate the applied cache so the
     // currently desired occlusion value is sent again after reattachment.
+    surfaceLogger.info(
+      "[CanvasExit] attachmentChange surface=\(debugID) "
+        + "desired=\(String(describing: occlusionState.desired)) "
+        + "attached=\(superview != nil) window=\(window != nil)"
+    )
     _ = occlusionState.invalidateForAttachmentChange()
     guard superview != nil else { return }
     DispatchQueue.main.async { [weak self] in
@@ -972,6 +991,10 @@ final class GhosttySurfaceView: NSView, Identifiable {
 
   private func reapplyOcclusionIfNeeded() {
     guard superview != nil, let desired = occlusionState.desired else { return }
+    surfaceLogger.info(
+      "[CanvasExit] reapplyOcclusion surface=\(debugID) desired=\(desired) "
+        + "attached=\(superview != nil) window=\(window != nil)"
+    )
     setOcclusion(desired)
   }
 


### PR DESCRIPTION
## Summary
- force-refresh terminal surface activity when exiting Canvas back to a focused worktree
- invalidate per-surface occlusion caches before reapplying tab-view visibility/focus state
- add targeted `[CanvasExit]` diagnostics across selection, tab view appearance, and surface reattachment

## Why
We still see cases where exiting Canvas returns to the expected tab, but the terminal stays blank until switching away and back. The reducer-side selection flow appears correct; this change adds a more aggressive surface-state refresh on canvas exit and logs the critical path for future repros.

## Testing
- Not fully verified with `make build-app` because the branch currently has an unrelated existing compile error:
  - `supacode/Infrastructure/Ghostty/GhosttyRuntime.swift:513: cannot find 'ghostty_config_load_file' in scope`
- Code paths were inspected against the current Canvas exit flow and previous fixes around occlusion/reattachment.
