### PR TITLE
fix(worktree): include local branches in base ref options

### DIFF
--- a/supacode/Clients/Git/GitClient.swift
+++ b/supacode/Clients/Git/GitClient.swift
@@ -605,20 +605,25 @@ struct GitClient {
   nonisolated private func parseLocalRefsWithUpstream(_ output: String) -> [String] {
     output
       .split(whereSeparator: \.isNewline)
-      .compactMap { line in
+      .flatMap { line -> [String] in
         let parts = line.split(separator: "\t", omittingEmptySubsequences: false)
         guard let local = parts.first else {
-          return nil
+          return []
         }
         let localRef = String(local).trimmingCharacters(in: .whitespacesAndNewlines)
         let upstreamRef =
           parts.count > 1
           ? String(parts[1]).trimmingCharacters(in: .whitespacesAndNewlines)
           : ""
-        if !upstreamRef.isEmpty {
-          return upstreamRef
+
+        var refs: [String] = []
+        if !localRef.isEmpty {
+          refs.append(localRef)
         }
-        return localRef.isEmpty ? nil : localRef
+        if !upstreamRef.isEmpty {
+          refs.append(upstreamRef)
+        }
+        return refs
       }
   }
 

--- a/supacodeTests/GitClientBranchRefsTests.swift
+++ b/supacodeTests/GitClientBranchRefsTests.swift
@@ -12,7 +12,7 @@ actor ShellCallStore {
 }
 
 struct GitClientBranchRefsTests {
-  @Test func branchRefsUsesUpstreamsOrLocalRefs() async throws {
+  @Test func branchRefsIncludesLocalAndUpstreamRefs() async throws {
     let store = ShellCallStore()
     let output = """
       feature\torigin/feature
@@ -31,7 +31,7 @@ struct GitClientBranchRefsTests {
 
     let refs = try await client.branchRefs(for: repoRoot)
 
-    let expected = ["origin/bugfix", "origin/feature", "main"]
+    let expected = ["bugfix", "feature", "main", "origin/bugfix", "origin/feature"]
       .sorted { $0.localizedStandardCompare($1) == .orderedAscending }
     #expect(refs == expected)
     let calls = await store.calls
@@ -57,7 +57,7 @@ struct GitClientBranchRefsTests {
 
     let refs = try await client.branchRefs(for: repoRoot)
 
-    #expect(refs == ["origin/main"])
+    #expect(refs == ["head", "main", "origin/main"])
   }
 
   @Test func defaultRemoteBranchRefStripsPrefix() async throws {


### PR DESCRIPTION
## Summary
- include both local branch refs and upstream refs when building worktree base-ref options
- keep deduplication and sorting unchanged
- this restores selecting local branches that track remotes (previously only upstream refs were surfaced)

## Why this happens
`branchRefs(for:)` currently maps each local branch to its upstream when one exists. For tracking branches, the local ref is dropped entirely, so the picker can look like it only supports remote refs.

## Validation
- updated `GitClientBranchRefsTests` to verify local + upstream refs are both returned
- ran:
  - `xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -only-testing:supacodeTests/GitClientBranchRefsTests ...`

Fixes #166
