### PR TITLE
fix: stop restored terminal surfaces from spinning CPU when not displayed

### DIFF
--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
@@ -997,6 +997,14 @@ final class GhosttySurfaceView: NSView, Identifiable {
   func setOcclusion(_ visible: Bool) {
     guard let surface else {
       guard skipsSurfaceCreationForTesting else { return }
+      // Occluding (pausing render) is always safe, even without a view
+      // hierarchy. This handles restored surfaces that haven't been attached
+      // to a window yet.
+      if !visible {
+        guard occlusionState.prepareToApply(false) else { return }
+        onOcclusionAppliedForTesting?(false)
+        return
+      }
       guard isReadyToApplyOcclusion else {
         if occlusionState.desired != visible {
           surfaceLogger.info(
@@ -1009,6 +1017,15 @@ final class GhosttySurfaceView: NSView, Identifiable {
       }
       guard occlusionState.prepareToApply(visible) else { return }
       onOcclusionAppliedForTesting?(visible)
+      return
+    }
+    // Occluding (pausing render) is always safe, even without a view
+    // hierarchy. This stops restored surfaces from spinning the GPU when
+    // they are not displayed.
+    if !visible {
+      guard occlusionState.prepareToApply(false) else { return }
+      onOcclusionAppliedForTesting?(false)
+      ghostty_surface_set_occlusion(surface, false)
       return
     }
     guard isReadyToApplyOcclusion else {

--- a/supacodeTests/GhosttySurfaceViewTests.swift
+++ b/supacodeTests/GhosttySurfaceViewTests.swift
@@ -142,16 +142,52 @@ struct GhosttySurfaceViewTests {
     surfaceView.handleAttachmentChangeForTesting()
     await drainMainQueue()
 
+    // Occluding (false) applies immediately even while detached to stop
+    // the render loop.  Un-occluding (true) is deferred until reattached.
     surfaceView.setOcclusion(false)
     surfaceView.setOcclusion(true)
     surfaceView.setOcclusion(false)
     await drainMainQueue()
-    #expect(appliedValues == [true])
+    #expect(appliedValues == [true, false])
 
     attachmentState = (hasSuperview: true, hasWindow: true)
     surfaceView.handleAttachmentChangeForTesting()
     await drainMainQueue()
-    #expect(appliedValues == [true, false])
+    // Reattachment re-applies the desired value (false) even though it
+    // was already applied, because invalidateForAttachmentChange clears
+    // the applied cache.
+    #expect(appliedValues == [true, false, false])
+  }
+
+  @Test func occlusionFalseAppliesImmediatelyWithoutViewAttachment() async {
+    let runtime = GhosttyRuntime()
+    let surfaceView = GhosttySurfaceView(
+      runtime: runtime,
+      workingDirectory: nil,
+      context: GHOSTTY_SURFACE_CONTEXT_TAB,
+      skipsSurfaceCreationForTesting: true
+    )
+    var appliedValues: [Bool] = []
+    surfaceView.onOcclusionAppliedForTesting = { appliedValues.append($0) }
+    var attachmentState = (hasSuperview: false, hasWindow: false)
+    surfaceView.attachmentStateForTesting = { attachmentState }
+
+    // Occluding without a view hierarchy applies immediately (stops the
+    // Metal render loop for restored surfaces that are never displayed).
+    surfaceView.setOcclusion(false)
+    await drainMainQueue()
+    #expect(appliedValues == [false])
+
+    // Un-occluding without a view hierarchy is deferred.
+    surfaceView.setOcclusion(true)
+    await drainMainQueue()
+    #expect(appliedValues == [false])
+
+    // Once attached, the deferred un-occlude is applied.
+    attachmentState = (hasSuperview: true, hasWindow: true)
+    surfaceView.handleAttachmentChangeForTesting()
+    await drainMainQueue()
+    #expect(appliedValues == [false, true])
   }
 
   private func drainMainQueue() async {


### PR DESCRIPTION
## Summary
- Fix restored terminal surfaces spinning the CPU/GPU when they are not displayed
- When occluding (pausing render), apply immediately even without a view hierarchy, so restored surfaces that haven't been attached to a window don't keep the Metal render loop running
- Add test coverage for the new occlusion behavior

## Test plan
- [x] Existing occlusion tests updated and passing
- [x] New test `occlusionFalseAppliesImmediatelyWithoutViewAttachment` added
- [x] Manual: restore a session with multiple terminals, verify CPU usage stays low for non-visible tabs