### PR TITLE
Add Change Tab Title action to tab context menu

### DIFF
--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -1120,6 +1120,12 @@ final class WorktreeTerminalState {
     }
   }
 
+  func promptChangeTabTitle(_ tabId: TerminalTabID) {
+    let surfaceWindow = focusedSurfaceIdByTab[tabId].flatMap { surfaces[$0]?.window }
+    guard let window = surfaceWindow ?? NSApp.keyWindow else { return }
+    promptTabTitle(for: tabId, in: window)
+  }
+
   private func promptTabTitle(for tabId: TerminalTabID, in window: NSWindow) {
     guard let tabIndex = tabManager.tabs.firstIndex(where: { $0.id == tabId }) else { return }
 

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabBarView.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabBarView.swift
@@ -6,6 +6,7 @@ struct TerminalTabBarView: View {
   let splitHorizontally: () -> Void
   let splitVertically: () -> Void
   let canSplit: Bool
+  let changeTitle: (TerminalTabID) -> Void
   let closeTab: (TerminalTabID) -> Void
   let closeOthers: (TerminalTabID) -> Void
   let closeToRight: (TerminalTabID) -> Void
@@ -17,6 +18,7 @@ struct TerminalTabBarView: View {
     HStack(spacing: 0) {
       TerminalTabsView(
         manager: manager,
+        changeTitle: changeTitle,
         closeTab: closeTab,
         closeOthers: closeOthers,
         closeToRight: closeToRight,

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabContextMenu.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabContextMenu.swift
@@ -23,6 +23,12 @@ struct TerminalTabContextMenu: ViewModifier {
 
   func body(content: Content) -> some View {
     content.contextMenu {
+      Button("Change Tab Title...") {
+        actions.changeTitle(tabId)
+      }
+
+      Divider()
+
       Button("Close Tab") {
         actions.closeTab(tabId)
       }

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabContextMenuActions.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabContextMenuActions.swift
@@ -1,4 +1,5 @@
 struct TerminalTabContextMenuActions {
+  let changeTitle: (TerminalTabID) -> Void
   let closeTab: (TerminalTabID) -> Void
   let closeOthers: (TerminalTabID) -> Void
   let closeToRight: (TerminalTabID) -> Void

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabsRowView.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabsRowView.swift
@@ -8,6 +8,7 @@ struct TerminalTabsRowView: View {
   @Binding var draggingStartLocation: CGFloat?
   @Binding var closeButtonGestureActive: Bool
   let fixedTabWidth: CGFloat?
+  let changeTitle: (TerminalTabID) -> Void
   let closeTab: (TerminalTabID) -> Void
   let closeOthers: (TerminalTabID) -> Void
   let closeToRight: (TerminalTabID) -> Void
@@ -49,6 +50,7 @@ struct TerminalTabsRowView: View {
               tabId: id,
               tabs: manager.tabs,
               actions: TerminalTabContextMenuActions(
+                changeTitle: changeTitle,
                 closeTab: closeTab,
                 closeOthers: closeOthers,
                 closeToRight: closeToRight,

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabsView.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabsView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct TerminalTabsView: View {
   @Bindable var manager: TerminalTabManager
+  let changeTitle: (TerminalTabID) -> Void
   let closeTab: (TerminalTabID) -> Void
   let closeOthers: (TerminalTabID) -> Void
   let closeToRight: (TerminalTabID) -> Void
@@ -28,6 +29,7 @@ struct TerminalTabsView: View {
             draggingStartLocation: $draggingStartLocation,
             closeButtonGestureActive: $closeButtonGestureActive,
             fixedTabWidth: effectiveTabWidth,
+            changeTitle: changeTitle,
             closeTab: closeTab,
             closeOthers: closeOthers,
             closeToRight: closeToRight,

--- a/supacode/Features/Terminal/Views/WorktreeTerminalTabsView.swift
+++ b/supacode/Features/Terminal/Views/WorktreeTerminalTabsView.swift
@@ -24,6 +24,9 @@ struct WorktreeTerminalTabsView: View {
           _ = state.performBindingActionOnFocusedSurface("new_split:right")
         },
         canSplit: state.tabManager.selectedTabId != nil,
+        changeTitle: { tabId in
+          state.promptChangeTabTitle(tabId)
+        },
         closeTab: { tabId in
           state.closeTab(tabId)
         },


### PR DESCRIPTION
## Summary
- Add a "Change Tab Title..." entry at the top of the terminal tab right-click menu, separated by a divider from the close actions.
- Expose `WorktreeTerminalState.promptChangeTabTitle(_:)` that reuses the existing `promptTabTitle` NSAlert flow (focused-surface window first, falling back to `NSApp.keyWindow`).
- Thread a `changeTitle` closure through `TerminalTabBarView` → `TerminalTabsView` → `TerminalTabsRowView` → `TerminalTabContextMenu` and wire it in `WorktreeTerminalTabsView`.

Empty input still calls `clearTitleOverride`, matching the existing Ghostty `prompt_title` behavior.

## Test plan
- [x] `make build-app` succeeds.
- [x] Right-click a terminal tab → "Change Tab Title..." opens the rename sheet, OK applies the override, blank input restores the auto title.
