### PR TITLE
Fix canvas two-finger pan gesture interrupted by focused terminals

### DIFF
--- a/supacode/Features/Canvas/Views/CanvasView.swift
+++ b/supacode/Features/Canvas/Views/CanvasView.swift
@@ -753,11 +753,119 @@ private class CanvasScrollCoordinator {
 private class CanvasScrollContainerView: NSView {
   var scrollCoordinator: CanvasScrollCoordinator?
 
+  /// Whether the container is actively redirecting scroll events to canvas
+  /// panning (as opposed to the brief bounce period after a gesture ends).
+  private var isPanning = false
+  private var scrollMonitor: Any?
+  /// Brief delay after finger-up to wait for momentum events.
+  private var momentumTimer: Timer?
+  /// Grace period after a pan gesture ends. A follow-up gesture that begins
+  /// during this window is still treated as canvas panning, even if the
+  /// cursor now sits on a focused terminal.
+  private var bounceTimer: Timer?
+
   override func scrollWheel(with event: NSEvent) {
+    if event.phase == .began {
+      startPanning()
+    }
     if event.phase == .began || event.phase == .changed || event.phase == .mayBegin || event.momentumPhase != [] {
       scrollCoordinator?.handleScroll(deltaX: event.scrollingDeltaX, deltaY: event.scrollingDeltaY)
       return
     }
     super.scrollWheel(with: event)
+  }
+
+  // MARK: - Pan lifecycle
+
+  private func startPanning() {
+    isPanning = true
+    momentumTimer?.invalidate()
+    momentumTimer = nil
+    bounceTimer?.invalidate()
+    bounceTimer = nil
+    guard scrollMonitor == nil else { return }
+    installMonitor()
+  }
+
+  private func installMonitor() {
+    scrollMonitor = NSEvent.addLocalMonitorForEvents(matching: .scrollWheel) { [weak self] event in
+      guard let self, event.window === self.window else { return event }
+
+      // --- New gesture ------------------------------------------------
+      if event.phase == .began {
+        if self.isPanning {
+          // Already panning (edge case). Let normal dispatch decide.
+          return event
+        }
+        // Within the bounce window — treat as a continuation of panning.
+        self.startPanning()
+        self.scrollCoordinator?.handleScroll(
+          deltaX: event.scrollingDeltaX,
+          deltaY: event.scrollingDeltaY
+        )
+        return nil
+      }
+
+      // Only intercept while actively panning (not during bounce).
+      guard self.isPanning else { return event }
+
+      // --- Ongoing gesture / momentum --------------------------------
+      self.momentumTimer?.invalidate()
+      self.momentumTimer = nil
+
+      if event.phase == .changed || event.momentumPhase != [] {
+        self.scrollCoordinator?.handleScroll(
+          deltaX: event.scrollingDeltaX,
+          deltaY: event.scrollingDeltaY
+        )
+      }
+
+      // Finger lifted — momentum may follow shortly.
+      if event.phase == .ended || event.phase == .cancelled {
+        self.momentumTimer = Timer.scheduledTimer(
+          withTimeInterval: 0.1, repeats: false
+        ) { [weak self] _ in
+          MainActor.assumeIsolated { self?.enterBounce() }
+        }
+      }
+
+      // Momentum finished.
+      if event.momentumPhase == .ended || event.momentumPhase == .cancelled {
+        self.enterBounce()
+      }
+
+      return nil
+    }
+  }
+
+  /// Transition from active panning to the bounce (grace) period.
+  /// The monitor stays alive so a quick follow-up gesture resumes panning.
+  private func enterBounce() {
+    isPanning = false
+    momentumTimer?.invalidate()
+    momentumTimer = nil
+    bounceTimer?.invalidate()
+    bounceTimer = Timer.scheduledTimer(
+      withTimeInterval: 0.3, repeats: false
+    ) { [weak self] _ in
+      MainActor.assumeIsolated { self?.tearDownMonitor() }
+    }
+  }
+
+  private func tearDownMonitor() {
+    isPanning = false
+    momentumTimer?.invalidate()
+    momentumTimer = nil
+    bounceTimer?.invalidate()
+    bounceTimer = nil
+    if let monitor = scrollMonitor {
+      scrollMonitor = nil
+      DispatchQueue.main.async { MainActor.assumeIsolated { NSEvent.removeMonitor(monitor) } }
+    }
+  }
+
+  override func removeFromSuperview() {
+    tearDownMonitor()
+    super.removeFromSuperview()
   }
 }

--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
@@ -888,6 +888,15 @@ final class GhosttySurfaceView: NSView, Identifiable {
 
   override func scrollWheel(with event: NSEvent) {
     guard let surface else { return }
+
+    // In canvas mode, if the terminal has no scrollback content the scroll
+    // event is useless here. Let it bubble up to the canvas container so
+    // two-finger gestures pan the canvas instead of being swallowed.
+    if scrollWrapper?.hostKind == .canvas, !hasScrollbackContent {
+      scrollWrapper?.forwardScrollToParent(with: event)
+      return
+    }
+
     var scrollX = event.scrollingDeltaX
     var scrollY = event.scrollingDeltaY
     if event.hasPreciseScrollingDeltas {
@@ -895,6 +904,11 @@ final class GhosttySurfaceView: NSView, Identifiable {
       scrollY *= 2
     }
     ghostty_surface_mouse_scroll(surface, scrollX, scrollY, scrollMods(for: event))
+  }
+
+  private var hasScrollbackContent: Bool {
+    guard let lastScrollbar else { return false }
+    return lastScrollbar.total > lastScrollbar.length
   }
 
   override func pressureChange(with event: NSEvent) {
@@ -2540,6 +2554,14 @@ final class GhosttySurfaceScrollView: NSView {
   func updateScrollbar(total: UInt64, offset: UInt64, length: UInt64) {
     scrollbar = ScrollbarState(total: total, offset: offset, length: length)
     synchronizeScrollView()
+  }
+
+  /// Forward a scroll event to the parent responder chain, bypassing the
+  /// internal NSScrollView which would otherwise consume it.  Used in
+  /// canvas mode when the terminal has no scrollback content so the event
+  /// can reach CanvasScrollContainerView for canvas panning.
+  func forwardScrollToParent(with event: NSEvent) {
+    super.scrollWheel(with: event)
   }
 
   func refreshAppearance() {


### PR DESCRIPTION
## Summary
- **Gesture continuity**: Install a local `NSEvent` monitor when a canvas pan begins so focused terminals under the cursor cannot steal scroll events mid-gesture.
- **Bounce window**: After a pan gesture ends (including momentum), keep the monitor alive for 0.3s so a quick follow-up gesture is still treated as canvas panning — even if the cursor now rests on a focused card.
- **No-scrollback passthrough**: In canvas mode, terminals with no scrollback content forward scroll events to the parent responder chain (bypassing the internal `NSScrollView`) so they reach `CanvasScrollContainerView` and pan the canvas instead of being silently consumed.

## Test plan
- [x] In canvas, two-finger pan starting on empty space — verify smooth panning
- [x] During a pan, move cursor over a focused card — verify panning continues uninterrupted
- [x] Pan, lift fingers on a focused card, immediately pan again within ~0.3s — verify second gesture continues panning
- [x] Scroll on a focused card with scrollback content — verify terminal scrolls normally
- [x] Scroll on a focused card with no scrollback (fresh shell prompt) — verify canvas pans instead
- [x] Wait >0.3s after panning, then scroll on a focused card with scrollback — verify terminal scrolls normally