### PR TITLE
Add hover close and expand buttons to canvas cards

### DIFF
--- a/supacode/Features/Canvas/Models/CanvasSelectionState.swift
+++ b/supacode/Features/Canvas/Models/CanvasSelectionState.swift
@@ -90,4 +90,57 @@ struct CanvasSelectionState: Equatable {
       clear()
     }
   }
+
+  /// Prune against `currentOrder` and, if the primary was removed while cards
+  /// remain visible, auto-focus the nearest surviving neighbor in
+  /// `previousOrder` (searching forward first, then backward). This keeps a
+  /// card highlighted after the primary is closed so users never lose the
+  /// selection indicator for the "next" focused card.
+  mutating func pruneAutoAdvancingPrimary(
+    previousOrder: [TerminalTabID],
+    currentOrder: [TerminalTabID]
+  ) {
+    let previousPrimary = primaryTabID
+    let currentSet = Set(currentOrder)
+    prune(to: currentSet)
+
+    guard primaryTabID == nil,
+      let previousPrimary,
+      !currentSet.contains(previousPrimary),
+      !currentOrder.isEmpty
+    else {
+      return
+    }
+
+    let replacement =
+      Self.nearestSurvivor(
+        of: previousPrimary,
+        previousOrder: previousOrder,
+        currentSet: currentSet
+      ) ?? currentOrder[0]
+    focusSingle(replacement)
+  }
+
+  private static func nearestSurvivor(
+    of removedID: TerminalTabID,
+    previousOrder: [TerminalTabID],
+    currentSet: Set<TerminalTabID>
+  ) -> TerminalTabID? {
+    guard let removedIndex = previousOrder.firstIndex(of: removedID) else {
+      return nil
+    }
+    var offset = 1
+    while offset < previousOrder.count {
+      let forward = removedIndex + offset
+      if forward < previousOrder.count, currentSet.contains(previousOrder[forward]) {
+        return previousOrder[forward]
+      }
+      let backward = removedIndex - offset
+      if backward >= 0, currentSet.contains(previousOrder[backward]) {
+        return previousOrder[backward]
+      }
+      offset += 1
+    }
+    return nil
+  }
 }

