### PR TITLE
Watch process memory and emit baseline + threshold crossings

### DIFF
--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -95,6 +95,7 @@ struct SupacodeApp: App {
   @State private var commandKeyObserver: CommandKeyObserver
   @State private var cliSocketServer: CLISocketServer
   @State private var store: StoreOf<AppFeature>
+  @State private var memoryWatchdog: MemoryWatchdog
 
   private static func cliLaunchOpenPath() -> String? {
     let args = ProcessInfo.processInfo.arguments
@@ -216,6 +217,22 @@ struct SupacodeApp: App {
 
     let cliServer = Self.makeCLISocketServer(appStore: appStore, terminalManager: terminalManager)
     _cliSocketServer = State(initialValue: cliServer)
+
+    let watchdog = MemoryWatchdog(
+      analyticsCapture: AnalyticsClient.liveValue.capture,
+      contextProvider: { [appStore, terminalManager] in
+        let state = appStore.state
+        return MemoryWatchdog.Context(
+          repositoryCount: state.repositories.repositories.count,
+          openedWorktreeCount: state.repositories.repositories.flatMap(\.worktrees).count,
+          terminalTabCount: terminalManager.activeWorktreeStates.flatMap(\.tabManager.tabs).count
+        )
+      }
+    )
+    #if !DEBUG
+      watchdog.start()
+    #endif
+    _memoryWatchdog = State(initialValue: watchdog)
 
     runtime.onQuit = { [weak appStore] in
       appStore?.send(.requestQuit)

--- a/supacode/Support/MemoryProbe.swift
+++ b/supacode/Support/MemoryProbe.swift
@@ -1,0 +1,23 @@
+import Darwin.Mach
+import Foundation
+
+/// Reads the current process's physical memory footprint in megabytes.
+///
+/// Uses `phys_footprint` from `task_info(TASK_VM_INFO)` — the same value
+/// Activity Monitor reports for "Memory" and Apple's recommended metric for
+/// "real RAM pressure this app contributes" (it folds in compressed memory).
+nonisolated enum MemoryProbe {
+  static func physFootprintMegabytes() -> Int {
+    var info = task_vm_info_data_t()
+    var count = mach_msg_type_number_t(
+      MemoryLayout<task_vm_info_data_t>.size / MemoryLayout<integer_t>.size
+    )
+    let result = withUnsafeMutablePointer(to: &info) { pointer -> kern_return_t in
+      pointer.withMemoryRebound(to: integer_t.self, capacity: Int(count)) { reboundPointer in
+        task_info(mach_task_self_, task_flavor_t(TASK_VM_INFO), reboundPointer, &count)
+      }
+    }
+    guard result == KERN_SUCCESS else { return 0 }
+    return Int(info.phys_footprint / (1024 * 1024))
+  }
+}

--- a/supacode/Support/MemoryWatchdog.swift
+++ b/supacode/Support/MemoryWatchdog.swift
@@ -1,0 +1,142 @@
+import Foundation
+import Sentry
+
+/// Monitors process memory footprint over the app's lifetime and emits exactly
+/// these analytics events per session:
+///
+/// - `app_memory_baseline` fires once, `baselineDelay` seconds after start,
+///   establishing the steady-state working set for this launch.
+/// - `memory_threshold_<N>mb` fires at most once per threshold per session
+///   when phys_footprint first crosses N. 4GB+ additionally surfaces a Sentry
+///   event so dashboards pair the spike with breadcrumbs/context.
+///
+/// Noise-controlled by design — long-lived sessions with stable memory emit
+/// exactly one event (the baseline); only genuine growth produces more.
+@MainActor
+@Observable
+final class MemoryWatchdog {
+  struct Context: Sendable, Equatable {
+    let repositoryCount: Int
+    let openedWorktreeCount: Int
+    let terminalTabCount: Int
+  }
+
+  typealias AnalyticsCapture = @Sendable (_ event: String, _ properties: [String: Any]?) -> Void
+  typealias SentryCapture = @Sendable (_ message: String) -> Void
+
+  private let probe: @Sendable () -> Int
+  private let clock: @Sendable () -> Date
+  private let tickInterval: TimeInterval
+  private let baselineDelay: TimeInterval
+  private let thresholdsMB: [Int]
+  private let sentryThresholdMB: Int
+  private let analyticsCapture: AnalyticsCapture
+  private let sentryCapture: SentryCapture
+  private let contextProvider: @MainActor () -> Context
+
+  private let startedAt: Date
+  private(set) var baselineMB: Int?
+  private(set) var firedThresholds: Set<Int> = []
+  private var tickTask: Task<Void, Never>?
+
+  init(
+    probe: @escaping @Sendable () -> Int = MemoryProbe.physFootprintMegabytes,
+    clock: @escaping @Sendable () -> Date = Date.init,
+    tickInterval: TimeInterval = 300,
+    baselineDelay: TimeInterval = 180,
+    thresholdsMB: [Int] = [2048, 4096, 8192],
+    sentryThresholdMB: Int = 4096,
+    analyticsCapture: @escaping AnalyticsCapture,
+    sentryCapture: @escaping SentryCapture = { SentrySDK.capture(message: $0) },
+    contextProvider: @escaping @MainActor () -> Context
+  ) {
+    self.probe = probe
+    self.clock = clock
+    self.tickInterval = tickInterval
+    self.baselineDelay = baselineDelay
+    self.thresholdsMB = thresholdsMB.sorted()
+    self.sentryThresholdMB = sentryThresholdMB
+    self.analyticsCapture = analyticsCapture
+    self.sentryCapture = sentryCapture
+    self.contextProvider = contextProvider
+    self.startedAt = clock()
+  }
+
+  /// Begins periodic ticking on a background Task. Safe to call more than once.
+  func start() {
+    tickTask?.cancel()
+    let interval = tickInterval
+    tickTask = Task { [weak self] in
+      while !Task.isCancelled {
+        try? await Task.sleep(for: .seconds(interval))
+        guard !Task.isCancelled else { return }
+        self?.tick()
+      }
+    }
+  }
+
+  func stop() {
+    tickTask?.cancel()
+    tickTask = nil
+  }
+
+  /// One monitoring pass. Exposed for tests; `start()` drives it on a schedule.
+  func tick() {
+    let now = clock()
+    let currentMB = probe()
+    let uptime = now.timeIntervalSince(startedAt)
+
+    if baselineMB == nil, uptime >= baselineDelay {
+      baselineMB = currentMB
+      let ctx = contextProvider()
+      analyticsCapture("app_memory_baseline", baselineProperties(currentMB: currentMB, uptime: uptime, context: ctx))
+    }
+
+    guard let baseline = baselineMB else { return }
+
+    for threshold in thresholdsMB where currentMB >= threshold && !firedThresholds.contains(threshold) {
+      firedThresholds.insert(threshold)
+      let ctx = contextProvider()
+      let props = thresholdProperties(
+        currentMB: currentMB,
+        baselineMB: baseline,
+        uptime: uptime,
+        context: ctx
+      )
+      analyticsCapture("memory_threshold_\(threshold)mb", props)
+      if threshold >= sentryThresholdMB {
+        sentryCapture(
+          "Memory threshold \(threshold) MB crossed (current=\(currentMB)MB, baseline=\(baseline)MB)"
+        )
+      }
+    }
+  }
+
+  private func baselineProperties(currentMB: Int, uptime: TimeInterval, context: Context) -> [String: Any] {
+    [
+      "resident_mb": currentMB,
+      "uptime_seconds": Int(uptime),
+      "repository_count": context.repositoryCount,
+      "opened_worktree_count": context.openedWorktreeCount,
+      "terminal_tab_count": context.terminalTabCount,
+    ]
+  }
+
+  private func thresholdProperties(
+    currentMB: Int,
+    baselineMB: Int,
+    uptime: TimeInterval,
+    context: Context
+  ) -> [String: Any] {
+    let growth = baselineMB > 0 ? (Double(currentMB) / Double(baselineMB)) : 0
+    return [
+      "resident_mb": currentMB,
+      "baseline_mb": baselineMB,
+      "growth_ratio": (growth * 100).rounded() / 100,
+      "uptime_seconds": Int(uptime),
+      "repository_count": context.repositoryCount,
+      "opened_worktree_count": context.openedWorktreeCount,
+      "terminal_tab_count": context.terminalTabCount,
+    ]
+  }
+}

--- a/supacodeTests/MemoryWatchdogTests.swift
+++ b/supacodeTests/MemoryWatchdogTests.swift
@@ -1,0 +1,166 @@
+import ConcurrencyExtras
+import Foundation
+import Testing
+
+@testable import supacode
+
+@MainActor
+struct MemoryWatchdogTests {
+  @Test func baselineDoesNotFireBeforeDelay() {
+    let env = makeEnv(baselineMB: 500)
+    env.now.setValue(baseDate.addingTimeInterval(60))
+    env.watchdog.tick()
+    #expect(env.events.value.isEmpty)
+    #expect(env.watchdog.baselineMB == nil)
+  }
+
+  @Test func baselineFiresAtDelayAndOnlyOnce() {
+    let env = makeEnv(baselineMB: 500)
+    env.now.setValue(baseDate.addingTimeInterval(180))
+    env.watchdog.tick()
+    #expect(env.events.value.count == 1)
+    #expect(env.events.value[0].event == "app_memory_baseline")
+    #expect(env.events.value[0].residentMB == 500)
+    #expect(env.watchdog.baselineMB == 500)
+
+    env.now.setValue(baseDate.addingTimeInterval(600))
+    env.watchdog.tick()
+    #expect(env.events.value.count == 1, "baseline must not fire twice")
+  }
+
+  @Test func thresholdFiresOnceEachAndSentryAtOrAbove4GB() {
+    let env = makeEnv(baselineMB: 500)
+    env.now.setValue(baseDate.addingTimeInterval(180))
+    env.watchdog.tick()
+
+    env.currentMB.setValue(2_500)
+    env.now.setValue(baseDate.addingTimeInterval(3_600))
+    env.watchdog.tick()
+    env.currentMB.setValue(5_000)
+    env.now.setValue(baseDate.addingTimeInterval(7_200))
+    env.watchdog.tick()
+    env.currentMB.setValue(9_000)
+    env.now.setValue(baseDate.addingTimeInterval(10_800))
+    env.watchdog.tick()
+
+    let thresholdEvents = env.events.value.map(\.event).filter { $0.hasPrefix("memory_threshold_") }
+    #expect(thresholdEvents == ["memory_threshold_2048mb", "memory_threshold_4096mb", "memory_threshold_8192mb"])
+
+    env.watchdog.tick()
+    let afterReplay = env.events.value.map(\.event).filter { $0.hasPrefix("memory_threshold_") }
+    #expect(afterReplay.count == 3, "thresholds must not re-fire")
+
+    #expect(env.sentryMessages.value.count == 2, "Sentry fires for 4GB and 8GB only")
+  }
+
+  @Test func droppingBelowThresholdDoesNotRearm() {
+    let env = makeEnv(baselineMB: 500)
+    env.now.setValue(baseDate.addingTimeInterval(180))
+    env.watchdog.tick()
+
+    env.currentMB.setValue(2_500)
+    env.now.setValue(baseDate.addingTimeInterval(3_600))
+    env.watchdog.tick()
+    env.currentMB.setValue(800)
+    env.now.setValue(baseDate.addingTimeInterval(7_200))
+    env.watchdog.tick()
+    env.currentMB.setValue(2_500)
+    env.now.setValue(baseDate.addingTimeInterval(10_800))
+    env.watchdog.tick()
+
+    let thresholdEvents = env.events.value.map(\.event).filter { $0.hasPrefix("memory_threshold_") }
+    #expect(thresholdEvents == ["memory_threshold_2048mb"])
+  }
+
+  @Test func thresholdsNeverFireWithoutBaseline() {
+    let env = makeEnv(baselineMB: 3_000)
+    env.now.setValue(baseDate.addingTimeInterval(30))
+    env.watchdog.tick()
+    #expect(env.events.value.isEmpty)
+    #expect(env.sentryMessages.value.isEmpty)
+  }
+
+  @Test func thresholdPropertiesIncludeContextAndGrowthRatio() {
+    let env = makeEnv(baselineMB: 500)
+    env.now.setValue(baseDate.addingTimeInterval(180))
+    env.watchdog.tick()
+
+    env.currentMB.setValue(2_500)
+    env.now.setValue(baseDate.addingTimeInterval(3_600))
+    env.watchdog.tick()
+
+    let event = env.events.value.last { $0.event == "memory_threshold_2048mb" }
+    #expect(event?.residentMB == 2_500)
+    #expect(event?.baselineMB == 500)
+    #expect(event?.growthRatio == 5.0)
+    #expect(event?.repositoryCount == 1)
+    #expect(event?.openedWorktreeCount == 2)
+    #expect(event?.terminalTabCount == 3)
+  }
+
+  // MARK: - Test helpers
+
+  private let baseDate = Date(timeIntervalSince1970: 1_700_000_000)
+
+  private nonisolated struct CapturedEvent: Sendable, Equatable {
+    let event: String
+    let residentMB: Int?
+    let baselineMB: Int?
+    let growthRatio: Double?
+    let uptimeSeconds: Int?
+    let repositoryCount: Int?
+    let openedWorktreeCount: Int?
+    let terminalTabCount: Int?
+
+    init(event: String, properties: [String: Any]) {
+      self.event = event
+      residentMB = properties["resident_mb"] as? Int
+      baselineMB = properties["baseline_mb"] as? Int
+      growthRatio = properties["growth_ratio"] as? Double
+      uptimeSeconds = properties["uptime_seconds"] as? Int
+      repositoryCount = properties["repository_count"] as? Int
+      openedWorktreeCount = properties["opened_worktree_count"] as? Int
+      terminalTabCount = properties["terminal_tab_count"] as? Int
+    }
+  }
+
+  private struct Env {
+    let watchdog: MemoryWatchdog
+    let currentMB: LockIsolated<Int>
+    let now: LockIsolated<Date>
+    let events: LockIsolated<[CapturedEvent]>
+    let sentryMessages: LockIsolated<[String]>
+  }
+
+  private func makeEnv(baselineMB: Int) -> Env {
+    let currentMB = LockIsolated(baselineMB)
+    let now = LockIsolated(baseDate)
+    let events = LockIsolated<[CapturedEvent]>([])
+    let sentryMessages = LockIsolated<[String]>([])
+    let watchdog = MemoryWatchdog(
+      probe: { currentMB.value },
+      clock: { now.value },
+      tickInterval: 300,
+      baselineDelay: 180,
+      thresholdsMB: [2_048, 4_096, 8_192],
+      sentryThresholdMB: 4_096,
+      analyticsCapture: { event, properties in
+        let captured = CapturedEvent(event: event, properties: properties ?? [:])
+        events.withValue { $0.append(captured) }
+      },
+      sentryCapture: { message in
+        sentryMessages.withValue { $0.append(message) }
+      },
+      contextProvider: {
+        .init(repositoryCount: 1, openedWorktreeCount: 2, terminalTabCount: 3)
+      }
+    )
+    return Env(
+      watchdog: watchdog,
+      currentMB: currentMB,
+      now: now,
+      events: events,
+      sentryMessages: sentryMessages
+    )
+  }
+}


### PR DESCRIPTION
## Summary

P2 of the observability reboot. The single thing I actually care about here: **turning the "runs for hours, memory explodes to tens of GB" report into data we can query**. Every session now contributes a healthy-state baseline and, if memory ever drifts up, one event per crossing threshold — enough to reconstruct the trajectory, few enough to stay inside the free tier.

## What ships

- **`MemoryProbe`** — `static func physFootprintMegabytes() -> Int` via `task_info(TASK_VM_INFO)`. Uses `phys_footprint` (the value Activity Monitor shows, which folds in compressed memory), not raw `resident_size`. Marked `nonisolated` so it composes with any actor.
- **`MemoryWatchdog`** — `@MainActor @Observable` class ticking every 5 minutes:
  - Fires `app_memory_baseline` **once**, at 3 min uptime. Establishes the session's steady-state working set.
  - Fires `memory_threshold_2048mb` / `4096mb` / `8192mb` **at most once each** when phys_footprint first crosses. **Re-crossing after dropping does NOT re-fire** — we want the monotonic envelope, not noise.
  - 4GB+ also routes through `SentrySDK.capture(message:)` so the spike shows up in Sentry paired with action breadcrumbs + device context.
  - Every event carries `repository_count` / `opened_worktree_count` / `terminal_tab_count` + `growth_ratio` so PostHog can answer *"does the leak scale with worktree count?"* via a single query.

## Why this shape

| Choice | Why |
|---|---|
| `phys_footprint` over `resident_size` | Matches Activity Monitor, reflects macOS's real memory pressure contribution |
| Baseline at 3 min (not 0) | Lets first-time-setup settle so baseline is a real steady-state |
| 2 / 4 / 8 GB threshold ladder | Matches the "500 MB → tens of GB" report; each stage signals escalation |
| Monotonic (no re-arm after drop) | We want shape, not count. GC / page-out should not cause event storms |
| 4 GB+ also Sentry | Pairs the spike with action breadcrumbs to narrow down what the user was doing |
| Context provider closure | Watchdog stays TCA-agnostic; `supacodeApp.swift` assembles the context from store + terminal manager |
| `#if !DEBUG` gated via analytics pipeline | Consistent with every other telemetry call in the app |

## Event budget

Per 100 DAU / month estimate:
- Baseline: 1 event × ~3 launches/day × 30 days × 100 DAU = **9,000 events/mo**
- Threshold crossings: only from users who actually leak — realistically **hundreds/mo**, not millions
- Well under the 1M/mo PostHog free tier

## Test plan

- [x] `make build-app` Debug + Release paths compile (reordered init to satisfy strict Swift 6 init semantics)
- [x] `make check` clean for touched files (7 unrelated swift-format reflows restored — same as prior observability PRs)
- [x] `MemoryWatchdogTests` — 6 tests, all pass:
  - no baseline before delay
  - baseline fires exactly once
  - thresholds fire once each, Sentry only at 4GB+
  - re-crossing after drop does NOT re-fire
  - thresholds silent without baseline
  - properties payload contains counters + growth_ratio
- [x] Live verification: next release, idle Prowl for 3 min → `app_memory_baseline` should appear in PostHog with reasonable `resident_mb`

## Out of scope (intentional)

- `terminal_tab_closed.tab_lifetime_seconds` — requires `TerminalClient.Event` change, separate PR.
- `script_run.exit_code` — ghostty doesn't expose shell exit status. Skipping.
- Sentry `profilesSampleRate` — explicitly off; profiling only samples during transactions, so it can't catch the "drift over 8 hours between transactions" scenario this PR targets. The watchdog is the right tool for that.
- Ghostty surface count — private on `WorktreeTerminalState`. Tab count is a good-enough proxy (surfaces ≥ tabs, same order of magnitude).

## Follow-up

Once we have a few weeks of data:
- If `growth_ratio` correlates with one of the counters (say `terminal_tab_count`), we have our suspect region — narrow with Instruments.
- If memory grows but all counters stay flat, the leak is inside a fixed-count structure (scrollback, cache). Expose a surface-level byte counter in a later PR.
