### PR TITLE
Fix canvas exit terminal host reattachment

### DIFF
--- a/doc-onevcat/canvas-exit-terminal-blank-tracking.md
+++ b/doc-onevcat/canvas-exit-terminal-blank-tracking.md
@@ -1,7 +1,7 @@
 # Canvas Exit Terminal Blank Tracking
 
-Last updated: 2026-04-11
-Status: Open, intermittent, likely long-lived native state issue
+Last updated: 2026-04-15
+Status: Open, intermittent, narrowed from occlusion-only suspicion to host reattachment failure
 
 ## Symptom
 
@@ -32,6 +32,7 @@ This strongly suggests a sticky stale state in the long-lived terminal/native vi
 - `supacode/Features/Terminal/Views/WorktreeTerminalTabsView.swift`
 - `supacode/Features/Terminal/Views/WindowFocusObserverView.swift`
 - `supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift`
+- `supacode/Infrastructure/Ghostty/GhosttyTerminalView.swift`
 - `supacode/Infrastructure/Ghostty/GhosttyRuntime.swift`
 - `supacode/Features/Canvas/Views/CanvasView.swift`
 
@@ -47,6 +48,11 @@ Known commits that attempted to address this family of issues:
 - `d4e59155` Add canvas exit terminal diagnostics and occlusion refresh
 - `e2a29b2c` test: cover Ghostty attachment occlusion behavior
 - `32f51451` Fix canvas exit terminal occlusion recovery
+- current branch `fix/canvas-exit-surface-reattach`
+  - add detach-intent stack logging before `GhosttySurfaceView` loses its superview/window
+  - add wrapper host diagnostics (`hostKind`, wrapper id, surface id)
+  - add terminal-only defensive reattach in `GhosttySurfaceScrollView.ensureSurfaceAttached()`
+  - add focused tests for terminal-vs-canvas wrapper ownership behavior
 
 Relevant changelog entries:
 
@@ -56,23 +62,28 @@ Relevant changelog entries:
 
 ## Current Working Theory
 
-The highest-probability root cause is a stale native terminal surface state after reparenting, likely amplified by long app lifetime and sleep/wake transitions.
+The highest-probability root cause is no longer "occlusion state got stale while the surface stayed attached".
 
-Current best hypothesis:
+New evidence from a reduced two-tab repro points to a more concrete failure mode:
 
-- Exiting Canvas causes `GhosttySurfaceView` to be reattached into the normal terminal hierarchy.
-- Reparenting invalidates the occlusion-applied cache.
-- In some sessions, especially after sleep/wake, the expected "surface is ready again, now reapply visible occlusion" chain does not complete reliably.
-- SwiftUI has already switched back to the normal terminal view, but Ghostty's renderer remains effectively paused or not fully resumed for that surface.
-- Switching tabs forces another round of visibility/focus activity, which recovers the surface.
+- the selected surface (`desired=Optional(true)`, focused, first responder) is briefly attached during Canvas exit
+- it reaches the normal terminal layout size
+- it is later detached (`attached=false window=false`)
+- no subsequent log shows that surface reattached to the final terminal host
 
-What is less likely at this point:
+This suggests the blank terminal is caused by host ownership loss:
 
-- Wrong worktree selection
-- Wrong selected tab restoration
-- Basic reducer ordering bug in `toggleCanvas`
+- SwiftUI/AppKit reparenting during Canvas teardown temporarily moves the `GhosttySurfaceView`
+- a later teardown or host rebuild removes the surface from the active view tree
+- the normal terminal host does not currently guarantee that its `documentView` still owns the surface after updates
+- once detached, occlusion recovery is irrelevant because there is no live host left to present the surface
 
-Those paths have been observed as correct in diagnostic logs while the surface still remained blank.
+What now looks less likely:
+
+- wrong worktree selection
+- wrong selected tab restoration
+- pure reducer ordering bug in `toggleCanvas`
+- occlusion cache invalidation as the sole root cause
 
 ## Logs Added For Ongoing Investigation
 
