### PR TITLE
Improve archived worktrees discoverability

### DIFF
--- a/supacode/Commands/WorktreeCommands.swift
+++ b/supacode/Commands/WorktreeCommands.swift
@@ -45,6 +45,12 @@ struct WorktreeCommands: Commands {
       ForEach(worktreeMenuEntries(orderedRows: orderedRows)) { entry in
         worktreeMenuButton(entry: entry)
       }
+      Divider()
+      Button("Archived Worktrees") {
+        store.send(.repositories(.selectArchivedWorktrees))
+      }
+      .modifier(KeyboardShortcutModifier(shortcut: keyboardShortcut(for: AppShortcuts.CommandID.archivedWorktrees)))
+      .help(helpText(title: "Archived Worktrees", commandID: AppShortcuts.CommandID.archivedWorktrees))
     }
     CommandGroup(replacing: .newItem) {
       if !customCommands.isEmpty {
@@ -82,11 +88,6 @@ struct WorktreeCommands: Commands {
       .modifier(KeyboardShortcutModifier(shortcut: keyboardShortcut(for: AppShortcuts.CommandID.newWorktree)))
       .help(helpText(title: "New Worktree", commandID: AppShortcuts.CommandID.newWorktree))
       .disabled(!repositories.canCreateWorktree)
-      Button("Archived Worktrees") {
-        store.send(.repositories(.selectArchivedWorktrees))
-      }
-      .modifier(KeyboardShortcutModifier(shortcut: keyboardShortcut(for: AppShortcuts.CommandID.archivedWorktrees)))
-      .help(helpText(title: "Archived Worktrees", commandID: AppShortcuts.CommandID.archivedWorktrees))
       Button("Archive Worktree") {
         archiveWorktreeAction?()
       }

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -839,6 +839,9 @@ struct AppFeature {
       case .commandPalette(.delegate(.archiveWorktree(let worktreeID, let repositoryID))):
         return .send(.repositories(.worktreeLifecycle(.requestArchiveWorktree(worktreeID, repositoryID))))
 
+      case .commandPalette(.delegate(.viewArchivedWorktrees)):
+        return .send(.repositories(.selectArchivedWorktrees))
+
       case .commandPalette(.delegate(.refreshWorktrees)):
         return .send(.repositories(.refreshWorktrees))
 

--- a/supacode/Features/CommandPalette/CommandPaletteItem.swift
+++ b/supacode/Features/CommandPalette/CommandPaletteItem.swift
@@ -29,6 +29,7 @@ struct CommandPaletteItem: Identifiable, Equatable {
     case newWorktree
     case removeWorktree(Worktree.ID, Repository.ID)
     case archiveWorktree(Worktree.ID, Repository.ID)
+    case viewArchivedWorktrees
     case refreshWorktrees
     case ghosttyCommand(String)
     case openPullRequest(Worktree.ID)
@@ -47,7 +48,8 @@ struct CommandPaletteItem: Identifiable, Equatable {
 
   var isGlobal: Bool {
     switch kind {
-    case .checkForUpdates, .openRepository, .openSettings, .newWorktree, .refreshWorktrees, .installCLI:
+    case .checkForUpdates, .openRepository, .openSettings, .newWorktree, .viewArchivedWorktrees,
+      .refreshWorktrees, .installCLI:
       return true
     case .ghosttyCommand:
       return false
@@ -71,7 +73,8 @@ struct CommandPaletteItem: Identifiable, Equatable {
 
   var isRootAction: Bool {
     switch kind {
-    case .checkForUpdates, .openRepository, .openSettings, .newWorktree, .refreshWorktrees, .installCLI:
+    case .checkForUpdates, .openRepository, .openSettings, .newWorktree, .viewArchivedWorktrees,
+      .refreshWorktrees, .installCLI:
       return true
     case .ghosttyCommand:
       return false
@@ -104,6 +107,8 @@ struct CommandPaletteItem: Identifiable, Equatable {
       return AppShortcuts.CommandID.openSettings
     case .newWorktree:
       return AppShortcuts.CommandID.newWorktree
+    case .viewArchivedWorktrees:
+      return AppShortcuts.CommandID.archivedWorktrees
     case .refreshWorktrees:
       return AppShortcuts.CommandID.refreshWorktrees
     case .openPullRequest:

--- a/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
+++ b/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
@@ -38,6 +38,7 @@ struct CommandPaletteFeature {
     case openRepository
     case removeWorktree(Worktree.ID, Repository.ID)
     case archiveWorktree(Worktree.ID, Repository.ID)
+    case viewArchivedWorktrees
     case refreshWorktrees
     case ghosttyCommand(String)
     case openPullRequest(Worktree.ID)
@@ -204,6 +205,14 @@ struct CommandPaletteFeature {
         title: "Refresh Worktrees",
         subtitle: nil,
         kind: .refreshWorktrees
+      )
+    )
+    items.append(
+      CommandPaletteItem(
+        id: CommandPaletteItemID.globalViewArchivedWorktrees,
+        title: "View Archived Worktrees",
+        subtitle: nil,
+        kind: .viewArchivedWorktrees
       )
     )
     items.append(
@@ -438,6 +447,7 @@ private enum CommandPaletteItemID {
   static let globalOpenRepository = "global.open-repository"
   static let globalNewWorktree = "global.new-worktree"
   static let globalRefreshWorktrees = "global.refresh-worktrees"
+  static let globalViewArchivedWorktrees = "global.view-archived-worktrees"
   static let globalInstallCLI = "global.install-cli"
 
   static var globalIDs: [CommandPaletteItem.ID] {
@@ -447,6 +457,7 @@ private enum CommandPaletteItemID {
       globalOpenRepository,
       globalNewWorktree,
       globalRefreshWorktrees,
+      globalViewArchivedWorktrees,
       globalInstallCLI,
     ]
   }
@@ -553,6 +564,8 @@ private func delegateAction(for kind: CommandPaletteItem.Kind) -> CommandPalette
     return .removeWorktree(worktreeID, repositoryID)
   case .archiveWorktree(let worktreeID, let repositoryID):
     return .archiveWorktree(worktreeID, repositoryID)
+  case .viewArchivedWorktrees:
+    return .viewArchivedWorktrees
   case .refreshWorktrees:
     return .refreshWorktrees
   case .installCLI:
@@ -602,6 +615,7 @@ private func pullRequestDelegateAction(
     .openRepository,
     .removeWorktree,
     .archiveWorktree,
+    .viewArchivedWorktrees,
     .refreshWorktrees,
     .installCLI,
     .ghosttyCommand:

--- a/supacode/Features/CommandPalette/Views/CommandPaletteOverlayView.swift
+++ b/supacode/Features/CommandPalette/Views/CommandPaletteOverlayView.swift
@@ -347,8 +347,8 @@ private struct CommandPaletteRowView: View {
 
   private var badge: String? {
     switch row.kind {
-    case .checkForUpdates, .openRepository, .openSettings, .newWorktree, .refreshWorktrees,
-      .installCLI, .ghosttyCommand,
+    case .checkForUpdates, .openRepository, .openSettings, .newWorktree, .viewArchivedWorktrees,
+      .refreshWorktrees, .installCLI, .ghosttyCommand,
       .openPullRequest, .markPullRequestReady, .mergePullRequest, .closePullRequest, .copyFailingJobURL,
       .copyCiFailureLogs,
       .rerunFailedJobs, .openFailingCheckDetails, .worktreeSelect:
@@ -374,6 +374,8 @@ private struct CommandPaletteRowView: View {
       return "gearshape"
     case .newWorktree:
       return "plus"
+    case .viewArchivedWorktrees:
+      return "archivebox"
     case .refreshWorktrees:
       return "arrow.clockwise"
     case .ghosttyCommand:
@@ -411,8 +413,8 @@ private struct CommandPaletteRowView: View {
 
   private var emphasis: Bool {
     switch row.kind {
-    case .checkForUpdates, .openRepository, .openSettings, .newWorktree, .refreshWorktrees,
-      .installCLI, .ghosttyCommand,
+    case .checkForUpdates, .openRepository, .openSettings, .newWorktree, .viewArchivedWorktrees,
+      .refreshWorktrees, .installCLI, .ghosttyCommand,
       .openPullRequest, .markPullRequestReady, .mergePullRequest, .closePullRequest, .copyFailingJobURL,
       .copyCiFailureLogs,
       .rerunFailedJobs, .openFailingCheckDetails:
@@ -503,6 +505,8 @@ private struct CommandPaletteRowView: View {
       base = "Open Settings"
     case .newWorktree:
       base = "New Worktree"
+    case .viewArchivedWorktrees:
+      base = "View Archived Worktrees"
     case .refreshWorktrees:
       base = "Refresh Worktrees"
     case .ghosttyCommand:

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+WorktreeLifecycle.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+WorktreeLifecycle.swift
@@ -43,7 +43,7 @@ extension RepositoriesFeature {
           TextState("Cancel")
         }
       } message: {
-        TextState("Archive \(worktree.name)?")
+        TextState(archiveWorktreeAlertMessage(for: worktree.name))
       }
       return .none
 
@@ -86,7 +86,7 @@ extension RepositoriesFeature {
           TextState("Cancel")
         }
       } message: {
-        TextState("Archive \(count) worktrees?")
+        TextState(archiveWorktreesAlertMessage())
       }
       return .none
 
@@ -502,4 +502,14 @@ extension RepositoriesFeature {
       return reduceWorktreeLifecycle(state: &state, action: action)
     }
   }
+}
+
+private func archiveWorktreeAlertMessage(for name: String) -> String {
+  let shortcut = AppShortcuts.archivedWorktrees.display
+  return "Find \(name) later in Menu Bar > Worktrees > Archived Worktrees (\(shortcut))."
+}
+
+private func archiveWorktreesAlertMessage() -> String {
+  let shortcut = AppShortcuts.archivedWorktrees.display
+  return "Find them later in Menu Bar > Worktrees > Archived Worktrees (\(shortcut))."
 }

--- a/supacodeTests/AppFeatureCommandPaletteTests.swift
+++ b/supacodeTests/AppFeatureCommandPaletteTests.swift
@@ -178,6 +178,7 @@ struct AppFeatureCommandPaletteTests {
       AppFeature()
     }
 
+    let archivedDisplay = AppShortcuts.archivedWorktrees.display
     let expectedAlert = AlertState<RepositoriesFeature.Alert> {
       TextState("Archive worktree?")
     } actions: {
@@ -188,7 +189,7 @@ struct AppFeatureCommandPaletteTests {
         TextState("Cancel")
       }
     } message: {
-      TextState("Archive \(worktree.name)?")
+      TextState("Find \(worktree.name) later in Menu Bar > Worktrees > Archived Worktrees (\(archivedDisplay)).")
     }
 
     await store.send(.commandPalette(.delegate(.archiveWorktree(worktree.id, repository.id))))

--- a/supacodeTests/CommandPaletteFeatureTests.swift
+++ b/supacodeTests/CommandPaletteFeatureTests.swift
@@ -16,6 +16,7 @@ struct CommandPaletteFeatureTests {
       "global.open-repository",
       "global.new-worktree",
       "global.refresh-worktrees",
+      "global.view-archived-worktrees",
       "global.install-cli",
     ]
     #if DEBUG

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -1581,6 +1581,7 @@ struct RepositoriesFeatureTests {
       RepositoriesFeature()
     }
 
+    let archivedDisplay = AppShortcuts.archivedWorktrees.display
     let expectedAlert = AlertState<RepositoriesFeature.Alert> {
       TextState("Archive worktree?")
     } actions: {
@@ -1591,7 +1592,7 @@ struct RepositoriesFeatureTests {
         TextState("Cancel")
       }
     } message: {
-      TextState("Archive \(worktree.name)?")
+      TextState("Find \(worktree.name) later in Menu Bar > Worktrees > Archived Worktrees (\(archivedDisplay)).")
     }
 
     await store.send(.worktreeLifecycle(.requestArchiveWorktree(worktree.id, repository.id))) {
@@ -1611,6 +1612,7 @@ struct RepositoriesFeatureTests {
       RepositoriesFeature()
     }
 
+    let archivedDisplay = AppShortcuts.archivedWorktrees.display
     let expectedAlert = AlertState<RepositoriesFeature.Alert> {
       TextState("Archive 2 worktrees?")
     } actions: {
@@ -1621,7 +1623,7 @@ struct RepositoriesFeatureTests {
         TextState("Cancel")
       }
     } message: {
-      TextState("Archive 2 worktrees?")
+      TextState("Find them later in Menu Bar > Worktrees > Archived Worktrees (\(archivedDisplay)).")
     }
 
     await store.send(.worktreeLifecycle(.requestArchiveWorktrees(targets))) {


### PR DESCRIPTION
## Summary

- Update archive confirmation alerts to show where to find archived worktrees: "Menu Bar > Worktrees > Archived Worktrees (⌃⌘A)"
- Add "View Archived Worktrees" command to the command palette with archivebox icon and keyboard shortcut display

## Test plan

- [x] Archive single worktree alert shows new message with hotkey
- [x] Bulk archive alert shows new message with hotkey
- [x] Command palette includes "View Archived Worktrees" entry
- [x] Command palette entry dispatches `selectArchivedWorktrees`
- [x] Global item IDs list includes the new entry
- [x] Build and lint clean

Closes #181