### PR TITLE
Fix ANR-path crash in SentryEventFilter (PROWL-MACOS-5)

### DIFF
--- a/supacode/Support/SentryEventFilter.swift
+++ b/supacode/Support/SentryEventFilter.swift
@@ -4,12 +4,18 @@ import Sentry
 /// Client-side filter for Sentry events.
 ///
 /// Wired into `SentrySDK.start { options.beforeSend = SentryEventFilter.filterSystemHang }`.
+///
+/// Members are explicitly `nonisolated`: Sentry invokes `beforeSend` synchronously
+/// from its own background threads (notably `SentryANRTrackerV1`'s detection thread).
+/// Under the project's `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor` setting, any
+/// un-annotated member would implicitly be `@MainActor`, and Swift 6.2's executor
+/// check aborts the process via libdispatch when such code runs off the main thread.
 enum SentryEventFilter {
   /// Known stack frame function-name fragments that indicate a system-induced
   /// App Hang (wake-from-sleep, active space change, external display connect,
   /// menu bar redraw, etc.). These hangs are observable but have no app-level
   /// remedy — filter them out to avoid drowning real hangs in noise.
-  static let systemHangSignatures = [
+  nonisolated static let systemHangSignatures = [
     "_NSMenuBarDisplayManagerActiveSpaceChanged",
     "NSMenuBarLocalDisplayWindow",
     "NSMenuBarPresentationInstance",
@@ -20,7 +26,7 @@ enum SentryEventFilter {
   /// at least one known system signature. Conservative by design: if the hang
   /// involves any app code, keep it; if the stack is all-system but matches no
   /// known pattern, keep it too (so we still see novel system-level issues).
-  static func filterSystemHang(_ event: Event) -> Event? {
+  nonisolated static func filterSystemHang(_ event: Event) -> Event? {
     guard let exception = event.exceptions?.first,
       exception.mechanism?.type == "AppHang"
     else {

--- a/supacodeTests/SentryEventFilterTests.swift
+++ b/supacodeTests/SentryEventFilterTests.swift
@@ -48,6 +48,36 @@ struct SentryEventFilterTests {
     #expect(SentryEventFilter.filterSystemHang(event) === event)
   }
 
+  /// Regression guard for PROWL-MACOS-5 / Sentry issue 7424130201.
+  ///
+  /// Sentry's `SentryANRTrackerV1` invokes `beforeSend` synchronously from a
+  /// background thread. Because the project sets
+  /// `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`, un-annotated members of
+  /// `SentryEventFilter` are implicitly `@MainActor` and Swift 6.2's executor
+  /// check aborts the process via libdispatch when called off-main.
+  ///
+  /// This test exercises the exact off-main invocation path. If
+  /// `filterSystemHang` ever loses `nonisolated`, the `@Sendable` closure below
+  /// will fail to compile — turning the runtime crash into a build-time error.
+  @Test func filterIsInvokableFromBackgroundThread() async {
+    await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+      DispatchQueue.global(qos: .userInitiated).async {
+        let event = Event()
+        let exception = Exception(value: "test", type: "test")
+        exception.mechanism = Mechanism(type: "AppHang")
+        let frame = Frame()
+        frame.function = "_NSMenuBarDisplayManagerActiveSpaceChanged"
+        frame.inApp = NSNumber(value: false)
+        exception.stacktrace = SentryStacktrace(frames: [frame], registers: [:])
+        event.exceptions = [exception]
+
+        #expect(!Thread.isMainThread)
+        #expect(SentryEventFilter.filterSystemHang(event) == nil)
+        continuation.resume()
+      }
+    }
+  }
+
   private func makeEvent(mechanismType: String, frames: [Frame]) -> Event {
     let event = Event()
     let exception = Exception(value: "test", type: "test")


### PR DESCRIPTION
## Summary

- Fix a fatal `EXC_BREAKPOINT` libdispatch abort reported as [PROWL-MACOS-5](https://onevs-den.sentry.io/issues/7424130201/) on `prowl@2026.4.18`.
- Add a regression test that executes `filterSystemHang` off the main thread. Because the filter is now `nonisolated`, the `@Sendable` closure compiles; if `nonisolated` is ever dropped, the test **fails to build** — upgrading the runtime crash to a compile-time error.

## Root cause

1. The project sets `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`, so un-annotated members of `SentryEventFilter` are implicitly `@MainActor`.
2. Sentry's `SentryANRTrackerV1` invokes `options.beforeSend` **synchronously from its own background detection thread** — documented SDK behavior.
3. Swift 6.2's `swift_task_isCurrentExecutorWithFlagsImpl` detects the off-main invocation of a MainActor-bound function and libdispatch aborts the process (`Block was expected to execute on queue [com.apple.main-thread]`).

The Objective-C `beforeSend` block type drops Swift actor isolation across the bridge, so the compiler has no way to catch this at the call site in `supacodeApp.swift`. Marking the callee `nonisolated` is the correct fix.

## Test plan

- [x] `xcodebuild test -only-testing:supacodeTests/SentryEventFilterTests` — 6/6 pass, including the new off-main case.
- [x] Verified the regression guard by temporarily removing `nonisolated` and re-building the test target: compiler reports `error: non-Sendable 'Event?'-typed result can not be returned from main actor-isolated static method 'filterSystemHang' to nonisolated context`.
- [x] `make build-app` — clean.
- [x] `make lint` — clean.
