### PR TITLE
CLI/focus v1 runtime implementation (contract-driven)

### DIFF
--- a/ProwlCLI/Commands/FocusCommand.swift
+++ b/ProwlCLI/Commands/FocusCommand.swift
@@ -13,7 +13,7 @@ struct FocusCommand: ParsableCommand {
   @OptionGroup var options: GlobalOptions
 
   mutating func run() throws {
-    try CLIExecution.run(command: "focus", output: options.outputMode) {
+    try CLIExecution.run(command: "focus", output: options.outputMode, colorEnabled: options.colorEnabled) {
       let sel = try selector.resolve()
       let envelope = CommandEnvelope(
         output: options.outputMode,

--- a/ProwlCLI/Output/OutputRenderer.swift
+++ b/ProwlCLI/Output/OutputRenderer.swift
@@ -57,6 +57,14 @@ enum OutputRenderer {
         return
       }
 
+      if response.command == "focus",
+         let data = response.data,
+         let payload = try? data.decode(as: FocusCommandPayload.self)
+      {
+        print(renderFocus(payload))
+        return
+      }
+
       print("ok: \(response.command)")
       return
     }
@@ -185,6 +193,32 @@ enum OutputRenderer {
       lines.append("  \("wait:".dim) \("none (fire-and-forget)".dim)")
     }
 
+    return lines.joined(separator: "\n")
+  }
+
+  private static func renderFocus(_ payload: FocusCommandPayload) -> String {
+    let wt = payload.target.worktree
+    let tab = payload.target.tab
+    let pane = payload.target.pane
+
+    let projectName = projectName(from: wt.path)
+    let frontLabel = payload.broughtToFront ? "yes".green : "no".red.bold
+    let requestedValue = payload.requested.value ?? "current"
+
+    var lines: [String] = []
+    lines.append(
+      "Focused \(projectName.cyan.bold)\(":".dim)\(wt.name) → \(pane.title.green)"
+      + "  \(pane.id.dim)"
+    )
+    lines.append(
+      "  \("requested:".dim) \(payload.requested.selector.rawValue)=\(requestedValue)"
+      + "  \("resolved:".dim) \(payload.resolvedVia.rawValue)"
+      + "  \("front:".dim) \(frontLabel)"
+    )
+    lines.append("  \("tab:".dim) \(tab.title)  \(tab.id.dim)")
+    if let cwd = pane.cwd {
+      lines.append("  \("cwd:".dim) \(cwd)")
+    }
     return lines.joined(separator: "\n")
   }
 

--- a/ProwlCLITests/ProwlCLIIntegrationTests.swift
+++ b/ProwlCLITests/ProwlCLIIntegrationTests.swift
@@ -100,6 +100,86 @@ final class ProwlCLIIntegrationTests: XCTestCase {
     XCTAssertEqual(payload["command"] as? String, "focus")
   }
 
+  func testFocusCommandWithoutSelectorSendsCurrentTarget() throws {
+    let socketPath = temporarySocketPath(suffix: "focus-current")
+    let response = CommandResponse(
+      ok: true,
+      command: "focus",
+      schemaVersion: "prowl.cli.focus.v1"
+    )
+
+    let (requestData, result) = try runWithMockServer(
+      socketPath: socketPath,
+      response: response,
+      args: ["focus", "--json"]
+    )
+
+    XCTAssertEqual(result.exitCode, 0)
+    let envelope = try JSONDecoder().decode(CommandEnvelope.self, from: requestData)
+    if case .focus(let input) = envelope.command {
+      XCTAssertEqual(input.selector, .none)
+    } else {
+      XCTFail("Expected focus command envelope")
+    }
+  }
+
+  func testFocusRejectsMultipleSelectorsBeforeTransport() throws {
+    let result = try runProwl(args: ["focus", "--worktree", "Prowl", "--pane", "pane-123", "--json"])
+
+    XCTAssertNotEqual(result.exitCode, 0)
+    let payload = try jsonObject(from: result.stdout)
+    XCTAssertEqual(payload["ok"] as? Bool, false)
+    XCTAssertEqual(payload["command"] as? String, "focus")
+    let error = try XCTUnwrap(payload["error"] as? [String: Any])
+    XCTAssertEqual(error["code"] as? String, CLIErrorCode.invalidArgument)
+  }
+
+  func testFocusCommandTextRenderingFromSocket() throws {
+    let socketPath = temporarySocketPath(suffix: "focus-text")
+    let response = try CommandResponse(
+      ok: true,
+      command: "focus",
+      schemaVersion: "prowl.cli.focus.v1",
+      data: RawJSON(encoding: FocusResponseData(
+        requested: FocusRequested(selector: "pane", value: "6E1A2A10-D99F-4E3F-920C-D93AA3C05764"),
+        resolvedVia: "pane",
+        broughtToFront: true,
+        target: FocusResponseTarget(
+          worktree: ListWorktree(
+            id: "Prowl:/Users/onevcat/Projects/Prowl",
+            name: "Prowl",
+            path: "/Users/onevcat/Projects/Prowl",
+            rootPath: "/Users/onevcat/Projects/Prowl",
+            kind: "git"
+          ),
+          tab: FocusResponseTab(
+            id: "2FC00CF0-3974-4E1B-BEF8-7A08A8E3B7C0",
+            title: "Prowl 1",
+            selected: true
+          ),
+          pane: FocusResponsePane(
+            id: "6E1A2A10-D99F-4E3F-920C-D93AA3C05764",
+            title: "zsh",
+            cwd: "/Users/onevcat/Projects/Prowl",
+            focused: true
+          )
+        )
+      ))
+    )
+
+    let (_, result) = try runWithMockServer(
+      socketPath: socketPath,
+      response: response,
+      args: ["focus"]
+    )
+
+    XCTAssertEqual(result.exitCode, 0)
+    XCTAssertTrue(result.stdout.contains("Focused Prowl:Prowl"), "Missing focus header: \(result.stdout)")
+    XCTAssertTrue(result.stdout.contains("requested: pane"), "Missing requested field: \(result.stdout)")
+    XCTAssertTrue(result.stdout.contains("resolved: pane"), "Missing resolved field: \(result.stdout)")
+    XCTAssertTrue(result.stdout.contains("tab: Prowl 1"), "Missing tab field: \(result.stdout)")
+  }
+
 
   func testListCommandTextRenderingFromSocket() throws {
     let socketPath = temporarySocketPath(suffix: "list-text")
@@ -697,6 +777,45 @@ private struct ListPane: Encodable {
 
 private struct ListTask: Encodable {
   let status: String?
+}
+
+private struct FocusResponseData: Encodable {
+  let requested: FocusRequested
+
+  enum CodingKeys: String, CodingKey {
+    case requested
+    case resolvedVia = "resolved_via"
+    case broughtToFront = "brought_to_front"
+    case target
+  }
+
+  let resolvedVia: String
+  let broughtToFront: Bool
+  let target: FocusResponseTarget
+}
+
+private struct FocusRequested: Encodable {
+  let selector: String
+  let value: String?
+}
+
+private struct FocusResponseTarget: Encodable {
+  let worktree: ListWorktree
+  let tab: FocusResponseTab
+  let pane: FocusResponsePane
+}
+
+private struct FocusResponseTab: Encodable {
+  let id: String
+  let title: String
+  let selected: Bool
+}
+
+private struct FocusResponsePane: Encodable {
+  let id: String
+  let title: String
+  let cwd: String?
+  let focused: Bool
 }
 
 private struct SendResponseData: Encodable {

--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -229,7 +229,36 @@ struct SupacodeApp: App {
           .waitForCommandFinished(surfaceID: surfaceID)
       }
     )
-    let cliRouter = CLICommandRouter(listHandler: listHandler, sendHandler: sendHandler)
+    let focusHandler = FocusCommandHandler(
+      resolveProvider: { selector in
+        let resolver = TargetResolver {
+          TargetResolutionSnapshotBuilder.makeSnapshot(
+            repositoriesState: appStore.state.repositories,
+            terminalManager: terminalManager
+          )
+        }
+        return resolver.resolve(selector).map { FocusResolvedTarget(from: $0) }
+      },
+      focusPerformer: { target in
+        selectCLIWorktreeContext(
+          worktreeID: target.worktreeID,
+          appStore: appStore,
+          terminalManager: terminalManager
+        )
+        guard let state = terminalManager.stateIfExists(for: target.worktreeID) else {
+          return false
+        }
+        return state.focusSurface(id: target.paneID)
+      },
+      bringToFront: {
+        bringMainWindowToFront()
+      }
+    )
+    let cliRouter = CLICommandRouter(
+      listHandler: listHandler,
+      focusHandler: focusHandler,
+      sendHandler: sendHandler
+    )
     let cliServer = CLISocketServer(router: cliRouter)
     let logger = SupaLogger("CLIService")
     do {
@@ -239,6 +268,45 @@ struct SupacodeApp: App {
       logger.warning("Failed to start CLI socket server: \(String(describing: error))")
     }
     return cliServer
+  }
+
+  private static func selectCLIWorktreeContext(
+    worktreeID: Worktree.ID,
+    appStore: StoreOf<AppFeature>,
+    terminalManager: WorktreeTerminalManager
+  ) {
+    let repositories = appStore.state.repositories
+    if repositories.worktree(for: worktreeID) != nil {
+      appStore.send(.repositories(.selectWorktree(worktreeID)))
+    } else if let repository = repositories.repositories[id: worktreeID],
+      repository.capabilities.supportsRunnableFolderActions
+    {
+      appStore.send(.repositories(.selectRepository(worktreeID)))
+    }
+    terminalManager.handleCommand(.setSelectedWorktreeID(worktreeID))
+  }
+
+  private static func bringMainWindowToFront() -> Bool {
+    let app = NSApplication.shared
+    guard let window = mainWindow(from: app) else {
+      return false
+    }
+    if window.isMiniaturized {
+      window.deminiaturize(nil)
+    }
+    app.activate(ignoringOtherApps: true)
+    window.makeKeyAndOrderFront(nil)
+    return true
+  }
+
+  private static func mainWindow(from app: NSApplication) -> NSWindow? {
+    if let window = app.windows.first(where: { $0.identifier?.rawValue == "main" }) {
+      return window
+    }
+    if let window = app.windows.first(where: { $0.identifier?.rawValue != "settings" }) {
+      return window
+    }
+    return app.windows.first
   }
 
   var body: some Scene {

--- a/supacode/CLIService/FocusCommandHandler.swift
+++ b/supacode/CLIService/FocusCommandHandler.swift
@@ -1,0 +1,183 @@
+// supacode/CLIService/FocusCommandHandler.swift
+// Handles `prowl focus` by resolving, focusing, and returning final pane context.
+
+import Foundation
+
+/// Resolved target metadata for focus payload construction.
+struct FocusResolvedTarget: Sendable {
+  let worktreeID: String
+  let worktreeName: String
+  let worktreePath: String
+  let worktreeRootPath: String
+  let worktreeKind: ListCommandWorktree.Kind
+  let tabID: UUID
+  let tabTitle: String
+  let tabSelected: Bool
+  let paneID: UUID
+  let paneTitle: String
+  let paneCWD: String?
+  let paneFocused: Bool
+}
+
+extension FocusResolvedTarget {
+  init(from resolved: ResolvedTarget) {
+    self.worktreeID = resolved.worktreeID
+    self.worktreeName = resolved.worktreeName
+    self.worktreePath = resolved.worktreePath
+    self.worktreeRootPath = resolved.worktreeRootPath
+    self.worktreeKind = resolved.worktreeKind
+    self.tabID = resolved.tabID
+    self.tabTitle = resolved.tabTitle
+    self.tabSelected = resolved.tabSelected
+    self.paneID = resolved.paneID
+    self.paneTitle = resolved.paneTitle
+    self.paneCWD = resolved.paneCWD
+    self.paneFocused = resolved.paneFocused
+  }
+}
+
+@MainActor
+final class FocusCommandHandler: CommandHandler {
+  typealias ResolveProvider = @MainActor (TargetSelector) -> Result<FocusResolvedTarget, TargetResolverError>
+  typealias FocusPerformer = @MainActor (FocusResolvedTarget) -> Bool
+  typealias BringToFront = @MainActor () -> Bool
+
+  private let resolveProvider: ResolveProvider
+  private let focusPerformer: FocusPerformer
+  private let bringToFront: BringToFront
+
+  init(
+    resolveProvider: @escaping ResolveProvider,
+    focusPerformer: @escaping FocusPerformer,
+    bringToFront: @escaping BringToFront
+  ) {
+    self.resolveProvider = resolveProvider
+    self.focusPerformer = focusPerformer
+    self.bringToFront = bringToFront
+  }
+
+  func handle(envelope: CommandEnvelope) -> CommandResponse {
+    guard case .focus(let input) = envelope.command else {
+      return errorResponse(code: CLIErrorCode.focusFailed, message: "Invalid command.")
+    }
+
+    let requested = makeRequestedTarget(from: input.selector)
+    let resolvedVia = makeResolvedVia(from: input.selector)
+
+    // Resolve requested selector.
+    let requestedTarget: FocusResolvedTarget
+    switch resolveProvider(input.selector) {
+    case .success(let target):
+      requestedTarget = target
+    case .failure(let error):
+      return mapResolverError(error)
+    }
+
+    // Apply focus operation.
+    guard focusPerformer(requestedTarget) else {
+      return errorResponse(code: CLIErrorCode.focusFailed, message: "Failed to focus requested target.")
+    }
+
+    // Bring app window to front.
+    guard bringToFront() else {
+      return errorResponse(code: CLIErrorCode.focusFailed, message: "Failed to bring Prowl to front.")
+    }
+
+    // Always return the final active pane context for command chaining.
+    let finalTarget: FocusResolvedTarget
+    switch resolveProvider(.none) {
+    case .success(let target):
+      finalTarget = target
+    case .failure:
+      return errorResponse(code: CLIErrorCode.focusFailed, message: "Focused target could not be resolved.")
+    }
+
+    // Contract invariant: successful focus must end at selected tab + focused pane.
+    guard finalTarget.tabSelected, finalTarget.paneFocused else {
+      return errorResponse(code: CLIErrorCode.focusFailed, message: "Focused target was not activated.")
+    }
+
+    let payload = FocusCommandPayload(
+      requested: requested,
+      resolvedVia: resolvedVia,
+      broughtToFront: true,
+      target: makePayloadTarget(from: finalTarget)
+    )
+
+    do {
+      return try CommandResponse(
+        ok: true,
+        command: "focus",
+        schemaVersion: "prowl.cli.focus.v1",
+        data: RawJSON(encoding: payload)
+      )
+    } catch {
+      return errorResponse(code: CLIErrorCode.focusFailed, message: "Failed to encode response.")
+    }
+  }
+
+  private func makeRequestedTarget(from selector: TargetSelector) -> FocusRequestedTarget {
+    switch selector {
+    case .worktree(let value):
+      return FocusRequestedTarget(selector: .worktree, value: value)
+    case .tab(let value):
+      return FocusRequestedTarget(selector: .tab, value: value)
+    case .pane(let value):
+      return FocusRequestedTarget(selector: .pane, value: value)
+    case .none:
+      return FocusRequestedTarget(selector: .current, value: nil)
+    }
+  }
+
+  private func makeResolvedVia(from selector: TargetSelector) -> FocusResolvedVia {
+    switch selector {
+    case .worktree:
+      return .worktree
+    case .tab:
+      return .tab
+    case .pane, .none:
+      return .pane
+    }
+  }
+
+  private func makePayloadTarget(from target: FocusResolvedTarget) -> FocusTarget {
+    FocusTarget(
+      worktree: FocusTargetWorktree(
+        id: target.worktreeID,
+        name: target.worktreeName,
+        path: target.worktreePath,
+        rootPath: target.worktreeRootPath,
+        kind: target.worktreeKind.rawValue
+      ),
+      tab: FocusTargetTab(
+        id: target.tabID.uuidString,
+        title: target.tabTitle,
+        selected: target.tabSelected
+      ),
+      pane: FocusTargetPane(
+        id: target.paneID.uuidString,
+        title: target.paneTitle,
+        cwd: target.paneCWD,
+        focused: target.paneFocused
+      )
+    )
+  }
+
+  private func mapResolverError(_ error: TargetResolverError) -> CommandResponse {
+    switch error {
+    case .notFound(let message):
+      return errorResponse(code: CLIErrorCode.targetNotFound, message: message)
+    case .notUnique(let message):
+      return errorResponse(code: CLIErrorCode.targetNotUnique, message: message)
+    }
+  }
+
+  private func errorResponse(code: String, message: String) -> CommandResponse {
+    CommandResponse(
+      ok: false,
+      command: "focus",
+      schemaVersion: "prowl.cli.focus.v1",
+      error: CommandError(code: code, message: message)
+    )
+  }
+}

--- a/supacode/CLIService/Shared/FocusCommandPayload.swift
+++ b/supacode/CLIService/Shared/FocusCommandPayload.swift
@@ -1,0 +1,115 @@
+// ProwlShared/FocusCommandPayload.swift
+// Success payload for `prowl focus --json` matching focus.md contract.
+
+import Foundation
+
+public struct FocusCommandPayload: Codable, Sendable, Equatable {
+  public let requested: FocusRequestedTarget
+  public let resolvedVia: FocusResolvedVia
+  public let broughtToFront: Bool
+  public let target: FocusTarget
+
+  enum CodingKeys: String, CodingKey {
+    case requested
+    case resolvedVia = "resolved_via"
+    case broughtToFront = "brought_to_front"
+    case target
+  }
+
+  public init(
+    requested: FocusRequestedTarget,
+    resolvedVia: FocusResolvedVia,
+    broughtToFront: Bool,
+    target: FocusTarget
+  ) {
+    self.requested = requested
+    self.resolvedVia = resolvedVia
+    self.broughtToFront = broughtToFront
+    self.target = target
+  }
+}
+
+public struct FocusRequestedTarget: Codable, Sendable, Equatable {
+  public let selector: FocusRequestedSelector
+  public let value: String?
+
+  public init(selector: FocusRequestedSelector, value: String?) {
+    self.selector = selector
+    self.value = value
+  }
+}
+
+public enum FocusRequestedSelector: String, Codable, Sendable {
+  case worktree
+  case tab
+  case pane
+  case current
+}
+
+public enum FocusResolvedVia: String, Codable, Sendable {
+  case worktree
+  case tab
+  case pane
+}
+
+public struct FocusTarget: Codable, Sendable, Equatable {
+  public let worktree: FocusTargetWorktree
+  public let tab: FocusTargetTab
+  public let pane: FocusTargetPane
+
+  public init(worktree: FocusTargetWorktree, tab: FocusTargetTab, pane: FocusTargetPane) {
+    self.worktree = worktree
+    self.tab = tab
+    self.pane = pane
+  }
+}
+
+public struct FocusTargetWorktree: Codable, Sendable, Equatable {
+  public let id: String
+  public let name: String
+  public let path: String
+  public let rootPath: String
+  public let kind: String
+
+  enum CodingKeys: String, CodingKey {
+    case id
+    case name
+    case path
+    case rootPath = "root_path"
+    case kind
+  }
+
+  public init(id: String, name: String, path: String, rootPath: String, kind: String) {
+    self.id = id
+    self.name = name
+    self.path = path
+    self.rootPath = rootPath
+    self.kind = kind
+  }
+}
+
+public struct FocusTargetTab: Codable, Sendable, Equatable {
+  public let id: String
+  public let title: String
+  public let selected: Bool
+
+  public init(id: String, title: String, selected: Bool) {
+    self.id = id
+    self.title = title
+    self.selected = selected
+  }
+}
+
+public struct FocusTargetPane: Codable, Sendable, Equatable {
+  public let id: String
+  public let title: String
+  public let cwd: String?
+  public let focused: Bool
+
+  public init(id: String, title: String, cwd: String?, focused: Bool) {
+    self.id = id
+    self.title = title
+    self.cwd = cwd
+    self.focused = focused
+  }
+}

--- a/supacodeTests/CLIFocusCommandHandlerTests.swift
+++ b/supacodeTests/CLIFocusCommandHandlerTests.swift
@@ -1,0 +1,196 @@
+import Foundation
+import Testing
+
+@testable import supacode
+
+@MainActor
+struct CLIFocusCommandHandlerTests {
+  private static let paneID = UUID(uuidString: "6E1A2A10-D99F-4E3F-920C-D93AA3C05764")!
+  private static let tabID = UUID(uuidString: "2FC00CF0-3974-4E1B-BEF8-7A08A8E3B7C0")!
+
+  private static func makeTarget(
+    tabSelected: Bool = true,
+    paneFocused: Bool = true
+  ) -> FocusResolvedTarget {
+    FocusResolvedTarget(
+      worktreeID: "Prowl:/Users/onevcat/Projects/Prowl",
+      worktreeName: "Prowl",
+      worktreePath: "/Users/onevcat/Projects/Prowl",
+      worktreeRootPath: "/Users/onevcat/Projects/Prowl",
+      worktreeKind: .git,
+      tabID: tabID,
+      tabTitle: "Prowl 1",
+      tabSelected: tabSelected,
+      paneID: paneID,
+      paneTitle: "zsh",
+      paneCWD: "/Users/onevcat/Projects/Prowl",
+      paneFocused: paneFocused
+    )
+  }
+
+  @Test func successfulFocusReturnsSchemaConformantPayload() async throws {
+    var focusedTarget: FocusResolvedTarget?
+    let handler = FocusCommandHandler(
+      resolveProvider: { selector in
+        switch selector {
+        case .pane(let paneID):
+          #expect(paneID == Self.paneID.uuidString)
+          return .success(Self.makeTarget(tabSelected: false, paneFocused: false))
+        case .none:
+          return .success(Self.makeTarget(tabSelected: true, paneFocused: true))
+        default:
+          Issue.record("Unexpected selector: \(selector)")
+          return .failure(.notFound("Unexpected selector"))
+        }
+      },
+      focusPerformer: { target in
+        focusedTarget = target
+        return true
+      },
+      bringToFront: { true }
+    )
+
+    let response = await handler.handle(
+      envelope: CommandEnvelope(
+        output: .json,
+        command: .focus(FocusInput(selector: .pane(Self.paneID.uuidString)))
+      )
+    )
+
+    #expect(response.ok)
+    #expect(response.command == "focus")
+    #expect(response.schemaVersion == "prowl.cli.focus.v1")
+    #expect(focusedTarget?.paneID == Self.paneID)
+
+    let payload = try #require(try response.data?.decode(as: FocusCommandPayload.self))
+    #expect(payload.requested.selector == .pane)
+    #expect(payload.requested.value == Self.paneID.uuidString)
+    #expect(payload.resolvedVia == .pane)
+    #expect(payload.broughtToFront == true)
+    #expect(payload.target.worktree.id == "Prowl:/Users/onevcat/Projects/Prowl")
+    #expect(payload.target.tab.id == Self.tabID.uuidString)
+    #expect(payload.target.tab.selected == true)
+    #expect(payload.target.pane.id == Self.paneID.uuidString)
+    #expect(payload.target.pane.focused == true)
+  }
+
+  @Test func currentSelectorUsesNilRequestedValue() async throws {
+    var resolveNoneCount = 0
+    let handler = FocusCommandHandler(
+      resolveProvider: { selector in
+        #expect(selector == .none)
+        resolveNoneCount += 1
+        if resolveNoneCount == 1 {
+          return .success(Self.makeTarget(tabSelected: false, paneFocused: false))
+        }
+        return .success(Self.makeTarget(tabSelected: true, paneFocused: true))
+      },
+      focusPerformer: { _ in true },
+      bringToFront: { true }
+    )
+
+    let response = await handler.handle(
+      envelope: CommandEnvelope(output: .json, command: .focus(FocusInput(selector: .none)))
+    )
+
+    #expect(response.ok)
+    #expect(resolveNoneCount == 2)
+    let payload = try #require(try response.data?.decode(as: FocusCommandPayload.self))
+    #expect(payload.requested.selector == .current)
+    #expect(payload.requested.value == nil)
+    #expect(payload.resolvedVia == .pane)
+  }
+
+  @Test func targetNotFoundMapsToContractCode() async {
+    let handler = FocusCommandHandler(
+      resolveProvider: { _ in .failure(.notFound("Pane missing")) },
+      focusPerformer: { _ in true },
+      bringToFront: { true }
+    )
+
+    let response = await handler.handle(
+      envelope: CommandEnvelope(
+        output: .json,
+        command: .focus(FocusInput(selector: .pane("missing")))
+      )
+    )
+
+    #expect(response.ok == false)
+    #expect(response.error?.code == CLIErrorCode.targetNotFound)
+  }
+
+  @Test func targetNotUniqueMapsToContractCode() async {
+    let handler = FocusCommandHandler(
+      resolveProvider: { _ in .failure(.notUnique("Ambiguous worktree")) },
+      focusPerformer: { _ in true },
+      bringToFront: { true }
+    )
+
+    let response = await handler.handle(
+      envelope: CommandEnvelope(
+        output: .json,
+        command: .focus(FocusInput(selector: .worktree("Prowl")))
+      )
+    )
+
+    #expect(response.ok == false)
+    #expect(response.error?.code == CLIErrorCode.targetNotUnique)
+  }
+
+  @Test func focusFailureReturnsFocusFailedCode() async {
+    let handler = FocusCommandHandler(
+      resolveProvider: { _ in .success(Self.makeTarget()) },
+      focusPerformer: { _ in false },
+      bringToFront: { true }
+    )
+
+    let response = await handler.handle(
+      envelope: CommandEnvelope(output: .json, command: .focus(FocusInput(selector: .none)))
+    )
+
+    #expect(response.ok == false)
+    #expect(response.error?.code == CLIErrorCode.focusFailed)
+  }
+
+  @Test func bringToFrontFailureReturnsFocusFailedCode() async {
+    let handler = FocusCommandHandler(
+      resolveProvider: { _ in .success(Self.makeTarget()) },
+      focusPerformer: { _ in true },
+      bringToFront: { false }
+    )
+
+    let response = await handler.handle(
+      envelope: CommandEnvelope(output: .json, command: .focus(FocusInput(selector: .none)))
+    )
+
+    #expect(response.ok == false)
+    #expect(response.error?.code == CLIErrorCode.focusFailed)
+  }
+
+  @Test func finalTargetMustBeActiveOrFocusFails() async {
+    var resolveNoneCount = 0
+    let handler = FocusCommandHandler(
+      resolveProvider: { selector in
+        switch selector {
+        case .none:
+          resolveNoneCount += 1
+          if resolveNoneCount == 1 {
+            return .success(Self.makeTarget(tabSelected: true, paneFocused: true))
+          }
+          return .success(Self.makeTarget(tabSelected: false, paneFocused: false))
+        default:
+          return .failure(.notFound("Unexpected selector"))
+        }
+      },
+      focusPerformer: { _ in true },
+      bringToFront: { true }
+    )
+
+    let response = await handler.handle(
+      envelope: CommandEnvelope(output: .json, command: .focus(FocusInput(selector: .none)))
+    )
+
+    #expect(response.ok == false)
+    #expect(response.error?.code == CLIErrorCode.focusFailed)
+  }
+}


### PR DESCRIPTION
## Summary
- implement `prowl focus` runtime handler end-to-end via CLI -> app command service
- align output with `doc-onevcat/contracts/cli/focus.md` and `schema.md` (`prowl.cli.focus.v1`)
- keep selector exclusivity and parser normalization in CLI layer, runtime resolution in app layer

## What Changed
- add app-side `FocusCommandHandler` with contract-aligned error mapping
- add shared `FocusCommandPayload` models for schema fields (`requested`, `resolved_via`, `brought_to_front`, final `target`)
- wire focus handler into CLI socket router in `supacodeApp`
- implement actual runtime focusing (worktree context select + pane focus + bring app to front)
- add text-mode renderer for `prowl focus` output
- apply `--no-color` behavior to `focus` command path

## Tests
- `make build-cli`
- `make test-cli-smoke`
- `make test-cli-integration`
- `xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -only-testing:supacodeTests/CLIFocusCommandHandlerTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation`
- `make build-app`
- `make lint`
- `make check`

Closes #108
