### PR TITLE
fix(sentry): cheapen release action breadcrumbs

### DIFF
--- a/supacode/Features/Repositories/BusinessLogic/WorktreeInfoWatcherManager.swift
+++ b/supacode/Features/Repositories/BusinessLogic/WorktreeInfoWatcherManager.swift
@@ -378,9 +378,6 @@ final class WorktreeInfoWatcherManager {
         return
       }
       while !Task.isCancelled {
-        guard !Task.isCancelled else {
-          return
-        }
         await MainActor.run {
           self?.emitPullRequestRefresh(repositoryRootURL: repositoryRootURL)
         }
@@ -460,9 +457,6 @@ final class WorktreeInfoWatcherManager {
         return
       }
       while !Task.isCancelled {
-        guard !Task.isCancelled else {
-          return
-        }
         await MainActor.run {
           self?.emit(request.makeEvent(worktreeID))
         }
@@ -492,7 +486,7 @@ final class WorktreeInfoWatcherManager {
 
   nonisolated private static func stablePhaseOffset(seed: String, interval: Duration) -> Duration {
     let intervalMilliseconds = durationMilliseconds(interval)
-    guard intervalMilliseconds > 1 else {
+    guard intervalMilliseconds > 0 else {
       return .zero
     }
     let hash = stableHash(seed)

--- a/supacode/Features/Repositories/BusinessLogic/WorktreeInfoWatcherManager.swift
+++ b/supacode/Features/Repositories/BusinessLogic/WorktreeInfoWatcherManager.swift
@@ -4,6 +4,9 @@ import Foundation
 
 @MainActor
 final class WorktreeInfoWatcherManager {
+  typealias WorktreePhaseOffset = @Sendable (Worktree.ID, Duration) -> Duration
+  typealias RepositoryPhaseOffset = @Sendable (URL, Duration) -> Duration
+
   private struct HeadWatcher {
     let headURL: URL
     let source: DispatchSourceFileSystemObject
@@ -22,6 +25,7 @@ final class WorktreeInfoWatcherManager {
   private struct RepeatingTaskRequest {
     let worktreeID: Worktree.ID
     let interval: Duration
+    let initialDelay: Duration
     let immediate: Bool
     let forceReschedule: Bool
     let makeEvent: (Worktree.ID) -> WorktreeInfoWatcherClient.Event
@@ -35,6 +39,8 @@ final class WorktreeInfoWatcherManager {
   private let filesChangedDebounceInterval: Duration
   private let pullRequestSelectionRefreshCooldown: Duration
   private let refreshTiming: RefreshTiming
+  private let lineChangePhaseOffset: WorktreePhaseOffset
+  private let pullRequestPhaseOffset: RepositoryPhaseOffset
   private let sleep: @Sendable (Duration) async throws -> Void
   private var worktrees: [Worktree.ID: Worktree] = [:]
   private var headWatchers: [Worktree.ID: HeadWatcher] = [:]
@@ -55,11 +61,15 @@ final class WorktreeInfoWatcherManager {
     unfocusedInterval: Duration = .seconds(60),
     filesChangedDebounceInterval: Duration = .seconds(5),
     pullRequestSelectionRefreshCooldown: Duration = .seconds(5),
+    lineChangePhaseOffset: @escaping WorktreePhaseOffset = WorktreeInfoWatcherManager.defaultLineChangePhaseOffset,
+    pullRequestPhaseOffset: @escaping RepositoryPhaseOffset = WorktreeInfoWatcherManager.defaultPullRequestPhaseOffset,
     clock: C = ContinuousClock()
   ) {
     refreshTiming = RefreshTiming(focused: focusedInterval, unfocused: unfocusedInterval)
     self.filesChangedDebounceInterval = filesChangedDebounceInterval
     self.pullRequestSelectionRefreshCooldown = pullRequestSelectionRefreshCooldown
+    self.lineChangePhaseOffset = lineChangePhaseOffset
+    self.pullRequestPhaseOffset = pullRequestPhaseOffset
     self.sleep = { duration in
       try await clock.sleep(for: duration)
     }
@@ -359,19 +369,25 @@ final class WorktreeInfoWatcherManager {
     if immediate {
       emitPullRequestRefresh(repositoryRootURL: repositoryRootURL)
     }
+    let initialDelay = interval + pullRequestPhaseOffset(repositoryRootURL, interval)
     let sleep = self.sleep
     let task = Task { [weak self, sleep] in
+      do {
+        try await sleep(initialDelay)
+      } catch {
+        return
+      }
       while !Task.isCancelled {
-        do {
-          try await sleep(interval)
-        } catch {
-          break
-        }
         guard !Task.isCancelled else {
-          break
+          return
         }
         await MainActor.run {
           self?.emitPullRequestRefresh(repositoryRootURL: repositoryRootURL)
+        }
+        do {
+          try await sleep(interval)
+        } catch {
+          return
         }
       }
     }
@@ -410,6 +426,7 @@ final class WorktreeInfoWatcherManager {
     let request = RepeatingTaskRequest(
       worktreeID: worktreeID,
       interval: interval,
+      initialDelay: interval + lineChangePhaseOffset(worktreeID, interval),
       immediate: shouldEmit,
       forceReschedule: forceReschedule,
       makeEvent: { [weak self] worktreeID in
@@ -437,21 +454,65 @@ final class WorktreeInfoWatcherManager {
     }
     let sleep = self.sleep
     let task = Task { [weak self, sleep] in
+      do {
+        try await sleep(request.initialDelay)
+      } catch {
+        return
+      }
       while !Task.isCancelled {
-        do {
-          try await sleep(request.interval)
-        } catch {
-          break
-        }
         guard !Task.isCancelled else {
-          break
+          return
         }
         await MainActor.run {
           self?.emit(request.makeEvent(worktreeID))
         }
+        do {
+          try await sleep(request.interval)
+        } catch {
+          return
+        }
       }
     }
     tasks[worktreeID] = RefreshTask(interval: request.interval, task: task)
+  }
+
+  nonisolated private static func defaultLineChangePhaseOffset(
+    worktreeID: Worktree.ID,
+    interval: Duration
+  ) -> Duration {
+    stablePhaseOffset(seed: worktreeID, interval: interval)
+  }
+
+  nonisolated private static func defaultPullRequestPhaseOffset(
+    repositoryRootURL: URL,
+    interval: Duration
+  ) -> Duration {
+    stablePhaseOffset(seed: repositoryRootURL.path(percentEncoded: false), interval: interval)
+  }
+
+  nonisolated private static func stablePhaseOffset(seed: String, interval: Duration) -> Duration {
+    let intervalMilliseconds = durationMilliseconds(interval)
+    guard intervalMilliseconds > 1 else {
+      return .zero
+    }
+    let hash = stableHash(seed)
+    return .milliseconds(Int64(hash % UInt64(intervalMilliseconds)))
+  }
+
+  nonisolated private static func durationMilliseconds(_ duration: Duration) -> Int64 {
+    let components = duration.components
+    let millisecondsFromSeconds = components.seconds * 1_000
+    let millisecondsFromAttoseconds = Int64(components.attoseconds / 1_000_000_000_000_000)
+    return millisecondsFromSeconds + millisecondsFromAttoseconds
+  }
+
+  nonisolated private static func stableHash(_ string: String) -> UInt64 {
+    var hash: UInt64 = 14_695_981_039_346_656_037
+    for byte in string.utf8 {
+      hash ^= UInt64(byte)
+      hash &*= 1_099_511_628_211
+    }
+    return hash
   }
 
   private func emit(_ event: WorktreeInfoWatcherClient.Event) {

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -985,8 +985,13 @@ struct RepositoriesFeature {
             }
             let worktreeURL = worktree.workingDirectory
             let gitClient = gitClient
+            let previousLineChanges = normalizedLineChanges(state.worktreeInfoByID[worktreeID])
             return .run { send in
               if let changes = await gitClient.lineChanges(worktreeURL) {
+                let nextLineChanges = normalizedLineChanges(added: changes.added, removed: changes.removed)
+                guard !lineChangesEqual(nextLineChanges, previousLineChanges) else {
+                  return
+                }
                 await send(
                   .worktreeLineChangesLoaded(
                     worktreeID: worktreeID,
@@ -2196,6 +2201,37 @@ func updateWorktreePullRequest(
     state.worktreeInfoByID.removeValue(forKey: worktreeID)
   } else {
     state.worktreeInfoByID[worktreeID] = entry
+  }
+}
+
+nonisolated private func normalizedLineChanges(_ entry: WorktreeInfoEntry?) -> (added: Int, removed: Int)? {
+  guard let added = entry?.addedLines, let removed = entry?.removedLines else {
+    return nil
+  }
+  return (added, removed)
+}
+
+nonisolated private func normalizedLineChanges(
+  added: Int,
+  removed: Int
+) -> (added: Int, removed: Int)? {
+  guard added != 0 || removed != 0 else {
+    return nil
+  }
+  return (added, removed)
+}
+
+nonisolated private func lineChangesEqual(
+  _ lhs: (added: Int, removed: Int)?,
+  _ rhs: (added: Int, removed: Int)?
+) -> Bool {
+  switch (lhs, rhs) {
+  case (nil, nil):
+    return true
+  case (.some(let lhs), .some(let rhs)):
+    return lhs.added == rhs.added && lhs.removed == rhs.removed
+  default:
+    return false
   }
 }
 

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -2208,7 +2208,7 @@ nonisolated private func normalizedLineChanges(_ entry: WorktreeInfoEntry?) -> (
   guard let added = entry?.addedLines, let removed = entry?.removedLines else {
     return nil
   }
-  return (added, removed)
+  return normalizedLineChanges(added: added, removed: removed)
 }
 
 nonisolated private func normalizedLineChanges(

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -2155,12 +2155,13 @@ private func updateWorktreeName(
   }
 }
 
-private func updateWorktreeLineChanges(
+@discardableResult
+func updateWorktreeLineChanges(
   worktreeID: Worktree.ID,
   added: Int,
   removed: Int,
   state: inout RepositoriesFeature.State
-) {
+) -> Bool {
   var entry = state.worktreeInfoByID[worktreeID] ?? WorktreeInfoEntry()
   if added == 0 && removed == 0 {
     entry.addedLines = nil
@@ -2169,11 +2170,19 @@ private func updateWorktreeLineChanges(
     entry.addedLines = added
     entry.removedLines = removed
   }
+  let previousEntry = state.worktreeInfoByID[worktreeID]
   if entry.isEmpty {
+    guard previousEntry != nil else {
+      return false
+    }
     state.worktreeInfoByID.removeValue(forKey: worktreeID)
-  } else {
-    state.worktreeInfoByID[worktreeID] = entry
+    return true
   }
+  guard previousEntry != entry else {
+    return false
+  }
+  state.worktreeInfoByID[worktreeID] = entry
+  return true
 }
 
 func updateWorktreePullRequest(

--- a/supacode/Support/DebugCaseOutput.swift
+++ b/supacode/Support/DebugCaseOutput.swift
@@ -16,9 +16,9 @@ struct LogActionsReducer<Base: Reducer>: Reducer where Base.State: Equatable {
   private let logger = SupaLogger("TCA")
 
   func reduce(into state: inout Base.State, action: Base.Action) -> Effect<Base.Action> {
-    let actionLabel = debugCaseOutput(action)
-    logger.debug("Action: \(actionLabel)")
     #if DEBUG
+      let actionLabel = debugCaseOutput(action)
+      logger.debug("Action: \(actionLabel)")
       let previousState = state
       let effects = base.reduce(into: &state, action: action)
       if previousState != state, let diff = CustomDump.diff(previousState, state) {
@@ -26,6 +26,8 @@ struct LogActionsReducer<Base: Reducer>: Reducer where Base.State: Equatable {
       }
       return effects
     #else
+      let actionLabel = releaseActionLabel(action)
+      logger.debug("Action: \(actionLabel)")
       SentrySDK.logger.info("Action: \(actionLabel)")
       let breadcrumb = Breadcrumb(level: .debug, category: "action")
       breadcrumb.message = actionLabel
@@ -66,8 +68,55 @@ func debugCaseOutput(
     ?? "\(abbreviated ? "" : typeName(type(of: value)))\(debugCaseOutputHelp(value))"
 }
 
+func releaseActionLabel(_ value: Any) -> String {
+  let rootType = shortTypeName(type(of: value))
+  let casePath = releaseEnumCasePath(value)
+  guard !casePath.isEmpty else {
+    return rootType
+  }
+  return "\(rootType).\(casePath.joined(separator: "."))"
+}
+
 private func isUnlabeledArgument(_ label: String) -> Bool {
   label.firstIndex(where: { $0 != "." && !$0.isNumber }) == nil
+}
+
+private func releaseEnumCasePath(_ value: Any) -> [String] {
+  var labels: [String] = []
+  var currentValue = value
+
+  while true {
+    let mirror = Mirror(reflecting: currentValue)
+    guard mirror.displayStyle == .enum else {
+      return labels
+    }
+    if let child = mirror.children.first, let label = child.label {
+      labels.append(label)
+      let childMirror = Mirror(reflecting: child.value)
+      guard childMirror.displayStyle == .enum else {
+        return labels
+      }
+      currentValue = child.value
+    } else {
+      labels.append(caseName(String(describing: currentValue)))
+      return labels
+    }
+  }
+}
+
+private func caseName(_ description: String) -> String {
+  if let parenIndex = description.firstIndex(of: "(") {
+    return String(description[..<parenIndex])
+  }
+  return description
+}
+
+private func shortTypeName(_ type: Any.Type) -> String {
+  let components = String(reflecting: type)
+    .split(separator: ".")
+    .filter { !$0.hasPrefix("(unknown context at $") }
+    .suffix(2)
+  return components.isEmpty ? String(reflecting: type) : components.joined(separator: ".")
 }
 
 private func typeName(

--- a/supacodeTests/ReleaseActionLabelTests.swift
+++ b/supacodeTests/ReleaseActionLabelTests.swift
@@ -1,0 +1,40 @@
+import Testing
+
+@testable import supacode
+
+struct ReleaseActionLabelTests {
+  private enum OuterAction {
+    case idle
+    case inner(InnerAction)
+    case payload(id: Int, title: String)
+  }
+
+  private enum InnerAction {
+    case ready
+    case deep(DeepAction)
+  }
+
+  private enum DeepAction {
+    case done(worktreeID: String, added: Int, removed: Int)
+  }
+
+  @Test func nestedEnumLabelUsesCasePathWithoutPayloads() {
+    let label = releaseActionLabel(
+      OuterAction.inner(.deep(.done(worktreeID: "wt-1", added: 3, removed: 1)))
+    )
+
+    #expect(label == "ReleaseActionLabelTests.OuterAction.inner.deep.done")
+  }
+
+  @Test func payloadCaseDoesNotExpandAssociatedValues() {
+    let label = releaseActionLabel(OuterAction.payload(id: 42, title: "repo"))
+
+    #expect(label == "ReleaseActionLabelTests.OuterAction.payload")
+  }
+
+  @Test func payloadlessCaseKeepsTypeAndCase() {
+    let label = releaseActionLabel(OuterAction.idle)
+
+    #expect(label == "ReleaseActionLabelTests.OuterAction.idle")
+  }
+}

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -135,6 +135,73 @@ struct RepositoriesFeatureTests {
     )
   }
 
+  @Test func filesChangedSkipsLineChangeActionWhenGitCountsMatchCurrentState() async {
+    let worktree = makeWorktree(id: "/tmp/repo/feature", name: "feature", repoRoot: "/tmp/repo")
+    let repository = makeRepository(id: "/tmp/repo", worktrees: [worktree])
+    var state = makeState(repositories: [repository])
+    state.worktreeInfoByID[worktree.id] = WorktreeInfoEntry(
+      addedLines: 12,
+      removedLines: 4,
+      pullRequest: nil
+    )
+
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.gitClient.lineChanges = { _ in (12, 4) }
+    }
+
+    await store.send(.worktreeInfoEvent(.filesChanged(worktreeID: worktree.id)))
+    await store.finish()
+  }
+
+  @Test func filesChangedSkipsLineChangeActionWhenGitReportsAlreadyEmptyDiff() async {
+    let worktree = makeWorktree(id: "/tmp/repo/feature", name: "feature", repoRoot: "/tmp/repo")
+    let repository = makeRepository(id: "/tmp/repo", worktrees: [worktree])
+    let pullRequest = makePullRequest(state: "OPEN", headRefName: worktree.name)
+    var state = makeState(repositories: [repository])
+    state.worktreeInfoByID[worktree.id] = WorktreeInfoEntry(
+      addedLines: nil,
+      removedLines: nil,
+      pullRequest: pullRequest
+    )
+
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.gitClient.lineChanges = { _ in (0, 0) }
+    }
+
+    await store.send(.worktreeInfoEvent(.filesChanged(worktreeID: worktree.id)))
+    await store.finish()
+  }
+
+  @Test func filesChangedEmitsLineChangeActionWhenGitCountsDiffer() async {
+    let worktree = makeWorktree(id: "/tmp/repo/feature", name: "feature", repoRoot: "/tmp/repo")
+    let repository = makeRepository(id: "/tmp/repo", worktrees: [worktree])
+    var state = makeState(repositories: [repository])
+    state.worktreeInfoByID[worktree.id] = WorktreeInfoEntry(
+      addedLines: 12,
+      removedLines: 4,
+      pullRequest: nil
+    )
+
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.gitClient.lineChanges = { _ in (15, 9) }
+    }
+
+    await store.send(.worktreeInfoEvent(.filesChanged(worktreeID: worktree.id)))
+    await store.receive(\.worktreeLineChangesLoaded) {
+      $0.worktreeInfoByID[worktree.id] = WorktreeInfoEntry(
+        addedLines: 15,
+        removedLines: 9,
+        pullRequest: nil
+      )
+    }
+  }
+
   @Test func repositoriesLoadedEmitsChangedDelegateWhenTransitioningFromRestoring() async {
     let worktree = makeWorktree(id: "/tmp/repo/main", name: "main")
     let repository = makeRepository(id: "/tmp/repo", worktrees: [worktree])

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -67,6 +67,74 @@ struct RepositoriesFeatureTests {
     }
   }
 
+  @Test func updateWorktreeLineChangesReturnsFalseWhenCountsMatchExistingEntry() {
+    let worktree = makeWorktree(id: "/tmp/repo/feature", name: "feature", repoRoot: "/tmp/repo")
+    let repository = makeRepository(id: "/tmp/repo", worktrees: [worktree])
+    var state = makeState(repositories: [repository])
+    state.worktreeInfoByID[worktree.id] = WorktreeInfoEntry(
+      addedLines: 12,
+      removedLines: 4,
+      pullRequest: nil
+    )
+
+    let changed = updateWorktreeLineChanges(
+      worktreeID: worktree.id,
+      added: 12,
+      removed: 4,
+      state: &state
+    )
+
+    #expect(changed == false)
+    #expect(
+      state.worktreeInfoByID[worktree.id]
+        == WorktreeInfoEntry(addedLines: 12, removedLines: 4, pullRequest: nil)
+    )
+  }
+
+  @Test func updateWorktreeLineChangesReturnsFalseWhenClearingAlreadyEmptyDiffs() {
+    let worktree = makeWorktree(id: "/tmp/repo/feature", name: "feature", repoRoot: "/tmp/repo")
+    let repository = makeRepository(id: "/tmp/repo", worktrees: [worktree])
+    var state = makeState(repositories: [repository])
+    let pullRequest = makePullRequest(state: "OPEN", headRefName: worktree.name)
+    state.worktreeInfoByID[worktree.id] = WorktreeInfoEntry(
+      addedLines: nil,
+      removedLines: nil,
+      pullRequest: pullRequest
+    )
+
+    let changed = updateWorktreeLineChanges(
+      worktreeID: worktree.id,
+      added: 0,
+      removed: 0,
+      state: &state
+    )
+
+    #expect(changed == false)
+    #expect(
+      state.worktreeInfoByID[worktree.id]
+        == WorktreeInfoEntry(addedLines: nil, removedLines: nil, pullRequest: pullRequest)
+    )
+  }
+
+  @Test func updateWorktreeLineChangesReturnsTrueWhenCountsChange() {
+    let worktree = makeWorktree(id: "/tmp/repo/feature", name: "feature", repoRoot: "/tmp/repo")
+    let repository = makeRepository(id: "/tmp/repo", worktrees: [worktree])
+    var state = makeState(repositories: [repository])
+
+    let changed = updateWorktreeLineChanges(
+      worktreeID: worktree.id,
+      added: 12,
+      removed: 4,
+      state: &state
+    )
+
+    #expect(changed == true)
+    #expect(
+      state.worktreeInfoByID[worktree.id]
+        == WorktreeInfoEntry(addedLines: 12, removedLines: 4, pullRequest: nil)
+    )
+  }
+
   @Test func repositoriesLoadedEmitsChangedDelegateWhenTransitioningFromRestoring() async {
     let worktree = makeWorktree(id: "/tmp/repo/main", name: "main")
     let repository = makeRepository(id: "/tmp/repo", worktrees: [worktree])

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -176,6 +176,26 @@ struct RepositoriesFeatureTests {
     await store.finish()
   }
 
+  @Test func filesChangedSkipsLineChangeActionWhenEntryExplicitlyHoldsZeros() async {
+    let worktree = makeWorktree(id: "/tmp/repo/feature", name: "feature", repoRoot: "/tmp/repo")
+    let repository = makeRepository(id: "/tmp/repo", worktrees: [worktree])
+    var state = makeState(repositories: [repository])
+    state.worktreeInfoByID[worktree.id] = WorktreeInfoEntry(
+      addedLines: 0,
+      removedLines: 0,
+      pullRequest: nil
+    )
+
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.gitClient.lineChanges = { _ in (0, 0) }
+    }
+
+    await store.send(.worktreeInfoEvent(.filesChanged(worktreeID: worktree.id)))
+    await store.finish()
+  }
+
   @Test func filesChangedEmitsLineChangeActionWhenGitCountsDiffer() async {
     let worktree = makeWorktree(id: "/tmp/repo/feature", name: "feature", repoRoot: "/tmp/repo")
     let repository = makeRepository(id: "/tmp/repo", worktrees: [worktree])

--- a/supacodeTests/WorktreeInfoWatcherManagerTests.swift
+++ b/supacodeTests/WorktreeInfoWatcherManagerTests.swift
@@ -33,6 +33,8 @@ struct WorktreeInfoWatcherManagerTests {
     let manager = WorktreeInfoWatcherManager(
       focusedInterval: .milliseconds(80),
       unfocusedInterval: .milliseconds(80),
+      lineChangePhaseOffset: { _, _ in .zero },
+      pullRequestPhaseOffset: { _, _ in .zero },
       clock: clock
     )
     let (collector, task) = startCollecting(manager.eventStream())
@@ -57,6 +59,116 @@ struct WorktreeInfoWatcherManagerTests {
     manager.handleCommand(.stop)
     await task.value
     try FileManager.default.removeItem(at: tempRepository.tempRoot)
+  }
+
+  @Test func staggersDeferredLineChangesAcrossWorktrees() async throws {
+    let clock = TestClock()
+    let tempRepository = try makeTempRepository(worktreeNames: ["sparrow", "swift", "eagle"])
+    let firstWorktree = try #require(tempRepository.worktrees.first)
+    let secondWorktree = try #require(tempRepository.worktrees.dropFirst().first)
+    let thirdWorktree = try #require(tempRepository.worktrees.dropFirst(2).first)
+    let manager = WorktreeInfoWatcherManager(
+      focusedInterval: .milliseconds(80),
+      unfocusedInterval: .milliseconds(80),
+      lineChangePhaseOffset: { worktreeID, _ in
+        switch worktreeID {
+        case secondWorktree.id:
+          return .milliseconds(10)
+        case thirdWorktree.id:
+          return .milliseconds(40)
+        default:
+          return .zero
+        }
+      },
+      pullRequestPhaseOffset: { _, _ in .zero },
+      clock: clock
+    )
+    let (collector, task) = startCollecting(manager.eventStream())
+
+    manager.handleCommand(.setPullRequestTrackingEnabled(false))
+    manager.handleCommand(.setWorktrees([firstWorktree]))
+    await drainAsyncEvents(120)
+    #expect(await collector.filesChangedCount(worktreeID: firstWorktree.id) == 1)
+
+    manager.handleCommand(.setWorktrees([firstWorktree, secondWorktree, thirdWorktree]))
+    await drainAsyncEvents(120)
+    #expect(await collector.filesChangedCount(worktreeID: secondWorktree.id) == 0)
+    #expect(await collector.filesChangedCount(worktreeID: thirdWorktree.id) == 0)
+
+    await clock.advance(by: .milliseconds(89))
+    await drainAsyncEvents(120)
+    #expect(await collector.filesChangedCount(worktreeID: secondWorktree.id) == 0)
+    #expect(await collector.filesChangedCount(worktreeID: thirdWorktree.id) == 0)
+
+    await clock.advance(by: .milliseconds(1))
+    await drainAsyncEvents(120)
+    #expect(await collector.filesChangedCount(worktreeID: secondWorktree.id) == 1)
+    #expect(await collector.filesChangedCount(worktreeID: thirdWorktree.id) == 0)
+
+    await clock.advance(by: .milliseconds(29))
+    await drainAsyncEvents(120)
+    #expect(await collector.filesChangedCount(worktreeID: thirdWorktree.id) == 0)
+
+    await clock.advance(by: .milliseconds(1))
+    await drainAsyncEvents(120)
+    #expect(await collector.filesChangedCount(worktreeID: thirdWorktree.id) == 1)
+
+    manager.handleCommand(.stop)
+    await task.value
+    try FileManager.default.removeItem(at: tempRepository.tempRoot)
+  }
+
+  @Test func staggersPeriodicPullRequestRefreshAcrossRepositories() async throws {
+    let clock = TestClock()
+    let firstRepository = try makeTempRepository(worktreeNames: ["sparrow"])
+    let secondRepository = try makeTempRepository(worktreeNames: ["swift"])
+    let firstWorktree = try #require(firstRepository.worktrees.first)
+    let secondWorktree = try #require(secondRepository.worktrees.first)
+    let manager = WorktreeInfoWatcherManager(
+      focusedInterval: .milliseconds(80),
+      unfocusedInterval: .milliseconds(80),
+      lineChangePhaseOffset: { _, _ in .zero },
+      pullRequestPhaseOffset: { repositoryRootURL, _ in
+        switch repositoryRootURL {
+        case firstRepository.tempRoot:
+          return .milliseconds(10)
+        case secondRepository.tempRoot:
+          return .milliseconds(40)
+        default:
+          return .zero
+        }
+      },
+      clock: clock
+    )
+    let (collector, task) = startCollecting(manager.eventStream())
+
+    manager.handleCommand(.setWorktrees([firstWorktree, secondWorktree]))
+    await drainAsyncEvents(120)
+    #expect(await collector.pullRequestRefreshCount(repositoryRootURL: firstRepository.tempRoot) == 1)
+    #expect(await collector.pullRequestRefreshCount(repositoryRootURL: secondRepository.tempRoot) == 1)
+
+    await clock.advance(by: .milliseconds(89))
+    await drainAsyncEvents(120)
+    #expect(await collector.pullRequestRefreshCount(repositoryRootURL: firstRepository.tempRoot) == 1)
+    #expect(await collector.pullRequestRefreshCount(repositoryRootURL: secondRepository.tempRoot) == 1)
+
+    await clock.advance(by: .milliseconds(1))
+    await drainAsyncEvents(120)
+    #expect(await collector.pullRequestRefreshCount(repositoryRootURL: firstRepository.tempRoot) == 2)
+    #expect(await collector.pullRequestRefreshCount(repositoryRootURL: secondRepository.tempRoot) == 1)
+
+    await clock.advance(by: .milliseconds(29))
+    await drainAsyncEvents(120)
+    #expect(await collector.pullRequestRefreshCount(repositoryRootURL: secondRepository.tempRoot) == 1)
+
+    await clock.advance(by: .milliseconds(1))
+    await drainAsyncEvents(120)
+    #expect(await collector.pullRequestRefreshCount(repositoryRootURL: secondRepository.tempRoot) == 2)
+
+    manager.handleCommand(.stop)
+    await task.value
+    try FileManager.default.removeItem(at: firstRepository.tempRoot)
+    try FileManager.default.removeItem(at: secondRepository.tempRoot)
   }
 
   @Test func selectionRefreshUsesCooldownWithinRepository() async throws {


### PR DESCRIPTION
## Summary
- **Sentry breadcrumbs**: keep the existing detailed `debugCaseOutput` path only for DEBUG builds, and use a cheap enum case-path label for release action logging / Sentry breadcrumbs.
- **Watcher staggering**: stagger per-worktree line-change and per-repository pull-request refresh schedules via a stable per-seed phase offset, so periodic work no longer fires in lockstep across many worktrees/repos.
- **No-op skip**: skip `worktreeLineChangesLoaded` actions (and the matching state writes) when the git-reported line counts already match the current state, to cut redundant reducer/Sentry traffic.

## Verification
- xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -only-testing:supacodeTests/ReleaseActionLabelTests -only-testing:supacodeTests/WorktreeInfoWatcherManagerTests -only-testing:supacodeTests/RepositoriesFeatureTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation -clonedSourcePackagesDirPath /tmp/supacode-spm-cache/SourcePackages
- make lint
- make build-app
