### PR TITLE
fix(sentry): expand system hang signatures to cut 4 new noise classes

### DIFF
--- a/supacode/Support/SentryEventFilter.swift
+++ b/supacode/Support/SentryEventFilter.swift
@@ -15,11 +15,33 @@ enum SentryEventFilter {
   /// App Hang (wake-from-sleep, active space change, external display connect,
   /// menu bar redraw, etc.). These hangs are observable but have no app-level
   /// remedy — filter them out to avoid drowning real hangs in noise.
+  ///
+  /// Matched via substring containment, so prefer distinctive fragments that
+  /// won't collide with app code.
   nonisolated static let systemHangSignatures = [
+    // Menu bar rebuild on active-space change / wake-from-sleep.
     "_NSMenuBarDisplayManagerActiveSpaceChanged",
     "NSMenuBarLocalDisplayWindow",
     "NSMenuBarPresentationInstance",
     "NSMenuBarReplicantWindow",
+    // SkyLight window-server event delivery. When the main run loop is idle
+    // waiting on the WindowServer mach port, SentryANRTracker can sample the
+    // thread mid-mach_msg and misreport the wait as a hang.
+    "CGSSnarfAndDispatchDatagrams",
+    "SLSGetNextEventRecordInternal",
+    "_CGSFindWindow",
+    "SLSFindWindowAndOwner",
+    // HIToolbox keyboard layout / input-source cache first-touch init. First
+    // query after boot or after a layout change walks the component catalog
+    // on the main thread.
+    "TSMCurrentKeyboardLayoutInputSourceRefCreate",
+    "InitializeInputSourceCache",
+    // SF Symbol image-rep loading on first access of a given symbol.
+    "NSImageSymbolRepProvider",
+    // RunningBoardServices XPC encoding on process-state transitions
+    // (e.g. assertion renewal); the main thread blocks on the XPC round trip.
+    "_RBSXPCEncodeObjectForKey",
+    "RBSDomainAttribute",
   ]
 
   /// Drop App Hang events whose stack contains zero in-app frames AND matches

--- a/supacodeTests/SentryEventFilterTests.swift
+++ b/supacodeTests/SentryEventFilterTests.swift
@@ -32,6 +32,52 @@ struct SentryEventFilterTests {
     #expect(SentryEventFilter.filterSystemHang(event) === event)
   }
 
+  @Test func appHangWithSkyLightEventLoopIdleIsDropped() {
+    let event = makeEvent(
+      mechanismType: "AppHang",
+      frames: [
+        makeFrame(function: "mach_msg2_trap", inApp: false),
+        makeFrame(function: "CGSSnarfAndDispatchDatagrams", inApp: false),
+        makeFrame(function: "SLSGetNextEventRecordInternal", inApp: false),
+      ]
+    )
+    #expect(SentryEventFilter.filterSystemHang(event) == nil)
+  }
+
+  @Test func appHangWithKeyboardLayoutInitIsDropped() {
+    let event = makeEvent(
+      mechanismType: "AppHang",
+      frames: [
+        makeFrame(function: "OpenCCFFile", inApp: false),
+        makeFrame(function: "InitializeInputSourceCache", inApp: false),
+        makeFrame(function: "TSMCurrentKeyboardLayoutInputSourceRefCreate.cold.1", inApp: false),
+      ]
+    )
+    #expect(SentryEventFilter.filterSystemHang(event) == nil)
+  }
+
+  @Test func appHangWithSFSymbolLoadIsDropped() {
+    let event = makeEvent(
+      mechanismType: "AppHang",
+      frames: [
+        makeFrame(function: "-[NSImage bestRepresentationForHints:]", inApp: false),
+        makeFrame(function: "-[NSImageSymbolRepProvider init]", inApp: false),
+      ]
+    )
+    #expect(SentryEventFilter.filterSystemHang(event) == nil)
+  }
+
+  @Test func appHangWithRunningBoardXPCIsDropped() {
+    let event = makeEvent(
+      mechanismType: "AppHang",
+      frames: [
+        makeFrame(function: "_RBSXPCEncodeObjectForKey", inApp: false),
+        makeFrame(function: "-[RBSDomainAttribute encodeWithRBSXPCCoder:]", inApp: false),
+      ]
+    )
+    #expect(SentryEventFilter.filterSystemHang(event) == nil)
+  }
+
   @Test func appHangWithNoKnownSystemSignatureIsKept() {
     let event = makeEvent(
       mechanismType: "AppHang",


### PR DESCRIPTION
## Summary

Extend `SentryEventFilter.systemHangSignatures` with four new noise classes observed in App Hang events from v2026.4.22/v2026.4.23. The filter contract is unchanged — only drop events where every frame is non-app **AND** at least one frame matches a known system-induced signature.

New signature groups (with one regression test per group):
- **SkyLight event-loop idle**: `CGSSnarfAndDispatchDatagrams`, `SLSGetNextEventRecordInternal`, `_CGSFindWindow`, `SLSFindWindowAndOwner` — main thread sampled mid-`mach_msg` while waiting on the WindowServer port.
- **HIToolbox keyboard layout cache**: `TSMCurrentKeyboardLayoutInputSourceRefCreate`, `InitializeInputSourceCache` — first query walks the component catalog on the main thread.
- **SF Symbol first-touch load**: `NSImageSymbolRepProvider`.
- **RunningBoardServices XPC encoding**: `_RBSXPCEncodeObjectForKey`, `RBSDomainAttribute` — main thread blocks on the XPC round trip during process-state transitions.

Sampled directly from recent PROWL-MACOS-7 events on v2026.4.23 that have zero in-app frames and no app-level remedy.

## Test plan

- [x] `make check` — format + lint clean.
- [x] `xcodebuild test -only-testing:supacodeTests/SentryEventFilterTests` — 10/10 passing (6 existing + 4 new drop-path regressions).
- [x] `make build-app` — Debug build green.
