### PR TITLE
feat: global defaults for copy flags and merge strategy

### DIFF
--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -377,12 +377,16 @@ struct AppFeature {
           }
           @Shared(.repositorySettings(repository.rootURL)) var repositorySettings
           @Shared(.userRepositorySettings(repository.rootURL)) var userRepositorySettings
-          state.settings.repositorySettings = RepositorySettingsFeature.State(
+          var repoSettingsState = RepositorySettingsFeature.State(
             rootURL: repository.rootURL,
             repositoryKind: repository.kind,
             settings: repositorySettings,
             userSettings: userRepositorySettings
           )
+          repoSettingsState.globalCopyIgnoredOnWorktreeCreate = state.settings.copyIgnoredOnWorktreeCreate
+          repoSettingsState.globalCopyUntrackedOnWorktreeCreate = state.settings.copyUntrackedOnWorktreeCreate
+          repoSettingsState.globalPullRequestMergeStrategy = state.settings.pullRequestMergeStrategy
+          state.settings.repositorySettings = repoSettingsState
         case .general, .notifications, .shortcuts, .worktree, .updates, .advanced, .github:
           state.settings.repositorySettings = nil
         }

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+GithubIntegration.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+GithubIntegration.swift
@@ -322,7 +322,8 @@ extension RepositoriesFeature {
             return
           }
           @Shared(.repositorySettings(repoRoot)) var repositorySettings
