### PR TITLE
Upload dSYMs and register Sentry release during publish

### DIFF
--- a/doc-onevcat/fork-sync-and-release.md
+++ b/doc-onevcat/fork-sync-and-release.md
@@ -95,6 +95,7 @@ Builds a Release archive, signs it locally, and installs to `/Applications`.
 | `APPLE_TEAM_ID` | from identity | Apple Team ID |
 | `APPLE_NOTARY_KEYCHAIN_PROFILE` | `supacode-notary` | Keychain profile for notarytool |
 | `SPARKLE_PRIVATE_KEY_FILE` | `~/.prowl-sparkle-private-key` | EdDSA private key for appcast |
+| `SKIP_SENTRY` | unset | Set to `1` to skip dSYM upload and Sentry release tracking |
 
 ## Notarization Credentials
 
@@ -105,6 +106,57 @@ xcrun notarytool store-credentials supacode-notary \
   --apple-id <email> \
   --password <app-specific-password> \
   --team-id <team-id>
+```
+
+## Sentry Integration
+
+The release script uploads dSYMs and registers each version as a Sentry release so crash reports get symbolicated stack traces and dashboards can associate issues with specific versions.
+
+### One-time setup
+
+Install `sentry-cli` (separate from the newer `sentry` CLI used for issue inspection):
+
+```bash
+brew install getsentry/tools/sentry-cli
+```
+
+Configure auth + defaults in `~/.sentryclirc`:
+
+```ini
+[auth]
+token=sntryu_xxxxxxxx
+
+[defaults]
+url=https://sentry.io/
+org=onevs-den
+project=prowl-macos
+```
+
+Token scopes required: `event:read`, `project:read`, `project:releases`. Generate at <https://sentry.io/settings/account/api/auth-tokens/>.
+
+### What the release script does
+
+After `make archive` produces `build/supacode.xcarchive/dSYMs/`:
+
+1. `sentry-cli releases new prowl@<VERSION>` — registers the release
+2. `sentry-cli debug-files upload --include-sources --wait <dSYM>` — uploads symbols + source context
+3. `sentry-cli releases set-commits --auto` — associates commits for "first seen in" tracking
+4. After GitHub Release is published: `sentry-cli releases finalize prowl@<VERSION>`
+
+The release name `prowl@<VERSION>` matches `options.releaseName` set in `supacode/App/supacodeApp.swift`, so dSYMs and issues align automatically.
+
+### Failure handling
+
+Any Sentry step that fails only prints a warning — the release continues. dSYMs can be re-uploaded later with:
+
+```bash
+sentry-cli debug-files upload --include-sources <path-to-dSYM>
+```
+
+To skip the entire Sentry block (e.g. emergency release, sentry-cli not installed):
+
+```bash
+SKIP_SENTRY=1 ./doc-onevcat/scripts/release.sh
 ```
 
 ## Helper Scripts

--- a/doc-onevcat/scripts/release.sh
+++ b/doc-onevcat/scripts/release.sh
@@ -13,6 +13,7 @@
 #   APPLE_NOTARY_KEYCHAIN_PROFILE   Keychain profile for notarytool (default: supacode-notary)
 #   SPARKLE_PRIVATE_KEY_FILE        Path to EdDSA private key file (default: ~/.prowl-sparkle-private-key)
 #   NETLIFY_BUILD_HOOK              Netlify Build Hook URL for Prowl-Site rebuild
+#   SKIP_SENTRY                     Set to 1 to skip dSYM upload and Sentry release tracking
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -67,6 +68,17 @@ for cmd in gh jq codesign xcrun create-dmg; do
   command -v "$cmd" >/dev/null 2>&1 || die "$cmd is required but not found"
 done
 [[ -x "$PROJECT_DIR/bins/generate_appcast" ]] || die "bins/generate_appcast not found"
+
+SENTRY_ENABLED=1
+if [[ "${SKIP_SENTRY:-}" == "1" ]]; then
+  SENTRY_ENABLED=0
+  log "SKIP_SENTRY=1 set, dSYM upload and release tracking will be skipped"
+elif ! command -v sentry-cli >/dev/null 2>&1; then
+  SENTRY_ENABLED=0
+  log "WARNING: sentry-cli not installed; dSYM upload will be skipped"
+  log "         install:  brew install getsentry/tools/sentry-cli"
+  log "         suppress: SKIP_SENTRY=1"
+fi
 
 if [[ -n "$(git status --porcelain)" ]]; then
   die "working tree is not clean — commit or stash changes first"
@@ -180,6 +192,31 @@ fi
 
 log "archiving Release build..."
 make archive APPLE_TEAM_ID="$TEAM_ID" DEVELOPER_ID_IDENTITY_SHA="$IDENTITY_SHA"
+
+# ── Sentry: register release + upload dSYM ──────────────────────────────────
+# Done right after archive so dSYM is ready before downstream steps. Failures
+# only warn — release proceeds because dSYM can be re-uploaded later with
+# `sentry-cli debug-files upload <dSYM>`.
+
+SENTRY_RELEASE_NAME="prowl@$VERSION"
+if [[ "$SENTRY_ENABLED" -eq 1 ]]; then
+  log "creating Sentry release $SENTRY_RELEASE_NAME..."
+  sentry-cli releases new "$SENTRY_RELEASE_NAME" \
+    || log "WARNING: failed to create Sentry release (continuing)"
+
+  DSYM_DIR="build/supacode.xcarchive/dSYMs"
+  if [[ -d "$DSYM_DIR" ]]; then
+    log "uploading dSYM from $DSYM_DIR to Sentry..."
+    sentry-cli debug-files upload --include-sources --wait "$DSYM_DIR" \
+      || log "WARNING: dSYM upload failed (release will continue; re-run sentry-cli debug-files upload later)"
+  else
+    log "WARNING: $DSYM_DIR not found, skipping dSYM upload"
+  fi
+
+  log "associating commits with Sentry release..."
+  sentry-cli releases set-commits "$SENTRY_RELEASE_NAME" --auto \
+    || log "WARNING: failed to associate commits (continuing)"
+fi
 
 # ── Export ───────────────────────────────────────────────────────────────────
 
@@ -334,6 +371,16 @@ gh release create "$TAG" "${UPLOAD_FILES[@]}" \
 
 RELEASE_URL="https://github.com/$REPO/releases/tag/$TAG"
 log "release created: $RELEASE_URL"
+
+# ── Finalize Sentry release ─────────────────────────────────────────────────
+# Marks the release as deployed in Sentry's dashboard so issue tracking can
+# associate "first seen in" with this version.
+
+if [[ "$SENTRY_ENABLED" -eq 1 ]]; then
+  log "finalizing Sentry release $SENTRY_RELEASE_NAME..."
+  sentry-cli releases finalize "$SENTRY_RELEASE_NAME" \
+    || log "WARNING: failed to finalize Sentry release (non-fatal)"
+fi
 
 # ── Trigger Prowl-Site rebuild ───────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Hooks `sentry-cli` into the existing `doc-onevcat/scripts/release.sh` so every public release ships its dSYMs to Sentry — without that, the crash reporting we just enabled in PR #208 produces stack traces that are a list of raw addresses with `<unknown>` function names. The change is intentionally small and isolated to the release pipeline (NOT `make install-release`, which is for local dev installs).

## What it does

Two insertions, both in `release.sh`:

**After `make archive`** (dSYMs ready in `build/supacode.xcarchive/dSYMs/`):
- `sentry-cli releases new prowl@<VERSION>` — release name matches `options.releaseName` set in `supacode/App/supacodeApp.swift`
- `sentry-cli debug-files upload --include-sources --wait <dSYM>` — symbols + source context (Prowl is open source, so embedding sources is fine and gives the dashboard inline source view)
- `sentry-cli releases set-commits --auto` — commit attribution for "first seen in this commit" tracking

**After GitHub Release is published**:
- `sentry-cli releases finalize prowl@<VERSION>` — marks the release as deployed in Sentry's dashboard

## Failure handling

Every `sentry-cli` call is best-effort: failure prints a warning and the release proceeds. dSYMs can be re-uploaded manually later. The release process should never be held hostage by a Sentry outage or token issue.

## Escape hatches

- `SKIP_SENTRY=1` — skips the whole sentry block (emergency releases, sentry-cli not installed, etc.)
- Preflight: `sentry-cli` missing → warning, not fatal. The script gracefully degrades.

## Configuration required

Documented in `doc-onevcat/fork-sync-and-release.md` (new "Sentry Integration" section):

- `brew install getsentry/tools/sentry-cli`
- `~/.sentryclirc` with auth token + `[defaults]` (org, project, url)
- Token scopes: `event:read`, `project:read`, `project:releases`

These are the same credentials/file the local dev uses for `sentry issue view` debugging — set up once.

## What it's NOT

- Not in `make install-release` (that's for local dev installs)
- Not adding any new build dependency at app-build time (sentry-cli is post-build only)
- Not blocking the release on Sentry — every step warns-on-failure

## Test plan

- [x] `bash -n` on release.sh
- [x] Documentation updated with env var table + setup section
- [x] Live verify: next public release should land dSYMs in Sentry → re-symbolicated stack traces visible on https://onevs-den.sentry.io/issues/

## Why now

Logically completes the observability arc: PR #207 wired credentials, PR #208 enables crash + analytics + super properties + sane PostHog autocapture, this PR makes the resulting crash data actually readable.
