### PR TITLE
Hide contextual palette actions from empty query state

### DIFF
--- a/supacode/Features/CommandPalette/CommandPaletteItem.swift
+++ b/supacode/Features/CommandPalette/CommandPaletteItem.swift
@@ -33,6 +33,7 @@ struct CommandPaletteItem: Identifiable, Equatable {
     case refreshWorktrees
     case ghosttyCommand(String)
     case openPullRequest(Worktree.ID)
+    case openRepositoryOnCodeHost(Worktree.ID)
     case markPullRequestReady(Worktree.ID)
     case mergePullRequest(Worktree.ID)
     case closePullRequest(Worktree.ID)
@@ -62,10 +63,13 @@ struct CommandPaletteItem: Identifiable, Equatable {
       .copyFailingJobURL,
       .copyCiFailureLogs,
       .rerunFailedJobs,
-      .openFailingCheckDetails,
-      .changeFocusedTabIcon:
+      .openFailingCheckDetails:
       return true
-    case .worktreeSelect, .removeWorktree, .archiveWorktree:
+    case .worktreeSelect,
+      .removeWorktree,
+      .archiveWorktree,
+      .changeFocusedTabIcon,
+      .openRepositoryOnCodeHost:
       return false
     #if DEBUG
       case .debugTestToast, .debugSimulateUpdateFound:
@@ -82,6 +86,7 @@ struct CommandPaletteItem: Identifiable, Equatable {
     case .ghosttyCommand:
       return false
     case .openPullRequest,
+      .openRepositoryOnCodeHost,
       .markPullRequestReady,
       .mergePullRequest,
       .closePullRequest,
@@ -115,7 +120,8 @@ struct CommandPaletteItem: Identifiable, Equatable {
       return AppShortcuts.CommandID.archivedWorktrees
     case .refreshWorktrees:
       return AppShortcuts.CommandID.refreshWorktrees
-    case .openPullRequest:
+    case .openPullRequest,
+      .openRepositoryOnCodeHost:
       return AppShortcuts.CommandID.openPullRequest
     case .ghosttyCommand,
       .markPullRequestReady,

--- a/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
+++ b/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
@@ -304,7 +304,7 @@ private func selectedCodeHostItems(
       id: CommandPaletteItemID.pullRequestOpen(repositoryID),
       title: "Open Repository on Code Host",
       subtitle: repository.name,
-      kind: .openPullRequest(selectedWorktreeID),
+      kind: .openRepositoryOnCodeHost(selectedWorktreeID),
       priorityTier: 2
     ),
   ]
@@ -622,6 +622,7 @@ private func delegateAction(for kind: CommandPaletteItem.Kind) -> CommandPalette
   case .changeFocusedTabIcon(let worktreeID):
     return .changeFocusedTabIcon(worktreeID)
   case .openPullRequest,
+    .openRepositoryOnCodeHost,
     .markPullRequestReady,
     .mergePullRequest,
     .closePullRequest,
@@ -643,7 +644,8 @@ private func pullRequestDelegateAction(
   for kind: CommandPaletteItem.Kind
 ) -> CommandPaletteFeature.Delegate? {
   switch kind {
-  case .openPullRequest(let worktreeID):
+  case .openPullRequest(let worktreeID),
+    .openRepositoryOnCodeHost(let worktreeID):
     return .openPullRequest(worktreeID)
   case .markPullRequestReady(let worktreeID):
     return .markPullRequestReady(worktreeID)

--- a/supacode/Features/CommandPalette/Views/CommandPaletteOverlayView.swift
+++ b/supacode/Features/CommandPalette/Views/CommandPaletteOverlayView.swift
@@ -349,7 +349,8 @@ private struct CommandPaletteRowView: View {
     switch row.kind {
     case .checkForUpdates, .openRepository, .openSettings, .newWorktree, .viewArchivedWorktrees,
       .refreshWorktrees, .installCLI, .ghosttyCommand,
-      .openPullRequest, .markPullRequestReady, .mergePullRequest, .closePullRequest, .copyFailingJobURL,
+      .openPullRequest, .openRepositoryOnCodeHost, .markPullRequestReady, .mergePullRequest, .closePullRequest,
+      .copyFailingJobURL,
       .copyCiFailureLogs,
       .rerunFailedJobs, .openFailingCheckDetails, .worktreeSelect, .changeFocusedTabIcon:
       return nil
@@ -380,7 +381,7 @@ private struct CommandPaletteRowView: View {
       return "arrow.clockwise"
     case .ghosttyCommand:
       return "terminal"
-    case .openPullRequest:
+    case .openPullRequest, .openRepositoryOnCodeHost:
       return "arrow.up.right.square"
     case .markPullRequestReady:
       return "checkmark.seal"
@@ -419,7 +420,8 @@ private struct CommandPaletteRowView: View {
     switch row.kind {
     case .checkForUpdates, .openRepository, .openSettings, .newWorktree, .viewArchivedWorktrees,
       .refreshWorktrees, .installCLI, .ghosttyCommand,
-      .openPullRequest, .markPullRequestReady, .mergePullRequest, .closePullRequest, .copyFailingJobURL,
+      .openPullRequest, .openRepositoryOnCodeHost, .markPullRequestReady, .mergePullRequest, .closePullRequest,
+      .copyFailingJobURL,
       .copyCiFailureLogs,
       .rerunFailedJobs, .openFailingCheckDetails, .changeFocusedTabIcon:
       return true
@@ -519,7 +521,7 @@ private struct CommandPaletteRowView: View {
       base = "Remove \(row.title)"
     case .archiveWorktree:
       base = "Archive \(row.title)"
-    case .openPullRequest:
+    case .openPullRequest, .openRepositoryOnCodeHost:
       base = "Open on Code Host"
     case .markPullRequestReady:
       base = "Mark pull request ready for review"

--- a/supacodeTests/CommandPaletteFeatureTests.swift
+++ b/supacodeTests/CommandPaletteFeatureTests.swift
@@ -188,7 +188,7 @@ struct CommandPaletteFeatureTests {
 
     let items = CommandPaletteFeature.commandPaletteItems(from: state)
     let openItem = items.first {
-      if case .openPullRequest(let worktreeID) = $0.kind {
+      if case .openRepositoryOnCodeHost(let worktreeID) = $0.kind {
         return worktreeID == worktree.id
       }
       return false
@@ -196,6 +196,33 @@ struct CommandPaletteFeatureTests {
 
     #expect(openItem?.title == "Open Repository on Code Host")
     #expect(openItem?.subtitle == repository.name)
+
+    let emptyQueryItems = CommandPaletteFeature.filterItems(items: items, query: "")
+    #expect(emptyQueryItems.contains(where: { $0.id == openItem?.id }) == false)
+
+    let searchedItems = CommandPaletteFeature.filterItems(items: items, query: "code host")
+    #expect(searchedItems.contains(where: { $0.id == openItem?.id }))
+  }
+
+  @Test func emptyQueryHidesChangeFocusedTabIcon() {
+    let rootPath = "/tmp/repo"
+    let worktree = makeWorktree(id: rootPath, name: "repo", repoRoot: rootPath)
+    let repository = makeRepository(rootPath: rootPath, name: "Repo", worktrees: [worktree])
+    var state = RepositoriesFeature.State(repositories: [repository])
+    state.selection = .worktree(worktree.id)
+
+    let items = CommandPaletteFeature.commandPaletteItems(from: state)
+    let changeIconItem = items.first {
+      if case .changeFocusedTabIcon = $0.kind { return true }
+      return false
+    }
+    #expect(changeIconItem != nil)
+
+    let emptyQueryItems = CommandPaletteFeature.filterItems(items: items, query: "")
+    #expect(emptyQueryItems.contains(where: { $0.id == changeIconItem?.id }) == false)
+
+    let searchedItems = CommandPaletteFeature.filterItems(items: items, query: "tab icon")
+    #expect(searchedItems.contains(where: { $0.id == changeIconItem?.id }))
   }
 
   @Test func emptyQueryHidesGhosttyCommands() {


### PR DESCRIPTION
## Summary

- Command palette now hides "Change Tab Icon..." and the non-PR "Open Repository on Code Host" fallback from the empty-query list, aligning them with Ghostty's "Change Tab Title…" and worktree selection rows (search to reveal).
- Introduces a dedicated `openRepositoryOnCodeHost` Kind for the fallback so the PR-open action stays visible when a pull request is active.
- Both affected items remain fully discoverable via fuzzy search and keep the existing `openPullRequest` shortcut binding.

## Test plan
- [x] `make test` — palette tests cover empty-state visibility + search recovery for both items
- [x] Empty palette: no "Change Tab Icon..." or "Open Repository on Code Host" rows
- [x] Search "tab icon" → "Change Tab Icon..." appears and works
- [x] Search "code host" in a non-GitHub repo → "Open Repository on Code Host" appears and opens the repo URL
- [x] GitHub repo with open PR: empty palette still shows PR action family (Merge, Mark Ready, etc.)
- [x] Bound shortcut for `openPullRequest` still triggers fallback "Open on Code Host" in non-GitHub repos

## Follow-up
- Mid-term: MRU + contextual items in empty palette (tracked in a separate issue #219).
