### PR TITLE
Cache main-worktree flag on Worktree to fix App Hang storm

### DIFF
--- a/supacode/Domain/Worktree.swift
+++ b/supacode/Domain/Worktree.swift
@@ -7,6 +7,7 @@ nonisolated struct Worktree: Identifiable, Hashable, Sendable {
   let workingDirectory: URL
   let repositoryRootURL: URL
   let createdAt: Date?
+  let isMain: Bool
 
   nonisolated init(
     id: String,
@@ -22,6 +23,14 @@ nonisolated struct Worktree: Identifiable, Hashable, Sendable {
     self.workingDirectory = workingDirectory
     self.repositoryRootURL = repositoryRootURL
     self.createdAt = createdAt
+    // Pre-compute the main-worktree flag at construction time so that hot SwiftUI
+    // paths never call the expensive `URL.standardizedFileURL` getter during view
+    // updates. The fast equality check covers the common case where callers
+    // already pass normalized URLs; the standardized fallback protects against
+    // any future call site that forgets to normalize first.
+    self.isMain =
+      workingDirectory == repositoryRootURL
+      || workingDirectory.standardizedFileURL == repositoryRootURL.standardizedFileURL
   }
 }
 

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -1573,7 +1573,7 @@ extension RepositoriesFeature.State {
   }
 
   func isMainWorktree(_ worktree: Worktree) -> Bool {
-    worktree.workingDirectory.standardizedFileURL == worktree.repositoryRootURL.standardizedFileURL
+    worktree.isMain
   }
 
   func isWorktreeMerged(_ worktree: Worktree) -> Bool {

--- a/supacodeTests/WorktreeIsMainTests.swift
+++ b/supacodeTests/WorktreeIsMainTests.swift
@@ -1,0 +1,66 @@
+import Foundation
+import Testing
+
+@testable import supacode
+
+@MainActor
+struct WorktreeIsMainTests {
+  @Test func identicalURLsAreMain() {
+    let root = URL(fileURLWithPath: "/tmp/repo")
+    let worktree = Worktree(
+      id: "/tmp/repo",
+      name: "main",
+      detail: ".",
+      workingDirectory: root,
+      repositoryRootURL: root,
+    )
+    #expect(worktree.isMain == true)
+  }
+
+  @Test func subdirectoryWorktreeIsNotMain() {
+    let worktree = Worktree(
+      id: "/tmp/repo/wt-1",
+      name: "feature",
+      detail: "wt-1",
+      workingDirectory: URL(fileURLWithPath: "/tmp/repo/wt-1"),
+      repositoryRootURL: URL(fileURLWithPath: "/tmp/repo"),
+    )
+    #expect(worktree.isMain == false)
+  }
+
+  @Test func siblingWorktreeIsNotMain() {
+    let worktree = Worktree(
+      id: "/tmp/repo.wt/feature",
+      name: "feature",
+      detail: "../repo.wt/feature",
+      workingDirectory: URL(fileURLWithPath: "/tmp/repo.wt/feature"),
+      repositoryRootURL: URL(fileURLWithPath: "/tmp/repo"),
+    )
+    #expect(worktree.isMain == false)
+  }
+
+  @Test func dotComponentEquivalentURLsAreMain() {
+    // `/tmp/./repo` and `/tmp/repo` are semantically the same directory.
+    // The standardization fallback in Worktree.init covers this case even
+    // if the caller forgot to normalize the URL beforehand.
+    let worktree = Worktree(
+      id: "/tmp/repo",
+      name: "main",
+      detail: ".",
+      workingDirectory: URL(fileURLWithPath: "/tmp/./repo"),
+      repositoryRootURL: URL(fileURLWithPath: "/tmp/repo"),
+    )
+    #expect(worktree.isMain == true)
+  }
+
+  @Test func dotDotComponentEquivalentURLsAreMain() {
+    let worktree = Worktree(
+      id: "/tmp/repo",
+      name: "main",
+      detail: ".",
+      workingDirectory: URL(fileURLWithPath: "/tmp/nested/../repo"),
+      repositoryRootURL: URL(fileURLWithPath: "/tmp/repo"),
+    )
+    #expect(worktree.isMain == true)
+  }
+}


### PR DESCRIPTION
## Summary

- Adds a precomputed `isMain: Bool` to `Worktree`, computed once in `init` with a fast `==` fast-path and a `standardizedFileURL` fallback
- Reduces `RepositoriesFeature.State.isMainWorktree(_:)` to `worktree.isMain` so all call sites become O(1) without touching them
- Adds `WorktreeIsMainTests` to lock in the behavior (identical URLs, subdirectory/sibling paths, and `.`/`..` equivalents)

## Why

30+ Sentry App Hang issues on `prowl@2026.4.20` (`PROWL-MACOS-16`, `-S`, `-13`, `-Y`, `-A`, `-N`, `-M`, `-10`, `-W`, `-15`, `-C`, `-X`, `-9`, …) share the same breadcrumb pattern: a burst of ~50 `repositoryPullRequestRefresh*` + ~20 `filesChanged` actions inside one runloop tick, followed by a 3s+ main-thread hang.

Stacks consistently bottom out in `URL.standardizedFileURL.getter` → `StringProtocol.removingURLPercentEncoding`, reached through `RepositoriesFeature.State.isMainWorktree(_:)`:

```swift
// before
func isMainWorktree(_ worktree: Worktree) -> Bool {
  worktree.workingDirectory.standardizedFileURL == worktree.repositoryRootURL.standardizedFileURL
}
```

That helper is the hot loop body for four separate call sites inside a single sidebar render: `worktreeRowSections` (`first(where:)`), `orderedUnpinnedWorktreeIDs` (`first(where:)` again), `orderedPinnedWorktreeIDs` (per-id `filter`), and `selectedRow`. `SidebarView.body` walks the repo list twice (`orderedWorktreeRows(includingRepositoryIDs:)` and `selectedRows(state:)`), so every view update fires `O(N repos × M worktrees²)` `standardizedFileURL` evaluations on the main thread. Under the action bursts listed above, SwiftUI re-renders fast enough that the accumulated string work breaches the 3s hang threshold.

`standardizedFileURL` itself does not call `realpath(3)` — the cost is repeated percent-decoding inside `_SwiftURL.standardizedFileURL.getter`. Precomputing the result once at construction time removes the whole loop.

## Design notes

- `workingDirectory` and `repositoryRootURL` are already standardized at every production construction site (`GitClient.worktrees`, `GitClient.create`, `RepositoryPersistenceClient`, plain-folder path in `AppFeature`/`supacodeApp`). The `==` fast-path covers them at near-zero cost.
- The `standardizedFileURL` fallback exists purely as defense-in-depth: it executes only when two URLs differ stringwise, and only during `Worktree` construction (off the main thread for the async `GitClient` pathway). Worst case it costs one standardization per constructed worktree at app startup — strictly less than the current per-render cost.
- `isMain` is derivable from other stored properties, so `Hashable`/`Equatable` semantics are unchanged: two Worktrees with equal other fields necessarily have equal `isMain`.
- Deliberately keeping `RepositoriesFeature.State.isMainWorktree(_:)` as a thin wrapper to minimize diff across ~10 call sites. A follow-up can inline it if desired.
- Not attempting to consolidate the three `first(where: isMainWorktree)` passes in `worktreeRowSections` — now that each call is O(1) pure comparison, the cost is negligible and the restructuring risks changing ordering semantics.

## Test plan

- [x] `make test` (scoped): `WorktreeIsMainTests`, `WorktreeEnvironmentTests`, `RepositoriesFeatureTests`, `RepositorySectionViewTests`, `RepositoryPersistenceClientTests`, `GitClientWorktreeDiscoveryTests`, `GitClientCreateWorktreeStreamTests` — 151 passed
- [x] `make lint` — clean
- [x] `make build-app` — succeeds
- [x] Post-release: monitor Sentry for 2–3 days; if the App Hang signatures above persist, follow up with a pass on `orderedRepositoryRoots()` / `orderedRepositoryIDs()` (which still call `standardizedFileURL` in a per-repo loop)
