### PR TITLE
fix(ui): use material for sidebar footer when background is transparent

### DIFF
--- a/supacode/Features/Repositories/Views/SidebarFooterView.swift
+++ b/supacode/Features/Repositories/Views/SidebarFooterView.swift
@@ -86,7 +86,13 @@ struct SidebarFooterView: View {
     .padding(.horizontal, 12)
     .padding(.vertical, 8)
     .frame(maxWidth: .infinity, alignment: .leading)
-    .background(Color(nsColor: .windowBackgroundColor).opacity(surfaceBottomChromeBackgroundOpacity))
+    .background {
+      if surfaceBottomChromeBackgroundOpacity < 1 {
+        Rectangle().fill(.regularMaterial)
+      } else {
+        Color(nsColor: .windowBackgroundColor)
+      }
+    }
     .overlay(alignment: .top) {
       Divider()
     }


### PR DESCRIPTION
## Summary
- When `background-opacity < 1`, the sidebar footer background was a semi-transparent color that let the wallpaper bleed through without blur
- Replace with `.regularMaterial` to get a proper frosted glass effect that respects dark/light mode

## Test plan
- [x] Set `background-opacity` < 1, verify sidebar footer has frosted glass effect
- [x] Verify opaque mode (opacity = 1): no visual change