### PR TITLE
feat(shelf): Shelf — a new stacked-book presentation mode

### DIFF
--- a/doc-onevcat/shelf-view.md
+++ b/doc-onevcat/shelf-view.md
@@ -281,7 +281,7 @@ keybinding system (`scope = configurableAppAction`), exposed in
 | `toggleShelf` | `Cmd+Shift+Enter` | New command. Symmetric with `toggleCanvas` (`Cmd+Option+Enter`). |
 | `selectTerminalTab1…9` | `Cmd+1..9` | **Existing** commands. In Shelf, they switch tabs within the open book. |
 | `selectPreviousTerminalTab` / `selectNextTerminalTab` | `Cmd+Shift+[` / `Cmd+Shift+]` | **Existing** — apply within the open book. |
-| `selectNextWorktree` / `selectPreviousWorktree` | Unchanged: `Cmd+Ctrl+↓` / `Cmd+Ctrl+↑` | Unchanged. See `selectNext/PreviousShelfBook` below for the `Cmd+Ctrl+→` / `Cmd+Ctrl+←` bindings on the Shelf. |
+| `selectNextWorktree` / `selectPreviousWorktree` | `Cmd+Ctrl+↓` / `Cmd+Ctrl+↑` | Mode-aware: outside Shelf, cycles worktrees (unchanged). Inside Shelf, reroutes to tab navigation within the open book — vertical arrows step through tabs on the spine, horizontal arrows step through books, matching the Shelf's two-axis layout. See `selectNext/PreviousShelfBook` below for the `Cmd+Ctrl+→` / `Cmd+Ctrl+←` bindings. |
 | `selectNextShelfBook` / `selectPreviousShelfBook` | `Cmd+Ctrl+→` / `Cmd+Ctrl+←` | **New commands**. Operate on the ordered Shelf-book list (worktrees + plain folders), which can diverge from the worktree list if plain folders are interleaved. See the Implementation Decisions Journal for why we took this over a two-binding alias on the worktree commands. |
 | `selectShelfBook1…9` | `Ctrl+Option+1..9` | **New commands**, deliberately distinct from `selectWorktree1..9` (`Ctrl+1..9`). Books and worktrees are not 1:1 in numbering: "books on the shelf" can diverge from "items in the left navigation" (e.g. presence/absence on the shelf, plain-folder ordering). Shelf-specific. |
 

--- a/doc-onevcat/shelf-view.md
+++ b/doc-onevcat/shelf-view.md
@@ -221,10 +221,15 @@ Mirror Prowl's normal-mode tab close behavior:
 
 ### Closing the Last Tab in a Book
 
-Closing the last tab does **not** remove the book from the shelf. Instead, the
-book remains, its spine stays in place, and the open area shows an **empty
-terminal placeholder UI** (consistent with normal-mode behavior). The user can
-add a tab back via the bottom controls (after opening the book).
+Closing the last tab **retires the book from the Shelf**. Its spine disappears;
+if the closed book was the one currently open, Shelf auto-advances to the next
+remaining book (in Shelf order). The user can bring the book back by clicking
+its worktree in the left navigation, which re-opens it and re-adds its spine
+with the standard spine-flow animation.
+
+(Earlier drafts of this doc proposed keeping the book on the shelf with an
+empty-terminal placeholder. Reversed: a lingering empty book felt unnatural and
+doubled as dead weight. See the Implementation Decisions Journal for the switch.)
 
 ### Removing a Book from the Shelf
 
@@ -403,12 +408,21 @@ Shelf-originated taps additionally pass the same animation to
 `store.send(_, animation:)` so the TCA-side mutation carries the transaction
 along.
 
-### Close-last-tab behavior
+### Close-last-tab behavior (revised)
 
-The empty-book state falls out naturally: `ShelfOpenBookView` already
-renders `EmptyTerminalPaneView(message: "No terminals open")` when
-`selectedTabId == nil`. The spine remains on the shelf, with its bottom
-controls still enabling new tab / split to recover.
+Reversed from the original decision. Closing the last tab now removes the
+book from the Shelf entirely. The implementation:
+
+- `TerminalClient.Event.tabClosed` gained a `remainingTabs: Int` payload so
+  AppFeature can detect the last-tab case. When it sees `remainingTabs == 0`,
+  it dispatches `.repositories(.markWorktreeClosed(id))`.
+- The `markWorktreeClosed` reducer handler removes the ID from
+  `openedWorktreeIDs`, and — only when Shelf is active and the closed
+  worktree was the open book — auto-advances selection to the next
+  remaining book (via `shelfBookSelectionEffect`). In normal view, the
+  selection is left alone so the user's current context isn't disturbed.
+- When the closed book was the last book on the Shelf, selection is kept
+  as-is; `ShelfView` falls through to its "No book selected" empty state.
 
 ### Opened-worktrees set
 

--- a/doc-onevcat/shelf-view.md
+++ b/doc-onevcat/shelf-view.md
@@ -65,6 +65,16 @@ Let `N` be the index of the currently open book among all books `1…last`:
 `WorktreeTerminalManager.selectedWorktreeID`; the open book's active tab is
 that worktree's currently active tab (no separate Shelf-only tab memory).
 
+**Book set = opened worktrees/folders only**: the spines shown on the Shelf
+are *not* the full list of worktrees + plain folders in the sidebar. The
+Shelf only includes books the user has interacted with at least once in
+the current session — i.e., those with an associated terminal state. A
+worktree that appears in the left navigation but has never been clicked (or
+touched by CLI / layout restore) does *not* get a spine. Clicking an
+as-yet-unopened worktree in the left navigation while Shelf is active is
+what makes its spine materialize — the normal spine-flow animation applies
+as the new spine slides into its sidebar-order position.
+
 ---
 
 ## Spine Specification
@@ -399,3 +409,24 @@ The empty-book state falls out naturally: `ShelfOpenBookView` already
 renders `EmptyTerminalPaneView(message: "No terminals open")` when
 `selectedTabId == nil`. The spine remains on the shelf, with its bottom
 controls still enabling new tab / split to recover.
+
+### Opened-worktrees set
+
+`RepositoriesFeature.State.openedWorktreeIDs: Set<Worktree.ID>` tracks
+which worktrees/plain folders are currently part of the Shelf's book list.
+It's updated by the reducer in three places:
+
+- `.selectWorktree(id, _)` handler inserts `id` (covers user click in
+  sidebar, Shelf click, CLI open, layout restore)
+- `.selectRepository(id)` handler inserts `id` when the repository is a
+  plain folder (same semantics for plain folders)
+- `.toggleShelf` entry path inserts the currently selected ID when the
+  selection is already compatible with Shelf (rare path, but guards
+  against state that was set without going through the two actions above)
+
+`orderedShelfBooks()` filters against this set. The set is pure
+additive in this iteration — archived / removed worktrees still drop off
+the Shelf because the book iteration is anchored on the live
+`repositories` array, not on `openedWorktreeIDs`. That leaves a handful
+of stale IDs in the set but no visible spines; pruning can be layered in
+later if the set grows unbounded.

--- a/doc-onevcat/shelf-view.md
+++ b/doc-onevcat/shelf-view.md
@@ -1,0 +1,317 @@
+# Shelf View
+
+Last updated: 2026-04-21
+Status: Design final (alignment complete, ready for implementation)
+
+A new terminal presentation mode that sits alongside Canvas. Where Canvas spreads
+worktrees out as flat cards and weakens the worktree concept, Shelf preserves and
+strengthens it: each worktree (or plain folder) becomes a "book" with a vertical
+spine that doubles as its tab bar. Exactly one book is "open" at any time,
+occupying the space between a left stack of already-passed spines and a right
+stack of upcoming spines.
+
+---
+
+## Mode & Entry Point
+
+- Shelf is a terminal-region presentation mode, **mutually exclusive** with
+  Canvas. The left navigation remains visible in Shelf mode (Shelf only occupies
+  the terminal region to the right of the navigation).
+- The Shelf toggle lives next to the Canvas toggle in the same toolbar `HStack`,
+  placed immediately to the **right of** (i.e. after) the Canvas entry.
+- Toggle hotkey: **`Cmd+Shift+Enter`** — symmetric with `Toggle Canvas`'s
+  `Cmd+Option+Enter`.
+- **Exit Shelf**: only by re-clicking the Shelf toggle (or pressing the toggle
+  hotkey). Clicking a different worktree in the left navigation does **not**
+  exit Shelf — it merely changes which book is open. (This differs from Canvas,
+  where left-nav clicks exit the mode, because Canvas weakens the worktree
+  concept while Shelf treats `book = worktree` 1:1.)
+
+---
+
+## Concept Mapping
+
+| Shelf concept | Prowl model |
+|---|---|
+| Book | A worktree or a plain folder |
+| Spine | The book's vertical tab bar; also carries its identity (worktree/folder name + branch) |
+| Open book body | The terminal surface (with splits) of the book's currently active tab |
+
+**Order of books on the shelf** equals the order of worktrees / plain folders in
+the left navigation. Reordering happens through the left nav, not on the shelf.
+
+---
+
+## Layout Invariant
+
+The terminal region (everything to the right of the left navigation) is split
+into three horizontal segments:
+
+```
+[ left spine stack ] [ open book terminal area ] [ right spine stack ]
+```
+
+Let `N` be the index of the currently open book among all books `1…last`:
+
+- **Left stack** = spines of books `1…N`, in book order. Book `N`'s spine is the
+  rightmost in the left stack and sits flush against the left edge of the
+  terminal area.
+- **Terminal area** = the surface of book `N`'s currently active tab (with the
+  existing split logic).
+- **Right stack** = spines of books `N+1…last`, in book order, flush against
+  the window's right edge.
+
+**Initial state on entering Shelf**: `N` is the worktree currently identified by
+`WorktreeTerminalManager.selectedWorktreeID`; the open book's active tab is
+that worktree's currently active tab (no separate Shelf-only tab memory).
+
+---
+
+## Spine Specification
+
+### Geometry
+
+- **Width**: one line of text (compact, fixed across all spines and across
+  open/closed states).
+- **Identical structure and width whether the book is open or closed**; only
+  the area to the spine's right changes (terminal surface vs. nothing).
+
+### Header (top of spine)
+
+- Worktree name + branch name, rendered **rotated 90°** (vertical reading
+  direction).
+- For **plain folders** (no branch): only the folder name is shown, with the
+  branch line entirely omitted (consistent with how plain folders are presented
+  in the left navigation today).
+- The header is **not** part of the scrollable area (see Tab List Overflow).
+
+### Tab List (below header)
+
+- Each tab is rendered as **its icon only** (Prowl already supports per-tab
+  custom icons). No label text in the slot.
+- Each slot is a uniform-sized clickable target.
+- **Hotkey overlay**: when the user holds **⌘ (Command)**, the icon in each
+  slot is **replaced** by the tab's `Cmd+N` digit (1–9). Slot size and position
+  do not change — there is zero layout shift. This matches Prowl's existing
+  "hold ⌘ to reveal hotkeys" behavior.
+- For tabs at index ≥ 10 (no `Cmd+N` hotkey): when ⌘ is held, the slot continues
+  to show the icon (optionally slightly dimmed to hint "no hotkey"); details left
+  to implementation.
+
+### Tab List Overflow
+
+- When the tab list does not fit the available spine height, the **tab list
+  area scrolls vertically**.
+- The header (worktree/branch) stays **pinned** and does not scroll.
+- The bottom controls (see below) also stay pinned and do not scroll.
+
+### Bottom Controls
+
+- A row of three buttons at the spine's bottom: **`+` / vertical split /
+  horizontal split**, mirroring Prowl's standard tab bar.
+- These controls are **only shown on the spine of the currently open book**.
+  Closed-book spines do not show them (acting on a non-open book first requires
+  opening it).
+
+### Per-Tab Visual States (must all be respected, simultaneously when applicable)
+
+- **Active tab highlight** — the book's currently selected tab.
+- **Notification highlight** — drives off the existing
+  `WorktreeTerminalState.hasUnseenNotification(for:)`. Visual: **slot
+  background tint**, using the same color/style as Canvas title-bar
+  notification highlights (reuse the existing token / style for consistency).
+
+### Book-Level Aggregated Notification
+
+- When **any** tab in a book has an unread notification, a **small dot badge**
+  is shown on the spine **header** (next to the worktree/branch text).
+- Purpose: when a notifying tab is scrolled out of view in the spine's tab
+  list, the user can still see at a glance "this book has activity".
+- No directional arrow / no "scroll up to see" hint — keep it minimal.
+
+---
+
+## Open Book Visual Distinction
+
+The open book's spine is visually distinguished from other spines through a
+**combination** of:
+
+- An **accent color / contrasting background tint** on the open book's spine,
+  and
+- **Visual continuity** with the terminal area: the spine and terminal area
+  share background color and/or border treatment so the spine reads as "the
+  left edge of the open page" — reinforcing the book metaphor.
+
+(Active-tab highlight on the spine's currently-active tab slot is a separate,
+**tab-level** signal, independent of the **book-level** open-book signal.
+Both can be visible at once.)
+
+---
+
+## Interaction
+
+### Book ↔ Left Navigation Sync (bidirectional)
+
+- **Shelf → Left nav**: clicking a different spine in Shelf updates
+  `selectedWorktreeID` (and therefore the left-nav selection).
+- **Left nav → Shelf**: while in Shelf mode, clicking a worktree in the left
+  navigation triggers the same spine-flow animation as clicking that book's
+  spine directly. The Shelf does not exit.
+
+The single source of truth for "which book is open" is `selectedWorktreeID`.
+
+### Switching Books (clicking a non-open book's spine)
+
+Clicking spine `M` (where `M ≠ N`):
+
+- If the click lands on a specific tab slot `T` on spine `M`: animate the
+  spine flow (rules below), open book `M`, and set `M`'s active tab to `T`.
+- If the click lands on the spine **header** only: animate the spine flow,
+  open book `M`, keep `M`'s previously active tab.
+
+**Spine flow rules:**
+
+- **`M > N` (forward)**: spines `N+1…M` slide from the right stack into the
+  tail of the left stack. Spines `M+1…last` do not move.
+- **`M < N` (backward)**: spines `M+1…N` slide from the left stack back to the
+  head of the right stack. Spines `1…M-1` do not move.
+
+In both cases the previously open book's spine ends up wherever the flow
+places it (no special case).
+
+### Switching Tabs Within the Open Book
+
+Clicking a tab slot on the **currently open** book's own spine:
+
+- **No spine animation, no page-turn transition.** The spine layout is
+  unchanged.
+- The terminal area is replaced with the newly selected tab's surface.
+
+### Unified Click Rule
+
+Every tab slot on every spine is a click target meaning "switch to this book
+and this tab". Whether the click triggers spine-flow animation depends solely
+on whether the targeted book is already the open book.
+
+### Creating Tabs / Splits
+
+- Use the **bottom controls** (`+` / vsplit / hsplit) on the **open book's**
+  spine, or the existing keyboard shortcuts.
+- To add a tab to a non-open book: open it first by clicking its spine, then
+  use the bottom controls.
+
+### Closing Tabs
+
+Mirror Prowl's normal-mode tab close behavior:
+
+- **Hover X**: hovering a tab slot reveals a small X button to close it.
+- **Right-click menu**: right-clicking a tab slot opens a tab-level context
+  menu containing Close (and any other existing tab actions).
+- **`Cmd+W`** keyboard shortcut continues to close the active tab.
+
+### Closing the Last Tab in a Book
+
+Closing the last tab does **not** remove the book from the shelf. Instead, the
+book remains, its spine stays in place, and the open area shows an **empty
+terminal placeholder UI** (consistent with normal-mode behavior). The user can
+add a tab back via the bottom controls (after opening the book).
+
+### Removing a Book from the Shelf
+
+A book is removed from the shelf only by:
+
+1. **Closing/removing the worktree** through the left navigation (existing
+   pathway), or
+2. **Right-clicking the spine header** → context menu → **"Remove book"**.
+
+Right-click scoping:
+
+- Right-click on a **tab slot** → tab-level context menu (Close, etc.).
+- Right-click on the **spine header or its empty body area** → book-level
+  context menu (Remove book, etc.).
+
+---
+
+## Animation Specification
+
+### Axis 1 — Spine flow character
+
+- **Snappy**: ~200ms, ease-in-out. Crisp, minimal hang time.
+
+### Axis 2 — Terminal area swap
+
+- Use SwiftUI **`matchedGeometryEffect`** (or the closest equivalent): the
+  terminal area is treated as a piece of "openable book content" that
+  geometrically transforms together with its spine.
+- During transitions, **two terminals may coexist briefly** in the terminal
+  region:
+  - **Forward (`M > N`, "pulling in")**: book `M`'s terminal slides in from
+    the right alongside `M`'s spine. The previously open book `N`'s terminal
+    stays in place and **fades out** as `M`'s terminal arrives, so the user
+    never sees a half-clipped or partially-replaced surface.
+  - **Backward (`M < N`, "pushing out")**: book `N`'s terminal slides out to
+    the right alongside `N`'s spine and **fades out** during the slide. Book
+    `M`'s terminal materializes at its destination (slide-in or fade-in, as
+    looks best in implementation).
+- **Unified rule**: the "about to be invisible" terminal handles the fade; the
+  "about to be visible" terminal stays opaque (slide-in) or fades in. This
+  prevents surface views from popping in / out abruptly and avoids visual
+  tears against the moving spines.
+
+---
+
+## Keyboard Shortcuts
+
+All Shelf-related shortcuts are **configurable** through Prowl's existing
+keybinding system (`scope = configurableAppAction`), exposed in
+`Settings → Shortcuts`.
+
+| Command | Default binding | Notes |
+|---|---|---|
+| `toggleShelf` | `Cmd+Shift+Enter` | New command. Symmetric with `toggleCanvas` (`Cmd+Option+Enter`). |
+| `selectTerminalTab1…9` | `Cmd+1..9` | **Existing** commands. In Shelf, they switch tabs within the open book. |
+| `selectPreviousTerminalTab` / `selectNextTerminalTab` | `Cmd+Shift+[` / `Cmd+Shift+]` | **Existing** — apply within the open book. |
+| `selectNextWorktree` / `selectPreviousWorktree` | **Existing** `Cmd+Ctrl+↓` / `Cmd+Ctrl+↑` **plus** new alias `Cmd+Ctrl+→` / `Cmd+Ctrl+←` | Same command, **two equivalent bindings**. The `←/→` aliases match Shelf's horizontal book layout intuition. Requires extending the keybinding schema to support multiple bindings per command. |
+| `selectShelfBook1…9` | `Ctrl+Option+1..9` | **New commands**, deliberately distinct from `selectWorktree1..9` (`Ctrl+1..9`). Books and worktrees are not 1:1 in numbering: "books on the shelf" can diverge from "items in the left navigation" (e.g. presence/absence on the shelf, plain-folder ordering). Shelf-specific. |
+
+### Implementation note on multi-binding
+
+The current `KeybindingSchema` / `AppShortcut` / `Binding` model holds a single
+`shortcut` per command. The `Cmd+Ctrl+←/→` alias for
+`selectNext/PreviousWorktree` requires a non-trivial extension to support a
+collection of bindings per command (and to surface that in the settings UI).
+If this cost proves prohibitive, the fallback is to introduce wrapper commands
+(e.g. `selectNextBookAlias`) that invoke the same underlying action, at the
+cost of duplicating rows in the shortcuts settings list.
+
+---
+
+## Mapping to Existing Models
+
+- The ordered list of spines mirrors the ordered list of worktrees + plain
+  folders tracked by `WorktreeTerminalManager`.
+- Each spine's tab list mirrors that worktree's `TerminalTabManager` tabs.
+- The terminal area renders the active tab's `GhosttySurfaceState` (and any
+  splits) using the existing surface-rendering path.
+- `WorktreeTerminalManager.selectedWorktreeID` ↔ "the open book", driven by
+  spine clicks and left-nav clicks alike (single source of truth).
+- Per-spine tab-slot notification highlights consume
+  `WorktreeTerminalState.hasUnseenNotification(for:)`.
+- Per-book aggregated header dot consumes
+  `WorktreeTerminalState.hasUnseenNotification` (book-wide).
+
+---
+
+## Open Implementation Questions (non-blocking)
+
+- Spine height budget per slot, and the exact dimming treatment for tabs ≥ 10
+  when ⌘ is held.
+- Exact accent color / continuity treatment for the open book's spine + terminal
+  area (decide during visual implementation; iterate if it looks off).
+- Whether the spine should auto-scroll to reveal a newly-arriving notification
+  (vs. relying solely on the aggregated header dot).
+- Multi-binding architectural change (see Keyboard Shortcuts → Implementation
+  note) — design before implementation.
+- Empty-state visuals for an empty Shelf (no books at all).
+- Animation behavior under user interruption (e.g. clicking a third spine while
+  a transition is mid-flight).

--- a/doc-onevcat/shelf-view.md
+++ b/doc-onevcat/shelf-view.md
@@ -414,15 +414,26 @@ controls still enabling new tab / split to recover.
 
 `RepositoriesFeature.State.openedWorktreeIDs: Set<Worktree.ID>` tracks
 which worktrees/plain folders are currently part of the Shelf's book list.
-It's updated by the reducer in three places:
+It's updated by the reducer in four places:
 
-- `.selectWorktree(id, _)` handler inserts `id` (covers user click in
-  sidebar, Shelf click, CLI open, layout restore)
+- `.selectWorktree(id, _)` handler inserts `id` (covers sidebar click,
+  Shelf click, most CLI opens, layout restore of the *active* worktree)
 - `.selectRepository(id)` handler inserts `id` when the repository is a
-  plain folder (same semantics for plain folders)
+  plain folder
 - `.toggleShelf` entry path inserts the currently selected ID when the
   selection is already compatible with Shelf (rare path, but guards
-  against state that was set without going through the two actions above)
+  against state set without going through the two actions above)
+- `.markWorktreeOpened(id)` — a dedicated action that AppFeature
+  dispatches in response to `.terminalEvent(.tabCreated(worktreeID:))`.
+  This is the *critical* catch-all for every path that sets
+  `state.selection` directly without going through `.selectWorktree` —
+  in particular, the cold-launch auto-selection that restores the last
+  focused worktree (`state.selection = state.lastFocusedWorktreeID…` in
+  `applyRepositories`) and the "first available after reload" fallback.
+  Layout restore is a third such path. The common downstream signal in
+  all of them is that the newly-focused worktree ends up materializing
+  its first tab, emitting `.tabCreated`, which this forwarder converts
+  into an `openedWorktreeIDs` insertion.
 
 `orderedShelfBooks()` filters against this set. The set is pure
 additive in this iteration — archived / removed worktrees still drop off

--- a/doc-onevcat/shelf-view.md
+++ b/doc-onevcat/shelf-view.md
@@ -1,7 +1,7 @@
 # Shelf View
 
 Last updated: 2026-04-21
-Status: Design final (alignment complete, ready for implementation)
+Status: Implemented (see **Implementation Decisions Journal** at the bottom for deviations taken during implementation)
 
 A new terminal presentation mode that sits alongside Canvas. Where Canvas spreads
 worktrees out as flat cards and weakens the worktree concept, Shelf preserves and
@@ -271,7 +271,8 @@ keybinding system (`scope = configurableAppAction`), exposed in
 | `toggleShelf` | `Cmd+Shift+Enter` | New command. Symmetric with `toggleCanvas` (`Cmd+Option+Enter`). |
 | `selectTerminalTab1…9` | `Cmd+1..9` | **Existing** commands. In Shelf, they switch tabs within the open book. |
 | `selectPreviousTerminalTab` / `selectNextTerminalTab` | `Cmd+Shift+[` / `Cmd+Shift+]` | **Existing** — apply within the open book. |
-| `selectNextWorktree` / `selectPreviousWorktree` | **Existing** `Cmd+Ctrl+↓` / `Cmd+Ctrl+↑` **plus** new alias `Cmd+Ctrl+→` / `Cmd+Ctrl+←` | Same command, **two equivalent bindings**. The `←/→` aliases match Shelf's horizontal book layout intuition. Requires extending the keybinding schema to support multiple bindings per command. |
+| `selectNextWorktree` / `selectPreviousWorktree` | Unchanged: `Cmd+Ctrl+↓` / `Cmd+Ctrl+↑` | Unchanged. See `selectNext/PreviousShelfBook` below for the `Cmd+Ctrl+→` / `Cmd+Ctrl+←` bindings on the Shelf. |
+| `selectNextShelfBook` / `selectPreviousShelfBook` | `Cmd+Ctrl+→` / `Cmd+Ctrl+←` | **New commands**. Operate on the ordered Shelf-book list (worktrees + plain folders), which can diverge from the worktree list if plain folders are interleaved. See the Implementation Decisions Journal for why we took this over a two-binding alias on the worktree commands. |
 | `selectShelfBook1…9` | `Ctrl+Option+1..9` | **New commands**, deliberately distinct from `selectWorktree1..9` (`Ctrl+1..9`). Books and worktrees are not 1:1 in numbering: "books on the shelf" can diverge from "items in the left navigation" (e.g. presence/absence on the shelf, plain-folder ordering). Shelf-specific. |
 
 ### Implementation note on multi-binding
@@ -315,3 +316,86 @@ cost of duplicating rows in the shortcuts settings list.
 - Empty-state visuals for an empty Shelf (no books at all).
 - Animation behavior under user interruption (e.g. clicking a third spine while
   a transition is mid-flight).
+
+---
+
+## Implementation Decisions Journal
+
+Decisions made during implementation that deviate from — or add nuance to —
+the earlier design, recorded for review.
+
+### Keyboard Shortcuts: wrapper commands over multi-binding
+
+**Design spec** had `Cmd+Ctrl+→` / `Cmd+Ctrl+←` as a second alias on the
+existing `selectNext/PreviousWorktree` commands, with a note that this
+requires a non-trivial extension to the keybinding schema (singular
+`shortcut` → collection).
+
+**Implemented** as distinct `selectNextShelfBook` / `selectPreviousShelfBook`
+commands. Reasons:
+
+- The Shelf-book ordering includes plain folders (interleaved per
+  `orderedShelfBooks()`), so "next book on the Shelf" is not semantically
+  equal to "next worktree" when plain folders exist. Aliasing would have
+  skipped plain folders when a user pressed the arrow alias.
+- The wrapper-command approach keeps `AppShortcut.Binding.shortcut` singular,
+  avoiding the schema change.
+- Both commands still live in `Settings → Shortcuts` so users can remap
+  either set independently.
+
+### Commands plumbing: merged into `SidebarCommands`
+
+Originally planned as a separate `ShelfCommands: Commands` struct. Moved into
+`SidebarCommands` because SwiftUI's `@CommandsBuilder` caps the number of
+direct children in a `.commands { }` block; adding a new top-level Commands
+struct pushed the builder past the cap and triggered a compile error on
+unrelated `CommandGroup`s. Merging keeps the external menu footprint the
+same (two visible toggles + one Worktrees menu).
+
+### `isShelfActive` as a separate flag
+
+`RepositoriesFeature.State` gained a new `isShelfActive: Bool` flag instead
+of adding a `.shelf` case to `SidebarSelection`. Reason: Shelf is a
+presentation mode that still needs `selection` to track a worktree or plain
+folder (the open book). Using a dedicated flag decouples "is Shelf active"
+from "which book is open", which lets the bidirectional sync with the left
+navigation fall out for free.
+
+### Auto-exit rules
+
+Entering Canvas or Archived Worktrees from any entry point clears
+`isShelfActive` — those two presentation modes are mutually exclusive with
+Shelf by design. Entering Shelf from Canvas / archived redirects selection
+to a compatible worktree / plain-folder before flipping the flag.
+
+### Terminal rendering in the open area
+
+Rather than reusing `WorktreeTerminalTabsView` (which includes the horizontal
+tab bar), we introduced `ShelfOpenBookView` — a leaner view that renders only
+the terminal content stack + icon picker sheet + window focus observer. In
+Shelf, the tab bar lives on the spine, so duplicating it would violate the
+design.
+
+### Plain folder spines
+
+`ShelfBook` uses `Worktree.ID` as its identity. For plain folders this is
+the repository ID, matching the synthetic worktree emitted by
+`RepositoriesFeature.State.selectedTerminalWorktree`. That way
+`openShelfBookID == selectedTerminalWorktree?.id` for both kinds without
+special-casing.
+
+### Animation: `.animation(value:)` for both entry points
+
+To make left-nav-originated book switches animate identically to
+Shelf-originated taps, the root `HStack` carries an explicit
+`.animation(.easeInOut(duration: 0.2), value: openBookID)` modifier.
+Shelf-originated taps additionally pass the same animation to
+`store.send(_, animation:)` so the TCA-side mutation carries the transaction
+along.
+
+### Close-last-tab behavior
+
+The empty-book state falls out naturally: `ShelfOpenBookView` already
+renders `EmptyTerminalPaneView(message: "No terminals open")` when
+`selectedTabId == nil`. The spine remains on the shelf, with its bottom
+controls still enabling new tab / split to recover.

