### PR TITLE
Surface background-detected updates via a toolbar badge

### DIFF
--- a/supacode/Assets.xcassets/ProwlAccent.colorset/Contents.json
+++ b/supacode/Assets.xcassets/ProwlAccent.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xC0",
+          "green" : "0xE4",
+          "red" : "0x5B"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/supacode/Clients/Updates/UpdaterClient.swift
+++ b/supacode/Clients/Updates/UpdaterClient.swift
@@ -1,14 +1,23 @@
 import ComposableArchitecture
 import Sparkle
 
+private let updaterLogger = SupaLogger("Updater")
+
 struct UpdaterClient {
   var configure: @MainActor @Sendable (_ checks: Bool, _ downloads: Bool, _ checkInBackground: Bool) -> Void
   var setUpdateChannel: @MainActor @Sendable (UpdateChannel) -> Void
   var checkForUpdates: @MainActor @Sendable () -> Void
+  var events: @MainActor @Sendable () -> AsyncStream<Event>
+}
+
+extension UpdaterClient {
+  enum Event: Equatable, Sendable {
+    case silentUpdateFound(version: String?)
+  }
 }
 
 @MainActor
-class SparkleUpdateDelegate: NSObject, SPUUpdaterDelegate {
+final class SparkleUpdateDelegate: NSObject, SPUUpdaterDelegate {
   var updateChannel: UpdateChannel = .stable
 
   nonisolated func allowedChannels(for updater: SPUUpdater) -> Set<String> {
@@ -17,26 +26,183 @@ class SparkleUpdateDelegate: NSObject, SPUUpdaterDelegate {
   }
 }
 
+/// Custom Sparkle user driver that turns background "update found" prompts into a silent signal,
+/// while forwarding user-initiated flows to the standard Sparkle UI.
+@MainActor
+final class SilentUpdateDriver: NSObject, SPUUserDriver {
+  private let standard: SPUStandardUserDriver
+  private var continuation: AsyncStream<UpdaterClient.Event>.Continuation?
+
+  init(hostBundle: Bundle) {
+    self.standard = SPUStandardUserDriver(hostBundle: hostBundle, delegate: nil)
+    super.init()
+  }
+
+  func setContinuation(_ continuation: AsyncStream<UpdaterClient.Event>.Continuation) {
+    self.continuation?.finish()
+    self.continuation = continuation
+  }
+
+  nonisolated func show(
+    _ request: SPUUpdatePermissionRequest,
+    reply: @escaping @Sendable (SUUpdatePermissionResponse) -> Void
+  ) {
+    MainActor.assumeIsolated {
+      standard.show(request, reply: reply)
+    }
+  }
+
+  nonisolated func showUserInitiatedUpdateCheck(cancellation: @escaping @Sendable () -> Void) {
+    MainActor.assumeIsolated {
+      standard.showUserInitiatedUpdateCheck(cancellation: cancellation)
+    }
+  }
+
+  nonisolated func showUpdateFound(
+    with appcastItem: SUAppcastItem,
+    state: SPUUserUpdateState,
+    reply: @escaping @Sendable (SPUUserUpdateChoice) -> Void
+  ) {
+    MainActor.assumeIsolated {
+      if state.userInitiated {
+        standard.showUpdateFound(with: appcastItem, state: state, reply: reply)
+        return
+      }
+      // Background check: surface the availability silently, then defer so Sparkle
+      // will re-offer the same update on the next (user-initiated) check.
+      continuation?.yield(.silentUpdateFound(version: appcastItem.displayVersionString))
+      reply(.dismiss)
+    }
+  }
+
+  nonisolated func showUpdateReleaseNotes(with downloadData: SPUDownloadData) {
+    MainActor.assumeIsolated {
+      standard.showUpdateReleaseNotes(with: downloadData)
+    }
+  }
+
+  nonisolated func showUpdateReleaseNotesFailedToDownloadWithError(_ error: any Error) {
+    MainActor.assumeIsolated {
+      standard.showUpdateReleaseNotesFailedToDownloadWithError(error)
+    }
+  }
+
+  nonisolated func showUpdateNotFoundWithError(
+    _ error: any Error,
+    acknowledgement: @escaping @Sendable () -> Void
+  ) {
+    MainActor.assumeIsolated {
+      standard.showUpdateNotFoundWithError(error, acknowledgement: acknowledgement)
+    }
+  }
+
+  nonisolated func showUpdaterError(
+    _ error: any Error,
+    acknowledgement: @escaping @Sendable () -> Void
+  ) {
+    MainActor.assumeIsolated {
+      standard.showUpdaterError(error, acknowledgement: acknowledgement)
+    }
+  }
+
+  nonisolated func showDownloadInitiated(cancellation: @escaping @Sendable () -> Void) {
+    MainActor.assumeIsolated {
+      standard.showDownloadInitiated(cancellation: cancellation)
+    }
+  }
+
+  nonisolated func showDownloadDidReceiveExpectedContentLength(_ expectedContentLength: UInt64) {
+    MainActor.assumeIsolated {
+      standard.showDownloadDidReceiveExpectedContentLength(expectedContentLength)
+    }
+  }
+
+  nonisolated func showDownloadDidReceiveData(ofLength length: UInt64) {
+    MainActor.assumeIsolated {
+      standard.showDownloadDidReceiveData(ofLength: length)
+    }
+  }
+
+  nonisolated func showDownloadDidStartExtractingUpdate() {
+    MainActor.assumeIsolated {
+      standard.showDownloadDidStartExtractingUpdate()
+    }
+  }
+
+  nonisolated func showExtractionReceivedProgress(_ progress: Double) {
+    MainActor.assumeIsolated {
+      standard.showExtractionReceivedProgress(progress)
+    }
+  }
+
+  nonisolated func showReady(toInstallAndRelaunch reply: @escaping @Sendable (SPUUserUpdateChoice) -> Void) {
+    MainActor.assumeIsolated {
+      standard.showReady(toInstallAndRelaunch: reply)
+    }
+  }
+
+  nonisolated func showInstallingUpdate(
+    withApplicationTerminated applicationTerminated: Bool,
+    retryTerminatingApplication: @escaping @Sendable () -> Void
+  ) {
+    MainActor.assumeIsolated {
+      standard.showInstallingUpdate(
+        withApplicationTerminated: applicationTerminated,
+        retryTerminatingApplication: retryTerminatingApplication
+      )
+    }
+  }
+
+  nonisolated func showUpdateInstalledAndRelaunched(
+    _ relaunched: Bool,
+    acknowledgement: @escaping @Sendable () -> Void
+  ) {
+    MainActor.assumeIsolated {
+      standard.showUpdateInstalledAndRelaunched(relaunched, acknowledgement: acknowledgement)
+    }
+  }
+
+  nonisolated func showUpdateInFocus() {
+    MainActor.assumeIsolated {
+      standard.showUpdateInFocus()
+    }
+  }
+
+  nonisolated func dismissUpdateInstallation() {
+    MainActor.assumeIsolated {
+      standard.dismissUpdateInstallation()
+    }
+  }
+}
+
 extension UpdaterClient: DependencyKey {
   static let liveValue: UpdaterClient = {
+    let hostBundle = Bundle.main
     let delegate = SparkleUpdateDelegate()
-    let controller = SPUStandardUpdaterController(
-      startingUpdater: true,
-      updaterDelegate: delegate,
-      userDriverDelegate: nil
+    let driver = SilentUpdateDriver(hostBundle: hostBundle)
+    let updater = SPUUpdater(
+      hostBundle: hostBundle,
+      applicationBundle: hostBundle,
+      userDriver: driver,
+      delegate: delegate
     )
-    let updater = controller.updater
+    do {
+      try updater.start()
+    } catch {
+      updaterLogger.warning("SPUUpdater start failed: \(String(describing: error))")
+    }
     return UpdaterClient(
-      configure: { checks, downloads, checkInBackground in
-        _ = controller
+      configure: { checks, _, checkInBackground in
         updater.automaticallyChecksForUpdates = checks
-        updater.automaticallyDownloadsUpdates = downloads
+        // Silent update flow requires Sparkle to always prompt us via `showUpdateFound`
+        // so we can decide whether to surface the toolbar button. Auto-download would
+        // bypass that callback, so we force it off regardless of user preference.
+        updater.automaticallyDownloadsUpdates = false
         if checkInBackground, checks {
           updater.checkForUpdatesInBackground()
         }
       },
       setUpdateChannel: { channel in
-        _ = controller
         delegate.updateChannel = channel
         updater.updateCheckInterval = 3600
         if updater.automaticallyChecksForUpdates {
@@ -44,8 +210,12 @@ extension UpdaterClient: DependencyKey {
         }
       },
       checkForUpdates: {
-        _ = controller
         updater.checkForUpdates()
+      },
+      events: {
+        let (stream, continuation) = AsyncStream.makeStream(of: Event.self)
+        driver.setContinuation(continuation)
+        return stream
       }
     )
   }()
@@ -53,7 +223,8 @@ extension UpdaterClient: DependencyKey {
   static let testValue = UpdaterClient(
     configure: { _, _, _ in },
     setUpdateChannel: { _ in },
-    checkForUpdates: {}
+    checkForUpdates: {},
+    events: { AsyncStream { _ in } }
   )
 }
 

--- a/supacode/Commands/UpdateCommands.swift
+++ b/supacode/Commands/UpdateCommands.swift
@@ -12,12 +12,6 @@ struct UpdateCommands: Commands {
       }
       .modifier(KeyboardShortcutModifier(shortcut: keyboardShortcut(for: AppShortcuts.CommandID.checkForUpdates)))
       .help(helpText(title: "Check for Updates", commandID: AppShortcuts.CommandID.checkForUpdates))
-      #if DEBUG
-        Button("Debug: Simulate Update Found") {
-          store.send(.debugSimulateUpdateFound)
-        }
-        .help("Force the toolbar update badge to appear without querying Sparkle.")
-      #endif
     }
   }
 

--- a/supacode/Commands/UpdateCommands.swift
+++ b/supacode/Commands/UpdateCommands.swift
@@ -12,6 +12,12 @@ struct UpdateCommands: Commands {
       }
       .modifier(KeyboardShortcutModifier(shortcut: keyboardShortcut(for: AppShortcuts.CommandID.checkForUpdates)))
       .help(helpText(title: "Check for Updates", commandID: AppShortcuts.CommandID.checkForUpdates))
+      #if DEBUG
+        Button("Debug: Simulate Update Found") {
+          store.send(.debugSimulateUpdateFound)
+        }
+        .help("Force the toolbar update badge to appear without querying Sparkle.")
+      #endif
     }
   }
 

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -913,6 +913,9 @@ struct AppFeature {
       #if DEBUG
         case .commandPalette(.delegate(.debugTestToast(let toast))):
           return .send(.repositories(.showToast(toast)))
+
+        case .commandPalette(.delegate(.debugSimulateUpdateFound)):
+          return .send(.updates(.debugSimulateUpdateFound))
       #endif
 
       case .commandPalette:

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -156,6 +156,7 @@ struct AppFeature {
         return .merge(
           .send(.repositories(.task)),
           .send(.settings(.task)),
+          .send(.updates(.task)),
           .run { _ in
             await MainActor.run {
               NSApplication.shared.dockTile.badgeLabel = nil

--- a/supacode/Features/CommandPalette/CommandPaletteItem.swift
+++ b/supacode/Features/CommandPalette/CommandPaletteItem.swift
@@ -43,6 +43,7 @@ struct CommandPaletteItem: Identifiable, Equatable {
     case installCLI
     #if DEBUG
       case debugTestToast(RepositoriesFeature.StatusToast)
+      case debugSimulateUpdateFound
     #endif
   }
 
@@ -65,7 +66,7 @@ struct CommandPaletteItem: Identifiable, Equatable {
     case .worktreeSelect, .removeWorktree, .archiveWorktree:
       return false
     #if DEBUG
-      case .debugTestToast:
+      case .debugTestToast, .debugSimulateUpdateFound:
         return true
     #endif
     }
@@ -91,7 +92,7 @@ struct CommandPaletteItem: Identifiable, Equatable {
       .archiveWorktree:
       return false
     #if DEBUG
-      case .debugTestToast:
+      case .debugTestToast, .debugSimulateUpdateFound:
         return false
     #endif
     }
@@ -127,7 +128,7 @@ struct CommandPaletteItem: Identifiable, Equatable {
       .archiveWorktree:
       return nil
     #if DEBUG
-      case .debugTestToast:
+      case .debugTestToast, .debugSimulateUpdateFound:
         return nil
     #endif
     }

--- a/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
+++ b/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
@@ -52,6 +52,7 @@ struct CommandPaletteFeature {
     case installCLI
     #if DEBUG
       case debugTestToast(RepositoriesFeature.StatusToast)
+      case debugSimulateUpdateFound
     #endif
   }
 
@@ -436,6 +437,12 @@ private func makeClosePullRequestItem(
         subtitle: "Simulates a success toast",
         kind: .debugTestToast(.success("Pull request merged"))
       ),
+      CommandPaletteItem(
+        id: "debug.update.simulate-found",
+        title: "[Debug] Simulate Update Found",
+        subtitle: "Shows the toolbar update badge without querying Sparkle",
+        kind: .debugSimulateUpdateFound
+      ),
     ]
   }
 #endif
@@ -584,6 +591,8 @@ private func delegateAction(for kind: CommandPaletteItem.Kind) -> CommandPalette
   #if DEBUG
     case .debugTestToast(let toast):
       return .debugTestToast(toast)
+    case .debugSimulateUpdateFound:
+      return .debugSimulateUpdateFound
   #endif
   }
 }
@@ -621,7 +630,7 @@ private func pullRequestDelegateAction(
     .ghosttyCommand:
     return nil
   #if DEBUG
-    case .debugTestToast:
+    case .debugTestToast, .debugSimulateUpdateFound:
       return nil
   #endif
   }

--- a/supacode/Features/CommandPalette/Views/CommandPaletteOverlayView.swift
+++ b/supacode/Features/CommandPalette/Views/CommandPaletteOverlayView.swift
@@ -358,7 +358,7 @@ private struct CommandPaletteRowView: View {
     case .archiveWorktree:
       return "Archive"
     #if DEBUG
-      case .debugTestToast:
+      case .debugTestToast, .debugSimulateUpdateFound:
         return "Debug"
     #endif
     }
@@ -407,6 +407,8 @@ private struct CommandPaletteRowView: View {
     #if DEBUG
       case .debugTestToast:
         return "ladybug"
+      case .debugSimulateUpdateFound:
+        return "ladybug"
     #endif
     }
   }
@@ -422,7 +424,7 @@ private struct CommandPaletteRowView: View {
     case .worktreeSelect, .removeWorktree, .archiveWorktree:
       return false
     #if DEBUG
-      case .debugTestToast:
+      case .debugTestToast, .debugSimulateUpdateFound:
         return true
     #endif
     }
@@ -534,7 +536,7 @@ private struct CommandPaletteRowView: View {
     case .installCLI:
       base = "Install Command Line Tool"
     #if DEBUG
-      case .debugTestToast:
+      case .debugTestToast, .debugSimulateUpdateFound:
         base = row.title
     #endif
     }

--- a/supacode/Features/Repositories/Views/ToolbarUpdateButton.swift
+++ b/supacode/Features/Repositories/Views/ToolbarUpdateButton.swift
@@ -16,7 +16,7 @@ struct ToolbarUpdateButton: View {
       onCheckForUpdates()
     } label: {
       Image(systemName: "arrow.down.circle.fill")
-        .foregroundStyle(.tint)
+        .foregroundStyle(Color("ProwlAccent"))
         .accessibilityHidden(true)
     }
     .help(tooltip)

--- a/supacode/Features/Repositories/Views/ToolbarUpdateButton.swift
+++ b/supacode/Features/Repositories/Views/ToolbarUpdateButton.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+
+struct ToolbarUpdateButton: View {
+  let availableVersion: String?
+  let onCheckForUpdates: () -> Void
+
+  private var tooltip: String {
+    if let availableVersion, !availableVersion.isEmpty {
+      return "Version \(availableVersion) is available. Click to review and install."
+    }
+    return "A new version is available. Click to review and install."
+  }
+
+  var body: some View {
+    Button {
+      onCheckForUpdates()
+    } label: {
+      Image(systemName: "arrow.down.circle.fill")
+        .foregroundStyle(.tint)
+        .accessibilityHidden(true)
+    }
+    .help(tooltip)
+    .accessibilityLabel("Install update")
+  }
+}

--- a/supacode/Features/Repositories/Views/WorktreeDetailView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailView.swift
@@ -13,6 +13,8 @@ struct WorktreeDetailView: View {
     let runScriptEnabled: Bool
     let runScriptIsRunning: Bool
     let customCommands: [UserCustomCommand]
+    let isUpdateAvailable: Bool
+    let availableUpdateVersion: String?
   }
 
   @Bindable var store: StoreOf<AppFeature>
@@ -61,14 +63,12 @@ struct WorktreeDetailView: View {
     .toolbar(removing: repositories.isShowingCanvas ? nil : .title)
     .toolbar {
       if repositories.isShowingCanvas {
-        ToolbarItem(placement: .primaryAction) {
-          ToolbarNotificationsPopoverButton(
-            groups: notificationGroups,
-            unseenWorktreeCount: unseenNotificationWorktreeCount,
-            onSelectNotification: selectToolbarNotification,
-            onDismissAll: { dismissAllToolbarNotifications(in: notificationGroups) }
-          )
-        }
+        canvasToolbarContent(
+          notificationGroups: notificationGroups,
+          unseenNotificationWorktreeCount: unseenNotificationWorktreeCount,
+          isUpdateAvailable: state.updates.isUpdateAvailable,
+          availableUpdateVersion: state.updates.availableVersion
+        )
       } else if hasActiveTerminalTarget,
         let toolbarState = toolbarState(
           input: ToolbarStateInput(
@@ -80,7 +80,9 @@ struct WorktreeDetailView: View {
             showExtras: commandKeyObserver.isPressed,
             runScriptEnabled: runScriptEnabled,
             runScriptIsRunning: runScriptIsRunning,
-            customCommands: customCommands
+            customCommands: customCommands,
+            isUpdateAvailable: state.updates.isUpdateAvailable,
+            availableUpdateVersion: state.updates.availableVersion
           )
         )
       {
@@ -107,7 +109,8 @@ struct WorktreeDetailView: View {
           onStopRunScript: { store.send(.stopRunScript) },
           onRunCustomCommand: { index in
             store.send(.runCustomCommand(index))
-          }
+          },
+          onCheckForUpdates: { store.send(.updates(.checkForUpdates)) }
         )
       }
     }
@@ -118,6 +121,28 @@ struct WorktreeDetailView: View {
       runScriptIsRunning: runScriptIsRunning
     )
     return applyFocusedActions(content: content, actions: actions)
+  }
+
+  @ToolbarContentBuilder
+  private func canvasToolbarContent(
+    notificationGroups: [ToolbarNotificationRepositoryGroup],
+    unseenNotificationWorktreeCount: Int,
+    isUpdateAvailable: Bool,
+    availableUpdateVersion: String?
+  ) -> some ToolbarContent {
+    ToolbarItemGroup(placement: .primaryAction) {
+      ToolbarNotificationsPopoverButton(
+        groups: notificationGroups,
+        unseenWorktreeCount: unseenNotificationWorktreeCount,
+        onSelectNotification: selectToolbarNotification,
+        onDismissAll: { dismissAllToolbarNotifications(in: notificationGroups) }
+      )
+      if isUpdateAvailable {
+        ToolbarUpdateButton(availableVersion: availableUpdateVersion) {
+          store.send(.updates(.checkForUpdates))
+        }
+      }
+    }
   }
 
   private func toolbarState(input: ToolbarStateInput) -> WorktreeToolbarState? {
@@ -146,7 +171,9 @@ struct WorktreeDetailView: View {
       showExtras: input.showExtras,
       runScriptEnabled: input.runScriptEnabled,
       runScriptIsRunning: input.runScriptIsRunning,
-      customCommands: input.customCommands
+      customCommands: input.customCommands,
+      isUpdateAvailable: input.isUpdateAvailable,
+      availableUpdateVersion: input.availableUpdateVersion
     )
   }
 
@@ -391,6 +418,8 @@ struct WorktreeDetailView: View {
     let runScriptEnabled: Bool
     let runScriptIsRunning: Bool
     let customCommands: [UserCustomCommand]
+    let isUpdateAvailable: Bool
+    let availableUpdateVersion: String?
   }
 
   fileprivate struct WorktreeToolbarContent: ToolbarContent {
@@ -404,6 +433,7 @@ struct WorktreeDetailView: View {
     let onRunScript: () -> Void
     let onStopRunScript: () -> Void
     let onRunCustomCommand: (Int) -> Void
+    let onCheckForUpdates: () -> Void
     @Environment(\.resolvedKeybindings) private var resolvedKeybindings
 
     var body: some ToolbarContent {
@@ -432,6 +462,12 @@ struct WorktreeDetailView: View {
           onSelectNotification: onSelectNotification,
           onDismissAll: onDismissAllNotifications
         )
+        if toolbarState.isUpdateAvailable {
+          ToolbarUpdateButton(
+            availableVersion: toolbarState.availableUpdateVersion,
+            onCheckForUpdates: onCheckForUpdates
+          )
+        }
       }
 
       ToolbarSpacer(.flexible)
@@ -865,7 +901,9 @@ private struct WorktreeToolbarPreview: View {
             modifiers: UserCustomShortcutModifiers()
           )
         ),
-      ]
+      ],
+      isUpdateAvailable: true,
+      availableUpdateVersion: "2026.5.1"
     )
     let observer = CommandKeyObserver()
     observer.isPressed = false
