### PR TITLE
feat: optional git fetch before worktree creation

### DIFF
--- a/supacode/Clients/Git/GitClient.swift
+++ b/supacode/Clients/Git/GitClient.swift
@@ -22,6 +22,8 @@ enum GitOperation: String {
   case untrackedFilePaths = "untracked_file_paths"
   case showFile = "show_file"
   case remoteInfo = "remote_info"
+  case remoteList = "remote_list"
+  case fetchOrigin = "fetch_origin"
 }
 
 enum GitClientError: LocalizedError {
@@ -528,6 +530,27 @@ struct GitClient {
       }
     }
     return nil
+  }
+
+  nonisolated func remoteNames(for repoRoot: URL) async throws -> [String] {
+    let path = repoRoot.path(percentEncoded: false)
+    let output = try await runGit(
+      operation: .remoteList,
+      arguments: ["-C", path, "remote"]
+    )
+    return
+      output
+      .split(whereSeparator: \.isNewline)
+      .map { String($0).trimmingCharacters(in: .whitespacesAndNewlines) }
+      .filter { !$0.isEmpty }
+  }
+
+  nonisolated func fetchRemote(_ remote: String, for repoRoot: URL) async throws {
+    let path = repoRoot.path(percentEncoded: false)
+    _ = try await runGit(
+      operation: .fetchOrigin,
+      arguments: ["-C", path, "fetch", remote]
+    )
   }
 
   nonisolated func removeWorktree(_ worktree: Worktree, deleteBranch: Bool) async throws -> URL {

--- a/supacode/Clients/Git/GitClient.swift
+++ b/supacode/Clients/Git/GitClient.swift
@@ -23,7 +23,7 @@ enum GitOperation: String {
   case showFile = "show_file"
   case remoteInfo = "remote_info"
   case remoteList = "remote_list"
-  case fetchOrigin = "fetch_origin"
+  case fetchRemote = "fetch_remote"
 }
 
 enum GitClientError: LocalizedError {
@@ -43,6 +43,14 @@ enum GitClientError: LocalizedError {
 enum GitWorktreeCreateEvent: Equatable, Sendable {
   case outputLine(ShellStreamLine)
   case finished(Worktree)
+}
+
+nonisolated enum GitRemoteMatcher {
+  static func matchingRemote(for ref: String, from remotes: [String]) -> String? {
+    remotes
+      .sorted { $0.count > $1.count }
+      .first { ref.hasPrefix("\($0)/") }
+  }
 }
 
 struct GitClient {
@@ -548,7 +556,7 @@ struct GitClient {
   nonisolated func fetchRemote(_ remote: String, for repoRoot: URL) async throws {
     let path = repoRoot.path(percentEncoded: false)
     _ = try await runGit(
-      operation: .fetchOrigin,
+      operation: .fetchRemote,
       arguments: ["-C", path, "fetch", remote]
     )
   }

--- a/supacode/Clients/Repositories/GitClientDependency.swift
+++ b/supacode/Clients/Repositories/GitClientDependency.swift
@@ -37,6 +37,8 @@ struct GitClientDependency: Sendable {
   var lineChanges: @Sendable (URL) async -> (added: Int, removed: Int)?
   var renameBranch: @Sendable (_ worktreeURL: URL, _ branchName: String) async throws -> Void
   var remoteInfo: @Sendable (_ repositoryRoot: URL) async -> GithubRemoteInfo?
+  var remoteNames: @Sendable (_ repoRoot: URL) async throws -> [String]
+  var fetchRemote: @Sendable (_ remote: String, _ repoRoot: URL) async throws -> Void
 }
 
 extension GitClientDependency: DependencyKey {
@@ -84,6 +86,12 @@ extension GitClientDependency: DependencyKey {
     },
     remoteInfo: { repositoryRoot in
       await GitClient().remoteInfo(for: repositoryRoot)
+    },
+    remoteNames: { repoRoot in
+      try await GitClient().remoteNames(for: repoRoot)
+    },
+    fetchRemote: { remote, repoRoot in
+      try await GitClient().fetchRemote(remote, for: repoRoot)
     }
   )
   static let testValue = liveValue

--- a/supacode/Domain/WorktreeCreationProgress.swift
+++ b/supacode/Domain/WorktreeCreationProgress.swift
@@ -54,7 +54,7 @@ nonisolated struct WorktreeCreationProgress: Hashable, Sendable {
       return "Checking repository mode"
     case .resolvingBaseReference:
       return "Resolving base reference (\(baseRefDisplay))"
-    case .fetchingOrigin:
+    case .fetchingRemote:
       if let fetchRemoteName, !fetchRemoteName.isEmpty {
         return "Fetching \(fetchRemoteName)"
       }
@@ -129,6 +129,6 @@ nonisolated enum WorktreeCreationStage: Hashable, Sendable {
   case choosingWorktreeName
   case checkingRepositoryMode
   case resolvingBaseReference
-  case fetchingOrigin
+  case fetchingRemote
   case creatingWorktree
 }

--- a/supacode/Domain/WorktreeCreationProgress.swift
+++ b/supacode/Domain/WorktreeCreationProgress.swift
@@ -2,6 +2,7 @@ nonisolated struct WorktreeCreationProgress: Hashable, Sendable {
   var stage: WorktreeCreationStage
   var worktreeName: String?
   var baseRef: String?
+  var fetchRemoteName: String?
   var copyIgnored: Bool?
   var copyUntracked: Bool?
   var ignoredFilesToCopyCount: Int?
@@ -14,6 +15,7 @@ nonisolated struct WorktreeCreationProgress: Hashable, Sendable {
     stage: WorktreeCreationStage,
     worktreeName: String? = nil,
     baseRef: String? = nil,
+    fetchRemoteName: String? = nil,
     copyIgnored: Bool? = nil,
     copyUntracked: Bool? = nil,
     ignoredFilesToCopyCount: Int? = nil,
@@ -25,6 +27,7 @@ nonisolated struct WorktreeCreationProgress: Hashable, Sendable {
     self.stage = stage
     self.worktreeName = worktreeName
     self.baseRef = baseRef
+    self.fetchRemoteName = fetchRemoteName
     self.copyIgnored = copyIgnored
     self.copyUntracked = copyUntracked
     self.ignoredFilesToCopyCount = ignoredFilesToCopyCount
@@ -51,6 +54,11 @@ nonisolated struct WorktreeCreationProgress: Hashable, Sendable {
       return "Checking repository mode"
     case .resolvingBaseReference:
       return "Resolving base reference (\(baseRefDisplay))"
+    case .fetchingOrigin:
+      if let fetchRemoteName, !fetchRemoteName.isEmpty {
+        return "Fetching \(fetchRemoteName)"
+      }
+      return "Fetching remote"
     case .creatingWorktree:
       if let outputLine = outputLines.last, !outputLine.isEmpty {
         return outputLine
@@ -121,5 +129,6 @@ nonisolated enum WorktreeCreationStage: Hashable, Sendable {
   case choosingWorktreeName
   case checkingRepositoryMode
   case resolvingBaseReference
+  case fetchingOrigin
   case creatingWorktree
 }

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+WorktreeCreation.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+WorktreeCreation.swift
@@ -71,7 +71,7 @@ extension RepositoriesFeature {
                 repositoryID: repository.id,
                 nameSource: .random,
                 baseRefSource: .repositorySetting,
-                fetchOrigin: settingsFile.global.fetchOriginBeforeWorktreeCreation
+                fetchRemote: settingsFile.global.fetchOriginBeforeWorktreeCreation
               )
             )
           )
@@ -146,12 +146,12 @@ extension RepositoriesFeature {
         baseRefOptions: baseRefOptions,
         branchName: "",
         selectedBaseRef: selectedBaseRef,
-        fetchOrigin: settingsFile.global.fetchOriginBeforeWorktreeCreation,
+        fetchRemote: settingsFile.global.fetchOriginBeforeWorktreeCreation,
         validationMessage: nil
       )
       return .none
 
-    case .startPromptedWorktreeCreation(let repositoryID, let branchName, let baseRef, let fetchOrigin):
+    case .startPromptedWorktreeCreation(let repositoryID, let branchName, let baseRef):
       guard let repository = state.repositories[id: repositoryID] else {
         state.worktreeCreationPrompt = nil
         state.alert = messageAlert(
@@ -160,6 +160,9 @@ extension RepositoriesFeature {
         )
         return .none
       }
+      @Shared(.settingsFile) var settingsFile
+      let fetchRemote =
+        state.worktreeCreationPrompt?.fetchRemote ?? settingsFile.global.fetchOriginBeforeWorktreeCreation
       state.worktreeCreationPrompt?.validationMessage = nil
       state.worktreeCreationPrompt?.isValidating = true
       let normalizedBranchName = branchName.lowercased()
@@ -182,7 +185,7 @@ extension RepositoriesFeature {
               repositoryID: repositoryID,
               branchName: branchName,
               baseRef: baseRef,
-              fetchOrigin: fetchOrigin,
+              fetchRemote: fetchRemote,
               duplicateMessage: duplicateMessage
             )
           )
@@ -194,7 +197,7 @@ extension RepositoriesFeature {
       let repositoryID,
       let branchName,
       let baseRef,
-      let fetchOrigin,
+      let fetchRemote,
       let duplicateMessage
     ):
       guard let prompt = state.worktreeCreationPrompt, prompt.repositoryID == repositoryID else {
@@ -212,12 +215,12 @@ extension RepositoriesFeature {
             repositoryID: repositoryID,
             nameSource: .explicit(branchName),
             baseRefSource: .explicit(baseRef),
-            fetchOrigin: fetchOrigin
+            fetchRemote: fetchRemote
           )
         )
       )
 
-    case .createWorktreeInRepository(let repositoryID, let nameSource, let baseRefSource, let fetchOrigin):
+    case .createWorktreeInRepository(let repositoryID, let nameSource, let baseRefSource, let fetchRemote):
       guard let repository = state.repositories[id: repositoryID] else {
         state.alert = messageAlert(
           title: "Unable to create worktree",
@@ -415,12 +418,12 @@ extension RepositoriesFeature {
             }
           }
           progress.baseRef = resolvedBaseRef
-          if fetchOrigin, !resolvedBaseRef.isEmpty {
+          if fetchRemote, !resolvedBaseRef.isEmpty {
             do {
               let remotes = try await gitClient.remoteNames(repository.rootURL)
-              if let matchedRemote = resolvedBaseRef.matchingRemote(from: remotes) {
+              if let matchedRemote = GitRemoteMatcher.matchingRemote(for: resolvedBaseRef, from: remotes) {
                 progress.fetchRemoteName = matchedRemote
-                progress.stage = .fetchingOrigin
+                progress.stage = .fetchingRemote
                 await send(
                   .worktreeCreation(
                     .pendingWorktreeProgressUpdated(
@@ -645,11 +648,3 @@ extension RepositoriesFeature {
 }
 
 private nonisolated let worktreeCreationLogger = SupaLogger("WorktreeCreation")
-
-extension String {
-  fileprivate nonisolated func matchingRemote(from remotes: [String]) -> String? {
-    remotes
-      .sorted { $0.count > $1.count }
-      .first { hasPrefix("\($0)/") }
-  }
-}

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+WorktreeCreation.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+WorktreeCreation.swift
@@ -70,7 +70,8 @@ extension RepositoriesFeature {
               .createWorktreeInRepository(
                 repositoryID: repository.id,
                 nameSource: .random,
-                baseRefSource: .repositorySetting
+                baseRefSource: .repositorySetting,
+                fetchOrigin: settingsFile.global.fetchOriginBeforeWorktreeCreation
               )
             )
           )
@@ -115,14 +116,12 @@ extension RepositoriesFeature {
         guard !Task.isCancelled else {
           return
         }
-        let automaticBaseRefLabel =
-          automaticBaseRef.isEmpty ? "Automatic" : "Automatic (\(automaticBaseRef))"
         await send(
           .worktreeCreation(
             .promptedWorktreeCreationDataLoaded(
               repositoryID: repositoryID,
               baseRefOptions: baseRefOptions,
-              automaticBaseRefLabel: automaticBaseRefLabel,
+              automaticBaseRef: automaticBaseRef,
               selectedBaseRef: selectedBaseRef
             )
           )
@@ -133,24 +132,26 @@ extension RepositoriesFeature {
     case .promptedWorktreeCreationDataLoaded(
       let repositoryID,
       let baseRefOptions,
-      let automaticBaseRefLabel,
+      let automaticBaseRef,
       let selectedBaseRef
     ):
       guard let repository = state.repositories[id: repositoryID] else {
         return .none
       }
+      @Shared(.settingsFile) var settingsFile
       state.worktreeCreationPrompt = WorktreeCreationPromptFeature.State(
         repositoryID: repository.id,
         repositoryName: repository.name,
-        automaticBaseRefLabel: automaticBaseRefLabel,
+        automaticBaseRef: automaticBaseRef,
         baseRefOptions: baseRefOptions,
         branchName: "",
         selectedBaseRef: selectedBaseRef,
+        fetchOrigin: settingsFile.global.fetchOriginBeforeWorktreeCreation,
         validationMessage: nil
       )
       return .none
 
-    case .startPromptedWorktreeCreation(let repositoryID, let branchName, let baseRef):
+    case .startPromptedWorktreeCreation(let repositoryID, let branchName, let baseRef, let fetchOrigin):
       guard let repository = state.repositories[id: repositoryID] else {
         state.worktreeCreationPrompt = nil
         state.alert = messageAlert(
@@ -181,6 +182,7 @@ extension RepositoriesFeature {
               repositoryID: repositoryID,
               branchName: branchName,
               baseRef: baseRef,
+              fetchOrigin: fetchOrigin,
               duplicateMessage: duplicateMessage
             )
           )
@@ -192,6 +194,7 @@ extension RepositoriesFeature {
       let repositoryID,
       let branchName,
       let baseRef,
+      let fetchOrigin,
       let duplicateMessage
     ):
       guard let prompt = state.worktreeCreationPrompt, prompt.repositoryID == repositoryID else {
@@ -208,12 +211,13 @@ extension RepositoriesFeature {
           .createWorktreeInRepository(
             repositoryID: repositoryID,
             nameSource: .explicit(branchName),
-            baseRefSource: .explicit(baseRef)
+            baseRefSource: .explicit(baseRef),
+            fetchOrigin: fetchOrigin
           )
         )
       )
 
-    case .createWorktreeInRepository(let repositoryID, let nameSource, let baseRefSource):
+    case .createWorktreeInRepository(let repositoryID, let nameSource, let baseRefSource, let fetchOrigin):
       guard let repository = state.repositories[id: repositoryID] else {
         state.alert = messageAlert(
           title: "Unable to create worktree",
@@ -411,6 +415,28 @@ extension RepositoriesFeature {
             }
           }
           progress.baseRef = resolvedBaseRef
+          if fetchOrigin, !resolvedBaseRef.isEmpty {
+            do {
+              let remotes = try await gitClient.remoteNames(repository.rootURL)
+              if let matchedRemote = resolvedBaseRef.matchingRemote(from: remotes) {
+                progress.fetchRemoteName = matchedRemote
+                progress.stage = .fetchingOrigin
+                await send(
+                  .worktreeCreation(
+                    .pendingWorktreeProgressUpdated(
+                      id: pendingID,
+                      progress: progress
+                    )
+                  )
+                )
+                try await gitClient.fetchRemote(matchedRemote, repository.rootURL)
+              }
+            } catch {
+              let errorMessage = "git fetch failed: \(error.localizedDescription)"
+              worktreeCreationLogger.warning(errorMessage)
+              progress.appendOutputLine(errorMessage, maxLines: worktreeCreationProgressLineLimit)
+            }
+          }
           progress.copyIgnored = copyIgnored
           progress.copyUntracked = copyUntracked
           progress.ignoredFilesToCopyCount =
@@ -615,5 +641,15 @@ extension RepositoriesFeature {
       }
       return reduceWorktreeCreation(state: &state, action: action)
     }
+  }
+}
+
+private nonisolated let worktreeCreationLogger = SupaLogger("WorktreeCreation")
+
+extension String {
+  fileprivate nonisolated func matchingRemote(from remotes: [String]) -> String? {
+    remotes
+      .sorted { $0.count > $1.count }
+      .first { hasPrefix("\($0)/") }
   }
 }

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -69,23 +69,26 @@ struct RepositoriesFeature {
     case createWorktreeInRepository(
       repositoryID: Repository.ID,
       nameSource: WorktreeCreationNameSource,
-      baseRefSource: WorktreeCreationBaseRefSource
+      baseRefSource: WorktreeCreationBaseRefSource,
+      fetchOrigin: Bool
     )
     case promptedWorktreeCreationDataLoaded(
       repositoryID: Repository.ID,
       baseRefOptions: [String],
-      automaticBaseRefLabel: String,
+      automaticBaseRef: String,
       selectedBaseRef: String?
     )
     case startPromptedWorktreeCreation(
       repositoryID: Repository.ID,
       branchName: String,
-      baseRef: String?
+      baseRef: String?,
+      fetchOrigin: Bool
     )
     case promptedWorktreeCreationChecked(
       repositoryID: Repository.ID,
       branchName: String,
       baseRef: String?,
+      fetchOrigin: Bool,
       duplicateMessage: String?
     )
     case pendingWorktreeProgressUpdated(id: Worktree.ID, progress: WorktreeCreationProgress)
@@ -649,14 +652,15 @@ struct RepositoriesFeature {
           return .send(.worktreeCreation(.promptCanceled))
 
         case .worktreeCreationPrompt(
-          .presented(.delegate(.submit(let repositoryID, let branchName, let baseRef)))
+          .presented(.delegate(.submit(let repositoryID, let branchName, let baseRef, let fetchOrigin)))
         ):
           return .send(
             .worktreeCreation(
               .startPromptedWorktreeCreation(
                 repositoryID: repositoryID,
                 branchName: branchName,
-                baseRef: baseRef
+                baseRef: baseRef,
+                fetchOrigin: fetchOrigin
               )
             )
           )

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -70,7 +70,7 @@ struct RepositoriesFeature {
       repositoryID: Repository.ID,
       nameSource: WorktreeCreationNameSource,
       baseRefSource: WorktreeCreationBaseRefSource,
-      fetchOrigin: Bool
+      fetchRemote: Bool
     )
     case promptedWorktreeCreationDataLoaded(
       repositoryID: Repository.ID,
@@ -81,14 +81,13 @@ struct RepositoriesFeature {
     case startPromptedWorktreeCreation(
       repositoryID: Repository.ID,
       branchName: String,
-      baseRef: String?,
-      fetchOrigin: Bool
+      baseRef: String?
     )
     case promptedWorktreeCreationChecked(
       repositoryID: Repository.ID,
       branchName: String,
       baseRef: String?,
-      fetchOrigin: Bool,
+      fetchRemote: Bool,
       duplicateMessage: String?
     )
     case pendingWorktreeProgressUpdated(id: Worktree.ID, progress: WorktreeCreationProgress)
@@ -652,15 +651,14 @@ struct RepositoriesFeature {
           return .send(.worktreeCreation(.promptCanceled))
 
         case .worktreeCreationPrompt(
-          .presented(.delegate(.submit(let repositoryID, let branchName, let baseRef, let fetchOrigin)))
+          .presented(.delegate(.submit(let repositoryID, let branchName, let baseRef)))
         ):
           return .send(
             .worktreeCreation(
               .startPromptedWorktreeCreation(
                 repositoryID: repositoryID,
                 branchName: branchName,
-                baseRef: baseRef,
-                fetchOrigin: fetchOrigin
+                baseRef: baseRef
               )
             )
           )

--- a/supacode/Features/Repositories/Reducer/WorktreeCreationPromptFeature.swift
+++ b/supacode/Features/Repositories/Reducer/WorktreeCreationPromptFeature.swift
@@ -11,7 +11,7 @@ struct WorktreeCreationPromptFeature {
     let baseRefOptions: [String]
     var branchName: String
     var selectedBaseRef: String?
-    var fetchOrigin: Bool
+    var fetchRemote: Bool
     var validationMessage: String?
     var isValidating = false
 
@@ -32,7 +32,7 @@ struct WorktreeCreationPromptFeature {
   @CasePathable
   enum Delegate: Equatable {
     case cancel
-    case submit(repositoryID: Repository.ID, branchName: String, baseRef: String?, fetchOrigin: Bool)
+    case submit(repositoryID: Repository.ID, branchName: String, baseRef: String?)
   }
 
   var body: some Reducer<State, Action> {
@@ -62,8 +62,7 @@ struct WorktreeCreationPromptFeature {
             .submit(
               repositoryID: state.repositoryID,
               branchName: trimmed,
-              baseRef: state.selectedBaseRef,
-              fetchOrigin: state.fetchOrigin
+              baseRef: state.selectedBaseRef
             )
           )
         )

--- a/supacode/Features/Repositories/Reducer/WorktreeCreationPromptFeature.swift
+++ b/supacode/Features/Repositories/Reducer/WorktreeCreationPromptFeature.swift
@@ -7,12 +7,17 @@ struct WorktreeCreationPromptFeature {
   struct State: Equatable {
     let repositoryID: Repository.ID
     let repositoryName: String
-    let automaticBaseRefLabel: String
+    let automaticBaseRef: String
     let baseRefOptions: [String]
     var branchName: String
     var selectedBaseRef: String?
+    var fetchOrigin: Bool
     var validationMessage: String?
     var isValidating = false
+
+    var automaticBaseRefLabel: String {
+      automaticBaseRef.isEmpty ? "Automatic" : "Automatic (\(automaticBaseRef))"
+    }
   }
 
   enum Action: BindableAction, Equatable {
@@ -27,7 +32,7 @@ struct WorktreeCreationPromptFeature {
   @CasePathable
   enum Delegate: Equatable {
     case cancel
-    case submit(repositoryID: Repository.ID, branchName: String, baseRef: String?)
+    case submit(repositoryID: Repository.ID, branchName: String, baseRef: String?, fetchOrigin: Bool)
   }
 
   var body: some Reducer<State, Action> {
@@ -57,7 +62,8 @@ struct WorktreeCreationPromptFeature {
             .submit(
               repositoryID: state.repositoryID,
               branchName: trimmed,
-              baseRef: state.selectedBaseRef
+              baseRef: state.selectedBaseRef,
+              fetchOrigin: state.fetchOrigin
             )
           )
         )

--- a/supacode/Features/Repositories/Views/WorktreeCreationPromptView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeCreationPromptView.swift
@@ -34,6 +34,17 @@ struct WorktreeCreationPromptView: View {
         }
       }
 
+      VStack(alignment: .leading) {
+        Toggle(
+          "Fetch remote branch",
+          isOn: $store.fetchOrigin
+        )
+        .help("Run git fetch before creating the worktree to ensure the base branch is up to date.")
+        Text("Runs git fetch to ensure the base branch is up to date.")
+          .font(.footnote)
+          .foregroundStyle(.secondary)
+      }
+
       if let validationMessage = store.validationMessage, !validationMessage.isEmpty {
         Text(validationMessage)
           .font(.footnote)

--- a/supacode/Features/Repositories/Views/WorktreeCreationPromptView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeCreationPromptView.swift
@@ -36,11 +36,11 @@ struct WorktreeCreationPromptView: View {
 
       VStack(alignment: .leading) {
         Toggle(
-          "Fetch remote branch",
-          isOn: $store.fetchOrigin
+          "Fetch remote before creating worktree",
+          isOn: $store.fetchRemote
         )
-        .help("Run git fetch before creating the worktree to ensure the base branch is up to date.")
-        Text("Runs git fetch to ensure the base branch is up to date.")
+        .help("Runs git fetch <remote> before creating the worktree.")
+        Text("Keeps remote-tracking base branches current. Fetch failures are logged and creation continues.")
           .font(.footnote)
           .foregroundStyle(.secondary)
       }

--- a/supacode/Features/Settings/Models/GlobalSettings.swift
+++ b/supacode/Features/Settings/Models/GlobalSettings.swift
@@ -17,6 +17,7 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
   var deleteBranchOnDeleteWorktree: Bool
   var automaticallyArchiveMergedWorktrees: Bool
   var promptForWorktreeCreation: Bool
+  var fetchOriginBeforeWorktreeCreation: Bool
   var defaultWorktreeBaseDirectoryPath: String?
   var restoreTerminalLayoutOnLaunch: Bool
   var terminalFontSize: Float32?
@@ -41,6 +42,7 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     deleteBranchOnDeleteWorktree: true,
     automaticallyArchiveMergedWorktrees: false,
     promptForWorktreeCreation: true,
+    fetchOriginBeforeWorktreeCreation: true,
     defaultWorktreeBaseDirectoryPath: nil,
     restoreTerminalLayoutOnLaunch: false,
     terminalFontSize: nil,
@@ -66,6 +68,7 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     deleteBranchOnDeleteWorktree: Bool,
     automaticallyArchiveMergedWorktrees: Bool,
     promptForWorktreeCreation: Bool,
+    fetchOriginBeforeWorktreeCreation: Bool = true,
     defaultWorktreeBaseDirectoryPath: String? = nil,
     restoreTerminalLayoutOnLaunch: Bool = false,
     terminalFontSize: Float32? = nil,
@@ -89,6 +92,7 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     self.deleteBranchOnDeleteWorktree = deleteBranchOnDeleteWorktree
     self.automaticallyArchiveMergedWorktrees = automaticallyArchiveMergedWorktrees
     self.promptForWorktreeCreation = promptForWorktreeCreation
+    self.fetchOriginBeforeWorktreeCreation = fetchOriginBeforeWorktreeCreation
     self.defaultWorktreeBaseDirectoryPath = defaultWorktreeBaseDirectoryPath
     self.restoreTerminalLayoutOnLaunch = restoreTerminalLayoutOnLaunch
     self.terminalFontSize = terminalFontSize
@@ -145,6 +149,9 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     promptForWorktreeCreation =
       try container.decodeIfPresent(Bool.self, forKey: .promptForWorktreeCreation)
       ?? Self.default.promptForWorktreeCreation
+    fetchOriginBeforeWorktreeCreation =
+      try container.decodeIfPresent(Bool.self, forKey: .fetchOriginBeforeWorktreeCreation)
+      ?? Self.default.fetchOriginBeforeWorktreeCreation
     defaultWorktreeBaseDirectoryPath =
       try container.decodeIfPresent(String.self, forKey: .defaultWorktreeBaseDirectoryPath)
       ?? Self.default.defaultWorktreeBaseDirectoryPath

--- a/supacode/Features/Settings/Reducer/SettingsFeature.swift
+++ b/supacode/Features/Settings/Reducer/SettingsFeature.swift
@@ -23,6 +23,7 @@ struct SettingsFeature {
     var deleteBranchOnDeleteWorktree: Bool
     var automaticallyArchiveMergedWorktrees: Bool
     var promptForWorktreeCreation: Bool
+    var fetchOriginBeforeWorktreeCreation: Bool
     var defaultWorktreeBaseDirectoryPath: String
     var restoreTerminalLayoutOnLaunch: Bool
     var terminalFontSize: Float32?
@@ -53,6 +54,7 @@ struct SettingsFeature {
       deleteBranchOnDeleteWorktree = settings.deleteBranchOnDeleteWorktree
       automaticallyArchiveMergedWorktrees = settings.automaticallyArchiveMergedWorktrees
       promptForWorktreeCreation = settings.promptForWorktreeCreation
+      fetchOriginBeforeWorktreeCreation = settings.fetchOriginBeforeWorktreeCreation
       defaultWorktreeBaseDirectoryPath =
         SupacodePaths.normalizedWorktreeBaseDirectoryPath(settings.defaultWorktreeBaseDirectoryPath) ?? ""
       restoreTerminalLayoutOnLaunch = settings.restoreTerminalLayoutOnLaunch
@@ -80,6 +82,7 @@ struct SettingsFeature {
         deleteBranchOnDeleteWorktree: deleteBranchOnDeleteWorktree,
         automaticallyArchiveMergedWorktrees: automaticallyArchiveMergedWorktrees,
         promptForWorktreeCreation: promptForWorktreeCreation,
+        fetchOriginBeforeWorktreeCreation: fetchOriginBeforeWorktreeCreation,
         defaultWorktreeBaseDirectoryPath: SupacodePaths.normalizedWorktreeBaseDirectoryPath(
           defaultWorktreeBaseDirectoryPath
         ),
@@ -176,6 +179,7 @@ struct SettingsFeature {
         state.deleteBranchOnDeleteWorktree = normalizedSettings.deleteBranchOnDeleteWorktree
         state.automaticallyArchiveMergedWorktrees = normalizedSettings.automaticallyArchiveMergedWorktrees
         state.promptForWorktreeCreation = normalizedSettings.promptForWorktreeCreation
+        state.fetchOriginBeforeWorktreeCreation = normalizedSettings.fetchOriginBeforeWorktreeCreation
         state.defaultWorktreeBaseDirectoryPath = normalizedSettings.defaultWorktreeBaseDirectoryPath ?? ""
         state.restoreTerminalLayoutOnLaunch = normalizedSettings.restoreTerminalLayoutOnLaunch
         state.terminalFontSize = normalizedSettings.terminalFontSize

--- a/supacode/Features/Settings/Reducer/SettingsFeature.swift
+++ b/supacode/Features/Settings/Reducer/SettingsFeature.swift
@@ -23,7 +23,7 @@ struct SettingsFeature {
     var deleteBranchOnDeleteWorktree: Bool
     var automaticallyArchiveMergedWorktrees: Bool
     var promptForWorktreeCreation: Bool
-    var fetchOriginBeforeWorktreeCreation: Bool
+    var fetchRemoteBeforeWorktreeCreation: Bool
     var defaultWorktreeBaseDirectoryPath: String
     var restoreTerminalLayoutOnLaunch: Bool
     var terminalFontSize: Float32?
@@ -54,7 +54,7 @@ struct SettingsFeature {
       deleteBranchOnDeleteWorktree = settings.deleteBranchOnDeleteWorktree
       automaticallyArchiveMergedWorktrees = settings.automaticallyArchiveMergedWorktrees
       promptForWorktreeCreation = settings.promptForWorktreeCreation
-      fetchOriginBeforeWorktreeCreation = settings.fetchOriginBeforeWorktreeCreation
+      fetchRemoteBeforeWorktreeCreation = settings.fetchOriginBeforeWorktreeCreation
       defaultWorktreeBaseDirectoryPath =
         SupacodePaths.normalizedWorktreeBaseDirectoryPath(settings.defaultWorktreeBaseDirectoryPath) ?? ""
       restoreTerminalLayoutOnLaunch = settings.restoreTerminalLayoutOnLaunch
@@ -82,7 +82,7 @@ struct SettingsFeature {
         deleteBranchOnDeleteWorktree: deleteBranchOnDeleteWorktree,
         automaticallyArchiveMergedWorktrees: automaticallyArchiveMergedWorktrees,
         promptForWorktreeCreation: promptForWorktreeCreation,
-        fetchOriginBeforeWorktreeCreation: fetchOriginBeforeWorktreeCreation,
+        fetchOriginBeforeWorktreeCreation: fetchRemoteBeforeWorktreeCreation,
         defaultWorktreeBaseDirectoryPath: SupacodePaths.normalizedWorktreeBaseDirectoryPath(
           defaultWorktreeBaseDirectoryPath
         ),
@@ -179,7 +179,7 @@ struct SettingsFeature {
         state.deleteBranchOnDeleteWorktree = normalizedSettings.deleteBranchOnDeleteWorktree
         state.automaticallyArchiveMergedWorktrees = normalizedSettings.automaticallyArchiveMergedWorktrees
         state.promptForWorktreeCreation = normalizedSettings.promptForWorktreeCreation
-        state.fetchOriginBeforeWorktreeCreation = normalizedSettings.fetchOriginBeforeWorktreeCreation
+        state.fetchRemoteBeforeWorktreeCreation = normalizedSettings.fetchOriginBeforeWorktreeCreation
         state.defaultWorktreeBaseDirectoryPath = normalizedSettings.defaultWorktreeBaseDirectoryPath ?? ""
         state.restoreTerminalLayoutOnLaunch = normalizedSettings.restoreTerminalLayoutOnLaunch
         state.terminalFontSize = normalizedSettings.terminalFontSize

--- a/supacode/Features/Settings/Views/WorktreeSettingsView.swift
+++ b/supacode/Features/Settings/Views/WorktreeSettingsView.swift
@@ -56,11 +56,11 @@ struct WorktreeSettingsView: View {
           }
           VStack(alignment: .leading) {
             Toggle(
-              "Fetch remote branch before creating worktree",
-              isOn: $store.fetchOriginBeforeWorktreeCreation
+              "Fetch remote before creating worktree",
+              isOn: $store.fetchRemoteBeforeWorktreeCreation
             )
-            .help("Run git fetch to ensure the base branch is up to date before creating a worktree.")
-            Text("Runs git fetch to ensure the base branch is up to date.")
+            .help("Runs git fetch <remote> before creating a worktree.")
+            Text("Keeps remote-tracking base branches current. Fetch failures are logged and creation continues.")
               .foregroundStyle(.secondary)
           }
         }

--- a/supacode/Features/Settings/Views/WorktreeSettingsView.swift
+++ b/supacode/Features/Settings/Views/WorktreeSettingsView.swift
@@ -54,6 +54,15 @@ struct WorktreeSettingsView: View {
             Text("When enabled, you choose the branch name and where it branches from before creating the worktree.")
               .foregroundStyle(.secondary)
           }
+          VStack(alignment: .leading) {
+            Toggle(
+              "Fetch remote branch before creating worktree",
+              isOn: $store.fetchOriginBeforeWorktreeCreation
+            )
+            .help("Run git fetch to ensure the base branch is up to date before creating a worktree.")
+            Text("Runs git fetch to ensure the base branch is up to date.")
+              .foregroundStyle(.secondary)
+          }
         }
       }
       .formStyle(.grouped)

--- a/supacodeTests/GitClientBranchRefsTests.swift
+++ b/supacodeTests/GitClientBranchRefsTests.swift
@@ -12,6 +12,33 @@ actor ShellCallStore {
 }
 
 struct GitClientBranchRefsTests {
+  @Test func remoteMatcherUsesRemotePrefix() {
+    let remote = GitRemoteMatcher.matchingRemote(
+      for: "origin/main",
+      from: ["origin", "upstream"]
+    )
+
+    #expect(remote == "origin")
+  }
+
+  @Test func remoteMatcherUsesLongestRemotePrefix() {
+    let remote = GitRemoteMatcher.matchingRemote(
+      for: "origin-fork/main",
+      from: ["origin", "origin-fork"]
+    )
+
+    #expect(remote == "origin-fork")
+  }
+
+  @Test func remoteMatcherReturnsNilForLocalBranch() {
+    let remote = GitRemoteMatcher.matchingRemote(
+      for: "local-branch",
+      from: ["origin"]
+    )
+
+    #expect(remote == nil)
+  }
+
   @Test func branchRefsIncludesLocalAndUpstreamRefs() async throws {
     let store = ShellCallStore()
     let output = """

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -884,7 +884,7 @@ struct RepositoriesFeatureTests {
         baseRefOptions: ["origin/dev", "origin/main"],
         branchName: "",
         selectedBaseRef: nil,
-        fetchOrigin: true,
+        fetchRemote: true,
         validationMessage: nil
       )
     }
@@ -902,7 +902,7 @@ struct RepositoriesFeatureTests {
       baseRefOptions: ["origin/main"],
       branchName: "feature/new-branch",
       selectedBaseRef: nil,
-      fetchOrigin: true,
+      fetchRemote: true,
       validationMessage: nil
     )
     let store = TestStore(initialState: state) {
@@ -927,7 +927,7 @@ struct RepositoriesFeatureTests {
       baseRefOptions: ["origin/main"],
       branchName: "feature/existing",
       selectedBaseRef: nil,
-      fetchOrigin: true,
+      fetchRemote: true,
       validationMessage: nil
     )
     let store = TestStore(initialState: state) {
@@ -941,8 +941,7 @@ struct RepositoriesFeatureTests {
         .startPromptedWorktreeCreation(
           repositoryID: repository.id,
           branchName: "feature/existing",
-          baseRef: nil,
-          fetchOrigin: true
+          baseRef: nil
         ))
     ) {
       $0.worktreeCreationPrompt?.validationMessage = nil
@@ -1011,7 +1010,7 @@ struct RepositoriesFeatureTests {
         baseRefOptions: ["origin/main"],
         branchName: "",
         selectedBaseRef: nil,
-        fetchOrigin: true,
+        fetchRemote: true,
         validationMessage: nil
       )
     }
@@ -1031,7 +1030,7 @@ struct RepositoriesFeatureTests {
       baseRefOptions: ["origin/main"],
       branchName: "feature/new-branch",
       selectedBaseRef: nil,
-      fetchOrigin: true,
+      fetchRemote: true,
       validationMessage: nil
     )
     let store = TestStore(initialState: state) {
@@ -1048,8 +1047,7 @@ struct RepositoriesFeatureTests {
         .startPromptedWorktreeCreation(
           repositoryID: repository.id,
           branchName: "feature/new-branch",
-          baseRef: nil,
-          fetchOrigin: true
+          baseRef: nil
         ))
     ) {
       $0.worktreeCreationPrompt?.validationMessage = nil
@@ -1092,7 +1090,7 @@ struct RepositoriesFeatureTests {
           repositoryID: repository.id,
           nameSource: .explicit("../../Desktop"),
           baseRefSource: .repositorySetting,
-          fetchOrigin: true
+          fetchRemote: true
         ))
     )
     await store.receive(\.worktreeCreation.createRandomWorktreeFailed) {
@@ -1156,7 +1154,10 @@ struct RepositoriesFeatureTests {
       repoRoot: repoRoot
     )
     @Shared(.settingsFile) var settingsFile
-    $settingsFile.withLock { $0.global.promptForWorktreeCreation = false }
+    $settingsFile.withLock {
+      $0.global.promptForWorktreeCreation = false
+      $0.global.fetchOriginBeforeWorktreeCreation = false
+    }
     let store = TestStore(initialState: makeState(repositories: [repository])) {
       RepositoriesFeature()
     } withDependencies: {
@@ -1191,6 +1192,103 @@ struct RepositoriesFeatureTests {
     #expect(store.state.alert == nil)
   }
 
+  @Test(.dependencies) func createWorktreeFetchesMatchedRemoteBeforeCreatingWorktree() async {
+    let repoRoot = "/tmp/\(UUID().uuidString)-repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree])
+    let createdWorktree = makeWorktree(
+      id: "\(repoRoot)/swift-otter",
+      name: "swift-otter",
+      repoRoot: repoRoot
+    )
+    let events = LockIsolated<[String]>([])
+    let store = TestStore(initialState: makeState(repositories: [repository])) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.uuid = .incrementing
+      $0.gitClient.localBranchNames = { _ in [] }
+      $0.gitClient.isBareRepository = { _ in false }
+      $0.gitClient.automaticWorktreeBaseRef = { _ in "origin/main" }
+      $0.gitClient.remoteNames = { _ in ["origin", "upstream"] }
+      $0.gitClient.fetchRemote = { remote, _ in
+        events.withValue { $0.append("fetch:\(remote)") }
+      }
+      $0.gitClient.ignoredFileCount = { _ in 0 }
+      $0.gitClient.untrackedFileCount = { _ in 0 }
+      $0.gitClient.createWorktreeStream = { _, _, _, _, _, _ in
+        events.withValue { $0.append("create") }
+        return AsyncThrowingStream { continuation in
+          continuation.yield(.finished(createdWorktree))
+          continuation.finish()
+        }
+      }
+      $0.gitClient.worktrees = { _ in [createdWorktree, mainWorktree] }
+    }
+    store.exhaustivity = .off
+
+    await store.send(
+      .worktreeCreation(
+        .createWorktreeInRepository(
+          repositoryID: repository.id,
+          nameSource: .random,
+          baseRefSource: .repositorySetting,
+          fetchRemote: true
+        ))
+    )
+    await store.receive(\.worktreeCreation.createRandomWorktreeSucceeded)
+    await store.finish()
+
+    #expect(events.value == ["fetch:origin", "create"])
+  }
+
+  @Test(.dependencies) func createWorktreeSkipsFetchWhenDisabled() async {
+    let repoRoot = "/tmp/\(UUID().uuidString)-repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree])
+    let createdWorktree = makeWorktree(
+      id: "\(repoRoot)/swift-otter",
+      name: "swift-otter",
+      repoRoot: repoRoot
+    )
+    let store = TestStore(initialState: makeState(repositories: [repository])) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.uuid = .incrementing
+      $0.gitClient.localBranchNames = { _ in [] }
+      $0.gitClient.isBareRepository = { _ in false }
+      $0.gitClient.automaticWorktreeBaseRef = { _ in "origin/main" }
+      $0.gitClient.remoteNames = { _ in
+        Issue.record("remoteNames should not be requested when fetch is disabled")
+        return ["origin"]
+      }
+      $0.gitClient.fetchRemote = { _, _ in
+        Issue.record("fetchRemote should not run when fetch is disabled")
+      }
+      $0.gitClient.ignoredFileCount = { _ in 0 }
+      $0.gitClient.untrackedFileCount = { _ in 0 }
+      $0.gitClient.createWorktreeStream = { _, _, _, _, _, _ in
+        AsyncThrowingStream { continuation in
+          continuation.yield(.finished(createdWorktree))
+          continuation.finish()
+        }
+      }
+      $0.gitClient.worktrees = { _ in [createdWorktree, mainWorktree] }
+    }
+    store.exhaustivity = .off
+
+    await store.send(
+      .worktreeCreation(
+        .createWorktreeInRepository(
+          repositoryID: repository.id,
+          nameSource: .random,
+          baseRefSource: .repositorySetting,
+          fetchRemote: false
+        ))
+    )
+    await store.receive(\.worktreeCreation.createRandomWorktreeSucceeded)
+    await store.finish()
+  }
+
   @Test(.dependencies) func createRandomWorktreeUsesRepositoryWorktreeBaseDirectoryOverride() async {
     let repoRoot = "/tmp/repo"
     let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
@@ -1204,6 +1302,7 @@ struct RepositoriesFeatureTests {
     @Shared(.settingsFile) var settingsFile
     $settingsFile.withLock {
       $0.global.promptForWorktreeCreation = false
+      $0.global.fetchOriginBeforeWorktreeCreation = false
       $0.global.defaultWorktreeBaseDirectoryPath = "/tmp/global-worktrees"
     }
     @Shared(.repositorySettings(repository.rootURL)) var repositorySettings
@@ -1255,6 +1354,7 @@ struct RepositoriesFeatureTests {
     @Shared(.settingsFile) var settingsFile
     $settingsFile.withLock {
       $0.global.promptForWorktreeCreation = false
+      $0.global.fetchOriginBeforeWorktreeCreation = false
       $0.global.defaultWorktreeBaseDirectoryPath = "/tmp/global-worktrees"
     }
     @Shared(.repositorySettings(repository.rootURL)) var repositorySettings
@@ -1298,7 +1398,10 @@ struct RepositoriesFeatureTests {
     let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
     let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree])
     @Shared(.settingsFile) var settingsFile
-    $settingsFile.withLock { $0.global.promptForWorktreeCreation = false }
+    $settingsFile.withLock {
+      $0.global.promptForWorktreeCreation = false
+      $0.global.fetchOriginBeforeWorktreeCreation = false
+    }
     let store = TestStore(initialState: makeState(repositories: [repository])) {
       RepositoriesFeature()
     } withDependencies: {

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -880,10 +880,11 @@ struct RepositoriesFeatureTests {
       $0.worktreeCreationPrompt = WorktreeCreationPromptFeature.State(
         repositoryID: repository.id,
         repositoryName: repository.name,
-        automaticBaseRefLabel: "Automatic (origin/main)",
+        automaticBaseRef: "origin/main",
         baseRefOptions: ["origin/dev", "origin/main"],
         branchName: "",
         selectedBaseRef: nil,
+        fetchOrigin: true,
         validationMessage: nil
       )
     }
@@ -897,10 +898,11 @@ struct RepositoriesFeatureTests {
     state.worktreeCreationPrompt = WorktreeCreationPromptFeature.State(
       repositoryID: repository.id,
       repositoryName: repository.name,
-      automaticBaseRefLabel: "Automatic (origin/main)",
+      automaticBaseRef: "origin/main",
       baseRefOptions: ["origin/main"],
       branchName: "feature/new-branch",
       selectedBaseRef: nil,
+      fetchOrigin: true,
       validationMessage: nil
     )
     let store = TestStore(initialState: state) {
@@ -921,10 +923,11 @@ struct RepositoriesFeatureTests {
     state.worktreeCreationPrompt = WorktreeCreationPromptFeature.State(
       repositoryID: repository.id,
       repositoryName: repository.name,
-      automaticBaseRefLabel: "Automatic (origin/main)",
+      automaticBaseRef: "origin/main",
       baseRefOptions: ["origin/main"],
       branchName: "feature/existing",
       selectedBaseRef: nil,
+      fetchOrigin: true,
       validationMessage: nil
     )
     let store = TestStore(initialState: state) {
@@ -938,7 +941,8 @@ struct RepositoriesFeatureTests {
         .startPromptedWorktreeCreation(
           repositoryID: repository.id,
           branchName: "feature/existing",
-          baseRef: nil
+          baseRef: nil,
+          fetchOrigin: true
         ))
     ) {
       $0.worktreeCreationPrompt?.validationMessage = nil
@@ -1003,10 +1007,11 @@ struct RepositoriesFeatureTests {
       $0.worktreeCreationPrompt = WorktreeCreationPromptFeature.State(
         repositoryID: repoB.id,
         repositoryName: repoB.name,
-        automaticBaseRefLabel: "Automatic (origin/main)",
+        automaticBaseRef: "origin/main",
         baseRefOptions: ["origin/main"],
         branchName: "",
         selectedBaseRef: nil,
+        fetchOrigin: true,
         validationMessage: nil
       )
     }
@@ -1022,10 +1027,11 @@ struct RepositoriesFeatureTests {
     state.worktreeCreationPrompt = WorktreeCreationPromptFeature.State(
       repositoryID: repository.id,
       repositoryName: repository.name,
-      automaticBaseRefLabel: "Automatic (origin/main)",
+      automaticBaseRef: "origin/main",
       baseRefOptions: ["origin/main"],
       branchName: "feature/new-branch",
       selectedBaseRef: nil,
+      fetchOrigin: true,
       validationMessage: nil
     )
     let store = TestStore(initialState: state) {
@@ -1042,7 +1048,8 @@ struct RepositoriesFeatureTests {
         .startPromptedWorktreeCreation(
           repositoryID: repository.id,
           branchName: "feature/new-branch",
-          baseRef: nil
+          baseRef: nil,
+          fetchOrigin: true
         ))
     ) {
       $0.worktreeCreationPrompt?.validationMessage = nil
@@ -1084,7 +1091,8 @@ struct RepositoriesFeatureTests {
         .createWorktreeInRepository(
           repositoryID: repository.id,
           nameSource: .explicit("../../Desktop"),
-          baseRefSource: .repositorySetting
+          baseRefSource: .repositorySetting,
+          fetchOrigin: true
         ))
     )
     await store.receive(\.worktreeCreation.createRandomWorktreeFailed) {

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -1289,6 +1289,96 @@ struct RepositoriesFeatureTests {
     await store.finish()
   }
 
+  @Test(.dependencies) func createWorktreeContinuesWhenFetchFails() async {
+    let repoRoot = "/tmp/\(UUID().uuidString)-repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree])
+    let createdWorktree = makeWorktree(
+      id: "\(repoRoot)/swift-otter",
+      name: "swift-otter",
+      repoRoot: repoRoot
+    )
+    let store = TestStore(initialState: makeState(repositories: [repository])) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.uuid = .incrementing
+      $0.gitClient.localBranchNames = { _ in [] }
+      $0.gitClient.isBareRepository = { _ in false }
+      $0.gitClient.automaticWorktreeBaseRef = { _ in "origin/main" }
+      $0.gitClient.remoteNames = { _ in ["origin"] }
+      $0.gitClient.fetchRemote = { _, _ in
+        throw NSError(domain: "git", code: 128, userInfo: [NSLocalizedDescriptionKey: "network unreachable"])
+      }
+      $0.gitClient.ignoredFileCount = { _ in 0 }
+      $0.gitClient.untrackedFileCount = { _ in 0 }
+      $0.gitClient.createWorktreeStream = { _, _, _, _, _, _ in
+        AsyncThrowingStream { continuation in
+          continuation.yield(.finished(createdWorktree))
+          continuation.finish()
+        }
+      }
+      $0.gitClient.worktrees = { _ in [createdWorktree, mainWorktree] }
+    }
+    store.exhaustivity = .off
+
+    await store.send(
+      .worktreeCreation(
+        .createWorktreeInRepository(
+          repositoryID: repository.id,
+          nameSource: .random,
+          baseRefSource: .repositorySetting,
+          fetchRemote: true
+        ))
+    )
+    await store.receive(\.worktreeCreation.createRandomWorktreeSucceeded)
+    await store.finish()
+  }
+
+  @Test(.dependencies) func createWorktreeSkipsFetchWhenNoMatchedRemote() async {
+    let repoRoot = "/tmp/\(UUID().uuidString)-repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree])
+    let createdWorktree = makeWorktree(
+      id: "\(repoRoot)/swift-otter",
+      name: "swift-otter",
+      repoRoot: repoRoot
+    )
+    let store = TestStore(initialState: makeState(repositories: [repository])) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.uuid = .incrementing
+      $0.gitClient.localBranchNames = { _ in [] }
+      $0.gitClient.isBareRepository = { _ in false }
+      $0.gitClient.automaticWorktreeBaseRef = { _ in "local-branch" }
+      $0.gitClient.remoteNames = { _ in ["origin", "upstream"] }
+      $0.gitClient.fetchRemote = { _, _ in
+        Issue.record("fetchRemote should not run when no remote matches the base ref")
+      }
+      $0.gitClient.ignoredFileCount = { _ in 0 }
+      $0.gitClient.untrackedFileCount = { _ in 0 }
+      $0.gitClient.createWorktreeStream = { _, _, _, _, _, _ in
+        AsyncThrowingStream { continuation in
+          continuation.yield(.finished(createdWorktree))
+          continuation.finish()
+        }
+      }
+      $0.gitClient.worktrees = { _ in [createdWorktree, mainWorktree] }
+    }
+    store.exhaustivity = .off
+
+    await store.send(
+      .worktreeCreation(
+        .createWorktreeInRepository(
+          repositoryID: repository.id,
+          nameSource: .random,
+          baseRefSource: .repositorySetting,
+          fetchRemote: true
+        ))
+    )
+    await store.receive(\.worktreeCreation.createRandomWorktreeSucceeded)
+    await store.finish()
+  }
+
   @Test(.dependencies) func createRandomWorktreeUsesRepositoryWorktreeBaseDirectoryOverride() async {
     let repoRoot = "/tmp/repo"
     let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)

--- a/supacodeTests/WorktreeCreationProgressTests.swift
+++ b/supacodeTests/WorktreeCreationProgressTests.swift
@@ -13,6 +13,17 @@ struct WorktreeCreationProgressTests {
     #expect(progress.detailText == "Resolving base reference (HEAD)")
   }
 
+  @Test func fetchingRemoteIncludesRemoteName() {
+    let progress = WorktreeCreationProgress(
+      stage: .fetchingRemote,
+      worktreeName: "swift-otter",
+      fetchRemoteName: "origin"
+    )
+
+    #expect(progress.titleText == "Creating swift-otter")
+    #expect(progress.detailText == "Fetching origin")
+  }
+
   @Test func creatingWorktreeIncludesBaseRefAndCopyFlags() {
     let progress = WorktreeCreationProgress(
       stage: .creatingWorktree,


### PR DESCRIPTION
## Summary

- Add `fetchOriginBeforeWorktreeCreation` global setting (default `true`) with UI toggle in Worktree settings
- Thread `fetchOrigin` through the worktree creation flow (prompt → validation → creation)
- After resolving the base ref, match it against `git remote` output (longest-prefix) and run `git fetch <remote>` before creating the worktree
- Add `fetchingOrigin` stage to `WorktreeCreationProgress` for UI feedback during fetch
- Fetch errors are logged and appended to progress output but do not block worktree creation

Closes #176

## Test plan

- [x] Tests need to be updated for changed action signatures (deferred to separate commit)
- [x] Verify toggle appears in Settings → Worktree and persists across app restarts
- [x] Create a worktree with fetch enabled — confirm fetch stage appears in progress
- [x] Create a worktree with fetch disabled — confirm no fetch stage
- [x] Create a worktree via prompt dialog — verify the fetch toggle appears and its value is respected
- [x] Simulate fetch failure (e.g. offline) — verify worktree creation still succeeds