-          let strategy = repositorySettings.pullRequestMergeStrategy
+          @Shared(.settingsFile) var settingsFile
+          let strategy = repositorySettings.pullRequestMergeStrategy ?? settingsFile.global.pullRequestMergeStrategy
           await send(.showToast(.inProgress("Merging pull request…")))
           do {
             try await githubCLI.mergePullRequest(worktreeRoot, pullRequest.number, strategy)

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+WorktreeCreation.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+WorktreeCreation.swift
@@ -239,8 +239,10 @@ extension RepositoriesFeature {
         repositoryOverridePath: repositorySettings.worktreeBaseDirectoryPath
       )
       let selectedBaseRef = repositorySettings.worktreeBaseRef
-      let copyIgnoredOnWorktreeCreate = repositorySettings.copyIgnoredOnWorktreeCreate
-      let copyUntrackedOnWorktreeCreate = repositorySettings.copyUntrackedOnWorktreeCreate
+      let copyIgnoredOnWorktreeCreate =
+        repositorySettings.copyIgnoredOnWorktreeCreate ?? settingsFile.global.copyIgnoredOnWorktreeCreate
+      let copyUntrackedOnWorktreeCreate =
+        repositorySettings.copyUntrackedOnWorktreeCreate ?? settingsFile.global.copyUntrackedOnWorktreeCreate
       state.pendingWorktrees.append(
         PendingWorktree(
           id: pendingID,

--- a/supacode/Features/RepositorySettings/Reducer/RepositorySettingsFeature.swift
+++ b/supacode/Features/RepositorySettings/Reducer/RepositorySettingsFeature.swift
@@ -10,6 +10,9 @@ struct RepositorySettingsFeature {
     var settings: RepositorySettings
     var userSettings: UserRepositorySettings
     var globalDefaultWorktreeBaseDirectoryPath: String?
+    var globalCopyIgnoredOnWorktreeCreate: Bool = false
+    var globalCopyUntrackedOnWorktreeCreate: Bool = false
+    var globalPullRequestMergeStrategy: PullRequestMergeStrategy = .merge
     var isBareRepository = false
     var branchOptions: [String] = []
     var defaultWorktreeBaseRef = "origin/main"
@@ -65,6 +68,9 @@ struct RepositorySettingsFeature {
       UserRepositorySettings,
       isBareRepository: Bool,
       globalDefaultWorktreeBaseDirectoryPath: String?,
+      globalCopyIgnoredOnWorktreeCreate: Bool,
+      globalCopyUntrackedOnWorktreeCreate: Bool,
+      globalPullRequestMergeStrategy: PullRequestMergeStrategy,
       keybindingUserOverrides: KeybindingUserOverrideStore
     )
     case branchDataLoaded([String], defaultBaseRef: String)
@@ -90,13 +96,17 @@ struct RepositorySettingsFeature {
             @Shared(.repositorySettings(rootURL)) var repositorySettings
             @Shared(.userRepositorySettings(rootURL)) var userRepositorySettings
             @Shared(.settingsFile) var settingsFile
+            let global = settingsFile.global
             await send(
               .settingsLoaded(
                 repositorySettings,
                 userRepositorySettings,
                 isBareRepository: false,
-                globalDefaultWorktreeBaseDirectoryPath: settingsFile.global.defaultWorktreeBaseDirectoryPath,
-                keybindingUserOverrides: settingsFile.global.keybindingUserOverrides
+                globalDefaultWorktreeBaseDirectoryPath: global.defaultWorktreeBaseDirectoryPath,
+                globalCopyIgnoredOnWorktreeCreate: global.copyIgnoredOnWorktreeCreate,
+                globalCopyUntrackedOnWorktreeCreate: global.copyUntrackedOnWorktreeCreate,
+                globalPullRequestMergeStrategy: global.pullRequestMergeStrategy,
+                keybindingUserOverrides: global.keybindingUserOverrides
               )
             )
           }
@@ -107,13 +117,17 @@ struct RepositorySettingsFeature {
           @Shared(.repositorySettings(rootURL)) var repositorySettings
           @Shared(.userRepositorySettings(rootURL)) var userRepositorySettings
           @Shared(.settingsFile) var settingsFile
+          let global = settingsFile.global
           await send(
             .settingsLoaded(
               repositorySettings,
               userRepositorySettings,
               isBareRepository: isBareRepository,
-              globalDefaultWorktreeBaseDirectoryPath: settingsFile.global.defaultWorktreeBaseDirectoryPath,
-              keybindingUserOverrides: settingsFile.global.keybindingUserOverrides
+              globalDefaultWorktreeBaseDirectoryPath: global.defaultWorktreeBaseDirectoryPath,
+              globalCopyIgnoredOnWorktreeCreate: global.copyIgnoredOnWorktreeCreate,
+              globalCopyUntrackedOnWorktreeCreate: global.copyUntrackedOnWorktreeCreate,
+              globalPullRequestMergeStrategy: global.pullRequestMergeStrategy,
+              keybindingUserOverrides: global.keybindingUserOverrides
             )
           )
           let branches: [String]
@@ -135,6 +149,9 @@ struct RepositorySettingsFeature {
         let userSettings,
         let isBareRepository,
         let globalDefaultWorktreeBaseDirectoryPath,
+        let globalCopyIgnoredOnWorktreeCreate,
+        let globalCopyUntrackedOnWorktreeCreate,
+        let globalPullRequestMergeStrategy,
         let keybindingUserOverrides
       ):
         var updatedSettings = settings
@@ -143,13 +160,16 @@ struct RepositorySettingsFeature {
           repositoryRootURL: state.rootURL
         )
         if isBareRepository {
-          updatedSettings.copyIgnoredOnWorktreeCreate = false
-          updatedSettings.copyUntrackedOnWorktreeCreate = false
+          updatedSettings.copyIgnoredOnWorktreeCreate = nil
+          updatedSettings.copyUntrackedOnWorktreeCreate = nil
         }
         state.settings = updatedSettings
         state.userSettings = userSettings.normalized()
         state.globalDefaultWorktreeBaseDirectoryPath =
           SupacodePaths.normalizedWorktreeBaseDirectoryPath(globalDefaultWorktreeBaseDirectoryPath)
+        state.globalCopyIgnoredOnWorktreeCreate = globalCopyIgnoredOnWorktreeCreate
+        state.globalCopyUntrackedOnWorktreeCreate = globalCopyUntrackedOnWorktreeCreate
+        state.globalPullRequestMergeStrategy = globalPullRequestMergeStrategy
         state.isBareRepository = isBareRepository
         state.keybindingUserOverrides = keybindingUserOverrides
         guard updatedSettings != settings else { return .none }
@@ -173,8 +193,8 @@ struct RepositorySettingsFeature {
 
       case .binding:
         if state.isBareRepository {
-          state.settings.copyIgnoredOnWorktreeCreate = false
-          state.settings.copyUntrackedOnWorktreeCreate = false
+          state.settings.copyIgnoredOnWorktreeCreate = nil
+          state.settings.copyUntrackedOnWorktreeCreate = nil
         }
         state.userSettings = state.userSettings.normalized()
         let rootURL = state.rootURL

--- a/supacode/Features/Settings/Models/GlobalSettings.swift
+++ b/supacode/Features/Settings/Models/GlobalSettings.swift
@@ -18,6 +18,9 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
   var automaticallyArchiveMergedWorktrees: Bool
   var promptForWorktreeCreation: Bool
   var defaultWorktreeBaseDirectoryPath: String?
+  var copyIgnoredOnWorktreeCreate: Bool
+  var copyUntrackedOnWorktreeCreate: Bool
+  var pullRequestMergeStrategy: PullRequestMergeStrategy
   var restoreTerminalLayoutOnLaunch: Bool
   var terminalFontSize: Float32?
   var keybindingUserOverrides: KeybindingUserOverrideStore
@@ -42,6 +45,9 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     automaticallyArchiveMergedWorktrees: false,
     promptForWorktreeCreation: true,
     defaultWorktreeBaseDirectoryPath: nil,
+    copyIgnoredOnWorktreeCreate: false,
+    copyUntrackedOnWorktreeCreate: false,
+    pullRequestMergeStrategy: .merge,
     restoreTerminalLayoutOnLaunch: false,
     terminalFontSize: nil,
     keybindingUserOverrides: .empty
@@ -67,6 +73,9 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     automaticallyArchiveMergedWorktrees: Bool,
     promptForWorktreeCreation: Bool,
     defaultWorktreeBaseDirectoryPath: String? = nil,
+    copyIgnoredOnWorktreeCreate: Bool = false,
+    copyUntrackedOnWorktreeCreate: Bool = false,
+    pullRequestMergeStrategy: PullRequestMergeStrategy = .merge,
     restoreTerminalLayoutOnLaunch: Bool = false,
     terminalFontSize: Float32? = nil,
     keybindingUserOverrides: KeybindingUserOverrideStore = .empty
@@ -90,6 +99,9 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     self.automaticallyArchiveMergedWorktrees = automaticallyArchiveMergedWorktrees
     self.promptForWorktreeCreation = promptForWorktreeCreation
     self.defaultWorktreeBaseDirectoryPath = defaultWorktreeBaseDirectoryPath
+    self.copyIgnoredOnWorktreeCreate = copyIgnoredOnWorktreeCreate
+    self.copyUntrackedOnWorktreeCreate = copyUntrackedOnWorktreeCreate
+    self.pullRequestMergeStrategy = pullRequestMergeStrategy
     self.restoreTerminalLayoutOnLaunch = restoreTerminalLayoutOnLaunch
     self.terminalFontSize = terminalFontSize
     self.keybindingUserOverrides = keybindingUserOverrides
@@ -148,6 +160,15 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     defaultWorktreeBaseDirectoryPath =
       try container.decodeIfPresent(String.self, forKey: .defaultWorktreeBaseDirectoryPath)
       ?? Self.default.defaultWorktreeBaseDirectoryPath
+    copyIgnoredOnWorktreeCreate =
+      try container.decodeIfPresent(Bool.self, forKey: .copyIgnoredOnWorktreeCreate)
+      ?? Self.default.copyIgnoredOnWorktreeCreate
+    copyUntrackedOnWorktreeCreate =
+      try container.decodeIfPresent(Bool.self, forKey: .copyUntrackedOnWorktreeCreate)
+      ?? Self.default.copyUntrackedOnWorktreeCreate
+    pullRequestMergeStrategy =
+      try container.decodeIfPresent(PullRequestMergeStrategy.self, forKey: .pullRequestMergeStrategy)
+      ?? Self.default.pullRequestMergeStrategy
     restoreTerminalLayoutOnLaunch =
       try container.decodeIfPresent(Bool.self, forKey: .restoreTerminalLayoutOnLaunch)
       ?? Self.default.restoreTerminalLayoutOnLaunch

--- a/supacode/Features/Settings/Models/RepositorySettings.swift
+++ b/supacode/Features/Settings/Models/RepositorySettings.swift
@@ -1,6 +1,11 @@
 import Foundation
 
 nonisolated struct RepositorySettings: Codable, Equatable, Sendable {
+  private static let currentSchemaVersion = 2
+  private static let legacyCopyIgnoredDefault = false
+  private static let legacyCopyUntrackedDefault = false
+  private static let legacyMergeStrategyDefault: PullRequestMergeStrategy = .merge
+
   var setupScript: String
   var archiveScript: String
   var runScript: String
@@ -10,8 +15,10 @@ nonisolated struct RepositorySettings: Codable, Equatable, Sendable {
   var copyIgnoredOnWorktreeCreate: Bool?
   var copyUntrackedOnWorktreeCreate: Bool?
   var pullRequestMergeStrategy: PullRequestMergeStrategy?
+  private var schemaVersion: Int
 
   private enum CodingKeys: String, CodingKey {
+    case schemaVersion
     case setupScript
     case archiveScript
     case runScript
@@ -55,10 +62,14 @@ nonisolated struct RepositorySettings: Codable, Equatable, Sendable {
     self.copyIgnoredOnWorktreeCreate = copyIgnoredOnWorktreeCreate
     self.copyUntrackedOnWorktreeCreate = copyUntrackedOnWorktreeCreate
     self.pullRequestMergeStrategy = pullRequestMergeStrategy
+    schemaVersion = Self.currentSchemaVersion
   }
 
   init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
+    let decodedSchemaVersion =
+      try container.decodeIfPresent(Int.self, forKey: .schemaVersion)
+      ?? 1
     setupScript =
       try container.decodeIfPresent(String.self, forKey: .setupScript)
       ?? Self.default.setupScript
@@ -75,20 +86,55 @@ nonisolated struct RepositorySettings: Codable, Equatable, Sendable {
       try container.decodeIfPresent(String.self, forKey: .worktreeBaseRef)
     worktreeBaseDirectoryPath =
       try container.decodeIfPresent(String.self, forKey: .worktreeBaseDirectoryPath)
-    copyIgnoredOnWorktreeCreate =
-      try container.decodeIfPresent(
-        Bool.self,
-        forKey: .copyIgnoredOnWorktreeCreate
+    if decodedSchemaVersion >= Self.currentSchemaVersion {
+      copyIgnoredOnWorktreeCreate =
+        try container.decodeIfPresent(
+          Bool.self,
+          forKey: .copyIgnoredOnWorktreeCreate
+        )
+      copyUntrackedOnWorktreeCreate =
+        try container.decodeIfPresent(
+          Bool.self,
+          forKey: .copyUntrackedOnWorktreeCreate
+        )
+      pullRequestMergeStrategy =
+        try container.decodeIfPresent(
+          PullRequestMergeStrategy.self,
+          forKey: .pullRequestMergeStrategy
+        )
+    } else {
+      copyIgnoredOnWorktreeCreate = Self.normalizeLegacyOverride(
+        try container.decodeIfPresent(
+          Bool.self,
+          forKey: .copyIgnoredOnWorktreeCreate
+        ),
+        legacyDefault: Self.legacyCopyIgnoredDefault
       )
-    copyUntrackedOnWorktreeCreate =
-      try container.decodeIfPresent(
-        Bool.self,
-        forKey: .copyUntrackedOnWorktreeCreate
+      copyUntrackedOnWorktreeCreate = Self.normalizeLegacyOverride(
+        try container.decodeIfPresent(
+          Bool.self,
+          forKey: .copyUntrackedOnWorktreeCreate
+        ),
+        legacyDefault: Self.legacyCopyUntrackedDefault
       )
-    pullRequestMergeStrategy =
-      try container.decodeIfPresent(
-        PullRequestMergeStrategy.self,
-        forKey: .pullRequestMergeStrategy
+      pullRequestMergeStrategy = Self.normalizeLegacyOverride(
+        try container.decodeIfPresent(
+          PullRequestMergeStrategy.self,
+          forKey: .pullRequestMergeStrategy
+        ),
+        legacyDefault: Self.legacyMergeStrategyDefault
       )
+    }
+    schemaVersion = Self.currentSchemaVersion
+  }
+}
+
+extension RepositorySettings {
+  nonisolated private static func normalizeLegacyOverride<Value: Equatable>(
+    _ value: Value?,
+    legacyDefault: Value
+  ) -> Value? {
+    guard let value else { return nil }
+    return value == legacyDefault ? nil : value
   }
 }

--- a/supacode/Features/Settings/Models/RepositorySettings.swift
+++ b/supacode/Features/Settings/Models/RepositorySettings.swift
@@ -7,9 +7,9 @@ nonisolated struct RepositorySettings: Codable, Equatable, Sendable {
   var openActionID: String
   var worktreeBaseRef: String?
   var worktreeBaseDirectoryPath: String?
-  var copyIgnoredOnWorktreeCreate: Bool
-  var copyUntrackedOnWorktreeCreate: Bool
-  var pullRequestMergeStrategy: PullRequestMergeStrategy
+  var copyIgnoredOnWorktreeCreate: Bool?
+  var copyUntrackedOnWorktreeCreate: Bool?
+  var pullRequestMergeStrategy: PullRequestMergeStrategy?
 
   private enum CodingKeys: String, CodingKey {
     case setupScript
@@ -30,9 +30,9 @@ nonisolated struct RepositorySettings: Codable, Equatable, Sendable {
     openActionID: OpenWorktreeAction.automaticSettingsID,
     worktreeBaseRef: nil,
     worktreeBaseDirectoryPath: nil,
-    copyIgnoredOnWorktreeCreate: false,
-    copyUntrackedOnWorktreeCreate: false,
-    pullRequestMergeStrategy: .merge
+    copyIgnoredOnWorktreeCreate: nil,
+    copyUntrackedOnWorktreeCreate: nil,
+    pullRequestMergeStrategy: nil
   )
 
   init(
@@ -42,9 +42,9 @@ nonisolated struct RepositorySettings: Codable, Equatable, Sendable {
     openActionID: String,
     worktreeBaseRef: String?,
     worktreeBaseDirectoryPath: String? = nil,
-    copyIgnoredOnWorktreeCreate: Bool,
-    copyUntrackedOnWorktreeCreate: Bool,
-    pullRequestMergeStrategy: PullRequestMergeStrategy
+    copyIgnoredOnWorktreeCreate: Bool? = nil,
+    copyUntrackedOnWorktreeCreate: Bool? = nil,
+    pullRequestMergeStrategy: PullRequestMergeStrategy? = nil
   ) {
     self.setupScript = setupScript
     self.archiveScript = archiveScript
@@ -79,16 +79,16 @@ nonisolated struct RepositorySettings: Codable, Equatable, Sendable {
       try container.decodeIfPresent(
         Bool.self,
         forKey: .copyIgnoredOnWorktreeCreate
-      ) ?? Self.default.copyIgnoredOnWorktreeCreate
+      )
     copyUntrackedOnWorktreeCreate =
       try container.decodeIfPresent(
         Bool.self,
         forKey: .copyUntrackedOnWorktreeCreate
-      ) ?? Self.default.copyUntrackedOnWorktreeCreate
+      )
     pullRequestMergeStrategy =
       try container.decodeIfPresent(
         PullRequestMergeStrategy.self,
         forKey: .pullRequestMergeStrategy
-      ) ?? Self.default.pullRequestMergeStrategy
+      )
   }
 }

--- a/supacode/Features/Settings/Reducer/SettingsFeature.swift
+++ b/supacode/Features/Settings/Reducer/SettingsFeature.swift
@@ -24,6 +24,9 @@ struct SettingsFeature {
     var automaticallyArchiveMergedWorktrees: Bool
     var promptForWorktreeCreation: Bool
     var defaultWorktreeBaseDirectoryPath: String
+    var copyIgnoredOnWorktreeCreate: Bool
+    var copyUntrackedOnWorktreeCreate: Bool
+    var pullRequestMergeStrategy: PullRequestMergeStrategy
     var restoreTerminalLayoutOnLaunch: Bool
     var terminalFontSize: Float32?
     var keybindingUserOverrides: KeybindingUserOverrideStore
@@ -55,6 +58,9 @@ struct SettingsFeature {
       promptForWorktreeCreation = settings.promptForWorktreeCreation
       defaultWorktreeBaseDirectoryPath =
         SupacodePaths.normalizedWorktreeBaseDirectoryPath(settings.defaultWorktreeBaseDirectoryPath) ?? ""
+      copyIgnoredOnWorktreeCreate = settings.copyIgnoredOnWorktreeCreate
+      copyUntrackedOnWorktreeCreate = settings.copyUntrackedOnWorktreeCreate
+      pullRequestMergeStrategy = settings.pullRequestMergeStrategy
       restoreTerminalLayoutOnLaunch = settings.restoreTerminalLayoutOnLaunch
       terminalFontSize = settings.terminalFontSize
       keybindingUserOverrides = settings.keybindingUserOverrides
@@ -83,6 +89,9 @@ struct SettingsFeature {
         defaultWorktreeBaseDirectoryPath: SupacodePaths.normalizedWorktreeBaseDirectoryPath(
           defaultWorktreeBaseDirectoryPath
         ),
+        copyIgnoredOnWorktreeCreate: copyIgnoredOnWorktreeCreate,
+        copyUntrackedOnWorktreeCreate: copyUntrackedOnWorktreeCreate,
+        pullRequestMergeStrategy: pullRequestMergeStrategy,
         restoreTerminalLayoutOnLaunch: restoreTerminalLayoutOnLaunch,
         terminalFontSize: terminalFontSize,
         keybindingUserOverrides: keybindingUserOverrides
@@ -177,18 +186,18 @@ struct SettingsFeature {
         state.automaticallyArchiveMergedWorktrees = normalizedSettings.automaticallyArchiveMergedWorktrees
         state.promptForWorktreeCreation = normalizedSettings.promptForWorktreeCreation
         state.defaultWorktreeBaseDirectoryPath = normalizedSettings.defaultWorktreeBaseDirectoryPath ?? ""
+        state.copyIgnoredOnWorktreeCreate = normalizedSettings.copyIgnoredOnWorktreeCreate
+        state.copyUntrackedOnWorktreeCreate = normalizedSettings.copyUntrackedOnWorktreeCreate
+        state.pullRequestMergeStrategy = normalizedSettings.pullRequestMergeStrategy
         state.restoreTerminalLayoutOnLaunch = normalizedSettings.restoreTerminalLayoutOnLaunch
         state.terminalFontSize = normalizedSettings.terminalFontSize
         state.keybindingUserOverrides = normalizedSettings.keybindingUserOverrides
-        state.repositorySettings?.globalDefaultWorktreeBaseDirectoryPath =
-          normalizedSettings.defaultWorktreeBaseDirectoryPath
+        state.syncGlobalDefaults(from: normalizedSettings)
         return .send(.delegate(.settingsChanged(normalizedSettings)))
 
       case .binding:
         state.commandFinishedNotificationThreshold = min(max(state.commandFinishedNotificationThreshold, 0), 600)
-        let defaultWorktreeBaseDirectoryPath = state.globalSettings.defaultWorktreeBaseDirectoryPath
-        state.repositorySettings?.globalDefaultWorktreeBaseDirectoryPath =
-          defaultWorktreeBaseDirectoryPath
+        state.syncGlobalDefaults(from: state.globalSettings)
         return persist(state)
 
       case .setCommandFinishedNotificationThreshold(let text):
@@ -201,9 +210,7 @@ struct SettingsFeature {
 
       case .setSystemNotificationsEnabled(let isEnabled):
         state.systemNotificationsEnabled = isEnabled
-        let defaultWorktreeBaseDirectoryPath = state.globalSettings.defaultWorktreeBaseDirectoryPath
-        state.repositorySettings?.globalDefaultWorktreeBaseDirectoryPath =
-          defaultWorktreeBaseDirectoryPath
+        state.syncGlobalDefaults(from: state.globalSettings)
         return persist(state)
 
       case .setTerminalFontSize(let fontSize):
@@ -356,5 +363,18 @@ struct SettingsFeature {
       return .send(.delegate(.settingsChanged(settings)))
     }
     return .none
+  }
+}
+
+extension SettingsFeature.State {
+  mutating func syncGlobalDefaults(from settings: GlobalSettings) {
+    repositorySettings?.globalDefaultWorktreeBaseDirectoryPath =
+      settings.defaultWorktreeBaseDirectoryPath
+    repositorySettings?.globalCopyIgnoredOnWorktreeCreate =
+      settings.copyIgnoredOnWorktreeCreate
+    repositorySettings?.globalCopyUntrackedOnWorktreeCreate =
+      settings.copyUntrackedOnWorktreeCreate
+    repositorySettings?.globalPullRequestMergeStrategy =
+      settings.pullRequestMergeStrategy
   }
 }

--- a/supacode/Features/Settings/Views/GithubSettingsView.swift
+++ b/supacode/Features/Settings/Views/GithubSettingsView.swift
@@ -120,6 +120,16 @@ struct GithubSettingsView: View {
             }
           }
         }
+        Section("Pull Requests") {
+          Picker(selection: $store.pullRequestMergeStrategy) {
+            ForEach(PullRequestMergeStrategy.allCases) { strategy in
+              Text(strategy.title).tag(strategy)
+            }
+          } label: {
+            Text("Merge strategy")
+            Text("Default strategy when merging PRs from the command palette.")
+          }
+        }
       }
       .formStyle(.grouped)
 

--- a/supacode/Features/Settings/Views/RepositorySettingsView.swift
+++ b/supacode/Features/Settings/Views/RepositorySettingsView.swift
@@ -125,16 +125,30 @@ struct RepositorySettingsView: View {
           }
           .frame(maxWidth: .infinity, alignment: .leading)
 
-          Toggle(
-            "Copy ignored files to new worktrees",
-            isOn: settings.copyIgnoredOnWorktreeCreate
-          )
+          Picker(selection: settings.copyIgnoredOnWorktreeCreate) {
+            Text(
+              "Global \(Text(store.globalCopyIgnoredOnWorktreeCreate ? "Yes" : "No").foregroundStyle(.secondary))"
+            )
+            .tag(Bool?.none)
+            Text("Yes").tag(Bool?.some(true))
+            Text("No").tag(Bool?.some(false))
+          } label: {
+            Text("Copy ignored files to new worktrees")
+            Text("Copies gitignored files from the main worktree.")
+          }
           .disabled(store.isBareRepository)
 
-          Toggle(
-            "Copy untracked files to new worktrees",
-            isOn: settings.copyUntrackedOnWorktreeCreate
-          )
+          Picker(selection: settings.copyUntrackedOnWorktreeCreate) {
+            Text(
+              "Global \(Text(store.globalCopyUntrackedOnWorktreeCreate ? "Yes" : "No").foregroundStyle(.secondary))"
+            )
+            .tag(Bool?.none)
+            Text("Yes").tag(Bool?.some(true))
+            Text("No").tag(Bool?.some(false))
+          } label: {
+            Text("Copy untracked files to new worktrees")
+            Text("Copies untracked files from the main worktree.")
+          }
           .disabled(store.isBareRepository)
 
           if store.isBareRepository {
@@ -152,16 +166,18 @@ struct RepositorySettingsView: View {
 
       if store.showsPullRequestSettings {
         Section {
-          Picker(
-            "Merge strategy",
-            selection: settings.pullRequestMergeStrategy
-          ) {
+          Picker(selection: settings.pullRequestMergeStrategy) {
+            Text(
+              "Global \(Text(store.globalPullRequestMergeStrategy.title).foregroundStyle(.secondary))"
+            )
+            .tag(PullRequestMergeStrategy?.none)
             ForEach(PullRequestMergeStrategy.allCases) { strategy in
-              Text(strategy.title)
-                .tag(strategy)
+              Text(strategy.title).tag(PullRequestMergeStrategy?.some(strategy))
             }
+          } label: {
+            Text("Merge strategy")
+            Text("Used when merging PRs from the command palette.")
           }
-          .labelsHidden()
         } header: {
           VStack(alignment: .leading, spacing: 4) {
             Text("Pull Requests")

--- a/supacode/Features/Settings/Views/WorktreeSettingsView.swift
+++ b/supacode/Features/Settings/Views/WorktreeSettingsView.swift
@@ -55,6 +55,16 @@ struct WorktreeSettingsView: View {
               .foregroundStyle(.secondary)
           }
         }
+        Section("Copy Defaults") {
+          Toggle(isOn: $store.copyIgnoredOnWorktreeCreate) {
+            Text("Copy ignored files to new worktrees")
+            Text("Copies gitignored files from the main worktree.")
+          }
+          Toggle(isOn: $store.copyUntrackedOnWorktreeCreate) {
+            Text("Copy untracked files to new worktrees")
+            Text("Copies untracked files from the main worktree.")
+          }
+        }
       }
       .formStyle(.grouped)
     }

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -1285,6 +1285,104 @@ struct RepositoriesFeatureTests {
     #expect(observedBaseDirectory.value == expectedBaseDirectory)
   }
 
+  @Test(.dependencies) func createRandomWorktreeUsesGlobalCopyFlagsWhenRepositoryOverridesMissing() async {
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree])
+    let createdWorktree = makeWorktree(
+      id: "/tmp/repo/swift-otter",
+      name: "swift-otter",
+      repoRoot: repoRoot
+    )
+    let observedCopyFlags = LockIsolated<(Bool, Bool)?>(nil)
+    @Shared(.settingsFile) var settingsFile
+    $settingsFile.withLock {
+      $0.global.promptForWorktreeCreation = false
+      $0.global.copyIgnoredOnWorktreeCreate = true
+      $0.global.copyUntrackedOnWorktreeCreate = true
+    }
+    @Shared(.repositorySettings(repository.rootURL)) var repositorySettings
+    $repositorySettings.withLock {
+      $0.copyIgnoredOnWorktreeCreate = nil
+      $0.copyUntrackedOnWorktreeCreate = nil
+    }
+    let store = TestStore(initialState: makeState(repositories: [repository])) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.uuid = .incrementing
+      $0.gitClient.localBranchNames = { _ in [] }
+      $0.gitClient.isBareRepository = { _ in false }
+      $0.gitClient.automaticWorktreeBaseRef = { _ in "origin/main" }
+      $0.gitClient.ignoredFileCount = { _ in 0 }
+      $0.gitClient.untrackedFileCount = { _ in 0 }
+      $0.gitClient.createWorktreeStream = { _, _, _, copyIgnored, copyUntracked, _ in
+        observedCopyFlags.withValue { $0 = (copyIgnored, copyUntracked) }
+        return AsyncThrowingStream { continuation in
+          continuation.yield(.finished(createdWorktree))
+          continuation.finish()
+        }
+      }
+      $0.gitClient.worktrees = { _ in [createdWorktree, mainWorktree] }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.worktreeCreation(.createRandomWorktreeInRepository(repository.id)))
+    await store.receive(\.worktreeCreation.createRandomWorktreeSucceeded)
+    await store.finish()
+
+    #expect(observedCopyFlags.value?.0 == true)
+    #expect(observedCopyFlags.value?.1 == true)
+  }
+
+  @Test(.dependencies) func createRandomWorktreeInBareRepositoryIgnoresGlobalCopyFlags() async {
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree])
+    let createdWorktree = makeWorktree(
+      id: "/tmp/repo/swift-otter",
+      name: "swift-otter",
+      repoRoot: repoRoot
+    )
+    let observedCopyFlags = LockIsolated<(Bool, Bool)?>(nil)
+    @Shared(.settingsFile) var settingsFile
+    $settingsFile.withLock {
+      $0.global.promptForWorktreeCreation = false
+      $0.global.copyIgnoredOnWorktreeCreate = true
+      $0.global.copyUntrackedOnWorktreeCreate = true
+    }
+    @Shared(.repositorySettings(repository.rootURL)) var repositorySettings
+    $repositorySettings.withLock {
+      $0.copyIgnoredOnWorktreeCreate = nil
+      $0.copyUntrackedOnWorktreeCreate = nil
+    }
+    let store = TestStore(initialState: makeState(repositories: [repository])) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.uuid = .incrementing
+      $0.gitClient.localBranchNames = { _ in [] }
+      $0.gitClient.isBareRepository = { _ in true }
+      $0.gitClient.automaticWorktreeBaseRef = { _ in "origin/main" }
+      $0.gitClient.ignoredFileCount = { _ in 0 }
+      $0.gitClient.untrackedFileCount = { _ in 0 }
+      $0.gitClient.createWorktreeStream = { _, _, _, copyIgnored, copyUntracked, _ in
+        observedCopyFlags.withValue { $0 = (copyIgnored, copyUntracked) }
+        return AsyncThrowingStream { continuation in
+          continuation.yield(.finished(createdWorktree))
+          continuation.finish()
+        }
+      }
+      $0.gitClient.worktrees = { _ in [createdWorktree, mainWorktree] }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.worktreeCreation(.createRandomWorktreeInRepository(repository.id)))
+    await store.receive(\.worktreeCreation.createRandomWorktreeSucceeded)
+    await store.finish()
+
+    #expect(observedCopyFlags.value?.0 == false)
+    #expect(observedCopyFlags.value?.1 == false)
+  }
+
   @Test(.dependencies) func createRandomWorktreeInRepositoryStreamFailureRemovesPendingWorktree() async {
     let repoRoot = "/tmp/repo"
     let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
@@ -2561,6 +2659,54 @@ struct RepositoriesFeatureTests {
     #expect(store.state.worktreeInfoByID[featureWorktree.id]?.pullRequest?.state == "OPEN")
     #expect(store.state.archivedWorktreeIDs.isEmpty)
     #expect(mergedNumbers.value == [12])
+    await store.finish()
+  }
+
+  @Test func pullRequestActionMergeUsesGlobalStrategyWhenRepositoryOverrideMissing() async {
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let featureWorktree = makeWorktree(
+      id: "\(repoRoot)/feature",
+      name: "feature",
+      repoRoot: repoRoot
+    )
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree, featureWorktree])
+    let openPullRequest = makePullRequest(state: "OPEN", headRefName: featureWorktree.name, number: 12)
+    var state = makeState(repositories: [repository])
+    state.githubIntegrationAvailability = .disabled
+    state.worktreeInfoByID[featureWorktree.id] = WorktreeInfoEntry(
+      addedLines: nil,
+      removedLines: nil,
+      pullRequest: openPullRequest
+    )
+    let mergedStrategies = LockIsolated<[PullRequestMergeStrategy]>([])
+    @Shared(.settingsFile) var settingsFile
+    $settingsFile.withLock {
+      $0.global.pullRequestMergeStrategy = .squash
+    }
+    @Shared(.repositorySettings(repository.rootURL)) var repositorySettings
+    $repositorySettings.withLock {
+      $0.pullRequestMergeStrategy = nil
+    }
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.githubIntegration.isAvailable = { true }
+      $0.githubCLI.mergePullRequest = { _, _, strategy in
+        mergedStrategies.withValue { $0.append(strategy) }
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.githubIntegration(.pullRequestAction(featureWorktree.id, .merge)))
+    await store.receive(\.showToast) {
+      $0.statusToast = .inProgress("Merging pull request…")
+    }
+    await store.receive(\.showToast) {
+      $0.statusToast = .success("Pull request merged")
+    }
+    await store.receive(\.worktreeInfoEvent)
+    #expect(mergedStrategies.value == [.squash])
     await store.finish()
   }
 

--- a/supacodeTests/RepositorySettingsFeatureTests.swift
+++ b/supacodeTests/RepositorySettingsFeatureTests.swift
@@ -22,7 +22,7 @@ struct RepositorySettingsFeatureTests {
       worktreeBaseRef: "origin/main",
       copyIgnoredOnWorktreeCreate: true,
       copyUntrackedOnWorktreeCreate: true,
-      pullRequestMergeStrategy: .squash
+      pullRequestMergeStrategy: .squash,
     )
     let storedOnevcatSettings = UserRepositorySettings(
       customCommands: [.default(index: 0)]

--- a/supacodeTests/RepositorySettingsKeyTests.swift
+++ b/supacodeTests/RepositorySettingsKeyTests.swift
@@ -81,6 +81,61 @@ struct RepositorySettingsKeyTests {
     #expect(settings.archiveScript.isEmpty)
   }
 
+  @Test(.dependencies) func loadNormalizesLegacyDefaultOverridesToInheritedValues() throws {
+    let globalStorage = SettingsTestStorage()
+    let localStorage = RepositoryLocalSettingsTestStorage()
+    let rootURL = URL(fileURLWithPath: "/tmp/repo")
+    let settingsFileURL = URL(fileURLWithPath: "/tmp/supacode-settings-\(UUID().uuidString).json")
+    let localURL = SupacodePaths.repositorySettingsURL(for: rootURL)
+    let legacyData = Data(
+      """
+      {
+        "setupScript": "",
+        "archiveScript": "",
+        "runScript": "echo run",
+        "openActionID": "automatic",
+        "copyIgnoredOnWorktreeCreate": false,
+        "copyUntrackedOnWorktreeCreate": true,
+        "pullRequestMergeStrategy": "merge"
+      }
+      """.utf8
+    )
+
+    try localStorage.save(legacyData, at: localURL)
+
+    let loaded = withDependencies {
+      $0.settingsFileStorage = globalStorage.storage
+      $0.settingsFileURL = settingsFileURL
+      $0.repositoryLocalSettingsStorage = localStorage.storage
+    } operation: {
+      @Shared(.repositorySettings(rootURL)) var repositorySettings: RepositorySettings
+      return repositorySettings
+    }
+
+    #expect(loaded.copyIgnoredOnWorktreeCreate == nil)
+    #expect(loaded.copyUntrackedOnWorktreeCreate == true)
+    #expect(loaded.pullRequestMergeStrategy == nil)
+  }
+
+  @Test func decodeCurrentSchemaPreservesExplicitDefaultOverrides() throws {
+    let settings = RepositorySettings(
+      setupScript: "",
+      archiveScript: "",
+      runScript: "echo run",
+      openActionID: OpenWorktreeAction.automaticSettingsID,
+      worktreeBaseRef: nil,
+      copyIgnoredOnWorktreeCreate: false,
+      copyUntrackedOnWorktreeCreate: false,
+      pullRequestMergeStrategy: .merge,
+    )
+
+    let decoded = try JSONDecoder().decode(RepositorySettings.self, from: encode(settings))
+
+    #expect(decoded.copyIgnoredOnWorktreeCreate == false)
+    #expect(decoded.copyUntrackedOnWorktreeCreate == false)
+    #expect(decoded.pullRequestMergeStrategy == .merge)
+  }
+
   @Test(.dependencies) func loadPrefersLocalSupacodeJSONOverGlobalEntry() throws {
     let globalStorage = SettingsTestStorage()
     let localStorage = RepositoryLocalSettingsTestStorage()

--- a/supacodeTests/SettingsFeatureTests.swift
+++ b/supacodeTests/SettingsFeatureTests.swift
@@ -248,6 +248,47 @@ struct SettingsFeatureTests {
     #expect(settingsFile.global.defaultWorktreeBaseDirectoryPath == expectedPath)
   }
 
+  @Test(.dependencies) func changingGlobalOverrideDefaultsUpdatesRepositorySettingsState() async {
+    let rootURL = URL(fileURLWithPath: "/tmp/repo")
+    @Shared(.settingsFile) var settingsFile
+    $settingsFile.withLock { $0.global = .default }
+    var state = SettingsFeature.State()
+    state.repositorySettings = RepositorySettingsFeature.State(
+      rootURL: rootURL,
+      repositoryKind: .git,
+      settings: .default,
+      userSettings: .default
+    )
+    let store = TestStore(initialState: state) {
+      SettingsFeature()
+    }
+
+    await store.send(.binding(.set(\.copyIgnoredOnWorktreeCreate, true))) {
+      $0.copyIgnoredOnWorktreeCreate = true
+      $0.repositorySettings?.globalCopyIgnoredOnWorktreeCreate = true
+    }
+    await store.receive(\.delegate.settingsChanged)
+
+    await store.send(.binding(.set(\.copyUntrackedOnWorktreeCreate, true))) {
+      $0.copyUntrackedOnWorktreeCreate = true
+      $0.repositorySettings?.globalCopyUntrackedOnWorktreeCreate = true
+    }
+    await store.receive(\.delegate.settingsChanged)
+
+    await store.send(.binding(.set(\.pullRequestMergeStrategy, .squash))) {
+      $0.pullRequestMergeStrategy = .squash
+      $0.repositorySettings?.globalPullRequestMergeStrategy = .squash
+    }
+    await store.receive(\.delegate.settingsChanged)
+
+    #expect(store.state.repositorySettings?.globalCopyIgnoredOnWorktreeCreate == true)
+    #expect(store.state.repositorySettings?.globalCopyUntrackedOnWorktreeCreate == true)
+    #expect(store.state.repositorySettings?.globalPullRequestMergeStrategy == .squash)
+    #expect(settingsFile.global.copyIgnoredOnWorktreeCreate == true)
+    #expect(settingsFile.global.copyUntrackedOnWorktreeCreate == true)
+    #expect(settingsFile.global.pullRequestMergeStrategy == .squash)
+  }
+
   @Test(.dependencies) func setTerminalFontSizePersistsWithoutAnalyticsOrGlobalFanout() async {
     var initialSettings = GlobalSettings.default
     initialSettings.analyticsEnabled = true


### PR DESCRIPTION
## Summary

Closes #178

- Promotes `copyIgnoredOnWorktreeCreate`, `copyUntrackedOnWorktreeCreate`, and `pullRequestMergeStrategy` from repo-only settings to global defaults in `GlobalSettings`, with per-repo optional overrides (`nil` = use global).
- Adds global UI controls: copy flag toggles in Worktree settings tab, merge strategy picker in GitHub settings tab.
- Converts repo-level toggles to three-option pickers showing "Global (current value)" as the nil/default option alongside explicit Yes/No or strategy choices.
- Worktree creation and PR merge logic now falls back to global defaults when repo settings are nil.

## Test plan

- [x] `make build-app` succeeds
- [x] `make lint` passes
- [x] All existing tests pass (`** TEST SUCCEEDED **`)
- [x] Manual: verify global copy flag toggles appear in Settings > Worktree
- [x] Manual: verify global merge strategy picker appears in Settings > GitHub
- [x] Manual: verify repo-level pickers show "Global (Yes/No)" and "Global (Merge/Squash/Rebase)"
- [x] Manual: verify worktree creation honors global default when repo override is nil
- [x] Manual: verify PR merge honors global default when repo override is nil
- [x] Manual: verify repo-level override takes precedence when set
