### PR TITLE
fix(cli): move socket out of tmp to survive macOS cleanup

### DIFF
--- a/supacode/CLIService/CLISocketServer.swift
+++ b/supacode/CLIService/CLISocketServer.swift
@@ -24,6 +24,13 @@ final class CLISocketServer {
 
   /// Start listening for CLI connections.
   func start() throws {
+    // Ensure parent directory exists (e.g. ~/Library/Application Support/com.onevcat.prowl)
+    let parentDir = (socketPath as NSString).deletingLastPathComponent
+    try? FileManager.default.createDirectory(
+      atPath: parentDir,
+      withIntermediateDirectories: true
+    )
+
     // Clean up stale socket file
     unlink(socketPath)
 

--- a/supacode/CLIService/Shared/SocketConstants.swift
+++ b/supacode/CLIService/Shared/SocketConstants.swift
@@ -16,12 +16,27 @@ public enum ProwlSocket {
   public static let cliOpenPathArgument = "--prowl-cli-open-path"
 
   /// Default Unix domain socket path.
-  /// Located in user's temporary directory to avoid permission issues.
+  ///
+  /// Located under `~/Library/Application Support/com.onevcat.prowl/` because macOS periodically
+  /// sweeps `/var/folders/.../T/` (NSTemporaryDirectory) and removes the socket file out from
+  /// under a long-running app, leaving a bound FD with no path entry — connect() then fails with
+  /// ENOENT and the CLI mistakenly reports `APP_NOT_RUNNING`.
   ///
   /// If `PROWL_CLI_SOCKET` is set and not empty, it takes precedence.
+  /// Falls back to NSTemporaryDirectory if the preferred path would exceed the AF_UNIX limit.
   public static var defaultPath: String {
     if let override = ProcessInfo.processInfo.environment[environmentKey], !override.isEmpty {
       return override
+    }
+    let preferred = FileManager.default.homeDirectoryForCurrentUser
+      .appending(path: "Library", directoryHint: .isDirectory)
+      .appending(path: "Application Support", directoryHint: .isDirectory)
+      .appending(path: "com.onevcat.prowl", directoryHint: .isDirectory)
+      .appending(path: "cli.sock", directoryHint: .notDirectory)
+      .path(percentEncoded: false)
+    // sockaddr_un.sun_path is 104 bytes on Darwin (including NUL terminator).
+    if preferred.utf8.count < 104 {
+      return preferred
     }
     let tmpDir = NSTemporaryDirectory()
     return (tmpDir as NSString).appendingPathComponent("prowl-cli.sock")


### PR DESCRIPTION
## Problem

After Prowl runs for ~3 days, `prowl <anything>` starts failing with:

```
error [APP_NOT_RUNNING]: Cannot connect to Prowl. Is the app running?
```

…even though the app is clearly running.

## Root cause

`ProwlSocket.defaultPath` puts the CLI socket under `NSTemporaryDirectory()`, which on macOS resolves to `/var/folders/<x>/<y>/T/`. macOS periodically sweeps that directory and removes files the user hasn't accessed in a while — including our socket file.

The kernel-side socket is still alive (the app holds a bound FD), but the path entry that `connect()` looks up is gone. Symptoms:

```sh
$ lsof -U | grep prowl-cli
ProwlApp ... /var/folders/.../T/prowl-cli.sock      # FD still bound
$ ls /var/folders/.../T/prowl-cli.sock
ls: ... No such file or directory                    # path entry deleted
```

The CLI's `connect()` then fails with `ENOENT`, which we surface as `APP_NOT_RUNNING`. There is no recovery path short of relaunching the app.

## Fix

Move the default socket path to `~/Library/Application Support/com.onevcat.prowl/cli.sock`. macOS does not auto-clean Application Support, so the path entry persists for the lifetime of the app.

- `SocketConstants.swift`: compute the new default; fall back to `NSTemporaryDirectory()` only if the preferred path would exceed AF_UNIX `sun_path` (104 bytes on Darwin) — practically only triggers for extremely long usernames.
- `CLISocketServer.swift`: ensure the parent directory exists before `bind`.
- `PROWL_CLI_SOCKET` env-var override behavior is unchanged.

## Notes

- After upgrading, **the existing running Prowl instance must be quit and relaunched** so the server binds the new path.
- Integration tests inject paths via `PROWL_CLI_SOCKET`, so they're unaffected by the default change.

## Test plan

- [x] `make build-cli`
- [x] `make build-app`
- [x] `make test-cli-smoke`
- [x] Manual: relaunch Prowl, run `prowl list`, verify socket appears at `~/Library/Application Support/com.onevcat.prowl/cli.sock` and the command succeeds.
- [x] Manual: leave app running for several days and confirm socket is no longer cleaned up (longer-term verification).
