### PR TITLE
fix: show CLI install feedback via toolbar toast for all entry points

### DIFF
--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -618,7 +618,7 @@ struct SupacodeApp: App {
       }
       CommandGroup(after: .appSettings) {
         Button("Install Command Line Tool") {
-          store.send(.settings(.installCLIButtonTapped))
+          store.send(.settings(.installCLIButtonTapped(showAlert: false)))
         }
         .help("Install the prowl command line tool to /usr/local/bin")
       }

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -843,7 +843,7 @@ struct AppFeature {
         return .send(.repositories(.refreshWorktrees))
 
       case .commandPalette(.delegate(.installCLI)):
-        return .send(.settings(.installCLIButtonTapped))
+        return .send(.settings(.installCLIButtonTapped(showAlert: false)))
 
       case .commandPalette(.delegate(.ghosttyCommand(let action))):
         guard let worktree = state.repositories.selectedTerminalWorktree else {

--- a/supacode/Features/Settings/Reducer/SettingsFeature.swift
+++ b/supacode/Features/Settings/Reducer/SettingsFeature.swift
@@ -28,6 +28,7 @@ struct SettingsFeature {
     var terminalFontSize: Float32?
     var keybindingUserOverrides: KeybindingUserOverrideStore
     var cliInstallStatus: CLIInstallStatus = .notInstalled
+    var cliInstallShowAlert: Bool = true
     var selection: SettingsSection? = .general
     var repositorySettings: RepositorySettingsFeature.State?
     @Presents var alert: AlertState<Alert>?
@@ -97,7 +98,7 @@ struct SettingsFeature {
     case setCommandFinishedNotificationThreshold(String)
     case setTerminalFontSize(Float32?)
     case clearTerminalLayoutSnapshotButtonTapped
-    case installCLIButtonTapped
+    case installCLIButtonTapped(showAlert: Bool = true)
     case uninstallCLIButtonTapped
     case cliInstallCompleted(Result<String, CLIInstallError>)
     case refreshCLIInstallStatus
@@ -219,7 +220,8 @@ struct SettingsFeature {
           await send(.delegate(.terminalLayoutSnapshotCleared(success: success)))
         }
 
-      case .installCLIButtonTapped:
+      case .installCLIButtonTapped(let showAlert):
+        state.cliInstallShowAlert = showAlert
         let installPath = cliDefaultInstallPath
         return .run { [cliInstallClient] send in
           do {
@@ -247,21 +249,23 @@ struct SettingsFeature {
         }
 
       case .cliInstallCompleted(.success(let path)):
-        if path.isEmpty {
-          state.alert = AlertState {
-            TextState("Command Line Tool Uninstalled")
-          } actions: {
-            ButtonState(action: .dismiss) { TextState("OK") }
-          } message: {
-            TextState("The prowl command line tool has been removed.")
-          }
-        } else {
-          state.alert = AlertState {
-            TextState("Command Line Tool Installed")
-          } actions: {
-            ButtonState(action: .dismiss) { TextState("OK") }
-          } message: {
-            TextState("The prowl command is now available at \(path).")
+        if state.cliInstallShowAlert {
+          if path.isEmpty {
+            state.alert = AlertState {
+              TextState("Command Line Tool Uninstalled")
+            } actions: {
+              ButtonState(action: .dismiss) { TextState("OK") }
+            } message: {
+              TextState("The prowl command line tool has been removed.")
+            }
+          } else {
+            state.alert = AlertState {
+              TextState("Command Line Tool Installed")
+            } actions: {
+              ButtonState(action: .dismiss) { TextState("OK") }
+            } message: {
+              TextState("The prowl command is now available at \(path).")
+            }
           }
         }
         state.cliInstallStatus = cliInstallClient.installationStatus(cliDefaultInstallPath)
@@ -269,12 +273,14 @@ struct SettingsFeature {
         return .send(.delegate(.cliInstallCompleted(result)))
 
       case .cliInstallCompleted(.failure(let error)):
-        state.alert = AlertState {
-          TextState("Command Line Tool Error")
-        } actions: {
-          ButtonState(action: .dismiss) { TextState("OK") }
-        } message: {
-          TextState(error.message)
+        if state.cliInstallShowAlert {
+          state.alert = AlertState {
+            TextState("Command Line Tool Error")
+          } actions: {
+            ButtonState(action: .dismiss) { TextState("OK") }
+          } message: {
+            TextState(error.message)
+          }
         }
         state.cliInstallStatus = cliInstallClient.installationStatus(cliDefaultInstallPath)
         return .send(.delegate(.cliInstallCompleted(.failed(message: error.message))))

--- a/supacode/Features/Settings/Views/AdvancedSettingsView.swift
+++ b/supacode/Features/Settings/Views/AdvancedSettingsView.swift
@@ -38,7 +38,7 @@ struct AdvancedSettingsView: View {
               switch store.cliInstallStatus {
               case .notInstalled:
                 Button("Install") {
-                  store.send(.installCLIButtonTapped)
+                  store.send(.installCLIButtonTapped())
                 }
                 .help("Install prowl command line tool to /usr/local/bin")
                 .buttonStyle(.bordered)
@@ -50,7 +50,7 @@ struct AdvancedSettingsView: View {
                 .buttonStyle(.bordered)
               case .installedDifferentSource:
                 Button("Reinstall") {
-                  store.send(.installCLIButtonTapped)
+                  store.send(.installCLIButtonTapped())
                 }
                 .help("Replace the existing prowl command with the version bundled in this app")
                 .buttonStyle(.bordered)

--- a/supacodeTests/AppFeatureCLIInstallTests.swift
+++ b/supacodeTests/AppFeatureCLIInstallTests.swift
@@ -20,7 +20,7 @@ struct SettingsFeatureCLIInstallTests {
       $0.cliInstallClient.installationStatus = { _ in .installed(path: "/usr/local/bin/prowl") }
     }
 
-    await store.send(.installCLIButtonTapped)
+    await store.send(.installCLIButtonTapped())
     await store.receive(\.cliInstallCompleted.success) {
       $0.alert = AlertState {
         TextState("Command Line Tool Installed")
@@ -48,7 +48,7 @@ struct SettingsFeatureCLIInstallTests {
       $0.cliInstallClient.installationStatus = { _ in .notInstalled }
     }
 
-    await store.send(.installCLIButtonTapped)
+    await store.send(.installCLIButtonTapped())
     await store.receive(\.cliInstallCompleted.failure) {
       $0.alert = AlertState {
         TextState("Command Line Tool Error")
@@ -104,15 +104,10 @@ struct SettingsFeatureCLIInstallTests {
     store.exhaustivity = .off
 
     await store.send(.commandPalette(.delegate(.installCLI)))
-    await store.receive(\.settings.installCLIButtonTapped)
+    await store.receive(\.settings.installCLIButtonTapped) {
+      $0.settings.cliInstallShowAlert = false
+    }
     await store.receive(\.settings.cliInstallCompleted.success) {
-      $0.settings.alert = AlertState {
-        TextState("Command Line Tool Installed")
-      } actions: {
-        ButtonState(action: .dismiss) { TextState("OK") }
-      } message: {
-        TextState("The prowl command is now available at /usr/local/bin/prowl.")
-      }
       $0.settings.cliInstallStatus = .installed(path: "/usr/local/bin/prowl")
     }
     await store.receive(\.settings.delegate.cliInstallCompleted)


### PR DESCRIPTION
## Summary

- Command Palette's "Install Command Line Tool" ran the install silently when the Settings window wasn't open — no success/failure feedback was shown (#146 comment).
- CLI install/uninstall results now dispatch a `StatusToast` on the main window's toolbar, ensuring consistent feedback regardless of entry point (Command Palette, menu bar, or Settings buttons).
- Settings buttons retain their alert dialog in addition to the toast (Settings window sits above the main window, so a toast-only approach is easy to miss there).
- Menu bar "Install Command Line Tool" no longer opens the Settings window first — feedback comes via toast.

## Changes

| File | What |
|------|------|
| `SettingsFeature.swift` | Added `CLIInstallResultMessage` enum; delegate `cliInstallStatusChanged` → `cliInstallCompleted(CLIInstallResultMessage)` |
| `AppFeature.swift` | Handle new delegate by dispatching `.repositories(.showToast(...))` |
| `supacodeApp.swift` | Removed `SettingsWindowManager.shared.show()` from menu install action |
| `AppFeatureCLIInstallTests.swift` | Updated delegate assertions; command palette test now verifies toast dispatch |

## Test plan

- [x] All 4 `SettingsFeatureCLIInstallTests` pass
- [x] Manual: trigger "Install Command Line Tool" from Command Palette without Settings open → toast appears in toolbar
- [x] Manual: trigger install from Settings → alert shows in Settings window AND toast in toolbar
- [x] Manual: trigger install from menu bar → toast appears in toolbar (Settings does not open)

Closes #146