@@ -86,10 +97,14 @@ Two log markers should be collected together:
 Existing and previous diagnostics already cover:
 
 - `WorktreeTerminalTabsView.onAppear`
+- `WorktreeTerminalTabsView.onDisappear`
 - surface attachment changes
 - deferred occlusion
 - reapply occlusion
 - selected worktree transition when leaving Canvas
+- surface detach intent (`viewWillMove(toSuperview:/toWindow:)`) with call stack
+- host wrapper lifecycle (`hostMake`, `hostInit`, `hostUpdate`, `hostDeinit`, `hostReattach`)
+- per-surface host metadata (`hostKind`, wrapper id)
 
 ### `[TerminalWake]`
 
@@ -147,26 +162,27 @@ log stream --style compact \
 When the bug reproduces again, compare a healthy exit and a broken exit for:
 
 - whether `workspaceDidWake` or `screensDidWake` happened shortly before failures started
-- whether the affected surface reports `desired=Optional(true)` but never logs `reapplyOcclusion`
+- whether the affected surface logs `detachIntent` before going blank, and which stack removes it
+- whether a terminal host logs `hostUpdate` but never `hostReattach` for the affected surface
+- whether the terminal host does log `hostReattach`, but the surface still remains blank afterward
 - whether `WindowFocusObserverView` still reports the window as visible/key when the blank terminal is shown
-- whether the affected surface is attached to a superview and window but still does not recover
-- whether `bounds` and `backing` stop changing for the affected surface while the view is visibly present
 
 ## Open Questions
 
 - Is sleep/wake the true trigger, or just the most common way to enter the stale state?
-- Is the bad state owned by `GhosttySurfaceView`, underlying `ghostty_surface_t`, or AppKit/Metal attachment?
-- Does the failure always affect the same surface instance for a worktree, or any surface after the session becomes "poisoned"?
-- Would an explicit post-wake surface refresh solve the actual root cause, or only mask a lower-level Ghostty/AppKit lifecycle issue?
+- Which host teardown path actually performs the final detach: Canvas wrapper cleanup, terminal wrapper replacement, or another AppKit rebuild?
+- If terminal-side defensive reattach works, is it sufficient as the durable fix or just masking a lower-level host lifecycle race?
+- If reattach does not work, is the detached native view still valid, or do we need to recreate the underlying `ghostty_surface_t`?
 
 ## Next Step Candidates
 
 Do not do these preemptively unless new logs support them:
 
+- widen defensive reattach beyond the normal terminal host
+- recreate a surface when host reattach fails
 - add explicit post-wake repair for all active surfaces
 - force-resend occlusion and size after wake
 - force content-scale/display-id refresh after wake
-- invalidate more cached state after wake, not only after attachment changes
 
 ## Notes
 
@@ -177,3 +193,23 @@ This document should be updated every time:
 - a repro pattern changes
 - a candidate fix is attempted
 - a failed fix is ruled out
+
+## 2026-04-15 Snapshot
+
+Latest reduced repro:
+
+- two tabs only
+- selected tab surface detached after briefly reaching terminal-sized bounds
+- no reattach log observed afterward
+
+Current tactical response:
+
+- add detach stack logging to identify who removes the surface
+- add host wrapper diagnostics to correlate `surface ↔ wrapper ↔ canvas/terminal`
+- attempt a narrow fix: terminal host reattaches the surface if updates/layout find it missing
+
+Expected interpretation of the next repro:
+
+- if `hostReattach` appears and the terminal becomes visible again, the bug is likely host ownership loss during Canvas teardown
+- if `hostReattach` appears but the terminal stays blank, the issue may still involve stale native surface/render state after detach
+- if no terminal `hostReattach` appears, the active terminal host may not be rebuilding/updating as expected

