### PR TITLE
Clean test warnings and CI Node runtime debt

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,7 @@ jobs:
     env:
       MISE_HTTP_TIMEOUT: 120
       MISE_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - uses: actions/checkout@v6
         with:

--- a/supacodeTests/CLIFocusCommandHandlerTests.swift
+++ b/supacodeTests/CLIFocusCommandHandlerTests.swift
@@ -28,7 +28,7 @@ struct CLIFocusCommandHandlerTests {
     )
   }
 
-  @Test func successfulFocusReturnsSchemaConformantPayload() async throws {
+  @Test func successfulFocusReturnsSchemaConformantPayload() throws {
     var focusedTarget: FocusResolvedTarget?
     let handler = FocusCommandHandler(
       resolveProvider: { selector in
@@ -50,7 +50,7 @@ struct CLIFocusCommandHandlerTests {
       bringToFront: { true }
     )
 
-    let response = await handler.handle(
+    let response = handler.handle(
       envelope: CommandEnvelope(
         output: .json,
         command: .focus(FocusInput(selector: .pane(Self.paneID.uuidString)))
@@ -74,7 +74,7 @@ struct CLIFocusCommandHandlerTests {
     #expect(payload.target.pane.focused == true)
   }
 
-  @Test func currentSelectorUsesNilRequestedValue() async throws {
+  @Test func currentSelectorUsesNilRequestedValue() throws {
     var resolveNoneCount = 0
     let handler = FocusCommandHandler(
       resolveProvider: { selector in
@@ -89,7 +89,7 @@ struct CLIFocusCommandHandlerTests {
       bringToFront: { true }
     )
 
-    let response = await handler.handle(
+    let response = handler.handle(
       envelope: CommandEnvelope(output: .json, command: .focus(FocusInput(selector: .none)))
     )
 
@@ -101,14 +101,14 @@ struct CLIFocusCommandHandlerTests {
     #expect(payload.resolvedVia == .pane)
   }
 
-  @Test func targetNotFoundMapsToContractCode() async {
+  @Test func targetNotFoundMapsToContractCode() {
     let handler = FocusCommandHandler(
       resolveProvider: { _ in .failure(.notFound("Pane missing")) },
       focusPerformer: { _ in true },
       bringToFront: { true }
     )
 
-    let response = await handler.handle(
+    let response = handler.handle(
       envelope: CommandEnvelope(
         output: .json,
         command: .focus(FocusInput(selector: .pane("missing")))
@@ -119,14 +119,14 @@ struct CLIFocusCommandHandlerTests {
     #expect(response.error?.code == CLIErrorCode.targetNotFound)
   }
 
-  @Test func targetNotUniqueMapsToContractCode() async {
+  @Test func targetNotUniqueMapsToContractCode() {
     let handler = FocusCommandHandler(
       resolveProvider: { _ in .failure(.notUnique("Ambiguous worktree")) },
       focusPerformer: { _ in true },
       bringToFront: { true }
     )
 
-    let response = await handler.handle(
+    let response = handler.handle(
       envelope: CommandEnvelope(
         output: .json,
         command: .focus(FocusInput(selector: .worktree("Prowl")))
@@ -137,14 +137,14 @@ struct CLIFocusCommandHandlerTests {
     #expect(response.error?.code == CLIErrorCode.targetNotUnique)
   }
 
-  @Test func focusFailureReturnsFocusFailedCode() async {
+  @Test func focusFailureReturnsFocusFailedCode() {
     let handler = FocusCommandHandler(
       resolveProvider: { _ in .success(Self.makeTarget()) },
       focusPerformer: { _ in false },
       bringToFront: { true }
     )
 
-    let response = await handler.handle(
+    let response = handler.handle(
       envelope: CommandEnvelope(output: .json, command: .focus(FocusInput(selector: .none)))
     )
 
@@ -152,14 +152,14 @@ struct CLIFocusCommandHandlerTests {
     #expect(response.error?.code == CLIErrorCode.focusFailed)
   }
 
-  @Test func bringToFrontFailureReturnsFocusFailedCode() async {
+  @Test func bringToFrontFailureReturnsFocusFailedCode() {
     let handler = FocusCommandHandler(
       resolveProvider: { _ in .success(Self.makeTarget()) },
       focusPerformer: { _ in true },
       bringToFront: { false }
     )
 
-    let response = await handler.handle(
+    let response = handler.handle(
       envelope: CommandEnvelope(output: .json, command: .focus(FocusInput(selector: .none)))
     )
 
@@ -167,7 +167,7 @@ struct CLIFocusCommandHandlerTests {
     #expect(response.error?.code == CLIErrorCode.focusFailed)
   }
 
-  @Test func finalTargetMustBeActiveOrFocusFails() async {
+  @Test func finalTargetMustBeActiveOrFocusFails() {
     var resolveNoneCount = 0
     let handler = FocusCommandHandler(
       resolveProvider: { selector in
@@ -186,7 +186,7 @@ struct CLIFocusCommandHandlerTests {
       bringToFront: { true }
     )
 
-    let response = await handler.handle(
+    let response = handler.handle(
       envelope: CommandEnvelope(output: .json, command: .focus(FocusInput(selector: .none)))
     )
 

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -3234,7 +3234,7 @@ struct RepositoriesFeatureTests {
       $0.repositoryPersistence.loadRoots = { [repoRootA, repoRootB] }
       $0.gitClient.worktrees = { root in
         let path = root.path(percentEncoded: false)
-        startedRoots.withValue { $0.insert(path) }
+        _ = startedRoots.withValue { $0.insert(path) }
         if path == repoRootA {
           await gate.wait()
           return [worktreeA]

--- a/supacodeTests/SplitTreeTests.swift
+++ b/supacodeTests/SplitTreeTests.swift
@@ -38,7 +38,7 @@ struct SplitTreeTests {
     let tree = try SplitTree(view: first)
       .inserting(view: second, at: first, direction: .right)
 
-    let zoomed = tree.settingZoomed(try #require(tree.find(id: second.id)))
+    let zoomed = tree.settingZoomed(tree.find(id: second.id))
     let visibleLeaves = zoomed.visibleLeaves()
 
     #expect(visibleLeaves.count == 1)


### PR DESCRIPTION
## Summary

This PR addresses warning/debt cleanup requested for build/test runs.

- Fix local compiler warnings in tests:
  - remove redundant `await` usage in `CLIFocusCommandHandlerTests`
  - consume `LockIsolated.withValue` return value in `RepositoriesFeatureTests`
  - remove redundant `#require` in `SplitTreeTests`
- Opt GitHub Actions into Node 24 runtime to avoid Node 20 deprecation warnings for JavaScript actions (`actions/cache@v4`).

## Validation

Executed locally:

- `make lint`
- `make build-app`
- `make test`
- `make test-cli-smoke`
- `make test-cli-integration`

## Notes

On a fully clean DerivedData build, remaining warnings are from external dependencies (`swift-dependencies` / `xctest-dynamic-overlay`) and GhosttyKit generated headers, not from local test source. This PR removes the local test warnings and CI runtime deprecation debt.
