### PR TITLE
feat(canvas): Cmd+wheel zoom and middle-click pan

### DIFF
--- a/supacode/Features/Canvas/Views/CanvasView.swift
+++ b/supacode/Features/Canvas/Views/CanvasView.swift
@@ -26,6 +26,10 @@ struct CanvasView: View {
   private let maxCardHeight: CGFloat = 1600
   private let titleBarHeight: CGFloat = 28
   private let cardSpacing: CGFloat = 20
+  /// Reserved height at the bottom of the viewport for the help button and
+  /// layout toolbar so cards don't sit underneath them after auto-fit.
+  /// Cards end up shifted upward by half of this amount.
+  private let bottomToolbarReserve: CGFloat = 30
 
   var body: some View {
     let selectAllCanvasShortcut = AppShortcuts.resolvedShortcut(
@@ -408,7 +412,7 @@ struct CanvasView: View {
 
     canvasOffset = CGSize(
       width: canvasSize.width / 2 - bboxCenterX * newScale,
-      height: canvasSize.height / 2 - bboxCenterY * newScale
+      height: (canvasSize.height - bottomToolbarReserve) / 2 - bboxCenterY * newScale
     )
     canvasScale = newScale
     lastCanvasScale = newScale

--- a/supacode/Features/Canvas/Views/CanvasView.swift
+++ b/supacode/Features/Canvas/Views/CanvasView.swift
@@ -1,4 +1,5 @@
 import AppKit
+import GameController
 import SwiftUI
 
 struct CanvasView: View {
@@ -18,6 +19,9 @@ struct CanvasView: View {
   @State private var activeResize: [TerminalTabID: ActiveResize] = [:]
   @State private var hasPerformedInitialFit = false
   @State private var viewportSize: CGSize = .zero
+  @State private var hasConnectedMouse: Bool = !GCMouse.mice().isEmpty
+  @State private var showsMouseHelp = false
+  @State private var mouseConnectionObservers: [NSObjectProtocol] = []
 
   private let minCardWidth: CGFloat = 300
   private let minCardHeight: CGFloat = 200
@@ -165,6 +169,13 @@ struct CanvasView: View {
     .overlay(alignment: .bottomTrailing) {
       canvasToolbar
     }
+    .overlay(alignment: .bottomLeading) {
+      if hasConnectedMouse {
+        mouseHelpButton
+      }
+    }
+    .onAppear { startObservingMouseConnections() }
+    .onDisappear { stopObservingMouseConnections() }
     .onKeyPress(.escape) {
       guard selectionState.isBroadcasting else { return .ignored }
       clearSelection(states: terminalManager.activeWorktreeStates)
@@ -421,6 +432,72 @@ struct CanvasView: View {
       layouts.removeValue(forKey: key)
     }
     layoutStore.cardLayouts = layouts
+  }
+
+  private var mouseHelpButton: some View {
+    Button {
+      showsMouseHelp.toggle()
+    } label: {
+      Image(systemName: "questionmark.circle")
+        .font(.body)
+        .accessibilityLabel("Canvas mouse shortcuts")
+    }
+    .buttonStyle(.bordered)
+    .help("Canvas mouse shortcuts")
+    .popover(isPresented: $showsMouseHelp, arrowEdge: .bottom) {
+      mouseHelpContent
+    }
+    .padding()
+  }
+
+  private var mouseHelpContent: some View {
+    VStack(alignment: .leading, spacing: 12) {
+      Text("Canvas Mouse Shortcuts")
+        .font(.headline)
+
+      VStack(alignment: .leading, spacing: 8) {
+        Label {
+          Text("Hold ⌘ + scroll wheel to zoom")
+        } icon: {
+          Image(systemName: "plus.magnifyingglass")
+            .foregroundStyle(.secondary)
+            .accessibilityHidden(true)
+        }
+        Label {
+          Text("Middle-click and drag to pan canvas")
+        } icon: {
+          Image(systemName: "hand.draw")
+            .foregroundStyle(.secondary)
+            .accessibilityHidden(true)
+        }
+      }
+      .font(.callout)
+    }
+    .padding()
+    .frame(maxWidth: 280, alignment: .leading)
+  }
+
+  private func startObservingMouseConnections() {
+    hasConnectedMouse = !GCMouse.mice().isEmpty
+    // queue: .main guarantees main-thread delivery, so MainActor.assumeIsolated
+    // is safe for touching @State from this @Sendable closure.
+    let recheck: @Sendable (Notification) -> Void = { _ in
+      MainActor.assumeIsolated {
+        hasConnectedMouse = !GCMouse.mice().isEmpty
+      }
+    }
+    let center = NotificationCenter.default
+    mouseConnectionObservers = [
+      center.addObserver(forName: .GCMouseDidConnect, object: nil, queue: .main, using: recheck),
+      center.addObserver(forName: .GCMouseDidDisconnect, object: nil, queue: .main, using: recheck),
+    ]
+  }
+
+  private func stopObservingMouseConnections() {
+    for observer in mouseConnectionObservers {
+      NotificationCenter.default.removeObserver(observer)
+    }
+    mouseConnectionObservers = []
   }
 
   private var canvasToolbar: some View {
@@ -811,7 +888,7 @@ enum CanvasZoomMath {
     anchor: CGPoint,
     isPrecise: Bool
   ) -> Result {
-    let sensitivity: CGFloat = isPrecise ? 0.005 : 0.01
+    let sensitivity: CGFloat = isPrecise ? 0.0025 : 0.005
     let factor = exp(deltaY * sensitivity)
     let newScale = max(minScale, min(maxScale, currentScale * factor))
     guard newScale != currentScale else {

--- a/supacode/Features/Canvas/Views/CanvasView.swift
+++ b/supacode/Features/Canvas/Views/CanvasView.swift
@@ -1,5 +1,4 @@
 import AppKit
-import GameController
 import SwiftUI
 
 struct CanvasView: View {
@@ -19,11 +18,7 @@ struct CanvasView: View {
   @State private var activeResize: [TerminalTabID: ActiveResize] = [:]
   @State private var hasPerformedInitialFit = false
   @State private var viewportSize: CGSize = .zero
-  @State private var hasConnectedMouse: Bool = !GCMouse.mice().isEmpty
-  @State private var hasMouseWithMiddleButton: Bool =
-    GCMouse.mice().contains { $0.mouseInput?.middleButton != nil }
-  @State private var showsMouseHelp = false
-  @State private var mouseConnectionObservers: [NSObjectProtocol] = []
+  @State private var showsCanvasHelp = false
 
   private let minCardWidth: CGFloat = 300
   private let minCardHeight: CGFloat = 200
@@ -172,12 +167,8 @@ struct CanvasView: View {
       canvasToolbar
     }
     .overlay(alignment: .bottomLeading) {
-      if hasConnectedMouse {
-        mouseHelpButton
-      }
+      canvasHelpButton
     }
-    .onAppear { startObservingMouseConnections() }
-    .onDisappear { stopObservingMouseConnections() }
     .onKeyPress(.escape) {
       guard selectionState.isBroadcasting else { return .ignored }
       clearSelection(states: terminalManager.activeWorktreeStates)
@@ -436,78 +427,55 @@ struct CanvasView: View {
     layoutStore.cardLayouts = layouts
   }
 
-  private var mouseHelpButton: some View {
+  private var canvasHelpButton: some View {
     Button {
-      showsMouseHelp.toggle()
+      showsCanvasHelp.toggle()
     } label: {
       Image(systemName: "questionmark.circle")
         .font(.body)
-        .accessibilityLabel("Canvas mouse shortcuts")
+        .accessibilityLabel("Canvas navigation help")
     }
     .buttonStyle(.bordered)
-    .help("Canvas mouse shortcuts")
-    .popover(isPresented: $showsMouseHelp, arrowEdge: .bottom) {
-      mouseHelpContent
+    .help("Canvas navigation help")
+    .popover(isPresented: $showsCanvasHelp, arrowEdge: .bottom) {
+      canvasHelpContent
     }
     .padding()
   }
 
-  private var mouseHelpContent: some View {
-    VStack(alignment: .leading, spacing: 12) {
-      Text("Canvas Mouse Shortcuts")
+  private var canvasHelpContent: some View {
+    VStack(alignment: .leading, spacing: 14) {
+      Text("Canvas Navigation")
         .font(.headline)
 
-      VStack(alignment: .leading, spacing: 8) {
-        Label {
-          Text("Hold ⌘ + scroll to zoom")
-        } icon: {
-          Image(systemName: "plus.magnifyingglass")
-            .foregroundStyle(.secondary)
-            .accessibilityHidden(true)
-        }
-        if hasMouseWithMiddleButton {
-          Label {
-            Text("Middle-click and drag to pan canvas")
-          } icon: {
-            Image(systemName: "hand.draw")
-              .foregroundStyle(.secondary)
-              .accessibilityHidden(true)
-          }
-        }
+      VStack(alignment: .leading, spacing: 12) {
+        canvasHelpRow(
+          icon: "plus.magnifyingglass",
+          title: "Zoom in/out",
+          detail: "⌘ + scroll, or pinch gesture"
+        )
+        canvasHelpRow(
+          icon: "hand.draw",
+          title: "Pan canvas",
+          detail: "Drag empty area, middle-click drag, or two-finger swipe"
+        )
       }
-      .font(.callout)
     }
     .padding()
-    .frame(maxWidth: 280, alignment: .leading)
+    .frame(maxWidth: 320, alignment: .leading)
   }
 
-  private func startObservingMouseConnections() {
-    refreshMouseState()
-    // queue: .main guarantees main-thread delivery, so MainActor.assumeIsolated
-    // is safe for touching @State from this @Sendable closure.
-    let recheck: @Sendable (Notification) -> Void = { _ in
-      MainActor.assumeIsolated {
-        refreshMouseState()
+  private func canvasHelpRow(icon: String, title: String, detail: String) -> some View {
+    HStack(alignment: .firstTextBaseline, spacing: 10) {
+      Image(systemName: icon)
+        .foregroundStyle(.secondary)
+        .frame(width: 18)
+        .accessibilityHidden(true)
+      VStack(alignment: .leading, spacing: 2) {
+        Text(title).font(.callout).fontWeight(.medium)
+        Text(detail).font(.caption).foregroundStyle(.secondary)
       }
     }
-    let center = NotificationCenter.default
-    mouseConnectionObservers = [
-      center.addObserver(forName: .GCMouseDidConnect, object: nil, queue: .main, using: recheck),
-      center.addObserver(forName: .GCMouseDidDisconnect, object: nil, queue: .main, using: recheck),
-    ]
-  }
-
-  private func refreshMouseState() {
-    let mice = GCMouse.mice()
-    hasConnectedMouse = !mice.isEmpty
-    hasMouseWithMiddleButton = mice.contains { $0.mouseInput?.middleButton != nil }
-  }
-
-  private func stopObservingMouseConnections() {
-    for observer in mouseConnectionObservers {
-      NotificationCenter.default.removeObserver(observer)
-    }
-    mouseConnectionObservers = []
   }
 
   private var canvasToolbar: some View {

--- a/supacode/Features/Canvas/Views/CanvasView.swift
+++ b/supacode/Features/Canvas/Views/CanvasView.swift
@@ -29,7 +29,7 @@ struct CanvasView: View {
   /// Reserved height at the bottom of the viewport for the help button and
   /// layout toolbar so cards don't sit underneath them after auto-fit.
   /// Cards end up shifted upward by half of this amount.
-  private let bottomToolbarReserve: CGFloat = 30
+  private let bottomToolbarReserve: CGFloat = 50
 
   var body: some View {
     let selectAllCanvasShortcut = AppShortcuts.resolvedShortcut(
@@ -402,7 +402,7 @@ struct CanvasView: View {
 
     guard minX.isFinite else { return }
 
-    let padding: CGFloat = 40
+    let padding: CGFloat = 30
     let bboxW = maxX - minX + padding * 2
     let bboxH = maxY - minY + padding * 2
     let bboxCenterX = (minX + maxX) / 2

--- a/supacode/Features/Canvas/Views/CanvasView.swift
+++ b/supacode/Features/Canvas/Views/CanvasView.swift
@@ -20,6 +20,8 @@ struct CanvasView: View {
   @State private var hasPerformedInitialFit = false
   @State private var viewportSize: CGSize = .zero
   @State private var hasConnectedMouse: Bool = !GCMouse.mice().isEmpty
+  @State private var hasMouseWithMiddleButton: Bool =
+    GCMouse.mice().contains { $0.mouseInput?.middleButton != nil }
   @State private var showsMouseHelp = false
   @State private var mouseConnectionObservers: [NSObjectProtocol] = []
 
@@ -457,18 +459,20 @@ struct CanvasView: View {
 
       VStack(alignment: .leading, spacing: 8) {
         Label {
-          Text("Hold ⌘ + scroll wheel to zoom")
+          Text("Hold ⌘ + scroll to zoom")
         } icon: {
           Image(systemName: "plus.magnifyingglass")
             .foregroundStyle(.secondary)
             .accessibilityHidden(true)
         }
-        Label {
-          Text("Middle-click and drag to pan canvas")
-        } icon: {
-          Image(systemName: "hand.draw")
-            .foregroundStyle(.secondary)
-            .accessibilityHidden(true)
+        if hasMouseWithMiddleButton {
+          Label {
+            Text("Middle-click and drag to pan canvas")
+          } icon: {
+            Image(systemName: "hand.draw")
+              .foregroundStyle(.secondary)
+              .accessibilityHidden(true)
+          }
         }
       }
       .font(.callout)
@@ -478,12 +482,12 @@ struct CanvasView: View {
   }
 
   private func startObservingMouseConnections() {
-    hasConnectedMouse = !GCMouse.mice().isEmpty
+    refreshMouseState()
     // queue: .main guarantees main-thread delivery, so MainActor.assumeIsolated
     // is safe for touching @State from this @Sendable closure.
     let recheck: @Sendable (Notification) -> Void = { _ in
       MainActor.assumeIsolated {
-        hasConnectedMouse = !GCMouse.mice().isEmpty
+        refreshMouseState()
       }
     }
     let center = NotificationCenter.default
@@ -491,6 +495,12 @@ struct CanvasView: View {
       center.addObserver(forName: .GCMouseDidConnect, object: nil, queue: .main, using: recheck),
       center.addObserver(forName: .GCMouseDidDisconnect, object: nil, queue: .main, using: recheck),
     ]
+  }
+
+  private func refreshMouseState() {
+    let mice = GCMouse.mice()
+    hasConnectedMouse = !mice.isEmpty
+    hasMouseWithMiddleButton = mice.contains { $0.mouseInput?.middleButton != nil }
   }
 
   private func stopObservingMouseConnections() {

--- a/supacode/Features/Canvas/Views/CanvasView.swift
+++ b/supacode/Features/Canvas/Views/CanvasView.swift
@@ -31,7 +31,12 @@ struct CanvasView: View {
       for: AppShortcuts.CommandID.selectAllCanvasCards,
       in: resolvedKeybindings
     )
-    CanvasScrollContainer(offset: $canvasOffset, lastOffset: $lastCanvasOffset) {
+    CanvasScrollContainer(
+      offset: $canvasOffset,
+      lastOffset: $lastCanvasOffset,
+      scale: $canvasScale,
+      lastScale: $lastCanvasScale
+    ) {
       GeometryReader { _ in
         let activeStates = terminalManager.activeWorktreeStates
         let allCardKeys = collectCardKeys(from: activeStates)
@@ -716,6 +721,8 @@ private struct ActiveResize {
 private struct CanvasScrollContainer<Content: View>: NSViewRepresentable {
   @Binding var offset: CGSize
   @Binding var lastOffset: CGSize
+  @Binding var scale: CGFloat
+  @Binding var lastScale: CGFloat
   @ViewBuilder var content: Content
 
   func makeCoordinator() -> CanvasScrollCoordinator {
@@ -740,6 +747,8 @@ private struct CanvasScrollContainer<Content: View>: NSViewRepresentable {
   func updateNSView(_ nsView: CanvasScrollContainerView, context: Context) {
     context.coordinator.offset = $offset
     context.coordinator.lastOffset = $lastOffset
+    context.coordinator.scale = $scale
+    context.coordinator.lastScale = $lastScale
     if let hosting = nsView.subviews.first as? NSHostingView<Content> {
       hosting.rootView = content
     }
@@ -749,6 +758,8 @@ private struct CanvasScrollContainer<Content: View>: NSViewRepresentable {
 private class CanvasScrollCoordinator {
   var offset: Binding<CGSize> = .constant(.zero)
   var lastOffset: Binding<CGSize> = .constant(.zero)
+  var scale: Binding<CGFloat> = .constant(1.0)
+  var lastScale: Binding<CGFloat> = .constant(1.0)
 
   func handleScroll(deltaX: CGFloat, deltaY: CGFloat) {
     let current = offset.wrappedValue
@@ -758,6 +769,61 @@ private class CanvasScrollCoordinator {
     )
     offset.wrappedValue = newOffset
     lastOffset.wrappedValue = newOffset
+  }
+
+  func handleZoom(deltaY: CGFloat, anchor: CGPoint, isPrecise: Bool) {
+    let result = CanvasZoomMath.zoom(
+      currentScale: scale.wrappedValue,
+      currentOffset: offset.wrappedValue,
+      deltaY: deltaY,
+      anchor: anchor,
+      isPrecise: isPrecise
+    )
+    scale.wrappedValue = result.scale
+    lastScale.wrappedValue = result.scale
+    offset.wrappedValue = result.offset
+    lastOffset.wrappedValue = result.offset
+  }
+
+  func setOffset(_ newOffset: CGSize) {
+    offset.wrappedValue = newOffset
+    lastOffset.wrappedValue = newOffset
+  }
+}
+
+/// Pure zoom math, extracted for testability.
+enum CanvasZoomMath {
+  static let minScale: CGFloat = 0.25
+  static let maxScale: CGFloat = 2.0
+
+  struct Result: Equatable {
+    let scale: CGFloat
+    let offset: CGSize
+  }
+
+  /// Compute the new scale and offset for a Cmd+wheel zoom step.
+  /// Keeps the canvas point under `anchor` fixed under the cursor:
+  /// `screen = canvas * scale + offset` ⇒ `canvas = (anchor - offset) / scale`.
+  static func zoom(
+    currentScale: CGFloat,
+    currentOffset: CGSize,
+    deltaY: CGFloat,
+    anchor: CGPoint,
+    isPrecise: Bool
+  ) -> Result {
+    let sensitivity: CGFloat = isPrecise ? 0.005 : 0.01
+    let factor = exp(deltaY * sensitivity)
+    let newScale = max(minScale, min(maxScale, currentScale * factor))
+    guard newScale != currentScale else {
+      return Result(scale: currentScale, offset: currentOffset)
+    }
+    let canvasX = (anchor.x - currentOffset.width) / currentScale
+    let canvasY = (anchor.y - currentOffset.height) / currentScale
+    let newOffset = CGSize(
+      width: anchor.x - canvasX * newScale,
+      height: anchor.y - canvasY * newScale
+    )
+    return Result(scale: newScale, offset: newOffset)
   }
 }
 
@@ -775,7 +841,15 @@ private class CanvasScrollContainerView: NSView {
   /// cursor now sits on a focused terminal.
   private var bounceTimer: Timer?
 
+  // MARK: - Middle-click pan
+  private var middleButtonMonitor: Any?
+  private var isMiddlePanning = false
+  private var middlePanStartLocation: NSPoint = .zero
+  private var middlePanStartOffset: CGSize = .zero
+  private var hasPushedPanCursor = false
+
   override func scrollWheel(with event: NSEvent) {
+    if handleZoomEventIfNeeded(event) { return }
     if event.phase == .began {
       startPanning()
     }
@@ -784,6 +858,21 @@ private class CanvasScrollContainerView: NSView {
       return
     }
     super.scrollWheel(with: event)
+  }
+
+  /// If the event is a Cmd+scroll, route it to canvas zoom and report `true`.
+  /// Used by both the direct `scrollWheel` override and the local monitor so
+  /// pressing Cmd mid-gesture switches behavior immediately.
+  fileprivate func handleZoomEventIfNeeded(_ event: NSEvent) -> Bool {
+    guard event.modifierFlags.contains(.command), event.scrollingDeltaY != 0 else { return false }
+    let viewLocation = convert(event.locationInWindow, from: nil)
+    let anchor = CGPoint(x: viewLocation.x, y: bounds.height - viewLocation.y)
+    scrollCoordinator?.handleZoom(
+      deltaY: event.scrollingDeltaY,
+      anchor: anchor,
+      isPrecise: event.hasPreciseScrollingDeltas
+    )
+    return true
   }
 
   // MARK: - Pan lifecycle
@@ -801,6 +890,9 @@ private class CanvasScrollContainerView: NSView {
   private func installMonitor() {
     scrollMonitor = NSEvent.addLocalMonitorForEvents(matching: .scrollWheel) { [weak self] event in
       guard let self, event.window === self.window else { return event }
+
+      // Cmd toggled mid-gesture — switch to zoom for this event.
+      if self.handleZoomEventIfNeeded(event) { return nil }
 
       // --- New gesture ------------------------------------------------
       if event.phase == .began {
@@ -875,8 +967,83 @@ private class CanvasScrollContainerView: NSView {
     }
   }
 
+  // MARK: - Middle-click pan
+
+  override func viewDidMoveToWindow() {
+    super.viewDidMoveToWindow()
+    if window != nil {
+      installMiddleButtonMonitor()
+    } else {
+      tearDownMiddleButtonMonitor()
+    }
+  }
+
+  private func installMiddleButtonMonitor() {
+    guard middleButtonMonitor == nil else { return }
+    let mask: NSEvent.EventTypeMask = [.otherMouseDown, .otherMouseDragged, .otherMouseUp]
+    middleButtonMonitor = NSEvent.addLocalMonitorForEvents(matching: mask) { [weak self] event in
+      guard let self, event.window === self.window, event.buttonNumber == 2 else { return event }
+
+      switch event.type {
+      case .otherMouseDown:
+        let location = self.convert(event.locationInWindow, from: nil)
+        guard self.bounds.contains(location) else { return event }
+        self.beginMiddlePan(at: event.locationInWindow)
+        return nil
+      case .otherMouseDragged:
+        guard self.isMiddlePanning else { return event }
+        self.updateMiddlePan(to: event.locationInWindow)
+        return nil
+      case .otherMouseUp:
+        guard self.isMiddlePanning else { return event }
+        self.endMiddlePan()
+        return nil
+      default:
+        return event
+      }
+    }
+  }
+
+  private func beginMiddlePan(at windowLocation: NSPoint) {
+    isMiddlePanning = true
+    middlePanStartLocation = windowLocation
+    middlePanStartOffset = scrollCoordinator?.offset.wrappedValue ?? .zero
+    if !hasPushedPanCursor {
+      NSCursor.closedHand.push()
+      hasPushedPanCursor = true
+    }
+  }
+
+  private func updateMiddlePan(to windowLocation: NSPoint) {
+    let deltaX = windowLocation.x - middlePanStartLocation.x
+    // Window Y grows upward; canvas offset Y grows downward (SwiftUI top-left).
+    let deltaY = middlePanStartLocation.y - windowLocation.y
+    let newOffset = CGSize(
+      width: middlePanStartOffset.width + deltaX,
+      height: middlePanStartOffset.height + deltaY
+    )
+    scrollCoordinator?.setOffset(newOffset)
+  }
+
+  private func endMiddlePan() {
+    isMiddlePanning = false
+    if hasPushedPanCursor {
+      NSCursor.pop()
+      hasPushedPanCursor = false
+    }
+  }
+
+  private func tearDownMiddleButtonMonitor() {
+    if isMiddlePanning { endMiddlePan() }
+    if let monitor = middleButtonMonitor {
+      middleButtonMonitor = nil
+      DispatchQueue.main.async { MainActor.assumeIsolated { NSEvent.removeMonitor(monitor) } }
+    }
+  }
+
   override func removeFromSuperview() {
     tearDownMonitor()
+    tearDownMiddleButtonMonitor()
     super.removeFromSuperview()
   }
 }

--- a/supacode/Features/Canvas/Views/CanvasView.swift
+++ b/supacode/Features/Canvas/Views/CanvasView.swift
@@ -462,7 +462,7 @@ struct CanvasView: View {
       }
     }
     .padding()
-    .frame(maxWidth: 320, alignment: .leading)
+    .frame(width: 320, alignment: .leading)
   }
 
   private func canvasHelpRow(icon: String, title: String, detail: String) -> some View {
@@ -473,7 +473,10 @@ struct CanvasView: View {
         .accessibilityHidden(true)
       VStack(alignment: .leading, spacing: 2) {
         Text(title).font(.callout).fontWeight(.medium)
-        Text(detail).font(.caption).foregroundStyle(.secondary)
+        Text(detail)
+          .font(.caption)
+          .foregroundStyle(.secondary)
+          .fixedSize(horizontal: false, vertical: true)
       }
     }
   }

--- a/supacodeTests/CanvasZoomMathTests.swift
+++ b/supacodeTests/CanvasZoomMathTests.swift
@@ -1,0 +1,118 @@
+import CoreGraphics
+import Foundation
+import Testing
+
+@testable import supacode
+
+struct CanvasZoomMathTests {
+  @Test func positiveDeltaIncreasesScale() {
+    let result = CanvasZoomMath.zoom(
+      currentScale: 1.0,
+      currentOffset: .zero,
+      deltaY: 10,
+      anchor: .zero,
+      isPrecise: false
+    )
+
+    #expect(result.scale > 1.0)
+  }
+
+  @Test func negativeDeltaDecreasesScale() {
+    let result = CanvasZoomMath.zoom(
+      currentScale: 1.0,
+      currentOffset: .zero,
+      deltaY: -10,
+      anchor: .zero,
+      isPrecise: false
+    )
+
+    #expect(result.scale < 1.0)
+  }
+
+  @Test func scaleIsClampedToMaximum() {
+    let result = CanvasZoomMath.zoom(
+      currentScale: CanvasZoomMath.maxScale,
+      currentOffset: .zero,
+      deltaY: 1000,
+      anchor: .zero,
+      isPrecise: false
+    )
+
+    #expect(result.scale == CanvasZoomMath.maxScale)
+  }
+
+  @Test func scaleIsClampedToMinimum() {
+    let result = CanvasZoomMath.zoom(
+      currentScale: CanvasZoomMath.minScale,
+      currentOffset: .zero,
+      deltaY: -1000,
+      anchor: .zero,
+      isPrecise: false
+    )
+
+    #expect(result.scale == CanvasZoomMath.minScale)
+  }
+
+  @Test func anchorPointStaysPutAfterZoom() {
+    // The canvas point under the anchor must map to the same screen position
+    // before and after zooming. Using `screen = canvas * scale + offset`,
+    // the canvas point under `anchor` is `(anchor - offset) / scale`. After
+    // applying the new scale and offset, it must still land on `anchor`.
+    let currentScale: CGFloat = 1.0
+    let currentOffset = CGSize(width: 50, height: 30)
+    let anchor = CGPoint(x: 200, y: 150)
+
+    let result = CanvasZoomMath.zoom(
+      currentScale: currentScale,
+      currentOffset: currentOffset,
+      deltaY: 25,
+      anchor: anchor,
+      isPrecise: false
+    )
+
+    let canvasX = (anchor.x - currentOffset.width) / currentScale
+    let canvasY = (anchor.y - currentOffset.height) / currentScale
+    let projectedX = canvasX * result.scale + result.offset.width
+    let projectedY = canvasY * result.scale + result.offset.height
+
+    #expect(abs(projectedX - anchor.x) < 0.0001)
+    #expect(abs(projectedY - anchor.y) < 0.0001)
+  }
+
+  @Test func clampedScaleLeavesOffsetUnchanged() {
+    // When the new scale is clamped to the same as the current scale, the
+    // offset should not drift — otherwise the canvas would jump even though
+    // the zoom did nothing.
+    let currentOffset = CGSize(width: 100, height: 80)
+    let result = CanvasZoomMath.zoom(
+      currentScale: CanvasZoomMath.maxScale,
+      currentOffset: currentOffset,
+      deltaY: 50,
+      anchor: CGPoint(x: 300, y: 200),
+      isPrecise: false
+    )
+
+    #expect(result.offset == currentOffset)
+    #expect(result.scale == CanvasZoomMath.maxScale)
+  }
+
+  @Test func preciseScrollUsesGentlerSensitivity() {
+    let imprecise = CanvasZoomMath.zoom(
+      currentScale: 1.0,
+      currentOffset: .zero,
+      deltaY: 10,
+      anchor: .zero,
+      isPrecise: false
+    )
+    let precise = CanvasZoomMath.zoom(
+      currentScale: 1.0,
+      currentOffset: .zero,
+      deltaY: 10,
+      anchor: .zero,
+      isPrecise: true
+    )
+
+    #expect(precise.scale < imprecise.scale)
+    #expect(precise.scale > 1.0)
+  }
+}


### PR DESCRIPTION
## Summary

Closes #197.

Adds two mouse-driven canvas navigation gestures requested by users:

- **Cmd + scroll wheel → zoom**: held Cmd routes wheel events to a new `CanvasScrollCoordinator.handleZoom`. The math (`CanvasZoomMath.zoom`) is extracted from the existing `MagnifyGesture` anchor-preserving formula, with sensitivity tuned per `event.hasPreciseScrollingDeltas` so it feels right for both mouse wheels and trackpads.
- **Middle-click drag → pan**: a window-scoped `NSEvent` local monitor installed by `CanvasScrollContainerView` while it is in a window. It intercepts `otherMouseDown/Dragged/Up` with `buttonNumber == 2` and drives `canvasOffset` directly, swallowing the events so focused Ghostty surfaces never see them. The monitor is torn down with the view, so it has no effect outside Canvas mode.

The Cmd+scroll path is also wired into the existing pan-momentum monitor, so flipping Cmd mid-gesture switches behavior immediately.

## Test plan

- [x] `make build-app` clean
- [x] `make lint` clean
- [x] New `CanvasZoomMathTests` cover anchor preservation, clamp behavior, and sensitivity differences
- [x] Manual: open Canvas, Cmd+scroll over a card → zoom anchored on cursor
- [x] Manual: middle-drag while a terminal is focused → canvas pans, terminal does not see the click
- [x] Manual: leave Canvas → middle-click in a focused terminal works normally again