--- a/doc-onevcat/canvas-exit-terminal-blank-tracking.md
+++ b/doc-onevcat/canvas-exit-terminal-blank-tracking.md
@@ -104,6 +104,7 @@ Existing and previous diagnostics already cover:
 - selected worktree transition when leaving Canvas
 - surface detach intent (`viewWillMove(toSuperview:/toWindow:)`) with call stack
 - host wrapper lifecycle (`hostMake`, `hostInit`, `hostUpdate`, `hostDeinit`, `hostReattach`)
+- host reattach completion snapshot (`hostReattachComplete`)
 - per-surface host metadata (`hostKind`, wrapper id)
 
 ### `[TerminalWake]`
@@ -120,6 +121,7 @@ Added on 2026-04-11 to correlate future failures with sleep/wake and long-lived 
   - per-surface state snapshot on workspace sleep/wake
   - per-surface state snapshot on `viewDidMoveToWindow`
   - per-surface state snapshot on `viewDidMoveToSuperview`
+  - detach-time safety-net request back to the last known terminal host
 - `WindowFocusObserverView`
   - window activity changes (`key`, `visible`, `force`, `windowNumber`)
 
@@ -207,6 +209,7 @@ Current tactical response:
 - add detach stack logging to identify who removes the surface
 - add host wrapper diagnostics to correlate `surface ↔ wrapper ↔ canvas/terminal`
 - attempt a narrow fix: terminal host reattaches the surface if updates/layout find it missing
+- add a detach-time safety net so a just-detached surface asks its last terminal host to try reattachment on the next main-loop turn
 
 Expected interpretation of the next repro:
 

--- a/supacode/Features/Terminal/Views/WorktreeTerminalTabsView.swift
+++ b/supacode/Features/Terminal/Views/WorktreeTerminalTabsView.swift
@@ -67,6 +67,14 @@ struct WorktreeTerminalTabsView: View {
       )
       state.syncFocus(windowIsKey: activity.isKeyWindow, windowIsVisible: activity.isVisible)
     }