--- a/supacode/App/AppShortcuts.swift
+++ b/supacode/App/AppShortcuts.swift
@@ -99,6 +99,7 @@ enum AppShortcuts {
     static let checkForUpdates = "check_for_updates"
     static let showDiff = "show_diff"
     static let toggleCanvas = "toggle_canvas"
+    static let toggleShelf = "toggle_shelf"
     static let revealInSidebar = "reveal_in_sidebar"
     static let archivedWorktrees = "archived_worktrees"
     static let selectNextWorktree = "select_next_worktree"
@@ -174,6 +175,9 @@ enum AppShortcuts {
   static let showDiff = AppShortcut(key: "y", modifiers: [.command, .shift])
   static let toggleCanvas = AppShortcut(
     keyEquivalent: .return, ghosttyKeyName: "return", modifiers: [.command, .option]
+  )
+  static let toggleShelf = AppShortcut(
+    keyEquivalent: .return, ghosttyKeyName: "return", modifiers: [.command, .shift]
   )
   static let revealInSidebar = AppShortcut(key: "l", modifiers: [.command, .shift])
   static let archivedWorktrees = AppShortcut(key: "a", modifiers: [.command, .control])
@@ -373,6 +377,12 @@ enum AppShortcuts {
       title: "Toggle Canvas",
       scope: .configurableAppAction,
       shortcut: toggleCanvas
+    ),
+    .init(
+      id: CommandID.toggleShelf,
+      title: "Toggle Shelf",
+      scope: .configurableAppAction,
+      shortcut: toggleShelf
     ),
     .init(
       id: CommandID.revealInSidebar,
@@ -720,6 +730,7 @@ enum AppShortcuts {
     checkForUpdates,
     showDiff,
     toggleCanvas,
+    toggleShelf,
     archivedWorktrees,
     selectNextWorktree,
     selectPreviousWorktree,

--- a/supacode/App/AppShortcuts.swift
+++ b/supacode/App/AppShortcuts.swift
@@ -100,6 +100,17 @@ enum AppShortcuts {
     static let showDiff = "show_diff"
     static let toggleCanvas = "toggle_canvas"
     static let toggleShelf = "toggle_shelf"
+    static let selectNextShelfBook = "select_next_shelf_book"
+    static let selectPreviousShelfBook = "select_previous_shelf_book"
+    static let selectShelfBook1 = "select_shelf_book_1"
+    static let selectShelfBook2 = "select_shelf_book_2"
+    static let selectShelfBook3 = "select_shelf_book_3"
+    static let selectShelfBook4 = "select_shelf_book_4"
+    static let selectShelfBook5 = "select_shelf_book_5"
+    static let selectShelfBook6 = "select_shelf_book_6"
+    static let selectShelfBook7 = "select_shelf_book_7"
+    static let selectShelfBook8 = "select_shelf_book_8"
+    static let selectShelfBook9 = "select_shelf_book_9"
     static let revealInSidebar = "reveal_in_sidebar"
     static let archivedWorktrees = "archived_worktrees"
     static let selectNextWorktree = "select_next_worktree"
@@ -179,6 +190,44 @@ enum AppShortcuts {
   static let toggleShelf = AppShortcut(
     keyEquivalent: .return, ghosttyKeyName: "return", modifiers: [.command, .shift]
   )
+  static let selectNextShelfBook = AppShortcut(
+    keyEquivalent: .rightArrow, ghosttyKeyName: "arrow_right", modifiers: [.command, .control]
+  )
+  static let selectPreviousShelfBook = AppShortcut(
+    keyEquivalent: .leftArrow, ghosttyKeyName: "arrow_left", modifiers: [.command, .control]
+  )
+  static let selectShelfBook1 = AppShortcut(key: "1", modifiers: [.control, .option])
+  static let selectShelfBook2 = AppShortcut(key: "2", modifiers: [.control, .option])
+  static let selectShelfBook3 = AppShortcut(key: "3", modifiers: [.control, .option])
+  static let selectShelfBook4 = AppShortcut(key: "4", modifiers: [.control, .option])
+  static let selectShelfBook5 = AppShortcut(key: "5", modifiers: [.control, .option])
+  static let selectShelfBook6 = AppShortcut(key: "6", modifiers: [.control, .option])
+  static let selectShelfBook7 = AppShortcut(key: "7", modifiers: [.control, .option])
+  static let selectShelfBook8 = AppShortcut(key: "8", modifiers: [.control, .option])
+  static let selectShelfBook9 = AppShortcut(key: "9", modifiers: [.control, .option])
+  static let shelfBookSelection: [AppShortcut] = [
+    selectShelfBook1,
+    selectShelfBook2,
+    selectShelfBook3,
+    selectShelfBook4,
+    selectShelfBook5,
+    selectShelfBook6,
+    selectShelfBook7,
+    selectShelfBook8,
+    selectShelfBook9,
+  ]
+
+  static let shelfBookSelectionCommandIDs: [String] = [
+    CommandID.selectShelfBook1,
+    CommandID.selectShelfBook2,
+    CommandID.selectShelfBook3,
+    CommandID.selectShelfBook4,
+    CommandID.selectShelfBook5,
+    CommandID.selectShelfBook6,
+    CommandID.selectShelfBook7,
+    CommandID.selectShelfBook8,
+    CommandID.selectShelfBook9,
+  ]
   static let revealInSidebar = AppShortcut(key: "l", modifiers: [.command, .shift])
   static let archivedWorktrees = AppShortcut(key: "a", modifiers: [.command, .control])
   static let selectNextWorktree = AppShortcut(
@@ -383,6 +432,72 @@ enum AppShortcuts {
       title: "Toggle Shelf",
       scope: .configurableAppAction,
       shortcut: toggleShelf
+    ),
+    .init(
+      id: CommandID.selectNextShelfBook,
+      title: "Select Next Book",
+      scope: .configurableAppAction,
+      shortcut: selectNextShelfBook
+    ),
+    .init(
+      id: CommandID.selectPreviousShelfBook,
+      title: "Select Previous Book",
+      scope: .configurableAppAction,
+      shortcut: selectPreviousShelfBook
+    ),
+    .init(
+      id: CommandID.selectShelfBook1,
+      title: "Select Book 1",
+      scope: .configurableAppAction,
+      shortcut: selectShelfBook1
+    ),
+    .init(
+      id: CommandID.selectShelfBook2,
+      title: "Select Book 2",
+      scope: .configurableAppAction,
+      shortcut: selectShelfBook2
+    ),
+    .init(
+      id: CommandID.selectShelfBook3,
+      title: "Select Book 3",
+      scope: .configurableAppAction,
+      shortcut: selectShelfBook3
+    ),
+    .init(
+      id: CommandID.selectShelfBook4,
+      title: "Select Book 4",
+      scope: .configurableAppAction,
+      shortcut: selectShelfBook4
+    ),
+    .init(
+      id: CommandID.selectShelfBook5,
+      title: "Select Book 5",
+      scope: .configurableAppAction,
+      shortcut: selectShelfBook5
+    ),
+    .init(
+      id: CommandID.selectShelfBook6,
+      title: "Select Book 6",
+      scope: .configurableAppAction,
+      shortcut: selectShelfBook6
+    ),
+    .init(
+      id: CommandID.selectShelfBook7,
+      title: "Select Book 7",
+      scope: .configurableAppAction,
+      shortcut: selectShelfBook7
+    ),
+    .init(
+      id: CommandID.selectShelfBook8,
+      title: "Select Book 8",
+      scope: .configurableAppAction,
+      shortcut: selectShelfBook8
+    ),
+    .init(
+      id: CommandID.selectShelfBook9,
+      title: "Select Book 9",
+      scope: .configurableAppAction,
+      shortcut: selectShelfBook9
     ),
     .init(
       id: CommandID.revealInSidebar,
@@ -731,6 +846,17 @@ enum AppShortcuts {
     showDiff,
     toggleCanvas,
     toggleShelf,
+    selectNextShelfBook,
+    selectPreviousShelfBook,
+    selectShelfBook1,
+    selectShelfBook2,
+    selectShelfBook3,
+    selectShelfBook4,
+    selectShelfBook5,
+    selectShelfBook6,
+    selectShelfBook7,
+    selectShelfBook8,
+    selectShelfBook9,
     archivedWorktrees,
     selectNextWorktree,
     selectPreviousWorktree,

--- a/supacode/App/AppShortcuts.swift
+++ b/supacode/App/AppShortcuts.swift
@@ -513,13 +513,13 @@ enum AppShortcuts {
     ),
     .init(
       id: CommandID.selectNextWorktree,
-      title: "Select Next Worktree",
+      title: "Select Next Worktree (Tab in Shelf View)",
       scope: .configurableAppAction,
       shortcut: selectNextWorktree
     ),
     .init(
       id: CommandID.selectPreviousWorktree,
-      title: "Select Previous Worktree",
+      title: "Select Previous Worktree (Tab in Shelf View)",
       scope: .configurableAppAction,
       shortcut: selectPreviousWorktree
     ),

--- a/supacode/Clients/Terminal/TerminalClient.swift
+++ b/supacode/Clients/Terminal/TerminalClient.swift
@@ -50,7 +50,7 @@ struct TerminalClient {
     case notificationReceived(worktreeID: Worktree.ID, title: String, body: String)
     case notificationIndicatorChanged(count: Int)
     case tabCreated(worktreeID: Worktree.ID)
-    case tabClosed(worktreeID: Worktree.ID)
+    case tabClosed(worktreeID: Worktree.ID, remainingTabs: Int)
     case focusChanged(worktreeID: Worktree.ID, surfaceID: UUID)
     case taskStatusChanged(worktreeID: Worktree.ID, status: WorktreeTaskStatus)
     case runScriptStatusChanged(worktreeID: Worktree.ID, isRunning: Bool)

--- a/supacode/Commands/SidebarCommands.swift
+++ b/supacode/Commands/SidebarCommands.swift
@@ -26,6 +26,11 @@ struct SidebarCommands: Commands {
       }
       .modifier(KeyboardShortcutModifier(shortcut: keyboardShortcut(for: AppShortcuts.CommandID.toggleCanvas)))
       .help(helpText(title: "Canvas", commandID: AppShortcuts.CommandID.toggleCanvas))
+      Button("Shelf") {
+        store.send(.repositories(.toggleShelf))
+      }
+      .modifier(KeyboardShortcutModifier(shortcut: keyboardShortcut(for: AppShortcuts.CommandID.toggleShelf)))
+      .help(helpText(title: "Shelf", commandID: AppShortcuts.CommandID.toggleShelf))
       Button("Show Diff") {
         let repos = store.repositories
         guard let worktreeID = repos.selectedWorktreeID,

--- a/supacode/Commands/SidebarCommands.swift
+++ b/supacode/Commands/SidebarCommands.swift
@@ -31,6 +31,23 @@ struct SidebarCommands: Commands {
       }
       .modifier(KeyboardShortcutModifier(shortcut: keyboardShortcut(for: AppShortcuts.CommandID.toggleShelf)))
       .help(helpText(title: "Shelf", commandID: AppShortcuts.CommandID.toggleShelf))
+      Button("Select Next Book") {
+        store.send(.repositories(.selectNextShelfBook))
+      }
+      .modifier(
+        KeyboardShortcutModifier(shortcut: keyboardShortcut(for: AppShortcuts.CommandID.selectNextShelfBook))
+      )
+      .help(helpText(title: "Select Next Book", commandID: AppShortcuts.CommandID.selectNextShelfBook))
+      Button("Select Previous Book") {
+        store.send(.repositories(.selectPreviousShelfBook))
+      }
+      .modifier(
+        KeyboardShortcutModifier(
+          shortcut: keyboardShortcut(for: AppShortcuts.CommandID.selectPreviousShelfBook)
+        )
+      )
+      .help(helpText(title: "Select Previous Book", commandID: AppShortcuts.CommandID.selectPreviousShelfBook))
+      shelfBookMenuButtons
       Button("Show Diff") {
         let repos = store.repositories
         guard let worktreeID = repos.selectedWorktreeID,
@@ -45,6 +62,18 @@ struct SidebarCommands: Commands {
       .modifier(KeyboardShortcutModifier(shortcut: keyboardShortcut(for: AppShortcuts.CommandID.showDiff)))
       .help(helpText(title: "Show Diff", commandID: AppShortcuts.CommandID.showDiff))
       .disabled(store.repositories.selectedWorktreeID == nil)
+    }
+  }
+
+  @ViewBuilder
+  private var shelfBookMenuButtons: some View {
+    ForEach(Array(AppShortcuts.shelfBookSelectionCommandIDs.enumerated()), id: \.element) { index, commandID in
+      let title = "Select Book \(index + 1)"
+      Button(title) {
+        store.send(.repositories(.selectShelfBook(index + 1)))
+      }
+      .modifier(KeyboardShortcutModifier(shortcut: keyboardShortcut(for: commandID)))
+      .help(helpText(title: title, commandID: commandID))
     }
   }
 

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -1031,6 +1031,12 @@ struct AppFeature {
         // worktree; other restored worktrees only surface here.
         return .send(.repositories(.markWorktreeOpened(worktreeID)))
 
+      case .terminalEvent(.tabClosed(let worktreeID, let remainingTabs)):
+        // Closing the last tab retires the book from the Shelf. Other
+        // closes are routine and need no Reducer-side bookkeeping.
+        guard remainingTabs == 0 else { return .none }
+        return .send(.repositories(.markWorktreeClosed(worktreeID)))
+
       case .terminalEvent:
         return .none
       }

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -1009,16 +1009,31 @@ struct AppFeature {
 
       case .terminalEvent(.layoutRestored(let selectedWorktreeID)):
         appLogger.info("[LayoutRestore] layoutRestored: selectedWorktreeID=\(selectedWorktreeID ?? "nil")")
+        // Once layout is restored the saved tabs have all been re-created
+        // (each emits `tabCreated` → `markWorktreeOpened`) and a valid
+        // active worktree is in hand — the right moment to honor the
+        // "Default View = Shelf" preference for Layout-Restore launches,
+        // which the `repositorySnapshotLoaded` hook intentionally
+        // deferred to avoid a selection flash.
+        @Shared(.settingsFile) var settingsFile
+        let shouldEnterShelf =
+          settingsFile.global.defaultViewMode == .shelf
+          && !state.repositories.isShelfActive
+        var effects: [Effect<Action>] = []
         if let selectedWorktreeID {
           // Plain folders use .repository selection, not .worktree
           if let repo = state.repositories.repositories[id: selectedWorktreeID],
             repo.kind == .plain
           {
-            return .send(.repositories(.selectRepository(selectedWorktreeID)))
+            effects.append(.send(.repositories(.selectRepository(selectedWorktreeID))))
+          } else {
+            effects.append(.send(.repositories(.selectWorktree(selectedWorktreeID))))
           }
-          return .send(.repositories(.selectWorktree(selectedWorktreeID)))
         }
-        return .none
+        if shouldEnterShelf {
+          effects.append(.send(.repositories(.toggleShelf)))
+        }
+        return effects.isEmpty ? .none : .merge(effects)
 
       case .terminalEvent(.layoutRestoreFailed(let message)):
         appLogger.warning("[LayoutRestore] layoutRestoreFailed: \(message)")

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -1024,6 +1024,13 @@ struct AppFeature {
         appLogger.warning("[LayoutRestore] layoutRestoreFailed: \(message)")
         return .send(.repositories(.showToast(.warning(message))))
 
+      case .terminalEvent(.tabCreated(let worktreeID)):
+        // Every tab creation (user +, CLI open, layout restore, …)
+        // marks its worktree as Shelf-visible. Layout restore in
+        // particular only calls `selectWorktree` for the one active
+        // worktree; other restored worktrees only surface here.
+        return .send(.repositories(.markWorktreeOpened(worktreeID)))
+
       case .terminalEvent:
         return .none
       }

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -769,10 +769,23 @@ struct RepositoriesFeature {
           return .send(.delegate(.selectedWorktreeChanged(selectedWorktree)))
 
         case .selectNextWorktree:
+          // In Shelf, the vertical arrow pair maps to tab navigation
+          // within the open book — horizontal (← / →) is already book
+          // navigation, so the two axes match the Shelf layout.
+          if state.isShelfActive, let worktree = state.selectedTerminalWorktree {
+            return .run { _ in
+              await terminalClient.send(.performBindingAction(worktree, action: "next_tab"))
+            }
+          }
           guard let id = state.worktreeID(byOffset: 1) else { return .none }
           return .send(.selectWorktree(id))
 
         case .selectPreviousWorktree:
+          if state.isShelfActive, let worktree = state.selectedTerminalWorktree {
+            return .run { _ in
+              await terminalClient.send(.performBindingAction(worktree, action: "previous_tab"))
+            }
+          }
           guard let id = state.worktreeID(byOffset: -1) else { return .none }
           return .send(.selectWorktree(id))
 

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -762,7 +762,16 @@ struct RepositoriesFeature {
             }
             return .none
           }
-          let targetID = state.lastFocusedWorktreeID ?? state.orderedWorktreeRows().first?.id
+          // Same fallback chain as `toggleCanvas`'s exit path: prefer
+          // the card the user was actively focused on in Canvas so a
+          // Canvas → Shelf switch opens *that* card as the active book,
+          // not whatever was selected before Canvas was entered.
+          let targetID =
+            terminalClient.canvasFocusedWorktreeID()
+            ?? state.preCanvasTerminalTargetID
+            ?? state.preCanvasWorktreeID
+            ?? state.lastFocusedWorktreeID
+            ?? state.orderedWorktreeRows().first?.id
           guard let targetID else { return .none }
           if state.worktree(for: targetID) == nil,
             let repository = state.repositories[id: targetID],

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -284,6 +284,7 @@ struct RepositoriesFeature {
     case selectPreviousShelfBook
     case selectShelfBook(Int)
     case markWorktreeOpened(Worktree.ID)
+    case markWorktreeClosed(Worktree.ID)
     case setSidebarSelectedWorktreeIDs(Set<Worktree.ID>)
     case selectRepository(Repository.ID?)
     case selectWorktree(Worktree.ID?, focusTerminal: Bool = false)
@@ -681,6 +682,24 @@ struct RepositoriesFeature {
         case .markWorktreeOpened(let worktreeID):
           state.openedWorktreeIDs.insert(worktreeID)
           return .none
+
+        case .markWorktreeClosed(let worktreeID):
+          // Closing the last tab of a book retires the book from the
+          // Shelf. If this book was the one currently open on the
+          // Shelf, move focus to the next remaining book (by Shelf
+          // order) so the user lands on something useful rather than
+          // an empty-Shelf placeholder.
+          state.openedWorktreeIDs.remove(worktreeID)
+          guard state.isShelfActive,
+            state.selectedTerminalWorktree?.id == worktreeID
+          else {
+            return .none
+          }
+          let remaining = state.orderedShelfBooks()
+          guard let next = remaining.first else {
+            return .none
+          }
+          return shelfBookSelectionEffect(for: next)
 
         case .toggleShelf:
           if state.isShelfActive {

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -207,6 +207,12 @@ struct RepositoriesFeature {
     var preCanvasWorktreeID: Worktree.ID?
     var preCanvasTerminalTargetID: Worktree.ID?
     var isShelfActive: Bool = false
+    /// IDs of worktrees (and plain-folder repositories) that have been
+    /// "opened" at least once in this session — i.e., had their
+    /// terminal state created by a user selection or CLI activation.
+    /// The Shelf's book list is derived from this set so a sidebar
+    /// worktree that's never been touched does not appear as a spine.
+    var openedWorktreeIDs: Set<Worktree.ID> = []
     var launchRestoreMode: LaunchRestoreMode = .lastFocusedWorktree
     var shouldRestoreLastFocusedWorktree = false
     var shouldSelectFirstAfterReload = false
@@ -688,7 +694,22 @@ struct RepositoriesFeature {
             needsRedirect = true
           }
           state.isShelfActive = true
-          guard needsRedirect else { return .none }
+          if !needsRedirect {
+            // The current selection is the open book — make sure it's
+            // registered as opened so the Shelf renders at least this
+            // spine. Guards the case where `selection` was set without
+            // going through `.selectWorktree` / `.selectRepository`.
+            switch state.selection {
+            case .some(.worktree(let id)):
+              state.openedWorktreeIDs.insert(id)
+            case .some(.repository(let id))
+            where state.repositories[id: id]?.kind == .plain:
+              state.openedWorktreeIDs.insert(id)
+            default:
+              break
+            }
+            return .none
+          }
           let targetID = state.lastFocusedWorktreeID ?? state.orderedWorktreeRows().first?.id
           guard let targetID else { return .none }
           if state.worktree(for: targetID) == nil,
@@ -713,12 +734,19 @@ struct RepositoriesFeature {
           guard let repositoryID, state.repositories[id: repositoryID] != nil else { return .none }
           state.selection = .repository(repositoryID)
           state.sidebarSelectedWorktreeIDs = []
+          if state.repositories[id: repositoryID]?.kind == .plain {
+            // Plain folder selection opens the folder as a Shelf book.
+            state.openedWorktreeIDs.insert(repositoryID)
+          }
           return .send(.delegate(.selectedWorktreeChanged(state.selectedTerminalWorktree)))
 
         case .selectWorktree(let worktreeID, let focusTerminal):
           setSingleWorktreeSelection(worktreeID, state: &state)
           if focusTerminal, let worktreeID {
             state.pendingTerminalFocusWorktreeIDs.insert(worktreeID)
+          }
+          if let worktreeID {
+            state.openedWorktreeIDs.insert(worktreeID)
           }
           let selectedWorktree = state.worktree(for: worktreeID)
           return .send(.delegate(.selectedWorktreeChanged(selectedWorktree)))

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -686,20 +686,19 @@ struct RepositoriesFeature {
         case .markWorktreeClosed(let worktreeID):
           // Closing the last tab of a book retires the book from the
           // Shelf. If this book was the one currently open on the
-          // Shelf, move focus to the next remaining book (by Shelf
-          // order) so the user lands on something useful rather than
-          // an empty-Shelf placeholder.
+          // Shelf, move focus to the neighboring book — the one after
+          // the closed book if there is one, otherwise the one before
+          // — so the user lands close to where they were instead of
+          // always snapping back to the first spine.
+          let replacement = replacementBookAfterClosing(
+            worktreeID: worktreeID,
+            state: state
+          )
           state.openedWorktreeIDs.remove(worktreeID)
-          guard state.isShelfActive,
-            state.selectedTerminalWorktree?.id == worktreeID
-          else {
-            return .none
+          if let replacement {
+            return shelfBookSelectionEffect(for: replacement)
           }
-          let remaining = state.orderedShelfBooks()
-          guard let next = remaining.first else {
-            return .none
-          }
-          return shelfBookSelectionEffect(for: next)
+          return .none
 
         case .toggleShelf:
           if state.isShelfActive {
@@ -2216,6 +2215,33 @@ func isSelectionValid(
   state: RepositoriesFeature.State
 ) -> Bool {
   state.selectedRow(for: id) != nil
+}
+
+/// Choose the next book to open after `worktreeID`'s book is retired.
+/// Prefer the book immediately *after* the closed one in Shelf order;
+/// fall back to the one immediately *before* it; return `nil` when
+/// Shelf is inactive, when the closed book isn't the currently open
+/// one, or when no other books remain.
+func replacementBookAfterClosing(
+  worktreeID: Worktree.ID,
+  state: RepositoriesFeature.State
+) -> ShelfBook? {
+  guard state.isShelfActive,
+    state.selectedTerminalWorktree?.id == worktreeID
+  else { return nil }
+  let books = state.orderedShelfBooks()
+  guard let index = books.firstIndex(where: { $0.id == worktreeID }) else {
+    return nil
+  }
+  let remaining = books.enumerated().filter { $0.offset != index }.map(\.element)
+  guard !remaining.isEmpty else { return nil }
+  // After removing index `index`, the "next" book is now at position
+  // `index` in the reduced list (if it exists); otherwise the last one
+  // is the "previous" relative to what was closed.
+  if index < remaining.count {
+    return remaining[index]
+  }
+  return remaining.last
 }
 
 /// Returns the Shelf book at `offset` positions from the currently open

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -704,12 +704,24 @@ struct RepositoriesFeature {
             // registered as opened so the Shelf renders at least this
             // spine. Guards the case where `selection` was set without
             // going through `.selectWorktree` / `.selectRepository`.
+            //
+            // Also request terminal focus for this worktree so that
+            // `ShelfOpenBookView.onAppear` forces focus onto the
+            // surface (`forceAutoFocus: shouldFocusTerminal(for:)`).
+            // Without this, entering Shelf via keyboard shortcut
+            // leaves the first responder on the (now-dismissed) menu
+            // path, and `applySurfaceActivity`'s "only refocus if the
+            // current responder is a GhosttySurfaceView" guard skips
+            // the surface — user can't type until a second
+            // interaction (tab switch, etc.) forces focus through.
             switch state.selection {
             case .some(.worktree(let id)):
               state.openedWorktreeIDs.insert(id)
+              state.pendingTerminalFocusWorktreeIDs.insert(id)
             case .some(.repository(let id))
             where state.repositories[id: id]?.kind == .plain:
               state.openedWorktreeIDs.insert(id)
+              state.pendingTerminalFocusWorktreeIDs.insert(id)
             default:
               break
             }

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -206,6 +206,7 @@ struct RepositoriesFeature {
     var lastFocusedWorktreeID: Worktree.ID?
     var preCanvasWorktreeID: Worktree.ID?
     var preCanvasTerminalTargetID: Worktree.ID?
+    var isShelfActive: Bool = false
     var launchRestoreMode: LaunchRestoreMode = .lastFocusedWorktree
     var shouldRestoreLastFocusedWorktree = false
     var shouldSelectFirstAfterReload = false
@@ -272,6 +273,7 @@ struct RepositoriesFeature {
     case selectArchivedWorktrees
     case selectCanvas
     case toggleCanvas
+    case toggleShelf
     case setSidebarSelectedWorktreeIDs(Set<Worktree.ID>)
     case selectRepository(Repository.ID?)
     case selectWorktree(Worktree.ID?, focusTerminal: Bool = false)
@@ -611,6 +613,7 @@ struct RepositoriesFeature {
           return .none
 
         case .selectArchivedWorktrees:
+          state.isShelfActive = false
           state.selection = .archivedWorktrees
           state.sidebarSelectedWorktreeIDs = []
           return .send(.delegate(.selectedWorktreeChanged(nil)))
@@ -619,6 +622,7 @@ struct RepositoriesFeature {
           // Remember the current worktree so toggleCanvas can restore it.
           state.preCanvasWorktreeID = state.selectedWorktreeID
           state.preCanvasTerminalTargetID = state.selectedTerminalWorktree?.id
+          state.isShelfActive = false
           state.selection = .canvas
           state.sidebarSelectedWorktreeIDs = []
           return .run { _ in
@@ -649,6 +653,35 @@ struct RepositoriesFeature {
             guard !state.orderedWorktreeRows().isEmpty else { return .none }
             return .send(.selectCanvas)
           }
+
+        case .toggleShelf:
+          if state.isShelfActive {
+            state.isShelfActive = false
+            return .none
+          }
+          // Entering Shelf requires at least one book to render.
+          guard !state.orderedWorktreeRows().isEmpty else { return .none }
+          // Shelf is mutually exclusive with Canvas / archived views: when entering
+          // Shelf we need a worktree- or repository-scoped selection.
+          let needsRedirect: Bool
+          switch state.selection {
+          case .some(.worktree), .some(.repository):
+            needsRedirect = false
+          case .some(.canvas), .some(.archivedWorktrees), .none:
+            needsRedirect = true
+          }
+          state.isShelfActive = true
+          guard needsRedirect else { return .none }
+          let targetID = state.lastFocusedWorktreeID ?? state.orderedWorktreeRows().first?.id
+          guard let targetID else { return .none }
+          if state.worktree(for: targetID) == nil,
+            let repository = state.repositories[id: targetID],
+            repository.kind == .plain
+          {
+            state.pendingTerminalFocusWorktreeIDs.insert(targetID)
+            return .send(.selectRepository(targetID))
+          }
+          return .send(.selectWorktree(targetID, focusTerminal: true))
 
         case .setSidebarSelectedWorktreeIDs(let worktreeIDs):
           let validWorktreeIDs = Set(state.orderedWorktreeRows().map(\.id))
@@ -1385,6 +1418,10 @@ extension RepositoriesFeature.State {
 
   var isShowingCanvas: Bool {
     selection == .canvas
+  }
+
+  var isShowingShelf: Bool {
+    isShelfActive
   }
 
   var archivedWorktreeIDSet: Set<Worktree.ID> {

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -436,6 +436,23 @@ struct RepositoriesFeature {
           if selectionChanged {
             allEffects.append(.send(.delegate(.selectedWorktreeChanged(selectedWorktree))))
           }
+          // Apply "Default View = Shelf" preference once the initial
+          // repository snapshot has landed — reuses `.toggleShelf`'s
+          // guards (needs ≥1 book, falls back to `lastFocusedWorktreeID`
+          // when no selection is set yet). `repositorySnapshotLoaded`
+          // is only sent from `.task` at launch, so this won't re-enter
+          // Shelf if the user has already exited to Normal in the same
+          // session. When Layout Restore is about to run, defer to the
+          // `.layoutRestored` event in AppFeature — otherwise Layout
+          // Restore clears the selection we just set, and any books not
+          // in the saved layout would linger as stray spines.
+          @Shared(.settingsFile) var settingsFile
+          if settingsFile.global.defaultViewMode == .shelf,
+            state.launchRestoreMode != .restoreLayout,
+            !state.isShelfActive
+          {
+            allEffects.append(.send(.toggleShelf))
+          }
           return .merge(allEffects)
 
         case .pinnedWorktreeIDsLoaded(let pinnedWorktreeIDs):

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -283,6 +283,7 @@ struct RepositoriesFeature {
     case selectNextShelfBook
     case selectPreviousShelfBook
     case selectShelfBook(Int)
+    case markWorktreeOpened(Worktree.ID)
     case setSidebarSelectedWorktreeIDs(Set<Worktree.ID>)
     case selectRepository(Repository.ID?)
     case selectWorktree(Worktree.ID?, focusTerminal: Bool = false)
@@ -676,6 +677,10 @@ struct RepositoriesFeature {
           let zeroBased = index - 1
           guard books.indices.contains(zeroBased) else { return .none }
           return shelfBookSelectionEffect(for: books[zeroBased])
+
+        case .markWorktreeOpened(let worktreeID):
+          state.openedWorktreeIDs.insert(worktreeID)
+          return .none
 
         case .toggleShelf:
           if state.isShelfActive {

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -274,6 +274,9 @@ struct RepositoriesFeature {
     case selectCanvas
     case toggleCanvas
     case toggleShelf
+    case selectNextShelfBook
+    case selectPreviousShelfBook
+    case selectShelfBook(Int)
     case setSidebarSelectedWorktreeIDs(Set<Worktree.ID>)
     case selectRepository(Repository.ID?)
     case selectWorktree(Worktree.ID?, focusTerminal: Bool = false)
@@ -653,6 +656,20 @@ struct RepositoriesFeature {
             guard !state.orderedWorktreeRows().isEmpty else { return .none }
             return .send(.selectCanvas)
           }
+
+        case .selectNextShelfBook:
+          guard let book = shelfBook(atOffset: 1, state: state) else { return .none }
+          return shelfBookSelectionEffect(for: book)
+
+        case .selectPreviousShelfBook:
+          guard let book = shelfBook(atOffset: -1, state: state) else { return .none }
+          return shelfBookSelectionEffect(for: book)
+
+        case .selectShelfBook(let index):
+          let books = state.orderedShelfBooks()
+          let zeroBased = index - 1
+          guard books.indices.contains(zeroBased) else { return .none }
+          return shelfBookSelectionEffect(for: books[zeroBased])
 
         case .toggleShelf:
           if state.isShelfActive {
@@ -2122,6 +2139,39 @@ func isSelectionValid(
   state: RepositoriesFeature.State
 ) -> Bool {
   state.selectedRow(for: id) != nil
+}
+
+/// Returns the Shelf book at `offset` positions from the currently open
+/// book (wrapping around the book list). Returns nil if there are no
+/// books. When there is no open book, offset > 0 picks the first book
+/// and offset < 0 picks the last.
+func shelfBook(
+  atOffset offset: Int,
+  state: RepositoriesFeature.State
+) -> ShelfBook? {
+  let books = state.orderedShelfBooks()
+  guard !books.isEmpty else { return nil }
+  if let currentID = state.openShelfBookID,
+    let currentIndex = books.firstIndex(where: { $0.id == currentID })
+  {
+    let nextIndex = (currentIndex + offset + books.count) % books.count
+    return books[nextIndex]
+  }
+  return offset > 0 ? books.first : books.last
+}
+
+/// Dispatches the right selection action for a book — a worktree vs.
+/// a plain folder requires different Reducer actions even though the
+/// Shelf treats them uniformly.
+func shelfBookSelectionEffect(
+  for book: ShelfBook
+) -> Effect<RepositoriesFeature.Action> {
+  switch book.kind {
+  case .worktree:
+    return .send(.selectWorktree(book.id, focusTerminal: true))
+  case .plainFolder:
+    return .send(.selectRepository(book.repositoryID))
+  }
 }
 
 private func isSidebarSelectionValid(

--- a/supacode/Features/Repositories/Views/SidebarListView.swift
+++ b/supacode/Features/Repositories/Views/SidebarListView.swift
@@ -184,11 +184,18 @@ struct SidebarListView: View {
         }
       }
       .safeAreaInset(edge: .top) {
-        CanvasSidebarButton(
-          store: store,
-          isSelected: state.isShowingCanvas
-        )
+        HStack(spacing: 4) {
+          CanvasSidebarButton(
+            store: store,
+            isSelected: state.isShowingCanvas
+          )
+          ShelfSidebarButton(
+            store: store,
+            isSelected: state.isShowingShelf
+          )
+        }
         .padding(.top, 4)
+        .padding(.horizontal, 4)
         .background(.bar)
         .overlay(alignment: .bottom) {
           Divider()
@@ -319,7 +326,7 @@ struct SidebarListView: View {
       state.repositories = [repo1, repo2]
       state.pinnedWorktreeIDs = ["/tmp/wt/auth"]
       state.worktreeInfoByID = [
-        "/tmp/wt/sidebar": WorktreeInfoEntry(addedLines: 120, removedLines: 45, pullRequest: nil),
+        "/tmp/wt/sidebar": WorktreeInfoEntry(addedLines: 120, removedLines: 45, pullRequest: nil)
       ]
       return state
     }

--- a/supacode/Features/Repositories/Views/WorktreeDetailView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailView.swift
@@ -227,7 +227,8 @@ struct WorktreeDetailView: View {
     } else if repositories.isShowingShelf {
       ShelfView(
         store: store.scope(state: \.repositories, action: \.repositories),
-        terminalManager: terminalManager
+        terminalManager: terminalManager,
+        createTab: { store.send(.newTerminal) }
       )
       .frame(maxWidth: .infinity, maxHeight: .infinity)
     } else if repositories.isShowingArchivedWorktrees {

--- a/supacode/Features/Repositories/Views/WorktreeDetailView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailView.swift
@@ -224,6 +224,12 @@ struct WorktreeDetailView: View {
         onExitToTab: {
           store.send(.repositories(.toggleCanvas))
         })
+    } else if repositories.isShowingShelf {
+      ShelfView(
+        store: store.scope(state: \.repositories, action: \.repositories),
+        terminalManager: terminalManager
+      )
+      .frame(maxWidth: .infinity, maxHeight: .infinity)
     } else if repositories.isShowingArchivedWorktrees {
       ArchivedWorktreesDetailView(
         store: store.scope(state: \.repositories, action: \.repositories)

--- a/supacode/Features/Settings/Models/DefaultViewMode.swift
+++ b/supacode/Features/Settings/Models/DefaultViewMode.swift
@@ -1,0 +1,19 @@
+/// Which presentation the app enters on launch. `normal` keeps the
+/// historical behavior (sidebar + terminal detail); `shelf` boots
+/// straight into Shelf so power users who live in Shelf don't have to
+/// toggle it every time they open Prowl.
+enum DefaultViewMode: String, CaseIterable, Identifiable, Codable, Sendable {
+  case normal
+  case shelf
+
+  var id: String { rawValue }
+
+  var title: String {
+    switch self {
+    case .normal:
+      return "Normal View"
+    case .shelf:
+      return "Shelf View"
+    }
+  }
+}

--- a/supacode/Features/Settings/Models/GlobalSettings.swift
+++ b/supacode/Features/Settings/Models/GlobalSettings.swift
@@ -26,6 +26,7 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
   var terminalFontSize: Float32?
   var archivedAutoDeletePeriod: AutoDeletePeriod?
   var keybindingUserOverrides: KeybindingUserOverrideStore
+  var defaultViewMode: DefaultViewMode
 
   static let `default` = GlobalSettings(
     appearanceMode: .dark,
@@ -54,7 +55,8 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     restoreTerminalLayoutOnLaunch: false,
     archivedAutoDeletePeriod: nil,
     terminalFontSize: nil,
-    keybindingUserOverrides: .empty
+    keybindingUserOverrides: .empty,
+    defaultViewMode: .normal
   )
 
   init(
@@ -84,7 +86,8 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     restoreTerminalLayoutOnLaunch: Bool = false,
     archivedAutoDeletePeriod: AutoDeletePeriod? = nil,
     terminalFontSize: Float32? = nil,
-    keybindingUserOverrides: KeybindingUserOverrideStore = .empty
+    keybindingUserOverrides: KeybindingUserOverrideStore = .empty,
+    defaultViewMode: DefaultViewMode = .normal
   ) {
     self.appearanceMode = appearanceMode
     self.defaultEditorID = defaultEditorID
@@ -113,6 +116,7 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     self.archivedAutoDeletePeriod = archivedAutoDeletePeriod
     self.terminalFontSize = terminalFontSize
     self.keybindingUserOverrides = keybindingUserOverrides
+    self.defaultViewMode = defaultViewMode
   }
 
   func encode(to encoder: any Encoder) throws {
@@ -144,6 +148,7 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     try container.encodeIfPresent(archivedAutoDeletePeriod?.rawValue, forKey: .archivedAutoDeletePeriod)
     try container.encodeIfPresent(terminalFontSize, forKey: .terminalFontSize)
     try container.encode(keybindingUserOverrides, forKey: .keybindingUserOverrides)
+    try container.encode(defaultViewMode, forKey: .defaultViewMode)
   }
 
   private enum CodingKeys: String, CodingKey {
@@ -174,6 +179,7 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     case archivedAutoDeletePeriod
     case terminalFontSize
     case keybindingUserOverrides
+    case defaultViewMode
     // Legacy key for migration
     case automaticallyArchiveMergedWorktrees
   }
@@ -263,5 +269,8 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     keybindingUserOverrides =
       try container.decodeIfPresent(KeybindingUserOverrideStore.self, forKey: .keybindingUserOverrides)
       ?? Self.default.keybindingUserOverrides
+    defaultViewMode =
+      try container.decodeIfPresent(DefaultViewMode.self, forKey: .defaultViewMode)
+      ?? Self.default.defaultViewMode
   }
 }

--- a/supacode/Features/Settings/Reducer/SettingsFeature.swift
+++ b/supacode/Features/Settings/Reducer/SettingsFeature.swift
@@ -32,6 +32,7 @@ struct SettingsFeature {
     var restoreTerminalLayoutOnLaunch: Bool
     var terminalFontSize: Float32?
     var keybindingUserOverrides: KeybindingUserOverrideStore
+    var defaultViewMode: DefaultViewMode
     var cliInstallStatus: CLIInstallStatus = .notInstalled
     var cliInstallShowAlert: Bool = true
     var selection: SettingsSection? = .general
@@ -68,6 +69,7 @@ struct SettingsFeature {
       restoreTerminalLayoutOnLaunch = settings.restoreTerminalLayoutOnLaunch
       terminalFontSize = settings.terminalFontSize
       keybindingUserOverrides = settings.keybindingUserOverrides
+      defaultViewMode = settings.defaultViewMode
     }
 
     var globalSettings: GlobalSettings {
@@ -100,7 +102,8 @@ struct SettingsFeature {
         restoreTerminalLayoutOnLaunch: restoreTerminalLayoutOnLaunch,
         archivedAutoDeletePeriod: archivedAutoDeletePeriod,
         terminalFontSize: terminalFontSize,
-        keybindingUserOverrides: keybindingUserOverrides
+        keybindingUserOverrides: keybindingUserOverrides,
+        defaultViewMode: defaultViewMode
       )
     }
   }
@@ -200,6 +203,7 @@ struct SettingsFeature {
         state.restoreTerminalLayoutOnLaunch = normalizedSettings.restoreTerminalLayoutOnLaunch
         state.terminalFontSize = normalizedSettings.terminalFontSize
         state.keybindingUserOverrides = normalizedSettings.keybindingUserOverrides
+        state.defaultViewMode = normalizedSettings.defaultViewMode
         state.syncGlobalDefaults(from: normalizedSettings)
         return .send(.delegate(.settingsChanged(normalizedSettings)))
 

--- a/supacode/Features/Settings/Views/AppearanceSettingsView.swift
+++ b/supacode/Features/Settings/Views/AppearanceSettingsView.swift
@@ -30,6 +30,14 @@ struct AppearanceSettingsView: View {
           .foregroundStyle(.secondary)
           .textSelection(.enabled)
         }
+        Section("Default View") {
+          Picker("Launch in", selection: $store.defaultViewMode) {
+            ForEach(DefaultViewMode.allCases) { mode in
+              Text(mode.title).tag(mode)
+            }
+          }
+          .help("View Prowl starts in on launch. Shelf requires at least one worktree or folder.")
+        }
         Section("Default Editor") {
           Picker(
             "Default editor",

--- a/supacode/Features/Settings/Views/ShortcutsSettingsView.swift
+++ b/supacode/Features/Settings/Views/ShortcutsSettingsView.swift
@@ -923,6 +923,17 @@ private enum ShortcutGroup: String, CaseIterable, Identifiable {
       AppShortcuts.CommandID.showDiff,
       AppShortcuts.CommandID.toggleCanvas,
       AppShortcuts.CommandID.toggleShelf,
+      AppShortcuts.CommandID.selectNextShelfBook,
+      AppShortcuts.CommandID.selectPreviousShelfBook,
+      AppShortcuts.CommandID.selectShelfBook1,
+      AppShortcuts.CommandID.selectShelfBook2,
+      AppShortcuts.CommandID.selectShelfBook3,
+      AppShortcuts.CommandID.selectShelfBook4,
+      AppShortcuts.CommandID.selectShelfBook5,
+      AppShortcuts.CommandID.selectShelfBook6,
+      AppShortcuts.CommandID.selectShelfBook7,
+      AppShortcuts.CommandID.selectShelfBook8,
+      AppShortcuts.CommandID.selectShelfBook9,
       AppShortcuts.CommandID.selectAllCanvasCards,
       AppShortcuts.CommandID.archivedWorktrees:
       return .scripts

--- a/supacode/Features/Settings/Views/ShortcutsSettingsView.swift
+++ b/supacode/Features/Settings/Views/ShortcutsSettingsView.swift
@@ -922,6 +922,7 @@ private enum ShortcutGroup: String, CaseIterable, Identifiable {
       AppShortcuts.CommandID.stopScript,
       AppShortcuts.CommandID.showDiff,
       AppShortcuts.CommandID.toggleCanvas,
+      AppShortcuts.CommandID.toggleShelf,
       AppShortcuts.CommandID.selectAllCanvasCards,
       AppShortcuts.CommandID.archivedWorktrees:
       return .scripts

--- a/supacode/Features/Shelf/Models/ShelfBook.swift
+++ b/supacode/Features/Shelf/Models/ShelfBook.swift
@@ -27,12 +27,20 @@ extension RepositoriesFeature.State {
   /// Books rendered on the Shelf, in the same order the left navigation
   /// presents them (by repository, then by worktree rows within the
   /// repository). Plain folder repositories contribute a single book.
+  ///
+  /// The list is filtered to only books whose IDs are in
+  /// `openedWorktreeIDs` — a worktree (or plain folder) appears on the
+  /// Shelf only after the user has interacted with it at least once.
+  /// Clicking a previously-unopened worktree in the left navigation
+  /// while in Shelf mode adds its ID here, which causes its spine to
+  /// materialize (with the standard spine-flow animation).
   func orderedShelfBooks() -> [ShelfBook] {
     let repositoriesByID = Dictionary(uniqueKeysWithValues: repositories.map { ($0.id, $0) })
     var books: [ShelfBook] = []
     for repositoryID in orderedRepositoryIDs() {
       guard let repository = repositoriesByID[repositoryID] else { continue }
       if repository.kind == .plain {
+        guard openedWorktreeIDs.contains(repository.id) else { continue }
         books.append(
           ShelfBook(
             id: repository.id,
@@ -44,6 +52,7 @@ extension RepositoriesFeature.State {
         continue
       }
       for row in worktreeRows(in: repository) {
+        guard openedWorktreeIDs.contains(row.id) else { continue }
         books.append(
           ShelfBook(
             id: row.id,

--- a/supacode/Features/Shelf/Models/ShelfBook.swift
+++ b/supacode/Features/Shelf/Models/ShelfBook.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+/// A book on the Shelf — the unified abstraction over a Git worktree or
+/// a plain folder repository.
+///
+/// For worktrees the `id` is the underlying `Worktree.ID`. For plain
+/// folders the `id` is the owning `Repository.ID`; plain folders are
+/// represented in the terminal system as synthetic worktrees sharing the
+/// repository's ID, so using the repository ID here keeps it consistent
+/// with `selectedTerminalWorktree?.id`.
+struct ShelfBook: Identifiable, Equatable, Hashable, Sendable {
+  enum Kind: Equatable, Hashable, Sendable {
+    case worktree
+    case plainFolder
+  }
+
+  let id: Worktree.ID
+  let repositoryID: Repository.ID
+  let displayName: String
+  let branchName: String?
+  let kind: Kind
+
+  var isPlainFolder: Bool { kind == .plainFolder }
+}
+
+extension RepositoriesFeature.State {
+  /// Books rendered on the Shelf, in the same order the left navigation
+  /// presents them (by repository, then by worktree rows within the
+  /// repository). Plain folder repositories contribute a single book.
+  func orderedShelfBooks() -> [ShelfBook] {
+    let repositoriesByID = Dictionary(uniqueKeysWithValues: repositories.map { ($0.id, $0) })
+    var books: [ShelfBook] = []
+    for repositoryID in orderedRepositoryIDs() {
+      guard let repository = repositoriesByID[repositoryID] else { continue }
+      if repository.kind == .plain {
+        books.append(
+          ShelfBook(
+            id: repository.id,
+            repositoryID: repository.id,
+            displayName: repository.name,
+            branchName: nil,
+            kind: .plainFolder
+          ))
+        continue
+      }
+      for row in worktreeRows(in: repository) {
+        books.append(
+          ShelfBook(
+            id: row.id,
+            repositoryID: repositoryID,
+            displayName: row.name,
+            branchName: row.name,
+            kind: .worktree
+          ))
+      }
+    }
+    return books
+  }
+
+  /// Identifier of the book currently open on the Shelf, derived from the
+  /// active selection. Equal to `selectedTerminalWorktree?.id`, but kept as
+  /// its own property so call sites read as shelf-aware.
+  var openShelfBookID: Worktree.ID? {
+    selectedTerminalWorktree?.id
+  }
+}

--- a/supacode/Features/Shelf/Models/ShelfBook.swift
+++ b/supacode/Features/Shelf/Models/ShelfBook.swift
@@ -17,6 +17,9 @@ struct ShelfBook: Identifiable, Equatable, Hashable, Sendable {
   let id: Worktree.ID
   let repositoryID: Repository.ID
   let displayName: String
+  /// Project/repository name shown as the primary part of the spine
+  /// header. For plain folders this equals the folder name.
+  let projectName: String
   let branchName: String?
   let kind: Kind
 
@@ -46,6 +49,7 @@ extension RepositoriesFeature.State {
             id: repository.id,
             repositoryID: repository.id,
             displayName: repository.name,
+            projectName: repository.name,
             branchName: nil,
             kind: .plainFolder
           ))
@@ -58,6 +62,7 @@ extension RepositoriesFeature.State {
             id: row.id,
             repositoryID: repositoryID,
             displayName: row.name,
+            projectName: repository.name,
             branchName: row.name,
             kind: .worktree
           ))

--- a/supacode/Features/Shelf/Views/ShelfOpenBookView.swift
+++ b/supacode/Features/Shelf/Views/ShelfOpenBookView.swift
@@ -1,0 +1,56 @@
+import AppKit
+import SwiftUI
+
+/// Renders the terminal content for the currently open book.
+///
+/// Mirrors the terminal-content slice of `WorktreeTerminalTabsView` without
+/// the horizontal tab bar: in Shelf the tab bar lives on the book's spine,
+/// so we only render the content stack (plus icon picker sheet + focus
+/// observer) here.
+struct ShelfOpenBookView: View {
+  let worktree: Worktree
+  let manager: WorktreeTerminalManager
+  let shouldRunSetupScript: Bool
+
+  @State private var windowActivity = WindowActivityState.inactive
+
+  var body: some View {
+    let state = manager.state(for: worktree) { shouldRunSetupScript }
+    Group {
+      if let selectedId = state.tabManager.selectedTabId {
+        TerminalTabContentStack(tabs: state.tabManager.tabs, selectedTabId: selectedId) { tabId in
+          TerminalSplitTreeAXContainer(tree: state.splitTree(for: tabId)) { operation in
+            state.performSplitOperation(operation, in: tabId)
+          }
+        }
+      } else {
+        EmptyTerminalPaneView(message: "No terminals open")
+      }
+    }
+    .sheet(
+      item: Binding(
+        get: { state.iconPickerTabId },
+        set: { state.iconPickerTabId = $0 }
+      )
+    ) { tabId in
+      let currentIcon = state.tabManager.tabs.first(where: { $0.id == tabId })?.icon
+      TabIconPickerView(
+        initialIcon: currentIcon,
+        defaultIcon: state.defaultIcon(for: tabId),
+        onApply: { newIcon in
+          state.applyIconChange(tabId, icon: newIcon)
+          state.dismissIconPicker()
+        },
+        onCancel: {
+          state.dismissIconPicker()
+        }
+      )
+    }
+    .background(
+      WindowFocusObserverView { activity in
+        windowActivity = activity
+        state.syncFocus(windowIsKey: activity.isKeyWindow, windowIsVisible: activity.isVisible)
+      }
+    )
+  }
+}

--- a/supacode/Features/Shelf/Views/ShelfOpenBookView.swift
+++ b/supacode/Features/Shelf/Views/ShelfOpenBookView.swift
@@ -6,11 +6,15 @@ import SwiftUI
 /// Mirrors the terminal-content slice of `WorktreeTerminalTabsView` without
 /// the horizontal tab bar: in Shelf the tab bar lives on the book's spine,
 /// so we only render the content stack (plus icon picker sheet + focus
-/// observer) here.
+/// observer) here. Focus management (`ensureInitialTab`, `focusSelectedTab`,
+/// window-key syncing, and the `forceAutoFocus` on-change plumbing) is
+/// copied verbatim from `WorktreeTerminalTabsView` so that typing into the
+/// open book's surface works the same way it does in normal view.
 struct ShelfOpenBookView: View {
   let worktree: Worktree
   let manager: WorktreeTerminalManager
   let shouldRunSetupScript: Bool
+  let forceAutoFocus: Bool
 
   @State private var windowActivity = WindowActivityState.inactive
 
@@ -52,5 +56,38 @@ struct ShelfOpenBookView: View {
         state.syncFocus(windowIsKey: activity.isKeyWindow, windowIsVisible: activity.isVisible)
       }
     )
+    .onAppear {
+      state.ensureInitialTab(focusing: false)
+      if shouldAutoFocusTerminal {
+        state.focusSelectedTab()
+      }
+      let activity = resolvedWindowActivity
+      state.syncFocus(windowIsKey: activity.isKeyWindow, windowIsVisible: activity.isVisible)
+    }
+    .onChange(of: state.tabManager.selectedTabId) { _, _ in
+      if shouldAutoFocusTerminal {
+        state.focusSelectedTab()
+      }
+      let activity = resolvedWindowActivity
+      state.syncFocus(windowIsKey: activity.isKeyWindow, windowIsVisible: activity.isVisible)
+    }
+  }
+
+  private var shouldAutoFocusTerminal: Bool {
+    if forceAutoFocus {
+      return true
+    }
+    guard let responder = NSApp.keyWindow?.firstResponder else { return true }
+    return !(responder is NSTableView) && !(responder is NSOutlineView)
+  }
+
+  private var resolvedWindowActivity: WindowActivityState {
+    if let keyWindow = NSApp.keyWindow {
+      return WindowActivityState(
+        isKeyWindow: keyWindow.isKeyWindow,
+        isVisible: keyWindow.occlusionState.contains(.visible)
+      )
+    }
+    return windowActivity
   }
 }

--- a/supacode/Features/Shelf/Views/ShelfSidebarButton.swift
+++ b/supacode/Features/Shelf/Views/ShelfSidebarButton.swift
@@ -1,0 +1,37 @@
+import ComposableArchitecture
+import SwiftUI
+
+struct ShelfSidebarButton: View {
+  let store: StoreOf<RepositoriesFeature>
+  let isSelected: Bool
+  @Environment(CommandKeyObserver.self) private var commandKeyObserver
+  @Environment(\.resolvedKeybindings) private var resolvedKeybindings
+
+  var body: some View {
+    Button {
+      store.send(.toggleShelf)
+    } label: {
+      HStack(spacing: 6) {
+        Label("Shelf", systemImage: "books.vertical")
+          .font(.callout)
+          .frame(maxWidth: .infinity, alignment: .leading)
+        if commandKeyObserver.isPressed,
+          let shortcut = AppShortcuts.display(for: AppShortcuts.CommandID.toggleShelf, in: resolvedKeybindings)
+        {
+          ShortcutHintView(text: shortcut, color: .secondary)
+        }
+      }
+      .padding(.horizontal, 12)
+      .padding(.vertical, 6)
+      .contentShape(.rect)
+    }
+    .buttonStyle(.plain)
+    .background(isSelected ? Color.accentColor.opacity(0.15) : .clear, in: .rect(cornerRadius: 6))
+    .help(
+      AppShortcuts.helpText(
+        title: "Shelf",
+        commandID: AppShortcuts.CommandID.toggleShelf,
+        in: resolvedKeybindings
+      ))
+  }
+}

--- a/supacode/Features/Shelf/Views/ShelfSpineView.swift
+++ b/supacode/Features/Shelf/Views/ShelfSpineView.swift
@@ -18,6 +18,9 @@ struct ShelfSpineView: View {
   let onNewTab: (() -> Void)?
   let onSplitVertical: (() -> Void)?
   let onSplitHorizontal: (() -> Void)?
+  /// "Remove this book" — drives the book-level context menu entry on
+  /// the spine header / empty body. Nil disables the menu.
+  let onRemoveBook: (() -> Void)?
 
   var body: some View {
     VStack(spacing: 0) {
@@ -31,6 +34,7 @@ struct ShelfSpineView: View {
           .contentShape(.rect)
       }
       .buttonStyle(.plain)
+      .contextMenu { bookContextMenu }
       bottomControls
     }
     .frame(width: ShelfMetrics.spineWidth)
@@ -41,6 +45,17 @@ struct ShelfSpineView: View {
       }
     }
     .help(book.displayName)
+  }
+
+  @ViewBuilder
+  private var bookContextMenu: some View {
+    if let onRemoveBook {
+      Button(role: .destructive) {
+        onRemoveBook()
+      } label: {
+        Text("Remove Book")
+      }
+    }
   }
 
   @ViewBuilder
@@ -80,6 +95,7 @@ struct ShelfSpineView: View {
       .contentShape(.rect)
     }
     .buttonStyle(.plain)
+    .contextMenu { bookContextMenu }
   }
 
   @ViewBuilder
@@ -97,7 +113,20 @@ struct ShelfSpineView: View {
               hotkeyIndex: hotkeyIndex,
               isActive: terminalState.tabManager.selectedTabId == tab.id,
               hasUnseenNotification: terminalState.hasUnseenNotification(for: tab.id),
-              onTap: { onSelectTab(tab.id) }
+              onTap: { onSelectTab(tab.id) },
+              onClose: { terminalState.closeTab(tab.id) }
+            )
+            .terminalTabContextMenu(
+              tabId: tab.id,
+              tabs: terminalState.tabManager.tabs,
+              actions: TerminalTabContextMenuActions(
+                changeTitle: { terminalState.promptChangeTabTitle($0) },
+                changeIcon: { terminalState.presentIconPicker(for: $0) },
+                closeTab: { terminalState.closeTab($0) },
+                closeOthers: { terminalState.closeOtherTabs(keeping: $0) },
+                closeToRight: { terminalState.closeTabsToRight(of: $0) },
+                closeAll: { terminalState.closeAllTabs() }
+              )
             )
           }
         }
@@ -165,8 +194,10 @@ private struct ShelfSpineTabSlot: View {
   let isActive: Bool
   let hasUnseenNotification: Bool
   let onTap: () -> Void
+  let onClose: () -> Void
 
   @Environment(CommandKeyObserver.self) private var commandKeyObserver
+  @State private var isHovering = false
 
   var body: some View {
     Button(action: onTap) {
@@ -178,6 +209,23 @@ private struct ShelfSpineTabSlot: View {
       .contentShape(.rect)
     }
     .buttonStyle(.plain)
+    .overlay(alignment: .topTrailing) {
+      if isHovering && !commandKeyObserver.isPressed {
+        Button(action: onClose) {
+          Image(systemName: "xmark.circle.fill")
+            .imageScale(.small)
+            .foregroundStyle(.primary)
+            .background(Circle().fill(.background))
+            .accessibilityLabel("Close Tab")
+        }
+        .buttonStyle(.plain)
+        .offset(x: 3, y: -3)
+        .help("Close Tab")
+      }
+    }
+    .onHover { hovering in
+      isHovering = hovering
+    }
     .help(tab.title)
   }
 

--- a/supacode/Features/Shelf/Views/ShelfSpineView.swift
+++ b/supacode/Features/Shelf/Views/ShelfSpineView.swift
@@ -1,0 +1,78 @@
+import SwiftUI
+
+/// Vertical spine rendering for a single book on the Shelf.
+///
+/// Phase 2 scope: geometry (one-line-text width), rotated header
+/// (name/branch), and a fixed-width selection background. Tab slots,
+/// notification badges, ⌘-overlay digits, and bottom controls are added
+/// in later phases.
+struct ShelfSpineView: View {
+  let book: ShelfBook
+  let isOpen: Bool
+  let onTap: () -> Void
+
+  var body: some View {
+    Button(action: onTap) {
+      VStack(alignment: .center, spacing: 4) {
+        ShelfSpineHeader(book: book)
+          .padding(.top, 8)
+        Spacer(minLength: 0)
+      }
+      .frame(maxWidth: .infinity, maxHeight: .infinity)
+      .contentShape(.rect)
+    }
+    .buttonStyle(.plain)
+    .frame(width: ShelfMetrics.spineWidth)
+    .background(spineBackground)
+    .overlay(alignment: .trailing) {
+      if !isOpen {
+        Divider()
+          .opacity(0.4)
+      }
+    }
+    .help("\(book.displayName)")
+  }
+
+  @ViewBuilder
+  private var spineBackground: some View {
+    if isOpen {
+      Color.accentColor.opacity(0.12)
+    } else {
+      Color.clear
+    }
+  }
+}
+
+private struct ShelfSpineHeader: View {
+  let book: ShelfBook
+
+  var body: some View {
+    VStack(spacing: 6) {
+      Text(book.displayName)
+        .font(.callout.weight(.semibold))
+        .lineLimit(1)
+        .truncationMode(.tail)
+        .fixedSize()
+        .rotationEffect(.degrees(90))
+        .frame(width: ShelfMetrics.spineWidth, alignment: .center)
+      if let branchName = book.branchName, branchName != book.displayName {
+        Text(branchName)
+          .font(.caption)
+          .foregroundStyle(.secondary)
+          .lineLimit(1)
+          .truncationMode(.tail)
+          .fixedSize()
+          .rotationEffect(.degrees(90))
+          .frame(width: ShelfMetrics.spineWidth, alignment: .center)
+      }
+    }
+    .padding(.top, 36)
+    .padding(.bottom, 8)
+  }
+}
+
+/// Shared metrics for the Shelf layout so the three segments stay in sync.
+enum ShelfMetrics {
+  /// Width of a single spine (roughly one line of text).
+  static let spineWidth: CGFloat = 26
+}

--- a/supacode/Features/Shelf/Views/ShelfSpineView.swift
+++ b/supacode/Features/Shelf/Views/ShelfSpineView.swift
@@ -43,6 +43,7 @@ struct ShelfSpineView: View {
     // the spine to pull the book out.
     .contentShape(.rect)
     .onTapGesture { onOpenBook() }
+    .accessibilityAddTraits(.isButton)
     .contextMenu { bookContextMenu }
     .overlay(alignment: .trailing) {
       if !isOpen {

--- a/supacode/Features/Shelf/Views/ShelfSpineView.swift
+++ b/supacode/Features/Shelf/Views/ShelfSpineView.swift
@@ -29,7 +29,13 @@ struct ShelfSpineView: View {
       bottomControls
     }
     .frame(width: ShelfMetrics.spineWidth)
-    .background(spineBackground)
+    .background(
+      // Single `Rectangle` with a ternary fill so the open↔closed color
+      // change interpolates in place rather than swapping one view for
+      // another (which the previous `@ViewBuilder` if/else did).
+      Rectangle()
+        .fill(isOpen ? Color.accentColor.opacity(0.12) : Color.primary.opacity(0.06))
+    )
     // Whole-spine tap target. Inner Buttons (header, tab slots, controls)
     // absorb their own clicks; clicks that fall on empty areas (scroll
     // view negative space, gaps between tabs, etc.) bubble here and open
@@ -167,27 +173,6 @@ struct ShelfSpineView: View {
     .padding(.top, ShelfMetrics.slotSpacing)
   }
 
-  /// Visual treatment splits into two bands:
-  ///
-  /// - **Closed spines** get a subtle opaque tint so the collected stack
-  ///   reads as "books on the shelf" rather than leaking into the
-  ///   terminal-area background. We deliberately avoid `.thinMaterial`
-  ///   here: when adjacent spines all use the same material and the
-  ///   ScrollView's visible region has an edge, the material's vibrancy
-  ///   layer can render a visible banding line at that edge, lining up
-  ///   across every spine into a continuous horizontal stripe. A flat
-  ///   opaque fill sidesteps the issue entirely.
-  /// - **The open spine** gets an accent tint and no trailing divider,
-  ///   so it reads as the left edge of the "open page" (per the
-  ///   Open Book Visual Distinction section of the design doc).
-  @ViewBuilder
-  private var spineBackground: some View {
-    if isOpen {
-      Color.accentColor.opacity(0.12)
-    } else {
-      Color.primary.opacity(0.06)
-    }
-  }
 }
 
 private struct ShelfSpineHeader: View {

--- a/supacode/Features/Shelf/Views/ShelfSpineView.swift
+++ b/supacode/Features/Shelf/Views/ShelfSpineView.swift
@@ -2,35 +2,72 @@ import SwiftUI
 
 /// Vertical spine rendering for a single book on the Shelf.
 ///
-/// Phase 2 scope: geometry (one-line-text width), rotated header
-/// (name/branch), and a fixed-width selection background. Tab slots,
-/// notification badges, ⌘-overlay digits, and bottom controls are added
-/// in later phases.
+/// Phase 3 scope: header with book-level notification dot, a vertical
+/// scrollable tab list (icon-only slots), tap targets for header (opens
+/// the book with its current tab) and per-tab slot (opens the book with
+/// that tab). Animations, ⌘-held digit overlay, and bottom controls are
+/// layered in subsequent phases.
 struct ShelfSpineView: View {
   let book: ShelfBook
   let isOpen: Bool
-  let onTap: () -> Void
+  let terminalState: WorktreeTerminalState?
+  let onOpenBook: () -> Void
+  let onSelectTab: (TerminalTabID) -> Void
 
   var body: some View {
-    Button(action: onTap) {
-      VStack(alignment: .center, spacing: 4) {
-        ShelfSpineHeader(book: book)
-          .padding(.top, 8)
-        Spacer(minLength: 0)
+    VStack(spacing: 0) {
+      headerButton
+      tabList
+      // Flexible spacer keeps the tap target for "open this book" filling
+      // any leftover vertical space below the tab list.
+      Button(action: onOpenBook) {
+        Color.clear
+          .contentShape(.rect)
       }
-      .frame(maxWidth: .infinity, maxHeight: .infinity)
-      .contentShape(.rect)
+      .buttonStyle(.plain)
     }
-    .buttonStyle(.plain)
     .frame(width: ShelfMetrics.spineWidth)
     .background(spineBackground)
     .overlay(alignment: .trailing) {
       if !isOpen {
-        Divider()
-          .opacity(0.4)
+        Divider().opacity(0.35)
       }
     }
-    .help("\(book.displayName)")
+    .help(book.displayName)
+  }
+
+  @ViewBuilder
+  private var headerButton: some View {
+    Button(action: onOpenBook) {
+      ShelfSpineHeader(
+        book: book,
+        hasAggregatedNotification: terminalState?.hasUnseenNotification == true
+      )
+      .frame(maxWidth: .infinity)
+      .contentShape(.rect)
+    }
+    .buttonStyle(.plain)
+  }
+
+  @ViewBuilder
+  private var tabList: some View {
+    if let terminalState {
+      ScrollView(.vertical, showsIndicators: false) {
+        VStack(spacing: ShelfMetrics.slotSpacing) {
+          ForEach(terminalState.tabManager.tabs) { tab in
+            ShelfSpineTabSlot(
+              tab: tab,
+              isActive: terminalState.tabManager.selectedTabId == tab.id,
+              hasUnseenNotification: terminalState.hasUnseenNotification(for: tab.id),
+              onTap: { onSelectTab(tab.id) }
+            )
+          }
+        }
+        .padding(.horizontal, ShelfMetrics.slotHorizontalPadding)
+        .padding(.top, ShelfMetrics.slotSpacing)
+      }
+      .scrollBounceBehavior(.basedOnSize)
+    }
   }
 
   @ViewBuilder
@@ -45,29 +82,87 @@ struct ShelfSpineView: View {
 
 private struct ShelfSpineHeader: View {
   let book: ShelfBook
+  let hasAggregatedNotification: Bool
 
   var body: some View {
     VStack(spacing: 6) {
-      Text(book.displayName)
-        .font(.callout.weight(.semibold))
-        .lineLimit(1)
-        .truncationMode(.tail)
-        .fixedSize()
-        .rotationEffect(.degrees(90))
-        .frame(width: ShelfMetrics.spineWidth, alignment: .center)
-      if let branchName = book.branchName, branchName != book.displayName {
-        Text(branchName)
-          .font(.caption)
-          .foregroundStyle(.secondary)
+      ZStack(alignment: .top) {
+        Circle()
+          .fill(.orange)
+          .frame(width: ShelfMetrics.aggregatedDotSize, height: ShelfMetrics.aggregatedDotSize)
+          .opacity(hasAggregatedNotification ? 1 : 0)
+          .accessibilityLabel("Unread notifications")
+          .accessibilityHidden(!hasAggregatedNotification)
+      }
+      .frame(height: ShelfMetrics.aggregatedDotSize)
+      .padding(.top, 6)
+      VStack(spacing: 6) {
+        Text(book.displayName)
+          .font(.callout.weight(.semibold))
           .lineLimit(1)
           .truncationMode(.tail)
           .fixedSize()
           .rotationEffect(.degrees(90))
           .frame(width: ShelfMetrics.spineWidth, alignment: .center)
+        if let branchName = book.branchName, branchName != book.displayName {
+          Text(branchName)
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .lineLimit(1)
+            .truncationMode(.tail)
+            .fixedSize()
+            .rotationEffect(.degrees(90))
+            .frame(width: ShelfMetrics.spineWidth, alignment: .center)
+        }
       }
+      .padding(.top, 30)
+      .padding(.bottom, 10)
     }
-    .padding(.top, 36)
-    .padding(.bottom, 8)
+  }
+}
+
+private struct ShelfSpineTabSlot: View {
+  let tab: TerminalTabItem
+  let isActive: Bool
+  let hasUnseenNotification: Bool
+  let onTap: () -> Void
+
+  var body: some View {
+    Button(action: onTap) {
+      ZStack {
+        backgroundFill
+        Image(systemName: tab.icon ?? ShelfMetrics.defaultTabIcon)
+          .imageScale(.small)
+          .foregroundStyle(foregroundTint)
+          .accessibilityHidden(true)
+      }
+      .frame(width: ShelfMetrics.slotSize, height: ShelfMetrics.slotSize)
+      .contentShape(.rect)
+    }
+    .buttonStyle(.plain)
+    .help(tab.title)
+  }
+
+  @ViewBuilder
+  private var backgroundFill: some View {
+    if hasUnseenNotification {
+      // Same tint as Canvas title-bar notification highlight so Shelf's
+      // per-tab unread indicator reads as "this tab" rather than a new
+      // idiom. Wins over the active-tab highlight when both apply.
+      RoundedRectangle(cornerRadius: ShelfMetrics.slotCornerRadius, style: .continuous)
+        .fill(Color.orange.opacity(0.3))
+    } else if isActive {
+      RoundedRectangle(cornerRadius: ShelfMetrics.slotCornerRadius, style: .continuous)
+        .fill(Color.accentColor.opacity(0.2))
+    } else {
+      Color.clear
+    }
+  }
+
+  private var foregroundTint: Color {
+    if hasUnseenNotification { return .primary }
+    if isActive { return .primary }
+    return .secondary
   }
 }
 
@@ -75,4 +170,11 @@ private struct ShelfSpineHeader: View {
 enum ShelfMetrics {
   /// Width of a single spine (roughly one line of text).
   static let spineWidth: CGFloat = 26
+  static let slotSize: CGFloat = 22
+  static let slotCornerRadius: CGFloat = 4
+  static let slotSpacing: CGFloat = 3
+  static let slotHorizontalPadding: CGFloat = 2
+  static let aggregatedDotSize: CGFloat = 6
+  /// Fallback icon when a tab has no custom icon set.
+  static let defaultTabIcon: String = "terminal"
 }

--- a/supacode/Features/Shelf/Views/ShelfSpineView.swift
+++ b/supacode/Features/Shelf/Views/ShelfSpineView.swift
@@ -26,22 +26,28 @@ struct ShelfSpineView: View {
     VStack(spacing: 0) {
       headerButton
       tabList
-      // Flexible spacer keeps the tap target for "open this book" filling
-      // any leftover vertical space between the tab list and the bottom
-      // controls.
-      Button(action: onOpenBook) {
-        Color.clear
-          .contentShape(.rect)
-      }
-      .buttonStyle(.plain)
-      .contextMenu { bookContextMenu }
       bottomControls
     }
     .frame(width: ShelfMetrics.spineWidth)
     .background(spineBackground)
+    // Whole-spine tap target. Inner Buttons (header, tab slots, controls)
+    // absorb their own clicks; clicks that fall on empty areas (scroll
+    // view negative space, gaps between tabs, etc.) bubble here and open
+    // the book. Keeps the "books on a shelf" metaphor: grab anywhere on
+    // the spine to pull the book out.
+    .contentShape(.rect)
+    .onTapGesture { onOpenBook() }
+    .contextMenu { bookContextMenu }
     .overlay(alignment: .trailing) {
       if !isOpen {
-        Divider().opacity(0.35)
+        // Explicit 1pt vertical rule. `Divider()` used here before
+        // rendered a *horizontal* hairline (no stack context → default
+        // horizontal orientation) spanning the spine's full width at
+        // its vertical center, lining up across every closed spine and
+        // looking like a single white bar cutting through the Shelf.
+        Rectangle()
+          .fill(Color.secondary.opacity(0.1))
+          .frame(width: 1)
       }
     }
     .help(book.displayName)
@@ -60,24 +66,35 @@ struct ShelfSpineView: View {
 
   @ViewBuilder
   private var bottomControls: some View {
-    if let onNewTab, let onSplitVertical, let onSplitHorizontal {
+    // `+` is shown on every spine, not just the open one: clicking it on a
+    // closed book opens that book and creates a tab in one motion (the
+    // caller sequences `selectWorktree` → `newTerminal`). Splits only
+    // make sense against a focused surface, so they stay scoped to the
+    // open book.
+    if onNewTab != nil || onSplitVertical != nil || onSplitHorizontal != nil {
       VStack(spacing: ShelfMetrics.slotSpacing) {
         Divider().opacity(0.3)
-        ShelfSpineControlButton(
-          systemImage: "plus",
-          label: "New Tab",
-          action: onNewTab
-        )
-        ShelfSpineControlButton(
-          systemImage: "square.split.2x1",
-          label: "Split Vertically",
-          action: onSplitVertical
-        )
-        ShelfSpineControlButton(
-          systemImage: "square.split.1x2",
-          label: "Split Horizontally",
-          action: onSplitHorizontal
-        )
+        if let onNewTab {
+          ShelfSpineControlButton(
+            systemImage: "plus",
+            label: "New Tab",
+            action: onNewTab
+          )
+        }
+        if let onSplitVertical {
+          ShelfSpineControlButton(
+            systemImage: "square.split.2x1",
+            label: "Split Vertically",
+            action: onSplitVertical
+          )
+        }
+        if let onSplitHorizontal {
+          ShelfSpineControlButton(
+            systemImage: "square.split.1x2",
+            label: "Split Horizontally",
+            action: onSplitHorizontal
+          )
+        }
       }
       .padding(.horizontal, ShelfMetrics.slotHorizontalPadding)
       .padding(.bottom, ShelfMetrics.slotSpacing)
@@ -101,47 +118,65 @@ struct ShelfSpineView: View {
   @ViewBuilder
   private var tabList: some View {
     if let terminalState {
-      ScrollView(.vertical, showsIndicators: false) {
-        VStack(spacing: ShelfMetrics.slotSpacing) {
-          ForEach(Array(terminalState.tabManager.tabs.enumerated()), id: \.element.id) { index, tab in
-            // 1-based hotkey number that matches Cmd+1..9. Tabs at
-            // positions 10+ intentionally have no hotkey: they keep
-            // showing their icon even while ⌘ is held.
-            let hotkeyIndex = index < 9 ? index + 1 : nil
-            ShelfSpineTabSlot(
-              tab: tab,
-              hotkeyIndex: hotkeyIndex,
-              isActive: terminalState.tabManager.selectedTabId == tab.id,
-              hasUnseenNotification: terminalState.hasUnseenNotification(for: tab.id),
-              onTap: { onSelectTab(tab.id) },
-              onClose: { terminalState.closeTab(tab.id) }
-            )
-            .terminalTabContextMenu(
-              tabId: tab.id,
-              tabs: terminalState.tabManager.tabs,
-              actions: TerminalTabContextMenuActions(
-                changeTitle: { terminalState.promptChangeTabTitle($0) },
-                changeIcon: { terminalState.presentIconPicker(for: $0) },
-                closeTab: { terminalState.closeTab($0) },
-                closeOthers: { terminalState.closeOtherTabs(keeping: $0) },
-                closeToRight: { terminalState.closeTabsToRight(of: $0) },
-                closeAll: { terminalState.closeAllTabs() }
-              )
-            )
-          }
-        }
-        .padding(.horizontal, ShelfMetrics.slotHorizontalPadding)
-        .padding(.top, ShelfMetrics.slotSpacing)
-      }
-      .scrollBounceBehavior(.basedOnSize)
+      // We avoid wrapping the slots in a `ScrollView` here. On macOS 26,
+      // a vertical `ScrollView` renders a faint horizontal hairline at
+      // its content/clip-bounds boundary even with `showsIndicators` off
+      // and `scrollBounceBehavior(.basedOnSize)` set. Because the
+      // ScrollView's frame is identical across sibling spines (the
+      // header and bottom controls share height), that hairline lines
+      // up across every spine and looks like one continuous horizontal
+      // white bar cutting through the whole Shelf. Short tab lists
+      // don't need scrolling anyway; for very long lists we'll layer
+      // scrolling back in once the rendering issue is understood.
+      tabListContent(state: terminalState)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
     }
+  }
+
+  @ViewBuilder
+  private func tabListContent(state terminalState: WorktreeTerminalState) -> some View {
+    VStack(spacing: ShelfMetrics.slotSpacing) {
+      ForEach(Array(terminalState.tabManager.tabs.enumerated()), id: \.element.id) { index, tab in
+        // 1-based hotkey number that matches Cmd+1..9. Tabs at
+        // positions 10+ intentionally have no hotkey: they keep
+        // showing their icon even while ⌘ is held.
+        let hotkeyIndex = index < 9 ? index + 1 : nil
+        ShelfSpineTabSlot(
+          tab: tab,
+          hotkeyIndex: hotkeyIndex,
+          isActive: terminalState.tabManager.selectedTabId == tab.id,
+          hasUnseenNotification: terminalState.hasUnseenNotification(for: tab.id),
+          onTap: { onSelectTab(tab.id) },
+          onClose: { terminalState.closeTab(tab.id) }
+        )
+        .terminalTabContextMenu(
+          tabId: tab.id,
+          tabs: terminalState.tabManager.tabs,
+          actions: TerminalTabContextMenuActions(
+            changeTitle: { terminalState.promptChangeTabTitle($0) },
+            changeIcon: { terminalState.presentIconPicker(for: $0) },
+            closeTab: { terminalState.closeTab($0) },
+            closeOthers: { terminalState.closeOtherTabs(keeping: $0) },
+            closeToRight: { terminalState.closeTabsToRight(of: $0) },
+            closeAll: { terminalState.closeAllTabs() }
+          )
+        )
+      }
+    }
+    .padding(.horizontal, ShelfMetrics.slotHorizontalPadding)
+    .padding(.top, ShelfMetrics.slotSpacing)
   }
 
   /// Visual treatment splits into two bands:
   ///
-  /// - **Closed spines** get a subtle material tint so the collected
-  ///   stack reads as "books on the shelf" rather than leaking into the
-  ///   terminal-area background.
+  /// - **Closed spines** get a subtle opaque tint so the collected stack
+  ///   reads as "books on the shelf" rather than leaking into the
+  ///   terminal-area background. We deliberately avoid `.thinMaterial`
+  ///   here: when adjacent spines all use the same material and the
+  ///   ScrollView's visible region has an edge, the material's vibrancy
+  ///   layer can render a visible banding line at that edge, lining up
+  ///   across every spine into a continuous horizontal stripe. A flat
+  ///   opaque fill sidesteps the issue entirely.
   /// - **The open spine** gets an accent tint and no trailing divider,
   ///   so it reads as the left edge of the "open page" (per the
   ///   Open Book Visual Distinction section of the design doc).
@@ -150,8 +185,7 @@ struct ShelfSpineView: View {
     if isOpen {
       Color.accentColor.opacity(0.12)
     } else {
-      Rectangle()
-        .fill(.thinMaterial)
+      Color.primary.opacity(0.06)
     }
   }
 }
@@ -162,38 +196,45 @@ private struct ShelfSpineHeader: View {
 
   var body: some View {
     VStack(spacing: 6) {
-      ZStack(alignment: .top) {
-        Circle()
-          .fill(.orange)
-          .frame(width: ShelfMetrics.aggregatedDotSize, height: ShelfMetrics.aggregatedDotSize)
-          .opacity(hasAggregatedNotification ? 1 : 0)
-          .accessibilityLabel("Unread notifications")
-          .accessibilityHidden(!hasAggregatedNotification)
-      }
-      .frame(height: ShelfMetrics.aggregatedDotSize)
-      .padding(.top, 6)
-      VStack(spacing: 6) {
-        Text(book.displayName)
-          .font(.callout.weight(.semibold))
-          .lineLimit(1)
-          .truncationMode(.tail)
-          .fixedSize()
-          .rotationEffect(.degrees(90))
-          .frame(width: ShelfMetrics.spineWidth, alignment: .center)
-        if let branchName = book.branchName, branchName != book.displayName {
-          Text(branchName)
-            .font(.caption)
-            .foregroundStyle(.secondary)
-            .lineLimit(1)
-            .truncationMode(.tail)
-            .fixedSize()
-            .rotationEffect(.degrees(90))
-            .frame(width: ShelfMetrics.spineWidth, alignment: .center)
-        }
-      }
-      .padding(.top, 30)
-      .padding(.bottom, 10)
+      Circle()
+        .fill(.orange)
+        .frame(width: ShelfMetrics.aggregatedDotSize, height: ShelfMetrics.aggregatedDotSize)
+        .opacity(hasAggregatedNotification ? 1 : 0)
+        .accessibilityLabel("Unread notifications")
+        .accessibilityHidden(!hasAggregatedNotification)
+        .padding(.top, 6)
+      rotatedTitle
     }
+  }
+
+  /// Composed title rendered vertically (top-to-bottom reading direction).
+  /// Project name is primary; the `· branch` suffix is secondary so the
+  /// user can scan the spine and pick out the repo at a glance even on
+  /// repositories with many worktrees.
+  @ViewBuilder
+  private var rotatedTitle: some View {
+    combinedTitle
+      .font(.callout)
+      .lineLimit(1)
+      .truncationMode(.middle)
+      .frame(width: ShelfMetrics.headerMaxLength, alignment: .leading)
+      .rotationEffect(.degrees(90))
+      .frame(width: ShelfMetrics.spineWidth, height: ShelfMetrics.headerMaxLength)
+  }
+
+  /// Single composed `Text` (string-interpolation form) so middle-
+  /// truncation can operate across project + branch as one string.
+  /// `foregroundStyle` on each interpolated piece survives composition
+  /// and drives the primary/secondary split.
+  private var combinedTitle: Text {
+    let project = Text(book.projectName)
+      .font(.callout.weight(.semibold))
+      .foregroundStyle(.primary)
+    guard let branch = book.branchName, !branch.isEmpty else {
+      return project
+    }
+    let branchText = Text(" · \(branch)").foregroundStyle(.secondary)
+    return Text("\(project)\(branchText)")
   }
 }
 
@@ -239,19 +280,24 @@ private struct ShelfSpineTabSlot: View {
   }
 
   /// When ⌘ is held AND this tab has a `Cmd+N` hotkey, swap the icon
-  /// for the digit in-place. Slot frame stays the same either way so
-  /// nothing reflows.
+  /// for a compact `⌘N` glyph in-place. Slot frame stays the same either
+  /// way so nothing reflows.
   @ViewBuilder
   private var slotContent: some View {
     let showsHotkey = commandKeyObserver.isPressed && hotkeyIndex != nil
     if let hotkeyIndex, showsHotkey {
-      Text("\(hotkeyIndex)")
-        .font(.callout.weight(.semibold).monospacedDigit())
-        .foregroundStyle(foregroundTint)
-        .accessibilityHidden(true)
+      HStack(spacing: 1) {
+        Image(systemName: "command")
+          .font(.system(size: 8, weight: .semibold))
+          .foregroundStyle(foregroundTint)
+        Text("\(hotkeyIndex)")
+          .font(.callout.weight(.semibold).monospacedDigit())
+          .foregroundStyle(foregroundTint)
+      }
+      .accessibilityHidden(true)
     } else {
       Image(systemName: tab.icon ?? ShelfMetrics.defaultTabIcon)
-        .imageScale(.small)
+        .imageScale(.medium)
         .foregroundStyle(foregroundTint)
         // Dim tabs without a hotkey when ⌘ is held, so the "this slot
         // can't be jumped to via Cmd+N" affordance is legible without
@@ -292,7 +338,7 @@ private struct ShelfSpineControlButton: View {
   var body: some View {
     Button(action: action) {
       Image(systemName: systemImage)
-        .imageScale(.small)
+        .imageScale(.medium)
         .foregroundStyle(.secondary)
         .frame(width: ShelfMetrics.slotSize, height: ShelfMetrics.slotSize)
         .contentShape(.rect)
@@ -305,13 +351,17 @@ private struct ShelfSpineControlButton: View {
 
 /// Shared metrics for the Shelf layout so the three segments stay in sync.
 enum ShelfMetrics {
-  /// Width of a single spine (roughly one line of text).
-  static let spineWidth: CGFloat = 26
-  static let slotSize: CGFloat = 22
-  static let slotCornerRadius: CGFloat = 4
+  /// Width of a single spine. Sized for comfortable one-line-of-text plus
+  /// a bit of breathing room around the rotated title.
+  static let spineWidth: CGFloat = 34
+  static let slotSize: CGFloat = 28
+  static let slotCornerRadius: CGFloat = 5
   static let slotSpacing: CGFloat = 3
-  static let slotHorizontalPadding: CGFloat = 2
+  static let slotHorizontalPadding: CGFloat = 3
   static let aggregatedDotSize: CGFloat = 6
+  /// Max pre-rotation width (i.e. visual height after 90° rotation) of the
+  /// spine header title. Texts longer than this get middle-truncated.
+  static let headerMaxLength: CGFloat = 160
   /// Fallback icon when a tab has no custom icon set.
   static let defaultTabIcon: String = "terminal"
 }

--- a/supacode/Features/Shelf/Views/ShelfSpineView.swift
+++ b/supacode/Features/Shelf/Views/ShelfSpineView.swift
@@ -37,6 +37,11 @@ struct ShelfSpineView: View {
       bottomControls
     }
     .frame(width: ShelfMetrics.spineWidth)
+    // `maxHeight: .infinity` binds the spine to the parent Shelf's
+    // available height (set by `ShelfView.frame(maxHeight: .infinity)`).
+    // Without this, a long tab list would let the spine VStack grow to
+    // its intrinsic size and push the entire window taller.
+    .frame(maxHeight: .infinity, alignment: .top)
     .background(
       // Single `Rectangle` with a computed fill so the color change
       // interpolates in place as `distanceFromOpen` shifts, rather than
@@ -176,18 +181,22 @@ struct ShelfSpineView: View {
   @ViewBuilder
   private var tabList: some View {
     if let terminalState {
-      // We avoid wrapping the slots in a `ScrollView` here. On macOS 26,
-      // a vertical `ScrollView` renders a faint horizontal hairline at
-      // its content/clip-bounds boundary even with `showsIndicators` off
-      // and `scrollBounceBehavior(.basedOnSize)` set. Because the
-      // ScrollView's frame is identical across sibling spines (the
-      // header and bottom controls share height), that hairline lines
-      // up across every spine and looks like one continuous horizontal
-      // white bar cutting through the whole Shelf. Short tab lists
-      // don't need scrolling anyway; for very long lists we'll layer
-      // scrolling back in once the rendering issue is understood.
-      tabListContent(state: terminalState)
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+      // Scroll the tab slots when they overflow the spine so the window
+      // height stays capped instead of growing unbounded with tab count.
+      // `.scrollIndicators(.never)` — stronger than `.hidden`, which
+      // still shows scroll bars when the user has "Always show scroll
+      // bars" enabled in System Settings. The 34pt-wide spine has no
+      // room to donate to a scroll bar, so we always hide it.
+      // `.scrollBounceBehavior(.basedOnSize)` keeps short lists static.
+      // `.clipped()` eats any overdraw at the scroll-view edges so the
+      // spine boundary stays crisp.
+      ScrollView(.vertical) {
+        tabListContent(state: terminalState)
+      }
+      .scrollIndicators(.never)
+      .scrollBounceBehavior(.basedOnSize)
+      .clipped()
+      .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
     }
   }
 

--- a/supacode/Features/Shelf/Views/ShelfSpineView.swift
+++ b/supacode/Features/Shelf/Views/ShelfSpineView.swift
@@ -54,9 +54,14 @@ struct ShelfSpineView: View {
     if let terminalState {
       ScrollView(.vertical, showsIndicators: false) {
         VStack(spacing: ShelfMetrics.slotSpacing) {
-          ForEach(terminalState.tabManager.tabs) { tab in
+          ForEach(Array(terminalState.tabManager.tabs.enumerated()), id: \.element.id) { index, tab in
+            // 1-based hotkey number that matches Cmd+1..9. Tabs at
+            // positions 10+ intentionally have no hotkey: they keep
+            // showing their icon even while ⌘ is held.
+            let hotkeyIndex = index < 9 ? index + 1 : nil
             ShelfSpineTabSlot(
               tab: tab,
+              hotkeyIndex: hotkeyIndex,
               isActive: terminalState.tabManager.selectedTabId == tab.id,
               hasUnseenNotification: terminalState.hasUnseenNotification(for: tab.id),
               onTap: { onSelectTab(tab.id) }
@@ -123,24 +128,47 @@ private struct ShelfSpineHeader: View {
 
 private struct ShelfSpineTabSlot: View {
   let tab: TerminalTabItem
+  let hotkeyIndex: Int?
   let isActive: Bool
   let hasUnseenNotification: Bool
   let onTap: () -> Void
+
+  @Environment(CommandKeyObserver.self) private var commandKeyObserver
 
   var body: some View {
     Button(action: onTap) {
       ZStack {
         backgroundFill
-        Image(systemName: tab.icon ?? ShelfMetrics.defaultTabIcon)
-          .imageScale(.small)
-          .foregroundStyle(foregroundTint)
-          .accessibilityHidden(true)
+        slotContent
       }
       .frame(width: ShelfMetrics.slotSize, height: ShelfMetrics.slotSize)
       .contentShape(.rect)
     }
     .buttonStyle(.plain)
     .help(tab.title)
+  }
+
+  /// When ⌘ is held AND this tab has a `Cmd+N` hotkey, swap the icon
+  /// for the digit in-place. Slot frame stays the same either way so
+  /// nothing reflows.
+  @ViewBuilder
+  private var slotContent: some View {
+    let showsHotkey = commandKeyObserver.isPressed && hotkeyIndex != nil
+    if let hotkeyIndex, showsHotkey {
+      Text("\(hotkeyIndex)")
+        .font(.callout.weight(.semibold).monospacedDigit())
+        .foregroundStyle(foregroundTint)
+        .accessibilityHidden(true)
+    } else {
+      Image(systemName: tab.icon ?? ShelfMetrics.defaultTabIcon)
+        .imageScale(.small)
+        .foregroundStyle(foregroundTint)
+        // Dim tabs without a hotkey when ⌘ is held, so the "this slot
+        // can't be jumped to via Cmd+N" affordance is legible without
+        // shifting any layout.
+        .opacity(commandKeyObserver.isPressed && hotkeyIndex == nil ? 0.45 : 1)
+        .accessibilityHidden(true)
+    }
   }
 
   @ViewBuilder

--- a/supacode/Features/Shelf/Views/ShelfSpineView.swift
+++ b/supacode/Features/Shelf/Views/ShelfSpineView.swift
@@ -137,12 +137,21 @@ struct ShelfSpineView: View {
     }
   }
 
+  /// Visual treatment splits into two bands:
+  ///
+  /// - **Closed spines** get a subtle material tint so the collected
+  ///   stack reads as "books on the shelf" rather than leaking into the
+  ///   terminal-area background.
+  /// - **The open spine** gets an accent tint and no trailing divider,
+  ///   so it reads as the left edge of the "open page" (per the
+  ///   Open Book Visual Distinction section of the design doc).
   @ViewBuilder
   private var spineBackground: some View {
     if isOpen {
       Color.accentColor.opacity(0.12)
     } else {
-      Color.clear
+      Rectangle()
+        .fill(.thinMaterial)
     }
   }
 }

--- a/supacode/Features/Shelf/Views/ShelfSpineView.swift
+++ b/supacode/Features/Shelf/Views/ShelfSpineView.swift
@@ -13,18 +13,25 @@ struct ShelfSpineView: View {
   let terminalState: WorktreeTerminalState?
   let onOpenBook: () -> Void
   let onSelectTab: (TerminalTabID) -> Void
+  /// Bottom controls — provided only for the open book's spine. `nil`
+  /// suppresses the trio entirely.
+  let onNewTab: (() -> Void)?
+  let onSplitVertical: (() -> Void)?
+  let onSplitHorizontal: (() -> Void)?
 
   var body: some View {
     VStack(spacing: 0) {
       headerButton
       tabList
       // Flexible spacer keeps the tap target for "open this book" filling
-      // any leftover vertical space below the tab list.
+      // any leftover vertical space between the tab list and the bottom
+      // controls.
       Button(action: onOpenBook) {
         Color.clear
           .contentShape(.rect)
       }
       .buttonStyle(.plain)
+      bottomControls
     }
     .frame(width: ShelfMetrics.spineWidth)
     .background(spineBackground)
@@ -34,6 +41,32 @@ struct ShelfSpineView: View {
       }
     }
     .help(book.displayName)
+  }
+
+  @ViewBuilder
+  private var bottomControls: some View {
+    if let onNewTab, let onSplitVertical, let onSplitHorizontal {
+      VStack(spacing: ShelfMetrics.slotSpacing) {
+        Divider().opacity(0.3)
+        ShelfSpineControlButton(
+          systemImage: "plus",
+          label: "New Tab",
+          action: onNewTab
+        )
+        ShelfSpineControlButton(
+          systemImage: "square.split.2x1",
+          label: "Split Vertically",
+          action: onSplitVertical
+        )
+        ShelfSpineControlButton(
+          systemImage: "square.split.1x2",
+          label: "Split Horizontally",
+          action: onSplitHorizontal
+        )
+      }
+      .padding(.horizontal, ShelfMetrics.slotHorizontalPadding)
+      .padding(.bottom, ShelfMetrics.slotSpacing)
+    }
   }
 
   @ViewBuilder
@@ -191,6 +224,25 @@ private struct ShelfSpineTabSlot: View {
     if hasUnseenNotification { return .primary }
     if isActive { return .primary }
     return .secondary
+  }
+}
+
+private struct ShelfSpineControlButton: View {
+  let systemImage: String
+  let label: String
+  let action: () -> Void
+
+  var body: some View {
+    Button(action: action) {
+      Image(systemName: systemImage)
+        .imageScale(.small)
+        .foregroundStyle(.secondary)
+        .frame(width: ShelfMetrics.slotSize, height: ShelfMetrics.slotSize)
+        .contentShape(.rect)
+        .accessibilityHidden(true)
+    }
+    .buttonStyle(.plain)
+    .help(label)
   }
 }
 

--- a/supacode/Features/Shelf/Views/ShelfSpineView.swift
+++ b/supacode/Features/Shelf/Views/ShelfSpineView.swift
@@ -28,6 +28,8 @@ struct ShelfSpineView: View {
   /// the spine header / empty body. Nil disables the menu.
   let onRemoveBook: (() -> Void)?
 
+  @State private var isHovering = false
+
   var body: some View {
     VStack(spacing: 0) {
       headerButton
@@ -52,6 +54,8 @@ struct ShelfSpineView: View {
     .onTapGesture { onOpenBook() }
     .accessibilityAddTraits(.isButton)
     .contextMenu { bookContextMenu }
+    .onHover { isHovering = $0 }
+    .animation(.easeOut(duration: 0.12), value: isHovering)
     .overlay(alignment: .trailing) {
       if !isOpen {
         // Explicit 1pt vertical rule. `Divider()` used here before
@@ -81,12 +85,16 @@ struct ShelfSpineView: View {
 
   /// When no book is open (empty shelf), fall back to the neutral gray
   /// used everywhere else so spines don't become invisible; otherwise
-  /// derive from the proximity ladder.
+  /// derive from the proximity ladder. Hovering an unselected spine
+  /// bumps its tint to 80% of the selected book's intensity — a clear
+  /// "this is interactable" affordance that sits just below the open
+  /// book and animates in/out smoothly.
   private var spineBackgroundColor: Color {
     guard distanceFromOpen != nil else {
       return Color.primary.opacity(0.06)
     }
-    return Color.accentColor.opacity(0.20 * accentProximityMultiplier)
+    let multiplier = isHovering && !isOpen ? 0.8 : accentProximityMultiplier
+    return Color.accentColor.opacity(0.20 * multiplier)
   }
 
   /// Active-tab highlight fades more gently than the spine background —

--- a/supacode/Features/Shelf/Views/ShelfSpineView.swift
+++ b/supacode/Features/Shelf/Views/ShelfSpineView.swift
@@ -10,6 +10,12 @@ import SwiftUI
 struct ShelfSpineView: View {
   let book: ShelfBook
   let isOpen: Bool
+  /// Absolute distance along the ordered book list between this spine and
+  /// the currently open book (0 = this *is* the open book, 1 = immediate
+  /// neighbor, …). Nil when no book is open. Drives the step-wise accent
+  /// tint that fades outward from the open book, so proximity reads at a
+  /// glance instead of every non-open spine looking identical.
+  let distanceFromOpen: Int?
   let terminalState: WorktreeTerminalState?
   let onOpenBook: () -> Void
   let onSelectTab: (TerminalTabID) -> Void
@@ -30,11 +36,12 @@ struct ShelfSpineView: View {
     }
     .frame(width: ShelfMetrics.spineWidth)
     .background(
-      // Single `Rectangle` with a ternary fill so the open↔closed color
-      // change interpolates in place rather than swapping one view for
-      // another (which the previous `@ViewBuilder` if/else did).
-      Rectangle()
-        .fill(isOpen ? Color.accentColor.opacity(0.12) : Color.primary.opacity(0.06))
+      // Single `Rectangle` with a computed fill so the color change
+      // interpolates in place as `distanceFromOpen` shifts, rather than
+      // swapping one view for another (which the previous `@ViewBuilder`
+      // if/else did). Fill is derived from a stepped accent-alpha ladder
+      // so the open book glows strongest and neighbors fade outward.
+      Rectangle().fill(spineBackgroundColor)
     )
     // Whole-spine tap target. Inner Buttons (header, tab slots, controls)
     // absorb their own clicks; clicks that fall on empty areas (scroll
@@ -58,6 +65,42 @@ struct ShelfSpineView: View {
       }
     }
     .help(book.displayName)
+  }
+
+  /// Step-wise accent-alpha ladder keyed by `distanceFromOpen`. 100%
+  /// (selected) → 50% → 30% → 20% → 10% → 5%; beyond the ladder the
+  /// multiplier is 0 so the halo is bounded. The sharp drop at distance
+  /// 1 keeps the open book clearly dominant rather than blending into
+  /// its neighbors. Shared by the spine background and the per-tab
+  /// active-highlight fill so they fade in lockstep.
+  private var accentProximityMultiplier: Double {
+    guard let distance = distanceFromOpen else { return 0 }
+    let ladder: [Double] = [1.0, 0.5, 0.3, 0.2, 0.1, 0.05]
+    return distance < ladder.count ? ladder[distance] : 0
+  }
+
+  /// When no book is open (empty shelf), fall back to the neutral gray
+  /// used everywhere else so spines don't become invisible; otherwise
+  /// derive from the proximity ladder.
+  private var spineBackgroundColor: Color {
+    guard distanceFromOpen != nil else {
+      return Color.primary.opacity(0.06)
+    }
+    return Color.accentColor.opacity(0.20 * accentProximityMultiplier)
+  }
+
+  /// Active-tab highlight fades more gently than the spine background —
+  /// the tab-selection indicator has to stay legible even on far-away
+  /// books so users can still see which tab would open. Uses absolute
+  /// alpha stops (0.20 / 0.15 / 0.10) rather than the spine's multiplier
+  /// ladder; the two axes are tuned independently for their own roles.
+  private var activeTabHighlightAlpha: Double {
+    guard let distance = distanceFromOpen else { return 0.2 }
+    switch distance {
+    case 0: return 0.2
+    case 1: return 0.15
+    default: return 0.1
+    }
   }
 
   @ViewBuilder
@@ -153,6 +196,7 @@ struct ShelfSpineView: View {
           hotkeyIndex: hotkeyIndex,
           isActive: terminalState.tabManager.selectedTabId == tab.id,
           hasUnseenNotification: terminalState.hasUnseenNotification(for: tab.id),
+          activeHighlightAlpha: activeTabHighlightAlpha,
           onTap: { onSelectTab(tab.id) },
           onClose: { terminalState.closeTab(tab.id) }
         )
@@ -229,6 +273,13 @@ private struct ShelfSpineTabSlot: View {
   let hotkeyIndex: Int?
   let isActive: Bool
   let hasUnseenNotification: Bool
+  /// Absolute alpha for the active-tab accent fill, supplied by the
+  /// enclosing spine so it can fade with proximity on its own curve
+  /// (which decays more gently than the spine background — selection
+  /// indicators must stay legible even on far books). Orange
+  /// notification tint is left untouched so unread signals remain
+  /// attention-grabbing regardless of distance.
+  let activeHighlightAlpha: Double
   let onTap: () -> Void
   let onClose: () -> Void
 
@@ -303,7 +354,7 @@ private struct ShelfSpineTabSlot: View {
         .fill(Color.orange.opacity(0.3))
     } else if isActive {
       RoundedRectangle(cornerRadius: ShelfMetrics.slotCornerRadius, style: .continuous)
-        .fill(Color.accentColor.opacity(0.2))
+        .fill(Color.accentColor.opacity(activeHighlightAlpha))
     } else {
       Color.clear
     }

--- a/supacode/Features/Shelf/Views/ShelfView.swift
+++ b/supacode/Features/Shelf/Views/ShelfView.swift
@@ -14,6 +14,11 @@ struct ShelfView: View {
   let terminalManager: WorktreeTerminalManager
   let createTab: () -> Void
 
+  /// Shared namespace so each spine's `matchedGeometryEffect` can bridge
+  /// the left-stack ForEach and the right-stack ForEach without breaking
+  /// visual identity while it moves between them.
+  @Namespace private var spineNamespace
+
   var body: some View {
     let state = store.state
     let books = state.orderedShelfBooks()
@@ -26,6 +31,7 @@ struct ShelfView: View {
       if let openIndex {
         spineStack(books: Array(books[0...openIndex]))
         openBookArea(for: books[openIndex], state: state)
+          .transition(.opacity)
         let rightStart = openIndex + 1
         if rightStart < books.count {
           spineStack(books: Array(books[rightStart..<books.count]))
@@ -37,6 +43,11 @@ struct ShelfView: View {
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)
     .background(.background)
+    // Animate on every openBookID change — covers both Shelf-originated
+    // book switches (which also set their own TCA animation) and
+    // left-nav-originated switches, so the spine flow is consistent
+    // regardless of entry point.
+    .animation(.easeInOut(duration: 0.2), value: openBookID)
   }
 
   @ViewBuilder
@@ -53,6 +64,7 @@ struct ShelfView: View {
           onSplitVertical: isOpen(book) ? { performSplit(direction: "new_split:right") } : nil,
           onSplitHorizontal: isOpen(book) ? { performSplit(direction: "new_split:down") } : nil
         )
+        .matchedGeometryEffect(id: book.id, in: spineNamespace)
       }
     }
   }
@@ -108,11 +120,14 @@ struct ShelfView: View {
       state.tabManager.selectTab(tabID)
       return
     }
+    // Animate the spine flow and terminal crossfade. The duration and
+    // curve mirror the Shelf design doc: ~200ms ease-in-out, snappy but
+    // legible so the user can read each spine's movement.
     switch book.kind {
     case .worktree:
-      store.send(.selectWorktree(book.id, focusTerminal: true))
+      store.send(.selectWorktree(book.id, focusTerminal: true), animation: .easeInOut(duration: 0.2))
     case .plainFolder:
-      store.send(.selectRepository(book.repositoryID))
+      store.send(.selectRepository(book.repositoryID), animation: .easeInOut(duration: 0.2))
     }
     if let tabID {
       // Apply tab selection eagerly; the target book's state already exists

--- a/supacode/Features/Shelf/Views/ShelfView.swift
+++ b/supacode/Features/Shelf/Views/ShelfView.swift
@@ -3,11 +3,12 @@ import SwiftUI
 
 /// Root view for Shelf presentation mode.
 ///
-/// Phase 2 layout: three horizontal segments — a left stack of passed
-/// spines, the currently open book's terminal area, and a right stack of
-/// upcoming spines. Subsequent phases layer in tab slots, animations,
-/// notification badges, the bottom controls, and context menus described
-/// in `doc-onevcat/shelf-view.md`.
+/// Phase 3 layout: three horizontal segments — a left stack of passed
+/// spines (each showing its book's tabs), the currently open book's
+/// terminal area, and a right stack of upcoming spines. Clicking a tab
+/// on any spine opens that book (when different) and selects that tab.
+/// Animations and the ⌘-held digit overlay are layered in subsequent
+/// phases.
 struct ShelfView: View {
   let store: StoreOf<RepositoriesFeature>
   let terminalManager: WorktreeTerminalManager
@@ -22,18 +23,14 @@ struct ShelfView: View {
 
     HStack(spacing: 0) {
       if let openIndex {
-        spineStack(books: Array(books[0...openIndex]), openIndex: openIndex, isLeftStack: true)
+        spineStack(books: Array(books[0...openIndex]))
         openBookArea(for: books[openIndex], state: state)
         let rightStart = openIndex + 1
         if rightStart < books.count {
-          spineStack(
-            books: Array(books[rightStart..<books.count]),
-            openIndex: openIndex,
-            isLeftStack: false
-          )
+          spineStack(books: Array(books[rightStart..<books.count]))
         }
       } else {
-        spineStack(books: books, openIndex: nil, isLeftStack: true)
+        spineStack(books: books)
         emptyOpenArea()
       }
     }
@@ -42,13 +39,15 @@ struct ShelfView: View {
   }
 
   @ViewBuilder
-  private func spineStack(books: [ShelfBook], openIndex: Int?, isLeftStack: Bool) -> some View {
+  private func spineStack(books: [ShelfBook]) -> some View {
     HStack(spacing: 0) {
-      ForEach(Array(books.enumerated()), id: \.element.id) { _, book in
+      ForEach(books) { book in
         ShelfSpineView(
           book: book,
           isOpen: isOpen(book),
-          onTap: { handleSpineTap(book) }
+          terminalState: terminalManager.stateIfExists(for: book.id),
+          onOpenBook: { openBook(book, selectingTab: nil) },
+          onSelectTab: { tabID in openBook(book, selectingTab: tabID) }
         )
       }
     }
@@ -89,12 +88,26 @@ struct ShelfView: View {
     .frame(maxWidth: .infinity, maxHeight: .infinity)
   }
 
-  private func handleSpineTap(_ book: ShelfBook) {
+  /// Open `book` and optionally select a specific tab on it. For the open
+  /// book's own tab slots (no book change), this skips the worktree
+  /// re-selection and just tells the tab manager to switch tab.
+  private func openBook(_ book: ShelfBook, selectingTab tabID: TerminalTabID?) {
+    let isAlreadyOpen = store.state.openShelfBookID == book.id
+    if let tabID, isAlreadyOpen, let state = terminalManager.stateIfExists(for: book.id) {
+      state.tabManager.selectTab(tabID)
+      return
+    }
     switch book.kind {
     case .worktree:
       store.send(.selectWorktree(book.id, focusTerminal: true))
     case .plainFolder:
       store.send(.selectRepository(book.repositoryID))
+    }
+    if let tabID {
+      // Apply tab selection eagerly; the target book's state already exists
+      // if the user has opened it before. For first-time opens the tab
+      // manager seeds a default tab which we won't override.
+      terminalManager.stateIfExists(for: book.id)?.tabManager.selectTab(tabID)
     }
   }
 }

--- a/supacode/Features/Shelf/Views/ShelfView.swift
+++ b/supacode/Features/Shelf/Views/ShelfView.swift
@@ -62,7 +62,8 @@ struct ShelfView: View {
           onSelectTab: { tabID in openBook(book, selectingTab: tabID) },
           onNewTab: isOpen(book) ? createTab : nil,
           onSplitVertical: isOpen(book) ? { performSplit(direction: "new_split:right") } : nil,
-          onSplitHorizontal: isOpen(book) ? { performSplit(direction: "new_split:down") } : nil
+          onSplitHorizontal: isOpen(book) ? { performSplit(direction: "new_split:down") } : nil,
+          onRemoveBook: { removeBook(book) }
         )
         .matchedGeometryEffect(id: book.id, in: spineNamespace)
       }
@@ -74,6 +75,20 @@ struct ShelfView: View {
       let state = terminalManager.stateIfExists(for: openID)
     else { return }
     _ = state.performBindingActionOnFocusedSurface(direction)
+  }
+
+  /// "Remove Book" context action. Worktree books funnel through the
+  /// existing archive flow (which shows confirmation + progress); plain
+  /// folder books go through repository removal. Both pathways
+  /// eventually drop the book off the Shelf via the same prune logic
+  /// that drives the left navigation.
+  private func removeBook(_ book: ShelfBook) {
+    switch book.kind {
+    case .worktree:
+      store.send(.worktreeLifecycle(.requestArchiveWorktree(book.id, book.repositoryID)))
+    case .plainFolder:
+      store.send(.repositoryManagement(.requestRemoveRepository(book.repositoryID)))
+    }
   }
 
   private func isOpen(_ book: ShelfBook) -> Bool {

--- a/supacode/Features/Shelf/Views/ShelfView.swift
+++ b/supacode/Features/Shelf/Views/ShelfView.swift
@@ -3,33 +3,98 @@ import SwiftUI
 
 /// Root view for Shelf presentation mode.
 ///
-/// This is the Phase 1 stub; subsequent phases layer in the three-segment
-/// spine stack, tab slots, animations, and context menus described in
-/// `doc-onevcat/shelf-view.md`.
+/// Phase 2 layout: three horizontal segments — a left stack of passed
+/// spines, the currently open book's terminal area, and a right stack of
+/// upcoming spines. Subsequent phases layer in tab slots, animations,
+/// notification badges, the bottom controls, and context menus described
+/// in `doc-onevcat/shelf-view.md`.
 struct ShelfView: View {
   let store: StoreOf<RepositoriesFeature>
   let terminalManager: WorktreeTerminalManager
 
   var body: some View {
-    VStack(spacing: 12) {
-      Image(systemName: "books.vertical")
-        .font(.system(size: 48))
-        .foregroundStyle(.secondary)
-        .accessibilityHidden(true)
-      Text("Shelf view")
-        .font(.title2)
-      Text("Phase 1 placeholder — spine stack and book content arrive in subsequent phases.")
-        .font(.callout)
-        .foregroundStyle(.secondary)
-        .multilineTextAlignment(.center)
-        .frame(maxWidth: 420)
-      if let worktree = store.selectedTerminalWorktree {
-        Text("Current open book: \(worktree.name)")
-          .font(.callout.monospaced())
-          .foregroundStyle(.tertiary)
+    let state = store.state
+    let books = state.orderedShelfBooks()
+    let openBookID = state.openShelfBookID
+    let openIndex = openBookID.flatMap { id in
+      books.firstIndex(where: { $0.id == id })
+    }
+
+    HStack(spacing: 0) {
+      if let openIndex {
+        spineStack(books: Array(books[0...openIndex]), openIndex: openIndex, isLeftStack: true)
+        openBookArea(for: books[openIndex], state: state)
+        let rightStart = openIndex + 1
+        if rightStart < books.count {
+          spineStack(
+            books: Array(books[rightStart..<books.count]),
+            openIndex: openIndex,
+            isLeftStack: false
+          )
+        }
+      } else {
+        spineStack(books: books, openIndex: nil, isLeftStack: true)
+        emptyOpenArea()
       }
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)
     .background(.background)
+  }
+
+  @ViewBuilder
+  private func spineStack(books: [ShelfBook], openIndex: Int?, isLeftStack: Bool) -> some View {
+    HStack(spacing: 0) {
+      ForEach(Array(books.enumerated()), id: \.element.id) { _, book in
+        ShelfSpineView(
+          book: book,
+          isOpen: isOpen(book),
+          onTap: { handleSpineTap(book) }
+        )
+      }
+    }
+  }
+
+  private func isOpen(_ book: ShelfBook) -> Bool {
+    store.state.openShelfBookID == book.id
+  }
+
+  @ViewBuilder
+  private func openBookArea(for book: ShelfBook, state: RepositoriesFeature.State) -> some View {
+    if let worktree = state.selectedTerminalWorktree, worktree.id == book.id {
+      ShelfOpenBookView(
+        worktree: worktree,
+        manager: terminalManager,
+        shouldRunSetupScript: state.pendingSetupScriptWorktreeIDs.contains(worktree.id)
+      )
+      .frame(maxWidth: .infinity, maxHeight: .infinity)
+      .id(worktree.id)
+    } else {
+      emptyOpenArea()
+    }
+  }
+
+  @ViewBuilder
+  private func emptyOpenArea() -> some View {
+    VStack(spacing: 10) {
+      Image(systemName: "books.vertical")
+        .font(.system(size: 40))
+        .foregroundStyle(.secondary)
+        .accessibilityHidden(true)
+      Text("No book selected")
+        .font(.headline)
+      Text("Click a spine to open a book.")
+        .font(.callout)
+        .foregroundStyle(.secondary)
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+  }
+
+  private func handleSpineTap(_ book: ShelfBook) {
+    switch book.kind {
+    case .worktree:
+      store.send(.selectWorktree(book.id, focusTerminal: true))
+    case .plainFolder:
+      store.send(.selectRepository(book.repositoryID))
+    }
   }
 }

--- a/supacode/Features/Shelf/Views/ShelfView.swift
+++ b/supacode/Features/Shelf/Views/ShelfView.swift
@@ -19,6 +19,13 @@ struct ShelfView: View {
   /// visual identity while it moves between them.
   @Namespace private var spineNamespace
 
+  /// Mirrors the Ghostty `background-opacity` setting so the Shelf can
+  /// honor the same window transparency as normal view mode. A previous
+  /// plain `.background(.background)` defeated transparency entirely by
+  /// stamping an opaque layer behind every child — including the
+  /// terminal surface and empty-state area.
+  @Environment(\.surfaceBackgroundOpacity) private var surfaceBackgroundOpacity
+
   var body: some View {
     let state = store.state
     let books = state.orderedShelfBooks()
@@ -46,7 +53,7 @@ struct ShelfView: View {
       }
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)
-    .background(.background)
+    .background(Color(nsColor: .windowBackgroundColor).opacity(surfaceBackgroundOpacity))
     // Animate on every openBookID change — covers both Shelf-originated
     // book switches (which also set their own TCA animation) and
     // left-nav-originated switches, so the spine flow is consistent

--- a/supacode/Features/Shelf/Views/ShelfView.swift
+++ b/supacode/Features/Shelf/Views/ShelfView.swift
@@ -98,13 +98,20 @@ struct ShelfView: View {
   @ViewBuilder
   private func openBookArea(for book: ShelfBook, state: RepositoriesFeature.State) -> some View {
     if let worktree = state.selectedTerminalWorktree, worktree.id == book.id {
+      let shouldFocus = state.shouldFocusTerminal(for: worktree.id)
       ShelfOpenBookView(
         worktree: worktree,
         manager: terminalManager,
-        shouldRunSetupScript: state.pendingSetupScriptWorktreeIDs.contains(worktree.id)
+        shouldRunSetupScript: state.pendingSetupScriptWorktreeIDs.contains(worktree.id),
+        forceAutoFocus: shouldFocus
       )
       .frame(maxWidth: .infinity, maxHeight: .infinity)
       .id(worktree.id)
+      .onAppear {
+        if shouldFocus {
+          store.send(.worktreeCreation(.consumeTerminalFocus(worktree.id)))
+        }
+      }
     } else {
       emptyOpenArea()
     }

--- a/supacode/Features/Shelf/Views/ShelfView.swift
+++ b/supacode/Features/Shelf/Views/ShelfView.swift
@@ -12,6 +12,7 @@ import SwiftUI
 struct ShelfView: View {
   let store: StoreOf<RepositoriesFeature>
   let terminalManager: WorktreeTerminalManager
+  let createTab: () -> Void
 
   var body: some View {
     let state = store.state
@@ -47,10 +48,20 @@ struct ShelfView: View {
           isOpen: isOpen(book),
           terminalState: terminalManager.stateIfExists(for: book.id),
           onOpenBook: { openBook(book, selectingTab: nil) },
-          onSelectTab: { tabID in openBook(book, selectingTab: tabID) }
+          onSelectTab: { tabID in openBook(book, selectingTab: tabID) },
+          onNewTab: isOpen(book) ? createTab : nil,
+          onSplitVertical: isOpen(book) ? { performSplit(direction: "new_split:right") } : nil,
+          onSplitHorizontal: isOpen(book) ? { performSplit(direction: "new_split:down") } : nil
         )
       }
     }
+  }
+
+  private func performSplit(direction: String) {
+    guard let openID = store.state.openShelfBookID,
+      let state = terminalManager.stateIfExists(for: openID)
+    else { return }
+    _ = state.performBindingActionOnFocusedSurface(direction)
   }
 
   private func isOpen(_ book: ShelfBook) -> Bool {

--- a/supacode/Features/Shelf/Views/ShelfView.swift
+++ b/supacode/Features/Shelf/Views/ShelfView.swift
@@ -60,13 +60,32 @@ struct ShelfView: View {
           terminalState: terminalManager.stateIfExists(for: book.id),
           onOpenBook: { openBook(book, selectingTab: nil) },
           onSelectTab: { tabID in openBook(book, selectingTab: tabID) },
-          onNewTab: isOpen(book) ? createTab : nil,
+          onNewTab: {
+            // On a closed spine, `+` doubles as "pull this book out and
+            // start a fresh tab". Sequencing is fine because TCA runs
+            // reducers synchronously — `newTerminal` will observe the
+            // new `selectedTerminalWorktree` set by `selectWorktree`.
+            switchToBookIfNeeded(book)
+            createTab()
+          },
           onSplitVertical: isOpen(book) ? { performSplit(direction: "new_split:right") } : nil,
           onSplitHorizontal: isOpen(book) ? { performSplit(direction: "new_split:down") } : nil,
           onRemoveBook: { removeBook(book) }
         )
         .matchedGeometryEffect(id: book.id, in: spineNamespace)
       }
+    }
+  }
+
+  /// Dispatch the open-book action only when `book` isn't already the open
+  /// one — idempotent helper for taps that imply a book change.
+  private func switchToBookIfNeeded(_ book: ShelfBook) {
+    guard !isOpen(book) else { return }
+    switch book.kind {
+    case .worktree:
+      store.send(.selectWorktree(book.id, focusTerminal: true), animation: .easeInOut(duration: 0.2))
+    case .plainFolder:
+      store.send(.selectRepository(book.repositoryID), animation: .easeInOut(duration: 0.2))
     }
   }
 

--- a/supacode/Features/Shelf/Views/ShelfView.swift
+++ b/supacode/Features/Shelf/Views/ShelfView.swift
@@ -29,15 +29,19 @@ struct ShelfView: View {
 
     HStack(spacing: 0) {
       if let openIndex {
-        spineStack(books: Array(books[0...openIndex]))
+        spineStack(books: Array(books[0...openIndex]), openIndex: openIndex, baseOffset: 0)
         openBookArea(for: books[openIndex], state: state)
           .transition(.opacity)
         let rightStart = openIndex + 1
         if rightStart < books.count {
-          spineStack(books: Array(books[rightStart..<books.count]))
+          spineStack(
+            books: Array(books[rightStart..<books.count]),
+            openIndex: openIndex,
+            baseOffset: rightStart
+          )
         }
       } else {
-        spineStack(books: books)
+        spineStack(books: books, openIndex: nil, baseOffset: 0)
         emptyOpenArea()
       }
     }
@@ -50,13 +54,20 @@ struct ShelfView: View {
     .animation(.easeInOut(duration: 0.2), value: openBookID)
   }
 
+  /// `baseOffset` is the index of `books.first` within the full ordered
+  /// list, so we can reconstruct each spine's global index and compute
+  /// its distance to `openIndex` without re-scanning the full list.
   @ViewBuilder
-  private func spineStack(books: [ShelfBook]) -> some View {
+  private func spineStack(books: [ShelfBook], openIndex: Int?, baseOffset: Int) -> some View {
     HStack(spacing: 0) {
-      ForEach(books) { book in
+      ForEach(Array(books.enumerated()), id: \.element.id) { localIndex, book in
+        let globalIndex = baseOffset + localIndex
+        let distance = openIndex.map { abs(globalIndex - $0) }
+        let open = globalIndex == openIndex
         ShelfSpineView(
           book: book,
-          isOpen: isOpen(book),
+          isOpen: open,
+          distanceFromOpen: distance,
           terminalState: terminalManager.stateIfExists(for: book.id),
           onOpenBook: { openBook(book, selectingTab: nil) },
           onSelectTab: { tabID in openBook(book, selectingTab: tabID) },
@@ -68,8 +79,8 @@ struct ShelfView: View {
             switchToBookIfNeeded(book)
             createTab()
           },
-          onSplitVertical: isOpen(book) ? { performSplit(direction: "new_split:right") } : nil,
-          onSplitHorizontal: isOpen(book) ? { performSplit(direction: "new_split:down") } : nil,
+          onSplitVertical: open ? { performSplit(direction: "new_split:right") } : nil,
+          onSplitHorizontal: open ? { performSplit(direction: "new_split:down") } : nil,
           onRemoveBook: { removeBook(book) }
         )
         .matchedGeometryEffect(id: book.id, in: spineNamespace)

--- a/supacode/Features/Shelf/Views/ShelfView.swift
+++ b/supacode/Features/Shelf/Views/ShelfView.swift
@@ -1,0 +1,35 @@
+import ComposableArchitecture
+import SwiftUI
+
+/// Root view for Shelf presentation mode.
+///
+/// This is the Phase 1 stub; subsequent phases layer in the three-segment
+/// spine stack, tab slots, animations, and context menus described in
+/// `doc-onevcat/shelf-view.md`.
+struct ShelfView: View {
+  let store: StoreOf<RepositoriesFeature>
+  let terminalManager: WorktreeTerminalManager
+
+  var body: some View {
+    VStack(spacing: 12) {
+      Image(systemName: "books.vertical")
+        .font(.system(size: 48))
+        .foregroundStyle(.secondary)
+        .accessibilityHidden(true)
+      Text("Shelf view")
+        .font(.title2)
+      Text("Phase 1 placeholder — spine stack and book content arrive in subsequent phases.")
+        .font(.callout)
+        .foregroundStyle(.secondary)
+        .multilineTextAlignment(.center)
+        .frame(maxWidth: 420)
+      if let worktree = store.selectedTerminalWorktree {
+        Text("Current open book: \(worktree.name)")
+          .font(.callout.monospaced())
+          .foregroundStyle(.tertiary)
+      }
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .background(.background)
+  }
+}

--- a/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
+++ b/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
@@ -231,8 +231,10 @@ final class WorktreeTerminalManager {
     state.onTabCreated = { [weak self] in
       self?.emit(.tabCreated(worktreeID: worktree.id))
     }
-    state.onTabClosed = { [weak self] in
-      self?.emit(.tabClosed(worktreeID: worktree.id))
+    state.onTabClosed = { [weak self, weak state] in
+      guard let self else { return }
+      let remaining = state?.tabManager.tabs.count ?? 0
+      emit(.tabClosed(worktreeID: worktree.id, remainingTabs: remaining))
     }
     state.onFocusChanged = { [weak self] surfaceID in
       self?.emit(.focusChanged(worktreeID: worktree.id, surfaceID: surfaceID))

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -840,6 +840,16 @@ final class WorktreeTerminalState {
       lastEmittedFocusSurfaceId = nil
     }
     emitTaskStatusIfChanged()
+    // Signal "this worktree now has tabs" so downstream Shelf
+    // bookkeeping (`markWorktreeOpened` via `terminalEvent(.tabCreated)`)
+    // adds the restored worktree to `openedWorktreeIDs`. Without this
+    // emit, only the active worktree (which goes through
+    // `.selectWorktree` on `.layoutRestored`) shows as a book on the
+    // Shelf — every other restored worktree is missing, even though
+    // the sidebar lists it and its terminal state is live.
+    if !restoredTabs.isEmpty {
+      onTabCreated?()
+    }
     terminalStateLogger.info(
       "[LayoutRestore] applySnapshot: success, restored \(restoredTabs.count) tab(s)"
         + " selectedTab=\(selectedTabID?.rawValue.uuidString ?? "nil")"

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -1585,6 +1585,12 @@ final class WorktreeTerminalState {
       if tabId == runScriptTabId {
         setRunScriptTabId(nil)
       }
+      // Mirror `state.closeTab(_:)`'s `onTabClosed` emit: this path
+      // fires when the shell process exits (ghostty-driven close)
+      // and historically skipped the callback, which meant the
+      // Shelf's "retire the book when its last tab closes" logic
+      // never saw this very common path.
+      onTabClosed?()
       return
     }
     updateTree(newTree, for: tabId)

--- a/supacode/Features/Terminal/Views/WindowFocusObserverView.swift
+++ b/supacode/Features/Terminal/Views/WindowFocusObserverView.swift
@@ -1,8 +1,6 @@
 import AppKit
 import SwiftUI
 
-private let windowFocusLogger = SupaLogger("WindowFocus")
-
 struct WindowActivityState: Equatable {
   let isKeyWindow: Bool
   let isVisible: Bool
@@ -51,7 +49,16 @@ final class WindowFocusObserverNSView: NSView {
     clearObservers()
     observedWindow = window
     guard let window else {
-      emitActivityIfNeeded(force: true)
+      // View is being torn down from its window (e.g. a sibling view
+      // swap in SwiftUI). The window itself is not going away — other
+      // observers watching the same `WorktreeTerminalState` are still
+      // live and reflect the real window activity. Emitting an
+      // inactive signal here would poison the shared state's
+      // `lastWindowIsKey`/`lastWindowIsVisible`, causing
+      // `applySurfaceActivity` to demote focus even though the window
+      // is still key. Just stop observing silently and let the
+      // surviving observer drive state. This branch is covered by
+      // `WindowFocusObserverViewTests.detachFromWindowEmitsNothingNew`.
       return
     }
     let center = NotificationCenter.default
@@ -94,11 +101,6 @@ final class WindowFocusObserverNSView: NSView {
       return
     }
     lastEmittedActivity = activity
-    windowFocusLogger.info(
-      "[TerminalWake] activityChanged key=\(activity.isKeyWindow) "
-        + "visible=\(activity.isVisible) force=\(force) "
-        + "windowNumber=\(window?.windowNumber ?? -1)"
-    )
     onWindowActivityChanged(activity)
   }
 

--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
@@ -119,6 +119,7 @@ final class GhosttySurfaceView: NSView, Identifiable {
   private var lastPerformKeyEvent: TimeInterval?
   private var currentCursor: NSCursor = .iBeam
   private var focused = false
+  private var detachedFocusClearTask: Task<Void, Never>?
   private var markedText = NSMutableAttributedString()
   private var keyboardLayoutChangeKeyUpSuppression: KeyboardLayoutChangeKeyUpSuppression?
   private var keyTextAccumulator: [String]?
@@ -473,9 +474,24 @@ final class GhosttySurfaceView: NSView, Identifiable {
   override func viewDidMoveToWindow() {
     super.viewDidMoveToWindow()
     if window == nil {
-      // SwiftUI can temporarily detach a pane while rebuilding split/zoom layout.
-      // If we keep the stale local focus bit, detached panes still intercept bindings.
-      focusDidChange(false)
+      // SwiftUI can temporarily detach a pane while rebuilding split/zoom
+      // layout — or when another SwiftUI subtree (e.g. Shelf) takes over
+      // hosting the same surface. Clearing the focused bit immediately
+      // here is wrong for the re-attach case: AppKit silently resigns the
+      // surface without a call path we can observe, and same-window
+      // re-attach does not trigger `becomeFirstResponder`, so the focused
+      // bit never recovers. Delay the clear so a prompt re-attach
+      // cancels it; only when the surface truly stays detached past the
+      // grace window do we flip the bit.
+      detachedFocusClearTask?.cancel()
+      detachedFocusClearTask = Task { @MainActor [weak self] in
+        try? await ContinuousClock().sleep(for: .milliseconds(150))
+        guard !Task.isCancelled, let self, self.window == nil else { return }
+        focusDidChange(false)
+      }
+    } else {
+      detachedFocusClearTask?.cancel()
+      detachedFocusClearTask = nil
     }
     updateScreenObservers()
     updateContentScale()
@@ -570,6 +586,12 @@ final class GhosttySurfaceView: NSView, Identifiable {
   func focusDidChange(_ focused: Bool) {
     guard surface != nil else { return }
     guard self.focused != focused else { return }
+    // Retained as the single diagnostic entry point for focus regressions.
+    // Filter `make log-stream | grep '\[ShelfFocus\] focusDidChange'` to
+    // trace every focused-bit transition across the app.
+    SupaLogger("SurfaceFocus").info(
+      "[ShelfFocus] focusDidChange surface=\(debugID) \(self.focused) -> \(focused)"
+    )
     self.focused = focused
     if focused {
       bridge.state.bellCount = 0

--- a/supacodeTests/AppFeaturePlainFolderTerminalTests.swift
+++ b/supacodeTests/AppFeaturePlainFolderTerminalTests.swift
@@ -65,6 +65,7 @@ struct AppFeaturePlainFolderTerminalTests {
 
     await store.send(.repositories(.selectRepository(repository.id))) {
       $0.repositories.selection = .repository(repository.id)
+      $0.repositories.openedWorktreeIDs = [repository.id]
     }
     await store.receive(\.repositories.delegate.selectedWorktreeChanged)
     await store.receive(\.worktreeSettingsLoaded) {

--- a/supacodeTests/AppFeatureTerminalSetupScriptTests.swift
+++ b/supacodeTests/AppFeatureTerminalSetupScriptTests.swift
@@ -81,6 +81,9 @@ struct AppFeatureTerminalSetupScriptTests {
     }
 
     await store.send(.terminalEvent(.tabCreated(worktreeID: worktree.id)))
+    await store.receive(\.repositories.markWorktreeOpened) {
+      $0.repositories.openedWorktreeIDs = [worktree.id]
+    }
     #expect(store.state.repositories.pendingSetupScriptWorktreeIDs.contains(worktree.id))
     await store.finish()
   }

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -727,6 +727,7 @@ struct RepositoriesFeatureTests {
     await store.send(.selectWorktree(worktree.id)) {
       $0.selection = .worktree(worktree.id)
       $0.sidebarSelectedWorktreeIDs = [worktree.id]
+      $0.openedWorktreeIDs = [worktree.id]
     }
     await store.receive(\.delegate.selectedWorktreeChanged)
   }
@@ -746,6 +747,7 @@ struct RepositoriesFeatureTests {
     await store.send(.selectWorktree(wt2.id)) {
       $0.selection = .worktree(wt2.id)
       $0.sidebarSelectedWorktreeIDs = [wt2.id]
+      $0.openedWorktreeIDs = [wt2.id]
     }
     await store.receive(\.delegate.selectedWorktreeChanged)
   }
@@ -781,6 +783,7 @@ struct RepositoriesFeatureTests {
     await store.send(.selectRepository(repository.id)) {
       $0.selection = .repository(repository.id)
       $0.sidebarSelectedWorktreeIDs = []
+      $0.openedWorktreeIDs = [repository.id]
     }
     #expect(
       store.state.selectedTerminalWorktree
@@ -816,6 +819,7 @@ struct RepositoriesFeatureTests {
     await store.receive(\.selectRepository) {
       $0.selection = .repository(repository.id)
       $0.sidebarSelectedWorktreeIDs = []
+      $0.openedWorktreeIDs = [repository.id]
     }
     await store.receive(\.delegate.selectedWorktreeChanged)
   }
@@ -842,6 +846,7 @@ struct RepositoriesFeatureTests {
     await store.receive(\.selectRepository) {
       $0.selection = .repository(repository.id)
       $0.sidebarSelectedWorktreeIDs = []
+      $0.openedWorktreeIDs = [repository.id]
     }
     await store.receive(\.delegate.selectedWorktreeChanged)
   }
@@ -3714,6 +3719,7 @@ struct RepositoriesFeatureTests {
     await store.receive(\.selectWorktree) {
       $0.selection = .worktree(wt1.id)
       $0.sidebarSelectedWorktreeIDs = [wt1.id]
+      $0.openedWorktreeIDs = [wt1.id]
     }
     await store.receive(\.delegate.selectedWorktreeChanged)
   }
@@ -3732,6 +3738,7 @@ struct RepositoriesFeatureTests {
     await store.receive(\.selectWorktree) {
       $0.selection = .worktree(wt2.id)
       $0.sidebarSelectedWorktreeIDs = [wt2.id]
+      $0.openedWorktreeIDs = [wt2.id]
     }
     await store.receive(\.delegate.selectedWorktreeChanged)
   }
@@ -3748,6 +3755,7 @@ struct RepositoriesFeatureTests {
     await store.receive(\.selectWorktree) {
       $0.selection = .worktree(wt1.id)
       $0.sidebarSelectedWorktreeIDs = [wt1.id]
+      $0.openedWorktreeIDs = [wt1.id]
     }
     await store.receive(\.delegate.selectedWorktreeChanged)
   }
@@ -3768,6 +3776,7 @@ struct RepositoriesFeatureTests {
     await store.receive(\.selectWorktree) {
       $0.selection = .worktree(wt2.id)
       $0.sidebarSelectedWorktreeIDs = [wt2.id]
+      $0.openedWorktreeIDs = [wt2.id]
     }
     await store.receive(\.delegate.selectedWorktreeChanged)
   }
@@ -3784,6 +3793,7 @@ struct RepositoriesFeatureTests {
     await store.receive(\.selectWorktree) {
       $0.selection = .worktree(wt2.id)
       $0.sidebarSelectedWorktreeIDs = [wt2.id]
+      $0.openedWorktreeIDs = [wt2.id]
     }
     await store.receive(\.delegate.selectedWorktreeChanged)
   }
@@ -3809,6 +3819,7 @@ struct RepositoriesFeatureTests {
     await store.receive(\.selectWorktree) {
       $0.selection = .worktree(worktree.id)
       $0.sidebarSelectedWorktreeIDs = [worktree.id]
+      $0.openedWorktreeIDs = [worktree.id]
     }
     await store.receive(\.delegate.selectedWorktreeChanged)
   }
@@ -3831,6 +3842,7 @@ struct RepositoriesFeatureTests {
     await store.receive(\.selectWorktree) {
       $0.selection = .worktree(wt3.id)
       $0.sidebarSelectedWorktreeIDs = [wt3.id]
+      $0.openedWorktreeIDs = [wt3.id]
     }
     await store.receive(\.delegate.selectedWorktreeChanged)
   }
@@ -3853,6 +3865,7 @@ struct RepositoriesFeatureTests {
     await store.receive(\.selectWorktree) {
       $0.selection = .worktree(wt1.id)
       $0.sidebarSelectedWorktreeIDs = [wt1.id]
+      $0.openedWorktreeIDs = [wt1.id]
     }
     await store.receive(\.delegate.selectedWorktreeChanged)
   }
@@ -3901,6 +3914,7 @@ struct RepositoriesFeatureTests {
     await store.receive(\.selectWorktree) {
       $0.selection = .worktree(wt1.id)
       $0.sidebarSelectedWorktreeIDs = [wt1.id]
+      $0.openedWorktreeIDs = [wt1.id]
     }
     await store.receive(\.delegate.selectedWorktreeChanged)
   }

--- a/supacodeTests/ShelfBookOrderingTests.swift
+++ b/supacodeTests/ShelfBookOrderingTests.swift
@@ -1,0 +1,141 @@
+import Foundation
+import IdentifiedCollections
+import Testing
+
+@testable import supacode
+
+@MainActor
+struct ShelfBookOrderingTests {
+  @Test func emptyRepositoriesProduceNoBooks() {
+    let state = RepositoriesFeature.State()
+    #expect(state.orderedShelfBooks().isEmpty)
+  }
+
+  @Test func singleWorktreeRepositoryProducesOneBookPerWorktree() {
+    let rootURL = URL(fileURLWithPath: "/tmp/repo")
+    let main = Worktree(
+      id: "/tmp/repo",
+      name: "main",
+      detail: "",
+      workingDirectory: rootURL,
+      repositoryRootURL: rootURL
+    )
+    let feature = Worktree(
+      id: "/tmp/repo/feature",
+      name: "feature/login",
+      detail: "",
+      workingDirectory: URL(fileURLWithPath: "/tmp/repo/feature"),
+      repositoryRootURL: rootURL
+    )
+    let repository = Repository(
+      id: rootURL.path(percentEncoded: false),
+      rootURL: rootURL,
+      name: "repo",
+      worktrees: IdentifiedArray(uniqueElements: [main, feature])
+    )
+    var state = RepositoriesFeature.State(repositories: [repository])
+    state.repositoryRoots = [rootURL]
+    state.repositoryOrderIDs = [repository.id]
+
+    let books = state.orderedShelfBooks()
+    #expect(books.count == 2)
+    #expect(books[0].id == main.id)
+    #expect(books[0].kind == .worktree)
+    #expect(books[0].displayName == "main")
+    #expect(books[1].id == feature.id)
+    #expect(books[1].kind == .worktree)
+    #expect(books[1].displayName == "feature/login")
+  }
+
+  @Test func plainFolderRepositoryProducesOnePlainFolderBook() {
+    let rootURL = URL(fileURLWithPath: "/tmp/folder")
+    let repository = Repository(
+      id: rootURL.path(percentEncoded: false),
+      rootURL: rootURL,
+      name: "folder",
+      kind: .plain,
+      worktrees: []
+    )
+    var state = RepositoriesFeature.State(repositories: [repository])
+    state.repositoryRoots = [rootURL]
+    state.repositoryOrderIDs = [repository.id]
+
+    let books = state.orderedShelfBooks()
+    #expect(books.count == 1)
+    #expect(books[0].id == repository.id)
+    #expect(books[0].kind == .plainFolder)
+    #expect(books[0].branchName == nil)
+    #expect(books[0].displayName == "folder")
+  }
+
+  @Test func mixedRepositoriesPreserveOrder() {
+    let gitRootURL = URL(fileURLWithPath: "/tmp/git")
+    let gitMain = Worktree(
+      id: "/tmp/git",
+      name: "main",
+      detail: "",
+      workingDirectory: gitRootURL,
+      repositoryRootURL: gitRootURL
+    )
+    let gitRepo = Repository(
+      id: gitRootURL.path(percentEncoded: false),
+      rootURL: gitRootURL,
+      name: "git",
+      worktrees: IdentifiedArray(uniqueElements: [gitMain])
+    )
+    let plainRootURL = URL(fileURLWithPath: "/tmp/plain")
+    let plainRepo = Repository(
+      id: plainRootURL.path(percentEncoded: false),
+      rootURL: plainRootURL,
+      name: "plain",
+      kind: .plain,
+      worktrees: []
+    )
+    var state = RepositoriesFeature.State(repositories: [gitRepo, plainRepo])
+    state.repositoryRoots = [gitRootURL, plainRootURL]
+    state.repositoryOrderIDs = [gitRepo.id, plainRepo.id]
+
+    let books = state.orderedShelfBooks()
+    #expect(books.count == 2)
+    #expect(books[0].id == gitMain.id)
+    #expect(books[0].kind == .worktree)
+    #expect(books[1].id == plainRepo.id)
+    #expect(books[1].kind == .plainFolder)
+  }
+
+  @Test func openShelfBookIDFollowsSelectedWorktree() {
+    let rootURL = URL(fileURLWithPath: "/tmp/repo")
+    let worktree = Worktree(
+      id: "/tmp/repo",
+      name: "main",
+      detail: "",
+      workingDirectory: rootURL,
+      repositoryRootURL: rootURL
+    )
+    let repository = Repository(
+      id: rootURL.path(percentEncoded: false),
+      rootURL: rootURL,
+      name: "repo",
+      worktrees: IdentifiedArray(uniqueElements: [worktree])
+    )
+    var state = RepositoriesFeature.State(repositories: [repository])
+    state.selection = .worktree(worktree.id)
+
+    #expect(state.openShelfBookID == worktree.id)
+  }
+
+  @Test func openShelfBookIDResolvesPlainFolderViaRepositoryID() {
+    let rootURL = URL(fileURLWithPath: "/tmp/plain")
+    let repository = Repository(
+      id: rootURL.path(percentEncoded: false),
+      rootURL: rootURL,
+      name: "plain",
+      kind: .plain,
+      worktrees: []
+    )
+    var state = RepositoriesFeature.State(repositories: [repository])
+    state.selection = .repository(repository.id)
+
+    #expect(state.openShelfBookID == repository.id)
+  }
+}

--- a/supacodeTests/ShelfBookOrderingTests.swift
+++ b/supacodeTests/ShelfBookOrderingTests.swift
@@ -11,7 +11,30 @@ struct ShelfBookOrderingTests {
     #expect(state.orderedShelfBooks().isEmpty)
   }
 
-  @Test func singleWorktreeRepositoryProducesOneBookPerWorktree() {
+  @Test func unopenedWorktreesDoNotAppearOnShelf() {
+    let rootURL = URL(fileURLWithPath: "/tmp/repo")
+    let main = Worktree(
+      id: "/tmp/repo",
+      name: "main",
+      detail: "",
+      workingDirectory: rootURL,
+      repositoryRootURL: rootURL
+    )
+    let repository = Repository(
+      id: rootURL.path(percentEncoded: false),
+      rootURL: rootURL,
+      name: "repo",
+      worktrees: IdentifiedArray(uniqueElements: [main])
+    )
+    var state = RepositoriesFeature.State(repositories: [repository])
+    state.repositoryRoots = [rootURL]
+    state.repositoryOrderIDs = [repository.id]
+    // Empty `openedWorktreeIDs` → no spines even though the worktree
+    // exists. The Shelf only shows interactive books.
+    #expect(state.orderedShelfBooks().isEmpty)
+  }
+
+  @Test func singleWorktreeRepositoryProducesOneBookPerOpenedWorktree() {
     let rootURL = URL(fileURLWithPath: "/tmp/repo")
     let main = Worktree(
       id: "/tmp/repo",
@@ -36,6 +59,7 @@ struct ShelfBookOrderingTests {
     var state = RepositoriesFeature.State(repositories: [repository])
     state.repositoryRoots = [rootURL]
     state.repositoryOrderIDs = [repository.id]
+    state.openedWorktreeIDs = [main.id, feature.id]
 
     let books = state.orderedShelfBooks()
     #expect(books.count == 2)
@@ -45,6 +69,38 @@ struct ShelfBookOrderingTests {
     #expect(books[1].id == feature.id)
     #expect(books[1].kind == .worktree)
     #expect(books[1].displayName == "feature/login")
+  }
+
+  @Test func unopenedWorktreesInOpenedRepoAreFiltered() {
+    let rootURL = URL(fileURLWithPath: "/tmp/repo")
+    let main = Worktree(
+      id: "/tmp/repo",
+      name: "main",
+      detail: "",
+      workingDirectory: rootURL,
+      repositoryRootURL: rootURL
+    )
+    let feature = Worktree(
+      id: "/tmp/repo/feature",
+      name: "feature/login",
+      detail: "",
+      workingDirectory: URL(fileURLWithPath: "/tmp/repo/feature"),
+      repositoryRootURL: rootURL
+    )
+    let repository = Repository(
+      id: rootURL.path(percentEncoded: false),
+      rootURL: rootURL,
+      name: "repo",
+      worktrees: IdentifiedArray(uniqueElements: [main, feature])
+    )
+    var state = RepositoriesFeature.State(repositories: [repository])
+    state.repositoryRoots = [rootURL]
+    state.repositoryOrderIDs = [repository.id]
+    state.openedWorktreeIDs = [feature.id]  // only feature has been opened
+
+    let books = state.orderedShelfBooks()
+    #expect(books.count == 1)
+    #expect(books[0].id == feature.id)
   }
 
   @Test func plainFolderRepositoryProducesOnePlainFolderBook() {
@@ -59,6 +115,7 @@ struct ShelfBookOrderingTests {
     var state = RepositoriesFeature.State(repositories: [repository])
     state.repositoryRoots = [rootURL]
     state.repositoryOrderIDs = [repository.id]
+    state.openedWorktreeIDs = [repository.id]
 
     let books = state.orderedShelfBooks()
     #expect(books.count == 1)
@@ -94,6 +151,7 @@ struct ShelfBookOrderingTests {
     var state = RepositoriesFeature.State(repositories: [gitRepo, plainRepo])
     state.repositoryRoots = [gitRootURL, plainRootURL]
     state.repositoryOrderIDs = [gitRepo.id, plainRepo.id]
+    state.openedWorktreeIDs = [gitMain.id, plainRepo.id]
 
     let books = state.orderedShelfBooks()
     #expect(books.count == 2)

--- a/supacodeTests/ShelfFeatureTests.swift
+++ b/supacodeTests/ShelfFeatureTests.swift
@@ -31,6 +31,7 @@ struct ShelfFeatureTests {
 
     await store.send(.toggleShelf) {
       $0.isShelfActive = true
+      $0.openedWorktreeIDs = [worktree.id]
     }
     await store.finish()
   }
@@ -101,6 +102,7 @@ struct ShelfFeatureTests {
       $0.selection = .worktree(worktree.id)
       $0.sidebarSelectedWorktreeIDs = [worktree.id]
       $0.pendingTerminalFocusWorktreeIDs = [worktree.id]
+      $0.openedWorktreeIDs = [worktree.id]
     }
     await store.receive(\.delegate.selectedWorktreeChanged)
     await store.finish()
@@ -134,6 +136,7 @@ struct ShelfFeatureTests {
       $0.selection = .worktree(worktree.id)
       $0.sidebarSelectedWorktreeIDs = [worktree.id]
       $0.pendingTerminalFocusWorktreeIDs = [worktree.id]
+      $0.openedWorktreeIDs = [worktree.id]
     }
     await store.receive(\.delegate.selectedWorktreeChanged)
     await store.finish()
@@ -175,6 +178,7 @@ struct ShelfFeatureTests {
       $0.selection = .worktree(second.id)
       $0.sidebarSelectedWorktreeIDs = [second.id]
       $0.pendingTerminalFocusWorktreeIDs = [second.id]
+      $0.openedWorktreeIDs = [second.id]
     }
     await store.receive(\.delegate.selectedWorktreeChanged)
     await store.finish()
@@ -241,6 +245,7 @@ struct ShelfFeatureTests {
     state.repositoryOrderIDs = [repo.id]
     state.selection = .worktree(wt1.id)
     state.isShelfActive = true
+    state.openedWorktreeIDs = [wt1.id, wt2.id]
     let store = TestStore(initialState: state) {
       RepositoriesFeature()
     }
@@ -308,6 +313,7 @@ struct ShelfFeatureTests {
     state.repositoryRoots = [rootURL]
     state.repositoryOrderIDs = [repo.id]
     state.selection = .worktree(wt2.id)  // Currently on the last book.
+    state.openedWorktreeIDs = [wt1.id, wt2.id]
     let store = TestStore(initialState: state) {
       RepositoriesFeature()
     }

--- a/supacodeTests/ShelfFeatureTests.swift
+++ b/supacodeTests/ShelfFeatureTests.swift
@@ -434,6 +434,120 @@ struct ShelfFeatureTests {
     await store.finish()
   }
 
+  @Test(.dependencies) func markWorktreeClosedRemovesFromOpenedSet() async {
+    let rootURL = URL(fileURLWithPath: "/tmp/repo")
+    let wt1 = Worktree(
+      id: "/tmp/repo/wt1",
+      name: "wt1",
+      detail: "",
+      workingDirectory: URL(fileURLWithPath: "/tmp/repo/wt1"),
+      repositoryRootURL: rootURL
+    )
+    let repo = Repository(
+      id: rootURL.path(percentEncoded: false),
+      rootURL: rootURL,
+      name: "repo",
+      worktrees: IdentifiedArray(uniqueElements: [wt1])
+    )
+    var state = RepositoriesFeature.State(repositories: [repo])
+    state.openedWorktreeIDs = [wt1.id]
+    state.selection = nil  // Not currently selected, no auto-next needed.
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    }
+
+    await store.send(.markWorktreeClosed(wt1.id)) {
+      $0.openedWorktreeIDs = []
+    }
+    await store.finish()
+  }
+
+  @Test(.dependencies) func markWorktreeClosedAutoAdvancesToNextBookWhenOpen() async {
+    let rootURL = URL(fileURLWithPath: "/tmp/repo")
+    let wt1 = Worktree(
+      id: "/tmp/repo/wt1",
+      name: "wt1",
+      detail: "",
+      workingDirectory: URL(fileURLWithPath: "/tmp/repo/wt1"),
+      repositoryRootURL: rootURL
+    )
+    let wt2 = Worktree(
+      id: "/tmp/repo/wt2",
+      name: "wt2",
+      detail: "",
+      workingDirectory: URL(fileURLWithPath: "/tmp/repo/wt2"),
+      repositoryRootURL: rootURL
+    )
+    let repo = Repository(
+      id: rootURL.path(percentEncoded: false),
+      rootURL: rootURL,
+      name: "repo",
+      worktrees: IdentifiedArray(uniqueElements: [wt1, wt2])
+    )
+    var state = RepositoriesFeature.State(repositories: [repo])
+    state.repositoryRoots = [rootURL]
+    state.repositoryOrderIDs = [repo.id]
+    state.selection = .worktree(wt1.id)
+    state.isShelfActive = true
+    state.openedWorktreeIDs = [wt1.id, wt2.id]
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    }
+
+    // Close wt1 (the open book on the Shelf). wt2 is the only remaining
+    // book → reducer should auto-select wt2 so the user lands on
+    // content rather than an empty-Shelf placeholder.
+    await store.send(.markWorktreeClosed(wt1.id)) {
+      $0.openedWorktreeIDs = [wt2.id]
+    }
+    await store.receive(\.selectWorktree) {
+      $0.selection = .worktree(wt2.id)
+      $0.sidebarSelectedWorktreeIDs = [wt2.id]
+      $0.pendingTerminalFocusWorktreeIDs = [wt2.id]
+      $0.openedWorktreeIDs = [wt2.id]
+    }
+    await store.receive(\.delegate.selectedWorktreeChanged)
+    await store.finish()
+  }
+
+  @Test(.dependencies) func markWorktreeClosedLeavesSelectionAloneInNormalView() async {
+    let rootURL = URL(fileURLWithPath: "/tmp/repo")
+    let wt1 = Worktree(
+      id: "/tmp/repo/wt1",
+      name: "wt1",
+      detail: "",
+      workingDirectory: URL(fileURLWithPath: "/tmp/repo/wt1"),
+      repositoryRootURL: rootURL
+    )
+    let wt2 = Worktree(
+      id: "/tmp/repo/wt2",
+      name: "wt2",
+      detail: "",
+      workingDirectory: URL(fileURLWithPath: "/tmp/repo/wt2"),
+      repositoryRootURL: rootURL
+    )
+    let repo = Repository(
+      id: rootURL.path(percentEncoded: false),
+      rootURL: rootURL,
+      name: "repo",
+      worktrees: IdentifiedArray(uniqueElements: [wt1, wt2])
+    )
+    var state = RepositoriesFeature.State(repositories: [repo])
+    state.selection = .worktree(wt1.id)
+    state.isShelfActive = false  // Normal view.
+    state.openedWorktreeIDs = [wt1.id, wt2.id]
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    }
+
+    // In normal view, removing from the opened set must not also steal
+    // selection away from the user — they are actively on wt1.
+    await store.send(.markWorktreeClosed(wt1.id)) {
+      $0.openedWorktreeIDs = [wt2.id]
+    }
+    await store.finish()
+  }
+
   @Test(.dependencies) func markWorktreeOpenedAddsToOpenedSet() async {
     let rootURL = URL(fileURLWithPath: "/tmp/repo")
     let wt1 = Worktree(

--- a/supacodeTests/ShelfFeatureTests.swift
+++ b/supacodeTests/ShelfFeatureTests.swift
@@ -330,6 +330,110 @@ struct ShelfFeatureTests {
     await store.finish()
   }
 
+  @Test(.dependencies) func selectNextWorktreeRoutesToTabNavigationInShelf() async {
+    let rootURL = URL(fileURLWithPath: "/tmp/repo")
+    let wt1 = Worktree(
+      id: "/tmp/repo/wt1",
+      name: "wt1",
+      detail: "",
+      workingDirectory: URL(fileURLWithPath: "/tmp/repo/wt1"),
+      repositoryRootURL: rootURL
+    )
+    let repo = Repository(
+      id: rootURL.path(percentEncoded: false),
+      rootURL: rootURL,
+      name: "repo",
+      worktrees: IdentifiedArray(uniqueElements: [wt1])
+    )
+    var state = RepositoriesFeature.State(repositories: [repo])
+    state.selection = .worktree(wt1.id)
+    state.isShelfActive = true
+    let sentCommands = LockIsolated<[TerminalClient.Command]>([])
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in
+        sentCommands.withValue { $0.append(command) }
+      }
+    }
+
+    await store.send(.selectNextWorktree)
+    await store.finish()
+    #expect(sentCommands.value == [.performBindingAction(wt1, action: "next_tab")])
+  }
+
+  @Test(.dependencies) func selectPreviousWorktreeRoutesToTabNavigationInShelf() async {
+    let rootURL = URL(fileURLWithPath: "/tmp/repo")
+    let wt1 = Worktree(
+      id: "/tmp/repo/wt1",
+      name: "wt1",
+      detail: "",
+      workingDirectory: URL(fileURLWithPath: "/tmp/repo/wt1"),
+      repositoryRootURL: rootURL
+    )
+    let repo = Repository(
+      id: rootURL.path(percentEncoded: false),
+      rootURL: rootURL,
+      name: "repo",
+      worktrees: IdentifiedArray(uniqueElements: [wt1])
+    )
+    var state = RepositoriesFeature.State(repositories: [repo])
+    state.selection = .worktree(wt1.id)
+    state.isShelfActive = true
+    let sentCommands = LockIsolated<[TerminalClient.Command]>([])
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in
+        sentCommands.withValue { $0.append(command) }
+      }
+    }
+
+    await store.send(.selectPreviousWorktree)
+    await store.finish()
+    #expect(sentCommands.value == [.performBindingAction(wt1, action: "previous_tab")])
+  }
+
+  @Test(.dependencies) func selectNextWorktreeOutsideShelfStillCyclesWorktrees() async {
+    let rootURL = URL(fileURLWithPath: "/tmp/repo")
+    let wt1 = Worktree(
+      id: "/tmp/repo/wt1",
+      name: "wt1",
+      detail: "",
+      workingDirectory: URL(fileURLWithPath: "/tmp/repo/wt1"),
+      repositoryRootURL: rootURL
+    )
+    let wt2 = Worktree(
+      id: "/tmp/repo/wt2",
+      name: "wt2",
+      detail: "",
+      workingDirectory: URL(fileURLWithPath: "/tmp/repo/wt2"),
+      repositoryRootURL: rootURL
+    )
+    let repo = Repository(
+      id: rootURL.path(percentEncoded: false),
+      rootURL: rootURL,
+      name: "repo",
+      worktrees: IdentifiedArray(uniqueElements: [wt1, wt2])
+    )
+    var state = RepositoriesFeature.State(repositories: [repo])
+    state.selection = .worktree(wt1.id)
+    // Shelf NOT active — existing worktree-cycling behavior must survive.
+    state.isShelfActive = false
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    }
+
+    await store.send(.selectNextWorktree)
+    await store.receive(\.selectWorktree) {
+      $0.selection = .worktree(wt2.id)
+      $0.sidebarSelectedWorktreeIDs = [wt2.id]
+      $0.openedWorktreeIDs = [wt2.id]
+    }
+    await store.receive(\.delegate.selectedWorktreeChanged)
+    await store.finish()
+  }
+
   @Test(.dependencies) func markWorktreeOpenedAddsToOpenedSet() async {
     let rootURL = URL(fileURLWithPath: "/tmp/repo")
     let wt1 = Worktree(

--- a/supacodeTests/ShelfFeatureTests.swift
+++ b/supacodeTests/ShelfFeatureTests.swift
@@ -110,6 +110,53 @@ struct ShelfFeatureTests {
     await store.finish()
   }
 
+  @Test(.dependencies) func toggleShelfFromCanvasPrefersCanvasFocusedCard() async {
+    // Canvas can have a focused card distinct from `lastFocusedWorktreeID`
+    // (which is only updated while `selection` is `.worktree`). A direct
+    // Canvas → Shelf switch should open *that* card as the active book.
+    let rootURL = URL(fileURLWithPath: "/tmp/repo")
+    let worktreeA = Worktree(
+      id: "/tmp/repo/wt-a",
+      name: "wt-a",
+      detail: "",
+      workingDirectory: URL(fileURLWithPath: "/tmp/repo/wt-a"),
+      repositoryRootURL: rootURL
+    )
+    let worktreeB = Worktree(
+      id: "/tmp/repo/wt-b",
+      name: "wt-b",
+      detail: "",
+      workingDirectory: URL(fileURLWithPath: "/tmp/repo/wt-b"),
+      repositoryRootURL: rootURL
+    )
+    let repository = Repository(
+      id: rootURL.path(percentEncoded: false),
+      rootURL: rootURL,
+      name: "repo",
+      worktrees: IdentifiedArray(uniqueElements: [worktreeA, worktreeB])
+    )
+    var state = RepositoriesFeature.State(repositories: [repository])
+    state.selection = .canvas
+    state.lastFocusedWorktreeID = worktreeA.id
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.terminalClient.canvasFocusedWorktreeID = { worktreeB.id }
+    }
+
+    await store.send(.toggleShelf) {
+      $0.isShelfActive = true
+    }
+    await store.receive(\.selectWorktree) {
+      $0.selection = .worktree(worktreeB.id)
+      $0.sidebarSelectedWorktreeIDs = [worktreeB.id]
+      $0.pendingTerminalFocusWorktreeIDs = [worktreeB.id]
+      $0.openedWorktreeIDs = [worktreeB.id]
+    }
+    await store.receive(\.delegate.selectedWorktreeChanged)
+    await store.finish()
+  }
+
   @Test(.dependencies) func toggleShelfFromArchivedRedirectsToWorktreeAndEntersShelf() async {
     let rootURL = URL(fileURLWithPath: "/tmp/repo")
     let worktree = Worktree(

--- a/supacodeTests/ShelfFeatureTests.swift
+++ b/supacodeTests/ShelfFeatureTests.swift
@@ -1,0 +1,206 @@
+import ComposableArchitecture
+import DependenciesTestSupport
+import Foundation
+import IdentifiedCollections
+import Testing
+
+@testable import supacode
+
+@MainActor
+struct ShelfFeatureTests {
+  @Test(.dependencies) func toggleShelfFromWorktreeEntersShelfWithoutRedirecting() async {
+    let rootURL = URL(fileURLWithPath: "/tmp/repo")
+    let worktree = Worktree(
+      id: "/tmp/repo/wt1",
+      name: "wt1",
+      detail: "",
+      workingDirectory: URL(fileURLWithPath: "/tmp/repo/wt1"),
+      repositoryRootURL: rootURL
+    )
+    let repository = Repository(
+      id: rootURL.path(percentEncoded: false),
+      rootURL: rootURL,
+      name: "repo",
+      worktrees: IdentifiedArray(uniqueElements: [worktree])
+    )
+    var state = RepositoriesFeature.State(repositories: [repository])
+    state.selection = .worktree(worktree.id)
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    }
+
+    await store.send(.toggleShelf) {
+      $0.isShelfActive = true
+    }
+    await store.finish()
+  }
+
+  @Test(.dependencies) func toggleShelfWhileActiveExitsShelf() async {
+    let rootURL = URL(fileURLWithPath: "/tmp/repo")
+    let worktree = Worktree(
+      id: "/tmp/repo/wt1",
+      name: "wt1",
+      detail: "",
+      workingDirectory: URL(fileURLWithPath: "/tmp/repo/wt1"),
+      repositoryRootURL: rootURL
+    )
+    let repository = Repository(
+      id: rootURL.path(percentEncoded: false),
+      rootURL: rootURL,
+      name: "repo",
+      worktrees: IdentifiedArray(uniqueElements: [worktree])
+    )
+    var state = RepositoriesFeature.State(repositories: [repository])
+    state.selection = .worktree(worktree.id)
+    state.isShelfActive = true
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    }
+
+    await store.send(.toggleShelf) {
+      $0.isShelfActive = false
+    }
+    await store.finish()
+  }
+
+  @Test(.dependencies) func toggleShelfWithoutWorktreesIsNoOp() async {
+    let store = TestStore(initialState: RepositoriesFeature.State()) {
+      RepositoriesFeature()
+    }
+
+    await store.send(.toggleShelf)
+    await store.finish()
+  }
+
+  @Test(.dependencies) func toggleShelfFromCanvasRedirectsToWorktreeAndEntersShelf() async {
+    let rootURL = URL(fileURLWithPath: "/tmp/repo")
+    let worktree = Worktree(
+      id: "/tmp/repo/wt1",
+      name: "wt1",
+      detail: "",
+      workingDirectory: URL(fileURLWithPath: "/tmp/repo/wt1"),
+      repositoryRootURL: rootURL
+    )
+    let repository = Repository(
+      id: rootURL.path(percentEncoded: false),
+      rootURL: rootURL,
+      name: "repo",
+      worktrees: IdentifiedArray(uniqueElements: [worktree])
+    )
+    var state = RepositoriesFeature.State(repositories: [repository])
+    state.selection = .canvas
+    state.lastFocusedWorktreeID = worktree.id
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    }
+
+    await store.send(.toggleShelf) {
+      $0.isShelfActive = true
+    }
+    await store.receive(\.selectWorktree) {
+      $0.selection = .worktree(worktree.id)
+      $0.sidebarSelectedWorktreeIDs = [worktree.id]
+      $0.pendingTerminalFocusWorktreeIDs = [worktree.id]
+    }
+    await store.receive(\.delegate.selectedWorktreeChanged)
+    await store.finish()
+  }
+
+  @Test(.dependencies) func toggleShelfFromArchivedRedirectsToWorktreeAndEntersShelf() async {
+    let rootURL = URL(fileURLWithPath: "/tmp/repo")
+    let worktree = Worktree(
+      id: "/tmp/repo/wt1",
+      name: "wt1",
+      detail: "",
+      workingDirectory: URL(fileURLWithPath: "/tmp/repo/wt1"),
+      repositoryRootURL: rootURL
+    )
+    let repository = Repository(
+      id: rootURL.path(percentEncoded: false),
+      rootURL: rootURL,
+      name: "repo",
+      worktrees: IdentifiedArray(uniqueElements: [worktree])
+    )
+    var state = RepositoriesFeature.State(repositories: [repository])
+    state.selection = .archivedWorktrees
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    }
+
+    await store.send(.toggleShelf) {
+      $0.isShelfActive = true
+    }
+    await store.receive(\.selectWorktree) {
+      $0.selection = .worktree(worktree.id)
+      $0.sidebarSelectedWorktreeIDs = [worktree.id]
+      $0.pendingTerminalFocusWorktreeIDs = [worktree.id]
+    }
+    await store.receive(\.delegate.selectedWorktreeChanged)
+    await store.finish()
+  }
+
+  @Test(.dependencies) func selectCanvasClearsShelfActiveFlag() async {
+    let rootURL = URL(fileURLWithPath: "/tmp/repo")
+    let worktree = Worktree(
+      id: "/tmp/repo/wt1",
+      name: "wt1",
+      detail: "",
+      workingDirectory: URL(fileURLWithPath: "/tmp/repo/wt1"),
+      repositoryRootURL: rootURL
+    )
+    let repository = Repository(
+      id: rootURL.path(percentEncoded: false),
+      rootURL: rootURL,
+      name: "repo",
+      worktrees: IdentifiedArray(uniqueElements: [worktree])
+    )
+    var state = RepositoriesFeature.State(repositories: [repository])
+    state.selection = .worktree(worktree.id)
+    state.isShelfActive = true
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { _ in }
+    }
+
+    await store.send(.selectCanvas) {
+      $0.preCanvasWorktreeID = worktree.id
+      $0.preCanvasTerminalTargetID = worktree.id
+      $0.isShelfActive = false
+      $0.selection = .canvas
+      $0.sidebarSelectedWorktreeIDs = []
+    }
+    await store.finish()
+  }
+
+  @Test(.dependencies) func selectArchivedWorktreesClearsShelfActiveFlag() async {
+    let rootURL = URL(fileURLWithPath: "/tmp/repo")
+    let worktree = Worktree(
+      id: "/tmp/repo/wt1",
+      name: "wt1",
+      detail: "",
+      workingDirectory: URL(fileURLWithPath: "/tmp/repo/wt1"),
+      repositoryRootURL: rootURL
+    )
+    let repository = Repository(
+      id: rootURL.path(percentEncoded: false),
+      rootURL: rootURL,
+      name: "repo",
+      worktrees: IdentifiedArray(uniqueElements: [worktree])
+    )
+    var state = RepositoriesFeature.State(repositories: [repository])
+    state.selection = .worktree(worktree.id)
+    state.isShelfActive = true
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    }
+
+    await store.send(.selectArchivedWorktrees) {
+      $0.isShelfActive = false
+      $0.selection = .archivedWorktrees
+      $0.sidebarSelectedWorktreeIDs = []
+    }
+    await store.receive(\.delegate.selectedWorktreeChanged)
+    await store.finish()
+  }
+}

--- a/supacodeTests/ShelfFeatureTests.swift
+++ b/supacodeTests/ShelfFeatureTests.swift
@@ -329,6 +329,34 @@ struct ShelfFeatureTests {
     await store.finish()
   }
 
+  @Test(.dependencies) func markWorktreeOpenedAddsToOpenedSet() async {
+    let rootURL = URL(fileURLWithPath: "/tmp/repo")
+    let wt1 = Worktree(
+      id: "/tmp/repo/wt1",
+      name: "wt1",
+      detail: "",
+      workingDirectory: URL(fileURLWithPath: "/tmp/repo/wt1"),
+      repositoryRootURL: rootURL
+    )
+    let repo = Repository(
+      id: rootURL.path(percentEncoded: false),
+      rootURL: rootURL,
+      name: "repo",
+      worktrees: IdentifiedArray(uniqueElements: [wt1])
+    )
+    let store = TestStore(initialState: RepositoriesFeature.State(repositories: [repo])) {
+      RepositoriesFeature()
+    }
+
+    // Mirrors the AppFeature forwarding `terminalEvent(.tabCreated)` →
+    // `.markWorktreeOpened`. Any tab creation (including restored
+    // layouts) adds its worktree to the Shelf's visible book set.
+    await store.send(.markWorktreeOpened(wt1.id)) {
+      $0.openedWorktreeIDs = [wt1.id]
+    }
+    await store.finish()
+  }
+
   @Test(.dependencies) func selectArchivedWorktreesClearsShelfActiveFlag() async {
     let rootURL = URL(fileURLWithPath: "/tmp/repo")
     let worktree = Worktree(

--- a/supacodeTests/ShelfFeatureTests.swift
+++ b/supacodeTests/ShelfFeatureTests.swift
@@ -2,6 +2,7 @@ import ComposableArchitecture
 import DependenciesTestSupport
 import Foundation
 import IdentifiedCollections
+import Sharing
 import Testing
 
 @testable import supacode
@@ -640,6 +641,127 @@ struct ShelfFeatureTests {
       $0.sidebarSelectedWorktreeIDs = []
     }
     await store.receive(\.delegate.selectedWorktreeChanged)
+    await store.finish()
+  }
+
+  @Test(.dependencies) func defaultViewShelfPreferenceDispatchesToggleAfterSnapshot() async {
+    let repoRoot = "/tmp/default-shelf-repo"
+    let rootURL = URL(fileURLWithPath: repoRoot)
+    let worktree = Worktree(
+      id: "\(repoRoot)/main",
+      name: "main",
+      detail: "",
+      workingDirectory: URL(fileURLWithPath: "\(repoRoot)/main"),
+      repositoryRootURL: rootURL
+    )
+    let repository = Repository(
+      id: repoRoot,
+      rootURL: rootURL,
+      name: "repo",
+      worktrees: IdentifiedArray(uniqueElements: [worktree])
+    )
+
+    @Shared(.settingsFile) var settingsFile
+    $settingsFile.withLock {
+      var updated = $0.global
+      updated.defaultViewMode = .shelf
+      $0.global = updated
+    }
+    // Restore settings after the test so `@Shared` state doesn't leak
+    // across parallel test runs in the same process.
+    defer {
+      $settingsFile.withLock {
+        var updated = $0.global
+        updated.defaultViewMode = .normal
+        $0.global = updated
+      }
+    }
+
+    // Drive only the reducer action under test, not the full `.task`
+    // flow — the launch pipeline is covered elsewhere. This isolates
+    // the new "default view shelf" hook from unrelated effects and
+    // keeps the assertion surface minimal.
+    var initialState = RepositoriesFeature.State()
+    initialState.lastFocusedWorktreeID = worktree.id
+    initialState.shouldRestoreLastFocusedWorktree = true
+    initialState.snapshotPersistencePhase = .restoring
+    let store = TestStore(initialState: initialState) {
+      RepositoriesFeature()
+    }
+
+    await store.send(.repositorySnapshotLoaded([repository])) {
+      $0.repositories = [repository]
+      $0.repositoryRoots = [rootURL]
+      $0.selection = .worktree(worktree.id)
+      $0.shouldRestoreLastFocusedWorktree = false
+      $0.isInitialLoadComplete = true
+    }
+    await store.receive(\.delegate.repositoriesChanged)
+    await store.receive(\.delegate.selectedWorktreeChanged)
+    await store.receive(\.toggleShelf) {
+      $0.isShelfActive = true
+      $0.openedWorktreeIDs = [worktree.id]
+      $0.pendingTerminalFocusWorktreeIDs = [worktree.id]
+    }
+    await store.finish()
+  }
+
+  @Test(.dependencies) func defaultViewShelfDefersDuringLayoutRestore() async {
+    // When Layout Restore is active the snapshot-load hook must stay
+    // quiet: Layout Restore clears selection and replays tabs, so
+    // entering Shelf here would flash an empty open area and leave a
+    // stray spine if the restored active book differs from
+    // `lastFocusedWorktreeID`. The AppFeature hook on `.layoutRestored`
+    // takes over once Layout Restore has settled.
+    let repoRoot = "/tmp/default-shelf-restore-repo"
+    let rootURL = URL(fileURLWithPath: repoRoot)
+    let worktree = Worktree(
+      id: "\(repoRoot)/main",
+      name: "main",
+      detail: "",
+      workingDirectory: URL(fileURLWithPath: "\(repoRoot)/main"),
+      repositoryRootURL: rootURL
+    )
+    let repository = Repository(
+      id: repoRoot,
+      rootURL: rootURL,
+      name: "repo",
+      worktrees: IdentifiedArray(uniqueElements: [worktree])
+    )
+
+    @Shared(.settingsFile) var settingsFile
+    $settingsFile.withLock {
+      var updated = $0.global
+      updated.defaultViewMode = .shelf
+      $0.global = updated
+    }
+    defer {
+      $settingsFile.withLock {
+        var updated = $0.global
+        updated.defaultViewMode = .normal
+        $0.global = updated
+      }
+    }
+
+    var initialState = RepositoriesFeature.State()
+    initialState.lastFocusedWorktreeID = worktree.id
+    initialState.shouldRestoreLastFocusedWorktree = true
+    initialState.snapshotPersistencePhase = .restoring
+    initialState.launchRestoreMode = .restoreLayout
+    let store = TestStore(initialState: initialState) {
+      RepositoriesFeature()
+    }
+
+    await store.send(.repositorySnapshotLoaded([repository])) {
+      $0.repositories = [repository]
+      $0.repositoryRoots = [rootURL]
+      $0.selection = .worktree(worktree.id)
+      $0.shouldRestoreLastFocusedWorktree = false
+      $0.isInitialLoadComplete = true
+    }
+    await store.receive(\.delegate.repositoriesChanged)
+    await store.receive(\.delegate.selectedWorktreeChanged)
+    // No `.toggleShelf` here — the Layout Restore path is responsible.
     await store.finish()
   }
 }

--- a/supacodeTests/ShelfFeatureTests.swift
+++ b/supacodeTests/ShelfFeatureTests.swift
@@ -139,6 +139,47 @@ struct ShelfFeatureTests {
     await store.finish()
   }
 
+  @Test(.dependencies) func selectingADifferentWorktreeKeepsShelfActive() async {
+    let rootURL = URL(fileURLWithPath: "/tmp/repo")
+    let first = Worktree(
+      id: "/tmp/repo/wt1",
+      name: "wt1",
+      detail: "",
+      workingDirectory: URL(fileURLWithPath: "/tmp/repo/wt1"),
+      repositoryRootURL: rootURL
+    )
+    let second = Worktree(
+      id: "/tmp/repo/wt2",
+      name: "wt2",
+      detail: "",
+      workingDirectory: URL(fileURLWithPath: "/tmp/repo/wt2"),
+      repositoryRootURL: rootURL
+    )
+    let repository = Repository(
+      id: rootURL.path(percentEncoded: false),
+      rootURL: rootURL,
+      name: "repo",
+      worktrees: IdentifiedArray(uniqueElements: [first, second])
+    )
+    var state = RepositoriesFeature.State(repositories: [repository])
+    state.selection = .worktree(first.id)
+    state.isShelfActive = true
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    }
+
+    // Mirrors "user clicks second worktree in the left navigation
+    // while in Shelf mode": Shelf must not exit; only the open book
+    // changes via the new `selectedWorktreeID`.
+    await store.send(.selectWorktree(second.id, focusTerminal: true)) {
+      $0.selection = .worktree(second.id)
+      $0.sidebarSelectedWorktreeIDs = [second.id]
+      $0.pendingTerminalFocusWorktreeIDs = [second.id]
+    }
+    await store.receive(\.delegate.selectedWorktreeChanged)
+    await store.finish()
+  }
+
   @Test(.dependencies) func selectCanvasClearsShelfActiveFlag() async {
     let rootURL = URL(fileURLWithPath: "/tmp/repo")
     let worktree = Worktree(

--- a/supacodeTests/ShelfFeatureTests.swift
+++ b/supacodeTests/ShelfFeatureTests.swift
@@ -32,6 +32,7 @@ struct ShelfFeatureTests {
     await store.send(.toggleShelf) {
       $0.isShelfActive = true
       $0.openedWorktreeIDs = [worktree.id]
+      $0.pendingTerminalFocusWorktreeIDs = [worktree.id]
     }
     await store.finish()
   }

--- a/supacodeTests/ShelfFeatureTests.swift
+++ b/supacodeTests/ShelfFeatureTests.swift
@@ -462,52 +462,88 @@ struct ShelfFeatureTests {
     await store.finish()
   }
 
-  @Test(.dependencies) func markWorktreeClosedAutoAdvancesToNextBookWhenOpen() async {
-    let rootURL = URL(fileURLWithPath: "/tmp/repo")
-    let wt1 = Worktree(
-      id: "/tmp/repo/wt1",
-      name: "wt1",
-      detail: "",
-      workingDirectory: URL(fileURLWithPath: "/tmp/repo/wt1"),
-      repositoryRootURL: rootURL
-    )
-    let wt2 = Worktree(
-      id: "/tmp/repo/wt2",
-      name: "wt2",
-      detail: "",
-      workingDirectory: URL(fileURLWithPath: "/tmp/repo/wt2"),
-      repositoryRootURL: rootURL
-    )
-    let repo = Repository(
-      id: rootURL.path(percentEncoded: false),
-      rootURL: rootURL,
-      name: "repo",
-      worktrees: IdentifiedArray(uniqueElements: [wt1, wt2])
-    )
-    var state = RepositoriesFeature.State(repositories: [repo])
-    state.repositoryRoots = [rootURL]
-    state.repositoryOrderIDs = [repo.id]
-    state.selection = .worktree(wt1.id)
+  @Test(.dependencies) func markWorktreeClosedAdvancesToNextBookWhenAvailable() async {
+    let fixture = threeWorktreeFixture()
+    var state = RepositoriesFeature.State(repositories: [fixture.repo])
+    state.repositoryRoots = [fixture.repo.rootURL]
+    state.repositoryOrderIDs = [fixture.repo.id]
+    state.selection = .worktree(fixture.worktrees[1].id)  // Middle book open.
     state.isShelfActive = true
-    state.openedWorktreeIDs = [wt1.id, wt2.id]
+    state.openedWorktreeIDs = Set(fixture.worktrees.map(\.id))
     let store = TestStore(initialState: state) {
       RepositoriesFeature()
     }
 
-    // Close wt1 (the open book on the Shelf). wt2 is the only remaining
-    // book → reducer should auto-select wt2 so the user lands on
-    // content rather than an empty-Shelf placeholder.
-    await store.send(.markWorktreeClosed(wt1.id)) {
-      $0.openedWorktreeIDs = [wt2.id]
+    // Closing the middle book → replacement is the one AFTER it (wt3),
+    // not the first book (wt1). The user stays close to where they
+    // were on the shelf.
+    let closingID = fixture.worktrees[1].id
+    let nextID = fixture.worktrees[2].id
+    await store.send(.markWorktreeClosed(closingID)) {
+      $0.openedWorktreeIDs = [fixture.worktrees[0].id, nextID]
     }
     await store.receive(\.selectWorktree) {
-      $0.selection = .worktree(wt2.id)
-      $0.sidebarSelectedWorktreeIDs = [wt2.id]
-      $0.pendingTerminalFocusWorktreeIDs = [wt2.id]
-      $0.openedWorktreeIDs = [wt2.id]
+      $0.selection = .worktree(nextID)
+      $0.sidebarSelectedWorktreeIDs = [nextID]
+      $0.pendingTerminalFocusWorktreeIDs = [nextID]
+      $0.openedWorktreeIDs = [fixture.worktrees[0].id, nextID]
     }
     await store.receive(\.delegate.selectedWorktreeChanged)
     await store.finish()
+  }
+
+  @Test(.dependencies) func markWorktreeClosedFallsBackToPreviousBookWhenClosingLast() async {
+    let fixture = threeWorktreeFixture()
+    var state = RepositoriesFeature.State(repositories: [fixture.repo])
+    state.repositoryRoots = [fixture.repo.rootURL]
+    state.repositoryOrderIDs = [fixture.repo.id]
+    state.selection = .worktree(fixture.worktrees[2].id)  // Last book open.
+    state.isShelfActive = true
+    state.openedWorktreeIDs = Set(fixture.worktrees.map(\.id))
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    }
+
+    // Closing the last book → no book after it, so the replacement is
+    // the book BEFORE it (wt2).
+    let closingID = fixture.worktrees[2].id
+    let prevID = fixture.worktrees[1].id
+    await store.send(.markWorktreeClosed(closingID)) {
+      $0.openedWorktreeIDs = [fixture.worktrees[0].id, prevID]
+    }
+    await store.receive(\.selectWorktree) {
+      $0.selection = .worktree(prevID)
+      $0.sidebarSelectedWorktreeIDs = [prevID]
+      $0.pendingTerminalFocusWorktreeIDs = [prevID]
+      $0.openedWorktreeIDs = [fixture.worktrees[0].id, prevID]
+    }
+    await store.receive(\.delegate.selectedWorktreeChanged)
+    await store.finish()
+  }
+
+  private struct ThreeWorktreeFixture {
+    let repo: Repository
+    let worktrees: [Worktree]
+  }
+
+  private func threeWorktreeFixture() -> ThreeWorktreeFixture {
+    let rootURL = URL(fileURLWithPath: "/tmp/repo")
+    let worktrees = (1...3).map { index in
+      Worktree(
+        id: "/tmp/repo/wt\(index)",
+        name: "wt\(index)",
+        detail: "",
+        workingDirectory: URL(fileURLWithPath: "/tmp/repo/wt\(index)"),
+        repositoryRootURL: rootURL
+      )
+    }
+    let repo = Repository(
+      id: rootURL.path(percentEncoded: false),
+      rootURL: rootURL,
+      name: "repo",
+      worktrees: IdentifiedArray(uniqueElements: worktrees)
+    )
+    return ThreeWorktreeFixture(repo: repo, worktrees: worktrees)
   }
 
   @Test(.dependencies) func markWorktreeClosedLeavesSelectionAloneInNormalView() async {

--- a/supacodeTests/ShelfFeatureTests.swift
+++ b/supacodeTests/ShelfFeatureTests.swift
@@ -214,6 +214,115 @@ struct ShelfFeatureTests {
     await store.finish()
   }
 
+  @Test(.dependencies) func selectShelfBookByIndexDispatchesWorktreeSelection() async {
+    let rootURL = URL(fileURLWithPath: "/tmp/repo")
+    let wt1 = Worktree(
+      id: "/tmp/repo",
+      name: "main",
+      detail: "",
+      workingDirectory: rootURL,
+      repositoryRootURL: rootURL
+    )
+    let wt2 = Worktree(
+      id: "/tmp/repo/feature",
+      name: "feature",
+      detail: "",
+      workingDirectory: URL(fileURLWithPath: "/tmp/repo/feature"),
+      repositoryRootURL: rootURL
+    )
+    let repo = Repository(
+      id: rootURL.path(percentEncoded: false),
+      rootURL: rootURL,
+      name: "repo",
+      worktrees: IdentifiedArray(uniqueElements: [wt1, wt2])
+    )
+    var state = RepositoriesFeature.State(repositories: [repo])
+    state.repositoryRoots = [rootURL]
+    state.repositoryOrderIDs = [repo.id]
+    state.selection = .worktree(wt1.id)
+    state.isShelfActive = true
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    }
+
+    await store.send(.selectShelfBook(2))
+    await store.receive(\.selectWorktree) {
+      $0.selection = .worktree(wt2.id)
+      $0.sidebarSelectedWorktreeIDs = [wt2.id]
+      $0.pendingTerminalFocusWorktreeIDs = [wt2.id]
+    }
+    await store.receive(\.delegate.selectedWorktreeChanged)
+    await store.finish()
+  }
+
+  @Test(.dependencies) func selectShelfBookOutOfRangeIsNoOp() async {
+    let rootURL = URL(fileURLWithPath: "/tmp/repo")
+    let wt1 = Worktree(
+      id: "/tmp/repo",
+      name: "main",
+      detail: "",
+      workingDirectory: rootURL,
+      repositoryRootURL: rootURL
+    )
+    let repo = Repository(
+      id: rootURL.path(percentEncoded: false),
+      rootURL: rootURL,
+      name: "repo",
+      worktrees: IdentifiedArray(uniqueElements: [wt1])
+    )
+    var state = RepositoriesFeature.State(repositories: [repo])
+    state.repositoryRoots = [rootURL]
+    state.repositoryOrderIDs = [repo.id]
+    state.selection = .worktree(wt1.id)
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    }
+
+    await store.send(.selectShelfBook(5))
+    await store.finish()
+  }
+
+  @Test(.dependencies) func selectNextShelfBookWrapsAround() async {
+    let rootURL = URL(fileURLWithPath: "/tmp/repo")
+    let wt1 = Worktree(
+      id: "/tmp/repo",
+      name: "main",
+      detail: "",
+      workingDirectory: rootURL,
+      repositoryRootURL: rootURL
+    )
+    let wt2 = Worktree(
+      id: "/tmp/repo/feature",
+      name: "feature",
+      detail: "",
+      workingDirectory: URL(fileURLWithPath: "/tmp/repo/feature"),
+      repositoryRootURL: rootURL
+    )
+    let repo = Repository(
+      id: rootURL.path(percentEncoded: false),
+      rootURL: rootURL,
+      name: "repo",
+      worktrees: IdentifiedArray(uniqueElements: [wt1, wt2])
+    )
+    var state = RepositoriesFeature.State(repositories: [repo])
+    state.repositoryRoots = [rootURL]
+    state.repositoryOrderIDs = [repo.id]
+    state.selection = .worktree(wt2.id)  // Currently on the last book.
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    }
+
+    await store.send(.selectNextShelfBook)
+    // Wrapping: next-after-last lands back on the first book.
+    await store.receive(\.selectWorktree) {
+      $0.selection = .worktree(wt1.id)
+      $0.sidebarSelectedWorktreeIDs = [wt1.id]
+      $0.pendingTerminalFocusWorktreeIDs = [wt1.id]
+    }
+    await store.receive(\.delegate.selectedWorktreeChanged)
+    await store.finish()
+  }
+
   @Test(.dependencies) func selectArchivedWorktreesClearsShelfActiveFlag() async {
     let rootURL = URL(fileURLWithPath: "/tmp/repo")
     let worktree = Worktree(

--- a/supacodeTests/WindowFocusObserverViewTests.swift
+++ b/supacodeTests/WindowFocusObserverViewTests.swift
@@ -1,0 +1,46 @@
+import AppKit
+import Testing
+
+@testable import supacode
+
+/// Regression guard for the Shelf-entry focus bug: when a
+/// `WindowFocusObserverNSView` is torn off its host window (e.g. one
+/// SwiftUI subtree is swapped for another that continues to observe the
+/// same `WorktreeTerminalState`), the teardown must NOT fire an
+/// "inactive" activity callback. An inactive callback would overwrite
+/// the shared state's cached window-key flag and demote the surface's
+/// focused bit even though the window is still key.
+@MainActor
+struct WindowFocusObserverViewTests {
+  @Test func detachFromWindowEmitsNothingNew() {
+    let window = NSWindow(
+      contentRect: NSRect(x: 0, y: 0, width: 200, height: 200),
+      styleMask: [.titled],
+      backing: .buffered,
+      defer: true
+    )
+    let observer = WindowFocusObserverNSView()
+    var emits: [WindowActivityState] = []
+    observer.onWindowActivityChanged = { emits.append($0) }
+
+    // Attach: the observer may emit the window's current activity state
+    // once (headless test windows report key=false, visible=false — so
+    // that initial emit is itself "inactive" here; that's fine). We
+    // capture the count so the detach assertion compares against this
+    // baseline instead of against an idealized non-inactive list.
+    window.contentView?.addSubview(observer)
+    let emitsAtAttach = emits.count
+
+    // Detach: no new emit should fire, regardless of what the window's
+    // current state is. Prior to the fix, `updateObservers` called
+    // `emitActivityIfNeeded(force: true)` on detach, which always sent
+    // a (key=false, visible=false) inactive signal and poisoned the
+    // shared `WorktreeTerminalState`'s cached window-key flag.
+    observer.removeFromSuperview()
+    let emitsAfterDetach = emits.count
+    #expect(
+      emitsAfterDetach == emitsAtAttach,
+      "Detach must not emit new activity. attach=\(emitsAtAttach), afterDetach=\(emitsAfterDetach)"
+    )
+  }
+}


### PR DESCRIPTION
## Summary

Introduce **Shelf**, a new terminal presentation mode that sits next to Canvas. Where Canvas spreads worktrees out as flat cards, Shelf preserves and strengthens the worktree concept by stacking them as books with vertical spines that double as tab bars.

Design: [`doc-onevcat/shelf-view.md`](doc-onevcat/shelf-view.md) (spec + implementation-decisions journal at the bottom).

Key concepts:
- **Book** = a worktree or plain folder. Exactly one is "open" at a time.
- **Spine** = a one-line-text-wide vertical bar carrying the book's rotated name/branch header and its tabs' icon slots.
- **Layout** = `[ left spine stack | open book terminal | right spine stack ]`, where the open book's spine is the rightmost in the left stack.
- **Sync** = the open book is `selectedWorktreeID`, so Shelf and the left navigation stay in lockstep without Shelf ever auto-exiting.

## Implementation shape

- `RepositoriesFeature.State.isShelfActive: Bool` as an independent flag (not a `SidebarSelection` case). Selecting Canvas or archived clears it.
- `ShelfBook` model unifies worktrees and plain folders behind a single `Worktree.ID` (matching `selectedTerminalWorktree?.id` for plain folders).
- `ShelfView` + `ShelfSpineView` + `ShelfSpineTabSlot` + `ShelfOpenBookView` make up the view tree. `ShelfOpenBookView` reuses the existing terminal content stack without its horizontal tab bar.
- Spine flow animates at ~200ms ease-in-out via `matchedGeometryEffect` in a shared namespace. Terminal area uses `.transition(.opacity)` for the crossfade. The root `.animation(_, value: openBookID)` ensures left-nav-originated book switches animate identically.
- `CommandKeyObserver` drives the ⌘-held icon-to-digit swap with no layout shift. Slots ≥ 10 stay as icons with a slight dim to indicate "no hotkey here".
- Tab close mirrors the standard tab bar: hover X + right-click `terminalTabContextMenu`. Spine header/body gets a book-level context menu with "Remove Book".
- New keybindings (all configurable in `Settings → Shortcuts`):
  - `Toggle Shelf` → `Cmd+Shift+Enter` (symmetric with `Toggle Canvas` = `Cmd+Option+Enter`)
  - `Select Next / Previous Book` → `Cmd+Ctrl+→` / `Cmd+Ctrl+←`
  - `Select Book 1…9` → `Ctrl+Option+1..9` (distinct from `Ctrl+1..9` worktree selection because plain folders interleave)

## Test plan

### Automated
- [x] `make build-app` succeeds
- [x] `make lint` clean
- [x] `make test` — 778 tests pass, 0 failures
- [x] `make test-cli-smoke` — 40 passes
- [x] `make test-cli-integration` — passes

### Manual verification

**Entry & exit**
- [x] Press `Cmd+Shift+Enter` while viewing a worktree: Shelf opens with that worktree as the open book.
- [x] Press `Cmd+Shift+Enter` again: Shelf exits, returns to normal view on the same worktree.
- [x] Click the **Shelf** button in the sidebar toolbar (next to Canvas) to toggle.
- [x] Enter Canvas, then press `Cmd+Shift+Enter`: Canvas exits and Shelf opens on the worktree you came from.
- [x] Enter Archived Worktrees, then press `Cmd+Shift+Enter`: archived exits and Shelf opens on a sensible default.
- [x] While in Shelf, press `Cmd+Option+Enter` (Canvas toggle): Shelf exits, Canvas opens.

**Spine layout**
- [x] Open Shelf with multiple repositories + a plain folder. Verify books appear in left-nav order, plain folders as single spines without a branch line.
- [x] Click a spine to the **right** of the open book: spines between them slide leftward, the previously open book's spine joins them, new book's terminal crossfades in.
- [x] Click a spine to the **left** of the open book: spines between slide rightward.
- [x] Click the spine **header** vs a specific **tab slot** on a non-open book: both open the book; the tab-slot click also activates that tab.
- [x] Select a worktree in the **left navigation** while in Shelf: the same spine-flow animation plays and Shelf does **not** exit.

**Tab slots**
- [x] Open a book with custom tab icons. Verify each slot shows its icon.
- [x] Hold **⌘**: each slot's icon swaps for its `1..9` digit (slot size unchanged). Tabs 10+ stay as icons with slight dim.
- [x] Hover a tab slot (without ⌘): a small close X appears in the top-right corner.
- [x] Right-click a tab slot: context menu with Change Title, Change Icon, Close Tab, Close Others, etc.
- [x] Trigger a notification on a non-active tab: that slot's background turns orange.
- [x] Scroll the tab list so a notifying tab leaves view: spine header shows a small orange dot.
- [x] Create many tabs: the tab list scrolls vertically; header and bottom controls stay pinned.

**Bottom controls (open book only)**
- [x] `+` on the open spine: creates a new tab in the open book.
- [x] Vertical / horizontal split: splits the focused surface in the open book.
- [x] Verify bottom controls are **not** shown on non-open spines.

**Context menus & removal**
- [x] Right-click the spine header: "Remove Book" appears. Clicking it archives a worktree (with confirmation) or removes a plain folder (through the standard flow).
- [x] Close the last tab of a book: the book stays on the shelf; its open area shows "No terminals open"; the `+` button recovers a new tab.

**Keyboard**
- [x] `Cmd+1..9` switches tabs within the currently open book.
- [x] `Cmd+Ctrl+→` / `Cmd+Ctrl+←` cycles through books (wraps around at the ends).
- [x] `Ctrl+Option+1..9` jumps directly to that book on the Shelf (including plain folders — distinct from `Ctrl+1..9` which targets worktrees only).
- [x] `Settings → Shortcuts` shows all new commands under "Scripts & Panels" and lets you rebind them.

**Visual polish**
- [x] Closed spines render with a `.thinMaterial` stack background; the open spine reads as the left edge of the open page.
- [x] The open spine keeps its accent tint; the active tab slot carries a subtle accent fill.
- [x] Notification tint on a slot matches the Canvas title-bar unread tint.
