### PR TITLE
fix: prevent vertical jump on worktree row hover

### DIFF
--- a/supacode/Features/Repositories/Views/WorktreeRow.swift
+++ b/supacode/Features/Repositories/Views/WorktreeRow.swift
@@ -103,6 +103,7 @@ struct WorktreeRow: View {
             pinAction?()
           } label: {
             Image(systemName: isPinned ? "pin.slash" : "pin")
+              .font(.caption)
               .contentTransition(.symbolEffect(.replace))
               .accessibilityLabel(isPinned ? "Unpin worktree" : "Pin worktree")
           }
@@ -113,6 +114,7 @@ struct WorktreeRow: View {
             archiveAction?()
           } label: {
             Image(systemName: "archivebox")
+              .font(.caption)
               .accessibilityLabel("Archive worktree")
           }
           .buttonStyle(.plain)


### PR DESCRIPTION
## Summary
- Pin and archive button icons in the sidebar worktree row were using default `.body` font size while the branch icon uses `.caption`, causing the HStack height to increase when hovering.
- Applied `.font(.caption)` to both button images to match the branch icon size, eliminating the vertical jump.

## Test plan
- [x] Hover over a worktree row in the sidebar and verify no vertical shift occurs
- [x] Confirm pin/archive buttons still display and function correctly on hover