@@ -888,7 +926,8 @@ private struct WorktreeToolbarPreview: View {
         onDismissAllNotifications: {},
         onRunScript: {},
         onStopRunScript: {},
-        onRunCustomCommand: { _ in }
+        onRunCustomCommand: { _ in },
+        onCheckForUpdates: {}
       )
     }
     .environment(commandKeyObserver)

--- a/supacode/Features/Settings/Views/UpdatesSettingsView.swift
+++ b/supacode/Features/Settings/Views/UpdatesSettingsView.swift
@@ -14,16 +14,20 @@ struct UpdatesSettingsView: View {
             Text("Tip").tag(UpdateChannel.tip)
           }
         }
-        Section("Automatic Updates") {
+        Section {
           Toggle(
             "Check for updates automatically",
             isOn: $settingsStore.updatesAutomaticallyCheckForUpdates
           )
-          Toggle(
-            "Download and install updates automatically",
-            isOn: $settingsStore.updatesAutomaticallyDownloadUpdates
+        } header: {
+          Text("Automatic Updates")
+        } footer: {
+          Text(
+            "When a new version is available, a small badge appears next to the notifications bell. "
+              + "Click it to review and install the update."
           )
-          .disabled(!settingsStore.updatesAutomaticallyCheckForUpdates)
+          .font(.callout)
+          .foregroundStyle(.secondary)
         }
       }
       .formStyle(.grouped)

--- a/supacode/Features/Updates/Reducer/UpdatesFeature.swift
+++ b/supacode/Features/Updates/Reducer/UpdatesFeature.swift
@@ -6,15 +6,19 @@ struct UpdatesFeature {
   @ObservableState
   struct State: Equatable {
     var didConfigureUpdates = false
+    var isUpdateAvailable = false
+    var availableVersion: String?
   }
 
   enum Action {
+    case task
     case applySettings(
       updateChannel: UpdateChannel,
       automaticallyChecks: Bool,
       automaticallyDownloads: Bool
     )
     case checkForUpdates
+    case updaterEvent(UpdaterClient.Event)
   }
 
   @Dependency(AnalyticsClient.self) private var analyticsClient
@@ -23,6 +27,13 @@ struct UpdatesFeature {
   var body: some Reducer<State, Action> {
     Reduce { state, action in
       switch action {
+      case .task:
+        return .run { send in
+          for await event in await updaterClient.events() {
+            await send(.updaterEvent(event))
+          }
+        }
+
       case .applySettings(let channel, let checks, let downloads):
         let checkInBackground = !state.didConfigureUpdates
         state.didConfigureUpdates = true
@@ -33,9 +44,19 @@ struct UpdatesFeature {
 
       case .checkForUpdates:
         analyticsClient.capture("update_checked", nil)
+        // Clear the badge so a fresh user-initiated check drives the standard dialog.
+        // If the update is still available, Sparkle re-triggers `showUpdateFound` and
+        // the standard driver takes over.
+        state.isUpdateAvailable = false
+        state.availableVersion = nil
         return .run { _ in
           await updaterClient.checkForUpdates()
         }
+
+      case .updaterEvent(.silentUpdateFound(let version)):
+        state.isUpdateAvailable = true
+        state.availableVersion = version
+        return .none
       }
     }
   }

--- a/supacode/Features/Updates/Reducer/UpdatesFeature.swift
+++ b/supacode/Features/Updates/Reducer/UpdatesFeature.swift
@@ -19,6 +19,9 @@ struct UpdatesFeature {
     )
     case checkForUpdates
     case updaterEvent(UpdaterClient.Event)
+    #if DEBUG
+      case debugSimulateUpdateFound
+    #endif
   }
 
   @Dependency(AnalyticsClient.self) private var analyticsClient
@@ -57,6 +60,13 @@ struct UpdatesFeature {
         state.isUpdateAvailable = true
         state.availableVersion = version
         return .none
+
+      #if DEBUG
+        case .debugSimulateUpdateFound:
+          state.isUpdateAvailable = true
+          state.availableVersion = "9999.1.1"
+          return .none
+      #endif
       }
     }
   }

--- a/supacodeTests/CommandPaletteFeatureTests.swift
+++ b/supacodeTests/CommandPaletteFeatureTests.swift
@@ -23,6 +23,7 @@ struct CommandPaletteFeatureTests {
       expectedIDs.append(contentsOf: [
         "debug.toast.inProgress",
         "debug.toast.success",
+        "debug.update.simulate-found",
       ])
     #endif
     expectNoDifference(items.map(\.id), expectedIDs)


### PR DESCRIPTION
## Summary

- Replace Sparkle's auto-popup flow with silent background detection: a custom `SPUUserDriver` (`SilentUpdateDriver`) dismisses non-user-initiated `showUpdateFound` prompts and yields an `AsyncStream` event instead; user-initiated checks still forward to `SPUStandardUserDriver` so the native release-notes / install dialog is preserved.
- New `ToolbarUpdateButton` appears to the right of the notifications bell (in both the worktree and canvas toolbars) when an update is available. Clicking it — or invoking "Check for Updates…" — runs a user-initiated check that re-offers the update through the standard flow.
- Remove the "Download and install automatically" toggle from Settings (Sparkle's auto-download path bypasses `showUpdateFound` and would defeat the silent flow); `automaticallyDownloadsUpdates` is now always `false`.

## Behavior

1. Sparkle runs its usual hourly background check.
2. On `showUpdateFound(userInitiated: false)`, the driver replies `.dismiss` (so Sparkle re-offers the same update next cycle) and yields `silentUpdateFound(version:)` onto its event stream.
3. `UpdatesFeature` subscribes via `.task` (kicked off from `appLaunched`) and flips `isUpdateAvailable = true`, recording `availableVersion`.
4. `WorktreeDetailView` reads `state.updates.*` and conditionally renders `ToolbarUpdateButton`.
5. Clicking the button (or "Check for Updates…") clears the badge, calls `updater.checkForUpdates()`, and the standard driver takes over for the release-notes / install / relaunch dialogs.

## Test plan

- [x] Manual: set `SUFeedURL` to a test appcast pointing at a higher version; launch Debug build and confirm the toolbar badge appears silently after the first background check (no dialog).
- [x] Manual: click the badge and confirm Sparkle's standard "Update Available" dialog shows with release notes.
- [x] Manual: click "Check for Updates…" from the app menu when no update is available and confirm the standard "You're up to date" dialog still appears (forwarded to `SPUStandardUserDriver`).
- [x] Manual: after dismissing ("Remind me later"), verify the badge stays hidden until the next hourly background check re-detects the same version.
- [x] `make build-app`, `make check`, `make test` (720 tests) all pass.
