### PR TITLE
feat: auto-delete archived worktrees (#174)

### DIFF
--- a/supacode/Clients/Repositories/RepositoryPersistenceClient.swift
+++ b/supacode/Clients/Repositories/RepositoryPersistenceClient.swift
@@ -9,8 +9,8 @@ struct RepositoryPersistenceClient {
   var saveRoots: @Sendable ([String]) async -> Void
   var loadPinnedWorktreeIDs: @Sendable () async -> [Worktree.ID]
   var savePinnedWorktreeIDs: @Sendable ([Worktree.ID]) async -> Void
-  var loadArchivedWorktreeIDs: @Sendable () async -> [Worktree.ID]
-  var saveArchivedWorktreeIDs: @Sendable ([Worktree.ID]) async -> Void
+  var loadArchivedWorktrees: @Sendable () async -> [ArchivedWorktree]
+  var saveArchivedWorktrees: @Sendable ([ArchivedWorktree]) async -> Void
   var loadRepositoryOrderIDs: @Sendable () async -> [Repository.ID]
   var saveRepositoryOrderIDs: @Sendable ([Repository.ID]) async -> Void
   var loadWorktreeOrderByRepository: @Sendable () async -> [Repository.ID: [Worktree.ID]]
@@ -57,13 +57,19 @@ extension RepositoryPersistenceClient: DependencyKey {
           $0 = ids
         }
       },
-      loadArchivedWorktreeIDs: {
-        @Shared(.appStorage("archivedWorktreeIDs")) var archived: [Worktree.ID] = []
-        return RepositoryPathNormalizer.normalize(archived)
+      loadArchivedWorktrees: {
+        @Shared(.appStorage("archivedWorktrees")) var archived: [ArchivedWorktree] = []
+        if !archived.isEmpty {
+          return normalizeArchivedWorktrees(archived)
+        }
+        // Fall back to legacy format
+        @Shared(.appStorage("archivedWorktreeIDs")) var legacyArchived: [Worktree.ID] = []
+        let legacyIDs = RepositoryPathNormalizer.normalize(legacyArchived)
+        return legacyIDs.map { ArchivedWorktree(id: $0, archivedAt: .distantPast) }
       },
-      saveArchivedWorktreeIDs: { ids in
-        @Shared(.appStorage("archivedWorktreeIDs")) var sharedArchived: [Worktree.ID] = []
-        let normalized = RepositoryPathNormalizer.normalize(ids)
+      saveArchivedWorktrees: { worktrees in
+        @Shared(.appStorage("archivedWorktrees")) var sharedArchived: [ArchivedWorktree] = []
+        let normalized = normalizeArchivedWorktrees(worktrees)
         $sharedArchived.withLock {
           $0 = normalized
         }
@@ -180,8 +186,8 @@ extension RepositoryPersistenceClient: DependencyKey {
     saveRoots: { _ in },
     loadPinnedWorktreeIDs: { [] },
     savePinnedWorktreeIDs: { _ in },
-    loadArchivedWorktreeIDs: { [] },
-    saveArchivedWorktreeIDs: { _ in },
+    loadArchivedWorktrees: { [] },
+    saveArchivedWorktrees: { _ in },
     loadRepositoryOrderIDs: { [] },
     saveRepositoryOrderIDs: { _ in },
     loadWorktreeOrderByRepository: { [:] },
@@ -336,6 +342,19 @@ extension RepositorySnapshotCachePayload {
       )
     }
   }
+}
+
+private nonisolated func normalizeArchivedWorktrees(_ worktrees: [ArchivedWorktree]) -> [ArchivedWorktree] {
+  var seen = Set<Worktree.ID>()
+  var result: [ArchivedWorktree] = []
+  result.reserveCapacity(worktrees.count)
+  for entry in worktrees {
+    guard let normalized = normalizePath(entry.id), seen.insert(normalized).inserted else {
+      continue
+    }
+    result.append(ArchivedWorktree(id: normalized, archivedAt: entry.archivedAt))
+  }
+  return result
 }
 
 private nonisolated func normalizePath(_ path: String) -> String? {

--- a/supacode/Clients/Repositories/RepositoryPersistenceClient.swift
+++ b/supacode/Clients/Repositories/RepositoryPersistenceClient.swift
@@ -62,10 +62,15 @@ extension RepositoryPersistenceClient: DependencyKey {
         if !archived.isEmpty {
           return normalizeArchivedWorktrees(archived)
         }
-        // Fall back to legacy format
+        // One-time migration from legacy format
         @Shared(.appStorage("archivedWorktreeIDs")) var legacyArchived: [Worktree.ID] = []
         let legacyIDs = RepositoryPathNormalizer.normalize(legacyArchived)
-        return legacyIDs.map { ArchivedWorktree(id: $0, archivedAt: .distantPast) }
+        guard !legacyIDs.isEmpty else { return [] }
+        let now = Date()
+        let migrated = legacyIDs.map { ArchivedWorktree(id: $0, archivedAt: now) }
+        $archived.withLock { $0 = migrated }
+        $legacyArchived.withLock { $0 = [] }
+        return migrated
       },
       saveArchivedWorktrees: { worktrees in
         @Shared(.appStorage("archivedWorktrees")) var sharedArchived: [ArchivedWorktree] = []

--- a/supacode/Domain/ArchivedWorktree.swift
+++ b/supacode/Domain/ArchivedWorktree.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+nonisolated struct ArchivedWorktree: Codable, Equatable, Sendable, Identifiable {
+  let id: Worktree.ID
+  let archivedAt: Date
+}

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -418,6 +418,13 @@ struct AppFeature {
           ),
           .send(
             .repositories(
+              .setAutoDeleteArchivedWorktreesAfterDays(
+                settings.autoDeleteArchivedWorktreesAfterDays
+              )
+            )
+          ),
+          .send(
+            .repositories(
               .worktreeOrdering(
                 .setMoveNotifiedWorktreeToTop(
                   settings.moveNotifiedWorktreeToTop

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -418,8 +418,8 @@ struct AppFeature {
           ),
           .send(
             .repositories(
-              .setAutoDeleteArchivedWorktreesAfterDays(
-                settings.autoDeleteArchivedWorktreesAfterDays
+              .setArchivedAutoDeletePeriod(
+                settings.archivedAutoDeletePeriod
               )
             )
           ),

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+RepositoryManagement.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+RepositoryManagement.swift
@@ -81,7 +81,7 @@ extension RepositoriesFeature {
       let applyResult = applyRepositories(
         repositories,
         roots: roots,
-        shouldPruneArchivedWorktreeIDs: failures.isEmpty,
+        shouldPruneArchivedWorktrees: failures.isEmpty,
         state: &state,
         animated: false
       )
@@ -131,11 +131,11 @@ extension RepositoriesFeature {
             await repositoryPersistence.saveWorktreeOrderByRepository(worktreeOrderByRepository)
           })
       }
-      if applyResult.didPruneArchivedWorktreeIDs {
-        let archivedWorktreeIDs = state.archivedWorktreeIDs
+      if applyResult.didPruneArchivedWorktrees {
+        let archivedWorktrees = state.archivedWorktrees
         allEffects.append(
           .run { _ in
-            await repositoryPersistence.saveArchivedWorktreeIDs(archivedWorktreeIDs)
+            await repositoryPersistence.saveArchivedWorktrees(archivedWorktrees)
           }
         )
       }

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+WorktreeLifecycle.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+WorktreeLifecycle.swift
@@ -215,13 +215,13 @@ extension RepositoriesFeature {
           }
           didUpdateWorktreeOrder = true
         }
-        state.archivedWorktreeIDs.append(worktreeID)
+        state.archivedWorktrees.append(ArchivedWorktree(id: worktreeID, archivedAt: now))
         if selectionWasRemoved {
           let nextWorktreeID = nextSelection ?? firstAvailableWorktreeID(in: repositoryID, state: state)
           state.selection = nextWorktreeID.map(SidebarSelection.worktree)
         }
       }
-      let archivedWorktreeIDs = state.archivedWorktreeIDs
+      let archivedWorktrees = state.archivedWorktrees
       let repositories = state.repositories
       let selectedWorktree = state.worktree(for: state.selectedWorktreeID)
       let selectionChanged = selectionDidChange(
@@ -233,7 +233,7 @@ extension RepositoriesFeature {
       var effects: [Effect<Action>] = [
         .send(.delegate(.repositoriesChanged(repositories))),
         .run { _ in
-          await repositoryPersistence.saveArchivedWorktreeIDs(archivedWorktreeIDs)
+          await repositoryPersistence.saveArchivedWorktrees(archivedWorktrees)
         },
       ]
       if wasPinned {
@@ -262,14 +262,14 @@ extension RepositoriesFeature {
         return .none
       }
       withAnimation {
-        state.archivedWorktreeIDs.removeAll { $0 == worktreeID }
+        state.archivedWorktrees.removeAll { $0.id == worktreeID }
       }
-      let archivedWorktreeIDs = state.archivedWorktreeIDs
+      let archivedWorktrees = state.archivedWorktrees
       let repositories = state.repositories
       return .merge(
         .send(.delegate(.repositoriesChanged(repositories))),
         .run { _ in
-          await repositoryPersistence.saveArchivedWorktreeIDs(archivedWorktreeIDs)
+          await repositoryPersistence.saveArchivedWorktrees(archivedWorktrees)
         }
       )
 
@@ -423,7 +423,7 @@ extension RepositoriesFeature {
         state.archiveScriptProgressByWorktreeID.removeValue(forKey: worktreeID)
         state.worktreeInfoByID.removeValue(forKey: worktreeID)
         state.pinnedWorktreeIDs.removeAll { $0 == worktreeID }
-        state.archivedWorktreeIDs.removeAll { $0 == worktreeID }
+        state.archivedWorktrees.removeAll { $0.id == worktreeID }
         if var order = state.worktreeOrderByRepository[repositoryID] {
           order.removeAll { $0 == worktreeID }
           if order.isEmpty {
@@ -467,10 +467,10 @@ extension RepositoriesFeature {
         )
       }
       if wasArchived {
-        let archivedWorktreeIDs = state.archivedWorktreeIDs
+        let archivedWorktrees = state.archivedWorktrees
         followupEffects.append(
           .run { _ in
-            await repositoryPersistence.saveArchivedWorktreeIDs(archivedWorktreeIDs)
+            await repositoryPersistence.saveArchivedWorktrees(archivedWorktrees)
           }
         )
       }

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -9,6 +9,7 @@ nonisolated let githubIntegrationRecoveryInterval: Duration = .seconds(15)
 nonisolated let worktreeCreationProgressLineLimit = 200
 nonisolated let worktreeCreationProgressUpdateStride = 20
 nonisolated let archiveScriptProgressLineLimit = 200
+private let secondsPerDay: Double = 86_400
 
 nonisolated struct WorktreeCreationProgressUpdateThrottle {
   private let stride: Int
@@ -191,7 +192,8 @@ struct RepositoriesFeature {
     var deletingWorktreeIDs: Set<Worktree.ID> = []
     var removingRepositoryIDs: Set<Repository.ID> = []
     var pinnedWorktreeIDs: [Worktree.ID] = []
-    var archivedWorktreeIDs: [Worktree.ID] = []
+    var archivedWorktrees: [ArchivedWorktree] = []
+    var autoDeleteArchivedWorktreesAfterDays: AutoDeletePeriod?
     var automaticallyArchiveMergedWorktrees = false
     var moveNotifiedWorktreeToTop = true
     var lastFocusedWorktreeID: Worktree.ID?
@@ -247,7 +249,9 @@ struct RepositoriesFeature {
     case setOpenPanelPresented(Bool)
     case loadPersistedRepositories
     case pinnedWorktreeIDsLoaded([Worktree.ID])
-    case archivedWorktreeIDsLoaded([Worktree.ID])
+    case archivedWorktreesLoaded([ArchivedWorktree])
+    case setAutoDeleteArchivedWorktreesAfterDays(AutoDeletePeriod?)
+    case autoDeleteExpiredArchivedWorktrees
     case repositoryOrderIDsLoaded([Repository.ID])
     case worktreeOrderByRepositoryLoaded([Repository.ID: [Worktree.ID]])
     case lastFocusedWorktreeIDLoaded(Worktree.ID?)
@@ -293,7 +297,7 @@ struct RepositoriesFeature {
     let didPrunePinned: Bool
     let didPruneRepositoryOrder: Bool
     let didPruneWorktreeOrder: Bool
-    let didPruneArchivedWorktreeIDs: Bool
+    let didPruneArchivedWorktrees: Bool
   }
 
   enum StatusToast: Equatable {
@@ -342,6 +346,7 @@ struct RepositoriesFeature {
   @Dependency(GithubIntegrationClient.self) var githubIntegration
   @Dependency(RepositoryPersistenceClient.self) var repositoryPersistence
   @Dependency(ShellClient.self) var shellClient
+  @Dependency(\.date.now) var now
   @Dependency(\.uuid) var uuid
 
   var body: some Reducer<State, Action> {
@@ -355,14 +360,14 @@ struct RepositoriesFeature {
           state.snapshotPersistencePhase = .restoring
           return .run { send in
             let pinned = await repositoryPersistence.loadPinnedWorktreeIDs()
-            let archived = await repositoryPersistence.loadArchivedWorktreeIDs()
+            let archived = await repositoryPersistence.loadArchivedWorktrees()
             let lastFocused = await repositoryPersistence.loadLastFocusedWorktreeID()
             let repositoryOrderIDs = await repositoryPersistence.loadRepositoryOrderIDs()
             let worktreeOrderByRepository =
               await repositoryPersistence.loadWorktreeOrderByRepository()
             let repositorySnapshot = await repositoryPersistence.loadRepositorySnapshot()
             await send(.pinnedWorktreeIDsLoaded(pinned))
-            await send(.archivedWorktreeIDsLoaded(archived))
+            await send(.archivedWorktreesLoaded(archived))
             await send(.repositoryOrderIDsLoaded(repositoryOrderIDs))
             await send(.worktreeOrderByRepositoryLoaded(worktreeOrderByRepository))
             await send(.lastFocusedWorktreeIDLoaded(lastFocused))
@@ -383,7 +388,7 @@ struct RepositoriesFeature {
           _ = applyRepositories(
             repositories,
             roots: roots,
-            shouldPruneArchivedWorktreeIDs: true,
+            shouldPruneArchivedWorktrees: true,
             state: &state,
             animated: false
           )
@@ -410,9 +415,44 @@ struct RepositoriesFeature {
           state.pinnedWorktreeIDs = pinnedWorktreeIDs
           return .none
 
-        case .archivedWorktreeIDsLoaded(let archivedWorktreeIDs):
-          state.archivedWorktreeIDs = archivedWorktreeIDs
+        case .archivedWorktreesLoaded(let archivedWorktrees):
+          state.archivedWorktrees = archivedWorktrees
           return .none
+
+        case .setAutoDeleteArchivedWorktreesAfterDays(let period):
+          state.autoDeleteArchivedWorktreesAfterDays = period
+          guard period != nil else { return .none }
+          return .send(.autoDeleteExpiredArchivedWorktrees)
+
+        case .autoDeleteExpiredArchivedWorktrees:
+          guard let period = state.autoDeleteArchivedWorktreesAfterDays else {
+            return .none
+          }
+          let cutoff = now.addingTimeInterval(-Double(period.rawValue) * secondsPerDay)
+          let expiredEntries = state.archivedWorktrees.filter { $0.archivedAt <= cutoff }
+          guard !expiredEntries.isEmpty else {
+            return .none
+          }
+          var deleteEffects: [Effect<Action>] = []
+          for entry in expiredEntries {
+            guard
+              let (worktree, repository) = findWorktreeAndRepository(
+                worktreeID: entry.id,
+                state: state
+              ),
+              !state.isMainWorktree(worktree),
+              !state.deletingWorktreeIDs.contains(entry.id)
+            else {
+              continue
+            }
+            deleteEffects.append(
+              .send(.worktreeLifecycle(.deleteWorktreeConfirmed(worktree.id, repository.id)))
+            )
+          }
+          guard !deleteEffects.isEmpty else {
+            return .none
+          }
+          return .merge(deleteEffects)
 
         case .repositoryOrderIDsLoaded(let repositoryOrderIDs):
           state.repositoryOrderIDs = repositoryOrderIDs
@@ -477,7 +517,7 @@ struct RepositoriesFeature {
           let applyResult = applyRepositories(
             repositories,
             roots: roots,
-            shouldPruneArchivedWorktreeIDs: failures.isEmpty,
+            shouldPruneArchivedWorktrees: failures.isEmpty,
             state: &state,
             animated: animated
           )
@@ -521,11 +561,11 @@ struct RepositoriesFeature {
                 await repositoryPersistence.saveWorktreeOrderByRepository(worktreeOrderByRepository)
               })
           }
-          if applyResult.didPruneArchivedWorktreeIDs {
-            let archivedWorktreeIDs = state.archivedWorktreeIDs
+          if applyResult.didPruneArchivedWorktrees {
+            let archivedWorktrees = state.archivedWorktrees
             allEffects.append(
               .run { _ in
-                await repositoryPersistence.saveArchivedWorktreeIDs(archivedWorktreeIDs)
+                await repositoryPersistence.saveArchivedWorktrees(archivedWorktrees)
               }
             )
           }
@@ -536,6 +576,9 @@ struct RepositoriesFeature {
                 await repositoryPersistence.saveRepositorySnapshot(repositories)
               }
             )
+          }
+          if state.autoDeleteArchivedWorktreesAfterDays != nil {
+            allEffects.append(.send(.autoDeleteExpiredArchivedWorktrees))
           }
           return .merge(allEffects)
 
@@ -1038,7 +1081,7 @@ struct RepositoriesFeature {
   func applyRepositories(
     _ repositories: [Repository],
     roots: [URL],
-    shouldPruneArchivedWorktreeIDs: Bool,
+    shouldPruneArchivedWorktrees: Bool,
     state: inout State,
     animated: Bool
   ) -> ApplyRepositoriesResult {
@@ -1103,9 +1146,9 @@ struct RepositoriesFeature {
     let didPrunePinned = prunePinnedWorktreeIDs(state: &state)
     let didPruneRepositoryOrder = pruneRepositoryOrderIDs(roots: roots, state: &state)
     let didPruneWorktreeOrder = pruneWorktreeOrderByRepository(roots: roots, state: &state)
-    let didPruneArchivedWorktreeIDs =
-      shouldPruneArchivedWorktreeIDs
-      ? pruneArchivedWorktreeIDs(availableWorktreeIDs: availableWorktreeIDs, state: &state)
+    let didPruneArchivedWorktrees =
+      shouldPruneArchivedWorktrees
+      ? pruneArchivedWorktrees(availableWorktreeIDs: availableWorktreeIDs, state: &state)
       : false
     if !state.isShowingArchivedWorktrees, !state.isShowingCanvas,
       !isSidebarSelectionValid(state.selection, state: state)
@@ -1129,7 +1172,7 @@ struct RepositoriesFeature {
       didPrunePinned: didPrunePinned,
       didPruneRepositoryOrder: didPruneRepositoryOrder,
       didPruneWorktreeOrder: didPruneWorktreeOrder,
-      didPruneArchivedWorktreeIDs: didPruneArchivedWorktreeIDs
+      didPruneArchivedWorktrees: didPruneArchivedWorktrees
     )
   }
 
@@ -1270,7 +1313,7 @@ extension RepositoriesFeature.State {
   }
 
   var archivedWorktreeIDSet: Set<Worktree.ID> {
-    Set(archivedWorktreeIDs)
+    Set(archivedWorktrees.map(\.id))
   }
 
   func isWorktreeArchived(_ id: Worktree.ID) -> Bool {
@@ -2095,13 +2138,13 @@ private func pruneWorktreeOrderByRepository(
   return false
 }
 
-private func pruneArchivedWorktreeIDs(
+private func pruneArchivedWorktrees(
   availableWorktreeIDs: Set<Worktree.ID>,
   state: inout RepositoriesFeature.State
 ) -> Bool {
-  let pruned = state.archivedWorktreeIDs.filter { availableWorktreeIDs.contains($0) }
-  if pruned != state.archivedWorktreeIDs {
-    state.archivedWorktreeIDs = pruned
+  let pruned = state.archivedWorktrees.filter { availableWorktreeIDs.contains($0.id) }
+  if pruned != state.archivedWorktrees {
+    state.archivedWorktrees = pruned
     return true
   }
   return false
@@ -2127,6 +2170,18 @@ func firstAvailableWorktreeID(
     return nil
   }
   return state.orderedWorktrees(in: repository).first?.id
+}
+
+private func findWorktreeAndRepository(
+  worktreeID: Worktree.ID,
+  state: RepositoriesFeature.State
+) -> (worktree: Worktree, repository: Repository)? {
+  for repository in state.repositories {
+    if let worktree = repository.worktrees[id: worktreeID] {
+      return (worktree, repository)
+    }
+  }
+  return nil
 }
 
 func nextWorktreeID(

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -193,7 +193,7 @@ struct RepositoriesFeature {
     var removingRepositoryIDs: Set<Repository.ID> = []
     var pinnedWorktreeIDs: [Worktree.ID] = []
     var archivedWorktrees: [ArchivedWorktree] = []
-    var autoDeleteArchivedWorktreesAfterDays: AutoDeletePeriod?
+    var archivedAutoDeletePeriod: AutoDeletePeriod?
     var automaticallyArchiveMergedWorktrees = false
     var moveNotifiedWorktreeToTop = true
     var lastFocusedWorktreeID: Worktree.ID?
@@ -250,7 +250,7 @@ struct RepositoriesFeature {
     case loadPersistedRepositories
     case pinnedWorktreeIDsLoaded([Worktree.ID])
     case archivedWorktreesLoaded([ArchivedWorktree])
-    case setAutoDeleteArchivedWorktreesAfterDays(AutoDeletePeriod?)
+    case setArchivedAutoDeletePeriod(AutoDeletePeriod?)
     case autoDeleteExpiredArchivedWorktrees
     case repositoryOrderIDsLoaded([Repository.ID])
     case worktreeOrderByRepositoryLoaded([Repository.ID: [Worktree.ID]])
@@ -419,13 +419,13 @@ struct RepositoriesFeature {
           state.archivedWorktrees = archivedWorktrees
           return .none
 
-        case .setAutoDeleteArchivedWorktreesAfterDays(let period):
-          state.autoDeleteArchivedWorktreesAfterDays = period
+        case .setArchivedAutoDeletePeriod(let period):
+          state.archivedAutoDeletePeriod = period
           guard period != nil else { return .none }
           return .send(.autoDeleteExpiredArchivedWorktrees)
 
         case .autoDeleteExpiredArchivedWorktrees:
-          guard let period = state.autoDeleteArchivedWorktreesAfterDays else {
+          guard let period = state.archivedAutoDeletePeriod else {
             return .none
           }
           let cutoff = now.addingTimeInterval(-Double(period.rawValue) * secondsPerDay)
@@ -577,7 +577,7 @@ struct RepositoriesFeature {
               }
             )
           }
-          if state.autoDeleteArchivedWorktreesAfterDays != nil {
+          if state.archivedAutoDeletePeriod != nil {
             allEffects.append(.send(.autoDeleteExpiredArchivedWorktrees))
           }
           return .merge(allEffects)

--- a/supacode/Features/Settings/Models/AutoDeletePeriod.swift
+++ b/supacode/Features/Settings/Models/AutoDeletePeriod.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+nonisolated enum AutoDeletePeriod: Int, Codable, CaseIterable, Comparable, Sendable, Identifiable {
+  #if DEBUG
+    case immediately = 0
+  #endif
+  case oneDay = 1
+  case threeDays = 3
+  case sevenDays = 7
+  case fourteenDays = 14
+  case thirtyDays = 30
+
+  var id: Int { rawValue }
+
+  var label: String {
+    switch self {
+    #if DEBUG
+      case .immediately: "Immediately (debug)"
+    #endif
+    case .oneDay: "After 1 day"
+    case .threeDays: "After 3 days"
+    case .sevenDays: "After 7 days"
+    case .fourteenDays: "After 14 days"
+    case .thirtyDays: "After 30 days"
+    }
+  }
+
+  static func < (lhs: Self, rhs: Self) -> Bool {
+    lhs.rawValue < rhs.rawValue
+  }
+}

--- a/supacode/Features/Settings/Models/GlobalSettings.swift
+++ b/supacode/Features/Settings/Models/GlobalSettings.swift
@@ -20,6 +20,7 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
   var defaultWorktreeBaseDirectoryPath: String?
   var restoreTerminalLayoutOnLaunch: Bool
   var terminalFontSize: Float32?
+  var autoDeleteArchivedWorktreesAfterDays: AutoDeletePeriod?
   var keybindingUserOverrides: KeybindingUserOverrideStore
 
   static let `default` = GlobalSettings(
@@ -43,6 +44,7 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     promptForWorktreeCreation: true,
     defaultWorktreeBaseDirectoryPath: nil,
     restoreTerminalLayoutOnLaunch: false,
+    autoDeleteArchivedWorktreesAfterDays: nil,
     terminalFontSize: nil,
     keybindingUserOverrides: .empty
   )
@@ -68,6 +70,7 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     promptForWorktreeCreation: Bool,
     defaultWorktreeBaseDirectoryPath: String? = nil,
     restoreTerminalLayoutOnLaunch: Bool = false,
+    autoDeleteArchivedWorktreesAfterDays: AutoDeletePeriod? = nil,
     terminalFontSize: Float32? = nil,
     keybindingUserOverrides: KeybindingUserOverrideStore = .empty
   ) {
@@ -91,6 +94,7 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     self.promptForWorktreeCreation = promptForWorktreeCreation
     self.defaultWorktreeBaseDirectoryPath = defaultWorktreeBaseDirectoryPath
     self.restoreTerminalLayoutOnLaunch = restoreTerminalLayoutOnLaunch
+    self.autoDeleteArchivedWorktreesAfterDays = autoDeleteArchivedWorktreesAfterDays
     self.terminalFontSize = terminalFontSize
     self.keybindingUserOverrides = keybindingUserOverrides
   }
@@ -151,6 +155,11 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     restoreTerminalLayoutOnLaunch =
       try container.decodeIfPresent(Bool.self, forKey: .restoreTerminalLayoutOnLaunch)
       ?? Self.default.restoreTerminalLayoutOnLaunch
+    if let rawAutoDelete = try container.decodeIfPresent(Int.self, forKey: .autoDeleteArchivedWorktreesAfterDays) {
+      autoDeleteArchivedWorktreesAfterDays = AutoDeletePeriod(rawValue: rawAutoDelete)
+    } else {
+      autoDeleteArchivedWorktreesAfterDays = Self.default.autoDeleteArchivedWorktreesAfterDays
+    }
     terminalFontSize =
       try container.decodeIfPresent(Float32.self, forKey: .terminalFontSize)
       ?? Self.default.terminalFontSize

--- a/supacode/Features/Settings/Models/GlobalSettings.swift
+++ b/supacode/Features/Settings/Models/GlobalSettings.swift
@@ -20,7 +20,7 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
   var defaultWorktreeBaseDirectoryPath: String?
   var restoreTerminalLayoutOnLaunch: Bool
   var terminalFontSize: Float32?
-  var autoDeleteArchivedWorktreesAfterDays: AutoDeletePeriod?
+  var archivedAutoDeletePeriod: AutoDeletePeriod?
   var keybindingUserOverrides: KeybindingUserOverrideStore
 
   static let `default` = GlobalSettings(
@@ -44,7 +44,7 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     promptForWorktreeCreation: true,
     defaultWorktreeBaseDirectoryPath: nil,
     restoreTerminalLayoutOnLaunch: false,
-    autoDeleteArchivedWorktreesAfterDays: nil,
+    archivedAutoDeletePeriod: nil,
     terminalFontSize: nil,
     keybindingUserOverrides: .empty
   )
@@ -70,7 +70,7 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     promptForWorktreeCreation: Bool,
     defaultWorktreeBaseDirectoryPath: String? = nil,
     restoreTerminalLayoutOnLaunch: Bool = false,
-    autoDeleteArchivedWorktreesAfterDays: AutoDeletePeriod? = nil,
+    archivedAutoDeletePeriod: AutoDeletePeriod? = nil,
     terminalFontSize: Float32? = nil,
     keybindingUserOverrides: KeybindingUserOverrideStore = .empty
   ) {
@@ -94,7 +94,7 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     self.promptForWorktreeCreation = promptForWorktreeCreation
     self.defaultWorktreeBaseDirectoryPath = defaultWorktreeBaseDirectoryPath
     self.restoreTerminalLayoutOnLaunch = restoreTerminalLayoutOnLaunch
-    self.autoDeleteArchivedWorktreesAfterDays = autoDeleteArchivedWorktreesAfterDays
+    self.archivedAutoDeletePeriod = archivedAutoDeletePeriod
     self.terminalFontSize = terminalFontSize
     self.keybindingUserOverrides = keybindingUserOverrides
   }
@@ -155,10 +155,10 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     restoreTerminalLayoutOnLaunch =
       try container.decodeIfPresent(Bool.self, forKey: .restoreTerminalLayoutOnLaunch)
       ?? Self.default.restoreTerminalLayoutOnLaunch
-    if let rawAutoDelete = try container.decodeIfPresent(Int.self, forKey: .autoDeleteArchivedWorktreesAfterDays) {
-      autoDeleteArchivedWorktreesAfterDays = AutoDeletePeriod(rawValue: rawAutoDelete)
+    if let rawAutoDelete = try container.decodeIfPresent(Int.self, forKey: .archivedAutoDeletePeriod) {
+      archivedAutoDeletePeriod = AutoDeletePeriod(rawValue: rawAutoDelete)
     } else {
-      autoDeleteArchivedWorktreesAfterDays = Self.default.autoDeleteArchivedWorktreesAfterDays
+      archivedAutoDeletePeriod = Self.default.archivedAutoDeletePeriod
     }
     terminalFontSize =
       try container.decodeIfPresent(Float32.self, forKey: .terminalFontSize)

--- a/supacode/Features/Settings/Reducer/SettingsFeature.swift
+++ b/supacode/Features/Settings/Reducer/SettingsFeature.swift
@@ -22,6 +22,7 @@ struct SettingsFeature {
     var githubIntegrationEnabled: Bool
     var deleteBranchOnDeleteWorktree: Bool
     var automaticallyArchiveMergedWorktrees: Bool
+    var autoDeleteArchivedWorktreesAfterDays: AutoDeletePeriod?
     var promptForWorktreeCreation: Bool
     var defaultWorktreeBaseDirectoryPath: String
     var restoreTerminalLayoutOnLaunch: Bool
@@ -52,6 +53,7 @@ struct SettingsFeature {
       githubIntegrationEnabled = settings.githubIntegrationEnabled
       deleteBranchOnDeleteWorktree = settings.deleteBranchOnDeleteWorktree
       automaticallyArchiveMergedWorktrees = settings.automaticallyArchiveMergedWorktrees
+      autoDeleteArchivedWorktreesAfterDays = settings.autoDeleteArchivedWorktreesAfterDays
       promptForWorktreeCreation = settings.promptForWorktreeCreation
       defaultWorktreeBaseDirectoryPath =
         SupacodePaths.normalizedWorktreeBaseDirectoryPath(settings.defaultWorktreeBaseDirectoryPath) ?? ""
@@ -84,6 +86,7 @@ struct SettingsFeature {
           defaultWorktreeBaseDirectoryPath
         ),
         restoreTerminalLayoutOnLaunch: restoreTerminalLayoutOnLaunch,
+        autoDeleteArchivedWorktreesAfterDays: autoDeleteArchivedWorktreesAfterDays,
         terminalFontSize: terminalFontSize,
         keybindingUserOverrides: keybindingUserOverrides
       )
@@ -175,6 +178,7 @@ struct SettingsFeature {
         state.githubIntegrationEnabled = normalizedSettings.githubIntegrationEnabled
         state.deleteBranchOnDeleteWorktree = normalizedSettings.deleteBranchOnDeleteWorktree
         state.automaticallyArchiveMergedWorktrees = normalizedSettings.automaticallyArchiveMergedWorktrees
+        state.autoDeleteArchivedWorktreesAfterDays = normalizedSettings.autoDeleteArchivedWorktreesAfterDays
         state.promptForWorktreeCreation = normalizedSettings.promptForWorktreeCreation
         state.defaultWorktreeBaseDirectoryPath = normalizedSettings.defaultWorktreeBaseDirectoryPath ?? ""
         state.restoreTerminalLayoutOnLaunch = normalizedSettings.restoreTerminalLayoutOnLaunch

--- a/supacode/Features/Settings/Reducer/SettingsFeature.swift
+++ b/supacode/Features/Settings/Reducer/SettingsFeature.swift
@@ -22,7 +22,7 @@ struct SettingsFeature {
     var githubIntegrationEnabled: Bool
     var deleteBranchOnDeleteWorktree: Bool
     var automaticallyArchiveMergedWorktrees: Bool
-    var autoDeleteArchivedWorktreesAfterDays: AutoDeletePeriod?
+    var archivedAutoDeletePeriod: AutoDeletePeriod?
     var promptForWorktreeCreation: Bool
     var defaultWorktreeBaseDirectoryPath: String
     var restoreTerminalLayoutOnLaunch: Bool
@@ -53,7 +53,7 @@ struct SettingsFeature {
       githubIntegrationEnabled = settings.githubIntegrationEnabled
       deleteBranchOnDeleteWorktree = settings.deleteBranchOnDeleteWorktree
       automaticallyArchiveMergedWorktrees = settings.automaticallyArchiveMergedWorktrees
-      autoDeleteArchivedWorktreesAfterDays = settings.autoDeleteArchivedWorktreesAfterDays
+      archivedAutoDeletePeriod = settings.archivedAutoDeletePeriod
       promptForWorktreeCreation = settings.promptForWorktreeCreation
       defaultWorktreeBaseDirectoryPath =
         SupacodePaths.normalizedWorktreeBaseDirectoryPath(settings.defaultWorktreeBaseDirectoryPath) ?? ""
@@ -86,7 +86,7 @@ struct SettingsFeature {
           defaultWorktreeBaseDirectoryPath
         ),
         restoreTerminalLayoutOnLaunch: restoreTerminalLayoutOnLaunch,
-        autoDeleteArchivedWorktreesAfterDays: autoDeleteArchivedWorktreesAfterDays,
+        archivedAutoDeletePeriod: archivedAutoDeletePeriod,
         terminalFontSize: terminalFontSize,
         keybindingUserOverrides: keybindingUserOverrides
       )
@@ -178,7 +178,7 @@ struct SettingsFeature {
         state.githubIntegrationEnabled = normalizedSettings.githubIntegrationEnabled
         state.deleteBranchOnDeleteWorktree = normalizedSettings.deleteBranchOnDeleteWorktree
         state.automaticallyArchiveMergedWorktrees = normalizedSettings.automaticallyArchiveMergedWorktrees
-        state.autoDeleteArchivedWorktreesAfterDays = normalizedSettings.autoDeleteArchivedWorktreesAfterDays
+        state.archivedAutoDeletePeriod = normalizedSettings.archivedAutoDeletePeriod
         state.promptForWorktreeCreation = normalizedSettings.promptForWorktreeCreation
         state.defaultWorktreeBaseDirectoryPath = normalizedSettings.defaultWorktreeBaseDirectoryPath ?? ""
         state.restoreTerminalLayoutOnLaunch = normalizedSettings.restoreTerminalLayoutOnLaunch

--- a/supacode/Features/Settings/Views/WorktreeSettingsView.swift
+++ b/supacode/Features/Settings/Views/WorktreeSettingsView.swift
@@ -46,6 +46,17 @@ struct WorktreeSettingsView: View {
           )
           .help("Archive worktrees automatically when their pull requests are merged.")
           VStack(alignment: .leading) {
+            Picker(selection: $store.autoDeleteArchivedWorktreesAfterDays) {
+              Text("Never").tag(AutoDeletePeriod?.none)
+              ForEach(AutoDeletePeriod.allCases) { period in
+                Text(period.label).tag(AutoDeletePeriod?.some(period))
+              }
+            } label: {
+              Text("Auto-delete archived worktrees")
+              Text("Permanently removes archived worktrees after the selected period.")
+            }
+          }
+          VStack(alignment: .leading) {
             Toggle(
               "Prompt for branch name during creation",
               isOn: $store.promptForWorktreeCreation

--- a/supacode/Features/Settings/Views/WorktreeSettingsView.swift
+++ b/supacode/Features/Settings/Views/WorktreeSettingsView.swift
@@ -46,7 +46,7 @@ struct WorktreeSettingsView: View {
           )
           .help("Archive worktrees automatically when their pull requests are merged.")
           VStack(alignment: .leading) {
-            Picker(selection: $store.autoDeleteArchivedWorktreesAfterDays) {
+            Picker(selection: $store.archivedAutoDeletePeriod) {
               Text("Never").tag(AutoDeletePeriod?.none)
               ForEach(AutoDeletePeriod.allCases) { period in
                 Text(period.label).tag(AutoDeletePeriod?.some(period))

--- a/supacodeTests/AppFeatureArchivedSelectionTests.swift
+++ b/supacodeTests/AppFeatureArchivedSelectionTests.swift
@@ -73,7 +73,7 @@ struct AppFeatureArchivedSelectionTests {
     )
     var repositoriesState = RepositoriesFeature.State(repositories: [repository])
     repositoriesState.selection = .worktree(activeWorktree.id)
-    repositoriesState.archivedWorktreeIDs = [archivedWorktree.id]
+    repositoriesState.archivedWorktrees = [ArchivedWorktree(id: archivedWorktree.id, archivedAt: .distantPast)]
     var appState = AppFeature.State(
       repositories: repositoriesState,
       settings: SettingsFeature.State()

--- a/supacodeTests/AppFeatureSettingsChangedTests.swift
+++ b/supacodeTests/AppFeatureSettingsChangedTests.swift
@@ -23,6 +23,7 @@ struct AppFeatureSettingsChangedTests {
     await store.receive(\.repositories.githubIntegration.setAutomaticallyArchiveMergedWorktrees) {
       $0.repositories.automaticallyArchiveMergedWorktrees = true
     }
+    await store.receive(\.repositories.setAutoDeleteArchivedWorktreesAfterDays)
     await store.receive(\.repositories.worktreeOrdering.setMoveNotifiedWorktreeToTop) {
       $0.repositories.moveNotifiedWorktreeToTop = false
     }
@@ -82,6 +83,7 @@ struct AppFeatureSettingsChangedTests {
     }
     await store.receive(\.repositories.githubIntegration.setGithubIntegrationEnabled)
     await store.receive(\.repositories.githubIntegration.setAutomaticallyArchiveMergedWorktrees)
+    await store.receive(\.repositories.setAutoDeleteArchivedWorktreesAfterDays)
     await store.receive(\.repositories.worktreeOrdering.setMoveNotifiedWorktreeToTop)
     await store.receive(\.updates.applySettings) {
       $0.updates.didConfigureUpdates = true

--- a/supacodeTests/AppFeatureSettingsChangedTests.swift
+++ b/supacodeTests/AppFeatureSettingsChangedTests.swift
@@ -23,7 +23,7 @@ struct AppFeatureSettingsChangedTests {
     await store.receive(\.repositories.githubIntegration.setAutomaticallyArchiveMergedWorktrees) {
       $0.repositories.automaticallyArchiveMergedWorktrees = true
     }
-    await store.receive(\.repositories.setAutoDeleteArchivedWorktreesAfterDays)
+    await store.receive(\.repositories.setArchivedAutoDeletePeriod)
     await store.receive(\.repositories.worktreeOrdering.setMoveNotifiedWorktreeToTop) {
       $0.repositories.moveNotifiedWorktreeToTop = false
     }
@@ -83,7 +83,7 @@ struct AppFeatureSettingsChangedTests {
     }
     await store.receive(\.repositories.githubIntegration.setGithubIntegrationEnabled)
     await store.receive(\.repositories.githubIntegration.setAutomaticallyArchiveMergedWorktrees)
-    await store.receive(\.repositories.setAutoDeleteArchivedWorktreesAfterDays)
+    await store.receive(\.repositories.setArchivedAutoDeletePeriod)
     await store.receive(\.repositories.worktreeOrdering.setMoveNotifiedWorktreeToTop)
     await store.receive(\.updates.applySettings) {
       $0.updates.didConfigureUpdates = true

--- a/supacodeTests/RepositoriesFeaturePersistenceTests.swift
+++ b/supacodeTests/RepositoriesFeaturePersistenceTests.swift
@@ -28,11 +28,11 @@ struct RepositoriesFeaturePersistenceTests {
           return pinned
         },
         savePinnedWorktreeIDs: { _ in },
-        loadArchivedWorktreeIDs: {
-          calls.withValue { $0.append("loadArchivedWorktreeIDs") }
+        loadArchivedWorktrees: {
+          calls.withValue { $0.append("loadArchivedWorktrees") }
           return []
         },
-        saveArchivedWorktreeIDs: { _ in },
+        saveArchivedWorktrees: { _ in },
         loadRepositoryOrderIDs: {
           calls.withValue { $0.append("loadRepositoryOrderIDs") }
           return repositoryOrder
@@ -62,7 +62,7 @@ struct RepositoriesFeaturePersistenceTests {
     #expect(
       calls.value == [
         "loadPinnedWorktreeIDs",
-        "loadArchivedWorktreeIDs",
+        "loadArchivedWorktrees",
         "loadLastFocusedWorktreeID",
         "loadRepositoryOrderIDs",
         "loadWorktreeOrderByRepository",

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -2948,6 +2948,93 @@ struct RepositoriesFeatureTests {
     expectNoDifference(store.state.archivedWorktrees, [])
   }
 
+  // MARK: - Auto-delete Archived Worktrees
+
+  @Test func autoDeleteExpiredArchivedWorktreesDeletesExpired() async {
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let expiredWorktree = makeWorktree(id: "/tmp/repo/expired", name: "expired", repoRoot: repoRoot)
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree, expiredWorktree])
+    let fixedDate = Date(timeIntervalSince1970: 1_000_000)
+    let archivedAt = fixedDate.addingTimeInterval(-2 * 86_400)  // 2 days ago
+    var state = makeState(repositories: [repository])
+    state.archivedWorktrees = [ArchivedWorktree(id: expiredWorktree.id, archivedAt: archivedAt)]
+    state.autoDeleteArchivedWorktreesAfterDays = .oneDay
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.date = .constant(fixedDate)
+      $0.gitClient.removeWorktree = { worktree, _ in worktree.workingDirectory }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.autoDeleteExpiredArchivedWorktrees)
+    await store.receive(\.worktreeLifecycle.deleteWorktreeConfirmed) {
+      $0.deletingWorktreeIDs = [expiredWorktree.id]
+    }
+  }
+
+  @Test func autoDeleteKeepsUnexpiredArchivedWorktrees() async {
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let recentWorktree = makeWorktree(id: "/tmp/repo/recent", name: "recent", repoRoot: repoRoot)
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree, recentWorktree])
+    let fixedDate = Date(timeIntervalSince1970: 1_000_000)
+    let archivedAt = fixedDate.addingTimeInterval(-1 * 86_400)  // 1 day ago
+    var state = makeState(repositories: [repository])
+    state.archivedWorktrees = [ArchivedWorktree(id: recentWorktree.id, archivedAt: archivedAt)]
+    state.autoDeleteArchivedWorktreesAfterDays = .sevenDays
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.date = .constant(fixedDate)
+    }
+
+    await store.send(.autoDeleteExpiredArchivedWorktrees)
+    // No effects — worktree is not expired yet
+  }
+
+  @Test func autoDeleteNilPeriodDoesNothing() async {
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let worktree = makeWorktree(id: "/tmp/repo/wt", name: "wt", repoRoot: repoRoot)
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree, worktree])
+    let fixedDate = Date(timeIntervalSince1970: 1_000_000)
+    var state = makeState(repositories: [repository])
+    state.archivedWorktrees = [
+      ArchivedWorktree(id: worktree.id, archivedAt: .distantPast),
+    ]
+    state.autoDeleteArchivedWorktreesAfterDays = nil
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.date = .constant(fixedDate)
+    }
+
+    await store.send(.autoDeleteExpiredArchivedWorktrees)
+    // No effects — auto-delete is disabled
+  }
+
+  @Test func autoDeleteSkipsMainWorktree() async {
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree])
+    let fixedDate = Date(timeIntervalSince1970: 1_000_000)
+    var state = makeState(repositories: [repository])
+    state.archivedWorktrees = [
+      ArchivedWorktree(id: mainWorktree.id, archivedAt: .distantPast),
+    ]
+    state.autoDeleteArchivedWorktreesAfterDays = .oneDay
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.date = .constant(fixedDate)
+    }
+
+    await store.send(.autoDeleteExpiredArchivedWorktrees)
+    // No effects — main worktree must not be deleted
+  }
+
   // MARK: - Select Next/Previous Worktree
 
   @Test func selectNextWorktreeWrapsForward() async {

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -119,7 +119,7 @@ struct RepositoriesFeatureTests {
       $0.snapshotPersistencePhase = .restoring
     }
     await store.receive(\.pinnedWorktreeIDsLoaded)
-    await store.receive(\.archivedWorktreeIDsLoaded)
+    await store.receive(\.archivedWorktreesLoaded)
     await store.receive(\.repositoryOrderIDsLoaded)
     await store.receive(\.worktreeOrderByRepositoryLoaded)
     await store.receive(\.lastFocusedWorktreeIDLoaded) {
@@ -166,7 +166,7 @@ struct RepositoriesFeatureTests {
       $0.snapshotPersistencePhase = .restoring
     }
     await store.receive(\.pinnedWorktreeIDsLoaded)
-    await store.receive(\.archivedWorktreeIDsLoaded)
+    await store.receive(\.archivedWorktreesLoaded)
     await store.receive(\.repositoryOrderIDsLoaded)
     await store.receive(\.worktreeOrderByRepositoryLoaded)
     await store.receive(\.lastFocusedWorktreeIDLoaded) {
@@ -1649,14 +1649,17 @@ struct RepositoriesFeatureTests {
         pullRequest: makePullRequest(state: "MERGED")
       ),
     ]
+    let fixedDate = Date(timeIntervalSince1970: 1_000_000)
     let store = TestStore(initialState: state) {
       RepositoriesFeature()
+    } withDependencies: {
+      $0.date = .constant(fixedDate)
     }
 
     await store.send(.worktreeLifecycle(.requestArchiveWorktree(featureWorktree.id, repository.id)))
     await store.receive(\.worktreeLifecycle.archiveWorktreeConfirmed)
     await store.receive(\.worktreeLifecycle.archiveWorktreeApply) {
-      $0.archivedWorktreeIDs = [featureWorktree.id]
+      $0.archivedWorktrees = [ArchivedWorktree(id: featureWorktree.id, archivedAt: fixedDate)]
       $0.pinnedWorktreeIDs = []
       $0.worktreeOrderByRepository = [:]
       $0.selection = .worktree(mainWorktree.id)
@@ -1680,9 +1683,11 @@ struct RepositoriesFeatureTests {
     $repositorySettings.withLock {
       $0.archiveScript = "echo syncing\necho done"
     }
+    let fixedDate = Date(timeIntervalSince1970: 1_000_000)
     let store = TestStore(initialState: state) {
       RepositoriesFeature()
     } withDependencies: {
+      $0.date = .constant(fixedDate)
       $0.shellClient.runLoginStreamImpl = { _, _, _, _ in
         AsyncThrowingStream { continuation in
           continuation.yield(.line(ShellStreamLine(source: .stdout, text: "syncing")))
@@ -1722,7 +1727,7 @@ struct RepositoriesFeatureTests {
       $0.archiveScriptProgressByWorktreeID = [:]
     }
     await store.receive(\.worktreeLifecycle.archiveWorktreeApply) {
-      $0.archivedWorktreeIDs = [featureWorktree.id]
+      $0.archivedWorktrees = [ArchivedWorktree(id: featureWorktree.id, archivedAt: fixedDate)]
     }
     await store.receive(\.delegate.repositoriesChanged)
   }
@@ -1780,7 +1785,7 @@ struct RepositoriesFeatureTests {
       $0.archiveScriptProgressByWorktreeID = [:]
       $0.alert = expectedAlert
     }
-    #expect(store.state.archivedWorktreeIDs.isEmpty)
+    #expect(store.state.archivedWorktrees.isEmpty)
   }
 
   @Test func archiveScriptSucceededIgnoredWhenNotArchiving() async {
@@ -1799,7 +1804,7 @@ struct RepositoriesFeatureTests {
     await store.send(
       .worktreeLifecycle(.archiveScriptSucceeded(worktreeID: featureWorktree.id, repositoryID: repository.id))
     )
-    #expect(store.state.archivedWorktreeIDs.isEmpty)
+    #expect(store.state.archivedWorktrees.isEmpty)
   }
 
   @Test func archiveScriptFailedIgnoredWhenNotArchiving() async {
@@ -1817,7 +1822,7 @@ struct RepositoriesFeatureTests {
 
     await store.send(.worktreeLifecycle(.archiveScriptFailed(worktreeID: featureWorktree.id, message: "late failure")))
     #expect(store.state.alert == nil)
-    #expect(store.state.archivedWorktreeIDs.isEmpty)
+    #expect(store.state.archivedWorktrees.isEmpty)
   }
 
   @Test func repositoriesLoadedKeepsArchiveInFlightUntilSuccessCompletion() async {
@@ -2235,12 +2240,13 @@ struct RepositoriesFeatureTests {
     )
   }
 
-  @Test func archivedWorktreeIDsPreservedWhenRepositoryLoadFails() async {
+  @Test func archivedWorktreesPreservedWhenRepositoryLoadFails() async {
     let repoRoot = "/tmp/repo"
     let worktree = makeWorktree(id: "/tmp/repo/wt1", name: "wt1", repoRoot: repoRoot)
     let repository = makeRepository(id: repoRoot, worktrees: [worktree])
+    let fixedDate = Date(timeIntervalSince1970: 1_000_000)
     var initialState = makeState(repositories: [repository])
-    initialState.archivedWorktreeIDs = [worktree.id]
+    initialState.archivedWorktrees = [ArchivedWorktree(id: worktree.id, archivedAt: fixedDate)]
     let store = TestStore(initialState: initialState) {
       RepositoriesFeature()
     }
@@ -2259,7 +2265,7 @@ struct RepositoriesFeatureTests {
     }
 
     await store.receive(\.delegate.repositoriesChanged)
-    #expect(store.state.archivedWorktreeIDs == [worktree.id])
+    #expect(store.state.archivedWorktrees == [ArchivedWorktree(id: worktree.id, archivedAt: fixedDate)])
   }
 
   @Test func repositoriesLoadedSkipsSelectionChangeWhenOnlyDisplayDataChanges() async {
@@ -2469,8 +2475,11 @@ struct RepositoriesFeatureTests {
     let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree, featureWorktree])
     var state = makeState(repositories: [repository])
     state.automaticallyArchiveMergedWorktrees = true
+    let fixedDate = Date(timeIntervalSince1970: 1_000_000)
     let store = TestStore(initialState: state) {
       RepositoriesFeature()
+    } withDependencies: {
+      $0.date = .constant(fixedDate)
     }
     let mergedPullRequest = makePullRequest(state: "MERGED", headRefName: featureWorktree.name)
 
@@ -2489,7 +2498,7 @@ struct RepositoriesFeatureTests {
     }
     await store.receive(\.worktreeLifecycle.archiveWorktreeConfirmed)
     await store.receive(\.worktreeLifecycle.archiveWorktreeApply) {
-      $0.archivedWorktreeIDs = [featureWorktree.id]
+      $0.archivedWorktrees = [ArchivedWorktree(id: featureWorktree.id, archivedAt: fixedDate)]
     }
     await store.receive(\.delegate.repositoriesChanged)
   }
@@ -2559,7 +2568,7 @@ struct RepositoriesFeatureTests {
     }
     await store.receive(\.worktreeInfoEvent)
     #expect(store.state.worktreeInfoByID[featureWorktree.id]?.pullRequest?.state == "OPEN")
-    #expect(store.state.archivedWorktreeIDs.isEmpty)
+    #expect(store.state.archivedWorktrees.isEmpty)
     #expect(mergedNumbers.value == [12])
     await store.finish()
   }
@@ -2936,7 +2945,7 @@ struct RepositoriesFeatureTests {
     }
 
     await store.send(.worktreeLifecycle(.unarchiveWorktree(worktree.id)))
-    expectNoDifference(store.state.archivedWorktreeIDs, [])
+    expectNoDifference(store.state.archivedWorktrees, [])
   }
 
   // MARK: - Select Next/Previous Worktree
@@ -3366,7 +3375,7 @@ struct RepositoriesFeatureTests {
       $0.snapshotPersistencePhase = .restoring
     }
     await store.receive(\.pinnedWorktreeIDsLoaded)
-    await store.receive(\.archivedWorktreeIDsLoaded)
+    await store.receive(\.archivedWorktreesLoaded)
     await store.receive(\.repositoryOrderIDsLoaded)
     await store.receive(\.worktreeOrderByRepositoryLoaded)
     await store.receive(\.lastFocusedWorktreeIDLoaded) {

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -2959,7 +2959,7 @@ struct RepositoriesFeatureTests {
     let archivedAt = fixedDate.addingTimeInterval(-2 * 86_400)  // 2 days ago
     var state = makeState(repositories: [repository])
     state.archivedWorktrees = [ArchivedWorktree(id: expiredWorktree.id, archivedAt: archivedAt)]
-    state.autoDeleteArchivedWorktreesAfterDays = .oneDay
+    state.archivedAutoDeletePeriod = .oneDay
     let store = TestStore(initialState: state) {
       RepositoriesFeature()
     } withDependencies: {
@@ -2983,7 +2983,7 @@ struct RepositoriesFeatureTests {
     let archivedAt = fixedDate.addingTimeInterval(-1 * 86_400)  // 1 day ago
     var state = makeState(repositories: [repository])
     state.archivedWorktrees = [ArchivedWorktree(id: recentWorktree.id, archivedAt: archivedAt)]
-    state.autoDeleteArchivedWorktreesAfterDays = .sevenDays
+    state.archivedAutoDeletePeriod = .sevenDays
     let store = TestStore(initialState: state) {
       RepositoriesFeature()
     } withDependencies: {
@@ -3004,7 +3004,7 @@ struct RepositoriesFeatureTests {
     state.archivedWorktrees = [
       ArchivedWorktree(id: worktree.id, archivedAt: .distantPast),
     ]
-    state.autoDeleteArchivedWorktreesAfterDays = nil
+    state.archivedAutoDeletePeriod = nil
     let store = TestStore(initialState: state) {
       RepositoriesFeature()
     } withDependencies: {
@@ -3024,7 +3024,7 @@ struct RepositoriesFeatureTests {
     state.archivedWorktrees = [
       ArchivedWorktree(id: mainWorktree.id, archivedAt: .distantPast),
     ]
-    state.autoDeleteArchivedWorktreesAfterDays = .oneDay
+    state.archivedAutoDeletePeriod = .oneDay
     let store = TestStore(initialState: state) {
       RepositoriesFeature()
     } withDependencies: {
@@ -3033,6 +3033,41 @@ struct RepositoriesFeatureTests {
 
     await store.send(.autoDeleteExpiredArchivedWorktrees)
     // No effects — main worktree must not be deleted
+  }
+
+  @Test func autoDeleteMultipleExpiredWorktreesConcurrently() async {
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let expired1 = makeWorktree(id: "/tmp/repo/expired1", name: "expired1", repoRoot: repoRoot)
+    let expired2 = makeWorktree(id: "/tmp/repo/expired2", name: "expired2", repoRoot: repoRoot)
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree, expired1, expired2])
+    let fixedDate = Date(timeIntervalSince1970: 1_000_000)
+    let archivedAt = fixedDate.addingTimeInterval(-2 * 86_400)
+    var state = makeState(repositories: [repository])
+    state.archivedWorktrees = [
+      ArchivedWorktree(id: expired1.id, archivedAt: archivedAt),
+      ArchivedWorktree(id: expired2.id, archivedAt: archivedAt),
+    ]
+    state.archivedAutoDeletePeriod = .oneDay
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.date = .constant(fixedDate)
+      $0.gitClient.removeWorktree = { worktree, _ in worktree.workingDirectory }
+      $0.gitClient.worktrees = { _ in [mainWorktree] }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.autoDeleteExpiredArchivedWorktrees)
+    // Both deleteWorktreeConfirmed should fire
+    await store.receive(\.worktreeLifecycle.deleteWorktreeConfirmed)
+    await store.receive(\.worktreeLifecycle.deleteWorktreeConfirmed)
+    // Both worktreeDeleted should complete without crash
+    await store.receive(\.worktreeLifecycle.worktreeDeleted)
+    await store.receive(\.worktreeLifecycle.worktreeDeleted)
+    // State should be consistent: both worktrees removed from archives
+    #expect(store.state.archivedWorktrees.isEmpty)
+    #expect(store.state.deletingWorktreeIDs.isEmpty)
   }
 
   // MARK: - Select Next/Previous Worktree

--- a/supacodeTests/RepositoryPersistenceClientTests.swift
+++ b/supacodeTests/RepositoryPersistenceClientTests.swift
@@ -111,6 +111,37 @@ struct RepositoryPersistenceClientTests {
     )
   }
 
+  @Test(.dependencies) func legacyArchivedWorktreeIDsMigratedAndCleared() async {
+    let client = RepositoryPersistenceClient.liveValue
+
+    // Seed legacy key
+    @Shared(.appStorage("archivedWorktreeIDs")) var legacyArchived: [Worktree.ID] = []
+    $legacyArchived.withLock { $0 = ["/tmp/repo/wt-1", "/tmp/repo/wt-2"] }
+
+    // First load should migrate
+    let loaded = await client.loadArchivedWorktrees()
+    #expect(loaded.count == 2)
+    #expect(loaded.map(\.id) == ["/tmp/repo/wt-1", "/tmp/repo/wt-2"])
+    // Migrated timestamps should be recent, not distantPast
+    for entry in loaded {
+      #expect(entry.archivedAt > Date.distantPast)
+    }
+
+    // Legacy key should be cleared
+    #expect(legacyArchived.isEmpty)
+
+    // New key should be populated
+    @Shared(.appStorage("archivedWorktrees")) var newArchived: [ArchivedWorktree] = []
+    #expect(newArchived.count == 2)
+
+    // Save empty (user clears all archives)
+    await client.saveArchivedWorktrees([])
+
+    // Reload should return empty — no resurrection from legacy key
+    let reloaded = await client.loadArchivedWorktrees()
+    #expect(reloaded.isEmpty)
+  }
+
   @Test func repositorySnapshotPayloadRoundTripsRepositories() {
     let repoRoot = "/tmp/repo"
     let worktree = Worktree(

--- a/supacodeTests/ToolbarNotificationGroupingTests.swift
+++ b/supacodeTests/ToolbarNotificationGroupingTests.swift
@@ -58,7 +58,7 @@ struct ToolbarNotificationGroupingTests {
 
     var state = RepositoriesFeature.State(repositories: [repoA, repoB])
     state.repositoryRoots = [repoA.rootURL, repoB.rootURL]
-    state.archivedWorktreeIDs = [repoAArchived.id]
+    state.archivedWorktrees = [ArchivedWorktree(id: repoAArchived.id, archivedAt: .distantPast)]
 
     let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
     manager.state(for: repoAArchived).notifications = [


### PR DESCRIPTION
## Summary

- Replace flat `[Worktree.ID]` archived list with `[ArchivedWorktree]` struct model that tracks `archivedAt` timestamps
- Add `AutoDeletePeriod` enum with configurable periods (1/3/7/14/30 days, plus "Immediately" in DEBUG)
- Wire auto-delete setting through `GlobalSettings` → `SettingsFeature` → `RepositoriesFeature`
- Auto-delete runs on repository load and when the setting changes
- Add picker in Worktree settings for configuring the auto-delete period
- Persistence: new `archivedWorktrees` key with fallback migration from legacy `archivedWorktreeIDs`
- Update all tests to use the new `ArchivedWorktree` model

Closes #174

## Test plan

- [x] Build succeeds (`make build-app`)
- [x] Lint passes (`make lint`)
- [x] All 672 tests pass
- [x] Archive a worktree, set auto-delete to "After 1 day", wait/fast-forward time, verify deletion on next refresh
- [x] Verify "Never" (nil) disables auto-delete
- [x] Verify DEBUG-only "Immediately" option works in debug builds
- [x] Verify legacy `archivedWorktreeIDs` data migrates correctly on first load
