### PR TITLE
Allow users to change tab icon (#194)

### DIFF
--- a/supacode/Clients/Terminal/TerminalClient.swift
+++ b/supacode/Clients/Terminal/TerminalClient.swift
@@ -42,6 +42,7 @@ struct TerminalClient {
     case setSelectedWorktreeID(Worktree.ID?)
     case saveLayoutSnapshot
     case restoreLayoutSnapshot(worktrees: [Worktree])
+    case presentTabIconPicker(Worktree)
   }
 
   enum Event: Equatable {

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -899,6 +899,16 @@ struct AppFeature {
           await terminalClient.send(.performBindingAction(worktree, action: action))
         }
 
+      case .commandPalette(.delegate(.changeFocusedTabIcon(let worktreeID))):
+        guard let worktree = state.repositories.selectedTerminalWorktree,
+          worktree.id == worktreeID
+        else {
+          return .none
+        }
+        return .run { _ in
+          await terminalClient.send(.presentTabIconPicker(worktree))
+        }
+
       case .commandPalette(.delegate(.openPullRequest(let worktreeID))):
         return .send(.repositories(.githubIntegration(.pullRequestAction(worktreeID, .openOnGithub))))
 

--- a/supacode/Features/CommandPalette/CommandPaletteItem.swift
+++ b/supacode/Features/CommandPalette/CommandPaletteItem.swift
@@ -41,6 +41,7 @@ struct CommandPaletteItem: Identifiable, Equatable {
     case rerunFailedJobs(Worktree.ID)
     case openFailingCheckDetails(Worktree.ID)
     case installCLI
+    case changeFocusedTabIcon(Worktree.ID)
     #if DEBUG
       case debugTestToast(RepositoriesFeature.StatusToast)
       case debugSimulateUpdateFound
@@ -61,7 +62,8 @@ struct CommandPaletteItem: Identifiable, Equatable {
       .copyFailingJobURL,
       .copyCiFailureLogs,
       .rerunFailedJobs,
-      .openFailingCheckDetails:
+      .openFailingCheckDetails,
+      .changeFocusedTabIcon:
       return true
     case .worktreeSelect, .removeWorktree, .archiveWorktree:
       return false
@@ -89,7 +91,8 @@ struct CommandPaletteItem: Identifiable, Equatable {
       .openFailingCheckDetails,
       .worktreeSelect,
       .removeWorktree,
-      .archiveWorktree:
+      .archiveWorktree,
+      .changeFocusedTabIcon:
       return false
     #if DEBUG
       case .debugTestToast, .debugSimulateUpdateFound:
@@ -125,7 +128,8 @@ struct CommandPaletteItem: Identifiable, Equatable {
       .installCLI,
       .worktreeSelect,
       .removeWorktree,
-      .archiveWorktree:
+      .archiveWorktree,
+      .changeFocusedTabIcon:
       return nil
     #if DEBUG
       case .debugTestToast, .debugSimulateUpdateFound:

--- a/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
+++ b/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
@@ -50,6 +50,7 @@ struct CommandPaletteFeature {
     case rerunFailedJobs(Worktree.ID)
     case openFailingCheckDetails(Worktree.ID)
     case installCLI
+    case changeFocusedTabIcon(Worktree.ID)
     #if DEBUG
       case debugTestToast(RepositoriesFeature.StatusToast)
       case debugSimulateUpdateFound
@@ -224,7 +225,15 @@ struct CommandPaletteFeature {
         kind: .installCLI
       )
     )
-    if repositories.selectedTerminalWorktree != nil {
+    if let terminalWorktree = repositories.selectedTerminalWorktree {
+      items.append(
+        CommandPaletteItem(
+          id: CommandPaletteItemID.changeFocusedTabIcon(terminalWorktree.id),
+          title: "Change Tab Icon...",
+          subtitle: terminalWorktree.name,
+          kind: .changeFocusedTabIcon(terminalWorktree.id)
+        )
+      )
       items.append(contentsOf: ghosttyCommandItems(ghosttyCommands))
     }
     if let selectedWorktreeID = repositories.selectedWorktreeID,
@@ -268,6 +277,7 @@ struct CommandPaletteFeature {
       ids.append(contentsOf: CommandPaletteItemID.pullRequestIDs(repositoryID: repository.id))
       for worktree in repository.worktrees {
         ids.append(CommandPaletteItemID.worktreeSelect(worktree.id))
+        ids.append(CommandPaletteItemID.changeFocusedTabIcon(worktree.id))
       }
     }
     return ids
@@ -473,6 +483,10 @@ private enum CommandPaletteItemID {
     "worktree.\(worktreeID).select"
   }
 
+  static func changeFocusedTabIcon(_ worktreeID: Worktree.ID) -> CommandPaletteItem.ID {
+    "terminal.\(worktreeID).change-focused-tab-icon"
+  }
+
   static func ghosttyCommand(_ command: GhosttyCommand) -> CommandPaletteItem.ID {
     "\(ghosttyPrefix)\(command.action)|\(command.title)"
   }
@@ -579,6 +593,8 @@ private func delegateAction(for kind: CommandPaletteItem.Kind) -> CommandPalette
     return .installCLI
   case .ghosttyCommand(let action):
     return .ghosttyCommand(action)
+  case .changeFocusedTabIcon(let worktreeID):
+    return .changeFocusedTabIcon(worktreeID)
   case .openPullRequest,
     .markPullRequestReady,
     .mergePullRequest,
@@ -627,7 +643,8 @@ private func pullRequestDelegateAction(
     .viewArchivedWorktrees,
     .refreshWorktrees,
     .installCLI,
-    .ghosttyCommand:
+    .ghosttyCommand,
+    .changeFocusedTabIcon:
     return nil
   #if DEBUG
     case .debugTestToast, .debugSimulateUpdateFound:

--- a/supacode/Features/CommandPalette/Views/CommandPaletteOverlayView.swift
+++ b/supacode/Features/CommandPalette/Views/CommandPaletteOverlayView.swift
@@ -351,7 +351,7 @@ private struct CommandPaletteRowView: View {
       .refreshWorktrees, .installCLI, .ghosttyCommand,
       .openPullRequest, .markPullRequestReady, .mergePullRequest, .closePullRequest, .copyFailingJobURL,
       .copyCiFailureLogs,
-      .rerunFailedJobs, .openFailingCheckDetails, .worktreeSelect:
+      .rerunFailedJobs, .openFailingCheckDetails, .worktreeSelect, .changeFocusedTabIcon:
       return nil
     case .removeWorktree:
       return "Remove"
@@ -400,6 +400,8 @@ private struct CommandPaletteRowView: View {
       return "terminal"
     case .worktreeSelect:
       return nil
+    case .changeFocusedTabIcon:
+      return "rectangle.on.rectangle"
     case .removeWorktree:
       return "trash"
     case .archiveWorktree:
@@ -419,7 +421,7 @@ private struct CommandPaletteRowView: View {
       .refreshWorktrees, .installCLI, .ghosttyCommand,
       .openPullRequest, .markPullRequestReady, .mergePullRequest, .closePullRequest, .copyFailingJobURL,
       .copyCiFailureLogs,
-      .rerunFailedJobs, .openFailingCheckDetails:
+      .rerunFailedJobs, .openFailingCheckDetails, .changeFocusedTabIcon:
       return true
     case .worktreeSelect, .removeWorktree, .archiveWorktree:
       return false
@@ -535,6 +537,8 @@ private struct CommandPaletteRowView: View {
       base = "Open failing check details"
     case .installCLI:
       base = "Install Command Line Tool"
+    case .changeFocusedTabIcon:
+      base = "Change Tab Icon"
     #if DEBUG
       case .debugTestToast, .debugSimulateUpdateFound:
         base = row.title

--- a/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
+++ b/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
@@ -170,6 +170,8 @@ final class WorktreeTerminalManager {
     case .restoreLayoutSnapshot(let worktrees):
       terminalLogger.info("[LayoutRestore] received restoreLayoutSnapshot command, worktrees=\(worktrees.count)")
       Task { await restoreLayoutSnapshot(from: worktrees) }
+    case .presentTabIconPicker(let worktree):
+      state(for: worktree).presentIconPickerForFocusedTab()
     default:
       return
     }

--- a/supacode/Features/Terminal/Models/TerminalTabItem.swift
+++ b/supacode/Features/Terminal/Models/TerminalTabItem.swift
@@ -6,18 +6,21 @@ struct TerminalTabItem: Identifiable, Equatable, Sendable {
   var icon: String?
   var isDirty: Bool
   var isTitleLocked: Bool
+  var isIconLocked: Bool
 
   init(
     id: TerminalTabID = TerminalTabID(),
     title: String,
     icon: String?,
     isDirty: Bool = false,
-    isTitleLocked: Bool = false
+    isTitleLocked: Bool = false,
+    isIconLocked: Bool = false
   ) {
     self.id = id
     self.title = title
     self.icon = icon
     self.isDirty = isDirty
     self.isTitleLocked = isTitleLocked
+    self.isIconLocked = isIconLocked
   }
 }

--- a/supacode/Features/Terminal/Models/TerminalTabManager.swift
+++ b/supacode/Features/Terminal/Models/TerminalTabManager.swift
@@ -41,6 +41,23 @@ final class TerminalTabManager {
     tabs[index].isTitleLocked = false
   }
 
+  func updateIcon(_ id: TerminalTabID, icon: String?) {
+    guard let index = tabs.firstIndex(where: { $0.id == id }) else { return }
+    guard !tabs[index].isIconLocked else { return }
+    tabs[index].icon = icon
+  }
+
+  func overrideIcon(_ id: TerminalTabID, icon: String) {
+    guard let index = tabs.firstIndex(where: { $0.id == id }) else { return }
+    tabs[index].icon = icon
+    tabs[index].isIconLocked = true
+  }
+
+  func clearIconOverride(_ id: TerminalTabID) {
+    guard let index = tabs.firstIndex(where: { $0.id == id }) else { return }
+    tabs[index].isIconLocked = false
+  }
+
   func updateDirty(_ id: TerminalTabID, isDirty: Bool) {
     guard let index = tabs.firstIndex(where: { $0.id == id }) else { return }
     tabs[index].isDirty = isDirty

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -36,6 +36,8 @@ final class WorktreeTerminalState {
   /// `syncFocusIfNeeded` skips `applySurfaceActivity` to avoid overriding
   /// Canvas-set occlusion with stale normal-mode window activity values.
   var isCanvasManaged = false
+  /// Tab whose icon picker should be presented. `nil` hides the picker.
+  var iconPickerTabId: TerminalTabID?
   var notifications: [WorktreeTerminalNotification] = []
   var notificationsEnabled = true
   private var commandFinishedNotificationEnabled = true
@@ -719,12 +721,15 @@ final class WorktreeTerminalState {
         return nil
       }
       // Skip title/icon for blocking-script tabs as they are transient.
+      // Persist the icon only when the user has explicitly overridden it; otherwise
+      // restore should pick up the current default ("terminal").
       let isBlockingScriptTab = tab.id == runScriptTabId
+      let snapshotIcon: String? = (isBlockingScriptTab || !tab.isIconLocked) ? nil : tab.icon
       snapshotTabs.append(
         TerminalLayoutSnapshotPayload.SnapshotTab(
           tabID: tab.id.rawValue.uuidString,
           title: isBlockingScriptTab ? nil : tab.title,
-          icon: isBlockingScriptTab ? nil : tab.icon,
+          icon: snapshotIcon,
           splitRoot: splitRoot
         )
       )
@@ -812,7 +817,8 @@ final class WorktreeTerminalState {
           id: entry.tabID,
           title: entry.snapshotTab.title ?? "\(worktree.name) \(index + 1)",
           icon: entry.snapshotTab.icon ?? "terminal",
-          isTitleLocked: entry.snapshotTab.title != nil
+          isTitleLocked: entry.snapshotTab.title != nil,
+          isIconLocked: entry.snapshotTab.icon != nil
         )
       )
     }
@@ -1124,6 +1130,36 @@ final class WorktreeTerminalState {
     let surfaceWindow = focusedSurfaceIdByTab[tabId].flatMap { surfaces[$0]?.window }
     guard let window = surfaceWindow ?? NSApp.keyWindow else { return }
     promptTabTitle(for: tabId, in: window)
+  }
+
+  func presentIconPicker(for tabId: TerminalTabID) {
+    guard tabManager.tabs.contains(where: { $0.id == tabId }) else { return }
+    iconPickerTabId = tabId
+  }
+
+  func presentIconPickerForFocusedTab() {
+    guard let tabId = tabManager.selectedTabId else { return }
+    presentIconPicker(for: tabId)
+  }
+
+  func dismissIconPicker() {
+    iconPickerTabId = nil
+  }
+
+  /// Default SF Symbol used for a tab when the user has not set an override.
+  func defaultIcon(for tabId: TerminalTabID) -> String {
+    tabId == runScriptTabId ? "play.fill" : "terminal"
+  }
+
+  /// Apply an icon change for `tabId`. Pass `nil` to clear the override and
+  /// restore the tab's default icon.
+  func applyIconChange(_ tabId: TerminalTabID, icon newIcon: String?) {
+    if let newIcon, !newIcon.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+      tabManager.overrideIcon(tabId, icon: newIcon)
+    } else {
+      tabManager.clearIconOverride(tabId)
+      tabManager.updateIcon(tabId, icon: defaultIcon(for: tabId))
+    }
   }
 
   private func promptTabTitle(for tabId: TerminalTabID, in window: NSWindow) {

--- a/supacode/Features/Terminal/TabBar/Views/TabIconPickerView.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TabIconPickerView.swift
@@ -1,0 +1,205 @@
+import AppKit
+import SwiftUI
+
+struct TabIconPickerView: View {
+  let initialIcon: String?
+  let defaultIcon: String
+  let onApply: (String?) -> Void
+  let onCancel: () -> Void
+
+  @State private var symbolName: String
+  @FocusState private var symbolFieldFocused: Bool
+
+  init(
+    initialIcon: String?,
+    defaultIcon: String,
+    onApply: @escaping (String?) -> Void,
+    onCancel: @escaping () -> Void
+  ) {
+    self.initialIcon = initialIcon
+    self.defaultIcon = defaultIcon
+    self.onApply = onApply
+    self.onCancel = onCancel
+    _symbolName = State(initialValue: initialIcon ?? "")
+  }
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 12) {
+      Text("Tab Icon")
+        .font(.headline)
+      Text("Pick a preset or enter any SF Symbol name available in your system.")
+        .font(.caption)
+        .foregroundStyle(.secondary)
+
+      HStack(spacing: 8) {
+        Image(systemName: previewSymbol)
+          .imageScale(.large)
+          .foregroundStyle(isPreviewValid ? Color.primary : Color.secondary)
+          .frame(width: 28, height: 28)
+          .background(
+            RoundedRectangle(cornerRadius: 6, style: .continuous)
+              .fill(Color.secondary.opacity(0.15))
+          )
+          .accessibilityLabel(Text("Preview"))
+        TextField("SF Symbol name", text: $symbolName)
+          .textFieldStyle(.roundedBorder)
+          .focused($symbolFieldFocused)
+          .onSubmit { applyIfValid() }
+        Button("Open SF Symbols") {
+          openSFSymbolsReference()
+        }
+      }
+
+      ScrollView {
+        LazyVGrid(
+          columns: Array(repeating: GridItem(.fixed(28), spacing: 8), count: 10),
+          spacing: 8
+        ) {
+          ForEach(Self.symbolPresets, id: \.self) { symbol in
+            Button {
+              symbolName = symbol
+              symbolFieldFocused = true
+            } label: {
+              Image(systemName: symbol)
+                .frame(width: 28, height: 28)
+                .background(
+                  RoundedRectangle(cornerRadius: 6, style: .continuous)
+                    .stroke(symbolName == symbol ? Color.accentColor : Color.clear, lineWidth: 2)
+                )
+                .accessibilityHidden(true)
+            }
+            .buttonStyle(.plain)
+            .help(symbol)
+          }
+        }
+        .padding(8)
+      }
+      .frame(maxHeight: 160)
+      .background(
+        RoundedRectangle(cornerRadius: 6, style: .continuous)
+          .fill(Color.secondary.opacity(0.08))
+      )
+
+      HStack {
+        Button("Reset to Default") {
+          onApply(nil)
+        }
+        .help("Restore the default icon for this tab")
+        Spacer()
+        Button("Cancel", role: .cancel) {
+          onCancel()
+        }
+        .keyboardShortcut(.cancelAction)
+        Button("Done") {
+          applyIfValid()
+        }
+        .keyboardShortcut(.defaultAction)
+        .disabled(!canApply)
+      }
+    }
+    .padding(16)
+    .frame(width: 380)
+    .onAppear {
+      symbolFieldFocused = true
+    }
+  }
+
+  private var trimmedName: String {
+    symbolName.trimmingCharacters(in: .whitespacesAndNewlines)
+  }
+
+  private var previewSymbol: String {
+    isPreviewValid ? trimmedName : defaultIcon
+  }
+
+  private var isPreviewValid: Bool {
+    Self.isValidSymbol(trimmedName)
+  }
+
+  private var canApply: Bool {
+    !trimmedName.isEmpty && isPreviewValid
+  }
+
+  private func applyIfValid() {
+    guard canApply else { return }
+    onApply(trimmedName)
+  }
+
+  private func openSFSymbolsReference() {
+    if let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: "com.apple.SFSymbols") {
+      let configuration = NSWorkspace.OpenConfiguration()
+      NSWorkspace.shared.openApplication(at: appURL, configuration: configuration) { _, _ in }
+      return
+    }
+    guard let url = URL(string: "https://developer.apple.com/sf-symbols/") else { return }
+    NSWorkspace.shared.open(url)
+  }
+
+  static func isValidSymbol(_ name: String) -> Bool {
+    guard !name.isEmpty else { return false }
+    return NSImage(systemSymbolName: name, accessibilityDescription: nil) != nil
+  }
+
+  static let symbolPresets: [String] = [
+    "terminal",
+    "terminal.fill",
+    "play.fill",
+    "stop.fill",
+    "hammer.fill",
+    "wrench.and.screwdriver.fill",
+    "shippingbox.fill",
+    "archivebox.fill",
+    "doc.text.fill",
+    "doc.badge.plus",
+    "sparkles",
+    "wand.and.stars",
+    "bolt.fill",
+    "flame.fill",
+    "checkmark.circle.fill",
+    "xmark.circle.fill",
+    "exclamationmark.triangle.fill",
+    "ladybug.fill",
+    "clock.fill",
+    "repeat",
+    "arrow.clockwise",
+    "arrow.triangle.2.circlepath",
+    "folder.fill",
+    "folder.badge.plus",
+    "paperplane.fill",
+    "cloud.fill",
+    "tray.and.arrow.down.fill",
+    "tray.and.arrow.up.fill",
+    "icloud.and.arrow.up.fill",
+    "square.and.arrow.up.fill",
+    "magnifyingglass",
+    "tag.fill",
+    "bookmark.fill",
+    "gearshape.fill",
+    "cpu",
+    "person.fill",
+    "person.2.fill",
+    "chart.bar.fill",
+    "chart.line.uptrend.xyaxis",
+    "leaf.fill",
+  ]
+}
+
+#if DEBUG
+  #Preview("Default icon") {
+    TabIconPickerView(
+      initialIcon: nil,
+      defaultIcon: "terminal",
+      onApply: { _ in },
+      onCancel: {}
+    )
+  }
+
+  #Preview("With override") {
+    TabIconPickerView(
+      initialIcon: "sparkles",
+      defaultIcon: "terminal",
+      onApply: { _ in },
+      onCancel: {}
+    )
+  }
+#endif

--- a/supacode/Features/Terminal/TabBar/Views/TabIconPickerView.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TabIconPickerView.swift
@@ -24,18 +24,20 @@ struct TabIconPickerView: View {
   }
 
   var body: some View {
-    VStack(alignment: .leading, spacing: 12) {
-      Text("Tab Icon")
-        .font(.headline)
-      Text("Pick a preset or enter any SF Symbol name available in your system.")
-        .font(.caption)
-        .foregroundStyle(.secondary)
+    VStack(alignment: .leading, spacing: 16) {
+      VStack(alignment: .leading, spacing: 4) {
+        Text("Tab Icon")
+          .font(.headline)
+        Text("Pick a preset or enter any SF Symbol name available in your system.")
+          .font(.caption)
+          .foregroundStyle(.secondary)
+      }
 
-      HStack(spacing: 8) {
+      HStack(spacing: 10) {
         Image(systemName: previewSymbol)
           .imageScale(.large)
           .foregroundStyle(isPreviewValid ? Color.primary : Color.secondary)
-          .frame(width: 28, height: 28)
+          .frame(width: 32, height: 32)
           .background(
             RoundedRectangle(cornerRadius: 6, style: .continuous)
               .fill(Color.secondary.opacity(0.15))
@@ -52,8 +54,8 @@ struct TabIconPickerView: View {
 
       ScrollView {
         LazyVGrid(
-          columns: Array(repeating: GridItem(.fixed(28), spacing: 8), count: 10),
-          spacing: 8
+          columns: Array(repeating: GridItem(.fixed(32), spacing: 10), count: 8),
+          spacing: 10
         ) {
           ForEach(Self.symbolPresets, id: \.self) { symbol in
             Button {
@@ -61,7 +63,8 @@ struct TabIconPickerView: View {
               symbolFieldFocused = true
             } label: {
               Image(systemName: symbol)
-                .frame(width: 28, height: 28)
+                .imageScale(.medium)
+                .frame(width: 32, height: 32)
                 .background(
                   RoundedRectangle(cornerRadius: 6, style: .continuous)
                     .stroke(symbolName == symbol ? Color.accentColor : Color.clear, lineWidth: 2)
@@ -72,11 +75,11 @@ struct TabIconPickerView: View {
             .help(symbol)
           }
         }
-        .padding(8)
+        .padding(12)
       }
-      .frame(maxHeight: 160)
+      .frame(maxHeight: 220)
       .background(
-        RoundedRectangle(cornerRadius: 6, style: .continuous)
+        RoundedRectangle(cornerRadius: 8, style: .continuous)
           .fill(Color.secondary.opacity(0.08))
       )
 
@@ -97,8 +100,8 @@ struct TabIconPickerView: View {
         .disabled(!canApply)
       }
     }
-    .padding(16)
-    .frame(width: 380)
+    .padding(24)
+    .frame(width: 460)
     .onAppear {
       symbolFieldFocused = true
     }
@@ -140,6 +143,11 @@ struct TabIconPickerView: View {
     return NSImage(systemSymbolName: name, accessibilityDescription: nil) != nil
   }
 
+  /// Presets curated around common development workflows. Grouped loosely by
+  /// theme so scanning the grid reveals an intent quickly:
+  /// terminal → run/build → watch/refresh → server/network → source control →
+  /// code/files → tests/bugs → AI/agent → release/deploy → metrics/logs →
+  /// security → compute.
   static let symbolPresets: [String] = [
     "terminal",
     "terminal.fill",
@@ -147,40 +155,40 @@ struct TabIconPickerView: View {
     "stop.fill",
     "hammer.fill",
     "wrench.and.screwdriver.fill",
-    "shippingbox.fill",
-    "archivebox.fill",
-    "doc.text.fill",
-    "doc.badge.plus",
-    "sparkles",
-    "wand.and.stars",
+    "eye.fill",
+    "clock.fill",
+    "arrow.clockwise",
+    "arrow.triangle.2.circlepath",
     "bolt.fill",
-    "flame.fill",
+    "server.rack",
+    "network",
+    "cloud.fill",
+    "globe",
+    "antenna.radiowaves.left.and.right",
+    "externaldrive.fill",
+    "arrow.triangle.branch",
+    "arrow.triangle.pull",
+    "arrow.merge",
+    "chevron.left.forwardslash.chevron.right",
+    "curlybraces",
+    "doc.text.fill",
+    "folder.fill",
     "checkmark.circle.fill",
     "xmark.circle.fill",
     "exclamationmark.triangle.fill",
     "ladybug.fill",
-    "clock.fill",
-    "repeat",
-    "arrow.clockwise",
-    "arrow.triangle.2.circlepath",
-    "folder.fill",
-    "folder.badge.plus",
+    "sparkles",
+    "wand.and.stars",
+    "brain.head.profile",
+    "shippingbox.fill",
     "paperplane.fill",
-    "cloud.fill",
-    "tray.and.arrow.down.fill",
-    "tray.and.arrow.up.fill",
-    "icloud.and.arrow.up.fill",
-    "square.and.arrow.up.fill",
-    "magnifyingglass",
-    "tag.fill",
-    "bookmark.fill",
-    "gearshape.fill",
-    "cpu",
-    "person.fill",
-    "person.2.fill",
-    "chart.bar.fill",
+    "archivebox.fill",
     "chart.line.uptrend.xyaxis",
-    "leaf.fill",
+    "chart.bar.fill",
+    "magnifyingglass",
+    "lock.fill",
+    "key.fill",
+    "cpu",
   ]
 }
 

--- a/supacode/Features/Terminal/TabBar/Views/TabIconPickerView.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TabIconPickerView.swift
@@ -98,7 +98,7 @@ struct TabIconPickerView: View {
       }
     }
     .padding(24)
-    .frame(width: 460)
+    .frame(width: 410)
     .onAppear {
       symbolFieldFocused = true
     }

--- a/supacode/Features/Terminal/TabBar/Views/TabIconPickerView.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TabIconPickerView.swift
@@ -52,32 +52,29 @@ struct TabIconPickerView: View {
         }
       }
 
-      ScrollView {
-        LazyVGrid(
-          columns: Array(repeating: GridItem(.fixed(32), spacing: 10), count: 8),
-          spacing: 10
-        ) {
-          ForEach(Self.symbolPresets, id: \.self) { symbol in
-            Button {
-              symbolName = symbol
-              symbolFieldFocused = true
-            } label: {
-              Image(systemName: symbol)
-                .imageScale(.medium)
-                .frame(width: 32, height: 32)
-                .background(
-                  RoundedRectangle(cornerRadius: 6, style: .continuous)
-                    .stroke(symbolName == symbol ? Color.accentColor : Color.clear, lineWidth: 2)
-                )
-                .accessibilityHidden(true)
-            }
-            .buttonStyle(.plain)
-            .help(symbol)
+      LazyVGrid(
+        columns: Array(repeating: GridItem(.fixed(32), spacing: 6), count: 8),
+        spacing: 6
+      ) {
+        ForEach(Self.symbolPresets, id: \.self) { symbol in
+          Button {
+            symbolName = symbol
+            symbolFieldFocused = true
+          } label: {
+            Image(systemName: symbol)
+              .imageScale(.medium)
+              .frame(width: 32, height: 32)
+              .background(
+                RoundedRectangle(cornerRadius: 6, style: .continuous)
+                  .stroke(symbolName == symbol ? Color.accentColor : Color.clear, lineWidth: 2)
+              )
+              .accessibilityHidden(true)
           }
+          .buttonStyle(.plain)
+          .help(symbol)
         }
-        .padding(12)
       }
-      .frame(maxHeight: 220)
+      .padding(8)
       .background(
         RoundedRectangle(cornerRadius: 8, style: .continuous)
           .fill(Color.secondary.opacity(0.08))

--- a/supacode/Features/Terminal/TabBar/Views/TabIconPickerView.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TabIconPickerView.swift
@@ -68,6 +68,7 @@ struct TabIconPickerView: View {
                 RoundedRectangle(cornerRadius: 6, style: .continuous)
                   .stroke(symbolName == symbol ? Color.accentColor : Color.clear, lineWidth: 2)
               )
+              .contentShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
               .accessibilityHidden(true)
           }
           .buttonStyle(.plain)

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabBarView.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabBarView.swift
@@ -7,6 +7,7 @@ struct TerminalTabBarView: View {
   let splitVertically: () -> Void
   let canSplit: Bool
   let changeTitle: (TerminalTabID) -> Void
+  let changeIcon: (TerminalTabID) -> Void
   let closeTab: (TerminalTabID) -> Void
   let closeOthers: (TerminalTabID) -> Void
   let closeToRight: (TerminalTabID) -> Void
@@ -19,6 +20,7 @@ struct TerminalTabBarView: View {
       TerminalTabsView(
         manager: manager,
         changeTitle: changeTitle,
+        changeIcon: changeIcon,
         closeTab: closeTab,
         closeOthers: closeOthers,
         closeToRight: closeToRight,

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabContextMenu.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabContextMenu.swift
@@ -27,6 +27,10 @@ struct TerminalTabContextMenu: ViewModifier {
         actions.changeTitle(tabId)
       }
 
+      Button("Change Tab Icon...") {
+        actions.changeIcon(tabId)
+      }
+
       Divider()
 
       Button("Close Tab") {

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabContextMenuActions.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabContextMenuActions.swift
@@ -1,5 +1,6 @@
 struct TerminalTabContextMenuActions {
   let changeTitle: (TerminalTabID) -> Void
+  let changeIcon: (TerminalTabID) -> Void
   let closeTab: (TerminalTabID) -> Void
   let closeOthers: (TerminalTabID) -> Void
   let closeToRight: (TerminalTabID) -> Void

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabsRowView.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabsRowView.swift
@@ -9,6 +9,7 @@ struct TerminalTabsRowView: View {
   @Binding var closeButtonGestureActive: Bool
   let fixedTabWidth: CGFloat?
   let changeTitle: (TerminalTabID) -> Void
+  let changeIcon: (TerminalTabID) -> Void
   let closeTab: (TerminalTabID) -> Void
   let closeOthers: (TerminalTabID) -> Void
   let closeToRight: (TerminalTabID) -> Void
@@ -51,6 +52,7 @@ struct TerminalTabsRowView: View {
               tabs: manager.tabs,
               actions: TerminalTabContextMenuActions(
                 changeTitle: changeTitle,
+                changeIcon: changeIcon,
                 closeTab: closeTab,
                 closeOthers: closeOthers,
                 closeToRight: closeToRight,

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabsView.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabsView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct TerminalTabsView: View {
   @Bindable var manager: TerminalTabManager
   let changeTitle: (TerminalTabID) -> Void
+  let changeIcon: (TerminalTabID) -> Void
   let closeTab: (TerminalTabID) -> Void
   let closeOthers: (TerminalTabID) -> Void
   let closeToRight: (TerminalTabID) -> Void
@@ -30,6 +31,7 @@ struct TerminalTabsView: View {
             closeButtonGestureActive: $closeButtonGestureActive,
             fixedTabWidth: effectiveTabWidth,
             changeTitle: changeTitle,
+            changeIcon: changeIcon,
             closeTab: closeTab,
             closeOthers: closeOthers,
             closeToRight: closeToRight,

--- a/supacode/Features/Terminal/Views/WorktreeTerminalTabsView.swift
+++ b/supacode/Features/Terminal/Views/WorktreeTerminalTabsView.swift
@@ -27,6 +27,9 @@ struct WorktreeTerminalTabsView: View {
         changeTitle: { tabId in
           state.promptChangeTabTitle(tabId)
         },
+        changeIcon: { tabId in
+          state.presentIconPicker(for: tabId)
+        },
         closeTab: { tabId in
           state.closeTab(tabId)
         },
@@ -49,6 +52,25 @@ struct WorktreeTerminalTabsView: View {
       } else {
         EmptyTerminalPaneView(message: "No terminals open")
       }
+    }
+    .sheet(
+      item: Binding(
+        get: { state.iconPickerTabId },
+        set: { state.iconPickerTabId = $0 }
+      )
+    ) { tabId in
+      let currentIcon = state.tabManager.tabs.first(where: { $0.id == tabId })?.icon
+      TabIconPickerView(
+        initialIcon: currentIcon,
+        defaultIcon: state.defaultIcon(for: tabId),
+        onApply: { newIcon in
+          state.applyIconChange(tabId, icon: newIcon)
+          state.dismissIconPicker()
+        },
+        onCancel: {
+          state.dismissIconPicker()
+        }
+      )
     }
     .background(
       WindowFocusObserverView { activity in

--- a/supacodeTests/TerminalTabManagerTests.swift
+++ b/supacodeTests/TerminalTabManagerTests.swift
@@ -63,4 +63,30 @@ struct TerminalTabManagerTests {
     manager.updateDirty(tabId, isDirty: false)
     #expect(manager.tabs.first?.isDirty == false)
   }
+
+  @Test func overrideIconLocksAndSetsIcon() {
+    let manager = TerminalTabManager()
+    let tabId = manager.createTab(title: "one", icon: "terminal")
+    manager.overrideIcon(tabId, icon: "sparkles")
+    #expect(manager.tabs.first?.icon == "sparkles")
+    #expect(manager.tabs.first?.isIconLocked == true)
+  }
+
+  @Test func updateIconRespectsLock() {
+    let manager = TerminalTabManager()
+    let tabId = manager.createTab(title: "one", icon: "terminal")
+    manager.overrideIcon(tabId, icon: "sparkles")
+    manager.updateIcon(tabId, icon: "terminal")
+    #expect(manager.tabs.first?.icon == "sparkles")
+  }
+
+  @Test func clearIconOverrideUnlocksIcon() {
+    let manager = TerminalTabManager()
+    let tabId = manager.createTab(title: "one", icon: "terminal")
+    manager.overrideIcon(tabId, icon: "sparkles")
+    manager.clearIconOverride(tabId)
+    #expect(manager.tabs.first?.isIconLocked == false)
+    manager.updateIcon(tabId, icon: "play.fill")
+    #expect(manager.tabs.first?.icon == "play.fill")
+  }
 }


### PR DESCRIPTION
Closes #194.

## Summary
- New **Change Tab Icon...** entry in the tab right-click menu (right under "Change Tab Title...") and in the Cmd+P command palette ("Change Tab Icon..." with the active worktree as subtitle).
- A SwiftUI picker (`TabIconPickerView`) presents a curated 40-symbol preset grid plus a free-form **SF Symbol name** field with live preview, an **Open SF Symbols** shortcut, and a **Reset to Default** button. The Done button is disabled until the entered name resolves to a real `NSImage` system symbol.
- Tab model gains `isIconLocked` and `TerminalTabManager` exposes `overrideIcon` / `clearIconOverride` / `updateIcon`, mirroring the existing title-lock pattern.
- Layout snapshot capture now writes `tab.icon` only when the user has overridden it; restore sets `isIconLocked` from the snapshot so a chosen icon round-trips and is not silently overwritten.
- Palette wiring: new `CommandPaletteItem.Kind.changeFocusedTabIcon`, delegate case, and a `TerminalClient.Command.presentTabIconPicker(Worktree)` routed through `WorktreeTerminalManager` to `WorktreeTerminalState.presentIconPickerForFocusedTab()`.

## Test plan
Automated:
- `make build-app` ✅
- `make check` ✅
- `make test` — 742 tests passing, including new `TerminalTabManagerTests` covering `overrideIcon`, `updateIcon` lock-respect, and `clearIconOverride`.

Manual (recommended — sandbox lacks Screen Recording permission, so I could not screenshot the picker):
- [x] Right-click any terminal tab → **Change Tab Icon...** opens the picker; pick a preset, click **Done**, and confirm the tab badge updates.
- [x] Type a custom name like `flame.fill`, hit **Done**, confirm the icon updates and Done is disabled for invalid names.
- [x] Use **Reset to Default** and confirm the icon reverts to `terminal` (or `play.fill` for the RUN SCRIPT tab).
- [x] Press Cmd+P → search "icon" → activate **Change Tab Icon...** and confirm the same picker appears for the focused tab.
- [x] With *Restore Terminal Layout on Launch* enabled in Settings, set a custom icon, quit Prowl (Cmd+Q), relaunch, and confirm the icon survives.
