### PR TITLE
Fix canvas split pane rendering freeze

### DIFF
--- a/supacode/Features/Canvas/Views/CanvasView.swift
+++ b/supacode/Features/Canvas/Views/CanvasView.swift
@@ -644,6 +644,13 @@ struct CanvasView: View {
 
     let activeStates = terminalManager.activeWorktreeStates
 
+    // Mark all states as canvas-managed so that tree updates (e.g. split
+    // creation) don't trigger applySurfaceActivity with stale normal-mode
+    // window visibility, which would occlude every surface.
+    for state in activeStates {
+      state.isCanvasManaged = true
+    }
+
     // Auto-focus the card that was active before entering canvas.
     if let selectedID = terminalManager.selectedWorktreeID,
       let state = activeStates.first(where: { $0.worktreeID == selectedID }),
@@ -670,7 +677,11 @@ struct CanvasView: View {
   }
 
   private func deactivateCanvas() {
-    clearBroadcastCallbacks(states: terminalManager.activeWorktreeStates)
+    let activeStates = terminalManager.activeWorktreeStates
+    for state in activeStates {
+      state.isCanvasManaged = false
+    }
+    clearBroadcastCallbacks(states: activeStates)
     selectionState.clear()
     // Don't occlude surfaces here. In SwiftUI's if/else view swap,
     // onAppear fires before onDisappear, so occluding here would undo

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -32,6 +32,10 @@ final class WorktreeTerminalState {
   private var lastEmittedFocusSurfaceId: UUID?
   private var lastWindowIsKey: Bool?
   private var lastWindowIsVisible: Bool?
+  /// When `true`, Canvas owns occlusion management for this state's surfaces.
+  /// `syncFocusIfNeeded` skips `applySurfaceActivity` to avoid overriding
+  /// Canvas-set occlusion with stale normal-mode window activity values.
+  var isCanvasManaged = false
   var notifications: [WorktreeTerminalNotification] = []
   var notificationsEnabled = true
   private var commandFinishedNotificationEnabled = true
@@ -497,6 +501,10 @@ final class WorktreeTerminalState {
           direction: mapSplitDirection(direction)
         )
         updateTree(newTree, for: tabId)
+        // Canvas manages occlusion directly; ensure the new pane renders.
+        if isCanvasManaged {
+          newSurface.setOcclusion(true)
+        }
         focusSurface(newSurface, in: tabId)
         return true
       } catch {
@@ -1320,6 +1328,7 @@ final class WorktreeTerminalState {
   }
 
   private func syncFocusIfNeeded() {
+    guard !isCanvasManaged else { return }
     guard lastWindowIsKey != nil, lastWindowIsVisible != nil else { return }
     applySurfaceActivity()
   }


### PR DESCRIPTION
## Summary

- Fix rendering freeze when creating split panes (Cmd+D / Cmd+Shift+D) in Canvas mode
- All surfaces stopped rendering but still accepted input, making the tab appear frozen
- Regression since v2026.4.2 (commit 979e8e2f), confirmed working in v2026.3.28

## Root Cause

`979e8e2f` changed tree mutations to call `syncFocusIfNeeded` → `applySurfaceActivity` after every update. When entering Canvas, `WorktreeTerminalTabsView` is removed, causing `WindowFocusObserverNSView` to fire `syncFocus(windowIsKey: false, windowIsVisible: false)`. This stale `lastWindowIsVisible=false` then caused `applySurfaceActivity` to call `setOcclusion(false)` on every surface whenever the split tree changed in Canvas.

## Fix

Add `isCanvasManaged` flag on `WorktreeTerminalState` so `syncFocusIfNeeded` skips `applySurfaceActivity` while Canvas owns occlusion management. New split panes are explicitly un-occluded when the flag is active.

## Test plan

- [x] Enter Canvas mode with at least one card
- [x] Focus a card and press Cmd+D to create a vertical split — both panes should render and accept input
- [x] Press Cmd+Shift+D to create a horizontal split — same expectation
- [x] Exit Canvas back to normal view — terminal should display correctly (no regression on canvas-exit-blank)
- [x] Re-enter Canvas — all cards should render (no regression on canvas-entry-blank)
- [x] Existing unit tests pass: `TerminalRenderingPolicyTests`, `GhosttySurfaceViewTests`, `SplitTreeTests`
