### PR TITLE
Add Reveal in Sidebar command

### DIFF
--- a/supacode/App/AppShortcuts.swift
+++ b/supacode/App/AppShortcuts.swift
@@ -99,6 +99,7 @@ enum AppShortcuts {
     static let checkForUpdates = "check_for_updates"
     static let showDiff = "show_diff"
     static let toggleCanvas = "toggle_canvas"
+    static let revealInSidebar = "reveal_in_sidebar"
     static let archivedWorktrees = "archived_worktrees"
     static let selectNextWorktree = "select_next_worktree"
     static let selectPreviousWorktree = "select_previous_worktree"
@@ -174,6 +175,7 @@ enum AppShortcuts {
   static let toggleCanvas = AppShortcut(
     keyEquivalent: .return, ghosttyKeyName: "return", modifiers: [.command, .option]
   )
+  static let revealInSidebar = AppShortcut(key: "l", modifiers: [.command, .shift])
   static let archivedWorktrees = AppShortcut(key: "a", modifiers: [.command, .control])
   static let selectNextWorktree = AppShortcut(
     keyEquivalent: .downArrow, ghosttyKeyName: "arrow_down", modifiers: [.command, .control]
@@ -371,6 +373,12 @@ enum AppShortcuts {
       title: "Toggle Canvas",
       scope: .configurableAppAction,
       shortcut: toggleCanvas
+    ),
+    .init(
+      id: CommandID.revealInSidebar,
+      title: "Reveal in Sidebar",
+      scope: .configurableAppAction,
+      shortcut: revealInSidebar
     ),
     .init(
       id: CommandID.archivedWorktrees,
@@ -705,6 +713,7 @@ enum AppShortcuts {
     openRepository,
     openPullRequest,
     toggleLeftSidebar,
+    revealInSidebar,
     refreshWorktrees,
     runScript,
     stopRunScript,

--- a/supacode/App/ContentView.swift
+++ b/supacode/App/ContentView.swift
@@ -88,6 +88,7 @@ struct ContentView: View {
       )
     }
     .focusedSceneValue(\.toggleLeftSidebarAction, toggleLeftSidebar)
+    .focusedSceneValue(\.revealInSidebarAction, revealInSidebarAction)
     .overlay {
       CommandPaletteOverlayView(
         store: store.scope(state: \.commandPalette, action: \.commandPalette),
@@ -104,6 +105,16 @@ struct ContentView: View {
   private func toggleLeftSidebar() {
     withAnimation(.easeOut(duration: 0.2)) {
       leftSidebarVisibility = leftSidebarVisibility == .detailOnly ? .all : .detailOnly
+    }
+  }
+
+  private var revealInSidebarAction: (() -> Void)? {
+    guard store.repositories.selectedWorktreeID != nil else { return nil }
+    return {
+      withAnimation(.easeOut(duration: 0.2)) {
+        leftSidebarVisibility = .all
+      }
+      store.send(.repositories(.revealSelectedWorktreeInSidebar))
     }
   }
 

--- a/supacode/Commands/SidebarCommands.swift
+++ b/supacode/Commands/SidebarCommands.swift
@@ -4,6 +4,7 @@ import SwiftUI
 struct SidebarCommands: Commands {
   @Bindable var store: StoreOf<AppFeature>
   @FocusedValue(\.toggleLeftSidebarAction) private var toggleLeftSidebarAction
+  @FocusedValue(\.revealInSidebarAction) private var revealInSidebarAction
 
   var body: some Commands {
     CommandGroup(replacing: .sidebar) {
@@ -13,6 +14,12 @@ struct SidebarCommands: Commands {
       .modifier(KeyboardShortcutModifier(shortcut: keyboardShortcut(for: AppShortcuts.CommandID.toggleLeftSidebar)))
       .help(helpText(title: "Toggle Left Sidebar", commandID: AppShortcuts.CommandID.toggleLeftSidebar))
       .disabled(toggleLeftSidebarAction == nil)
+      Button("Reveal in Sidebar") {
+        revealInSidebarAction?()
+      }
+      .modifier(KeyboardShortcutModifier(shortcut: keyboardShortcut(for: AppShortcuts.CommandID.revealInSidebar)))
+      .help(helpText(title: "Reveal in Sidebar", commandID: AppShortcuts.CommandID.revealInSidebar))
+      .disabled(revealInSidebarAction == nil)
       Divider()
       Button("Canvas") {
         store.send(.repositories(.toggleCanvas))
@@ -52,9 +59,18 @@ private struct ToggleLeftSidebarActionKey: FocusedValueKey {
   typealias Value = () -> Void
 }
 
+private struct RevealInSidebarActionKey: FocusedValueKey {
+  typealias Value = () -> Void
+}
+
 extension FocusedValues {
   var toggleLeftSidebarAction: (() -> Void)? {
     get { self[ToggleLeftSidebarActionKey.self] }
     set { self[ToggleLeftSidebarActionKey.self] = newValue }
+  }
+
+  var revealInSidebarAction: (() -> Void)? {
+    get { self[RevealInSidebarActionKey.self] }
+    set { self[RevealInSidebarActionKey.self] = newValue }
   }
 }

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -43,6 +43,11 @@ nonisolated struct WorktreeCreationProgressUpdateThrottle {
   }
 }
 
+struct PendingSidebarReveal: Equatable, Sendable {
+  let id: Int
+  let worktreeID: Worktree.ID
+}
+
 @Reducer
 struct RepositoriesFeature {
   enum CancelID {
@@ -208,6 +213,8 @@ struct RepositoriesFeature {
     var inFlightPullRequestRefreshRepositoryIDs: Set<Repository.ID> = []
     var queuedPullRequestRefreshByRepositoryID: [Repository.ID: PendingPullRequestRefresh] = [:]
     var sidebarSelectedWorktreeIDs: Set<Worktree.ID> = []
+    var nextPendingSidebarRevealID = 0
+    var pendingSidebarReveal: PendingSidebarReveal?
     @Shared(.appStorage("sidebarCollapsedRepositoryIDs")) var collapsedRepositoryIDs: [Repository.ID] = []
     @Presents var worktreeCreationPrompt: WorktreeCreationPromptFeature.State?
     @Presents var alert: AlertState<Alert>?
@@ -262,6 +269,8 @@ struct RepositoriesFeature {
     case selectWorktree(Worktree.ID?, focusTerminal: Bool = false)
     case selectNextWorktree
     case selectPreviousWorktree
+    case revealSelectedWorktreeInSidebar
+    case consumePendingSidebarReveal(Int)
     case requestRenameBranch(Worktree.ID, String)
     case presentAlert(title: String, message: String)
     case worktreeInfoEvent(WorktreeInfoWatcherClient.Event)
@@ -609,6 +618,25 @@ struct RepositoriesFeature {
         case .selectPreviousWorktree:
           guard let id = state.worktreeID(byOffset: -1) else { return .none }
           return .send(.selectWorktree(id))
+
+        case .revealSelectedWorktreeInSidebar:
+          guard let worktreeID = state.selectedWorktreeID,
+            let repositoryID = state.repositoryID(containing: worktreeID)
+          else { return .none }
+          state.$collapsedRepositoryIDs.withLock {
+            $0.removeAll { $0 == repositoryID }
+          }
+          state.nextPendingSidebarRevealID += 1
+          state.pendingSidebarReveal = .init(
+            id: state.nextPendingSidebarRevealID,
+            worktreeID: worktreeID
+          )
+          return .none
+
+        case .consumePendingSidebarReveal(let revealID):
+          guard state.pendingSidebarReveal?.id == revealID else { return .none }
+          state.pendingSidebarReveal = nil
+          return .none
 
         case .requestRenameBranch(let worktreeID, let branchName):
           guard let worktree = state.worktree(for: worktreeID) else { return .none }

--- a/supacode/Features/Repositories/Views/SidebarListView.swift
+++ b/supacode/Features/Repositories/Views/SidebarListView.swift
@@ -91,60 +91,10 @@ struct SidebarListView: View {
     let pendingSidebarReveal = state.pendingSidebarReveal
 
     ScrollViewReader { scrollProxy in
-    List(selection: selection) {
-      if orderedRoots.isEmpty {
-        let repositories = store.repositories
-        ForEach(Array(repositories.enumerated()), id: \.element.id) { index, repository in
-          RepositorySectionView(
-            repository: repository,
-            hasTopSpacing: index > 0,
-            isDragActive: isDragActive,
-            hotkeyRows: hotkeyRows,
-            selectedWorktreeIDs: selectedWorktreeIDs,
-            expandedRepoIDs: $expandedRepoIDs,
-            store: store,
-            terminalManager: terminalManager
-          )
-          .listRowInsets(EdgeInsets())
-        }
-      } else {
-        let orderedRows = Array(orderedRoots.enumerated()).map { index, rootURL in
-          (
-            index: index,
-            rootURL: rootURL,
-            repositoryID: rootURL.standardizedFileURL.path(percentEncoded: false)
-          )
-        }
-        ForEach(orderedRows, id: \.repositoryID) { row in
-          let index = row.index
-          let rootURL = row.rootURL
-          let repositoryID = row.repositoryID
-          if let failureMessage = state.loadFailuresByID[repositoryID] {
-            let name = Repository.name(for: rootURL.standardizedFileURL)
-            let path = rootURL.standardizedFileURL.path(percentEncoded: false)
-            FailedRepositoryRow(
-              name: name,
-              path: path,
-              showFailure: {
-                let message = "\(path)\n\n\(failureMessage)"
-                store.send(.presentAlert(title: "Unable to load \(name)", message: message))
-              },
-              removeRepository: {
-                store.send(.repositoryManagement(.removeFailedRepository(repositoryID)))
-              }
-            )
-            .padding(.horizontal, 12)
-            .overlay(alignment: .top) {
-              if index > 0 {
-                Rectangle()
-                  .fill(.secondary)
-                  .frame(height: 1)
-                  .frame(maxWidth: .infinity)
-                  .accessibilityHidden(true)
-              }
-            }
-            .listRowInsets(EdgeInsets())
-          } else if let repository = repositoriesByID[repositoryID] {
+      List(selection: selection) {
+        if orderedRoots.isEmpty {
+          let repositories = store.repositories
+          ForEach(Array(repositories.enumerated()), id: \.element.id) { index, repository in
             RepositorySectionView(
               repository: repository,
               hasTopSpacing: index > 0,
@@ -157,78 +107,128 @@ struct SidebarListView: View {
             )
             .listRowInsets(EdgeInsets())
           }
+        } else {
+          let orderedRows = Array(orderedRoots.enumerated()).map { index, rootURL in
+            (
+              index: index,
+              rootURL: rootURL,
+              repositoryID: rootURL.standardizedFileURL.path(percentEncoded: false)
+            )
+          }
+          ForEach(orderedRows, id: \.repositoryID) { row in
+            let index = row.index
+            let rootURL = row.rootURL
+            let repositoryID = row.repositoryID
+            if let failureMessage = state.loadFailuresByID[repositoryID] {
+              let name = Repository.name(for: rootURL.standardizedFileURL)
+              let path = rootURL.standardizedFileURL.path(percentEncoded: false)
+              FailedRepositoryRow(
+                name: name,
+                path: path,
+                showFailure: {
+                  let message = "\(path)\n\n\(failureMessage)"
+                  store.send(.presentAlert(title: "Unable to load \(name)", message: message))
+                },
+                removeRepository: {
+                  store.send(.repositoryManagement(.removeFailedRepository(repositoryID)))
+                }
+              )
+              .padding(.horizontal, 12)
+              .overlay(alignment: .top) {
+                if index > 0 {
+                  Rectangle()
+                    .fill(.secondary)
+                    .frame(height: 1)
+                    .frame(maxWidth: .infinity)
+                    .accessibilityHidden(true)
+                }
+              }
+              .listRowInsets(EdgeInsets())
+            } else if let repository = repositoriesByID[repositoryID] {
+              RepositorySectionView(
+                repository: repository,
+                hasTopSpacing: index > 0,
+                isDragActive: isDragActive,
+                hotkeyRows: hotkeyRows,
+                selectedWorktreeIDs: selectedWorktreeIDs,
+                expandedRepoIDs: $expandedRepoIDs,
+                store: store,
+                terminalManager: terminalManager
+              )
+              .listRowInsets(EdgeInsets())
+            }
+          }
+          .onMove { offsets, destination in
+            store.send(.worktreeOrdering(.repositoriesMoved(offsets, destination)))
+          }
         }
-        .onMove { offsets, destination in
-          store.send(.worktreeOrdering(.repositoriesMoved(offsets, destination)))
+      }
+      .listStyle(.sidebar)
+      .scrollIndicators(.never)
+      .frame(minWidth: 220)
+      .onDragSessionUpdated { session in
+        if case .ended = session.phase {
+          if isDragActive {
+            isDragActive = false
+          }
+          return
+        }
+        if case .dataTransferCompleted = session.phase {
+          if isDragActive {
+            isDragActive = false
+          }
+          return
+        }
+        if !isDragActive {
+          isDragActive = true
         }
       }
-    }
-    .listStyle(.sidebar)
-    .scrollIndicators(.never)
-    .frame(minWidth: 220)
-    .onDragSessionUpdated { session in
-      if case .ended = session.phase {
-        if isDragActive {
-          isDragActive = false
+      .safeAreaInset(edge: .top) {
+        CanvasSidebarButton(
+          store: store,
+          isSelected: state.isShowingCanvas
+        )
+        .padding(.top, 4)
+        .background(.bar)
+        .overlay(alignment: .bottom) {
+          Divider()
         }
-        return
       }
-      if case .dataTransferCompleted = session.phase {
-        if isDragActive {
-          isDragActive = false
-        }
-        return
+      .safeAreaInset(edge: .bottom) {
+        SidebarFooterView(store: store)
       }
-      if !isDragActive {
-        isDragActive = true
+      .dropDestination(for: URL.self) { urls, _ in
+        let fileURLs = urls.filter(\.isFileURL)
+        guard !fileURLs.isEmpty else { return false }
+        store.send(.repositoryManagement(.openRepositories(fileURLs)))
+        return true
       }
-    }
-    .safeAreaInset(edge: .top) {
-      CanvasSidebarButton(
-        store: store,
-        isSelected: state.isShowingCanvas
-      )
-      .padding(.top, 4)
-      .background(.bar)
-      .overlay(alignment: .bottom) {
-        Divider()
+      .onKeyPress { keyPress in
+        guard !keyPress.characters.isEmpty else { return .ignored }
+        let isNavigationKey =
+          keyPress.key == .upArrow
+          || keyPress.key == .downArrow
+          || keyPress.key == .leftArrow
+          || keyPress.key == .rightArrow
+          || keyPress.key == .home
+          || keyPress.key == .end
+          || keyPress.key == .pageUp
+          || keyPress.key == .pageDown
+        if isNavigationKey { return .ignored }
+        let hasCommandModifier = keyPress.modifiers.contains(.command)
+        if hasCommandModifier { return .ignored }
+        guard let worktreeID = store.selectedWorktreeID,
+          state.sidebarSelectedWorktreeIDs.count == 1,
+          state.sidebarSelectedWorktreeIDs.contains(worktreeID),
+          let terminalState = terminalManager.stateIfExists(for: worktreeID)
+        else { return .ignored }
+        terminalState.focusAndInsertText(keyPress.characters)
+        return .handled
       }
-    }
-    .safeAreaInset(edge: .bottom) {
-      SidebarFooterView(store: store)
-    }
-    .dropDestination(for: URL.self) { urls, _ in
-      let fileURLs = urls.filter(\.isFileURL)
-      guard !fileURLs.isEmpty else { return false }
-      store.send(.repositoryManagement(.openRepositories(fileURLs)))
-      return true
-    }
-    .onKeyPress { keyPress in
-      guard !keyPress.characters.isEmpty else { return .ignored }
-      let isNavigationKey =
-        keyPress.key == .upArrow
-        || keyPress.key == .downArrow
-        || keyPress.key == .leftArrow
-        || keyPress.key == .rightArrow
-        || keyPress.key == .home
-        || keyPress.key == .end
-        || keyPress.key == .pageUp
-        || keyPress.key == .pageDown
-      if isNavigationKey { return .ignored }
-      let hasCommandModifier = keyPress.modifiers.contains(.command)
-      if hasCommandModifier { return .ignored }
-      guard let worktreeID = store.selectedWorktreeID,
-        state.sidebarSelectedWorktreeIDs.count == 1,
-        state.sidebarSelectedWorktreeIDs.contains(worktreeID),
-        let terminalState = terminalManager.stateIfExists(for: worktreeID)
-      else { return .ignored }
-      terminalState.focusAndInsertText(keyPress.characters)
-      return .handled
-    }
-    .focused($isSidebarFocused)
-    .task(id: pendingSidebarReveal?.id) {
-      await revealPendingSidebarWorktree(pendingSidebarReveal, with: scrollProxy)
-    }
+      .focused($isSidebarFocused)
+      .task(id: pendingSidebarReveal?.id) {
+        await revealPendingSidebarWorktree(pendingSidebarReveal, with: scrollProxy)
+      }
     }  // ScrollViewReader
   }
 

--- a/supacode/Features/Repositories/Views/SidebarListView.swift
+++ b/supacode/Features/Repositories/Views/SidebarListView.swift
@@ -6,6 +6,7 @@ struct SidebarListView: View {
   @Binding var expandedRepoIDs: Set<Repository.ID>
   @Binding var sidebarSelections: Set<SidebarSelection>
   let terminalManager: WorktreeTerminalManager
+  @FocusState private var isSidebarFocused: Bool
   @State private var isDragActive = false
 
   var body: some View {
@@ -87,6 +88,9 @@ struct SidebarListView: View {
       }
     )
     let repositoriesByID = Dictionary(uniqueKeysWithValues: store.repositories.map { ($0.id, $0) })
+    let pendingSidebarReveal = state.pendingSidebarReveal
+
+    ScrollViewReader { scrollProxy in
     List(selection: selection) {
       if orderedRoots.isEmpty {
         let repositories = store.repositories
@@ -221,6 +225,27 @@ struct SidebarListView: View {
       terminalState.focusAndInsertText(keyPress.characters)
       return .handled
     }
+    .focused($isSidebarFocused)
+    .task(id: pendingSidebarReveal?.id) {
+      await revealPendingSidebarWorktree(pendingSidebarReveal, with: scrollProxy)
+    }
+    }  // ScrollViewReader
+  }
+
+  @MainActor
+  private func revealPendingSidebarWorktree(
+    _ pendingSidebarReveal: PendingSidebarReveal?,
+    with scrollProxy: ScrollViewProxy
+  ) async {
+    guard let pendingSidebarReveal else { return }
+    // Give SwiftUI time to materialize newly expanded section rows before scrolling.
+    await Task.yield()
+    await Task.yield()
+    isSidebarFocused = true
+    withAnimation(.easeOut(duration: 0.2)) {
+      scrollProxy.scrollTo(pendingSidebarReveal.worktreeID, anchor: .center)
+    }
+    store.send(.consumePendingSidebarReveal(pendingSidebarReveal.id))
   }
 }
 

--- a/supacode/Features/Repositories/Views/WorktreeRowsView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeRowsView.swift
@@ -227,6 +227,7 @@ struct WorktreeRowsView: View {
       onStopRunScript: config.onStopRunScript,
     )
     .tag(SidebarSelection.worktree(row.id))
+    .id(row.id)
     .typeSelectEquivalent("")
     .listRowInsets(EdgeInsets())
     .listRowSeparator(.hidden)

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -472,6 +472,70 @@ struct RepositoriesFeatureTests {
     #expect(savedEntries.value == expectedSavedEntries)
   }
 
+  @Test func revealInSidebarExpandsCollapsedRepository() async {
+    let worktree = makeWorktree(id: "/tmp/repo/wt", name: "wt")
+    let repository = makeRepository(id: "/tmp/repo", worktrees: [worktree])
+    var initialState = makeState(repositories: [repository])
+    initialState.selection = .worktree(worktree.id)
+    initialState.sidebarSelectedWorktreeIDs = [worktree.id]
+    initialState.$collapsedRepositoryIDs.withLock { $0 = [repository.id] }
+    let store = TestStore(initialState: initialState) {
+      RepositoriesFeature()
+    }
+
+    await store.send(.revealSelectedWorktreeInSidebar) {
+      $0.$collapsedRepositoryIDs.withLock { $0 = [] }
+      $0.nextPendingSidebarRevealID = 1
+      $0.pendingSidebarReveal = .init(id: 1, worktreeID: worktree.id)
+    }
+  }
+
+  @Test func revealInSidebarWithNoSelectionIsNoOp() async {
+    let worktree = makeWorktree(id: "/tmp/repo/wt", name: "wt")
+    let repository = makeRepository(id: "/tmp/repo", worktrees: [worktree])
+    let initialState = makeState(repositories: [repository])
+    let store = TestStore(initialState: initialState) {
+      RepositoriesFeature()
+    }
+
+    await store.send(.revealSelectedWorktreeInSidebar)
+  }
+
+  @Test func revealInSidebarKeepsOtherRepositoriesCollapsed() async {
+    let worktree1 = makeWorktree(id: "/tmp/repo-a/wt", name: "wt", repoRoot: "/tmp/repo-a")
+    let worktree2 = makeWorktree(id: "/tmp/repo-b/wt", name: "wt", repoRoot: "/tmp/repo-b")
+    let repoA = makeRepository(id: "/tmp/repo-a", worktrees: [worktree1])
+    let repoB = makeRepository(id: "/tmp/repo-b", worktrees: [worktree2])
+    var initialState = makeState(repositories: [repoA, repoB])
+    initialState.selection = .worktree(worktree1.id)
+    initialState.sidebarSelectedWorktreeIDs = [worktree1.id]
+    initialState.$collapsedRepositoryIDs.withLock { $0 = [repoA.id, repoB.id] }
+    let store = TestStore(initialState: initialState) {
+      RepositoriesFeature()
+    }
+
+    await store.send(.revealSelectedWorktreeInSidebar) {
+      $0.$collapsedRepositoryIDs.withLock { $0 = [repoB.id] }
+      $0.nextPendingSidebarRevealID = 1
+      $0.pendingSidebarReveal = .init(id: 1, worktreeID: worktree1.id)
+    }
+  }
+
+  @Test func consumePendingSidebarRevealClearsMatchingRequest() async {
+    let worktree = makeWorktree(id: "/tmp/repo/wt", name: "wt")
+    let repository = makeRepository(id: "/tmp/repo", worktrees: [worktree])
+    var initialState = makeState(repositories: [repository])
+    initialState.nextPendingSidebarRevealID = 1
+    initialState.pendingSidebarReveal = .init(id: 1, worktreeID: worktree.id)
+    let store = TestStore(initialState: initialState) {
+      RepositoriesFeature()
+    }
+
+    await store.send(.consumePendingSidebarReveal(1)) {
+      $0.pendingSidebarReveal = nil
+    }
+  }
+
   @Test func openRepositoriesDoesNotDowngradeFoldersOnUnexpectedProbeError() async {
     let repoSelection = "/tmp/repo/subdir"
     let repoRoot = "/tmp/repo"

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -536,6 +536,20 @@ struct RepositoriesFeatureTests {
     }
   }
 
+  @Test func consumePendingSidebarRevealIgnoresStaleRequest() async {
+    let worktree = makeWorktree(id: "/tmp/repo/wt", name: "wt")
+    let repository = makeRepository(id: "/tmp/repo", worktrees: [worktree])
+    var initialState = makeState(repositories: [repository])
+    initialState.nextPendingSidebarRevealID = 2
+    initialState.pendingSidebarReveal = .init(id: 2, worktreeID: worktree.id)
+    let store = TestStore(initialState: initialState) {
+      RepositoriesFeature()
+    }
+
+    // Stale ID should be ignored, pendingSidebarReveal remains unchanged.
+    await store.send(.consumePendingSidebarReveal(1))
+  }
+
   @Test func openRepositoriesDoesNotDowngradeFoldersOnUnexpectedProbeError() async {
     let repoSelection = "/tmp/repo/subdir"
     let repoRoot = "/tmp/repo"


### PR DESCRIPTION
## Summary

- New `revealSelectedWorktreeInSidebar` action in RepositoriesFeature that expands the collapsed repo section and sets a pending reveal
- `SidebarListView` wrapped in `ScrollViewReader` to scroll to the revealed worktree row
- Worktree rows tagged with `.id(row.id)` for `ScrollViewReader` targeting
- Menu item "Reveal in Sidebar" in View > Sidebar menu with ⇧⌘L shortcut
- `ContentView` wiring via `focusedSceneValue` — also opens the sidebar if hidden
- `PendingSidebarReveal` struct for coordinating reveal requests with consume/dismiss pattern

## Test plan

- [x] Reveal expands collapsed repository section
- [x] No-op when no worktree is selected
- [x] Only the target repository is expanded, others stay collapsed
- [x] Consume clears matching pending reveal
- [x] Build and lint clean

Closes #180