### PR TITLE
feat(cli): build universal binary for release CLI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,8 +94,8 @@ sync-cli-version: # Sync app MARKETING_VERSION into ProwlCLIShared/ProwlVersion.
 build-cli: sync-cli-version # Build Swift CLI binary (SPM)
 	swift build --product prowl
 
-build-cli-release: sync-cli-version # Build CLI binary in release mode
-	swift build -c release --product prowl
+build-cli-release: sync-cli-version # Build universal CLI binary in release mode
+	swift build -c release --arch arm64 --arch x86_64 --product prowl
 
 embed-cli-debug: build-cli # Build debug CLI and copy into Resources for dev builds
 	@set -euo pipefail; \
@@ -108,7 +108,7 @@ embed-cli-debug: build-cli # Build debug CLI and copy into Resources for dev bui
 
 embed-cli: build-cli-release # Build release CLI and copy into Resources for distribution
 	@set -euo pipefail; \
-	bin="$$(swift build -c release --show-bin-path)/prowl"; \
+	bin="$$(swift build -c release --arch arm64 --arch x86_64 --show-bin-path)/prowl"; \
 	dst="$(CURRENT_MAKEFILE_DIR)/Resources/prowl-cli"; \
 	mkdir -p "$$dst"; \
 	cp "$$bin" "$$dst/prowl"; \


### PR DESCRIPTION
## Summary
- Build the `prowl` CLI as a universal binary (arm64 + x86_64) in release mode, so Intel Mac users can also use the command line tool.
- Debug builds remain single-architecture for faster iteration.
- `embed-cli` path resolution updated to match the multi-arch output location.

## Compatibility
Compatible with `fix/cli-debug-build-for-dev` (already merged to main) — only the release path is changed; the debug path (`embed-cli-debug` / `build-app`) is untouched.

## Test plan
- [x] `make build-cli-release` succeeds
- [x] Output binary verified as universal via `lipo -info` (x86_64 + arm64)
- [x] `make embed-cli` copies the correct universal binary
- [x] `make test-cli-smoke` passes