### PR TITLE
Revert canvas no-scrollback scroll passthrough

### DIFF
--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
@@ -924,15 +924,6 @@ final class GhosttySurfaceView: NSView, Identifiable {
 
   override func scrollWheel(with event: NSEvent) {
     guard let surface else { return }
-
-    // In canvas mode, if the terminal has no scrollback content the scroll
-    // event is useless here. Let it bubble up to the canvas container so
-    // two-finger gestures pan the canvas instead of being swallowed.
-    if scrollWrapper?.hostKind == .canvas, !hasScrollbackContent {
-      scrollWrapper?.forwardScrollToParent(with: event)
-      return
-    }
-
     var scrollX = event.scrollingDeltaX
     var scrollY = event.scrollingDeltaY
     if event.hasPreciseScrollingDeltas {
@@ -940,11 +931,6 @@ final class GhosttySurfaceView: NSView, Identifiable {
       scrollY *= 2
     }
     ghostty_surface_mouse_scroll(surface, scrollX, scrollY, scrollMods(for: event))
-  }
-
-  private var hasScrollbackContent: Bool {
-    guard let lastScrollbar else { return false }
-    return lastScrollbar.total > lastScrollbar.length
   }
 
   override func pressureChange(with event: NSEvent) {
@@ -2594,14 +2580,6 @@ final class GhosttySurfaceScrollView: NSView {
   func updateScrollbar(total: UInt64, offset: UInt64, length: UInt64) {
     scrollbar = ScrollbarState(total: total, offset: offset, length: length)
     synchronizeScrollView()
-  }
-
-  /// Forward a scroll event to the parent responder chain, bypassing the
-  /// internal NSScrollView which would otherwise consume it.  Used in
-  /// canvas mode when the terminal has no scrollback content so the event
-  /// can reach CanvasScrollContainerView for canvas panning.
-  func forwardScrollToParent(with event: NSEvent) {
-    super.scrollWheel(with: event)
   }
 
   func refreshAppearance() {


### PR DESCRIPTION
## Summary

Fixes #228 — TUI programs that handle their own mouse scroll protocol (pagers, editors, etc.) lost the ability to scroll with two-finger gestures inside Prowl's canvas mode. Hovering on the terminal would pan the canvas instead.

The regression came from #204, which added three optimizations:

1. Gesture continuity (local `NSEvent` monitor during a canvas pan).
2. Bounce window (0.3s grace period after a pan ends).
3. **No-scrollback passthrough** — if Ghostty reported no scrollback, the scroll event was forwarded up to `CanvasScrollContainerView` instead of the surface.

The third one is incorrect for TUIs that drive their own mouse scroll: Ghostty's scrollbar is empty but the app still wants the wheel events. This PR reverts only that branch and keeps the gesture-continuity / bounce-window optimizations intact, so rapid multi-finger canvas panning still feels as tight as before.

## Changes

- Drop the `hostKind == .canvas && !hasScrollbackContent` branch in `GhosttySurfaceView.scrollWheel`.
- Remove the now-unused `hasScrollbackContent` computed property.
- Remove `GhosttySurfaceScrollView.forwardScrollToParent` (its only caller is gone).

## Test plan

- [x] `make build-app` ✅ (locally)
- [x] `make lint` ✅ (locally)
- [x] In canvas mode, hover a focused TUI (e.g. `less`, `nvim`, `htop`) and confirm two-finger scroll drives the TUI, not the canvas.
- [x] Confirm two-finger panning still works when the cursor is on a non-scrollable terminal with idle canvas — no regression vs. pre-#204 behavior.
- [x] Quick repeated two-finger flicks on the canvas still chain smoothly (bounce window preserved).
