### PR TITLE
ci: avoid redundant Ghostty rebuild in build-app

### DIFF
--- a/.github/actions/setup-macos/action.yml
+++ b/.github/actions/setup-macos/action.yml
@@ -32,13 +32,21 @@ runs:
           Frameworks/GhosttyKit.xcframework
           Resources/ghostty
           Resources/terminfo
-        key: ${{ runner.os }}-${{ runner.arch }}-ghostty-${{ env.GHOSTTY_SHA }}
+          .ghostty_hash
+          .ghostty_build_stamp
+        key: ${{ runner.os }}-${{ runner.arch }}-ghostty-v1-${{ env.GHOSTTY_SHA }}
     - name: Build ghostty
       if: steps.ghostty_cache.outputs.cache-hit != 'true'
       shell: bash
       run: |
         set -euo pipefail
         make build-ghostty-xcframework
+    - name: Sync ghostty marker files
+      shell: bash
+      run: |
+        set -euo pipefail
+        printf '%s\n' "$GHOSTTY_SHA" > .ghostty_hash
+        touch .ghostty_build_stamp
 
     - name: SPM cache
       uses: actions/cache@v4


### PR DESCRIPTION
## Summary
- include `.ghostty_hash` and `.ghostty_build_stamp` in Ghostty cache payload
- bump Ghostty cache key namespace to `ghostty-v1` to avoid stale cache shape
- always refresh marker files after Ghostty cache restore/build so `make ensure-ghostty` fast-path works in CI

## Why
After #140, CI could hit Ghostty artifact cache but still rebuild Ghostty in `make build-app` because `.ghostty_hash` was not restored in clean runners. This made `build-app` take ~10 minutes repeatedly.

## Validation
- local: `make build-app` (passed)
- observed fast-path log before xcodebuild: `GhosttyKit up-to-date (SHA unchanged)`