+    .onDisappear {
+      let activity = resolvedWindowActivity
+      terminalTabsLogger.info(
+        "[CanvasExit] onDisappear worktree=\(worktree.id) "
+          + "selectedTab=\(state.tabManager.selectedTabId?.rawValue.uuidString ?? "nil") "
+          + "windowKey=\(activity.isKeyWindow) windowVisible=\(activity.isVisible)"
+      )
+    }
     .onChange(of: state.tabManager.selectedTabId) { _, newValue in
       if shouldAutoFocusTerminal {
         state.focusSelectedTab()

--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
@@ -6,6 +6,7 @@ import QuartzCore
 import SwiftUI
 
 private let surfaceLogger = SupaLogger("Surface")
+private let surfaceHostLogger = SupaLogger("SurfaceHost")
 
 final class GhosttySurfaceView: NSView, Identifiable {
   struct OcclusionState {
@@ -98,6 +99,9 @@ final class GhosttySurfaceView: NSView, Identifiable {
   let id = UUID()
   private var debugID: String {
     String(id.uuidString.prefix(8))
+  }
+  var debugIdentifierForLogging: String {
+    debugID
   }
   let bridge: GhosttySurfaceBridge
   private(set) var surface: ghostty_surface_t?
@@ -449,6 +453,20 @@ final class GhosttySurfaceView: NSView, Identifiable {
     super.viewDidMoveToSuperview()
     logLifecycleState("viewDidMoveToSuperview")
     handleAttachmentChange()
+  }
+
+  override func viewWillMove(toSuperview newSuperview: NSView?) {
+    if newSuperview == nil {
+      logDetachIntent(event: "viewWillMoveToSuperview")
+    }
+    super.viewWillMove(toSuperview: newSuperview)
+  }
+
+  override func viewWillMove(toWindow newWindow: NSWindow?) {
+    if newWindow == nil {
+      logDetachIntent(event: "viewWillMoveToWindow")
+    }
+    super.viewWillMove(toWindow: newWindow)
   }
 
   override func viewDidChangeBackingProperties() {
@@ -1108,7 +1126,9 @@ final class GhosttySurfaceView: NSView, Identifiable {
     surfaceLogger.info(
       "[CanvasExit] attachmentChange surface=\(debugID) "
         + "desired=\(String(describing: occlusionState.desired)) "
-        + "attached=\(hasAttachedSuperview) window=\(hasAttachedWindow)"
+        + "attached=\(hasAttachedSuperview) window=\(hasAttachedWindow) "
+        + "host=\(scrollWrapper?.hostKind.rawValue ?? "none") "
+        + "wrapper=\(scrollWrapper?.debugIdentifier ?? "none")"
     )
     _ = occlusionState.invalidateForAttachmentChange()
     guard isReadyToApplyOcclusion else { return }
@@ -1141,7 +1161,20 @@ final class GhosttySurfaceView: NSView, Identifiable {
         + "focused=\(focused) firstResponder=\(firstResponderMatches) "
         + "bounds=\(Int(bounds.width))x\(Int(bounds.height)) "
         + "backing=\(Int(lastBackingSize.width))x\(Int(lastBackingSize.height)) "
-        + "windowVisible=\(windowVisible) windowKey=\(windowKey)"
+        + "windowVisible=\(windowVisible) windowKey=\(windowKey) "
+        + "host=\(scrollWrapper?.hostKind.rawValue ?? "none") "
+        + "wrapper=\(scrollWrapper?.debugIdentifier ?? "none")"
+    )
+  }
+
+  private func logDetachIntent(event: String) {
+    let stack = Thread.callStackSymbols.prefix(12).joined(separator: " | ")
+    surfaceLogger.info(
+      "[CanvasExit] detachIntent event=\(event) surface=\(debugID) "
+        + "host=\(scrollWrapper?.hostKind.rawValue ?? "none") "
+        + "wrapper=\(scrollWrapper?.debugIdentifier ?? "none") "
+        + "superview=\(String(describing: superview)) window=\(window != nil) "
+        + "stack=\(stack)"
     )
   }
 
@@ -2311,6 +2344,11 @@ extension GhosttySurfaceView: NSServicesMenuRequestor {
 }
 
 final class GhosttySurfaceScrollView: NSView {
+  enum HostKind: String {
+    case terminal
+    case canvas
+  }
+
   private struct ScrollbarState {
     let total: UInt64
     let offset: UInt64
@@ -2320,6 +2358,11 @@ final class GhosttySurfaceScrollView: NSView {
   private let scrollView: NSScrollView
   private let documentView: NSView
   private let surfaceView: GhosttySurfaceView
+  let hostKind: HostKind
+  private let debugID = String(UUID().uuidString.prefix(8))
+  var debugIdentifier: String {
+    debugID
+  }
   private var observers: [NSObjectProtocol] = []
 
   private var isLiveScrolling = false
@@ -2333,8 +2376,9 @@ final class GhosttySurfaceScrollView: NSView {
   /// terminal reflow.
   var pinnedSize: CGSize?
 
-  init(surfaceView: GhosttySurfaceView) {
+  init(surfaceView: GhosttySurfaceView, hostKind: HostKind) {
     self.surfaceView = surfaceView
+    self.hostKind = hostKind
     scrollView = NSScrollView()
     scrollView.hasHorizontalScroller = false
     scrollView.autohidesScrollers = false
@@ -2348,6 +2392,11 @@ final class GhosttySurfaceScrollView: NSView {
     super.init(frame: .zero)
     addSubview(scrollView)
     surfaceView.scrollWrapper = self
+    surfaceHostLogger.info(
+      "[CanvasExit] hostInit wrapper=\(debugID) host=\(hostKind.rawValue) "
+        + "surface=\(surfaceView.debugIdentifierForLogging) "
+        + "attached=\(isSurfaceAttachedToDocumentView)"
+    )
     refreshAppearance()
 
     scrollView.contentView.postsBoundsChangedNotifications = true
@@ -2424,11 +2473,17 @@ final class GhosttySurfaceScrollView: NSView {
   }
 
   isolated deinit {
+    surfaceHostLogger.info(
+      "[CanvasExit] hostDeinit wrapper=\(debugID) host=\(hostKind.rawValue) "
+        + "surface=\(surfaceView.debugIdentifierForLogging) "
+        + "attached=\(isSurfaceAttachedToDocumentView)"
+    )
     observers.forEach { NotificationCenter.default.removeObserver($0) }
   }
 
   override func layout() {
     super.layout()
+    ensureSurfaceAttached()
     let effectiveSize = pinnedSize ?? bounds.size
     scrollView.frame = CGRect(origin: .zero, size: effectiveSize)
     surfaceView.frame.size = effectiveSize
@@ -2438,9 +2493,34 @@ final class GhosttySurfaceScrollView: NSView {
     surfaceView.updateSurfaceSize()
   }
 
+  override func viewDidMoveToWindow() {
+    super.viewDidMoveToWindow()
+    ensureSurfaceAttached()
+  }
+
   func updateSurfaceSize() {
     surfaceView.updateSurfaceSize()
     needsLayout = true
+  }
+
+  var isSurfaceAttachedToDocumentView: Bool {
+    surfaceView.superview === documentView
+  }
+
+  func ensureSurfaceAttached(requiresLiveHost: Bool = true) {
+    guard hostKind == .terminal else { return }
+    if requiresLiveHost {
+      guard superview != nil || window != nil else { return }
+    }
+    guard !isSurfaceAttachedToDocumentView else { return }
+    surfaceHostLogger.info(
+      "[CanvasExit] hostReattach wrapper=\(debugID) host=\(hostKind.rawValue) "
+        + "surface=\(surfaceView.debugIdentifierForLogging) "
+        + "currentSuperview=\(String(describing: surfaceView.superview)) "
+        + "wrapperWindow=\(window != nil)"
+    )
+    documentView.addSubview(surfaceView)
+    surfaceView.scrollWrapper = self
   }
 
   func updateScrollbar(total: UInt64, offset: UInt64, length: UInt64) {

--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
@@ -1131,6 +1131,11 @@ final class GhosttySurfaceView: NSView, Identifiable {
         + "wrapper=\(scrollWrapper?.debugIdentifier ?? "none")"
     )
     _ = occlusionState.invalidateForAttachmentChange()
+    if superview == nil {
+      DispatchQueue.main.async { [weak self] in
+        self?.scrollWrapper?.ensureSurfaceAttached()
+      }
+    }
     guard isReadyToApplyOcclusion else { return }
     DispatchQueue.main.async { [weak self] in
       self?.reapplyOcclusionIfNeeded()
@@ -2521,6 +2526,13 @@ final class GhosttySurfaceScrollView: NSView {
     )
     documentView.addSubview(surfaceView)
     surfaceView.scrollWrapper = self
+    surfaceHostLogger.info(
+      "[CanvasExit] hostReattachComplete wrapper=\(debugID) host=\(hostKind.rawValue) "
+        + "surface=\(surfaceView.debugIdentifierForLogging) "
+        + "superview=\(surfaceView.superview != nil) "
+        + "window=\(surfaceView.window != nil) "
+        + "bounds=\(Int(surfaceView.bounds.width))x\(Int(surfaceView.bounds.height))"
+    )
   }
 
   func updateScrollbar(total: UInt64, offset: UInt64, length: UInt64) {

--- a/supacode/Infrastructure/Ghostty/GhosttyTerminalView.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttyTerminalView.swift
@@ -1,16 +1,34 @@
 import SwiftUI
 
+private let terminalHostLogger = SupaLogger("TerminalHost")
+
 struct GhosttyTerminalView: NSViewRepresentable {
   let surfaceView: GhosttySurfaceView
   var pinnedSize: CGSize?
 
+  private var hostKind: GhosttySurfaceScrollView.HostKind {
+    pinnedSize == nil ? .terminal : .canvas
+  }
+
   func makeNSView(context: Context) -> GhosttySurfaceScrollView {
-    let view = GhosttySurfaceScrollView(surfaceView: surfaceView)
+    let view = GhosttySurfaceScrollView(surfaceView: surfaceView, hostKind: hostKind)
     view.pinnedSize = pinnedSize
+    terminalHostLogger.info(
+      "[CanvasExit] hostMake wrapper=\(view.debugIdentifier) host=\(hostKind.rawValue) "
+        + "surface=\(surfaceView.debugIdentifierForLogging) "
+        + "pinned=\(pinnedSize != nil)"
+    )
     return view
   }
 
   func updateNSView(_ view: GhosttySurfaceScrollView, context: Context) {
     view.pinnedSize = pinnedSize
+    terminalHostLogger.info(
+      "[CanvasExit] hostUpdate wrapper=\(view.debugIdentifier) host=\(hostKind.rawValue) "
+        + "surface=\(surfaceView.debugIdentifierForLogging) "
+        + "pinned=\(pinnedSize != nil) "
+        + "attached=\(view.isSurfaceAttachedToDocumentView)"
+    )
+    view.ensureSurfaceAttached()
   }
 }

--- a/supacodeTests/GhosttySurfaceViewTests.swift
+++ b/supacodeTests/GhosttySurfaceViewTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import GhosttyKit
 import Testing
@@ -215,6 +216,50 @@ struct GhosttySurfaceViewTests {
     surfaceView.resumeDeferredOcclusionIfNeededForTesting()
     await drainMainQueue()
     #expect(appliedValues == [true, true])
+  }
+
+  @Test func terminalHostReattachesDetachedSurface() {
+    let runtime = GhosttyRuntime()
+    let surfaceView = GhosttySurfaceView(
+      runtime: runtime,
+      workingDirectory: nil,
+      context: GHOSTTY_SURFACE_CONTEXT_TAB,
+      skipsSurfaceCreationForTesting: true
+    )
+    let terminalHost = GhosttySurfaceScrollView(surfaceView: surfaceView, hostKind: .terminal)
+    let foreignHost = NSView()
+
+    #expect(terminalHost.isSurfaceAttachedToDocumentView)
+
+    foreignHost.addSubview(surfaceView)
+    #expect(!terminalHost.isSurfaceAttachedToDocumentView)
+
+    terminalHost.ensureSurfaceAttached(requiresLiveHost: false)
+
+    #expect(terminalHost.isSurfaceAttachedToDocumentView)
+    #expect(surfaceView.scrollWrapper === terminalHost)
+  }
+
+  @Test func canvasHostDoesNotStealDetachedSurfaceBack() {
+    let runtime = GhosttyRuntime()
+    let surfaceView = GhosttySurfaceView(
+      runtime: runtime,
+      workingDirectory: nil,
+      context: GHOSTTY_SURFACE_CONTEXT_TAB,
+      skipsSurfaceCreationForTesting: true
+    )
+    let canvasHost = GhosttySurfaceScrollView(surfaceView: surfaceView, hostKind: .canvas)
+    let foreignHost = NSView()
+
+    #expect(canvasHost.isSurfaceAttachedToDocumentView)
+
+    foreignHost.addSubview(surfaceView)
+    #expect(!canvasHost.isSurfaceAttachedToDocumentView)
+
+    canvasHost.ensureSurfaceAttached(requiresLiveHost: false)
+
+    #expect(!canvasHost.isSurfaceAttachedToDocumentView)
+    #expect(surfaceView.superview === foreignHost)
   }
 
   private func drainMainQueue() async {


### PR DESCRIPTION
## Summary
- add detach-intent and host-wrapper diagnostics for canvas exit terminal surfaces
- add a terminal-only defensive reattach path when the active host detects its surface is no longer under its document view
- cover terminal vs canvas host ownership behavior in `GhosttySurfaceViewTests` and update the tracking document with the new hypothesis

## Verification
- `xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -only-testing:supacodeTests/GhosttySurfaceViewTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation 2>&1 | xcsift -f toon -E`
- `make lint`
- `make build-app`
