### PR TITLE
Improve test output with xcsift and xcresult failure details

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,3 +23,11 @@ jobs:
       - run: make test
       - run: make test-cli-smoke
       - run: make test-cli-integration
+      - name: Upload xcresult bundle (on failure)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: xcresult-${{ github.run_id }}-${{ github.run_attempt }}
+          path: build/test-results/**/*.xcresult
+          if-no-files-found: ignore
+          retention-days: 7

--- a/Makefile
+++ b/Makefile
@@ -241,7 +241,18 @@ export-archive: # Export xarchive
 	bash -o pipefail -c 'xcodebuild -exportArchive -archivePath build/supacode.xcarchive -exportPath build/export -exportOptionsPlist build/ExportOptions.plist 2>&1 | mise exec -- xcsift -qw --format toon'
 
 test: ensure-ghostty
-	xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation -clonedSourcePackagesDirPath $(SPM_CACHE_DIR) 2>&1
+	@set -euo pipefail; \
+	result_bundle="$(CURRENT_MAKEFILE_DIR)/build/test-results/supacode-tests.xcresult"; \
+	mkdir -p "$$(dirname "$$result_bundle")"; \
+	rm -rf "$$result_bundle"; \
+	set +e; \
+	xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -resultBundlePath "$$result_bundle" CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation -clonedSourcePackagesDirPath $(SPM_CACHE_DIR) 2>&1 | mise exec -- xcsift -w --format toon; \
+	xcodebuild_status=$${PIPESTATUS[0]}; \
+	set -e; \
+	if [ "$$xcodebuild_status" -ne 0 ]; then \
+		bash "$(CURRENT_MAKEFILE_DIR)/scripts/print-xcresult-failures.sh" "$$result_bundle" || true; \
+	fi; \
+	exit "$$xcodebuild_status"
 
 test-cli-smoke: build-cli # Smoke test CLI executable
 	@set -euo pipefail; \

--- a/scripts/print-xcresult-failures.sh
+++ b/scripts/print-xcresult-failures.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "usage: $0 <xcresult-path>" >&2
+  exit 0
+fi
+
+result_bundle="$1"
+
+if [ ! -d "$result_bundle" ]; then
+  echo "warning: xcresult bundle not found at $result_bundle"
+  exit 0
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "warning: jq is required to parse xcresult summary details"
+  exit 0
+fi
+
+summary_json="$(mktemp)"
+cleanup() {
+  rm -f "$summary_json"
+}
+trap cleanup EXIT
+
+if ! xcrun xcresulttool get test-results summary --path "$result_bundle" --compact >"$summary_json" 2>/dev/null; then
+  echo "warning: failed to parse xcresult summary from $result_bundle"
+  exit 0
+fi
+
+failed_tests="$(
+  jq -r '
+    if (.failedTests? | type) == "number" then .failedTests
+    elif (.failedTests? | type) == "string" then (.failedTests | tonumber? // 0)
+    else 0
+    end
+  ' "$summary_json"
+)"
+
+if [ "$failed_tests" -eq 0 ]; then
+  echo "No failed tests found in xcresult summary."
+  exit 0
+fi
+
+echo
+echo "================ xcresult failure details ================"
+
+jq -r '
+  (.testFailures // []) as $failures
+  | if ($failures | length) == 0 then
+      "warning: summary has failedTests=\(.failedTests // "unknown"), but no testFailures entries were found."
+    else
+      $failures[]
+      | "test: \(.testName // "unknown")",
+        "target: \(.targetName // "unknown")",
+        "identifier: \(.testIdentifierString // "n/a")",
+        ("failure: " + ((.failureText // "n/a") | gsub("\\n"; "\n         "))),
+        ""
+    end
+' "$summary_json"
+
+echo "=========================================================="


### PR DESCRIPTION
## Summary

Fixes #103 in this fork without waiting for upstream.

- Wire `make test` through `xcsift` TOON output
- Persist test result bundle at `build/test-results/supacode-tests.xcresult`
- When `xcodebuild test` fails, print actionable failure details from `.xcresult`
- Upload `.xcresult` artifact in CI when job fails

## Details

### `make test`

`Makefile` now runs:

- `xcodebuild test ... -resultBundlePath build/test-results/supacode-tests.xcresult 2>&1 | mise exec -- xcsift -w --format toon`
- Preserves original `xcodebuild` exit code via `PIPESTATUS[0]`
- On failure, invokes `scripts/print-xcresult-failures.sh` to print `testName`, `targetName`, `testIdentifierString`, and `failureText`

### CI artifact upload

Workflow `test.yml` now uploads `build/test-results/**/*.xcresult` using `actions/upload-artifact@v4` when `failure()` is true.

## Validation

Executed locally:

- `make test` (pass, structured xcsift output)
- `make build-app` (pass)
