### PR TITLE
[codex] Broaden code host opening fallback

### DIFF
--- a/supacode/App/AppShortcuts.swift
+++ b/supacode/App/AppShortcuts.swift
@@ -328,7 +328,7 @@ enum AppShortcuts {
     ),
     .init(
       id: CommandID.openPullRequest,
-      title: "Open Pull Request",
+      title: "Open on Code Host",
       scope: .configurableAppAction,
       shortcut: openPullRequest
     ),

--- a/supacode/Clients/Git/GitClient.swift
+++ b/supacode/Clients/Git/GitClient.swift
@@ -883,13 +883,13 @@ struct GitClient {
       guard hostParts.count == 2 else {
         return nil
       }
-      return parseRepositoryWebInfo(host: String(hostParts[0]), path: String(hostParts[1]))
+      return parseRepositoryWebInfo(host: String(hostParts[0]), port: nil, path: String(hostParts[1]))
     }
     guard let url = URL(string: trimmed), let host = url.host else {
       return nil
     }
     let path = url.path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
-    return parseRepositoryWebInfo(host: host, path: path)
+    return parseRepositoryWebInfo(host: host, port: url.port, path: path)
   }
 
   nonisolated static func parseGithubRemoteInfo(_ remoteURL: String) -> GithubRemoteInfo? {
@@ -899,7 +899,11 @@ struct GitClient {
     return parseGithubRemoteInfo(remoteWebInfo)
   }
 
-  nonisolated private static func parseRepositoryWebInfo(host: String, path: String) -> GitRemoteWebInfo? {
+  nonisolated private static func parseRepositoryWebInfo(
+    host: String,
+    port: Int?,
+    path: String
+  ) -> GitRemoteWebInfo? {
     let components = path.split(separator: "/", omittingEmptySubsequences: true)
     guard components.count >= 2 else {
       return nil
@@ -911,7 +915,7 @@ struct GitClient {
     guard !repositoryPath.isEmpty else {
       return nil
     }
-    return GitRemoteWebInfo(host: host, repositoryPath: repositoryPath)
+    return GitRemoteWebInfo(host: host, repositoryPath: repositoryPath, port: port)
   }
 
   nonisolated private static func parseGithubRemoteInfo(_ remoteWebInfo: GitRemoteWebInfo) -> GithubRemoteInfo? {

--- a/supacode/Clients/Git/GitClient.swift
+++ b/supacode/Clients/Git/GitClient.swift
@@ -503,7 +503,18 @@ struct GitClient {
     }
   }
 
+  nonisolated func repositoryWebURL(for repositoryRoot: URL) async -> URL? {
+    await remoteWebInfo(for: repositoryRoot)?.repositoryURL
+  }
+
   nonisolated func remoteInfo(for repositoryRoot: URL) async -> GithubRemoteInfo? {
+    guard let remoteWebInfo = await remoteWebInfo(for: repositoryRoot) else {
+      return nil
+    }
+    return Self.parseGithubRemoteInfo(remoteWebInfo)
+  }
+
+  nonisolated private func remoteWebInfo(for repositoryRoot: URL) async -> GitRemoteWebInfo? {
     let path = repositoryRoot.path(percentEncoded: false)
     guard
       let remotesOutput = try? await runGit(
@@ -533,7 +544,7 @@ struct GitClient {
       else {
         continue
       }
-      if let info = Self.parseGithubRemoteInfo(remoteURL) {
+      if let info = Self.parseRepositoryWebInfo(remoteURL) {
         return info
       }
     }
@@ -857,7 +868,7 @@ struct GitClient {
     return nil
   }
 
-  nonisolated static func parseGithubRemoteInfo(_ remoteURL: String) -> GithubRemoteInfo? {
+  nonisolated static func parseRepositoryWebInfo(_ remoteURL: String) -> GitRemoteWebInfo? {
     let trimmed = remoteURL.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !trimmed.isEmpty else {
       return nil
@@ -872,33 +883,52 @@ struct GitClient {
       guard hostParts.count == 2 else {
         return nil
       }
-      return parseGithubRemoteInfo(host: String(hostParts[0]), path: String(hostParts[1]))
+      return parseRepositoryWebInfo(host: String(hostParts[0]), path: String(hostParts[1]))
     }
     guard let url = URL(string: trimmed), let host = url.host else {
       return nil
     }
     let path = url.path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
-    return parseGithubRemoteInfo(host: host, path: path)
+    return parseRepositoryWebInfo(host: host, path: path)
   }
 
-  nonisolated private static func parseGithubRemoteInfo(host: String, path: String) -> GithubRemoteInfo? {
-    let normalizedHost = host.lowercased()
-    guard normalizedHost.contains("github") else {
+  nonisolated static func parseGithubRemoteInfo(_ remoteURL: String) -> GithubRemoteInfo? {
+    guard let remoteWebInfo = parseRepositoryWebInfo(remoteURL) else {
       return nil
     }
+    return parseGithubRemoteInfo(remoteWebInfo)
+  }
+
+  nonisolated private static func parseRepositoryWebInfo(host: String, path: String) -> GitRemoteWebInfo? {
     let components = path.split(separator: "/", omittingEmptySubsequences: true)
     guard components.count >= 2 else {
       return nil
     }
-    let owner = String(components[0])
-    var repo = String(components[1])
-    if repo.hasSuffix(".git") {
-      repo = String(repo.dropLast(4))
+    var repositoryPath = components.map(String.init).joined(separator: "/")
+    if repositoryPath.hasSuffix(".git") {
+      repositoryPath = String(repositoryPath.dropLast(4))
     }
+    guard !repositoryPath.isEmpty else {
+      return nil
+    }
+    return GitRemoteWebInfo(host: host, repositoryPath: repositoryPath)
+  }
+
+  nonisolated private static func parseGithubRemoteInfo(_ remoteWebInfo: GitRemoteWebInfo) -> GithubRemoteInfo? {
+    let normalizedHost = remoteWebInfo.host.lowercased()
+    guard normalizedHost.contains("github") else {
+      return nil
+    }
+    let components = remoteWebInfo.repositoryPath.split(separator: "/", omittingEmptySubsequences: true)
+    guard components.count >= 2 else {
+      return nil
+    }
+    let owner = String(components[0])
+    let repo = String(components[1])
     guard !owner.isEmpty, !repo.isEmpty else {
       return nil
     }
-    return GithubRemoteInfo(host: host, owner: owner, repo: repo)
+    return GithubRemoteInfo(host: remoteWebInfo.host, owner: owner, repo: repo)
   }
 
 }

--- a/supacode/Clients/Git/GitRemoteWebInfo.swift
+++ b/supacode/Clients/Git/GitRemoteWebInfo.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+struct GitRemoteWebInfo: Equatable, Sendable {
+  let host: String
+  let repositoryPath: String
+
+  var repositoryURL: URL? {
+    URL(string: "https://\(host)/\(repositoryPath)")
+  }
+}

--- a/supacode/Clients/Git/GitRemoteWebInfo.swift
+++ b/supacode/Clients/Git/GitRemoteWebInfo.swift
@@ -3,8 +3,20 @@ import Foundation
 struct GitRemoteWebInfo: Equatable, Sendable {
   let host: String
   let repositoryPath: String
+  let port: Int?
 
-  var repositoryURL: URL? {
-    URL(string: "https://\(host)/\(repositoryPath)")
+  nonisolated init(host: String, repositoryPath: String, port: Int? = nil) {
+    self.host = host
+    self.repositoryPath = repositoryPath
+    self.port = port
+  }
+
+  nonisolated var repositoryURL: URL? {
+    var components = URLComponents()
+    components.scheme = "https"
+    components.host = host
+    components.port = port
+    components.path = "/\(repositoryPath)"
+    return components.url
   }
 }

--- a/supacode/Clients/Repositories/GitClientDependency.swift
+++ b/supacode/Clients/Repositories/GitClientDependency.swift
@@ -36,6 +36,7 @@ struct GitClientDependency: Sendable {
   var branchName: @Sendable (URL) async -> String?
   var lineChanges: @Sendable (URL) async -> (added: Int, removed: Int)?
   var renameBranch: @Sendable (_ worktreeURL: URL, _ branchName: String) async throws -> Void
+  var repositoryWebURL: @Sendable (_ repositoryRoot: URL) async -> URL?
   var remoteInfo: @Sendable (_ repositoryRoot: URL) async -> GithubRemoteInfo?
   var remoteNames: @Sendable (_ repoRoot: URL) async throws -> [String]
   var fetchRemote: @Sendable (_ remote: String, _ repoRoot: URL) async throws -> Void
@@ -83,6 +84,9 @@ extension GitClientDependency: DependencyKey {
     lineChanges: { await GitClient().lineChanges(at: $0) },
     renameBranch: { worktreeURL, branchName in
       try await GitClient().renameBranch(in: worktreeURL, to: branchName)
+    },
+    repositoryWebURL: { repositoryRoot in
+      await GitClient().repositoryWebURL(for: repositoryRoot)
     },
     remoteInfo: { repositoryRoot in
       await GitClient().remoteInfo(for: repositoryRoot)

--- a/supacode/Clients/Workspace/OpenURLClient.swift
+++ b/supacode/Clients/Workspace/OpenURLClient.swift
@@ -1,0 +1,22 @@
+import AppKit
+import ComposableArchitecture
+import Foundation
+
+struct OpenURLClient {
+  var open: @MainActor @Sendable (_ url: URL) -> Void
+}
+
+extension OpenURLClient: DependencyKey {
+  static let liveValue = OpenURLClient { url in
+    NSWorkspace.shared.open(url)
+  }
+
+  static let testValue = OpenURLClient { _ in }
+}
+
+extension DependencyValues {
+  var openURLClient: OpenURLClient {
+    get { self[OpenURLClient.self] }
+    set { self[OpenURLClient.self] = newValue }
+  }
+}

--- a/supacode/Commands/WorktreeCommands.swift
+++ b/supacode/Commands/WorktreeCommands.swift
@@ -134,7 +134,7 @@ struct WorktreeCommands: Commands {
     guard let selectedWorktreeID = repositories.selectedWorktreeID else { return nil }
     guard
       let repositoryID = repositories.repositoryID(containing: selectedWorktreeID),
-      repositories.repositories[id: repositoryID]?.capabilities.supportsPullRequests == true
+      repositories.repositories[id: repositoryID]?.capabilities.supportsCodeHost == true
     else {
       return nil
     }

--- a/supacode/Commands/WorktreeCommands.swift
+++ b/supacode/Commands/WorktreeCommands.swift
@@ -20,8 +20,7 @@ struct WorktreeCommands: Commands {
     let repositories = store.repositories
     let hasActiveWorktree = repositories.worktree(for: repositories.selectedWorktreeID) != nil
     let orderedRows = visibleHotkeyWorktreeRows ?? repositories.orderedWorktreeRows()
-    let pullRequestURL = selectedPullRequestURL
-    let githubIntegrationEnabled = store.settings.githubIntegrationEnabled
+    let codeHostWorktreeID = selectedCodeHostWorktreeID
     let deleteShortcut = KeyboardShortcut(.delete, modifiers: [.command, .shift]).display
     let customCommands = store.selectedCustomCommands
     CommandMenu("Worktrees") {
@@ -74,14 +73,14 @@ struct WorktreeCommands: Commands {
       .modifier(KeyboardShortcutModifier(shortcut: keyboardShortcut(for: AppShortcuts.CommandID.openWorktree)))
       .help(helpText(title: "Open Worktree", commandID: AppShortcuts.CommandID.openWorktree))
       .disabled(openSelectedWorktreeAction == nil)
-      Button("Open Pull Request on GitHub") {
-        if let pullRequestURL {
-          NSWorkspace.shared.open(pullRequestURL)
+      Button("Open on Code Host") {
+        if let codeHostWorktreeID {
+          store.send(.repositories(.githubIntegration(.pullRequestAction(codeHostWorktreeID, .openOnCodeHost))))
         }
       }
       .modifier(KeyboardShortcutModifier(shortcut: keyboardShortcut(for: AppShortcuts.CommandID.openPullRequest)))
-      .help(helpText(title: "Open Pull Request on GitHub", commandID: AppShortcuts.CommandID.openPullRequest))
-      .disabled(pullRequestURL == nil || !githubIntegrationEnabled)
+      .help(helpText(title: "Open on Code Host", commandID: AppShortcuts.CommandID.openPullRequest))
+      .disabled(codeHostWorktreeID == nil)
       Button("New Worktree", systemImage: "plus") {
         store.send(.repositories(.worktreeCreation(.createRandomWorktree)))
       }
@@ -130,11 +129,16 @@ struct WorktreeCommands: Commands {
     AppShortcuts.worktreeSelectionCommandIDs
   }
 
-  private var selectedPullRequestURL: URL? {
+  private var selectedCodeHostWorktreeID: Worktree.ID? {
     let repositories = store.repositories
     guard let selectedWorktreeID = repositories.selectedWorktreeID else { return nil }
-    let pullRequest = repositories.worktreeInfoByID[selectedWorktreeID]?.pullRequest
-    return pullRequest.flatMap { URL(string: $0.url) }
+    guard
+      let repositoryID = repositories.repositoryID(containing: selectedWorktreeID),
+      repositories.repositories[id: repositoryID]?.capabilities.supportsPullRequests == true
+    else {
+      return nil
+    }
+    return selectedWorktreeID
   }
 
   private func keyboardShortcut(for commandID: String) -> KeyboardShortcut? {
@@ -178,16 +182,18 @@ struct WorktreeCommands: Commands {
     for repoID in repositories.orderedRepositoryIDs() {
       guard let repo = reposByID[repoID] else { continue }
       if repo.kind == .plain {
-        entries.append(WorktreeMenuEntry(
-          kind: .plainFolder(id: repo.id, name: repo.name),
-          shortcutCommandID: nil
-        ))
+        entries.append(
+          WorktreeMenuEntry(
+            kind: .plainFolder(id: repo.id, name: repo.name),
+            shortcutCommandID: nil
+          ))
       } else {
         for row in repositories.worktreeRows(in: repo) {
-          entries.append(WorktreeMenuEntry(
-            kind: .worktree(row),
-            shortcutCommandID: shortcutByWorktreeID[row.id]
-          ))
+          entries.append(
+            WorktreeMenuEntry(
+              kind: .worktree(row),
+              shortcutCommandID: shortcutByWorktreeID[row.id]
+            ))
         }
       }
     }
@@ -203,15 +209,18 @@ struct WorktreeCommands: Commands {
       Button(title) {
         store.send(.repositories(.selectWorktree(row.id)))
       }
-      .modifier(KeyboardShortcutModifier(
-        shortcut: entry.shortcutCommandID.flatMap { keyboardShortcut(for: $0) }
-      ))
-      .help({
-        if let commandID = entry.shortcutCommandID, let shortcut = shortcutDisplay(for: commandID) {
-          return "Switch to \(title) (\(shortcut))"
-        }
-        return "Switch to \(title)"
-      }())
+      .modifier(
+        KeyboardShortcutModifier(
+          shortcut: entry.shortcutCommandID.flatMap { keyboardShortcut(for: $0) }
+        )
+      )
+      .help(
+        {
+          if let commandID = entry.shortcutCommandID, let shortcut = shortcutDisplay(for: commandID) {
+            return "Switch to \(title) (\(shortcut))"
+          }
+          return "Switch to \(title)"
+        }())
     case .plainFolder(let repoID, let name):
       Button(name) {
         store.send(.repositories(.selectRepository(repoID)))

--- a/supacode/Domain/Repository.swift
+++ b/supacode/Domain/Repository.swift
@@ -11,6 +11,7 @@ nonisolated struct Repository: Identifiable, Hashable, Sendable {
     let supportsWorktrees: Bool
     let supportsBranchOperations: Bool
     let supportsPullRequests: Bool
+    let supportsCodeHost: Bool
     let supportsDiff: Bool
     let supportsGitStatus: Bool
     let supportsRunnableFolderActions: Bool
@@ -20,6 +21,7 @@ nonisolated struct Repository: Identifiable, Hashable, Sendable {
       supportsWorktrees: true,
       supportsBranchOperations: true,
       supportsPullRequests: true,
+      supportsCodeHost: true,
       supportsDiff: true,
       supportsGitStatus: true,
       supportsRunnableFolderActions: true,
@@ -30,6 +32,7 @@ nonisolated struct Repository: Identifiable, Hashable, Sendable {
       supportsWorktrees: false,
       supportsBranchOperations: false,
       supportsPullRequests: false,
+      supportsCodeHost: false,
       supportsDiff: false,
       supportsGitStatus: false,
       supportsRunnableFolderActions: true,

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -910,7 +910,7 @@ struct AppFeature {
         }
 
       case .commandPalette(.delegate(.openPullRequest(let worktreeID))):
-        return .send(.repositories(.githubIntegration(.pullRequestAction(worktreeID, .openOnGithub))))
+        return .send(.repositories(.githubIntegration(.pullRequestAction(worktreeID, .openOnCodeHost))))
 
       case .commandPalette(.delegate(.markPullRequestReady(let worktreeID))):
         return .send(.repositories(.githubIntegration(.pullRequestAction(worktreeID, .markReadyForReview))))

--- a/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
+++ b/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
@@ -236,20 +236,7 @@ struct CommandPaletteFeature {
       )
       items.append(contentsOf: ghosttyCommandItems(ghosttyCommands))
     }
-    if let selectedWorktreeID = repositories.selectedWorktreeID,
-      let repositoryID = repositories.repositoryID(containing: selectedWorktreeID),
-      repositories.repositories[id: repositoryID]?.capabilities.supportsPullRequests == true,
-      let pullRequest = repositories.worktreeInfo(for: selectedWorktreeID)?.pullRequest,
-      pullRequest.number > 0,
-      pullRequest.state.uppercased() != "CLOSED"
-    {
-      let pullRequestActions = pullRequestItems(
-        pullRequest: pullRequest,
-        worktreeID: selectedWorktreeID,
-        repositoryID: repositoryID
-      )
-      items.append(contentsOf: pullRequestActions)
-    }
+    items.append(contentsOf: selectedCodeHostItems(from: repositories))
     #if DEBUG
       items.append(contentsOf: debugToastItems())
     #endif
@@ -282,6 +269,38 @@ struct CommandPaletteFeature {
     }
     return ids
   }
+}
+
+private func selectedCodeHostItems(
+  from repositories: RepositoriesFeature.State
+) -> [CommandPaletteItem] {
+  guard
+    let selectedWorktreeID = repositories.selectedWorktreeID,
+    let repositoryID = repositories.repositoryID(containing: selectedWorktreeID),
+    let repository = repositories.repositories[id: repositoryID],
+    repository.capabilities.supportsPullRequests
+  else {
+    return []
+  }
+
+  let pullRequest = repositories.worktreeInfo(for: selectedWorktreeID)?.pullRequest
+  if let pullRequest, pullRequest.number > 0, pullRequest.state.uppercased() != "CLOSED" {
+    return pullRequestItems(
+      pullRequest: pullRequest,
+      worktreeID: selectedWorktreeID,
+      repositoryID: repositoryID
+    )
+  }
+
+  return [
+    CommandPaletteItem(
+      id: CommandPaletteItemID.pullRequestOpen(repositoryID),
+      title: "Open Repository on Code Host",
+      subtitle: repository.name,
+      kind: .openPullRequest(selectedWorktreeID),
+      priorityTier: 2
+    ),
+  ]
 }
 
 private func pullRequestItems(
@@ -361,7 +380,7 @@ private func pullRequestItems(
   var items: [CommandPaletteItem] = [
     CommandPaletteItem(
       id: CommandPaletteItemID.pullRequestOpen(repositoryID),
-      title: "Open PR on GitHub",
+      title: "Open Pull Request on GitHub",
       subtitle: pullRequest.title,
       kind: .openPullRequest(worktreeID),
       priorityTier: 2

--- a/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
+++ b/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
@@ -277,19 +277,26 @@ private func selectedCodeHostItems(
   guard
     let selectedWorktreeID = repositories.selectedWorktreeID,
     let repositoryID = repositories.repositoryID(containing: selectedWorktreeID),
-    let repository = repositories.repositories[id: repositoryID],
-    repository.capabilities.supportsPullRequests
+    let repository = repositories.repositories[id: repositoryID]
   else {
     return []
   }
 
   let pullRequest = repositories.worktreeInfo(for: selectedWorktreeID)?.pullRequest
-  if let pullRequest, pullRequest.number > 0, pullRequest.state.uppercased() != "CLOSED" {
+  if repository.capabilities.supportsPullRequests,
+    let pullRequest,
+    pullRequest.number > 0,
+    pullRequest.state.uppercased() != "CLOSED"
+  {
     return pullRequestItems(
       pullRequest: pullRequest,
       worktreeID: selectedWorktreeID,
       repositoryID: repositoryID
     )
+  }
+
+  guard repository.capabilities.supportsCodeHost else {
+    return []
   }
 
   return [

--- a/supacode/Features/CommandPalette/Views/CommandPaletteOverlayView.swift
+++ b/supacode/Features/CommandPalette/Views/CommandPaletteOverlayView.swift
@@ -520,7 +520,7 @@ private struct CommandPaletteRowView: View {
     case .archiveWorktree:
       base = "Archive \(row.title)"
     case .openPullRequest:
-      base = "Open on code host"
+      base = "Open on Code Host"
     case .markPullRequestReady:
       base = "Mark pull request ready for review"
     case .mergePullRequest:

--- a/supacode/Features/CommandPalette/Views/CommandPaletteOverlayView.swift
+++ b/supacode/Features/CommandPalette/Views/CommandPaletteOverlayView.swift
@@ -520,7 +520,7 @@ private struct CommandPaletteRowView: View {
     case .archiveWorktree:
       base = "Archive \(row.title)"
     case .openPullRequest:
-      base = "Open pull request on GitHub"
+      base = "Open on code host"
     case .markPullRequestReady:
       base = "Mark pull request ready for review"
     case .mergePullRequest:

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+GithubIntegration.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+GithubIntegration.swift
@@ -226,9 +226,19 @@ extension RepositoriesFeature {
     case .pullRequestAction(let worktreeID, let action):
       guard let worktree = state.worktree(for: worktreeID),
         let repositoryID = state.repositoryID(containing: worktreeID),
-        let repository = state.repositories[id: repositoryID],
-        let pullRequest = state.worktreeInfo(for: worktreeID)?.pullRequest
+        let repository = state.repositories[id: repositoryID]
       else {
+        return .send(
+          .presentAlert(
+            title: "Repository not available",
+            message: "Prowl could not find the selected repository."
+          )
+        )
+      }
+      let repoRoot = worktree.repositoryRootURL
+      let worktreeRoot = worktree.workingDirectory
+      let pullRequest = state.worktreeInfo(for: worktreeID)?.pullRequest
+      if action != .openOnCodeHost, pullRequest == nil {
         return .send(
           .presentAlert(
             title: "Pull request not available",
@@ -236,28 +246,34 @@ extension RepositoriesFeature {
           )
         )
       }
-      let repoRoot = worktree.repositoryRootURL
-      let worktreeRoot = worktree.workingDirectory
       let pullRequestRefresh = WorktreeInfoWatcherClient.Event.repositoryPullRequestRefresh(
         repositoryRootURL: repoRoot,
         worktreeIDs: repository.worktrees.map(\.id)
       )
-      let branchName = pullRequest.headRefName ?? worktree.name
-      let failingCheckDetailsURL = (pullRequest.statusCheckRollup?.checks ?? []).first {
+      let branchName = pullRequest?.headRefName ?? worktree.name
+      let failingCheckDetailsURL = (pullRequest?.statusCheckRollup?.checks ?? []).first {
         $0.checkState == .failure && $0.detailsUrl != nil
       }?.detailsUrl
       switch action {
-      case .openOnGithub:
-        guard let url = URL(string: pullRequest.url) else {
-          return .send(
-            .presentAlert(
-              title: "Invalid pull request URL",
-              message: "Prowl could not open the pull request URL."
+      case .openOnCodeHost:
+        let gitClient = gitClient
+        let openURLClient = openURLClient
+        let pullRequestURL = pullRequest.flatMap { URL(string: $0.url) }
+        return .run { send in
+          if let pullRequestURL {
+            await openURLClient.open(pullRequestURL)
+            return
+          }
+          guard let repositoryURL = await gitClient.repositoryWebURL(repoRoot) else {
+            await send(
+              .presentAlert(
+                title: "Repository URL not available",
+                message: "Prowl could not determine a code host URL for this repository."
+              )
             )
-          )
-        }
-        return .run { @MainActor _ in
-          NSWorkspace.shared.open(url)
+            return
+          }
+          await openURLClient.open(repositoryURL)
         }
 
       case .copyFailingJobURL:
@@ -294,6 +310,7 @@ extension RepositoriesFeature {
         let githubCLI = githubCLI
         let githubIntegration = githubIntegration
         return .run { send in
+          guard let pullRequest else { return }
           guard await githubIntegration.isAvailable() else {
             await send(
               .presentAlert(
@@ -323,6 +340,7 @@ extension RepositoriesFeature {
         let githubCLI = githubCLI
         let githubIntegration = githubIntegration
         return .run { send in
+          guard let pullRequest else { return }
           guard await githubIntegration.isAvailable() else {
             await send(
               .presentAlert(
@@ -356,6 +374,7 @@ extension RepositoriesFeature {
         let githubCLI = githubCLI
         let githubIntegration = githubIntegration
         return .run { send in
+          guard let pullRequest else { return }
           guard await githubIntegration.isAvailable() else {
             await send(
               .presentAlert(
@@ -386,6 +405,7 @@ extension RepositoriesFeature {
         let githubCLI = githubCLI
         let githubIntegration = githubIntegration
         return .run { send in
+          guard pullRequest != nil else { return }
           guard await githubIntegration.isAvailable() else {
             await send(
               .presentAlert(
@@ -463,6 +483,7 @@ extension RepositoriesFeature {
         let githubCLI = githubCLI
         let githubIntegration = githubIntegration
         return .run { send in
+          guard pullRequest != nil else { return }
           guard await githubIntegration.isAvailable() else {
             await send(
               .presentAlert(

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+GithubIntegration.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+GithubIntegration.swift
@@ -237,28 +237,11 @@ extension RepositoriesFeature {
       }
       let repoRoot = worktree.repositoryRootURL
       let worktreeRoot = worktree.workingDirectory
-      let pullRequest = state.worktreeInfo(for: worktreeID)?.pullRequest
-      if action != .openOnCodeHost, pullRequest == nil {
-        return .send(
-          .presentAlert(
-            title: "Pull request not available",
-            message: "Prowl could not find a pull request for this worktree."
-          )
-        )
-      }
-      let pullRequestRefresh = WorktreeInfoWatcherClient.Event.repositoryPullRequestRefresh(
-        repositoryRootURL: repoRoot,
-        worktreeIDs: repository.worktrees.map(\.id)
-      )
-      let branchName = pullRequest?.headRefName ?? worktree.name
-      let failingCheckDetailsURL = (pullRequest?.statusCheckRollup?.checks ?? []).first {
-        $0.checkState == .failure && $0.detailsUrl != nil
-      }?.detailsUrl
-      switch action {
-      case .openOnCodeHost:
+      let optionalPullRequest = state.worktreeInfo(for: worktreeID)?.pullRequest
+      if case .openOnCodeHost = action {
         let gitClient = gitClient
         let openURLClient = openURLClient
-        let pullRequestURL = pullRequest.flatMap { Self.validWebURL($0.url) }
+        let pullRequestURL = optionalPullRequest.flatMap { Self.validWebURL($0.url) }
         return .run { send in
           if let pullRequestURL {
             await openURLClient.open(pullRequestURL)
@@ -275,6 +258,26 @@ extension RepositoriesFeature {
           }
           await openURLClient.open(repositoryURL)
         }
+      }
+      guard let pullRequest = optionalPullRequest else {
+        return .send(
+          .presentAlert(
+            title: "Pull request not available",
+            message: "Prowl could not find a pull request for this worktree."
+          )
+        )
+      }
+      let pullRequestRefresh = WorktreeInfoWatcherClient.Event.repositoryPullRequestRefresh(
+        repositoryRootURL: repoRoot,
+        worktreeIDs: repository.worktrees.map(\.id)
+      )
+      let branchName = pullRequest.headRefName ?? worktree.name
+      let failingCheckDetailsURL = (pullRequest.statusCheckRollup?.checks ?? []).first {
+        $0.checkState == .failure && $0.detailsUrl != nil
+      }?.detailsUrl
+      switch action {
+      case .openOnCodeHost:
+        return .none
 
       case .copyFailingJobURL:
         guard let failingCheckDetailsURL, !failingCheckDetailsURL.isEmpty else {
@@ -310,7 +313,6 @@ extension RepositoriesFeature {
         let githubCLI = githubCLI
         let githubIntegration = githubIntegration
         return .run { send in
-          guard let pullRequest else { return }
           guard await githubIntegration.isAvailable() else {
             await send(
               .presentAlert(
@@ -340,7 +342,6 @@ extension RepositoriesFeature {
         let githubCLI = githubCLI
         let githubIntegration = githubIntegration
         return .run { send in
-          guard let pullRequest else { return }
           guard await githubIntegration.isAvailable() else {
             await send(
               .presentAlert(
@@ -374,7 +375,6 @@ extension RepositoriesFeature {
         let githubCLI = githubCLI
         let githubIntegration = githubIntegration
         return .run { send in
-          guard let pullRequest else { return }
           guard await githubIntegration.isAvailable() else {
             await send(
               .presentAlert(
@@ -405,7 +405,6 @@ extension RepositoriesFeature {
         let githubCLI = githubCLI
         let githubIntegration = githubIntegration
         return .run { send in
-          guard pullRequest != nil else { return }
           guard await githubIntegration.isAvailable() else {
             await send(
               .presentAlert(
@@ -483,7 +482,6 @@ extension RepositoriesFeature {
         let githubCLI = githubCLI
         let githubIntegration = githubIntegration
         return .run { send in
-          guard pullRequest != nil else { return }
           guard await githubIntegration.isAvailable() else {
             await send(
               .presentAlert(

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+GithubIntegration.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+GithubIntegration.swift
@@ -258,7 +258,7 @@ extension RepositoriesFeature {
       case .openOnCodeHost:
         let gitClient = gitClient
         let openURLClient = openURLClient
-        let pullRequestURL = pullRequest.flatMap { URL(string: $0.url) }
+        let pullRequestURL = pullRequest.flatMap { Self.validWebURL($0.url) }
         return .run { send in
           if let pullRequestURL {
             await openURLClient.open(pullRequestURL)
@@ -571,6 +571,17 @@ extension RepositoriesFeature {
       state.mergedWorktreeAction = action
       return .none
     }
+  }
+
+  nonisolated private static func validWebURL(_ raw: String) -> URL? {
+    guard let url = URL(string: raw),
+      let scheme = url.scheme?.lowercased(),
+      ["http", "https"].contains(scheme),
+      url.host != nil
+    else {
+      return nil
+    }
+    return url
   }
 
   var githubIntegrationReducer: some ReducerOf<Self> {

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -332,7 +332,7 @@ struct RepositoriesFeature {
   }
 
   enum PullRequestAction: Equatable {
-    case openOnGithub
+    case openOnCodeHost
     case markReadyForReview
     case merge
     case close
@@ -355,6 +355,7 @@ struct RepositoriesFeature {
   @Dependency(GitClientDependency.self) var gitClient
   @Dependency(GithubCLIClient.self) var githubCLI
   @Dependency(GithubIntegrationClient.self) var githubIntegration
+  @Dependency(OpenURLClient.self) var openURLClient
   @Dependency(RepositoryPersistenceClient.self) var repositoryPersistence
   @Dependency(ShellClient.self) var shellClient
   @Dependency(\.date.now) var now

--- a/supacodeTests/CommandPaletteFeatureTests.swift
+++ b/supacodeTests/CommandPaletteFeatureTests.swift
@@ -179,6 +179,25 @@ struct CommandPaletteFeatureTests {
     #expect(items.contains(where: { $0.id == "global.new-worktree" }) == false)
   }
 
+  @Test func commandPaletteItems_showsCodeHostActionWithoutPullRequest() {
+    let rootPath = "/tmp/repo"
+    let worktree = makeWorktree(id: rootPath, name: "repo", repoRoot: rootPath)
+    let repository = makeRepository(rootPath: rootPath, name: "Repo", worktrees: [worktree])
+    var state = RepositoriesFeature.State(repositories: [repository])
+    state.selection = .worktree(worktree.id)
+
+    let items = CommandPaletteFeature.commandPaletteItems(from: state)
+    let openItem = items.first {
+      if case .openPullRequest(let worktreeID) = $0.kind {
+        return worktreeID == worktree.id
+      }
+      return false
+    }
+
+    #expect(openItem?.title == "Open Repository on Code Host")
+    #expect(openItem?.subtitle == repository.name)
+  }
+
   @Test func emptyQueryHidesGhosttyCommands() {
     let ghosttyItem = CommandPaletteItem(
       id: "ghostty.goto_split:right|Focus Split Right",

--- a/supacodeTests/GitRemoteInfoTests.swift
+++ b/supacodeTests/GitRemoteInfoTests.swift
@@ -16,6 +16,17 @@ struct GitRemoteInfoTests {
     #expect(info?.repositoryURL == URL(string: "https://gitlab.com/group/subgroup/repo"))
   }
 
+  @Test func parseRepositoryWebInfoPreservesCustomPortAndPathPrefix() {
+    let info = GitClient.parseRepositoryWebInfo("ssh://git@git.example.com:8443/scm/platform/repo.git")
+    #expect(info == GitRemoteWebInfo(host: "git.example.com", repositoryPath: "scm/platform/repo", port: 8443))
+    #expect(info?.repositoryURL == URL(string: "https://git.example.com:8443/scm/platform/repo"))
+  }
+
+  @Test func parseRepositoryWebInfoRejectsUnparseableRemote() {
+    let info = GitClient.parseRepositoryWebInfo("/tmp/local-only/repo.git")
+    #expect(info == nil)
+  }
+
   @Test func parseSSHRemote() {
     let info = GitClient.parseGithubRemoteInfo("git@github.com:octo/repo.git")
     #expect(info == GithubRemoteInfo(host: "github.com", owner: "octo", repo: "repo"))

--- a/supacodeTests/GitRemoteInfoTests.swift
+++ b/supacodeTests/GitRemoteInfoTests.swift
@@ -4,6 +4,18 @@ import Testing
 @testable import supacode
 
 struct GitRemoteInfoTests {
+  @Test func parseRepositoryWebInfoFromGitHubRemote() {
+    let info = GitClient.parseRepositoryWebInfo("git@github.com:octo/repo.git")
+    #expect(info == GitRemoteWebInfo(host: "github.com", repositoryPath: "octo/repo"))
+    #expect(info?.repositoryURL == URL(string: "https://github.com/octo/repo"))
+  }
+
+  @Test func parseRepositoryWebInfoFromGitLabSubgroupRemote() {
+    let info = GitClient.parseRepositoryWebInfo("https://gitlab.com/group/subgroup/repo.git")
+    #expect(info == GitRemoteWebInfo(host: "gitlab.com", repositoryPath: "group/subgroup/repo"))
+    #expect(info?.repositoryURL == URL(string: "https://gitlab.com/group/subgroup/repo"))
+  }
+
   @Test func parseSSHRemote() {
     let info = GitClient.parseGithubRemoteInfo("git@github.com:octo/repo.git")
     #expect(info == GithubRemoteInfo(host: "github.com", owner: "octo", repo: "repo"))

--- a/supacodeTests/GitRepositoryWebURLIntegrationTests.swift
+++ b/supacodeTests/GitRepositoryWebURLIntegrationTests.swift
@@ -1,0 +1,78 @@
+import Foundation
+import Testing
+
+@testable import supacode
+
+struct GitRepositoryWebURLIntegrationTests {
+  @Test func returnsNilWhenRepositoryHasNoRemote() async throws {
+    let repoURL = try makeTemporaryRepo(namePrefix: "supacode-weburl-no-remote")
+    defer { try? FileManager.default.removeItem(at: repoURL) }
+
+    let url = await GitClient().repositoryWebURL(for: repoURL)
+
+    #expect(url == nil)
+  }
+
+  @Test func returnsNilWhenRemoteCannotBeParsed() async throws {
+    let repoURL = try makeTemporaryRepo(namePrefix: "supacode-weburl-unparseable")
+    defer { try? FileManager.default.removeItem(at: repoURL) }
+
+    try runGit([
+      "-C", repoURL.path(percentEncoded: false),
+      "remote", "add", "origin", "/tmp/local-only/repo.git",
+    ])
+
+    let url = await GitClient().repositoryWebURL(for: repoURL)
+
+    #expect(url == nil)
+  }
+
+  @Test func preservesCustomPortAndPathPrefixFromRemote() async throws {
+    let repoURL = try makeTemporaryRepo(namePrefix: "supacode-weburl-port-prefix")
+    defer { try? FileManager.default.removeItem(at: repoURL) }
+
+    try runGit([
+      "-C", repoURL.path(percentEncoded: false),
+      "remote", "add", "origin", "ssh://git@git.example.com:8443/scm/platform/repo.git",
+    ])
+
+    let url = await GitClient().repositoryWebURL(for: repoURL)
+
+    #expect(url == URL(string: "https://git.example.com:8443/scm/platform/repo"))
+  }
+}
+
+private struct GitCommandError: Error {
+  let output: String
+}
+
+private func makeTemporaryRepo(namePrefix: String) throws -> URL {
+  let tempRoot = URL(filePath: "/tmp", directoryHint: .isDirectory)
+  let repoURL = tempRoot.appending(
+    path: "\(namePrefix)-\(UUID().uuidString)",
+    directoryHint: URL.DirectoryHint.isDirectory
+  )
+  try runGit(["init", repoURL.path(percentEncoded: false)])
+  return repoURL
+}
+
+@discardableResult
+private func runGit(_ arguments: [String]) throws -> String {
+  let process = Process()
+  process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+  process.arguments = arguments
+  var environment = ProcessInfo.processInfo.environment
+  environment["GIT_CONFIG_GLOBAL"] = "/dev/null"
+  process.environment = environment
+  let pipe = Pipe()
+  process.standardOutput = pipe
+  process.standardError = pipe
+  try process.run()
+  process.waitUntilExit()
+  let data = pipe.fileHandleForReading.readDataToEndOfFile()
+  let output = String(data: data, encoding: .utf8) ?? ""
+  if process.terminationStatus != 0 {
+    throw GitCommandError(output: output)
+  }
+  return output
+}

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -3172,6 +3172,75 @@ struct RepositoriesFeatureTests {
     #expect(openedURLs.value == [repositoryURL])
   }
 
+  @Test func pullRequestActionOpenOnCodeHostFallsBackWhenPullRequestURLIsInvalid() async {
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let featureWorktree = makeWorktree(
+      id: "\(repoRoot)/feature",
+      name: "feature",
+      repoRoot: repoRoot
+    )
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree, featureWorktree])
+    let pullRequest = makePullRequest(
+      state: "OPEN",
+      headRefName: featureWorktree.name,
+      number: 12,
+      url: "/octo/repo/pull/12"
+    )
+    var state = makeState(repositories: [repository])
+    state.worktreeInfoByID[featureWorktree.id] = WorktreeInfoEntry(
+      addedLines: nil,
+      removedLines: nil,
+      pullRequest: pullRequest
+    )
+    let repositoryURL = URL(string: "https://git.example.com/scm/repo")!
+    let openedURLs = LockIsolated<[URL]>([])
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.gitClient.repositoryWebURL = { _ in
+        repositoryURL
+      }
+      $0.openURLClient.open = { url in
+        openedURLs.withValue { $0.append(url) }
+      }
+    }
+
+    await store.send(.githubIntegration(.pullRequestAction(featureWorktree.id, .openOnCodeHost)))
+    await store.finish()
+
+    #expect(openedURLs.value == [repositoryURL])
+  }
+
+  @Test func pullRequestActionOpenOnCodeHostShowsAlertWhenRepositoryURLUnavailable() async {
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let featureWorktree = makeWorktree(
+      id: "\(repoRoot)/feature",
+      name: "feature",
+      repoRoot: repoRoot
+    )
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree, featureWorktree])
+    let store = TestStore(initialState: makeState(repositories: [repository])) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.gitClient.repositoryWebURL = { _ in nil }
+    }
+
+    await store.send(.githubIntegration(.pullRequestAction(featureWorktree.id, .openOnCodeHost)))
+    await store.receive(\.presentAlert) {
+      $0.alert = AlertState<RepositoriesFeature.Alert> {
+        TextState("Repository URL not available")
+      } actions: {
+        ButtonState(role: .cancel) {
+          TextState("OK")
+        }
+      } message: {
+        TextState("Prowl could not determine a code host URL for this repository.")
+      }
+    }
+  }
+
   @Test func worktreeInfoEventRepositoryPullRequestRefreshMarksInFlightThenCompletes() async {
     let repoRoot = "/tmp/repo"
     let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -3104,6 +3104,74 @@ struct RepositoriesFeatureTests {
     await store.finish()
   }
 
+  @Test func pullRequestActionOpenOnCodeHostOpensPullRequestURLWhenAvailable() async {
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let featureWorktree = makeWorktree(
+      id: "\(repoRoot)/feature",
+      name: "feature",
+      repoRoot: repoRoot
+    )
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree, featureWorktree])
+    let pullRequest = makePullRequest(
+      state: "OPEN",
+      headRefName: featureWorktree.name,
+      number: 12,
+      url: "https://github.com/octo/repo/pull/12"
+    )
+    var state = makeState(repositories: [repository])
+    state.worktreeInfoByID[featureWorktree.id] = WorktreeInfoEntry(
+      addedLines: nil,
+      removedLines: nil,
+      pullRequest: pullRequest
+    )
+    let openedURLs = LockIsolated<[URL]>([])
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.gitClient.repositoryWebURL = { _ in
+        Issue.record("repositoryWebURL should not be requested when a pull request URL exists")
+        return nil
+      }
+      $0.openURLClient.open = { url in
+        openedURLs.withValue { $0.append(url) }
+      }
+    }
+
+    await store.send(.githubIntegration(.pullRequestAction(featureWorktree.id, .openOnCodeHost)))
+    await store.finish()
+
+    #expect(openedURLs.value == [URL(string: "https://github.com/octo/repo/pull/12")!])
+  }
+
+  @Test func pullRequestActionOpenOnCodeHostFallsBackToRepositoryURL() async {
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let featureWorktree = makeWorktree(
+      id: "\(repoRoot)/feature",
+      name: "feature",
+      repoRoot: repoRoot
+    )
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree, featureWorktree])
+    let repositoryURL = URL(string: "https://gitlab.com/group/subgroup/repo")!
+    let openedURLs = LockIsolated<[URL]>([])
+    let store = TestStore(initialState: makeState(repositories: [repository])) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.gitClient.repositoryWebURL = { _ in
+        repositoryURL
+      }
+      $0.openURLClient.open = { url in
+        openedURLs.withValue { $0.append(url) }
+      }
+    }
+
+    await store.send(.githubIntegration(.pullRequestAction(featureWorktree.id, .openOnCodeHost)))
+    await store.finish()
+
+    #expect(openedURLs.value == [repositoryURL])
+  }
+
   @Test func worktreeInfoEventRepositoryPullRequestRefreshMarksInFlightThenCompletes() async {
     let repoRoot = "/tmp/repo"
     let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
@@ -3493,7 +3561,7 @@ struct RepositoriesFeatureTests {
     let fixedDate = Date(timeIntervalSince1970: 1_000_000)
     var state = makeState(repositories: [repository])
     state.archivedWorktrees = [
-      ArchivedWorktree(id: worktree.id, archivedAt: .distantPast),
+      ArchivedWorktree(id: worktree.id, archivedAt: .distantPast)
     ]
     state.archivedAutoDeletePeriod = nil
     let store = TestStore(initialState: state) {
@@ -3513,7 +3581,7 @@ struct RepositoriesFeatureTests {
     let fixedDate = Date(timeIntervalSince1970: 1_000_000)
     var state = makeState(repositories: [repository])
     state.archivedWorktrees = [
-      ArchivedWorktree(id: mainWorktree.id, archivedAt: .distantPast),
+      ArchivedWorktree(id: mainWorktree.id, archivedAt: .distantPast)
     ]
     state.archivedAutoDeletePeriod = .oneDay
     let store = TestStore(initialState: state) {
@@ -3787,7 +3855,8 @@ struct RepositoriesFeatureTests {
   private func makePullRequest(
     state: String,
     headRefName: String? = nil,
-    number: Int = 1
+    number: Int = 1,
+    url: String? = nil
   ) -> GithubPullRequest {
     GithubPullRequest(
       number: number,
@@ -3800,7 +3869,7 @@ struct RepositoriesFeatureTests {
       mergeable: nil,
       mergeStateStatus: nil,
       updatedAt: nil,
-      url: "https://example.com/pull/\(number)",
+      url: url ?? "https://example.com/pull/\(number)",
       headRefName: headRefName,
       baseRefName: "main",
       commitsCount: 1,


### PR DESCRIPTION
## Summary
- broaden the open-on-GitHub shortcut into a generic code-host action
- keep opening the PR when one exists, and fall back to the repository homepage when it does not
- add generic remote web URL parsing so non-GitHub hosts like GitLab can still open the repository page

## Why
The shortcut and command entrypoints were gated on pull request availability and GitHub-specific remote parsing. That meant the action silently stopped working when a worktree had no PR, even though the repository still had a valid code host homepage.

## Impact
- GitHub worktrees with a PR keep the current behavior
- GitHub worktrees without a PR now open the repository homepage
- GitLab-style remotes can now use the same shortcut to open the repository homepage
- PR management actions remain GitHub-only

## Root Cause
The previous implementation modeled this feature as `open pull request on GitHub` end-to-end: UI gating, reducer behavior, and remote parsing all assumed a PR and a GitHub host.

## Validation
- `xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -only-testing:supacodeTests/GitRemoteInfoTests -only-testing:supacodeTests/CommandPaletteFeatureTests -only-testing:supacodeTests/RepositoriesFeatureTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation | xcsift`
- `make lint`
- `make build-app`