--- a/supacode/Features/Canvas/Views/CanvasCardView.swift
+++ b/supacode/Features/Canvas/Views/CanvasCardView.swift
@@ -18,6 +18,8 @@ struct CanvasCardView: View {
   let onResizeEnd: () -> Void
   let onSplitOperation: (TerminalSplitTreeView.Operation) -> Void
   let onTitleBarTap: () -> Void
+  let onExpand: () -> Void
+  let onClose: () -> Void
 
   enum CardResizeEdge {
     case leading, trailing, top, bottom
@@ -44,6 +46,7 @@ struct CanvasCardView: View {
 
   // Gesture-driven drag state: does NOT trigger body re-evaluation
   @GestureState private var dragTranslation: CGSize = .zero
+  @State private var isHoveringTitleBar: Bool = false
 
   var body: some View {
     VStack(spacing: 0) {
@@ -114,6 +117,7 @@ struct CanvasCardView: View {
         .foregroundStyle(.secondary)
         .lineLimit(1)
       Spacer()
+      titleBarActions
     }
     .padding(.horizontal, 8)
     .frame(height: titleBarHeight)
@@ -121,6 +125,9 @@ struct CanvasCardView: View {
     .background(titleBarBackground)
     .accessibilityAddTraits(.isButton)
     .onTapGesture { onTitleBarTap() }
+    .onHover { hovering in
+      isHoveringTitleBar = hovering
+    }
     .gesture(
       DragGesture(coordinateSpace: .global)
         .updating($dragTranslation) { value, state, _ in
@@ -134,6 +141,39 @@ struct CanvasCardView: View {
             ))
         }
     )
+  }
+
+  private var titleBarActions: some View {
+    HStack(spacing: 2) {
+      Button {
+        onExpand()
+      } label: {
+        Image(systemName: "arrow.up.left.and.arrow.down.right")
+          .font(.caption2.weight(.semibold))
+          .frame(width: 18, height: 18)
+          .contentShape(.rect)
+      }
+      .buttonStyle(.plain)
+      .foregroundStyle(.secondary)
+      .help("Expand to tab view")
+      .accessibilityLabel("Expand card")
+
+      Button {
+        onClose()
+      } label: {
+        Image(systemName: "xmark")
+          .font(.caption2.weight(.semibold))
+          .frame(width: 18, height: 18)
+          .contentShape(.rect)
+      }
+      .buttonStyle(.plain)
+      .foregroundStyle(.secondary)
+      .help("Close card")
+      .accessibilityLabel("Close card")
+    }
+    .opacity(isHoveringTitleBar ? 1 : 0)
+    .allowsHitTesting(isHoveringTitleBar)
+    .animation(.easeInOut(duration: 0.15), value: isHoveringTitleBar)
   }
 
   @ViewBuilder

--- a/supacode/Features/Canvas/Views/CanvasView.swift
+++ b/supacode/Features/Canvas/Views/CanvasView.swift
@@ -122,6 +122,13 @@ struct CanvasView: View {
                     onExitToTab()
                   }
                   lastTitleBarTapDate = now
+                },
+                onExpand: {
+                  focusSingleCard(tab.id, surfaceState: state, states: activeStates)
+                  onExitToTab()
+                },
+                onClose: {
+                  state.closeTab(tab.id)
                 }
               )
               .scaleEffect(canvasScale, anchor: .center)

--- a/supacode/Features/Canvas/Views/CanvasView.swift
+++ b/supacode/Features/Canvas/Views/CanvasView.swift
@@ -41,7 +41,7 @@ struct CanvasView: View {
         Color.clear
           .onAppear {
             ensureLayouts(for: allCardKeys)
-            pruneSelection(to: Set(allTabIDs), states: activeStates)
+            pruneSelection(previousOrder: [], currentOrder: allTabIDs, states: activeStates)
             syncBroadcastCallbacks(states: activeStates)
           }
           .onChange(of: allCardKeys) { _, newKeys in
@@ -51,8 +51,8 @@ struct CanvasView: View {
             ensureLayouts(for: newKeys)
             syncBroadcastCallbacks(states: activeStates)
           }
-          .onChange(of: allTabIDs) { _, newTabIDs in
-            pruneSelection(to: Set(newTabIDs), states: activeStates)
+          .onChange(of: allTabIDs) { oldTabIDs, newTabIDs in
+            pruneSelection(previousOrder: oldTabIDs, currentOrder: newTabIDs, states: activeStates)
           }
           .contentShape(.rect)
           .accessibilityAddTraits(.isButton)
@@ -556,9 +556,13 @@ struct CanvasView: View {
     }
   }
 
-  private func pruneSelection(to visibleTabIDs: Set<TerminalTabID>, states: [WorktreeTerminalState]) {
+  private func pruneSelection(
+    previousOrder: [TerminalTabID],
+    currentOrder: [TerminalTabID],
+    states: [WorktreeTerminalState]
+  ) {
     let previousPrimaryTabID = selectionState.primaryTabID
-    selectionState.prune(to: visibleTabIDs)
+    selectionState.pruneAutoAdvancingPrimary(previousOrder: previousOrder, currentOrder: currentOrder)
     syncPrimaryFocus(from: previousPrimaryTabID, to: selectionState.primaryTabID, states: states)
     syncBroadcastCallbacks(states: states)
   }

--- a/supacodeTests/CanvasSelectionStateTests.swift
+++ b/supacodeTests/CanvasSelectionStateTests.swift
@@ -127,4 +127,75 @@ struct CanvasSelectionStateTests {
     #expect(state.selectedTabIDs == [tab1, tab2])
     #expect(state.selectionOrder == [tab1, tab2])
   }
+
+  @Test func pruneAutoAdvancingMovesPrimaryToForwardNeighborWhenClosed() {
+    var state = CanvasSelectionState()
+    state.focusSingle(tab2)
+
+    state.pruneAutoAdvancingPrimary(
+      previousOrder: [tab1, tab2, tab3],
+      currentOrder: [tab1, tab3]
+    )
+
+    #expect(state.primaryTabID == tab3)
+    #expect(state.selectedTabIDs == [tab3])
+    #expect(state.mode == .idle)
+  }
+
+  @Test func pruneAutoAdvancingFallsBackToBackwardNeighborWhenLastClosed() {
+    var state = CanvasSelectionState()
+    state.focusSingle(tab3)
+
+    state.pruneAutoAdvancingPrimary(
+      previousOrder: [tab1, tab2, tab3],
+      currentOrder: [tab1, tab2]
+    )
+
+    #expect(state.primaryTabID == tab2)
+    #expect(state.selectedTabIDs == [tab2])
+  }
+
+  @Test func pruneAutoAdvancingClearsWhenAllCardsClosed() {
+    var state = CanvasSelectionState()
+    state.focusSingle(tab1)
+
+    state.pruneAutoAdvancingPrimary(
+      previousOrder: [tab1],
+      currentOrder: []
+    )
+
+    #expect(state.primaryTabID == nil)
+    #expect(state.selectedTabIDs.isEmpty)
+  }
+
+  @Test func pruneAutoAdvancingKeepsPrimaryWhenSurviving() {
+    var state = CanvasSelectionState()
+    state.focusSingle(tab2)
+
+    state.pruneAutoAdvancingPrimary(
+      previousOrder: [tab1, tab2, tab3],
+      currentOrder: [tab2, tab3]
+    )
+
+    #expect(state.primaryTabID == tab2)
+    #expect(state.selectedTabIDs == [tab2])
+  }
+
+  @Test func pruneAutoAdvancingPromotesRemainingBroadcastSelection() {
+    var state = CanvasSelectionState()
+    state.toggleSelection(tab1)
+    state.toggleSelection(tab2)
+    state.toggleSelection(tab3)
+
+    state.pruneAutoAdvancingPrimary(
+      previousOrder: [tab1, tab2, tab3],
+      currentOrder: [tab1, tab2]
+    )
+
+    // Primary (tab3) closed while broadcasting. `prune` should promote the
+    // newest surviving broadcast member instead of auto-advancing to a
+    // non-selected neighbor.
+    #expect(state.primaryTabID == tab2)
+    #expect(state.selectedTabIDs == [tab1, tab2])
+  }
 }


### PR DESCRIPTION
## Summary
- Canvas cards now expose per-card `expand` and `close` buttons in the title bar that fade in on hover, so users can dispatch actions against a specific card without having to focus it first.
- `expand` reuses the existing double-click-to-exit flow (focus the card, then call `onExitToTab`), and `close` invokes `state.closeTab(tab.id)` on the owning worktree state.
- Closing the primary card (via the new button, Cmd+W, or any other mutation) now auto-advances the canvas selection to the nearest surviving neighbor in the pre-close tab order, so highlight stays consistent with the terminal's own focus handoff and only drops when no cards remain.
- Context menu variant is intentionally deferred; this change closes the common path highlighted in #225.

## Test plan
- [x] Hover a canvas card — close (`xmark`) and expand (`arrow.up.left.and.arrow.down.right`) buttons fade in on the right edge of the title bar; leaving the title bar fades them out.
- [x] Click the expand button on a non-focused card — canvas exits to the regular tab view showing that card's worktree/tab.
- [x] Click the close button on a non-focused card — only that card is removed; other cards, selection, and broadcast state remain stable.
- [x] Close the currently highlighted card with the new close button — the next card (forward neighbor, then backward) becomes highlighted with the blue border and receives terminal focus.
- [x] With the same card highlighted, close it via Cmd+W — same handoff; no divergence between the two close paths.
- [x] Close the very last remaining card — no card stays highlighted, `canvasFocusedWorktreeID` resets cleanly.
- [x] Start broadcast across multiple cards, close a non-primary member — broadcast state and primary remain; close the primary member — broadcast continues with another selected card promoted to primary.
- [x] Drag a card by its title bar with the cursor near the action buttons — drag still works; a click on a button does not trigger a drag.

Closes #225
