### PR TITLE
Show all sidebar items in Worktrees menu

### DIFF
--- a/supacode/Commands/WorktreeCommands.swift
+++ b/supacode/Commands/WorktreeCommands.swift
@@ -212,7 +212,7 @@ struct WorktreeCommands: Commands {
         return "Switch to \(title)"
       }())
     case .plainFolder(let repoID, let name):
-      Button(name, systemImage: "folder") {
+      Button(name) {
         store.send(.repositories(.selectRepository(repoID)))
       }
       .help("Switch to \(name)")


### PR DESCRIPTION
## Summary

- Worktrees beyond the 9th (those without Control+1~9 shortcuts) were not shown in the Worktrees menu
- Plain folders (`Repository.Kind.plain`) were completely missing from the menu
- Rebuilt menu rendering with a unified `WorktreeMenuEntry` model that iterates repositories in order, matching the sidebar data source exactly
- Both worktrees and plain folders are now discoverable via **Help > Search**

## Test plan

- [x] Add 10+ worktrees — verify all appear in the Worktrees menu
- [x] Add a plain folder — verify it appears in the menu with a folder icon
- [x] Verify the first 9 visible worktrees still have Control+1~9 shortcuts
- [x] Verify plain folders do not consume shortcut slots
- [x] Verify menu order matches sidebar order
- [x] Use Help > Search to find a plain folder and a worktree beyond the 9th by name
- [x] Click a plain folder in the menu — verify it selects the repository
