### PR TITLE
Custom Command: New Split target + Close on success

### DIFF
--- a/supacode/Clients/Terminal/TerminalClient.swift
+++ b/supacode/Clients/Terminal/TerminalClient.swift
@@ -8,12 +8,19 @@ struct TerminalClient {
 
   enum Command: Equatable {
     case createTab(Worktree, runSetupScriptIfNew: Bool)
-    case createTabWithInput(Worktree, input: String, runSetupScriptIfNew: Bool, autoCloseOnSuccess: Bool)
+    case createTabWithInput(
+      Worktree,
+      input: String,
+      runSetupScriptIfNew: Bool,
+      autoCloseOnSuccess: Bool,
+      customCommandName: String? = nil
+    )
     case createSplitWithInput(
       Worktree,
       direction: UserCustomSplitDirection,
       input: String,
-      autoCloseOnSuccess: Bool
+      autoCloseOnSuccess: Bool,
+      customCommandName: String? = nil
     )
     case createTabInDirectory(Worktree, directory: URL)
     case ensureInitialTab(Worktree, runSetupScriptIfNew: Bool, focusing: Bool)
@@ -38,6 +45,7 @@ struct TerminalClient {
   }
 
   enum Event: Equatable {
+    case customCommandSucceeded(worktreeID: Worktree.ID, name: String, durationMs: Int)
     case notificationReceived(worktreeID: Worktree.ID, title: String, body: String)
     case notificationIndicatorChanged(count: Int)
     case tabCreated(worktreeID: Worktree.ID)

--- a/supacode/Clients/Terminal/TerminalClient.swift
+++ b/supacode/Clients/Terminal/TerminalClient.swift
@@ -8,7 +8,13 @@ struct TerminalClient {
 
   enum Command: Equatable {
     case createTab(Worktree, runSetupScriptIfNew: Bool)
-    case createTabWithInput(Worktree, input: String, runSetupScriptIfNew: Bool)
+    case createTabWithInput(Worktree, input: String, runSetupScriptIfNew: Bool, autoCloseOnSuccess: Bool)
+    case createSplitWithInput(
+      Worktree,
+      direction: UserCustomSplitDirection,
+      input: String,
+      autoCloseOnSuccess: Bool
+    )
     case createTabInDirectory(Worktree, directory: URL)
     case ensureInitialTab(Worktree, runSetupScriptIfNew: Bool, focusing: Bool)
     case runScript(Worktree, script: String)

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -627,6 +627,7 @@ struct AppFeature {
         }
         let command = customCommand.command
         let closeOnSuccess = customCommand.closeOnSuccess
+        let commandName = customCommand.resolvedTitle
         switch customCommand.execution {
         case .shellScript:
           return .run { _ in
@@ -635,7 +636,8 @@ struct AppFeature {
                 worktree,
                 input: command,
                 runSetupScriptIfNew: false,
-                autoCloseOnSuccess: closeOnSuccess
+                autoCloseOnSuccess: closeOnSuccess,
+                customCommandName: commandName
               )
             )
           }
@@ -647,7 +649,8 @@ struct AppFeature {
                 worktree,
                 direction: direction,
                 input: command,
-                autoCloseOnSuccess: closeOnSuccess
+                autoCloseOnSuccess: closeOnSuccess,
+                customCommandName: commandName
               )
             )
           }
@@ -914,6 +917,10 @@ struct AppFeature {
       case .commandPalette:
         return .none
 
+      case .terminalEvent(.customCommandSucceeded(_, let name, let durationMs)):
+        let message = "\(name) succeeded in \(formatCustomCommandDuration(durationMs))"
+        return .send(.repositories(.showToast(.success(message))))
+
       case .terminalEvent(.notificationReceived(let worktreeID, let title, let body)):
         var effects: [Effect<Action>] = [
           .send(.repositories(.worktreeOrdering(.worktreeNotificationReceived(worktreeID))))
@@ -1008,4 +1015,18 @@ struct AppFeature {
       CommandPaletteFeature()
     }
   }
+}
+
+// Renders Custom Command run duration for status toasts.
+// Sub-second runs show ms; short runs show one decimal; long runs reuse the
+// whole-seconds formatter used by other command-finished notifications.
+func formatCustomCommandDuration(_ durationMs: Int) -> String {
+  if durationMs < 1_000 {
+    return "\(max(durationMs, 0))ms"
+  }
+  let seconds = Double(durationMs) / 1_000.0
+  if seconds < 10 {
+    return String(format: "%.1fs", seconds)
+  }
+  return WorktreeTerminalState.formatDuration(Int(seconds))
 }

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -534,7 +534,8 @@ struct AppFeature {
               .createTabWithInput(
                 worktree,
                 input: "$EDITOR",
-                runSetupScriptIfNew: shouldRunSetupScript
+                runSetupScriptIfNew: shouldRunSetupScript,
+                autoCloseOnSuccess: false
               )
             )
           }
@@ -625,6 +626,7 @@ struct AppFeature {
           return .none
         }
         let command = customCommand.command
+        let closeOnSuccess = customCommand.closeOnSuccess
         switch customCommand.execution {
         case .shellScript:
           return .run { _ in
@@ -632,7 +634,20 @@ struct AppFeature {
               .createTabWithInput(
                 worktree,
                 input: command,
-                runSetupScriptIfNew: false
+                runSetupScriptIfNew: false,
+                autoCloseOnSuccess: closeOnSuccess
+              )
+            )
+          }
+        case .split:
+          let direction = customCommand.splitDirection
+          return .run { _ in
+            await terminalClient.send(
+              .createSplitWithInput(
+                worktree,
+                direction: direction,
+                input: command,
+                autoCloseOnSuccess: closeOnSuccess
               )
             )
           }

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -787,7 +787,7 @@ struct RepositoriesFeature {
             return .cancel(id: CancelID.toastAutoDismiss)
           case .success, .warning:
             return .run { send in
-              try? await ContinuousClock().sleep(for: .seconds(2.5))
+              try? await ContinuousClock().sleep(for: .seconds(3))
               await send(.dismissToast)
             }
             .cancellable(id: CancelID.toastAutoDismiss, cancelInFlight: true)

--- a/supacode/Features/Repositories/Views/ToolbarStatusView.swift
+++ b/supacode/Features/Repositories/Views/ToolbarStatusView.swift
@@ -4,108 +4,49 @@ struct ToolbarStatusView: View {
   let toast: RepositoriesFeature.StatusToast?
   let pullRequest: GithubPullRequest?
 
-  @State private var measuredSize: CGSize?
-
-  // Sequential crossfade: old content fades out first, then the width retargets
-  // and the new content fades in. Avoids the messy middle state where both
-  // messages sit on top of each other at partial opacity.
-  private static let fadeOutDuration: Double = 0.14
-  private static let widthDuration: Double = 0.22
-  private static let fadeInDuration: Double = 0.18
-
-  private static let transition: AnyTransition = .asymmetric(
-    insertion: .opacity.animation(
-      .easeOut(duration: fadeInDuration).delay(fadeOutDuration + widthDuration * 0.5)
-    ),
-    removal: .opacity.animation(.easeIn(duration: fadeOutDuration))
-  )
-  private static let sizeAnimation: Animation = .easeInOut(duration: widthDuration)
-    .delay(fadeOutDuration)
-
   var body: some View {
-    ZStack {
-      content
-        .id(identityKey)
-        .transition(Self.transition)
-    }
-    .frame(width: measuredSize?.width, height: measuredSize?.height)
-    .clipped()
-    // Hidden probe renders the current content at its intrinsic size so we
-    // can drive `measuredSize` with an animation, yielding a smooth width
-    // interpolation between consecutive toast messages.
-    .background(
-      content
-        .fixedSize()
-        .hidden()
-        .accessibilityHidden(true)
-        .background(
-          GeometryReader { proxy in
-            Color.clear.onChange(of: proxy.size, initial: true) { _, newSize in
-              withAnimation(Self.sizeAnimation) {
-                measuredSize = newSize
-              }
-            }
-          }
-        )
-    )
-    .animation(Self.sizeAnimation, value: identityKey)
-  }
-
-  @ViewBuilder
-  private var content: some View {
-    switch toast {
-    case .inProgress(let message):
-      HStack(spacing: 6) {
-        ProgressView()
-          .controlSize(.small)
-        Text(message)
-          .font(.footnote)
-          .foregroundStyle(.secondary)
-      }
-    case .success(let message):
-      HStack(spacing: 6) {
-        Image(systemName: "checkmark.circle.fill")
-          .foregroundStyle(.green)
-          .accessibilityHidden(true)
-        Text(message)
-          .font(.footnote)
-          .foregroundStyle(.secondary)
-      }
-    case .warning(let message):
-      HStack(spacing: 6) {
-        Image(systemName: "exclamationmark.triangle.fill")
-          .foregroundStyle(.orange)
-          .accessibilityHidden(true)
-        Text(message)
-          .font(.footnote)
-          .foregroundStyle(.secondary)
-      }
-    case nil:
-      if let model = PullRequestStatusModel(pullRequest: pullRequest) {
-        PullRequestStatusButton(model: model)
-      } else {
-        MotivationalStatusView()
+    Group {
+      switch toast {
+      case .inProgress(let message):
+        HStack(spacing: 6) {
+          ProgressView()
+            .controlSize(.small)
+          Text(message)
+            .font(.footnote)
+            .foregroundStyle(.secondary)
+        }
+        .transition(.opacity)
+      case .success(let message):
+        HStack(spacing: 6) {
+          Image(systemName: "checkmark.circle.fill")
+            .foregroundStyle(.green)
+            .accessibilityHidden(true)
+          Text(message)
+            .font(.footnote)
+            .foregroundStyle(.secondary)
+        }
+        .transition(.opacity)
+      case .warning(let message):
+        HStack(spacing: 6) {
+          Image(systemName: "exclamationmark.triangle.fill")
+            .foregroundStyle(.orange)
+            .accessibilityHidden(true)
+          Text(message)
+            .font(.footnote)
+            .foregroundStyle(.secondary)
+        }
+        .transition(.opacity)
+      case nil:
+        if let model = PullRequestStatusModel(pullRequest: pullRequest) {
+          PullRequestStatusButton(model: model)
+            .transition(.opacity)
+        } else {
+          MotivationalStatusView()
+            .transition(.opacity)
+        }
       }
     }
-  }
-
-  // Derive a stable per-content identity so SwiftUI can transition not only when
-  // the toast kind toggles but also when the message text changes between two
-  // consecutive successes / warnings.
-  private var identityKey: String {
-    switch toast {
-    case .inProgress(let message):
-      return "progress:\(message)"
-    case .success(let message):
-      return "success:\(message)"
-    case .warning(let message):
-      return "warning:\(message)"
-    case nil:
-      if let number = pullRequest?.number {
-        return "pr:\(number)"
-      }
-      return "idle"
-    }
+    .animation(.easeInOut(duration: 0.2), value: toast)
   }
 }
 

--- a/supacode/Features/Repositories/Views/ToolbarStatusView.swift
+++ b/supacode/Features/Repositories/Views/ToolbarStatusView.swift
@@ -4,49 +4,75 @@ struct ToolbarStatusView: View {
   let toast: RepositoriesFeature.StatusToast?
   let pullRequest: GithubPullRequest?
 
+  private static let transition: AnyTransition = .asymmetric(
+    insertion: .opacity.combined(with: .offset(y: -4)),
+    removal: .opacity.combined(with: .offset(y: 4))
+  )
+
   var body: some View {
-    Group {
-      switch toast {
-      case .inProgress(let message):
-        HStack(spacing: 6) {
-          ProgressView()
-            .controlSize(.small)
-          Text(message)
-            .font(.footnote)
-            .foregroundStyle(.secondary)
-        }
-        .transition(.opacity)
-      case .success(let message):
-        HStack(spacing: 6) {
-          Image(systemName: "checkmark.circle.fill")
-            .foregroundStyle(.green)
-            .accessibilityHidden(true)
-          Text(message)
-            .font(.footnote)
-            .foregroundStyle(.secondary)
-        }
-        .transition(.opacity)
-      case .warning(let message):
-        HStack(spacing: 6) {
-          Image(systemName: "exclamationmark.triangle.fill")
-            .foregroundStyle(.orange)
-            .accessibilityHidden(true)
-          Text(message)
-            .font(.footnote)
-            .foregroundStyle(.secondary)
-        }
-        .transition(.opacity)
-      case nil:
-        if let model = PullRequestStatusModel(pullRequest: pullRequest) {
-          PullRequestStatusButton(model: model)
-            .transition(.opacity)
-        } else {
-          MotivationalStatusView()
-            .transition(.opacity)
-        }
+    ZStack {
+      content
+        .id(identityKey)
+        .transition(Self.transition)
+    }
+    .animation(.easeInOut(duration: 0.28), value: identityKey)
+  }
+
+  @ViewBuilder
+  private var content: some View {
+    switch toast {
+    case .inProgress(let message):
+      HStack(spacing: 6) {
+        ProgressView()
+          .controlSize(.small)
+        Text(message)
+          .font(.footnote)
+          .foregroundStyle(.secondary)
+      }
+    case .success(let message):
+      HStack(spacing: 6) {
+        Image(systemName: "checkmark.circle.fill")
+          .foregroundStyle(.green)
+          .accessibilityHidden(true)
+        Text(message)
+          .font(.footnote)
+          .foregroundStyle(.secondary)
+      }
+    case .warning(let message):
+      HStack(spacing: 6) {
+        Image(systemName: "exclamationmark.triangle.fill")
+          .foregroundStyle(.orange)
+          .accessibilityHidden(true)
+        Text(message)
+          .font(.footnote)
+          .foregroundStyle(.secondary)
+      }
+    case nil:
+      if let model = PullRequestStatusModel(pullRequest: pullRequest) {
+        PullRequestStatusButton(model: model)
+      } else {
+        MotivationalStatusView()
       }
     }
-    .animation(.easeInOut(duration: 0.2), value: toast)
+  }
+
+  // Derive a stable per-content identity so SwiftUI can transition not only when
+  // the toast kind toggles but also when the message text changes between two
+  // consecutive successes / warnings.
+  private var identityKey: String {
+    switch toast {
+    case .inProgress(let message):
+      return "progress:\(message)"
+    case .success(let message):
+      return "success:\(message)"
+    case .warning(let message):
+      return "warning:\(message)"
+    case nil:
+      if let number = pullRequest?.number {
+        return "pr:\(number)"
+      }
+      return "idle"
+    }
   }
 }
 

--- a/supacode/Features/Repositories/Views/ToolbarStatusView.swift
+++ b/supacode/Features/Repositories/Views/ToolbarStatusView.swift
@@ -4,10 +4,23 @@ struct ToolbarStatusView: View {
   let toast: RepositoriesFeature.StatusToast?
   let pullRequest: GithubPullRequest?
 
+  @State private var measuredSize: CGSize?
+
+  // Sequential crossfade: old content fades out first, then the width retargets
+  // and the new content fades in. Avoids the messy middle state where both
+  // messages sit on top of each other at partial opacity.
+  private static let fadeOutDuration: Double = 0.14
+  private static let widthDuration: Double = 0.22
+  private static let fadeInDuration: Double = 0.18
+
   private static let transition: AnyTransition = .asymmetric(
-    insertion: .opacity.combined(with: .offset(y: -4)),
-    removal: .opacity.combined(with: .offset(y: 4))
+    insertion: .opacity.animation(
+      .easeOut(duration: fadeInDuration).delay(fadeOutDuration + widthDuration * 0.5)
+    ),
+    removal: .opacity.animation(.easeIn(duration: fadeOutDuration))
   )
+  private static let sizeAnimation: Animation = .easeInOut(duration: widthDuration)
+    .delay(fadeOutDuration)
 
   var body: some View {
     ZStack {
@@ -15,7 +28,27 @@ struct ToolbarStatusView: View {
         .id(identityKey)
         .transition(Self.transition)
     }
-    .animation(.easeInOut(duration: 0.28), value: identityKey)
+    .frame(width: measuredSize?.width, height: measuredSize?.height)
+    .clipped()
+    // Hidden probe renders the current content at its intrinsic size so we
+    // can drive `measuredSize` with an animation, yielding a smooth width
+    // interpolation between consecutive toast messages.
+    .background(
+      content
+        .fixedSize()
+        .hidden()
+        .accessibilityHidden(true)
+        .background(
+          GeometryReader { proxy in
+            Color.clear.onChange(of: proxy.size, initial: true) { _, newSize in
+              withAnimation(Self.sizeAnimation) {
+                measuredSize = newSize
+              }
+            }
+          }
+        )
+    )
+    .animation(Self.sizeAnimation, value: identityKey)
   }
 
   @ViewBuilder

--- a/supacode/Features/Settings/Models/UserRepositorySettings.swift
+++ b/supacode/Features/Settings/Models/UserRepositorySettings.swift
@@ -34,6 +34,8 @@ nonisolated struct UserCustomCommand: Codable, Equatable, Sendable, Identifiable
   var systemImage: String
   var command: String
   var execution: UserCustomCommandExecution
+  var splitDirection: UserCustomSplitDirection
+  var closeOnSuccess: Bool
   var shortcut: UserCustomShortcut?
 
   init(
@@ -42,6 +44,8 @@ nonisolated struct UserCustomCommand: Codable, Equatable, Sendable, Identifiable
     systemImage: String,
     command: String,
     execution: UserCustomCommandExecution,
+    splitDirection: UserCustomSplitDirection = .right,
+    closeOnSuccess: Bool = false,
     shortcut: UserCustomShortcut?
   ) {
     self.id = id
@@ -49,7 +53,27 @@ nonisolated struct UserCustomCommand: Codable, Equatable, Sendable, Identifiable
     self.systemImage = systemImage
     self.command = command
     self.execution = execution
+    self.splitDirection = splitDirection
+    self.closeOnSuccess = closeOnSuccess
     self.shortcut = shortcut?.normalized()
+  }
+
+  private enum CodingKeys: String, CodingKey {
+    case id, title, systemImage, command, execution, splitDirection, closeOnSuccess, shortcut
+  }
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    self.id = try container.decode(String.self, forKey: .id)
+    self.title = try container.decode(String.self, forKey: .title)
+    self.systemImage = try container.decode(String.self, forKey: .systemImage)
+    self.command = try container.decode(String.self, forKey: .command)
+    self.execution = try container.decode(UserCustomCommandExecution.self, forKey: .execution)
+    self.splitDirection =
+      try container.decodeIfPresent(UserCustomSplitDirection.self, forKey: .splitDirection) ?? .right
+    self.closeOnSuccess = try container.decodeIfPresent(Bool.self, forKey: .closeOnSuccess) ?? false
+    // Preserves raw shortcut so downstream migration/validation can inspect the original key.
+    self.shortcut = try container.decodeIfPresent(UserCustomShortcut.self, forKey: .shortcut)
   }
 
   static func `default`(index: Int) -> UserCustomCommand {
@@ -69,6 +93,8 @@ nonisolated struct UserCustomCommand: Codable, Equatable, Sendable, Identifiable
       systemImage: systemImage,
       command: command,
       execution: execution,
+      splitDirection: splitDirection,
+      closeOnSuccess: closeOnSuccess,
       shortcut: shortcut?.normalized()
     )
   }
@@ -97,6 +123,7 @@ nonisolated struct UserCustomCommand: Codable, Equatable, Sendable, Identifiable
 nonisolated enum UserCustomCommandExecution: String, Codable, CaseIterable, Identifiable, Sendable {
   case shellScript
   case terminalInput
+  case split
 
   var id: String { rawValue }
 
@@ -106,6 +133,35 @@ nonisolated enum UserCustomCommandExecution: String, Codable, CaseIterable, Iden
       return "New Tab"
     case .terminalInput:
       return "In Place"
+    case .split:
+      return "New Split"
+    }
+  }
+
+  var supportsCloseOnSuccess: Bool {
+    switch self {
+    case .shellScript, .split:
+      return true
+    case .terminalInput:
+      return false
+    }
+  }
+}
+
+nonisolated enum UserCustomSplitDirection: String, Codable, CaseIterable, Identifiable, Sendable {
+  case right
+  case left
+  case down
+  case top
+
+  var id: String { rawValue }
+
+  var title: String {
+    switch self {
+    case .right: return "Right"
+    case .left: return "Left"
+    case .down: return "Down"
+    case .top: return "Up"
     }
   }
 }

--- a/supacode/Features/Settings/Views/RepositorySettingsView.swift
+++ b/supacode/Features/Settings/Views/RepositorySettingsView.swift
@@ -716,6 +716,7 @@ struct RepositorySettingsView: View {
       Text("Choose where this command runs and edit the script used by this repository custom command.")
         .font(.caption)
         .foregroundStyle(.secondary)
+        .fixedSize(horizontal: false, vertical: true)
 
       Picker("Execution", selection: command.execution) {
         Text("New Tab")
@@ -748,10 +749,12 @@ struct RepositorySettingsView: View {
       Text(scriptDescription(for: command.wrappedValue.execution))
         .font(.caption)
         .foregroundStyle(.secondary)
+        .fixedSize(horizontal: false, vertical: true)
 
       if command.wrappedValue.execution.supportsCloseOnSuccess {
         Toggle("Close on success", isOn: command.closeOnSuccess)
           .help("Automatically closes the tab or split when the command exits with code 0.")
+          .toggleStyle(.checkbox)
       }
     }
     .padding(12)
@@ -925,6 +928,8 @@ struct RepositorySettingsView: View {
           command.systemImage = updatedCommand.systemImage
           command.command = updatedCommand.command
           command.execution = updatedCommand.execution
+          command.splitDirection = updatedCommand.splitDirection
+          command.closeOnSuccess = updatedCommand.closeOnSuccess
           command.shortcut = updatedCommand.shortcut
         }
       }

--- a/supacode/Features/Settings/Views/RepositorySettingsView.swift
+++ b/supacode/Features/Settings/Views/RepositorySettingsView.swift
@@ -649,6 +649,8 @@ struct RepositorySettingsView: View {
       return "New Tab"
     case .terminalInput:
       return "In Place"
+    case .split:
+      return "New Split"
     }
   }
 
@@ -720,8 +722,20 @@ struct RepositorySettingsView: View {
           .tag(UserCustomCommandExecution.shellScript)
         Text("In Place")
           .tag(UserCustomCommandExecution.terminalInput)
+        Text("New Split")
+          .tag(UserCustomCommandExecution.split)
       }
       .pickerStyle(.segmented)
+
+      if command.wrappedValue.execution == .split {
+        Picker("Split Direction", selection: command.splitDirection) {
+          ForEach(UserCustomSplitDirection.allCases) { direction in
+            Text(direction.title).tag(direction)
+          }
+        }
+        .pickerStyle(.menu)
+        .help("Direction to split the focused terminal pane.")
+      }
 
       PlainTextEditor(
         text: command.command,
@@ -734,6 +748,11 @@ struct RepositorySettingsView: View {
       Text(scriptDescription(for: command.wrappedValue.execution))
         .font(.caption)
         .foregroundStyle(.secondary)
+
+      if command.wrappedValue.execution.supportsCloseOnSuccess {
+        Toggle("Close on success", isOn: command.closeOnSuccess)
+          .help("Automatically closes the tab or split when the command exits with code 0.")
+      }
     }
     .padding(12)
     .frame(width: 420)
@@ -853,6 +872,8 @@ struct RepositorySettingsView: View {
       return "npm test && swift test"
     case .terminalInput:
       return "pnpm test --watch"
+    case .split:
+      return "tail -f logs/app.log"
     }
   }
 
@@ -862,6 +883,8 @@ struct RepositorySettingsView: View {
       return "Runs in a new terminal tab."
     case .terminalInput:
       return "Sends input to the currently focused terminal."
+    case .split:
+      return "Runs in a new split of the focused terminal."
     }
   }
 

--- a/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
+++ b/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
@@ -52,22 +52,25 @@ final class WorktreeTerminalManager {
     switch command {
     case .createTab(let worktree, let runSetupScriptIfNew):
       Task { createTabAsync(in: worktree, runSetupScriptIfNew: runSetupScriptIfNew) }
-    case .createTabWithInput(let worktree, let input, let runSetupScriptIfNew, let autoCloseOnSuccess):
+    case .createTabWithInput(
+      let worktree, let input, let runSetupScriptIfNew, let autoCloseOnSuccess, let customCommandName):
       Task {
         createTabAsync(
           in: worktree,
           runSetupScriptIfNew: runSetupScriptIfNew,
           initialInput: input,
-          autoCloseOnSuccess: autoCloseOnSuccess
+          autoCloseOnSuccess: autoCloseOnSuccess,
+          customCommandName: customCommandName
         )
       }
-    case .createSplitWithInput(let worktree, let direction, let input, let autoCloseOnSuccess):
+    case .createSplitWithInput(let worktree, let direction, let input, let autoCloseOnSuccess, let customCommandName):
       Task {
         createSplitAsync(
           in: worktree,
           direction: direction,
           initialInput: input,
-          autoCloseOnSuccess: autoCloseOnSuccess
+          autoCloseOnSuccess: autoCloseOnSuccess,
+          customCommandName: customCommandName
         )
       }
     case .createTabInDirectory(let worktree, let directory):
@@ -247,6 +250,9 @@ final class WorktreeTerminalManager {
     state.onFontSizeAdjusted = { [weak self] in
       self?.syncPreferredFontSize(from: worktree.id)
     }
+    state.onCustomCommandSucceeded = { [weak self] name, durationMs in
+      self?.emit(.customCommandSucceeded(worktreeID: worktree.id, name: name, durationMs: durationMs))
+    }
     states[worktree.id] = state
     terminalLogger.info("Created terminal state for worktree \(worktree.id)")
     return state
@@ -257,7 +263,8 @@ final class WorktreeTerminalManager {
     runSetupScriptIfNew: Bool,
     initialInput: String? = nil,
     workingDirectory: URL? = nil,
-    autoCloseOnSuccess: Bool = false
+    autoCloseOnSuccess: Bool = false,
+    customCommandName: String? = nil
   ) {
     let state = state(for: worktree) { runSetupScriptIfNew }
     let setupScript: String?
@@ -275,8 +282,13 @@ final class WorktreeTerminalManager {
       initialInput: initialInput,
       workingDirectoryOverride: workingDirectory
     )
-    if autoCloseOnSuccess, let tabId, let surfaceId = state.focusedSurfaceId(in: tabId) {
-      state.markSurfaceForAutoClose(surfaceId)
+    if let tabId, let surfaceId = state.focusedSurfaceId(in: tabId) {
+      if autoCloseOnSuccess {
+        state.markSurfaceForAutoClose(surfaceId)
+      }
+      if let customCommandName {
+        state.markSurfaceForCustomCommand(surfaceId, name: customCommandName)
+      }
     }
   }
 
@@ -284,7 +296,8 @@ final class WorktreeTerminalManager {
     in worktree: Worktree,
     direction: UserCustomSplitDirection,
     initialInput: String,
-    autoCloseOnSuccess: Bool
+    autoCloseOnSuccess: Bool,
+    customCommandName: String? = nil
   ) {
     let state = state(for: worktree)
     guard
@@ -297,6 +310,9 @@ final class WorktreeTerminalManager {
     }
     if autoCloseOnSuccess {
       state.markSurfaceForAutoClose(newSurfaceId)
+    }
+    if let customCommandName {
+      state.markSurfaceForCustomCommand(newSurfaceId, name: customCommandName)
     }
   }
 

--- a/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
+++ b/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
@@ -52,9 +52,23 @@ final class WorktreeTerminalManager {
     switch command {
     case .createTab(let worktree, let runSetupScriptIfNew):
       Task { createTabAsync(in: worktree, runSetupScriptIfNew: runSetupScriptIfNew) }
-    case .createTabWithInput(let worktree, let input, let runSetupScriptIfNew):
+    case .createTabWithInput(let worktree, let input, let runSetupScriptIfNew, let autoCloseOnSuccess):
       Task {
-        createTabAsync(in: worktree, runSetupScriptIfNew: runSetupScriptIfNew, initialInput: input)
+        createTabAsync(
+          in: worktree,
+          runSetupScriptIfNew: runSetupScriptIfNew,
+          initialInput: input,
+          autoCloseOnSuccess: autoCloseOnSuccess
+        )
+      }
+    case .createSplitWithInput(let worktree, let direction, let input, let autoCloseOnSuccess):
+      Task {
+        createSplitAsync(
+          in: worktree,
+          direction: direction,
+          initialInput: input,
+          autoCloseOnSuccess: autoCloseOnSuccess
+        )
       }
     case .createTabInDirectory(let worktree, let directory):
       Task {
@@ -71,7 +85,8 @@ final class WorktreeTerminalManager {
           createTabAsync(
             in: worktree,
             runSetupScriptIfNew: false,
-            initialInput: text
+            initialInput: text,
+            autoCloseOnSuccess: false
           )
         }
       }
@@ -241,22 +256,48 @@ final class WorktreeTerminalManager {
     in worktree: Worktree,
     runSetupScriptIfNew: Bool,
     initialInput: String? = nil,
-    workingDirectory: URL? = nil
+    workingDirectory: URL? = nil,
+    autoCloseOnSuccess: Bool = false
   ) {
     let state = state(for: worktree) { runSetupScriptIfNew }
     let setupScript: String?
-    if state.needsSetupScript() {
+    // Skip setup injection when auto-close is requested so the setup script's
+    // own exit code cannot trigger the close before the user's command runs.
+    if !autoCloseOnSuccess, state.needsSetupScript() {
       @SharedReader(.repositorySettings(worktree.repositoryRootURL))
       var settings = RepositorySettings.default
       setupScript = settings.setupScript
     } else {
       setupScript = nil
     }
-    _ = state.createTab(
+    let tabId = state.createTab(
       setupScript: setupScript,
       initialInput: initialInput,
       workingDirectoryOverride: workingDirectory
     )
+    if autoCloseOnSuccess, let tabId, let surfaceId = state.focusedSurfaceId(in: tabId) {
+      state.markSurfaceForAutoClose(surfaceId)
+    }
+  }
+
+  private func createSplitAsync(
+    in worktree: Worktree,
+    direction: UserCustomSplitDirection,
+    initialInput: String,
+    autoCloseOnSuccess: Bool
+  ) {
+    let state = state(for: worktree)
+    guard
+      let newSurfaceId = state.createSplitOnFocusedSurface(
+        direction: direction,
+        initialInput: initialInput
+      )
+    else {
+      return
+    }
+    if autoCloseOnSuccess {
+      state.markSurfaceForAutoClose(newSurfaceId)
+    }
   }
 
   @discardableResult

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -45,6 +45,9 @@ final class WorktreeTerminalState {
   /// Surfaces that should auto-close on the next `command_finished` event with exit code 0.
   /// Populated by `markSurfaceForAutoClose` and consumed (one-shot) in `handleCommandFinished`.
   private var autoCloseSurfaceIds: Set<UUID> = []
+  /// Surfaces running a tracked Custom Command. The stored name is surfaced as a success
+  /// toast when the command exits with code 0. One-shot: removed on the first finish event.
+  private var pendingCustomCommands: [UUID: String] = [:]
   var hasUnseenNotification: Bool {
     notifications.contains { !$0.isRead }
   }
@@ -64,6 +67,9 @@ final class WorktreeTerminalState {
   var onCommandPaletteToggle: (() -> Void)?
   var onSetupScriptConsumed: (() -> Void)?
   var onFontSizeAdjusted: (() -> Void)?
+  /// Emitted when a tracked Custom Command finishes with exit code 0.
+  /// Payload carries the user-facing command name and run duration in milliseconds.
+  var onCustomCommandSucceeded: ((String, Int) -> Void)?
 
   init(
     runtime: GhosttyRuntime,
@@ -536,6 +542,12 @@ final class WorktreeTerminalState {
     autoCloseSurfaceIds.contains(surfaceId)
   }
 
+  /// Records the user-facing Custom Command name associated with a freshly created surface,
+  /// so a success toast can be emitted when that surface's next command exits with code 0.
+  func markSurfaceForCustomCommand(_ surfaceId: UUID, name: String) {
+    pendingCustomCommands[surfaceId] = name
+  }
+
   // Short delay lets the user see the final output before the pane disappears.
   private static let autoCloseDelay: Duration = .milliseconds(800)
 
@@ -677,6 +689,7 @@ final class WorktreeTerminalState {
     focusedSurfaceIdByTab.removeAll()
     tabIsRunningById.removeAll()
     autoCloseSurfaceIds.removeAll()
+    pendingCustomCommands.removeAll()
     setRunScriptTabId(nil)
     tabManager.closeAll()
   }
@@ -1304,6 +1317,12 @@ final class WorktreeTerminalState {
       continuation.finish()
     }
 
+    // Custom command success toast. One-shot: removed regardless of outcome.
+    if let commandName = pendingCustomCommands.removeValue(forKey: surfaceId), exitCode == 0 {
+      let durationMs = Int(durationNs / 1_000_000)
+      onCustomCommandSucceeded?(commandName, durationMs)
+    }
+
     // Auto-close on success (exit 0). One-shot: the id is removed regardless of outcome.
     if autoCloseSurfaceIds.remove(surfaceId) != nil {
       if exitCode == 0, surfaces[surfaceId] != nil {
@@ -1355,6 +1374,7 @@ final class WorktreeTerminalState {
       surface.closeSurface()
       surfaces.removeValue(forKey: surface.id)
       autoCloseSurfaceIds.remove(surface.id)
+      pendingCustomCommands.removeValue(forKey: surface.id)
     }
     focusedSurfaceIdByTab.removeValue(forKey: tabId)
     tabIsRunningById.removeValue(forKey: tabId)
@@ -1497,12 +1517,14 @@ final class WorktreeTerminalState {
       view.closeSurface()
       surfaces.removeValue(forKey: view.id)
       autoCloseSurfaceIds.remove(view.id)
+      pendingCustomCommands.removeValue(forKey: view.id)
       return
     }
     guard let node = tree.find(id: view.id) else {
       view.closeSurface()
       surfaces.removeValue(forKey: view.id)
       autoCloseSurfaceIds.remove(view.id)
+      pendingCustomCommands.removeValue(forKey: view.id)
       return
     }
     let nextSurface =
@@ -1513,6 +1535,7 @@ final class WorktreeTerminalState {
     view.closeSurface()
     surfaces.removeValue(forKey: view.id)
     autoCloseSurfaceIds.remove(view.id)
+    pendingCustomCommands.removeValue(forKey: view.id)
     if newTree.isEmpty {
       trees.removeValue(forKey: tabId)
       focusedSurfaceIdByTab.removeValue(forKey: tabId)

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -42,6 +42,9 @@ final class WorktreeTerminalState {
   private var commandFinishedNotificationThreshold = 10
   private var lastKeyInputTimeBySurface: [UUID: ContinuousClock.Instant] = [:]
   private var commandFinishedWaiters: [UUID: AsyncStream<(exitCode: Int?, durationMs: Int)>.Continuation] = [:]
+  /// Surfaces that should auto-close on the next `command_finished` event with exit code 0.
+  /// Populated by `markSurfaceForAutoClose` and consumed (one-shot) in `handleCommandFinished`.
+  private var autoCloseSurfaceIds: Set<UUID> = []
   var hasUnseenNotification: Bool {
     notifications.contains { !$0.isRead }
   }
@@ -479,6 +482,60 @@ final class WorktreeTerminalState {
     return tree
   }
 
+  /// Splits the currently focused surface and seeds the new pane with `initialInput`.
+  /// Returns the new surface id, or nil if the split could not be created.
+  @discardableResult
+  func createSplitOnFocusedSurface(
+    direction: UserCustomSplitDirection,
+    initialInput: String
+  ) -> UUID? {
+    guard let tabId = tabManager.selectedTabId,
+      let parentSurfaceId = focusedSurfaceIdByTab[tabId],
+      let tree = trees[tabId],
+      let parentSurface = surfaces[parentSurfaceId]
+    else {
+      return nil
+    }
+    let newSurface = createSurface(
+      tabId: tabId,
+      initialInput: runScriptInput(initialInput),
+      inheritingFromSurfaceId: parentSurfaceId,
+      context: GHOSTTY_SURFACE_CONTEXT_SPLIT
+    )
+    do {
+      let newTree = try tree.inserting(
+        view: newSurface,
+        at: parentSurface,
+        direction: mapUserSplitDirection(direction)
+      )
+      updateTree(newTree, for: tabId)
+      if isCanvasManaged {
+        newSurface.setOcclusion(true)
+      }
+      focusSurface(newSurface, in: tabId)
+      return newSurface.id
+    } catch {
+      newSurface.closeSurface()
+      surfaces.removeValue(forKey: newSurface.id)
+      return nil
+    }
+  }
+
+  /// Returns the focused surface id for a given tab, if any.
+  func focusedSurfaceId(in tabId: TerminalTabID) -> UUID? {
+    focusedSurfaceIdByTab[tabId]
+  }
+
+  /// Marks a surface so that its next successful `command_finished` event (exit 0)
+  /// will trigger a one-shot close of that surface.
+  func markSurfaceForAutoClose(_ surfaceId: UUID) {
+    autoCloseSurfaceIds.insert(surfaceId)
+  }
+
+  func isMarkedForAutoClose(_ surfaceId: UUID) -> Bool {
+    autoCloseSurfaceIds.contains(surfaceId)
+  }
+
   func performSplitAction(_ action: GhosttySplitAction, for surfaceId: UUID) -> Bool {
     guard let tabId = tabId(containing: surfaceId), var tree = trees[tabId] else {
       return false
@@ -607,6 +664,7 @@ final class WorktreeTerminalState {
     trees.removeAll()
     focusedSurfaceIdByTab.removeAll()
     tabIsRunningById.removeAll()
+    autoCloseSurfaceIds.removeAll()
     setRunScriptTabId(nil)
     tabManager.closeAll()
   }
@@ -1236,6 +1294,14 @@ final class WorktreeTerminalState {
       continuation.finish()
     }
 
+    // Auto-close on success (exit 0). One-shot: the id is removed regardless of outcome.
+    if autoCloseSurfaceIds.remove(surfaceId) != nil {
+      if exitCode == 0, let view = surfaces[surfaceId] {
+        handleCloseRequest(for: view, processAlive: false)
+        return
+      }
+    }
+
     guard commandFinishedNotificationEnabled else { return }
     let durationSeconds = Int(durationNs / 1_000_000_000)
     guard durationSeconds >= commandFinishedNotificationThreshold else { return }
@@ -1278,6 +1344,7 @@ final class WorktreeTerminalState {
     for surface in tree.leaves() {
       surface.closeSurface()
       surfaces.removeValue(forKey: surface.id)
+      autoCloseSurfaceIds.remove(surface.id)
     }
     focusedSurfaceIdByTab.removeValue(forKey: tabId)
     tabIsRunningById.removeValue(forKey: tabId)
@@ -1365,6 +1432,21 @@ final class WorktreeTerminalState {
     }
   }
 
+  private func mapUserSplitDirection(_ direction: UserCustomSplitDirection)
+    -> SplitTree<GhosttySurfaceView>.NewDirection
+  {
+    switch direction {
+    case .left:
+      return .left
+    case .right:
+      return .right
+    case .top:
+      return .top
+    case .down:
+      return .down
+    }
+  }
+
   private func mapFocusDirection(_ direction: GhosttySplitAction.FocusDirection)
     -> SplitTree<GhosttySurfaceView>.FocusDirection
   {
@@ -1404,11 +1486,13 @@ final class WorktreeTerminalState {
     guard let tabId = tabId(containing: view.id), let tree = trees[tabId] else {
       view.closeSurface()
       surfaces.removeValue(forKey: view.id)
+      autoCloseSurfaceIds.remove(view.id)
       return
     }
     guard let node = tree.find(id: view.id) else {
       view.closeSurface()
       surfaces.removeValue(forKey: view.id)
+      autoCloseSurfaceIds.remove(view.id)
       return
     }
     let nextSurface =
@@ -1418,6 +1502,7 @@ final class WorktreeTerminalState {
     let newTree = tree.removing(node)
     view.closeSurface()
     surfaces.removeValue(forKey: view.id)
+    autoCloseSurfaceIds.remove(view.id)
     if newTree.isEmpty {
       trees.removeValue(forKey: tabId)
       focusedSurfaceIdByTab.removeValue(forKey: tabId)

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -536,6 +536,18 @@ final class WorktreeTerminalState {
     autoCloseSurfaceIds.contains(surfaceId)
   }
 
+  // Short delay lets the user see the final output before the pane disappears.
+  private static let autoCloseDelay: Duration = .milliseconds(800)
+
+  private func scheduleAutoClose(surfaceId: UUID) {
+    Task { [weak self] in
+      try? await Task.sleep(for: Self.autoCloseDelay)
+      guard let self else { return }
+      guard let view = self.surfaces[surfaceId] else { return }
+      self.handleCloseRequest(for: view, processAlive: false)
+    }
+  }
+
   func performSplitAction(_ action: GhosttySplitAction, for surfaceId: UUID) -> Bool {
     guard let tabId = tabId(containing: surfaceId), var tree = trees[tabId] else {
       return false
@@ -1294,8 +1306,8 @@ final class WorktreeTerminalState {
 
     // Auto-close on success (exit 0). One-shot: the id is removed regardless of outcome.
     if autoCloseSurfaceIds.remove(surfaceId) != nil {
-      if exitCode == 0, let view = surfaces[surfaceId] {
-        handleCloseRequest(for: view, processAlive: false)
+      if exitCode == 0, surfaces[surfaceId] != nil {
+        scheduleAutoClose(surfaceId: surfaceId)
         return
       }
     }

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -878,11 +878,11 @@ final class WorktreeTerminalState {
     return formatCommandInput(script)
   }
 
+  // Env vars are injected into the surface's shell process via
+  // `GhosttySurfaceView(environment:)`, so scripts no longer need a shell
+  // export prefix.
   private func formatCommandInput(_ script: String) -> String? {
-    makeCommandInput(
-      script: script,
-      environmentExportPrefix: worktree.scriptEnvironmentExportPrefix
-    )
+    makeCommandInput(script: script)
   }
 
   private func runScriptInput(_ script: String) -> String? {
@@ -894,10 +894,7 @@ final class WorktreeTerminalState {
   // Without this, the interactive shell stays alive after the script finishes
   // and GHOSTTY_ACTION_SHOW_CHILD_EXITED never fires for completion detection.
   private func blockingScriptInput(_ script: String) -> String? {
-    makeBlockingScriptInput(
-      script: script,
-      environmentExportPrefix: worktree.scriptEnvironmentExportPrefix
-    )
+    makeBlockingScriptInput(script: script)
   }
 
   private func setRunScriptTabId(_ tabId: TerminalTabID?) {
@@ -927,7 +924,8 @@ final class WorktreeTerminalState {
       workingDirectory: workingDirectoryOverride ?? inherited.workingDirectory ?? worktree.workingDirectory,
       initialInput: initialInput,
       fontSize: resolvedFontSize,
-      context: context
+      context: context,
+      environment: worktree.scriptEnvironment
     )
     // Sending a no-op font size action marks the Ghostty surface as
     // "font_size_adjusted", which prevents config reloads (triggered by
@@ -1696,26 +1694,13 @@ extension WorktreeTerminalState {
   }
 }
 
-nonisolated func makeCommandInput(
-  script: String,
-  environmentExportPrefix: String
-) -> String? {
+nonisolated func makeCommandInput(script: String) -> String? {
   let trimmed = script.trimmingCharacters(in: .whitespacesAndNewlines)
   guard !trimmed.isEmpty else { return nil }
-  return environmentExportPrefix + trimmed + "\n"
+  return trimmed + "\n"
 }
 
-nonisolated func makeBlockingScriptInput(
-  script: String,
-  environmentExportPrefix: String
-) -> String? {
-  guard
-    let input = makeCommandInput(
-      script: script,
-      environmentExportPrefix: environmentExportPrefix
-    )
-  else {
-    return nil
-  }
+nonisolated func makeBlockingScriptInput(script: String) -> String? {
+  guard let input = makeCommandInput(script: script) else { return nil }
   return input + "exit\n"
 }

--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
@@ -108,6 +108,9 @@ final class GhosttySurfaceView: NSView, Identifiable {
   private var surfaceRef: GhosttyRuntime.SurfaceReference?
   private let workingDirectoryCString: UnsafeMutablePointer<CChar>?
   private let initialInputCString: UnsafeMutablePointer<CChar>?
+  private let envVarCStrings: [UnsafeMutablePointer<CChar>]
+  private let envVarEntries: UnsafeMutablePointer<ghostty_env_var_s>?
+  private let envVarCount: Int
   private let fontSize: Float32
   private let context: ghostty_surface_context_e
   private let skipsSurfaceCreationForTesting: Bool
@@ -222,6 +225,7 @@ final class GhosttySurfaceView: NSView, Identifiable {
     initialInput: String? = nil,
     fontSize: Float32? = nil,
     context: ghostty_surface_context_e,
+    environment: [String: String] = [:],
     skipsSurfaceCreationForTesting: Bool = false
   ) {
     self.runtime = runtime
@@ -241,6 +245,32 @@ final class GhosttySurfaceView: NSView, Identifiable {
       initialInputCString = initialInput.withCString { strdup($0) }
     } else {
       initialInputCString = nil
+    }
+    let sortedEnv = environment.sorted { $0.key < $1.key }
+    var allocatedStrings: [UnsafeMutablePointer<CChar>] = []
+    allocatedStrings.reserveCapacity(sortedEnv.count * 2)
+    for (key, value) in sortedEnv {
+      guard let keyPtr = key.withCString({ strdup($0) }),
+        let valuePtr = value.withCString({ strdup($0) })
+      else { continue }
+      allocatedStrings.append(keyPtr)
+      allocatedStrings.append(valuePtr)
+    }
+    envVarCStrings = allocatedStrings
+    let pairCount = allocatedStrings.count / 2
+    if pairCount > 0 {
+      let entries = UnsafeMutablePointer<ghostty_env_var_s>.allocate(capacity: pairCount)
+      for index in 0..<pairCount {
+        entries[index] = ghostty_env_var_s(
+          key: UnsafePointer(allocatedStrings[index * 2]),
+          value: UnsafePointer(allocatedStrings[index * 2 + 1])
+        )
+      }
+      envVarEntries = entries
+      envVarCount = pairCount
+    } else {
+      envVarEntries = nil
+      envVarCount = 0
     }
     super.init(frame: NSRect(x: 0, y: 0, width: 800, height: 600))
     wantsLayer = true
@@ -280,6 +310,12 @@ final class GhosttySurfaceView: NSView, Identifiable {
     }
     if let initialInputCString {
       free(initialInputCString)
+    }
+    if let envVarEntries {
+      envVarEntries.deallocate()
+    }
+    for pointer in envVarCStrings {
+      free(pointer)
     }
   }
 
@@ -1047,6 +1083,10 @@ final class GhosttySurfaceView: NSView, Identifiable {
     config.working_directory = workingDirectoryCString.map { UnsafePointer($0) }
     config.initial_input = initialInputCString.map { UnsafePointer($0) }
     config.context = context
+    if let envVarEntries, envVarCount > 0 {
+      config.env_vars = envVarEntries
+      config.env_var_count = envVarCount
+    }
     surface = ghostty_surface_new(app, &config)
     bridge.surface = surface
     occlusionState.reset()

--- a/supacodeTests/AppFeatureCustomCommandTests.swift
+++ b/supacodeTests/AppFeatureCustomCommandTests.swift
@@ -37,7 +37,13 @@ struct AppFeatureCustomCommandTests {
 
     #expect(
       sent.value == [
-        .createTabWithInput(worktree, input: "swift test", runSetupScriptIfNew: false, autoCloseOnSuccess: false)
+        .createTabWithInput(
+          worktree,
+          input: "swift test",
+          runSetupScriptIfNew: false,
+          autoCloseOnSuccess: false,
+          customCommandName: "Test"
+        ),
       ],
     )
   }
@@ -108,7 +114,13 @@ struct AppFeatureCustomCommandTests {
 
     #expect(
       sent.value == [
-        .createSplitWithInput(worktree, direction: .down, input: "tail -f logs", autoCloseOnSuccess: false)
+        .createSplitWithInput(
+          worktree,
+          direction: .down,
+          input: "tail -f logs",
+          autoCloseOnSuccess: false,
+          customCommandName: "Tail"
+        ),
       ],
     )
   }
@@ -154,8 +166,20 @@ struct AppFeatureCustomCommandTests {
 
     #expect(
       sent.value == [
-        .createTabWithInput(worktree, input: "make build", runSetupScriptIfNew: false, autoCloseOnSuccess: true),
-        .createSplitWithInput(worktree, direction: .right, input: "make lint", autoCloseOnSuccess: true),
+        .createTabWithInput(
+          worktree,
+          input: "make build",
+          runSetupScriptIfNew: false,
+          autoCloseOnSuccess: true,
+          customCommandName: "Build"
+        ),
+        .createSplitWithInput(
+          worktree,
+          direction: .right,
+          input: "make lint",
+          autoCloseOnSuccess: true,
+          customCommandName: "Lint"
+        ),
       ],
     )
   }
@@ -257,7 +281,13 @@ struct AppFeatureCustomCommandTests {
 
     #expect(
       sent.value == [
-        .createTabWithInput(worktree, input: "echo five", runSetupScriptIfNew: false, autoCloseOnSuccess: false)
+        .createTabWithInput(
+          worktree,
+          input: "echo five",
+          runSetupScriptIfNew: false,
+          autoCloseOnSuccess: false,
+          customCommandName: "Five"
+        ),
       ],
     )
   }

--- a/supacodeTests/AppFeatureCustomCommandTests.swift
+++ b/supacodeTests/AppFeatureCustomCommandTests.swift
@@ -37,7 +37,7 @@ struct AppFeatureCustomCommandTests {
 
     #expect(
       sent.value == [
-        .createTabWithInput(worktree, input: "swift test", runSetupScriptIfNew: false)
+        .createTabWithInput(worktree, input: "swift test", runSetupScriptIfNew: false, autoCloseOnSuccess: false)
       ],
     )
   }
@@ -75,6 +75,106 @@ struct AppFeatureCustomCommandTests {
         .insertText(worktree, text: "pnpm test --watch")
       ],
     )
+  }
+
+  @Test(.dependencies) func splitCommandCreatesSplitWithInput() async {
+    let worktree = makeWorktree()
+    let sent = LockIsolated<[TerminalClient.Command]>([])
+    var state = AppFeature.State(
+      repositories: makeRepositoriesState(worktree: worktree),
+      settings: SettingsFeature.State()
+    )
+    state.selectedCustomCommands = [
+      UserCustomCommand(
+        title: "Tail",
+        systemImage: "doc.text",
+        command: "tail -f logs",
+        execution: .split,
+        splitDirection: .down,
+        shortcut: nil,
+      ),
+    ]
+
+    let store = TestStore(initialState: state) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in
+        sent.withValue { $0.append(command) }
+      }
+    }
+
+    await store.send(.runCustomCommand(0))
+    await store.finish()
+
+    #expect(
+      sent.value == [
+        .createSplitWithInput(worktree, direction: .down, input: "tail -f logs", autoCloseOnSuccess: false)
+      ],
+    )
+  }
+
+  @Test(.dependencies) func closeOnSuccessFlagIsForwarded() async {
+    let worktree = makeWorktree()
+    let sent = LockIsolated<[TerminalClient.Command]>([])
+    var state = AppFeature.State(
+      repositories: makeRepositoriesState(worktree: worktree),
+      settings: SettingsFeature.State()
+    )
+    state.selectedCustomCommands = [
+      UserCustomCommand(
+        title: "Build",
+        systemImage: "hammer",
+        command: "make build",
+        execution: .shellScript,
+        closeOnSuccess: true,
+        shortcut: nil,
+      ),
+      UserCustomCommand(
+        title: "Lint",
+        systemImage: "checkmark",
+        command: "make lint",
+        execution: .split,
+        splitDirection: .right,
+        closeOnSuccess: true,
+        shortcut: nil,
+      ),
+    ]
+
+    let store = TestStore(initialState: state) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in
+        sent.withValue { $0.append(command) }
+      }
+    }
+
+    await store.send(.runCustomCommand(0))
+    await store.send(.runCustomCommand(1))
+    await store.finish()
+
+    #expect(
+      sent.value == [
+        .createTabWithInput(worktree, input: "make build", runSetupScriptIfNew: false, autoCloseOnSuccess: true),
+        .createSplitWithInput(worktree, direction: .right, input: "make lint", autoCloseOnSuccess: true),
+      ],
+    )
+  }
+
+  @Test func userCustomCommandDecodesWithoutNewFields() throws {
+    let legacyJSON = """
+      {
+        "id": "abc",
+        "title": "Legacy",
+        "systemImage": "terminal",
+        "command": "echo hi",
+        "execution": "shellScript"
+      }
+      """
+    let data = Data(legacyJSON.utf8)
+    let decoded = try JSONDecoder().decode(UserCustomCommand.self, from: data)
+    #expect(decoded.splitDirection == .right)
+    #expect(decoded.closeOnSuccess == false)
+    #expect(decoded.execution == .shellScript)
   }
 
   @Test(.dependencies) func invalidCommandIndexDoesNothing() async {
@@ -157,7 +257,7 @@ struct AppFeatureCustomCommandTests {
 
     #expect(
       sent.value == [
-        .createTabWithInput(worktree, input: "echo five", runSetupScriptIfNew: false)
+        .createTabWithInput(worktree, input: "echo five", runSetupScriptIfNew: false, autoCloseOnSuccess: false)
       ],
     )
   }

--- a/supacodeTests/CommandFinishedNotificationTests.swift
+++ b/supacodeTests/CommandFinishedNotificationTests.swift
@@ -199,6 +199,61 @@ struct CommandFinishedNotificationTests {
     #expect(state.isMarkedForAutoClose(otherSurfaceId))
   }
 
+  // MARK: - Custom command success toast
+
+  @Test func customCommandSuccessEmitsNameAndDuration() {
+    let state = makeState()
+    var received: [(String, Int)] = []
+    state.onCustomCommandSucceeded = { name, durationMs in
+      received.append((name, durationMs))
+    }
+    state.markSurfaceForCustomCommand(surfaceId, name: "Build")
+
+    state.handleCommandFinished(exitCode: 0, durationNs: 1_500_000_000, surfaceId: surfaceId)
+
+    #expect(received.count == 1)
+    #expect(received.first?.0 == "Build")
+    #expect(received.first?.1 == 1_500)
+  }
+
+  @Test func customCommandFailureSkipsSuccessEvent() {
+    let state = makeState()
+    var received: [(String, Int)] = []
+    state.onCustomCommandSucceeded = { name, durationMs in
+      received.append((name, durationMs))
+    }
+    state.markSurfaceForCustomCommand(surfaceId, name: "Build")
+
+    state.handleCommandFinished(exitCode: 2, durationNs: 5_000_000_000, surfaceId: surfaceId)
+
+    #expect(received.isEmpty)
+  }
+
+  @Test func customCommandMarkIsOneShot() {
+    let state = makeState()
+    var received: [(String, Int)] = []
+    state.onCustomCommandSucceeded = { name, durationMs in
+      received.append((name, durationMs))
+    }
+    state.markSurfaceForCustomCommand(surfaceId, name: "Build")
+
+    state.handleCommandFinished(exitCode: 0, durationNs: 1_000_000_000, surfaceId: surfaceId)
+    state.handleCommandFinished(exitCode: 0, durationNs: 2_000_000_000, surfaceId: surfaceId)
+
+    #expect(received.count == 1)
+  }
+
+  @Test func customCommandDurationFormatter() {
+    #expect(formatCustomCommandDuration(0) == "0ms")
+    #expect(formatCustomCommandDuration(250) == "250ms")
+    #expect(formatCustomCommandDuration(999) == "999ms")
+    #expect(formatCustomCommandDuration(1_000) == "1.0s")
+    #expect(formatCustomCommandDuration(1_540) == "1.5s")
+    #expect(formatCustomCommandDuration(9_900) == "9.9s")
+    #expect(formatCustomCommandDuration(12_000) == "12s")
+    #expect(formatCustomCommandDuration(75_000) == "1m 15s")
+  }
+
   // MARK: - Helpers
 
   private func makeState(threshold: Int = 10) -> WorktreeTerminalState {

--- a/supacodeTests/CommandFinishedNotificationTests.swift
+++ b/supacodeTests/CommandFinishedNotificationTests.swift
@@ -165,6 +165,40 @@ struct CommandFinishedNotificationTests {
     #expect(state.notifications.count == 1)
   }
 
+  // MARK: - Auto-close on success
+
+  @Test func autoCloseFlagIsConsumedOnSuccess() {
+    let state = makeState()
+    state.markSurfaceForAutoClose(surfaceId)
+    #expect(state.isMarkedForAutoClose(surfaceId))
+
+    state.handleCommandFinished(exitCode: 0, durationNs: 1_000_000_000, surfaceId: surfaceId)
+
+    #expect(!state.isMarkedForAutoClose(surfaceId))
+  }
+
+  @Test func autoCloseFlagIsConsumedOnFailureButDoesNotClose() {
+    let state = makeState()
+    state.markSurfaceForAutoClose(surfaceId)
+
+    state.handleCommandFinished(exitCode: 1, durationNs: 30_000_000_000, surfaceId: surfaceId)
+
+    #expect(!state.isMarkedForAutoClose(surfaceId))
+    // Standard failure notification still fires since close was not triggered.
+    #expect(state.notifications.count == 1)
+    #expect(state.notifications.first?.title == "Command failed")
+  }
+
+  @Test func unmarkedSurfaceDoesNotConsumeAutoCloseState() {
+    let state = makeState()
+    let otherSurfaceId = UUID()
+    state.markSurfaceForAutoClose(otherSurfaceId)
+
+    state.handleCommandFinished(exitCode: 0, durationNs: 15_000_000_000, surfaceId: surfaceId)
+
+    #expect(state.isMarkedForAutoClose(otherSurfaceId))
+  }
+
   // MARK: - Helpers
 
   private func makeState(threshold: Int = 10) -> WorktreeTerminalState {

--- a/supacodeTests/WorktreeEnvironmentTests.swift
+++ b/supacodeTests/WorktreeEnvironmentTests.swift
@@ -63,20 +63,11 @@ struct WorktreeEnvironmentTests {
   }
 
   @Test func blockingScriptInputUsesPortableBareExit() {
-    let worktree = Worktree(
-      id: "/tmp/repo/wt-1",
-      name: "feature-branch",
-      detail: "detail",
-      workingDirectory: URL(fileURLWithPath: "/tmp/repo/wt-1"),
-      repositoryRootURL: URL(fileURLWithPath: "/tmp/repo"),
-    )
-
     let input = makeBlockingScriptInput(
       script: """
         docker compose down
         codex exec "test"
-        """,
-      environmentExportPrefix: worktree.scriptEnvironmentExportPrefix
+        """
     )
 
     #expect(input?.contains("docker compose down\ncodex exec \"test\"\nexit\n") == true)
@@ -84,12 +75,14 @@ struct WorktreeEnvironmentTests {
     #expect(input?.contains("exit $?") == false)
   }
 
+  @Test func commandInputDoesNotPrependEnvExports() {
+    // Environment variables are injected via ghostty_surface_config.env_vars
+    // now, so the shell input itself must stay free of `export` prefixes.
+    let input = makeCommandInput(script: "make build")
+    #expect(input == "make build\n")
+  }
+
   @Test func blockingScriptInputReturnsNilForWhitespaceOnlyScripts() {
-    #expect(
-      makeBlockingScriptInput(
-        script: "   \n  ",
-        environmentExportPrefix: "export PROWL_ROOT_PATH='/tmp/repo'\n"
-      ) == nil
-    )
+    #expect(makeBlockingScriptInput(script: "   \n  ") == nil)
   }
 }


### PR DESCRIPTION
## Summary
- Adds a third Custom Command execution target — **New Split** — that runs the command in a new pane splitting the currently focused terminal surface. Each command stores its own split direction (default `Right`, matching `Cmd+D`).
- Adds a per-command **Close on success** toggle for the New Tab and New Split targets. When enabled, Prowl dismisses the tab / split as soon as the command exits with code `0`. One-shot: failure or non-zero exit leaves the pane open and consumes the flag.
- Skips setup-script injection for tabs marked auto-close, so a successful setup script cannot accidentally close the pane before the user command starts.

## Implementation notes
- `UserCustomCommandExecution` gains `.split`; `UserCustomCommand` gains `splitDirection` + `closeOnSuccess`. Custom `init(from:)` uses `decodeIfPresent` with defaults, so older user settings keep decoding cleanly.
- `TerminalClient.Command` gains `createSplitWithInput` and extends `createTabWithInput` with `autoCloseOnSuccess`.
- `WorktreeTerminalState` tracks flagged surfaces in a `Set<UUID>` consumed once in `handleCommandFinished`; cleanup is threaded through `removeTree`, `handleCloseRequest`, and `closeAllSurfaces`.
- Settings UI shows the direction picker only for `.split` and the toggle only for targets that support it (not `In Place`).

## Test plan
- [x] `xcodebuild test` full suite (`make test`)
- [x] `make check` (format + swiftlint)
- [x] New tests: `splitCommandCreatesSplitWithInput`, `closeOnSuccessFlagIsForwarded`, `userCustomCommandDecodesWithoutNewFields`, `autoCloseFlagIsConsumedOnSuccess`, `autoCloseFlagIsConsumedOnFailureButDoesNotClose`, `unmarkedSurfaceDoesNotConsumeAutoCloseState`
- [x] Manual: add a Custom Command with `New Split` + `Close on success`, assign shortcut, confirm the split opens right, runs the command, and closes on exit 0
- [x] Manual: run a failing command (`false`) with `Close on success` — split stays open, standard failure notification fires
