### PR TITLE
Tag every PostHog event with app/OS/device context

### DIFF
--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -145,6 +145,8 @@ struct SupacodeApp: App {
       {
         let config = PostHogConfig(apiKey: apiKey, host: host)
         config.enableSwizzling = false
+        config.captureApplicationLifecycleEvents = false
+        config.captureScreenViews = false
         PostHogSDK.shared.setup(config)
         PostHogSDK.shared.register(AnalyticsContext.superProperties)
         PostHogSDK.shared.identify(InstallIdentifier.current)

--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -116,21 +116,13 @@ struct SupacodeApp: App {
     return value
   }
 
-  @MainActor init() {
-    NSWindow.allowsAutomaticWindowTabbing = false
-    UserDefaults.standard.set(200, forKey: "NSInitialToolTipDelay")
-    @Shared(.settingsFile) var settingsFile
-    let initialSettings = settingsFile.global
-    let initialResolvedKeybindings = KeybindingResolver.resolve(
-      schema: .appResolverSchema(),
-      userOverrides: initialSettings.keybindingUserOverrides
-    )
+  private static func bootstrapTelemetry(initialSettings: GlobalSettings) {
     #if !DEBUG
       let infoDictionary = Bundle.main.infoDictionary ?? [:]
       let releaseName = (infoDictionary["CFBundleShortVersionString"] as? String).map { "prowl@\($0)" }
       let environment = initialSettings.updateChannel == .tip ? "tip" : "production"
 
-      if initialSettings.crashReportsEnabled, let dsn = Self.infoPlistSecret(infoDictionary, key: "ProwlSentryDSN") {
+      if initialSettings.crashReportsEnabled, let dsn = infoPlistSecret(infoDictionary, key: "ProwlSentryDSN") {
         SentrySDK.start { options in
           options.dsn = dsn
           options.environment = environment
@@ -140,8 +132,8 @@ struct SupacodeApp: App {
         }
       }
       if initialSettings.analyticsEnabled,
-        let apiKey = Self.infoPlistSecret(infoDictionary, key: "ProwlPostHogAPIKey"),
-        let host = Self.infoPlistSecret(infoDictionary, key: "ProwlPostHogHost")
+        let apiKey = infoPlistSecret(infoDictionary, key: "ProwlPostHogAPIKey"),
+        let host = infoPlistSecret(infoDictionary, key: "ProwlPostHogHost")
       {
         let config = PostHogConfig(apiKey: apiKey, host: host)
         config.enableSwizzling = false
@@ -152,6 +144,18 @@ struct SupacodeApp: App {
         PostHogSDK.shared.identify(InstallIdentifier.current)
       }
     #endif
+  }
+
+  @MainActor init() {
+    NSWindow.allowsAutomaticWindowTabbing = false
+    UserDefaults.standard.set(200, forKey: "NSInitialToolTipDelay")
+    @Shared(.settingsFile) var settingsFile
+    let initialSettings = settingsFile.global
+    let initialResolvedKeybindings = KeybindingResolver.resolve(
+      schema: .appResolverSchema(),
+      userOverrides: initialSettings.keybindingUserOverrides
+    )
+    Self.bootstrapTelemetry(initialSettings: initialSettings)
     if let resourceURL = Bundle.main.resourceURL?.appendingPathComponent("ghostty") {
       setenv("GHOSTTY_RESOURCES_DIR", resourceURL.path, 1)
     }

--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -128,11 +128,12 @@ struct SupacodeApp: App {
     #if !DEBUG
       let infoDictionary = Bundle.main.infoDictionary ?? [:]
       let releaseName = (infoDictionary["CFBundleShortVersionString"] as? String).map { "prowl@\($0)" }
+      let environment = initialSettings.updateChannel == .tip ? "tip" : "production"
 
       if initialSettings.crashReportsEnabled, let dsn = Self.infoPlistSecret(infoDictionary, key: "ProwlSentryDSN") {
         SentrySDK.start { options in
           options.dsn = dsn
-          options.environment = "production"
+          options.environment = environment
           if let releaseName { options.releaseName = releaseName }
           options.tracesSampleRate = 0.05
           options.enableAppHangTracking = true
@@ -145,6 +146,7 @@ struct SupacodeApp: App {
         let config = PostHogConfig(apiKey: apiKey, host: host)
         config.enableSwizzling = false
         PostHogSDK.shared.setup(config)
+        PostHogSDK.shared.register(AnalyticsContext.superProperties)
         PostHogSDK.shared.identify(InstallIdentifier.current)
       }
     #endif

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -166,6 +166,7 @@ struct AppFeature {
         appLogger.info("[LayoutRestore] appLaunched: launchRestoreMode=\(String(describing: state.launchRestoreMode))")
         state.launchedAt = now
         state.repositories.launchRestoreMode = state.launchRestoreMode
+        analyticsClient.capture("app_activated", nil)
         return .merge(
           .send(.repositories(.task)),
           .send(.settings(.task)),
@@ -189,7 +190,6 @@ struct AppFeature {
       case .scenePhaseChanged(let phase):
         switch phase {
         case .active:
-          analyticsClient.capture("app_activated", nil)
           return .merge(
             .send(.repositories(.refreshWorktrees)),
             .run { send in

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -52,6 +52,7 @@ struct AppFeature {
     var lastKnownSystemNotificationsEnabled: Bool
     var launchRestoreMode: LaunchRestoreMode
     var suppressLayoutSaveUntilRelaunch = false
+    var launchedAt: Date?
     @Presents var alert: AlertState<Alert>?
 
     init(
@@ -104,6 +105,7 @@ struct AppFeature {
   }
 
   @Dependency(AnalyticsClient.self) private var analyticsClient
+  @Dependency(\.date.now) private var now
   @Dependency(RepositoryPersistenceClient.self) private var repositoryPersistence
   @Dependency(WorkspaceClient.self) private var workspaceClient
   @Dependency(SettingsWindowClient.self) private var settingsWindowClient
@@ -112,6 +114,16 @@ struct AppFeature {
   @Dependency(TerminalClient.self) private var terminalClient
   @Dependency(WorktreeInfoWatcherClient.self) private var worktreeInfoWatcher
   @Dependency(CustomShortcutRegistryClient.self) private var customShortcutRegistryClient
+
+  private func appQuitProperties(launchedAt: Date?) -> [String: Any]? {
+    guard let seconds = Self.sessionDurationSeconds(launchedAt: launchedAt, now: now) else { return nil }
+    return ["session_duration_seconds": seconds]
+  }
+
+  static func sessionDurationSeconds(launchedAt: Date?, now: Date) -> Int? {
+    guard let launchedAt else { return nil }
+    return max(0, Int(now.timeIntervalSince(launchedAt)))
+  }
 
   private func resolvedKeybindings(
     settings: SettingsFeature.State,
@@ -152,6 +164,7 @@ struct AppFeature {
       case .appLaunched:
         try? SupacodePaths.migrateLegacyCacheFilesIfNeeded()
         appLogger.info("[LayoutRestore] appLaunched: launchRestoreMode=\(String(describing: state.launchRestoreMode))")
+        state.launchedAt = now
         state.repositories.launchRestoreMode = state.launchRestoreMode
         return .merge(
           .send(.repositories(.task)),
@@ -561,7 +574,7 @@ struct AppFeature {
       case .requestQuit:
         #if !DEBUG
           guard state.settings.confirmBeforeQuit else {
-            analyticsClient.capture("app_quit", nil)
+            analyticsClient.capture("app_quit", appQuitProperties(launchedAt: state.launchedAt))
             return .run { @MainActor _ in
               NSApplication.shared.terminate(nil)
             }
@@ -824,7 +837,7 @@ struct AppFeature {
         return .none
 
       case .alert(.presented(.confirmQuit)):
-        analyticsClient.capture("app_quit", nil)
+        analyticsClient.capture("app_quit", appQuitProperties(launchedAt: state.launchedAt))
         state.alert = nil
         return .run { @MainActor _ in
           NSApplication.shared.terminate(nil)

--- a/supacode/Support/AnalyticsContext.swift
+++ b/supacode/Support/AnalyticsContext.swift
@@ -1,0 +1,48 @@
+import Darwin
+import Foundation
+
+/// Static metadata about the app and host machine. Registered once with PostHog
+/// at startup so every event ships with these dimensions and dashboards can
+/// slice by app version, OS, hardware, locale.
+nonisolated enum AnalyticsContext {
+  static var superProperties: [String: String] {
+    let bundle = Bundle.main
+    let osVersion = ProcessInfo.processInfo.operatingSystemVersion
+    let appVersion = bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "unknown"
+    let buildNumber = bundle.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "unknown"
+
+    return [
+      "app_version": appVersion,
+      "build_number": buildNumber,
+      "os_version": "\(osVersion.majorVersion).\(osVersion.minorVersion).\(osVersion.patchVersion)",
+      "os_major": "\(osVersion.majorVersion)",
+      "os_minor": "\(osVersion.minorVersion)",
+      "device_model": deviceModel,
+      "cpu_arch": cpuArch,
+      "locale": Locale.current.identifier,
+    ]
+  }
+
+  private static var deviceModel: String {
+    sysctlString("hw.model") ?? "unknown"
+  }
+
+  private static var cpuArch: String {
+    #if arch(arm64)
+      return "arm64"
+    #elseif arch(x86_64)
+      return "x86_64"
+    #else
+      return "unknown"
+    #endif
+  }
+
+  private static func sysctlString(_ name: String) -> String? {
+    var size = 0
+    guard sysctlbyname(name, nil, &size, nil, 0) == 0, size > 0 else { return nil }
+    var bytes = [UInt8](repeating: 0, count: size)
+    guard sysctlbyname(name, &bytes, &size, nil, 0) == 0 else { return nil }
+    let payload = bytes.prefix(while: { $0 != 0 })
+    return String(bytes: payload, encoding: .utf8)
+  }
+}

--- a/supacodeTests/AnalyticsContextTests.swift
+++ b/supacodeTests/AnalyticsContextTests.swift
@@ -1,0 +1,37 @@
+import Foundation
+import Testing
+
+@testable import supacode
+
+struct AnalyticsContextTests {
+  @Test func superPropertiesContainAllRequiredKeys() {
+    let props = AnalyticsContext.superProperties
+
+    let requiredKeys = [
+      "app_version",
+      "build_number",
+      "os_version",
+      "os_major",
+      "os_minor",
+      "device_model",
+      "cpu_arch",
+      "locale",
+    ]
+
+    for key in requiredKeys {
+      #expect(props[key] != nil, "missing key: \(key)")
+      #expect(!(props[key]?.isEmpty ?? true), "empty value for: \(key)")
+    }
+  }
+
+  @Test func cpuArchHasExpectedValue() {
+    let arch = AnalyticsContext.superProperties["cpu_arch"]
+    #expect(["arm64", "x86_64", "unknown"].contains(arch))
+  }
+
+  @Test func osMajorAndMinorAreNumeric() {
+    let props = AnalyticsContext.superProperties
+    #expect(Int(props["os_major"] ?? "") != nil)
+    #expect(Int(props["os_minor"] ?? "") != nil)
+  }
+}

--- a/supacodeTests/AppFeatureSessionDurationTests.swift
+++ b/supacodeTests/AppFeatureSessionDurationTests.swift
@@ -1,0 +1,28 @@
+import Foundation
+import Testing
+
+@testable import supacode
+
+struct AppFeatureSessionDurationTests {
+  @Test func returnsNilWhenLaunchedAtIsNil() {
+    #expect(AppFeature.sessionDurationSeconds(launchedAt: nil, now: Date()) == nil)
+  }
+
+  @Test func returnsElapsedSecondsAsInteger() {
+    let start = Date(timeIntervalSince1970: 1_000)
+    let later = Date(timeIntervalSince1970: 1_042)
+    #expect(AppFeature.sessionDurationSeconds(launchedAt: start, now: later) == 42)
+  }
+
+  @Test func clampsNegativeDurationsToZero() {
+    let future = Date(timeIntervalSince1970: 2_000)
+    let past = Date(timeIntervalSince1970: 1_000)
+    #expect(AppFeature.sessionDurationSeconds(launchedAt: future, now: past) == 0)
+  }
+
+  @Test func truncatesFractionalSeconds() {
+    let start = Date(timeIntervalSince1970: 1_000)
+    let later = Date(timeIntervalSince1970: 1_000.999)
+    #expect(AppFeature.sessionDurationSeconds(launchedAt: start, now: later) == 0)
+  }
+}


### PR DESCRIPTION
## Summary

Part 2 of the observability reboot (P1). Makes the data we already collect actually sliceable.

- **PostHog super properties**: `AnalyticsContext.swift` exposes a stable bag (`app_version`, `build_number`, `os_version`/`os_major`/`os_minor`, `device_model` via `sysctlbyname("hw.model")`, `cpu_arch` via `#if arch(arm64)`, `locale`). Registered once after `PostHogSDK.shared.setup`. Every existing event automatically inherits these — the 16 currently-naked events become filterable by version, OS, and hardware.
- **Sentry environment from update channel**: `tip` channel users land in their own Sentry bucket (`environment = "tip"`), so a regression on the bleeding edge doesn't pollute stable's crash rate.
- **`session_duration_seconds` on `app_quit`**: track `state.launchedAt` from the `.appLaunched` action using `@Dependency(\.date.now)`, compute on quit. This is the natural denominator for the long-running memory growth investigation in P2.

## Scope changes vs original P1 plan

`script_run` (exit_code, duration_ms) and `terminal_tab_closed` (tab_lifetime_seconds) were originally in P1, but both need `TerminalClient.Event` to grow new payloads (`.scriptFinished` / `.tabClosed`) and the capture site to move from action-trigger to event-receipt. That's the same terminal-layer surgery P2 needs for memory probing anyway, so they're folded into P2.

## Test plan

- [x] `make build-app` (Debug) succeeds, no warnings
- [x] `make check` clean for the touched files
- [x] `AnalyticsContextTests` (3 tests) — required keys present, cpu_arch in expected set, os_major/minor are numeric
- [x] `AppFeatureSessionDurationTests` (4 tests) — nil launchedAt → nil props, elapsed seconds correctly truncated, negative durations clamped to 0
- [x] Live verify: install Release with real credentials, quit after a few minutes, confirm PostHog `app_quit` event carries `session_duration_seconds` and all super properties

## Notes

- `AppFeature.sessionDurationSeconds(launchedAt:now:)` is `internal static` so the pure calculation can be unit-tested without spinning up `TestStore` (which would chase the infinite `terminalClient.events` stream from `.appLaunched`).
- swift-format wanted to reformat 7 unrelated upstream files; restored those — same situation as P0 PR #207.
