### PR TITLE
feat(shelf): replace Remove Book with Close Worktree/Folder

### DIFF
--- a/supacode/Features/Shelf/Views/ShelfSpineView.swift
+++ b/supacode/Features/Shelf/Views/ShelfSpineView.swift
@@ -24,9 +24,13 @@ struct ShelfSpineView: View {
   let onNewTab: (() -> Void)?
   let onSplitVertical: (() -> Void)?
   let onSplitHorizontal: (() -> Void)?
-  /// "Remove this book" — drives the book-level context menu entry on
-  /// the spine header / empty body. Nil disables the menu.
-  let onRemoveBook: (() -> Void)?
+  /// "Close this book" — drives the book-level context menu entry on
+  /// the spine header / empty body. Nil disables the menu. The label
+  /// text is supplied by the parent so it can vary per book kind
+  /// ("Close Worktree" vs "Close Folder") without leaking the `Kind`
+  /// enum into this view.
+  let closeMenuTitle: String
+  let onCloseBook: (() -> Void)?
 
   @State private var isHovering = false
 
@@ -118,11 +122,11 @@ struct ShelfSpineView: View {
 
   @ViewBuilder
   private var bookContextMenu: some View {
-    if let onRemoveBook {
-      Button(role: .destructive) {
-        onRemoveBook()
+    if let onCloseBook {
+      Button {
+        onCloseBook()
       } label: {
-        Text("Remove Book")
+        Text(closeMenuTitle)
       }
     }
   }

--- a/supacode/Features/Shelf/Views/ShelfView.swift
+++ b/supacode/Features/Shelf/Views/ShelfView.swift
@@ -88,7 +88,8 @@ struct ShelfView: View {
           },
           onSplitVertical: open ? { performSplit(direction: "new_split:right") } : nil,
           onSplitHorizontal: open ? { performSplit(direction: "new_split:down") } : nil,
-          onRemoveBook: { removeBook(book) }
+          closeMenuTitle: closeMenuTitle(for: book),
+          onCloseBook: { closeBook(book) }
         )
         .matchedGeometryEffect(id: book.id, in: spineNamespace)
       }
@@ -114,17 +115,27 @@ struct ShelfView: View {
     _ = state.performBindingActionOnFocusedSurface(direction)
   }
 
-  /// "Remove Book" context action. Worktree books funnel through the
-  /// existing archive flow (which shows confirmation + progress); plain
-  /// folder books go through repository removal. Both pathways
-  /// eventually drop the book off the Shelf via the same prune logic
-  /// that drives the left navigation.
-  private func removeBook(_ book: ShelfBook) {
+  /// "Close Worktree / Close Folder" context action. Equivalent to
+  /// closing the last tab on this book: tears down all of its terminal
+  /// tabs, which lets the existing `tabClosed(remainingTabs: 0)` →
+  /// `markWorktreeClosed` pipeline retire the book from the Shelf and
+  /// auto-advance selection. Intentionally does *not* archive the
+  /// worktree or remove the repository — Shelf removal is a view-state
+  /// concern, not a destructive resource operation.
+  private func closeBook(_ book: ShelfBook) {
+    if let state = terminalManager.stateIfExists(for: book.id), !state.tabManager.tabs.isEmpty {
+      state.closeAllTabs()
+    } else {
+      // No live tabs to fall through the closeAllTabs → tabClosed
+      // pipeline — drive the Shelf removal directly.
+      store.send(.markWorktreeClosed(book.id))
+    }
+  }
+
+  private func closeMenuTitle(for book: ShelfBook) -> String {
     switch book.kind {
-    case .worktree:
-      store.send(.worktreeLifecycle(.requestArchiveWorktree(book.id, book.repositoryID)))
-    case .plainFolder:
-      store.send(.repositoryManagement(.requestRemoveRepository(book.repositoryID)))
+    case .worktree: "Close Worktree"
+    case .plainFolder: "Close Folder"
     }
   }
 

--- a/supacodeTests/ShelfFeatureTests.swift
+++ b/supacodeTests/ShelfFeatureTests.swift
@@ -569,6 +569,87 @@ struct ShelfFeatureTests {
     await store.finish()
   }
 
+  @Test(.dependencies) func markWorktreeClosedRemovesPlainFolderBookFromOpenedSet() async {
+    // Plain-folder books live in `openedWorktreeIDs` under their
+    // `Repository.ID`. The Shelf "Close Folder" menu dispatches
+    // `.markWorktreeClosed(book.id)` for this path, so the reducer must
+    // handle a plain-folder ID the same way it handles a worktree ID.
+    let rootURL = URL(fileURLWithPath: "/tmp/folder")
+    let repo = Repository(
+      id: rootURL.path(percentEncoded: false),
+      rootURL: rootURL,
+      name: "folder",
+      kind: .plain,
+      worktrees: []
+    )
+    var state = RepositoriesFeature.State(repositories: [repo])
+    state.repositoryRoots = [rootURL]
+    state.repositoryOrderIDs = [repo.id]
+    state.selection = .repository(repo.id)
+    state.isShelfActive = true
+    state.openedWorktreeIDs = [repo.id]
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    }
+
+    // Only book on the Shelf — closing it leaves the opened set empty
+    // and produces no replacement selection, so the Shelf falls back to
+    // the empty state.
+    await store.send(.markWorktreeClosed(repo.id)) {
+      $0.openedWorktreeIDs = []
+    }
+    await store.finish()
+  }
+
+  @Test(.dependencies) func markWorktreeClosedAdvancesToPlainFolderNeighbor() async {
+    // Closing a worktree book whose neighbor is a plain folder must
+    // route through the `.selectRepository` branch of
+    // `shelfBookSelectionEffect`, not `.selectWorktree`. Covers the
+    // plain-folder path of the replacement dispatch that the new
+    // Shelf "Close Worktree/Folder" menu relies on.
+    let gitRootURL = URL(fileURLWithPath: "/tmp/git")
+    let worktree = Worktree(
+      id: "/tmp/git",
+      name: "main",
+      detail: "",
+      workingDirectory: gitRootURL,
+      repositoryRootURL: gitRootURL
+    )
+    let gitRepo = Repository(
+      id: gitRootURL.path(percentEncoded: false),
+      rootURL: gitRootURL,
+      name: "git",
+      worktrees: IdentifiedArray(uniqueElements: [worktree])
+    )
+    let plainRootURL = URL(fileURLWithPath: "/tmp/plain")
+    let plainRepo = Repository(
+      id: plainRootURL.path(percentEncoded: false),
+      rootURL: plainRootURL,
+      name: "plain",
+      kind: .plain,
+      worktrees: []
+    )
+    var state = RepositoriesFeature.State(repositories: [gitRepo, plainRepo])
+    state.repositoryRoots = [gitRootURL, plainRootURL]
+    state.repositoryOrderIDs = [gitRepo.id, plainRepo.id]
+    state.selection = .worktree(worktree.id)
+    state.isShelfActive = true
+    state.openedWorktreeIDs = [worktree.id, plainRepo.id]
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    }
+
+    await store.send(.markWorktreeClosed(worktree.id)) {
+      $0.openedWorktreeIDs = [plainRepo.id]
+    }
+    await store.receive(\.selectRepository) {
+      $0.selection = .repository(plainRepo.id)
+      $0.sidebarSelectedWorktreeIDs = []
+    }
+    await store.receive(\.delegate.selectedWorktreeChanged)
+    await store.finish()
+  }
+
   private struct ThreeWorktreeFixture {
     let repo: Repository
     let worktrees: [Worktree]


### PR DESCRIPTION
## Summary

The Shelf spine context menu's "Remove Book" entry over-reached:
- on worktree books it kicked off the archive flow (with confirmation
  + progress dialog), and silently no-op'd on the main worktree which
  can't be archived.
- on plain-folder books it removed the repository from the app entirely.

Both cases conflated "take this book off the Shelf" with destructive
resource lifecycle. The menu now reads "Close Worktree" / "Close Folder"
(kind-aware) and reuses the existing close-last-tab pipeline:

- If the book has live tabs, call `closeAllTabs()` → the existing
  `tabClosed(remainingTabs: 0)` → `markWorktreeClosed` chain retires
  the book and auto-advances Shelf selection.
- If the book has no tabs (or no terminal state), dispatch
  `markWorktreeClosed(book.id)` directly so the menu still works.

Drops the `.destructive` button role since this is a view-state action,
not data deletion.

## Test plan

- [x] Right-click a worktree spine → menu reads "Close Worktree"; click → spine vanishes, neighbor opens
- [x] Right-click a plain-folder spine → menu reads "Close Folder"; click → spine vanishes
- [x] Right-click the **main worktree** spine → "Close Worktree" works (previously a no-op)
- [x] Underlying worktree directory is *not* removed and the worktree stays in the left nav after Close
- [x] Closing the only book on the Shelf falls back to the empty-shelf state correctly
