### PR TITLE
Add per-repo icon and color identity (sidebar / shelf / canvas)

### DIFF
--- a/supacode/Clients/Repositories/RepositoryAppearancesKey.swift
+++ b/supacode/Clients/Repositories/RepositoryAppearancesKey.swift
@@ -1,0 +1,85 @@
+import Dependencies
+import Foundation
+import Sharing
+
+/// Persisted dictionary keyed by `Repository.ID` (the path-derived id
+/// from `RepositoryEntryNormalizer`) holding each repo's user-picked
+/// icon and color. One global file rather than per-repo so the sidebar
+/// — which renders every row — gets every appearance in a single
+/// `@Shared` read; per-repo settings would force one file load per
+/// row at startup.
+///
+/// On-disk location: `~/.prowl/repository-appearances.json`. Repos
+/// without an entry behave exactly like before (no icon, accent color
+/// fallback) so the file is purely additive.
+nonisolated struct RepositoryAppearancesKeyID: Hashable, Sendable {}
+
+nonisolated enum RepositoryAppearancesFileURLKey: DependencyKey {
+  static var liveValue: URL { SupacodePaths.repositoryAppearancesURL }
+  static var previewValue: URL { SupacodePaths.repositoryAppearancesURL }
+  static var testValue: URL { SupacodePaths.repositoryAppearancesURL }
+}
+
+extension DependencyValues {
+  nonisolated var repositoryAppearancesFileURL: URL {
+    get { self[RepositoryAppearancesFileURLKey.self] }
+    set { self[RepositoryAppearancesFileURLKey.self] = newValue }
+  }
+}
+
+nonisolated struct RepositoryAppearancesKey: SharedKey {
+  var id: RepositoryAppearancesKeyID {
+    RepositoryAppearancesKeyID()
+  }
+
+  func load(
+    context _: LoadContext<[Repository.ID: RepositoryAppearance]>,
+    continuation: LoadContinuation<[Repository.ID: RepositoryAppearance]>
+  ) {
+    @Dependency(\.settingsFileStorage) var storage
+    @Dependency(\.repositoryAppearancesFileURL) var url
+    let decoder = JSONDecoder()
+    if let data = try? storage.load(url),
+      let entries = try? decoder.decode([Repository.ID: RepositoryAppearance].self, from: data)
+    {
+      continuation.resume(returning: entries)
+      return
+    }
+    continuation.resumeReturningInitialValue()
+  }
+
+  func subscribe(
+    context _: LoadContext<[Repository.ID: RepositoryAppearance]>,
+    subscriber _: SharedSubscriber<[Repository.ID: RepositoryAppearance]>
+  ) -> SharedSubscription {
+    SharedSubscription {}
+  }
+
+  func save(
+    _ value: [Repository.ID: RepositoryAppearance],
+    context _: SaveContext,
+    continuation: SaveContinuation
+  ) {
+    @Dependency(\.settingsFileStorage) var storage
+    @Dependency(\.repositoryAppearancesFileURL) var url
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    do {
+      // Drop empty entries before writing so the file stays tight when
+      // a user clears both icon and color — the absence of a key is
+      // the canonical "no appearance" state.
+      let pruned = value.filter { !$0.value.isEmpty }
+      let data = try encoder.encode(pruned)
+      try storage.save(data, url)
+      continuation.resume()
+    } catch {
+      continuation.resume(throwing: error)
+    }
+  }
+}
+
+nonisolated extension SharedReaderKey where Self == RepositoryAppearancesKey.Default {
+  static var repositoryAppearances: Self {
+    Self[RepositoryAppearancesKey(), default: [:]]
+  }
+}

--- a/supacode/Clients/Repositories/RepositoryIconAssetStore.swift
+++ b/supacode/Clients/Repositories/RepositoryIconAssetStore.swift
@@ -39,23 +39,21 @@ nonisolated struct RepositoryIconAssetStore: Sendable {
     ) -> Bool
 }
 
-nonisolated enum RepositoryIconAssetStoreError: Error, Equatable {
-  case unsupportedExtension(String)
-}
-
 nonisolated extension RepositoryIconAssetStore {
-  /// Allowed input extensions. PNG and SVG only — JPEG and other
-  /// formats either don't suit repo icon use (no transparency) or
-  /// don't render well at small sidebar sizes.
-  static let supportedExtensions: Set<String> = ["png", "svg"]
-
   static var liveValue: RepositoryIconAssetStore {
     RepositoryIconAssetStore(
       importImage: { sourceURL, rootURL in
-        let normalizedExt = sourceURL.pathExtension.lowercased()
-        guard Self.supportedExtensions.contains(normalizedExt) else {
-          throw RepositoryIconAssetStoreError.unsupportedExtension(normalizedExt)
-        }
+        // No extension whitelist — the file picker filters down to
+        // image UTTypes already, and anything that NSImage can't
+        // render later falls back to the dashed-questionmark
+        // placeholder in `RepositoryIconImage`. The `.svg` suffix
+        // remains the lone meaningful signal because it gates the
+        // template-tinting branch downstream; everything else is
+        // treated as an opaque bitmap.
+        let normalizedExt =
+          sourceURL.pathExtension.lowercased().isEmpty
+          ? "img"
+          : sourceURL.pathExtension.lowercased()
         let directory = SupacodePaths.repositoryIconsDirectory(for: rootURL)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
         let filename = "\(UUID().uuidString.lowercased()).\(normalizedExt)"

--- a/supacode/Clients/Repositories/RepositoryIconAssetStore.swift
+++ b/supacode/Clients/Repositories/RepositoryIconAssetStore.swift
@@ -1,0 +1,96 @@
+import Dependencies
+import Foundation
+
+/// File-system gateway for user-imported repository icon images. Wraps
+/// the actual disk operations behind closures so both the live build
+/// (real `FileManager`) and tests (in-memory) can drive the same code
+/// paths without forking implementations.
+///
+/// All filenames returned by the store are bare names (e.g.
+/// `"3F2D…ABC.svg"`) — never absolute paths — so the persisted
+/// `RepositoryAppearance.icon` stays portable: moving a repository
+/// directory takes its icons with it without rewriting JSON.
+nonisolated struct RepositoryIconAssetStore: Sendable {
+  /// Imports a user-picked image into the per-repo icons directory and
+  /// returns the bare filename to persist. The implementation chooses
+  /// the filename (UUID + extension), creating intermediate directories
+  /// as needed.
+  var importImage:
+    @Sendable (
+      _ sourceURL: URL,
+      _ repositoryRootURL: URL
+    ) throws -> String
+
+  /// Removes a previously-imported image. No-op when the file is
+  /// already gone (idempotent so reset/replace can call without
+  /// guarding against stale state).
+  var remove:
+    @Sendable (
+      _ filename: String,
+      _ repositoryRootURL: URL
+    ) throws -> Void
+
+  /// Returns whether a previously-stored filename still resolves to an
+  /// existing file. Renderers use this to decide whether to fall back.
+  var exists:
+    @Sendable (
+      _ filename: String,
+      _ repositoryRootURL: URL
+    ) -> Bool
+}
+
+nonisolated enum RepositoryIconAssetStoreError: Error, Equatable {
+  case unsupportedExtension(String)
+}
+
+nonisolated extension RepositoryIconAssetStore {
+  /// Allowed input extensions. PNG and SVG only — JPEG and other
+  /// formats either don't suit repo icon use (no transparency) or
+  /// don't render well at small sidebar sizes.
+  static let supportedExtensions: Set<String> = ["png", "svg"]
+
+  static var liveValue: RepositoryIconAssetStore {
+    RepositoryIconAssetStore(
+      importImage: { sourceURL, rootURL in
+        let normalizedExt = sourceURL.pathExtension.lowercased()
+        guard Self.supportedExtensions.contains(normalizedExt) else {
+          throw RepositoryIconAssetStoreError.unsupportedExtension(normalizedExt)
+        }
+        let directory = SupacodePaths.repositoryIconsDirectory(for: rootURL)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let filename = "\(UUID().uuidString.lowercased()).\(normalizedExt)"
+        let destination = directory.appending(path: filename, directoryHint: .notDirectory)
+        let data = try Data(contentsOf: sourceURL)
+        try data.write(to: destination, options: [.atomic])
+        return filename
+      },
+      remove: { filename, rootURL in
+        let url = SupacodePaths.repositoryIconFileURL(
+          filename: filename, repositoryRootURL: rootURL
+        )
+        if FileManager.default.fileExists(atPath: url.path(percentEncoded: false)) {
+          try FileManager.default.removeItem(at: url)
+        }
+      },
+      exists: { filename, rootURL in
+        let url = SupacodePaths.repositoryIconFileURL(
+          filename: filename, repositoryRootURL: rootURL
+        )
+        return FileManager.default.fileExists(atPath: url.path(percentEncoded: false))
+      }
+    )
+  }
+}
+
+nonisolated enum RepositoryIconAssetStoreKey: DependencyKey {
+  static var liveValue: RepositoryIconAssetStore { .liveValue }
+  static var previewValue: RepositoryIconAssetStore { .liveValue }
+  static var testValue: RepositoryIconAssetStore { .liveValue }
+}
+
+extension DependencyValues {
+  nonisolated var repositoryIconAssetStore: RepositoryIconAssetStore {
+    get { self[RepositoryIconAssetStoreKey.self] }
+    set { self[RepositoryIconAssetStoreKey.self] = newValue }
+  }
+}

--- a/supacode/Domain/RepositoryAppearance.swift
+++ b/supacode/Domain/RepositoryAppearance.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// User-pinned visual identity for a single repository: an optional
+/// icon source and an optional color choice, both freely combinable.
+/// Both fields are independently optional so a user can color-tag a
+/// repo without picking an icon (and vice versa).
+///
+/// Persisted as part of a global `[Repository.ID: RepositoryAppearance]`
+/// dictionary — not nested in `Repository` or `RepositorySettings` —
+/// because the sidebar / shelf / canvas all need O(1) cross-repo
+/// lookups during render and a single `@Shared` dict is the lightest
+/// way to give every renderer the same view.
+nonisolated struct RepositoryAppearance: Codable, Equatable, Hashable, Sendable {
+  var icon: RepositoryIconSource?
+  var color: RepositoryColorChoice?
+
+  static let empty = RepositoryAppearance(icon: nil, color: nil)
+
+  init(icon: RepositoryIconSource? = nil, color: RepositoryColorChoice? = nil) {
+    self.icon = icon
+    self.color = color
+  }
+
+  var isEmpty: Bool {
+    icon == nil && color == nil
+  }
+}

--- a/supacode/Domain/RepositoryColorChoice.swift
+++ b/supacode/Domain/RepositoryColorChoice.swift
@@ -1,0 +1,58 @@
+import SwiftUI
+
+/// One of a fixed palette of system-provided colors a user can pin to a
+/// repository to make it identifiable in the sidebar, shelf spine, and
+/// canvas card title bar. The palette is intentionally closed (10 colors)
+/// to align with macOS Finder's tag colors and to keep `repoColor` a
+/// purely semantic system color — never a custom hex — per the project's
+/// "system provided only" rule.
+///
+/// Persistence: encoded as the raw `String` (case name). New cases are
+/// safe to append; cases must never be renamed once shipped because user
+/// JSON references them by name.
+nonisolated enum RepositoryColorChoice: String, Codable, CaseIterable, Sendable, Hashable {
+  case red
+  case orange
+  case yellow
+  case green
+  case mint
+  case cyan
+  case blue
+  case purple
+  case pink
+  case gray
+
+  /// User-facing label for the color picker.
+  var displayName: String {
+    switch self {
+    case .red: "Red"
+    case .orange: "Orange"
+    case .yellow: "Yellow"
+    case .green: "Green"
+    case .mint: "Mint"
+    case .cyan: "Cyan"
+    case .blue: "Blue"
+    case .purple: "Purple"
+    case .pink: "Pink"
+    case .gray: "Gray"
+    }
+  }
+
+  /// Resolved SwiftUI color. Only the bare named system colors are used
+  /// — never custom RGB — so the palette adapts to light/dark mode and
+  /// any future system tweaks.
+  var color: Color {
+    switch self {
+    case .red: .red
+    case .orange: .orange
+    case .yellow: .yellow
+    case .green: .green
+    case .mint: .mint
+    case .cyan: .cyan
+    case .blue: .blue
+    case .purple: .purple
+    case .pink: .pink
+    case .gray: .gray
+    }
+  }
+}

--- a/supacode/Domain/RepositoryIconPresets.swift
+++ b/supacode/Domain/RepositoryIconPresets.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+/// Repository-flavored SF Symbol picker presets. These are surfaced by
+/// `RepositoryAppearancePickerView` (which reuses `TabIconPickerView`
+/// with this list), distinct from the terminal-themed list the tab
+/// picker ships. The split exists because the same picker is used in
+/// two contexts that reach for different vocabulary: a tab picker
+/// favors `play.fill` / `terminal` / `ladybug.fill`, a repo picker
+/// favors `folder.fill` / `cube.fill` / `book.fill`.
+///
+/// Order is loosely thematic so scanning the grid surfaces intent:
+/// folders → boxes/data → tools → web/server → tech → ornament.
+nonisolated enum RepositoryIconPresets {
+  static let presets: [String] = [
+    "folder.fill",
+    "folder",
+    "folder.badge.gearshape",
+    "tray.full.fill",
+    "tray.2.fill",
+    "shippingbox.fill",
+    "cube.fill",
+    "cube.transparent",
+    "doc.text.fill",
+    "doc.fill",
+    "book.fill",
+    "books.vertical.fill",
+    "hammer.fill",
+    "wrench.and.screwdriver.fill",
+    "screwdriver.fill",
+    "paintpalette.fill",
+    "paintbrush.fill",
+    "globe",
+    "network",
+    "server.rack",
+    "cloud.fill",
+    "cpu",
+    "gearshape.fill",
+    "swift",
+    "ladybug.fill",
+    "leaf.fill",
+    "star.fill",
+    "heart.fill",
+    "bolt.fill",
+    "sparkles",
+    "flame.fill",
+    "rocket.fill",
+    "tag.fill",
+    "bookmark.fill",
+    "flag.fill",
+    "circle.hexagongrid.fill",
+  ]
+}

--- a/supacode/Domain/RepositoryIconPresets.swift
+++ b/supacode/Domain/RepositoryIconPresets.swift
@@ -6,47 +6,66 @@ import Foundation
 /// picker ships. The split exists because the same picker is used in
 /// two contexts that reach for different vocabulary: a tab picker
 /// favors `play.fill` / `terminal` / `ladybug.fill`, a repo picker
-/// favors `folder.fill` / `cube.fill` / `book.fill`.
+/// favors `folder.fill` / `book.fill` / `hammer.fill`.
 ///
 /// Order is loosely thematic so scanning the grid surfaces intent:
-/// folders → boxes/data → tools → web/server → tech → ornament.
+/// folders → boxes / data → docs / books → tools / dev → network →
+/// art → nature / vibes.
+///
+/// All entries are restricted to SF Symbols 1–2 (macOS 11–12) baseline
+/// so they're guaranteed-available on the project's macOS 26 minimum.
+/// `.fill` variants are only listed when the symbol actually has one
+/// (e.g. `rocket.fill` was tried but doesn't exist — only `rocket`
+/// does, which renders as a question-mark placeholder if mistakenly
+/// suffixed).
 nonisolated enum RepositoryIconPresets {
   static let presets: [String] = [
+    // Folders / containers (8)
     "folder.fill",
     "folder",
-    "folder.badge.gearshape",
+    "folder.badge.plus",
+    "tray.fill",
     "tray.full.fill",
-    "tray.2.fill",
     "shippingbox.fill",
-    "cube.fill",
-    "cube.transparent",
-    "doc.text.fill",
+    "archivebox.fill",
+    "externaldrive.fill",
+    // Docs / books (6)
     "doc.fill",
+    "doc.text.fill",
+    "doc.richtext.fill",
     "book.fill",
     "books.vertical.fill",
+    "bookmark.fill",
+    // Tags / markers (3)
+    "tag.fill",
+    "flag.fill",
+    "paperplane.fill",
+    // Tools / dev (8)
     "hammer.fill",
+    "wrench.fill",
     "wrench.and.screwdriver.fill",
     "screwdriver.fill",
-    "paintpalette.fill",
-    "paintbrush.fill",
+    "gearshape.fill",
+    "gear",
+    "cpu",
+    "ladybug.fill",
+    // Network / web (4)
     "globe",
     "network",
     "server.rack",
     "cloud.fill",
-    "cpu",
-    "gearshape.fill",
-    "swift",
-    "ladybug.fill",
-    "leaf.fill",
+    // Art (2)
+    "paintpalette.fill",
+    "paintbrush.fill",
+    // Nature / symbols (9)
     "star.fill",
     "heart.fill",
+    "leaf.fill",
     "bolt.fill",
     "sparkles",
     "flame.fill",
-    "rocket.fill",
-    "tag.fill",
-    "bookmark.fill",
-    "flag.fill",
-    "circle.hexagongrid.fill",
+    "sun.max.fill",
+    "moon.fill",
+    "envelope.fill",
   ]
 }

--- a/supacode/Domain/RepositoryIconSource.swift
+++ b/supacode/Domain/RepositoryIconSource.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+/// Where a repository's icon comes from. Storage is a single string so
+/// the on-disk JSON stays compact and migration-friendly; the marker
+/// convention mirrors `TabIconSource` / `ResolvedTabIcon` so a future
+/// reader looking at one knows the other.
+///
+/// - `sfSymbol`: a system SF Symbol name; tintable.
+/// - `bundledAsset`: a name from the app's asset catalog (reserved for
+///   future branded presets; not user-importable).
+/// - `userImage`: a file the user dropped in via the picker, stored at
+///   `~/.prowl/repo/<name>/icons/<filename>`. Filename includes its
+///   extension so `isTintable` can distinguish PNG (no tint) from SVG.
+nonisolated enum RepositoryIconSource: Equatable, Hashable, Sendable {
+  case sfSymbol(String)
+  case bundledAsset(String)
+  case userImage(filename: String)
+
+  static let assetMarker = "@asset:"
+  static let userImageMarker = "@file:"
+
+  /// Round-tripped form for JSON storage. Bare strings stay SF Symbols
+  /// for forward-compat with anything else that learns the convention.
+  var storageString: String {
+    switch self {
+    case .sfSymbol(let name):
+      name
+    case .bundledAsset(let name):
+      Self.assetMarker + name
+    case .userImage(let filename):
+      Self.userImageMarker + filename
+    }
+  }
+
+  /// Inverse of `storageString`. Returns `nil` for empty input so
+  /// callers can treat "no icon" and "blank string" identically.
+  static func parse(_ raw: String) -> RepositoryIconSource? {
+    let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return nil }
+    if trimmed.hasPrefix(userImageMarker) {
+      return .userImage(filename: String(trimmed.dropFirst(userImageMarker.count)))
+    }
+    if trimmed.hasPrefix(assetMarker) {
+      return .bundledAsset(String(trimmed.dropFirst(assetMarker.count)))
+    }
+    return .sfSymbol(trimmed)
+  }
+
+  /// PNG keeps its own colors; SF Symbols and SVGs are tintable. Bundled
+  /// assets default to non-tintable so future additions don't repaint
+  /// branded artwork unintentionally — flip per-asset if/when needed.
+  var isTintable: Bool {
+    switch self {
+    case .sfSymbol:
+      true
+    case .bundledAsset:
+      false
+    case .userImage(let filename):
+      filename.lowercased().hasSuffix(".svg")
+    }
+  }
+}
+
+extension RepositoryIconSource: Codable {
+  init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    let raw = try container.decode(String.self)
+    guard let parsed = Self.parse(raw) else {
+      throw DecodingError.dataCorruptedError(
+        in: container,
+        debugDescription: "Empty repository icon storage string"
+      )
+    }
+    self = parsed
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(storageString)
+  }
+}

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -393,6 +393,7 @@ struct AppFeature {
           @Shared(.userRepositorySettings(repository.rootURL)) var userRepositorySettings
           var repoSettingsState = RepositorySettingsFeature.State(
             rootURL: repository.rootURL,
+            repositoryID: repository.id,
             repositoryKind: repository.kind,
             settings: repositorySettings,
             userSettings: userRepositorySettings

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -391,12 +391,14 @@ struct AppFeature {
           }
           @Shared(.repositorySettings(repository.rootURL)) var repositorySettings
           @Shared(.userRepositorySettings(repository.rootURL)) var userRepositorySettings
+          @Shared(.repositoryAppearances) var repositoryAppearances
           var repoSettingsState = RepositorySettingsFeature.State(
             rootURL: repository.rootURL,
             repositoryID: repository.id,
             repositoryKind: repository.kind,
             settings: repositorySettings,
-            userSettings: userRepositorySettings
+            userSettings: userRepositorySettings,
+            appearance: repositoryAppearances[repository.id] ?? .empty
           )
           repoSettingsState.globalCopyIgnoredOnWorktreeCreate = state.settings.copyIgnoredOnWorktreeCreate
           repoSettingsState.globalCopyUntrackedOnWorktreeCreate = state.settings.copyUntrackedOnWorktreeCreate

--- a/supacode/Features/Canvas/Views/CanvasCardView.swift
+++ b/supacode/Features/Canvas/Views/CanvasCardView.swift
@@ -4,6 +4,17 @@ import SwiftUI
 struct CanvasCardView: View {
   let repositoryName: String
   let worktreeName: String
+  /// User-pinned icon for this card's repository, drawn before the
+  /// repo name in the title bar. `nil` keeps the historical text-only
+  /// title bar.
+  var repositoryIcon: RepositoryIconSource?
+  /// User-pinned color for this card's repository. When set, it tints
+  /// both the icon (if tintable) and the title-bar background as an
+  /// always-on identity strip.
+  var repositoryColor: Color?
+  /// Repo root URL, needed by `RepositoryIconImage` to resolve user
+  /// PNG/SVG filenames against the per-repo icons directory.
+  var repositoryRootURL: URL?
   let tree: SplitTree<GhosttySurfaceView>
   let isFocused: Bool
   let isSelected: Bool
@@ -109,6 +120,14 @@ struct CanvasCardView: View {
 
   private var titleBar: some View {
     HStack(spacing: 6) {
+      if let repositoryIcon, let repositoryRootURL {
+        RepositoryIconImage(
+          icon: repositoryIcon,
+          repositoryRootURL: repositoryRootURL,
+          tintColor: repositoryColor,
+          size: 12
+        )
+      }
       Text(repositoryName)
         .font(.caption.bold())
         .lineLimit(1)
@@ -178,6 +197,12 @@ struct CanvasCardView: View {
 
   @ViewBuilder
   private var titleBarBackground: some View {
+    // Layering: existing notification orange + selected accent stay
+    // BELOW the `.bar` material so their behavior is unchanged from
+    // before this feature shipped. The repo color sits ABOVE the bar
+    // as a thin always-on identity strip — putting it below would
+    // dilute it to invisibility against the 0.9-opaque material, and
+    // moving the bar to the bottom would amplify the existing tints.
     ZStack {
       if hasUnseenNotification {
         Color.orange.opacity(0.3)
@@ -188,6 +213,9 @@ struct CanvasCardView: View {
       Rectangle()
         .fill(.bar)
         .opacity(0.9)
+      if let repositoryColor {
+        repositoryColor.opacity(isFocused ? 0.18 : 0.10)
+      }
     }
   }
 

--- a/supacode/Features/Canvas/Views/CanvasCardView.swift
+++ b/supacode/Features/Canvas/Views/CanvasCardView.swift
@@ -197,23 +197,28 @@ struct CanvasCardView: View {
 
   @ViewBuilder
   private var titleBarBackground: some View {
-    // Layering: existing notification orange + selected accent stay
-    // BELOW the `.bar` material so their behavior is unchanged from
-    // before this feature shipped. The repo color sits ABOVE the bar
-    // as a thin always-on identity strip — putting it below would
-    // dilute it to invisibility against the 0.9-opaque material, and
-    // moving the bar to the bottom would amplify the existing tints.
+    // Layering, back-to-front:
+    //
+    //  1. selected-but-unfocused accent (subtle, sits under the bar
+    //     material — same behavior as before this feature shipped)
+    //  2. `.bar` material substrate
+    //  3. **either** the notification orange **or** the repo color
+    //     identity strip — never both. Without this mutual exclusion
+    //     the orange used to muddle into the repo color (e.g. a blue
+    //     repo's notification looked brownish-grey instead of the
+    //     intended attention-grabbing orange). The notification wins
+    //     on top with a much higher alpha (0.55) than the previous
+    //     under-bar 0.3 so the unread signal actually pops.
     ZStack {
-      if hasUnseenNotification {
-        Color.orange.opacity(0.3)
-      }
       if isSelected && !isFocused {
         Color.accentColor.opacity(0.12)
       }
       Rectangle()
         .fill(.bar)
         .opacity(0.9)
-      if let repositoryColor {
+      if hasUnseenNotification {
+        Color.orange.opacity(0.55)
+      } else if let repositoryColor {
         repositoryColor.opacity(isFocused ? 0.18 : 0.10)
       }
     }

--- a/supacode/Features/Canvas/Views/CanvasView.swift
+++ b/supacode/Features/Canvas/Views/CanvasView.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Sharing
 import SwiftUI
 
 struct CanvasView: View {
@@ -8,6 +9,7 @@ struct CanvasView: View {
   let terminalManager: WorktreeTerminalManager
   var onExitToTab: () -> Void = {}
   @State private var layoutStore = CanvasLayoutStore()
+  @Shared(.repositoryAppearances) private var repositoryAppearances
 
   @State private var canvasOffset: CGSize = .zero
   @State private var lastCanvasOffset: CGSize = .zero
@@ -82,9 +84,13 @@ struct CanvasView: View {
               let screenCenter = screenPosition(for: resized.center)
               let cardTotalHeight = resized.size.height + titleBarHeight
 
+              let repositoryAppearance = appearance(for: state.repositoryRootURL)
               CanvasCardView(
                 repositoryName: Repository.name(for: state.repositoryRootURL),
                 worktreeName: tab.title,
+                repositoryIcon: repositoryAppearance.icon,
+                repositoryColor: repositoryAppearance.color?.color,
+                repositoryRootURL: state.repositoryRootURL,
                 tree: tree,
                 isFocused: selectionState.primaryTabID == tab.id,
                 isSelected: selectionState.selectedTabIDs.contains(tab.id),
@@ -766,6 +772,19 @@ struct CanvasView: View {
     // WorktreeTerminalTabsView.onAppear's syncFocus() and cause blank
     // surfaces. Cleanup of non-selected worktrees is handled by
     // setSelectedWorktreeID in the async exit flow.
+  }
+
+  /// Looks up the user-pinned `RepositoryAppearance` for a given repo
+  /// root URL by deriving the canonical `Repository.ID` (the
+  /// path-policy-normalized path string) and querying the @Shared
+  /// dict. Returns `.empty` when no entry exists, which keeps cards
+  /// visually identical to before the appearance feature shipped.
+  private func appearance(for repositoryRootURL: URL) -> RepositoryAppearance {
+    let id =
+      PathPolicy.normalizePath(
+        repositoryRootURL.path(percentEncoded: false), resolvingSymlinks: true
+      ) ?? repositoryRootURL.path(percentEncoded: false)
+    return repositoryAppearances[id] ?? .empty
   }
 }
 

--- a/supacode/Features/Repositories/Views/RepoHeaderRow.swift
+++ b/supacode/Features/Repositories/Views/RepoHeaderRow.swift
@@ -5,9 +5,27 @@ struct RepoHeaderRow: View {
   let name: String
   let isRemoving: Bool
   let tabCount: Int
+  /// User-pinned icon, when set. Renders before the repo name.
+  /// `nil` keeps the historical text-only layout intact.
+  let icon: RepositoryIconSource?
+  /// Resolved tint applied to tintable icons (SF Symbols / SVGs).
+  /// PNGs and bundled assets ignore this and render their own colors.
+  let iconTint: Color?
+  /// Repo root URL — needed by `RepositoryIconImage` to resolve
+  /// user-imported image filenames into absolute file URLs.
+  let repositoryRootURL: URL?
   var nameTooltip: String?
+
   var body: some View {
     HStack {
+      if let icon, let repositoryRootURL {
+        RepositoryIconImage(
+          icon: icon,
+          repositoryRootURL: repositoryRootURL,
+          tintColor: iconTint,
+          size: 14
+        )
+      }
       Text(name)
         .foregroundStyle(.secondary)
         .help(nameTooltip ?? "")
@@ -44,9 +62,30 @@ struct RepoHeaderRow: View {
 
 #Preview("RepoHeaderRow") {
   VStack(alignment: .leading, spacing: 12) {
-    RepoHeaderRow(name: "supacode", isRemoving: false, tabCount: 3)
-    RepoHeaderRow(name: "ghostty", isRemoving: false, tabCount: 0)
-    RepoHeaderRow(name: "removing-repo", isRemoving: true, tabCount: 1)
+    RepoHeaderRow(
+      name: "supacode",
+      isRemoving: false,
+      tabCount: 3,
+      icon: nil,
+      iconTint: nil,
+      repositoryRootURL: nil
+    )
+    RepoHeaderRow(
+      name: "ghostty",
+      isRemoving: false,
+      tabCount: 0,
+      icon: .sfSymbol("folder.fill"),
+      iconTint: .blue,
+      repositoryRootURL: URL(fileURLWithPath: "/tmp/ghostty")
+    )
+    RepoHeaderRow(
+      name: "removing-repo",
+      isRemoving: true,
+      tabCount: 1,
+      icon: .sfSymbol("hammer.fill"),
+      iconTint: .orange,
+      repositoryRootURL: URL(fileURLWithPath: "/tmp/removing")
+    )
   }
   .padding()
 }

--- a/supacode/Features/Repositories/Views/RepositoryIconImage.swift
+++ b/supacode/Features/Repositories/Views/RepositoryIconImage.swift
@@ -1,0 +1,108 @@
+import AppKit
+import SwiftUI
+
+/// Single source of truth for rendering a `RepositoryIconSource` —
+/// shared by the settings preview, the sidebar row, the shelf spine
+/// header, and the canvas card title bar so tinting / fallback rules
+/// stay consistent in one place.
+///
+/// Tinting follows `RepositoryIconSource.isTintable`: SF Symbols and
+/// SVG user images pick up `tintColor`; PNG user images and bundled
+/// assets ignore it. Missing user images fall back to a neutral SF
+/// Symbol so a deleted file on disk doesn't turn into a blank slot.
+struct RepositoryIconImage: View {
+  let icon: RepositoryIconSource
+  let repositoryRootURL: URL
+  /// Color used for tintable artwork. Pass `nil` to keep the
+  /// renderer's natural foreground (`.primary` / template default).
+  let tintColor: Color?
+  /// Logical pixel size of the icon. Affects `Image` sizing for asset
+  /// and user-image cases; SF Symbols size off the surrounding font.
+  let size: CGFloat
+
+  init(
+    icon: RepositoryIconSource,
+    repositoryRootURL: URL,
+    tintColor: Color? = nil,
+    size: CGFloat = 16
+  ) {
+    self.icon = icon
+    self.repositoryRootURL = repositoryRootURL
+    self.tintColor = tintColor
+    self.size = size
+  }
+
+  var body: some View {
+    content
+      .frame(width: size, height: size)
+      .accessibilityHidden(true)
+  }
+
+  @ViewBuilder
+  private var content: some View {
+    switch icon {
+    case .sfSymbol(let name):
+      Image(systemName: name)
+        .resizable()
+        .aspectRatio(contentMode: .fit)
+        .symbolRenderingMode(.monochrome)
+        .foregroundStyle(resolvedTint)
+        .accessibilityHidden(true)
+    case .bundledAsset(let assetName):
+      Image(assetName)
+        .resizable()
+        .aspectRatio(contentMode: .fit)
+        .accessibilityHidden(true)
+    case .userImage(let filename):
+      userImage(filename: filename)
+    }
+  }
+
+  @ViewBuilder
+  private func userImage(filename: String) -> some View {
+    let url = SupacodePaths.repositoryIconFileURL(
+      filename: filename, repositoryRootURL: repositoryRootURL
+    )
+    if let nsImage = Self.loadImage(at: url, asTemplate: icon.isTintable) {
+      if icon.isTintable {
+        Image(nsImage: nsImage)
+          .resizable()
+          .aspectRatio(contentMode: .fit)
+          .foregroundStyle(resolvedTint)
+          .accessibilityHidden(true)
+      } else {
+        Image(nsImage: nsImage)
+          .resizable()
+          .aspectRatio(contentMode: .fit)
+          .accessibilityHidden(true)
+      }
+    } else {
+      // The icon file was renamed/deleted out from under us. Show a
+      // muted placeholder rather than an empty rect so the bug is
+      // visible.
+      Image(systemName: "questionmark.square.dashed")
+        .resizable()
+        .aspectRatio(contentMode: .fit)
+        .foregroundStyle(.tertiary)
+        .accessibilityHidden(true)
+    }
+  }
+
+  /// Loads an NSImage from disk and optionally flips it into template
+  /// mode so SwiftUI's `.foregroundStyle` can recolor it. Pulled out
+  /// of the ViewBuilder body so the side-effecting assignment doesn't
+  /// trip the builder's "type '()' cannot conform to 'View'" check.
+  private static func loadImage(at url: URL, asTemplate: Bool) -> NSImage? {
+    guard let image = NSImage(contentsOf: url) else { return nil }
+    image.isTemplate = asTemplate
+    return image
+  }
+
+  private var resolvedTint: AnyShapeStyle {
+    if let tintColor {
+      AnyShapeStyle(tintColor)
+    } else {
+      AnyShapeStyle(.primary)
+    }
+  }
+}

--- a/supacode/Features/Repositories/Views/RepositorySectionView.swift
+++ b/supacode/Features/Repositories/Views/RepositorySectionView.swift
@@ -1,4 +1,5 @@
 import ComposableArchitecture
+import Sharing
 import SwiftUI
 
 struct RepositorySectionView: View {
@@ -14,6 +15,7 @@ struct RepositorySectionView: View {
   @Environment(\.colorScheme) private var colorScheme
   @Environment(\.resolvedKeybindings) private var resolvedKeybindings
   @State private var isHovering = false
+  @Shared(.repositoryAppearances) private var repositoryAppearances
 
   var body: some View {
     let state = store.state
@@ -34,6 +36,7 @@ struct RepositorySectionView: View {
     }
     let isDragging = isDragActive
 
+    let appearance = repositoryAppearances[repository.id] ?? .empty
     let header = HStack {
       RepoHeaderRow(
         name: repository.name,
@@ -42,6 +45,9 @@ struct RepositorySectionView: View {
           for: repository,
           terminalManager: terminalManager
         ),
+        icon: appearance.icon,
+        iconTint: appearance.color?.color,
+        repositoryRootURL: repository.rootURL,
         nameTooltip: repository.capabilities.supportsWorktrees
           ? (isExpanded ? "Collapse" : "Expand")
           : "Open terminal in folder"
@@ -70,6 +76,13 @@ struct RepositorySectionView: View {
                 }
             }
           }
+      }
+      if let color = appearance.color {
+        Circle()
+          .fill(color.color)
+          .frame(width: 8, height: 8)
+          .help(color.displayName)
+          .accessibilityLabel(Text("Repo color: \(color.displayName)"))
       }
       if isHovering && !isDragging {
         Menu {

--- a/supacode/Features/RepositorySettings/Reducer/RepositorySettingsFeature.swift
+++ b/supacode/Features/RepositorySettings/Reducer/RepositorySettingsFeature.swift
@@ -6,9 +6,15 @@ struct RepositorySettingsFeature {
   @ObservableState
   struct State: Equatable {
     var rootURL: URL
+    /// Persistence key for `@Shared(.repositoryAppearances)`. Defaults
+    /// to empty so legacy test fixtures that only construct the four
+    /// originally-required fields keep compiling — production
+    /// callers (AppFeature) always pass the canonical `repository.id`.
+    var repositoryID: Repository.ID = ""
     var repositoryKind: Repository.Kind
     var settings: RepositorySettings
     var userSettings: UserRepositorySettings
+    var appearance: RepositoryAppearance = .empty
     var globalDefaultWorktreeBaseDirectoryPath: String?
     var globalCopyIgnoredOnWorktreeCreate: Bool = false
     var globalCopyUntrackedOnWorktreeCreate: Bool = false
@@ -18,6 +24,7 @@ struct RepositorySettingsFeature {
     var defaultWorktreeBaseRef = "origin/main"
     var isBranchDataLoaded = false
     var keybindingUserOverrides: KeybindingUserOverrideStore = .empty
+    var appearanceImportError: String?
 
     var capabilities: Repository.Capabilities {
       switch repositoryKind {
@@ -73,6 +80,14 @@ struct RepositorySettingsFeature {
       globalPullRequestMergeStrategy: PullRequestMergeStrategy,
       keybindingUserOverrides: KeybindingUserOverrideStore
     )
+    case appearanceLoaded(RepositoryAppearance)
+    case setAppearanceColor(RepositoryColorChoice?)
+    case setAppearanceIcon(RepositoryIconSource?)
+    case importUserImage(URL)
+    case userImageImported(filename: String)
+    case userImageImportFailed(String)
+    case dismissAppearanceImportError
+    case resetAppearance
     case branchDataLoaded([String], defaultBaseRef: String)
     case delegate(Delegate)
     case binding(BindingAction<State>)
@@ -84,6 +99,7 @@ struct RepositorySettingsFeature {
   }
 
   @Dependency(GitClientDependency.self) private var gitClient
+  @Dependency(\.repositoryIconAssetStore) private var repositoryIconAssetStore
 
   var body: some Reducer<State, Action> {
     BindingReducer()
@@ -91,11 +107,13 @@ struct RepositorySettingsFeature {
       switch action {
       case .task:
         let rootURL = state.rootURL
+        let repositoryID = state.repositoryID
         guard state.capabilities.supportsRepositoryGitSettings else {
           return .run { send in
             @Shared(.repositorySettings(rootURL)) var repositorySettings
             @Shared(.userRepositorySettings(rootURL)) var userRepositorySettings
             @Shared(.settingsFile) var settingsFile
+            @Shared(.repositoryAppearances) var appearances
             let global = settingsFile.global
             await send(
               .settingsLoaded(
@@ -109,6 +127,9 @@ struct RepositorySettingsFeature {
                 keybindingUserOverrides: global.keybindingUserOverrides
               )
             )
+            if let appearance = appearances[repositoryID], !appearance.isEmpty {
+              await send(.appearanceLoaded(appearance))
+            }
           }
         }
         let gitClient = gitClient
@@ -117,6 +138,7 @@ struct RepositorySettingsFeature {
           @Shared(.repositorySettings(rootURL)) var repositorySettings
           @Shared(.userRepositorySettings(rootURL)) var userRepositorySettings
           @Shared(.settingsFile) var settingsFile
+          @Shared(.repositoryAppearances) var appearances
           let global = settingsFile.global
           await send(
             .settingsLoaded(
@@ -130,6 +152,9 @@ struct RepositorySettingsFeature {
               keybindingUserOverrides: global.keybindingUserOverrides
             )
           )
+          if let appearance = appearances[repositoryID], !appearance.isEmpty {
+            await send(.appearanceLoaded(appearance))
+          }
           let branches: [String]
           do {
             branches = try await gitClient.branchRefs(rootURL)
@@ -178,6 +203,64 @@ struct RepositorySettingsFeature {
         $repositorySettings.withLock { $0 = updatedSettings }
         return .send(.delegate(.settingsChanged(rootURL)))
 
+      case .appearanceLoaded(let appearance):
+        state.appearance = appearance
+        return .none
+
+      case .setAppearanceColor(let color):
+        guard state.appearance.color != color else { return .none }
+        state.appearance.color = color
+        return persistAppearance(state.appearance, repositoryID: state.repositoryID)
+
+      case .setAppearanceIcon(let newIcon):
+        let previousIcon = state.appearance.icon
+        guard previousIcon != newIcon else { return .none }
+        state.appearance.icon = newIcon
+        let persist = persistAppearance(state.appearance, repositoryID: state.repositoryID)
+        let cleanup = removeAbandonedUserImage(
+          previous: previousIcon,
+          new: newIcon,
+          rootURL: state.rootURL
+        )
+        return .merge(persist, cleanup)
+
+      case .importUserImage(let sourceURL):
+        let rootURL = state.rootURL
+        let store = repositoryIconAssetStore
+        return .run { send in
+          do {
+            let filename = try store.importImage(sourceURL, rootURL)
+            await send(.userImageImported(filename: filename))
+          } catch let error as RepositoryIconAssetStoreError {
+            await send(.userImageImportFailed(Self.errorMessage(for: error)))
+          } catch {
+            await send(.userImageImportFailed(error.localizedDescription))
+          }
+        }
+
+      case .userImageImported(let filename):
+        return .send(.setAppearanceIcon(.userImage(filename: filename)))
+
+      case .userImageImportFailed(let message):
+        state.appearanceImportError = message
+        return .none
+
+      case .dismissAppearanceImportError:
+        state.appearanceImportError = nil
+        return .none
+
+      case .resetAppearance:
+        let previousIcon = state.appearance.icon
+        guard !state.appearance.isEmpty else { return .none }
+        state.appearance = .empty
+        let persist = persistAppearance(.empty, repositoryID: state.repositoryID)
+        let cleanup = removeAbandonedUserImage(
+          previous: previousIcon,
+          new: nil,
+          rootURL: state.rootURL
+        )
+        return .merge(persist, cleanup)
+
       case .branchDataLoaded(let branches, let defaultBaseRef):
         state.defaultWorktreeBaseRef = defaultBaseRef
         var options = branches
@@ -212,6 +295,50 @@ struct RepositorySettingsFeature {
       case .delegate:
         return .none
       }
+    }
+  }
+
+  /// Writes the appearance back to the global `@Shared` dict, dropping
+  /// the entry when it's been cleared so the on-disk file stays tight.
+  private func persistAppearance(
+    _ appearance: RepositoryAppearance,
+    repositoryID: Repository.ID
+  ) -> Effect<Action> {
+    .run { _ in
+      @Shared(.repositoryAppearances) var appearances
+      $appearances.withLock {
+        if appearance.isEmpty {
+          $0.removeValue(forKey: repositoryID)
+        } else {
+          $0[repositoryID] = appearance
+        }
+      }
+    }
+  }
+
+  /// When the icon transitions away from a user-imported file, the old
+  /// asset on disk is no longer referenced and should be cleaned up.
+  /// No-op when the previous icon wasn't a user image or when the new
+  /// icon is the same user image.
+  private func removeAbandonedUserImage(
+    previous: RepositoryIconSource?,
+    new: RepositoryIconSource?,
+    rootURL: URL
+  ) -> Effect<Action> {
+    guard case .userImage(let oldFilename) = previous else { return .none }
+    if case .userImage(let newFilename) = new, newFilename == oldFilename {
+      return .none
+    }
+    let store = repositoryIconAssetStore
+    return .run { _ in
+      try? store.remove(oldFilename, rootURL)
+    }
+  }
+
+  private static func errorMessage(for error: RepositoryIconAssetStoreError) -> String {
+    switch error {
+    case .unsupportedExtension(let ext):
+      return "Repository icons must be PNG or SVG. \(ext.uppercased()) files aren't supported."
     }
   }
 }

--- a/supacode/Features/RepositorySettings/Reducer/RepositorySettingsFeature.swift
+++ b/supacode/Features/RepositorySettings/Reducer/RepositorySettingsFeature.swift
@@ -222,8 +222,6 @@ struct RepositorySettingsFeature {
           do {
             let filename = try store.importImage(sourceURL, rootURL)
             await send(.userImageImported(filename: filename))
-          } catch let error as RepositoryIconAssetStoreError {
-            await send(.userImageImportFailed(Self.errorMessage(for: error)))
           } catch {
             await send(.userImageImportFailed(error.localizedDescription))
           }
@@ -326,10 +324,4 @@ struct RepositorySettingsFeature {
     }
   }
 
-  private static func errorMessage(for error: RepositoryIconAssetStoreError) -> String {
-    switch error {
-    case .unsupportedExtension(let ext):
-      return "Repository icons must be PNG or SVG. \(ext.uppercased()) files aren't supported."
-    }
-  }
 }

--- a/supacode/Features/RepositorySettings/Reducer/RepositorySettingsFeature.swift
+++ b/supacode/Features/RepositorySettings/Reducer/RepositorySettingsFeature.swift
@@ -107,13 +107,11 @@ struct RepositorySettingsFeature {
       switch action {
       case .task:
         let rootURL = state.rootURL
-        let repositoryID = state.repositoryID
         guard state.capabilities.supportsRepositoryGitSettings else {
           return .run { send in
             @Shared(.repositorySettings(rootURL)) var repositorySettings
             @Shared(.userRepositorySettings(rootURL)) var userRepositorySettings
             @Shared(.settingsFile) var settingsFile
-            @Shared(.repositoryAppearances) var appearances
             let global = settingsFile.global
             await send(
               .settingsLoaded(
@@ -127,9 +125,6 @@ struct RepositorySettingsFeature {
                 keybindingUserOverrides: global.keybindingUserOverrides
               )
             )
-            if let appearance = appearances[repositoryID], !appearance.isEmpty {
-              await send(.appearanceLoaded(appearance))
-            }
           }
         }
         let gitClient = gitClient
@@ -138,7 +133,6 @@ struct RepositorySettingsFeature {
           @Shared(.repositorySettings(rootURL)) var repositorySettings
           @Shared(.userRepositorySettings(rootURL)) var userRepositorySettings
           @Shared(.settingsFile) var settingsFile
-          @Shared(.repositoryAppearances) var appearances
           let global = settingsFile.global
           await send(
             .settingsLoaded(
@@ -152,9 +146,6 @@ struct RepositorySettingsFeature {
               keybindingUserOverrides: global.keybindingUserOverrides
             )
           )
-          if let appearance = appearances[repositoryID], !appearance.isEmpty {
-            await send(.appearanceLoaded(appearance))
-          }
           let branches: [String]
           do {
             branches = try await gitClient.branchRefs(rootURL)

--- a/supacode/Features/RepositorySettings/Views/RepositoryAppearancePickerView.swift
+++ b/supacode/Features/RepositorySettings/Views/RepositoryAppearancePickerView.swift
@@ -39,15 +39,21 @@ struct RepositoryAppearancePickerView: View {
         title: "Repository Icon",
         subtitle:
           "Pick a preset or enter any SF Symbol name. SVG and SF Symbol icons are tinted "
-          + "with the repo color; PNG keeps its own colors.",
+          + "with the repo color; bitmap formats keep their own colors.",
         presets: RepositoryIconPresets.presets,
         onApply: { applySymbolFromPicker($0) },
         onCancel: { isSymbolPickerPresented = false }
       )
     }
+    // Accept any image UTType — PNG / JPEG / WebP / HEIC / TIFF / GIF
+    // / etc. all flow through the same `NSImage(contentsOf:)` render
+    // path. SVG is listed explicitly because it's a structured-text
+    // format that doesn't always conform to `.image` in older
+    // UTType conformance tables. Anything that fails to decode falls
+    // back to the dashed placeholder at render time.
     .fileImporter(
       isPresented: $isImageImporterPresented,
-      allowedContentTypes: [.png, .svg],
+      allowedContentTypes: [.image, .svg],
       allowsMultipleSelection: false
     ) { result in
       handleImageImportResult(result)
@@ -171,7 +177,7 @@ struct RepositoryAppearancePickerView: View {
   private var iconHelpText: String {
     switch store.appearance.icon {
     case .userImage(let filename) where !filename.lowercased().hasSuffix(".svg"):
-      return "PNG icons keep their original colors and ignore the repo color."
+      return "Bitmap icons keep their original colors and ignore the repo color."
     case .userImage:
       return "User-provided SVGs are tinted with the repo color."
     case .sfSymbol:

--- a/supacode/Features/RepositorySettings/Views/RepositoryAppearancePickerView.swift
+++ b/supacode/Features/RepositorySettings/Views/RepositoryAppearancePickerView.swift
@@ -22,7 +22,18 @@ struct RepositoryAppearancePickerView: View {
   @State private var isHoveringIconTile = false
 
   private let previewSize: CGFloat = 40
-  private let dotSize: CGFloat = 22
+  /// Diameter of the colored swatch itself.
+  private let swatchDotSize: CGFloat = 20
+  /// Diameter of the "selected" ring drawn around the swatch. The
+  /// (ring − dot) / 2 gap (3pt) lives between the dot's edge and the
+  /// ring's inside, matching macOS-native color pickers.
+  private let swatchRingSize: CGFloat = 26
+  /// Outer slot every swatch occupies in the HStack so the row layout
+  /// stays stable whether or not a swatch is selected (without a fixed
+  /// slot the selection ring would expand the cell and shove its
+  /// neighbors aside on hover/select).
+  private let swatchSlotSize: CGFloat = 28
+  private let swatchRingLineWidth: CGFloat = 1.5
 
   var body: some View {
     VStack(alignment: .leading, spacing: 12) {
@@ -229,17 +240,14 @@ struct RepositoryAppearancePickerView: View {
     Button {
       store.send(.setAppearanceColor(choice))
     } label: {
-      Circle()
-        .fill(choice.color)
-        .frame(width: dotSize, height: dotSize)
-        .overlay {
-          Circle()
-            .stroke(Color.primary, lineWidth: isSelected ? 2 : 0)
-            .padding(2)
-        }
-        .help(choice.displayName)
-        .accessibilityLabel(choice.displayName)
-        .accessibilityAddTraits(isSelected ? [.isSelected, .isButton] : .isButton)
+      swatchSlot(isSelected: isSelected) {
+        Circle()
+          .fill(choice.color)
+          .frame(width: swatchDotSize, height: swatchDotSize)
+      }
+      .help(choice.displayName)
+      .accessibilityLabel(choice.displayName)
+      .accessibilityAddTraits(isSelected ? [.isSelected, .isButton] : .isButton)
     }
     .buttonStyle(.plain)
   }
@@ -250,24 +258,46 @@ struct RepositoryAppearancePickerView: View {
     Button {
       store.send(.setAppearanceColor(nil))
     } label: {
-      Circle()
-        .stroke(Color.secondary.opacity(0.5), style: StrokeStyle(lineWidth: 1, dash: [2, 2]))
-        .frame(width: dotSize, height: dotSize)
-        .overlay {
-          Image(systemName: "slash.circle")
-            .font(.system(size: 12))
-            .foregroundStyle(.secondary)
-        }
-        .overlay {
-          Circle()
-            .stroke(Color.primary, lineWidth: isSelected ? 2 : 0)
-            .padding(2)
-        }
-        .help("No color")
-        .accessibilityLabel("No color")
-        .accessibilityAddTraits(isSelected ? [.isSelected, .isButton] : .isButton)
+      swatchSlot(isSelected: isSelected) {
+        Circle()
+          .stroke(
+            Color.secondary.opacity(0.5),
+            style: StrokeStyle(lineWidth: 1, dash: [2, 2])
+          )
+          .frame(width: swatchDotSize, height: swatchDotSize)
+          .overlay {
+            Image(systemName: "slash.circle")
+              .font(.system(size: 11))
+              .foregroundStyle(.secondary)
+              .accessibilityHidden(true)
+          }
+      }
+      .help("No color")
+      .accessibilityLabel("No color")
+      .accessibilityAddTraits(isSelected ? [.isSelected, .isButton] : .isButton)
     }
     .buttonStyle(.plain)
+  }
+
+  /// Centers the swatch content in a fixed-size slot and overlays a
+  /// selection ring on top, sized larger than the swatch so a 3pt
+  /// transparent gap separates the swatch's edge from the ring's
+  /// inside — mirroring macOS-native color picker selection chrome.
+  /// The slot bounds stay constant whether selected or not so swatch
+  /// row layout doesn't reflow on selection change.
+  @ViewBuilder
+  private func swatchSlot<Content: View>(
+    isSelected: Bool, @ViewBuilder content: () -> Content
+  ) -> some View {
+    ZStack {
+      content()
+      if isSelected {
+        Circle()
+          .stroke(Color.primary, lineWidth: swatchRingLineWidth)
+          .frame(width: swatchRingSize, height: swatchRingSize)
+      }
+    }
+    .frame(width: swatchSlotSize, height: swatchSlotSize)
   }
 
   // MARK: - Error banner

--- a/supacode/Features/RepositorySettings/Views/RepositoryAppearancePickerView.swift
+++ b/supacode/Features/RepositorySettings/Views/RepositoryAppearancePickerView.swift
@@ -1,0 +1,270 @@
+import AppKit
+import ComposableArchitecture
+import SwiftUI
+import UniformTypeIdentifiers
+
+/// Inline section that drives a repository's icon and color choice.
+/// Hosted at the top of `RepositorySettingsView`'s Form. The actual SF
+/// Symbol picker is presented as a sheet via `TabIconPickerView`,
+/// parameterised with `RepositoryIconPresets.presets` so the shared
+/// picker code surfaces repo-flavored vocabulary instead of the
+/// terminal one used by tab icons.
+///
+/// All mutations go through `RepositorySettingsFeature` actions —
+/// never via direct `store.appearance.* = ...` writes — so the
+/// `store_state_mutation_in_views` SwiftLint rule stays clean and
+/// reducer tests can exercise every code path.
+struct RepositoryAppearancePickerView: View {
+  @Bindable var store: StoreOf<RepositorySettingsFeature>
+
+  @State private var isSymbolPickerPresented = false
+  @State private var isImageImporterPresented = false
+
+  private let previewSize: CGFloat = 36
+  private let dotSize: CGFloat = 22
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 12) {
+      iconRow
+      colorRow
+      if let message = store.appearanceImportError {
+        importErrorBanner(message: message)
+      }
+    }
+    .sheet(isPresented: $isSymbolPickerPresented) {
+      TabIconPickerView(
+        initialIcon: currentSymbolName,
+        defaultIcon: "folder.fill",
+        title: "Repository Icon",
+        subtitle:
+          "Pick a preset or enter any SF Symbol name. SVG and SF Symbol icons are tinted "
+          + "with the repo color; PNG keeps its own colors.",
+        presets: RepositoryIconPresets.presets,
+        onApply: { applySymbolFromPicker($0) },
+        onCancel: { isSymbolPickerPresented = false }
+      )
+    }
+    .fileImporter(
+      isPresented: $isImageImporterPresented,
+      allowedContentTypes: [.png, .svg],
+      allowsMultipleSelection: false
+    ) { result in
+      handleImageImportResult(result)
+    }
+  }
+
+  // MARK: - Icon row
+
+  @ViewBuilder
+  private var iconRow: some View {
+    HStack(alignment: .center, spacing: 12) {
+      iconPreview
+      VStack(alignment: .leading, spacing: 4) {
+        Text("Icon")
+          .font(.headline)
+        Text(iconHelpText)
+          .font(.caption)
+          .foregroundStyle(.secondary)
+          .fixedSize(horizontal: false, vertical: true)
+      }
+      Spacer(minLength: 8)
+      iconButtons
+    }
+  }
+
+  @ViewBuilder
+  private var iconPreview: some View {
+    let frame = RoundedRectangle(cornerRadius: 8, style: .continuous)
+    let fill = Color.secondary.opacity(0.12)
+    Group {
+      if let icon = store.appearance.icon {
+        RepositoryIconImage(
+          icon: icon,
+          repositoryRootURL: store.rootURL,
+          tintColor: tintColor,
+          size: 22
+        )
+      } else {
+        Image(systemName: "questionmark")
+          .font(.system(size: 16, weight: .semibold))
+          .foregroundStyle(.tertiary)
+      }
+    }
+    .frame(width: previewSize, height: previewSize)
+    .background(fill, in: frame)
+    .accessibilityLabel("Icon preview")
+  }
+
+  @ViewBuilder
+  private var iconButtons: some View {
+    HStack(spacing: 6) {
+      Button("Choose Symbol…") {
+        isSymbolPickerPresented = true
+      }
+      .help("Pick from a preset SF Symbol or enter any symbol name.")
+      Button("Choose Image…") {
+        isImageImporterPresented = true
+      }
+      .help("Import a PNG or SVG file as this repository's icon.")
+      if store.appearance.icon != nil {
+        Button("Clear Icon") {
+          store.send(.setAppearanceIcon(nil))
+        }
+        .help("Remove the current icon and stop showing one for this repo.")
+      }
+    }
+  }
+
+  private var iconHelpText: String {
+    switch store.appearance.icon {
+    case .userImage(let filename) where !filename.lowercased().hasSuffix(".svg"):
+      return "PNG icons keep their original colors and ignore the repo color."
+    case .userImage:
+      return "User-provided SVGs are tinted with the repo color."
+    case .sfSymbol:
+      return "SF Symbols pick up the repo color when one is set."
+    case .bundledAsset:
+      return "Bundled icons keep their original artwork."
+    case nil:
+      return "No icon set — the row in the sidebar shows just the repo name."
+    }
+  }
+
+  private var tintColor: Color {
+    store.appearance.color?.color ?? .accentColor
+  }
+
+  private var currentSymbolName: String? {
+    if case .sfSymbol(let name) = store.appearance.icon {
+      return name
+    }
+    return nil
+  }
+
+  // MARK: - Color row
+
+  @ViewBuilder
+  private var colorRow: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      Text("Color")
+        .font(.headline)
+      Text(
+        "Tints the row in the sidebar, the shelf spine background, and the canvas card title bar."
+      )
+      .font(.caption)
+      .foregroundStyle(.secondary)
+      .fixedSize(horizontal: false, vertical: true)
+      HStack(spacing: 8) {
+        ForEach(RepositoryColorChoice.allCases, id: \.self) { choice in
+          colorSwatch(for: choice)
+        }
+        noColorSwatch
+        Spacer(minLength: 0)
+      }
+    }
+  }
+
+  @ViewBuilder
+  private func colorSwatch(for choice: RepositoryColorChoice) -> some View {
+    let isSelected = store.appearance.color == choice
+    Button {
+      store.send(.setAppearanceColor(choice))
+    } label: {
+      Circle()
+        .fill(choice.color)
+        .frame(width: dotSize, height: dotSize)
+        .overlay {
+          Circle()
+            .stroke(Color.primary, lineWidth: isSelected ? 2 : 0)
+            .padding(2)
+        }
+        .help(choice.displayName)
+        .accessibilityLabel(choice.displayName)
+        .accessibilityAddTraits(isSelected ? [.isSelected, .isButton] : .isButton)
+    }
+    .buttonStyle(.plain)
+  }
+
+  @ViewBuilder
+  private var noColorSwatch: some View {
+    let isSelected = store.appearance.color == nil
+    Button {
+      store.send(.setAppearanceColor(nil))
+    } label: {
+      Circle()
+        .stroke(Color.secondary.opacity(0.5), style: StrokeStyle(lineWidth: 1, dash: [2, 2]))
+        .frame(width: dotSize, height: dotSize)
+        .overlay {
+          Image(systemName: "slash.circle")
+            .font(.system(size: 12))
+            .foregroundStyle(.secondary)
+        }
+        .overlay {
+          Circle()
+            .stroke(Color.primary, lineWidth: isSelected ? 2 : 0)
+            .padding(2)
+        }
+        .help("No color")
+        .accessibilityLabel("No color")
+        .accessibilityAddTraits(isSelected ? [.isSelected, .isButton] : .isButton)
+    }
+    .buttonStyle(.plain)
+  }
+
+  // MARK: - Error banner
+
+  @ViewBuilder
+  private func importErrorBanner(message: String) -> some View {
+    HStack(spacing: 6) {
+      Image(systemName: "exclamationmark.triangle.fill")
+        .foregroundStyle(.orange)
+        .accessibilityHidden(true)
+      Text(message)
+        .font(.caption)
+        .foregroundStyle(.primary)
+      Spacer(minLength: 0)
+      Button("Dismiss") {
+        store.send(.dismissAppearanceImportError)
+      }
+      .buttonStyle(.plain)
+      .font(.caption)
+      .foregroundStyle(.secondary)
+    }
+    .padding(.vertical, 4)
+    .padding(.horizontal, 8)
+    .background(
+      RoundedRectangle(cornerRadius: 6, style: .continuous)
+        .fill(Color.orange.opacity(0.12))
+    )
+  }
+
+  // MARK: - Actions
+
+  private func applySymbolFromPicker(_ name: String?) {
+    isSymbolPickerPresented = false
+    if let name {
+      store.send(.setAppearanceIcon(.sfSymbol(name)))
+    } else {
+      store.send(.setAppearanceIcon(nil))
+    }
+  }
+
+  private func handleImageImportResult(_ result: Result<[URL], Error>) {
+    isImageImporterPresented = false
+    switch result {
+    case .success(let urls):
+      guard let url = urls.first else { return }
+      // `fileImporter` returns security-scoped URLs on macOS — we need
+      // to start access before reading and stop it on the way out so
+      // the import store can copy the bytes into the sandboxed app
+      // support directory.
+      let needsScope = url.startAccessingSecurityScopedResource()
+      defer {
+        if needsScope { url.stopAccessingSecurityScopedResource() }
+      }
+      store.send(.importUserImage(url))
+    case .failure(let error):
+      store.send(.userImageImportFailed(error.localizedDescription))
+    }
+  }
+}

--- a/supacode/Features/RepositorySettings/Views/RepositoryAppearancePickerView.swift
+++ b/supacode/Features/RepositorySettings/Views/RepositoryAppearancePickerView.swift
@@ -78,6 +78,16 @@ struct RepositoryAppearancePickerView: View {
   /// Settings windows don't truncate "Choose Symbol…" / "Clear Icon".
   /// Pattern matches macOS native flows (System Settings user picture,
   /// Finder "Get Info" icon).
+  ///
+  /// Implementation notes — `.buttonStyle(.plain)` (NOT
+  /// `.menuStyle(.borderlessButton)`) is critical: the borderless
+  /// menu style applies its own padding and a system tint that
+  /// silently overrides the icon's `foregroundStyle`, so the user's
+  /// chosen color stops appearing on the preview. Plain button style
+  /// lets the label render exactly as authored. Hover detection,
+  /// overlay border, pointer style, and tooltip all sit on the
+  /// **outer** Menu — `.onHover` placed inside the Menu's label is
+  /// swallowed by the menu's pointer interception.
   @ViewBuilder
   private var iconMenu: some View {
     Menu {
@@ -96,16 +106,39 @@ struct RepositoryAppearancePickerView: View {
     } label: {
       iconPreviewTile
     }
-    .menuStyle(.borderlessButton)
+    .buttonStyle(.plain)
     .menuIndicator(.hidden)
     .fixedSize()
-    .help("Click to choose an icon for this repository")
+    .overlay {
+      RoundedRectangle(cornerRadius: 8, style: .continuous)
+        .stroke(
+          Color.accentColor.opacity(isHoveringIconTile ? 0.65 : 0),
+          lineWidth: 1.5
+        )
+    }
+    .onHover { isHoveringIconTile = $0 }
+    .pointerStyle(.link)
+    .animation(.easeOut(duration: 0.12), value: isHoveringIconTile)
+    .help("Click the icon preview to pick a symbol or import an image")
   }
 
+  /// Visual label for the menu trigger. The frame is locked to
+  /// `previewSize × previewSize` so the row layout (and the title /
+  /// description text alignment to its right) doesn't shift when the
+  /// inner content swaps between the user's icon and the
+  /// no-icon placeholder. `.contentShape` confines the click hit-test
+  /// to the rounded rectangle so clicks just outside the visible
+  /// tile don't open the menu.
+  ///
+  /// When no icon is set, a dashed border replaces the questionmark's
+  /// silence with a "drop zone"-style affordance — the same pattern
+  /// macOS uses for empty avatar / drag-target slots — so users see
+  /// the tile is interactive even before they hover.
   @ViewBuilder
   private var iconPreviewTile: some View {
     let frame = RoundedRectangle(cornerRadius: 8, style: .continuous)
     let fill = Color.secondary.opacity(0.12)
+    let hasIcon = store.appearance.icon != nil
     Group {
       if let icon = store.appearance.icon {
         RepositoryIconImage(
@@ -124,18 +157,14 @@ struct RepositoryAppearancePickerView: View {
     .frame(width: previewSize, height: previewSize)
     .background(fill, in: frame)
     .overlay {
-      // Hover affordance: a 1.5pt accent border tells the user the
-      // tile is actionable. We pair this with the link pointer style
-      // below so the cursor change reinforces it.
-      frame.stroke(
-        Color.accentColor.opacity(isHoveringIconTile ? 0.65 : 0),
-        lineWidth: 1.5
-      )
+      if !hasIcon {
+        frame.stroke(
+          Color.secondary.opacity(0.55),
+          style: StrokeStyle(lineWidth: 1, dash: [3, 3])
+        )
+      }
     }
     .contentShape(.rect(cornerRadius: 8, style: .continuous))
-    .onHover { isHoveringIconTile = $0 }
-    .pointerStyle(.link)
-    .animation(.easeOut(duration: 0.12), value: isHoveringIconTile)
     .accessibilityLabel("Icon picker")
   }
 
@@ -150,7 +179,7 @@ struct RepositoryAppearancePickerView: View {
     case .bundledAsset:
       return "Bundled icons keep their original artwork."
     case nil:
-      return "No icon set. Click the tile to pick a symbol or import an image."
+      return "No icon set. Click the icon preview to pick a symbol or import an image."
     }
   }
 

--- a/supacode/Features/RepositorySettings/Views/RepositoryAppearancePickerView.swift
+++ b/supacode/Features/RepositorySettings/Views/RepositoryAppearancePickerView.swift
@@ -19,8 +19,9 @@ struct RepositoryAppearancePickerView: View {
 
   @State private var isSymbolPickerPresented = false
   @State private var isImageImporterPresented = false
+  @State private var isHoveringIconTile = false
 
-  private let previewSize: CGFloat = 36
+  private let previewSize: CGFloat = 40
   private let dotSize: CGFloat = 22
 
   var body: some View {
@@ -58,7 +59,7 @@ struct RepositoryAppearancePickerView: View {
   @ViewBuilder
   private var iconRow: some View {
     HStack(alignment: .center, spacing: 12) {
-      iconPreview
+      iconMenu
       VStack(alignment: .leading, spacing: 4) {
         Text("Icon")
           .font(.headline)
@@ -67,13 +68,42 @@ struct RepositoryAppearancePickerView: View {
           .foregroundStyle(.secondary)
           .fixedSize(horizontal: false, vertical: true)
       }
-      Spacer(minLength: 8)
-      iconButtons
+      Spacer(minLength: 0)
     }
   }
 
+  /// Click target + menu trigger for the icon. The whole preview tile
+  /// is the action surface — clicking opens a popover menu with the
+  /// three options. Drops the trailing button cluster so narrow
+  /// Settings windows don't truncate "Choose Symbol…" / "Clear Icon".
+  /// Pattern matches macOS native flows (System Settings user picture,
+  /// Finder "Get Info" icon).
   @ViewBuilder
-  private var iconPreview: some View {
+  private var iconMenu: some View {
+    Menu {
+      Button("Choose Symbol…") {
+        isSymbolPickerPresented = true
+      }
+      Button("Choose Image…") {
+        isImageImporterPresented = true
+      }
+      if store.appearance.icon != nil {
+        Divider()
+        Button("Clear Icon", role: .destructive) {
+          store.send(.setAppearanceIcon(nil))
+        }
+      }
+    } label: {
+      iconPreviewTile
+    }
+    .menuStyle(.borderlessButton)
+    .menuIndicator(.hidden)
+    .fixedSize()
+    .help("Click to choose an icon for this repository")
+  }
+
+  @ViewBuilder
+  private var iconPreviewTile: some View {
     let frame = RoundedRectangle(cornerRadius: 8, style: .continuous)
     let fill = Color.secondary.opacity(0.12)
     Group {
@@ -88,31 +118,25 @@ struct RepositoryAppearancePickerView: View {
         Image(systemName: "questionmark")
           .font(.system(size: 16, weight: .semibold))
           .foregroundStyle(.tertiary)
+          .accessibilityHidden(true)
       }
     }
     .frame(width: previewSize, height: previewSize)
     .background(fill, in: frame)
-    .accessibilityLabel("Icon preview")
-  }
-
-  @ViewBuilder
-  private var iconButtons: some View {
-    HStack(spacing: 6) {
-      Button("Choose Symbol…") {
-        isSymbolPickerPresented = true
-      }
-      .help("Pick from a preset SF Symbol or enter any symbol name.")
-      Button("Choose Image…") {
-        isImageImporterPresented = true
-      }
-      .help("Import a PNG or SVG file as this repository's icon.")
-      if store.appearance.icon != nil {
-        Button("Clear Icon") {
-          store.send(.setAppearanceIcon(nil))
-        }
-        .help("Remove the current icon and stop showing one for this repo.")
-      }
+    .overlay {
+      // Hover affordance: a 1.5pt accent border tells the user the
+      // tile is actionable. We pair this with the link pointer style
+      // below so the cursor change reinforces it.
+      frame.stroke(
+        Color.accentColor.opacity(isHoveringIconTile ? 0.65 : 0),
+        lineWidth: 1.5
+      )
     }
+    .contentShape(.rect(cornerRadius: 8, style: .continuous))
+    .onHover { isHoveringIconTile = $0 }
+    .pointerStyle(.link)
+    .animation(.easeOut(duration: 0.12), value: isHoveringIconTile)
+    .accessibilityLabel("Icon picker")
   }
 
   private var iconHelpText: String {
@@ -126,7 +150,7 @@ struct RepositoryAppearancePickerView: View {
     case .bundledAsset:
       return "Bundled icons keep their original artwork."
     case nil:
-      return "No icon set — the row in the sidebar shows just the repo name."
+      return "No icon set. Click the tile to pick a symbol or import an image."
     }
   }
 

--- a/supacode/Features/Settings/Views/RepositorySettingsView.swift
+++ b/supacode/Features/Settings/Views/RepositorySettingsView.swift
@@ -66,6 +66,18 @@ struct RepositorySettingsView: View {
     let exampleWorktreePath = store.exampleWorktreePath
 
     Form {
+      Section {
+        RepositoryAppearancePickerView(store: store)
+      } header: {
+        VStack(alignment: .leading, spacing: 4) {
+          Text("Appearance")
+          Text(
+            "Pick an icon and color to make this repository easy to spot in the sidebar, shelf, and canvas."
+          )
+          .foregroundStyle(.secondary)
+        }
+      }
+
       if store.showsWorktreeSettings {
         Section {
           if store.isBranchDataLoaded {

--- a/supacode/Features/Shelf/Views/ShelfSpineView.swift
+++ b/supacode/Features/Shelf/Views/ShelfSpineView.swift
@@ -182,6 +182,7 @@ struct ShelfSpineView: View {
         }
       }
       .padding(.horizontal, ShelfMetrics.slotHorizontalPadding)
+      .padding(.top, ShelfMetrics.sectionGap)
       .padding(.bottom, ShelfMetrics.slotSpacing)
     }
   }
@@ -258,7 +259,7 @@ struct ShelfSpineView: View {
       }
     }
     .padding(.horizontal, ShelfMetrics.slotHorizontalPadding)
-    .padding(.top, ShelfMetrics.slotSpacing)
+    .padding(.top, ShelfMetrics.sectionGap)
   }
 
 }
@@ -510,6 +511,11 @@ enum ShelfMetrics {
   static let slotCornerRadius: CGFloat = 5
   static let slotSpacing: CGFloat = 3
   static let slotHorizontalPadding: CGFloat = 3
+  /// Vertical gap between major spine sections (header → tab list,
+  /// tab list → bottom controls). Larger than `slotSpacing` so the
+  /// rotated title doesn't crowd into the first tab and the last tab
+  /// doesn't crowd into the divider above the `+` button.
+  static let sectionGap: CGFloat = 10
   static let aggregatedDotSize: CGFloat = 6
   /// Max pre-rotation width (i.e. visual height after 90° rotation) of the
   /// spine header title. Texts longer than this get middle-truncated.

--- a/supacode/Features/Shelf/Views/ShelfSpineView.swift
+++ b/supacode/Features/Shelf/Views/ShelfSpineView.swift
@@ -32,6 +32,10 @@ struct ShelfSpineView: View {
   /// enum into this view.
   let closeMenuTitle: String
   let onCloseBook: (() -> Void)?
+  /// "Repo Settings" — opens the per-repo Settings tab. Always
+  /// available regardless of book kind since every book belongs to a
+  /// repository.
+  let onOpenRepositorySettings: () -> Void
 
   @State private var isHovering = false
   @Shared(.repositoryAppearances) private var repositoryAppearances
@@ -140,7 +144,13 @@ struct ShelfSpineView: View {
 
   @ViewBuilder
   private var bookContextMenu: some View {
+    Button {
+      onOpenRepositorySettings()
+    } label: {
+      Text("Repo Settings")
+    }
     if let onCloseBook {
+      Divider()
       Button {
         onCloseBook()
       } label: {

--- a/supacode/Features/Shelf/Views/ShelfSpineView.swift
+++ b/supacode/Features/Shelf/Views/ShelfSpineView.swift
@@ -1,3 +1,4 @@
+import Sharing
 import SwiftUI
 
 /// Vertical spine rendering for a single book on the Shelf.
@@ -33,6 +34,7 @@ struct ShelfSpineView: View {
   let onCloseBook: (() -> Void)?
 
   @State private var isHovering = false
+  @Shared(.repositoryAppearances) private var repositoryAppearances
 
   var body: some View {
     VStack(spacing: 0) {
@@ -98,12 +100,28 @@ struct ShelfSpineView: View {
   /// bumps its tint to 80% of the selected book's intensity — a clear
   /// "this is interactable" affordance that sits just below the open
   /// book and animates in/out smoothly.
+  ///
+  /// When the book's repository has a user-pinned color, that color
+  /// replaces `Color.accentColor` as the proximity-tint base so the
+  /// shelf reads as "books on shelves" instead of one continuous
+  /// accent ribbon. The proximity ladder is unchanged — we only swap
+  /// the hue.
   private var spineBackgroundColor: Color {
     guard distanceFromOpen != nil else {
       return Color.primary.opacity(0.06)
     }
     let multiplier = isHovering && !isOpen ? 0.8 : accentProximityMultiplier
-    return Color.accentColor.opacity(0.20 * multiplier)
+    return effectiveTintColor.opacity(0.20 * multiplier)
+  }
+
+  /// Repo's pinned color, or `.accentColor` when none — used as the
+  /// proximity-tint base and as the icon tint in the header.
+  private var effectiveTintColor: Color {
+    appearance.color?.color ?? .accentColor
+  }
+
+  private var appearance: RepositoryAppearance {
+    repositoryAppearances[book.repositoryID] ?? .empty
   }
 
   /// Active-tab highlight fades more gently than the spine background —
@@ -173,7 +191,10 @@ struct ShelfSpineView: View {
     Button(action: onOpenBook) {
       ShelfSpineHeader(
         book: book,
-        hasAggregatedNotification: terminalState?.hasUnseenNotification == true
+        hasAggregatedNotification: terminalState?.hasUnseenNotification == true,
+        icon: appearance.icon,
+        iconTint: effectiveTintColor,
+        repositoryRootURL: URL(fileURLWithPath: book.repositoryID)
       )
       .frame(maxWidth: .infinity)
       .contentShape(.rect)
@@ -244,16 +265,28 @@ struct ShelfSpineView: View {
 private struct ShelfSpineHeader: View {
   let book: ShelfBook
   let hasAggregatedNotification: Bool
+  let icon: RepositoryIconSource?
+  let iconTint: Color
+  let repositoryRootURL: URL
 
   var body: some View {
     VStack(spacing: 6) {
+      if let icon {
+        RepositoryIconImage(
+          icon: icon,
+          repositoryRootURL: repositoryRootURL,
+          tintColor: iconTint,
+          size: 14
+        )
+        .padding(.top, 6)
+      }
       Circle()
         .fill(.orange)
         .frame(width: ShelfMetrics.aggregatedDotSize, height: ShelfMetrics.aggregatedDotSize)
         .opacity(hasAggregatedNotification ? 1 : 0)
         .accessibilityLabel("Unread notifications")
         .accessibilityHidden(!hasAggregatedNotification)
-        .padding(.top, 6)
+        .padding(.top, icon == nil ? 6 : 0)
       rotatedTitle
     }
   }

--- a/supacode/Features/Shelf/Views/ShelfSpineView.swift
+++ b/supacode/Features/Shelf/Views/ShelfSpineView.swift
@@ -238,6 +238,7 @@ struct ShelfSpineView: View {
           hotkeyIndex: hotkeyIndex,
           isActive: terminalState.tabManager.selectedTabId == tab.id,
           hasUnseenNotification: terminalState.hasUnseenNotification(for: tab.id),
+          activeHighlightTint: effectiveTintColor,
           activeHighlightAlpha: activeTabHighlightAlpha,
           onTap: { onSelectTab(tab.id) },
           onClose: { terminalState.closeTab(tab.id) }
@@ -379,6 +380,12 @@ private struct ShelfSpineTabSlot: View {
   let hotkeyIndex: Int?
   let isActive: Bool
   let hasUnseenNotification: Bool
+  /// Hue used for the active-tab background fill — repo color when
+  /// the owning book has one pinned, otherwise `Color.accentColor`.
+  /// Threaded from the spine so the active-tab indicator stays in
+  /// the same color family as the surrounding spine background
+  /// instead of clashing with a contrasting accent.
+  let activeHighlightTint: Color
   /// Absolute alpha for the active-tab accent fill, supplied by the
   /// enclosing spine so it can fade with proximity on its own curve
   /// (which decays more gently than the spine background — selection
@@ -462,7 +469,7 @@ private struct ShelfSpineTabSlot: View {
         .fill(Color.orange.opacity(0.3))
     } else if isActive {
       RoundedRectangle(cornerRadius: ShelfMetrics.slotCornerRadius, style: .continuous)
-        .fill(Color.accentColor.opacity(activeHighlightAlpha))
+        .fill(activeHighlightTint.opacity(activeHighlightAlpha))
     } else {
       Color.clear
     }

--- a/supacode/Features/Shelf/Views/ShelfSpineView.swift
+++ b/supacode/Features/Shelf/Views/ShelfSpineView.swift
@@ -269,26 +269,78 @@ private struct ShelfSpineHeader: View {
   let iconTint: Color
   let repositoryRootURL: URL
 
+  /// Reserved slot for the top decoration (icon and/or notification),
+  /// sized at the maximum expected configuration (14pt icon plus a
+  /// 6pt badge nudged 3pt outward at the top-trailing corner).
+  /// Holding the slot at a constant size — whether or not an icon is
+  /// set — keeps every spine's header at the same total height so the
+  /// rotated titles align horizontally across the shelf row. When the
+  /// repo has no icon AND no notification, the slot is just empty
+  /// reserved space.
+  private let slotSize: CGFloat = 18
+  private let iconSize: CGFloat = 14
+  private let badgeSize: CGFloat = 6
+  private let badgeOffset: CGFloat = 3
+
   var body: some View {
-    VStack(spacing: 6) {
+    VStack(spacing: 8) {
+      slot
+      rotatedTitle
+    }
+    .padding(.top, 8)
+  }
+
+  /// Three rendering paths driven by the (icon, notification) matrix:
+  /// - icon set: render the icon, hang the notification on it as a
+  ///   small badge in the top-trailing corner (macOS app-icon style).
+  /// - no icon, has notification: fall back to the original
+  ///   standalone orange dot, centered in the slot.
+  /// - no icon, no notification: slot stays empty but reserved.
+  @ViewBuilder
+  private var slot: some View {
+    ZStack {
+      Color.clear
+        .frame(width: slotSize, height: slotSize)
+
       if let icon {
         RepositoryIconImage(
           icon: icon,
           repositoryRootURL: repositoryRootURL,
           tintColor: iconTint,
-          size: 14
+          size: iconSize
         )
-        .padding(.top, 6)
+        .overlay(alignment: .topTrailing) {
+          if hasAggregatedNotification {
+            notificationBadge
+          }
+        }
+      } else if hasAggregatedNotification {
+        Circle()
+          .fill(.orange)
+          .frame(
+            width: ShelfMetrics.aggregatedDotSize,
+            height: ShelfMetrics.aggregatedDotSize
+          )
       }
-      Circle()
-        .fill(.orange)
-        .frame(width: ShelfMetrics.aggregatedDotSize, height: ShelfMetrics.aggregatedDotSize)
-        .opacity(hasAggregatedNotification ? 1 : 0)
-        .accessibilityLabel("Unread notifications")
-        .accessibilityHidden(!hasAggregatedNotification)
-        .padding(.top, icon == nil ? 6 : 0)
-      rotatedTitle
     }
+    .accessibilityElement()
+    .accessibilityLabel(hasAggregatedNotification ? "Unread notifications" : "")
+    .accessibilityHidden(!hasAggregatedNotification)
+  }
+
+  /// Notification dot rendered as a corner badge over the icon. The
+  /// thin dark stroke keeps the orange visible on light spine
+  /// backgrounds; without it the badge would disappear on
+  /// orange-tinted repos.
+  @ViewBuilder
+  private var notificationBadge: some View {
+    Circle()
+      .fill(.orange)
+      .frame(width: badgeSize, height: badgeSize)
+      .overlay {
+        Circle().stroke(Color.black.opacity(0.25), lineWidth: 0.5)
+      }
+      .offset(x: badgeOffset, y: -badgeOffset)
   }
 
   /// Composed title rendered vertically (top-to-bottom reading direction).

--- a/supacode/Features/Shelf/Views/ShelfView.swift
+++ b/supacode/Features/Shelf/Views/ShelfView.swift
@@ -89,7 +89,10 @@ struct ShelfView: View {
           onSplitVertical: open ? { performSplit(direction: "new_split:right") } : nil,
           onSplitHorizontal: open ? { performSplit(direction: "new_split:down") } : nil,
           closeMenuTitle: closeMenuTitle(for: book),
-          onCloseBook: { closeBook(book) }
+          onCloseBook: { closeBook(book) },
+          onOpenRepositorySettings: {
+            store.send(.repositoryManagement(.openRepositorySettings(book.repositoryID)))
+          }
         )
         .matchedGeometryEffect(id: book.id, in: spineNamespace)
       }

--- a/supacode/Features/Terminal/TabBar/Views/TabIconPickerView.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TabIconPickerView.swift
@@ -4,6 +4,9 @@ import SwiftUI
 struct TabIconPickerView: View {
   let initialIcon: String?
   let defaultIcon: String
+  let title: String
+  let subtitle: String
+  let presets: [String]
   let onApply: (String?) -> Void
   let onCancel: () -> Void
 
@@ -13,11 +16,17 @@ struct TabIconPickerView: View {
   init(
     initialIcon: String?,
     defaultIcon: String,
+    title: String = "Tab Icon",
+    subtitle: String = "Pick a preset or enter any SF Symbol name available in your system.",
+    presets: [String] = TabIconPickerView.symbolPresets,
     onApply: @escaping (String?) -> Void,
     onCancel: @escaping () -> Void
   ) {
     self.initialIcon = initialIcon
     self.defaultIcon = defaultIcon
+    self.title = title
+    self.subtitle = subtitle
+    self.presets = presets
     self.onApply = onApply
     self.onCancel = onCancel
     _symbolName = State(initialValue: initialIcon ?? "")
@@ -26,9 +35,9 @@ struct TabIconPickerView: View {
   var body: some View {
     VStack(alignment: .leading, spacing: 16) {
       VStack(alignment: .leading, spacing: 4) {
-        Text("Tab Icon")
+        Text(title)
           .font(.headline)
-        Text("Pick a preset or enter any SF Symbol name available in your system.")
+        Text(subtitle)
           .font(.caption)
           .foregroundStyle(.secondary)
       }
@@ -56,7 +65,7 @@ struct TabIconPickerView: View {
         columns: Array(repeating: GridItem(.fixed(32), spacing: 6), count: 8),
         spacing: 6
       ) {
-        ForEach(Self.symbolPresets, id: \.self) { symbol in
+        ForEach(presets, id: \.self) { symbol in
           Button {
             symbolName = symbol
             symbolFieldFocused = true

--- a/supacode/Support/SupacodePaths.swift
+++ b/supacode/Support/SupacodePaths.swift
@@ -113,6 +113,26 @@ nonisolated enum SupacodePaths {
     baseDirectory.appending(path: "repository-entries.json", directoryHint: .notDirectory)
   }
 
+  static var repositoryAppearancesURL: URL {
+    baseDirectory.appending(path: "repository-appearances.json", directoryHint: .notDirectory)
+  }
+
+  /// Directory where user-imported repository icon images live, scoped
+  /// per-repo so cleanup is automatic when the per-repo settings
+  /// directory is removed.
+  static func repositoryIconsDirectory(for rootURL: URL) -> URL {
+    repositorySettingsDirectory(for: rootURL)
+      .appending(path: "icons", directoryHint: .isDirectory)
+  }
+
+  /// Resolved file URL for a stored icon filename. The filename is the
+  /// only thing persisted in `RepositoryAppearance` so that moving a
+  /// repository (or renaming its directory) leaves the artifact alone.
+  static func repositoryIconFileURL(filename: String, repositoryRootURL rootURL: URL) -> URL {
+    repositoryIconsDirectory(for: rootURL)
+      .appending(path: filename, directoryHint: .notDirectory)
+  }
+
   static func migrateLegacyCacheFilesIfNeeded(
     fileManager: FileManager = .default,
     legacyDirectory: URL? = nil,

--- a/supacodeTests/AppFeatureSettingsSelectionTests.swift
+++ b/supacodeTests/AppFeatureSettingsSelectionTests.swift
@@ -26,6 +26,7 @@ struct AppFeatureSettingsSelectionTests {
       $0.settings.selection = .repository(repository.id)
       $0.settings.repositorySettings = RepositorySettingsFeature.State(
         rootURL: repository.rootURL,
+        repositoryID: repository.id,
         repositoryKind: repository.kind,
         settings: .default,
         userSettings: .default
@@ -70,6 +71,7 @@ struct AppFeatureSettingsSelectionTests {
       $0.settings.selection = .repository(repository.id)
       $0.settings.repositorySettings = RepositorySettingsFeature.State(
         rootURL: repository.rootURL,
+        repositoryID: repository.id,
         repositoryKind: .plain,
         settings: .default,
         userSettings: .default

--- a/supacodeTests/AppFeatureSettingsSelectionTests.swift
+++ b/supacodeTests/AppFeatureSettingsSelectionTests.swift
@@ -1,5 +1,8 @@
 import ComposableArchitecture
+import Dependencies
+import DependenciesTestSupport
 import Foundation
+import Sharing
 import Testing
 
 @testable import supacode
@@ -76,6 +79,59 @@ struct AppFeatureSettingsSelectionTests {
         settings: .default,
         userSettings: .default
       )
+    }
+  }
+
+  @Test(.dependencies) func selectingRepositorySeedsAppearanceSynchronously() async {
+    // Regression: selecting a repo whose appearance is already in
+    // @Shared used to construct a State with `.empty` appearance and
+    // load asynchronously via .task. The async hop raced with the
+    // user's first click, sometimes wiping previously-saved fields.
+    // The State must now carry the appearance from frame zero.
+    let storage = SettingsTestStorage()
+    let appearancesURL = URL(fileURLWithPath: "/tmp/appearances-\(UUID().uuidString).json")
+    let savedAppearance = RepositoryAppearance(
+      icon: .sfSymbol("hammer.fill"), color: .blue
+    )
+    let repository = Repository(
+      id: "appearance-repo",
+      rootURL: URL(fileURLWithPath: "/tmp/appearance-repo"),
+      name: "AppearanceRepo",
+      worktrees: []
+    )
+
+    await withDependencies {
+      $0.settingsFileStorage = storage.storage
+      $0.repositoryAppearancesFileURL = appearancesURL
+    } operation: {
+      @Shared(.repositoryAppearances) var appearances
+      $appearances.withLock {
+        $0[repository.id] = savedAppearance
+      }
+
+      let store = TestStore(
+        initialState: AppFeature.State(
+          repositories: RepositoriesFeature.State(repositories: [repository]),
+          settings: SettingsFeature.State()
+        )
+      ) {
+        AppFeature()
+      } withDependencies: {
+        $0.settingsFileStorage = storage.storage
+        $0.repositoryAppearancesFileURL = appearancesURL
+      }
+
+      await store.send(.settings(.setSelection(.repository(repository.id)))) {
+        $0.settings.selection = .repository(repository.id)
+        $0.settings.repositorySettings = RepositorySettingsFeature.State(
+          rootURL: repository.rootURL,
+          repositoryID: repository.id,
+          repositoryKind: repository.kind,
+          settings: .default,
+          userSettings: .default,
+          appearance: savedAppearance
+        )
+      }
     }
   }
 

--- a/supacodeTests/RepositoryAppearanceTests.swift
+++ b/supacodeTests/RepositoryAppearanceTests.swift
@@ -1,0 +1,74 @@
+import Foundation
+import Testing
+
+@testable import supacode
+
+struct RepositoryAppearanceTests {
+  @Test func emptyHasBothNil() {
+    #expect(RepositoryAppearance.empty.icon == nil)
+    #expect(RepositoryAppearance.empty.color == nil)
+    #expect(RepositoryAppearance.empty.isEmpty)
+  }
+
+  @Test func iconOnlyIsNotEmpty() {
+    let appearance = RepositoryAppearance(icon: .sfSymbol("folder"), color: nil)
+    #expect(!appearance.isEmpty)
+  }
+
+  @Test func colorOnlyIsNotEmpty() {
+    let appearance = RepositoryAppearance(icon: nil, color: .blue)
+    #expect(!appearance.isEmpty)
+  }
+
+  @Test func bothSetIsNotEmpty() {
+    let appearance = RepositoryAppearance(icon: .sfSymbol("folder"), color: .blue)
+    #expect(!appearance.isEmpty)
+  }
+
+  @Test func codableRoundTripWithBoth() throws {
+    let original = RepositoryAppearance(
+      icon: .sfSymbol("folder.fill"),
+      color: .purple
+    )
+    let data = try JSONEncoder().encode(original)
+    let decoded = try JSONDecoder().decode(RepositoryAppearance.self, from: data)
+    #expect(decoded == original)
+  }
+
+  @Test func codableRoundTripIconOnly() throws {
+    let original = RepositoryAppearance(icon: .userImage(filename: "abc.svg"), color: nil)
+    let data = try JSONEncoder().encode(original)
+    let decoded = try JSONDecoder().decode(RepositoryAppearance.self, from: data)
+    #expect(decoded == original)
+  }
+
+  @Test func codableRoundTripColorOnly() throws {
+    let original = RepositoryAppearance(icon: nil, color: .green)
+    let data = try JSONEncoder().encode(original)
+    let decoded = try JSONDecoder().decode(RepositoryAppearance.self, from: data)
+    #expect(decoded == original)
+  }
+
+  @Test func codableRoundTripEmpty() throws {
+    let data = try JSONEncoder().encode(RepositoryAppearance.empty)
+    let decoded = try JSONDecoder().decode(RepositoryAppearance.self, from: data)
+    #expect(decoded == .empty)
+  }
+
+  @Test func decodingExtraFieldsIsTolerated() throws {
+    // Forward-compat: a future schema may add fields; older builds
+    // shouldn't refuse to decode.
+    let raw = Data(
+      """
+      {
+        "icon": "folder",
+        "color": "red",
+        "futureField": "ignored"
+      }
+      """.utf8
+    )
+    let decoded = try JSONDecoder().decode(RepositoryAppearance.self, from: raw)
+    #expect(decoded.icon == .sfSymbol("folder"))
+    #expect(decoded.color == .red)
+  }
+}

--- a/supacodeTests/RepositoryAppearancesKeyTests.swift
+++ b/supacodeTests/RepositoryAppearancesKeyTests.swift
@@ -1,0 +1,124 @@
+import Dependencies
+import DependenciesTestSupport
+import Foundation
+import Sharing
+import Testing
+
+@testable import supacode
+
+struct RepositoryAppearancesKeyTests {
+  @Test(.dependencies) func loadReturnsEmptyDictionaryWhenFileMissing() {
+    let storage = SettingsTestStorage()
+    let url = URL(fileURLWithPath: "/tmp/repo-appearances-\(UUID().uuidString).json")
+
+    let appearances: [Repository.ID: RepositoryAppearance] = withDependencies {
+      $0.settingsFileStorage = storage.storage
+      $0.repositoryAppearancesFileURL = url
+    } operation: {
+      @Shared(.repositoryAppearances) var appearances
+      return appearances
+    }
+
+    #expect(appearances.isEmpty)
+  }
+
+  @Test(.dependencies) func saveAndReloadRoundTrip() {
+    let storage = SettingsTestStorage()
+    let url = URL(fileURLWithPath: "/tmp/repo-appearances-\(UUID().uuidString).json")
+
+    withDependencies {
+      $0.settingsFileStorage = storage.storage
+      $0.repositoryAppearancesFileURL = url
+    } operation: {
+      @Shared(.repositoryAppearances) var appearances
+      $appearances.withLock {
+        $0["repo-1"] = RepositoryAppearance(icon: .sfSymbol("folder.fill"), color: .blue)
+        $0["repo-2"] = RepositoryAppearance(icon: nil, color: .purple)
+      }
+    }
+
+    let reloaded: [Repository.ID: RepositoryAppearance] = withDependencies {
+      $0.settingsFileStorage = storage.storage
+      $0.repositoryAppearancesFileURL = url
+    } operation: {
+      @Shared(.repositoryAppearances) var appearances
+      return appearances
+    }
+
+    #expect(
+      reloaded["repo-1"] == RepositoryAppearance(icon: .sfSymbol("folder.fill"), color: .blue)
+    )
+    #expect(reloaded["repo-2"] == RepositoryAppearance(icon: nil, color: .purple))
+  }
+
+  @Test(.dependencies) func saveDropsEmptyEntries() {
+    // Clearing both icon and color resets a repo to the implicit
+    // "no appearance" state — we don't want to leave dead `{}` entries
+    // in the file forever.
+    let storage = SettingsTestStorage()
+    let url = URL(fileURLWithPath: "/tmp/repo-appearances-\(UUID().uuidString).json")
+
+    withDependencies {
+      $0.settingsFileStorage = storage.storage
+      $0.repositoryAppearancesFileURL = url
+    } operation: {
+      @Shared(.repositoryAppearances) var appearances
+      $appearances.withLock {
+        $0["keep"] = RepositoryAppearance(icon: .sfSymbol("folder"), color: nil)
+        $0["drop"] = .empty
+      }
+    }
+
+    let reloaded: [Repository.ID: RepositoryAppearance] = withDependencies {
+      $0.settingsFileStorage = storage.storage
+      $0.repositoryAppearancesFileURL = url
+    } operation: {
+      @Shared(.repositoryAppearances) var appearances
+      return appearances
+    }
+
+    #expect(reloaded["keep"] != nil)
+    #expect(reloaded["drop"] == nil)
+  }
+
+  @Test(.dependencies) func loadIgnoresCorruptFile() {
+    let storage = SettingsTestStorage()
+    let url = URL(fileURLWithPath: "/tmp/repo-appearances-\(UUID().uuidString).json")
+    try? storage.storage.save(Data("not-json".utf8), url)
+
+    let appearances: [Repository.ID: RepositoryAppearance] = withDependencies {
+      $0.settingsFileStorage = storage.storage
+      $0.repositoryAppearancesFileURL = url
+    } operation: {
+      @Shared(.repositoryAppearances) var appearances
+      return appearances
+    }
+
+    // Corrupt JSON should fall back to default (empty) rather than crash.
+    #expect(appearances.isEmpty)
+  }
+
+  @Test(.dependencies) func savedJSONShape() throws {
+    // The on-disk shape is part of the public surface — pin it so a
+    // refactor of Codable defaults doesn't silently change the file
+    // format users have on disk.
+    let storage = SettingsTestStorage()
+    let url = URL(fileURLWithPath: "/tmp/repo-appearances-\(UUID().uuidString).json")
+
+    withDependencies {
+      $0.settingsFileStorage = storage.storage
+      $0.repositoryAppearancesFileURL = url
+    } operation: {
+      @Shared(.repositoryAppearances) var appearances
+      $appearances.withLock {
+        $0["alpha"] = RepositoryAppearance(icon: .sfSymbol("folder"), color: .red)
+      }
+    }
+
+    let data = try storage.storage.load(url)
+    let json = try JSONSerialization.jsonObject(with: data) as? [String: [String: String]]
+    let alpha = try #require(json?["alpha"])
+    #expect(alpha["icon"] == "folder")
+    #expect(alpha["color"] == "red")
+  }
+}

--- a/supacodeTests/RepositoryColorChoiceTests.swift
+++ b/supacodeTests/RepositoryColorChoiceTests.swift
@@ -1,0 +1,50 @@
+import Foundation
+import Testing
+
+@testable import supacode
+
+struct RepositoryColorChoiceTests {
+  @Test func paletteHasTenSystemColors() {
+    // The fixed palette is part of the persistence contract: once
+    // shipped, removing or renaming a case would break user JSON. This
+    // test pins the count so an accidental rename or removal trips a
+    // failure before release.
+    #expect(RepositoryColorChoice.allCases.count == 10)
+  }
+
+  @Test func paletteCasesAreStable() {
+    // Raw values are written to JSON; reordering allCases is fine but
+    // case names are forever. Pin them.
+    let names = RepositoryColorChoice.allCases.map(\.rawValue).sorted()
+    #expect(
+      names == [
+        "blue",
+        "cyan",
+        "gray",
+        "green",
+        "mint",
+        "orange",
+        "pink",
+        "purple",
+        "red",
+        "yellow",
+      ]
+    )
+  }
+
+  @Test func codableRoundTrip() throws {
+    let encoder = JSONEncoder()
+    let decoder = JSONDecoder()
+    for choice in RepositoryColorChoice.allCases {
+      let data = try encoder.encode(choice)
+      let decoded = try decoder.decode(RepositoryColorChoice.self, from: data)
+      #expect(decoded == choice)
+    }
+  }
+
+  @Test func displayNameNonEmpty() {
+    for choice in RepositoryColorChoice.allCases {
+      #expect(!choice.displayName.isEmpty)
+    }
+  }
+}

--- a/supacodeTests/RepositoryIconAssetStoreTests.swift
+++ b/supacodeTests/RepositoryIconAssetStoreTests.swift
@@ -80,15 +80,36 @@ struct RepositoryIconAssetStoreTests {
     #expect(filename.hasSuffix(".svg"))
   }
 
-  @Test func importImageRejectsUnsupportedExtension() throws {
+  @Test func importImageAcceptsArbitraryImageExtensions() throws {
+    // The store no longer enforces a PNG/SVG whitelist — the file
+    // picker filters down to image UTTypes already, and anything
+    // that NSImage can't decode falls back to a placeholder at
+    // render time. JPG / WebP / HEIC / GIF / TIFF / etc. all flow
+    // through the same byte-copy path and round-trip through
+    // `repositoryIconFileURL` like PNG does.
+    let store = RepositoryIconAssetStore.liveValue
+    let repoRoot = makeRepoRootScratch()
+
+    for ext in ["jpg", "jpeg", "webp", "heic", "gif", "tiff", "bmp"] {
+      let source = ScratchDirectory(prefix: "prowl-icon-source")
+      let sourceFile = try writeSourceFile(in: source, extension: ext)
+      let filename = try store.importImage(sourceFile, repoRoot.url)
+      #expect(filename.hasSuffix(".\(ext)"))
+    }
+  }
+
+  @Test func importImageHandlesFileWithNoExtension() throws {
+    // Defensive: a dragged-in file without an extension shouldn't
+    // crash the importer. The destination filename gets a generic
+    // fallback so the round-trip still works.
     let store = RepositoryIconAssetStore.liveValue
     let repoRoot = makeRepoRootScratch()
     let source = ScratchDirectory(prefix: "prowl-icon-source")
-    let sourceFile = try writeSourceFile(in: source, extension: "jpeg")
+    let sourceFile = source.url.appending(path: "icon", directoryHint: .notDirectory)
+    try Data([0xDE, 0xAD]).write(to: sourceFile)
 
-    #expect(throws: RepositoryIconAssetStoreError.self) {
-      _ = try store.importImage(sourceFile, repoRoot.url)
-    }
+    let filename = try store.importImage(sourceFile, repoRoot.url)
+    #expect(!filename.isEmpty)
   }
 
   @Test func importImageCreatesIconsDirectoryWhenMissing() throws {

--- a/supacodeTests/RepositoryIconAssetStoreTests.swift
+++ b/supacodeTests/RepositoryIconAssetStoreTests.swift
@@ -3,25 +3,37 @@ import Testing
 
 @testable import supacode
 
+/// RAII helper: creates a unique scratch directory under `$TMPDIR` and
+/// removes it on deinit so test runs don't accumulate orphan folders
+/// between invocations (we ship to `make test` repeatedly during dev).
+private final class ScratchDirectory {
+  let url: URL
+
+  init(prefix: String) {
+    url = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appending(path: "\(prefix)-\(UUID().uuidString)", directoryHint: .isDirectory)
+    try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+  }
+
+  deinit {
+    try? FileManager.default.removeItem(at: url)
+  }
+}
+
 @MainActor
 struct RepositoryIconAssetStoreTests {
   // MARK: - Helpers
 
-  private static func makeTempRepoRoot() -> URL {
-    let url = URL(fileURLWithPath: NSTemporaryDirectory())
-      .appending(path: "prowl-icon-store-\(UUID().uuidString)", directoryHint: .isDirectory)
-    try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
-    return url
+  private func makeRepoRootScratch() -> ScratchDirectory {
+    ScratchDirectory(prefix: "prowl-icon-store")
   }
 
-  private static func writeSourceFile(extension ext: String, contents: Data = Data([0xDE, 0xAD]))
-    throws
-    -> URL
-  {
-    let dir = URL(fileURLWithPath: NSTemporaryDirectory())
-      .appending(path: "prowl-icon-source-\(UUID().uuidString)", directoryHint: .isDirectory)
-    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-    let url = dir.appending(path: "icon.\(ext)", directoryHint: .notDirectory)
+  private func writeSourceFile(
+    in scratch: ScratchDirectory,
+    extension ext: String,
+    contents: Data = Data([0xDE, 0xAD])
+  ) throws -> URL {
+    let url = scratch.url.appending(path: "icon.\(ext)", directoryHint: .notDirectory)
     try contents.write(to: url)
     return url
   }
@@ -30,16 +42,19 @@ struct RepositoryIconAssetStoreTests {
 
   @Test func importImageCopiesFileWithUUIDName() throws {
     let store = RepositoryIconAssetStore.liveValue
-    let repoRoot = Self.makeTempRepoRoot()
-    let source = try Self.writeSourceFile(extension: "png", contents: Data([0x01, 0x02, 0x03]))
+    let repoRoot = makeRepoRootScratch()
+    let source = ScratchDirectory(prefix: "prowl-icon-source")
+    let sourceFile = try writeSourceFile(
+      in: source, extension: "png", contents: Data([0x01, 0x02, 0x03])
+    )
 
-    let filename = try store.importImage(source, repoRoot)
+    let filename = try store.importImage(sourceFile, repoRoot.url)
 
     #expect(filename.hasSuffix(".png"))
     #expect(UUID(uuidString: String(filename.dropLast(4))) != nil)
 
     let resolved = SupacodePaths.repositoryIconFileURL(
-      filename: filename, repositoryRootURL: repoRoot
+      filename: filename, repositoryRootURL: repoRoot.url
     )
     let copied = try Data(contentsOf: resolved)
     #expect(copied == Data([0x01, 0x02, 0x03]))
@@ -47,42 +62,46 @@ struct RepositoryIconAssetStoreTests {
 
   @Test func importImageNormalizesUppercaseExtension() throws {
     let store = RepositoryIconAssetStore.liveValue
-    let repoRoot = Self.makeTempRepoRoot()
-    let source = try Self.writeSourceFile(extension: "PNG")
+    let repoRoot = makeRepoRootScratch()
+    let source = ScratchDirectory(prefix: "prowl-icon-source")
+    let sourceFile = try writeSourceFile(in: source, extension: "PNG")
 
-    let filename = try store.importImage(source, repoRoot)
+    let filename = try store.importImage(sourceFile, repoRoot.url)
     #expect(filename.hasSuffix(".png"))
   }
 
   @Test func importImageAcceptsSVG() throws {
     let store = RepositoryIconAssetStore.liveValue
-    let repoRoot = Self.makeTempRepoRoot()
-    let source = try Self.writeSourceFile(extension: "svg")
+    let repoRoot = makeRepoRootScratch()
+    let source = ScratchDirectory(prefix: "prowl-icon-source")
+    let sourceFile = try writeSourceFile(in: source, extension: "svg")
 
-    let filename = try store.importImage(source, repoRoot)
+    let filename = try store.importImage(sourceFile, repoRoot.url)
     #expect(filename.hasSuffix(".svg"))
   }
 
   @Test func importImageRejectsUnsupportedExtension() throws {
     let store = RepositoryIconAssetStore.liveValue
-    let repoRoot = Self.makeTempRepoRoot()
-    let source = try Self.writeSourceFile(extension: "jpeg")
+    let repoRoot = makeRepoRootScratch()
+    let source = ScratchDirectory(prefix: "prowl-icon-source")
+    let sourceFile = try writeSourceFile(in: source, extension: "jpeg")
 
     #expect(throws: RepositoryIconAssetStoreError.self) {
-      _ = try store.importImage(source, repoRoot)
+      _ = try store.importImage(sourceFile, repoRoot.url)
     }
   }
 
   @Test func importImageCreatesIconsDirectoryWhenMissing() throws {
     let store = RepositoryIconAssetStore.liveValue
-    let repoRoot = Self.makeTempRepoRoot()
+    let repoRoot = makeRepoRootScratch()
     // Don't pre-create the icons directory — importImage should make
     // it itself, otherwise first-time imports would fail.
-    let source = try Self.writeSourceFile(extension: "png")
+    let source = ScratchDirectory(prefix: "prowl-icon-source")
+    let sourceFile = try writeSourceFile(in: source, extension: "png")
 
-    _ = try store.importImage(source, repoRoot)
+    _ = try store.importImage(sourceFile, repoRoot.url)
 
-    let iconsDir = SupacodePaths.repositoryIconsDirectory(for: repoRoot)
+    let iconsDir = SupacodePaths.repositoryIconsDirectory(for: repoRoot.url)
     var isDirectory: ObjCBool = false
     let exists = FileManager.default.fileExists(
       atPath: iconsDir.path(percentEncoded: false), isDirectory: &isDirectory
@@ -93,11 +112,12 @@ struct RepositoryIconAssetStoreTests {
 
   @Test func importImageGeneratesUniqueFilenamePerCall() throws {
     let store = RepositoryIconAssetStore.liveValue
-    let repoRoot = Self.makeTempRepoRoot()
-    let source = try Self.writeSourceFile(extension: "png")
+    let repoRoot = makeRepoRootScratch()
+    let source = ScratchDirectory(prefix: "prowl-icon-source")
+    let sourceFile = try writeSourceFile(in: source, extension: "png")
 
-    let first = try store.importImage(source, repoRoot)
-    let second = try store.importImage(source, repoRoot)
+    let first = try store.importImage(sourceFile, repoRoot.url)
+    let second = try store.importImage(sourceFile, repoRoot.url)
     #expect(first != second)
   }
 
@@ -105,35 +125,37 @@ struct RepositoryIconAssetStoreTests {
 
   @Test func existsReportsFalseWhenMissing() {
     let store = RepositoryIconAssetStore.liveValue
-    let repoRoot = Self.makeTempRepoRoot()
-    #expect(!store.exists("nonexistent.png", repoRoot))
+    let repoRoot = makeRepoRootScratch()
+    #expect(!store.exists("nonexistent.png", repoRoot.url))
   }
 
   @Test func existsReportsTrueAfterImport() throws {
     let store = RepositoryIconAssetStore.liveValue
-    let repoRoot = Self.makeTempRepoRoot()
-    let source = try Self.writeSourceFile(extension: "png")
-    let filename = try store.importImage(source, repoRoot)
-    #expect(store.exists(filename, repoRoot))
+    let repoRoot = makeRepoRootScratch()
+    let source = ScratchDirectory(prefix: "prowl-icon-source")
+    let sourceFile = try writeSourceFile(in: source, extension: "png")
+    let filename = try store.importImage(sourceFile, repoRoot.url)
+    #expect(store.exists(filename, repoRoot.url))
   }
 
   // MARK: - remove
 
   @Test func removeDeletesImportedFile() throws {
     let store = RepositoryIconAssetStore.liveValue
-    let repoRoot = Self.makeTempRepoRoot()
-    let source = try Self.writeSourceFile(extension: "png")
-    let filename = try store.importImage(source, repoRoot)
+    let repoRoot = makeRepoRootScratch()
+    let source = ScratchDirectory(prefix: "prowl-icon-source")
+    let sourceFile = try writeSourceFile(in: source, extension: "png")
+    let filename = try store.importImage(sourceFile, repoRoot.url)
 
-    try store.remove(filename, repoRoot)
-    #expect(!store.exists(filename, repoRoot))
+    try store.remove(filename, repoRoot.url)
+    #expect(!store.exists(filename, repoRoot.url))
   }
 
   @Test func removeIsIdempotent() throws {
     // Reset / replace flows can call remove repeatedly; missing files
     // shouldn't throw or the reducer would have to track existence.
     let store = RepositoryIconAssetStore.liveValue
-    let repoRoot = Self.makeTempRepoRoot()
-    try store.remove("never-existed.png", repoRoot)
+    let repoRoot = makeRepoRootScratch()
+    try store.remove("never-existed.png", repoRoot.url)
   }
 }

--- a/supacodeTests/RepositoryIconAssetStoreTests.swift
+++ b/supacodeTests/RepositoryIconAssetStoreTests.swift
@@ -1,0 +1,139 @@
+import Foundation
+import Testing
+
+@testable import supacode
+
+@MainActor
+struct RepositoryIconAssetStoreTests {
+  // MARK: - Helpers
+
+  private static func makeTempRepoRoot() -> URL {
+    let url = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appending(path: "prowl-icon-store-\(UUID().uuidString)", directoryHint: .isDirectory)
+    try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+    return url
+  }
+
+  private static func writeSourceFile(extension ext: String, contents: Data = Data([0xDE, 0xAD]))
+    throws
+    -> URL
+  {
+    let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appending(path: "prowl-icon-source-\(UUID().uuidString)", directoryHint: .isDirectory)
+    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    let url = dir.appending(path: "icon.\(ext)", directoryHint: .notDirectory)
+    try contents.write(to: url)
+    return url
+  }
+
+  // MARK: - importImage
+
+  @Test func importImageCopiesFileWithUUIDName() throws {
+    let store = RepositoryIconAssetStore.liveValue
+    let repoRoot = Self.makeTempRepoRoot()
+    let source = try Self.writeSourceFile(extension: "png", contents: Data([0x01, 0x02, 0x03]))
+
+    let filename = try store.importImage(source, repoRoot)
+
+    #expect(filename.hasSuffix(".png"))
+    #expect(UUID(uuidString: String(filename.dropLast(4))) != nil)
+
+    let resolved = SupacodePaths.repositoryIconFileURL(
+      filename: filename, repositoryRootURL: repoRoot
+    )
+    let copied = try Data(contentsOf: resolved)
+    #expect(copied == Data([0x01, 0x02, 0x03]))
+  }
+
+  @Test func importImageNormalizesUppercaseExtension() throws {
+    let store = RepositoryIconAssetStore.liveValue
+    let repoRoot = Self.makeTempRepoRoot()
+    let source = try Self.writeSourceFile(extension: "PNG")
+
+    let filename = try store.importImage(source, repoRoot)
+    #expect(filename.hasSuffix(".png"))
+  }
+
+  @Test func importImageAcceptsSVG() throws {
+    let store = RepositoryIconAssetStore.liveValue
+    let repoRoot = Self.makeTempRepoRoot()
+    let source = try Self.writeSourceFile(extension: "svg")
+
+    let filename = try store.importImage(source, repoRoot)
+    #expect(filename.hasSuffix(".svg"))
+  }
+
+  @Test func importImageRejectsUnsupportedExtension() throws {
+    let store = RepositoryIconAssetStore.liveValue
+    let repoRoot = Self.makeTempRepoRoot()
+    let source = try Self.writeSourceFile(extension: "jpeg")
+
+    #expect(throws: RepositoryIconAssetStoreError.self) {
+      _ = try store.importImage(source, repoRoot)
+    }
+  }
+
+  @Test func importImageCreatesIconsDirectoryWhenMissing() throws {
+    let store = RepositoryIconAssetStore.liveValue
+    let repoRoot = Self.makeTempRepoRoot()
+    // Don't pre-create the icons directory — importImage should make
+    // it itself, otherwise first-time imports would fail.
+    let source = try Self.writeSourceFile(extension: "png")
+
+    _ = try store.importImage(source, repoRoot)
+
+    let iconsDir = SupacodePaths.repositoryIconsDirectory(for: repoRoot)
+    var isDirectory: ObjCBool = false
+    let exists = FileManager.default.fileExists(
+      atPath: iconsDir.path(percentEncoded: false), isDirectory: &isDirectory
+    )
+    #expect(exists)
+    #expect(isDirectory.boolValue)
+  }
+
+  @Test func importImageGeneratesUniqueFilenamePerCall() throws {
+    let store = RepositoryIconAssetStore.liveValue
+    let repoRoot = Self.makeTempRepoRoot()
+    let source = try Self.writeSourceFile(extension: "png")
+
+    let first = try store.importImage(source, repoRoot)
+    let second = try store.importImage(source, repoRoot)
+    #expect(first != second)
+  }
+
+  // MARK: - exists
+
+  @Test func existsReportsFalseWhenMissing() {
+    let store = RepositoryIconAssetStore.liveValue
+    let repoRoot = Self.makeTempRepoRoot()
+    #expect(!store.exists("nonexistent.png", repoRoot))
+  }
+
+  @Test func existsReportsTrueAfterImport() throws {
+    let store = RepositoryIconAssetStore.liveValue
+    let repoRoot = Self.makeTempRepoRoot()
+    let source = try Self.writeSourceFile(extension: "png")
+    let filename = try store.importImage(source, repoRoot)
+    #expect(store.exists(filename, repoRoot))
+  }
+
+  // MARK: - remove
+
+  @Test func removeDeletesImportedFile() throws {
+    let store = RepositoryIconAssetStore.liveValue
+    let repoRoot = Self.makeTempRepoRoot()
+    let source = try Self.writeSourceFile(extension: "png")
+    let filename = try store.importImage(source, repoRoot)
+
+    try store.remove(filename, repoRoot)
+    #expect(!store.exists(filename, repoRoot))
+  }
+
+  @Test func removeIsIdempotent() throws {
+    // Reset / replace flows can call remove repeatedly; missing files
+    // shouldn't throw or the reducer would have to track existence.
+    let store = RepositoryIconAssetStore.liveValue
+    let repoRoot = Self.makeTempRepoRoot()
+    try store.remove("never-existed.png", repoRoot)
+  }
+}

--- a/supacodeTests/RepositoryIconPresetsTests.swift
+++ b/supacodeTests/RepositoryIconPresetsTests.swift
@@ -1,0 +1,37 @@
+import AppKit
+import Testing
+
+@testable import supacode
+
+struct RepositoryIconPresetsTests {
+  @Test func presetsCountIsForty() {
+    // Picker grid is 8 columns wide and we want full rows. Pinning
+    // the count here catches accidental drops or duplicates during
+    // refactors.
+    #expect(RepositoryIconPresets.presets.count == 40)
+  }
+
+  @Test func presetsAreUnique() {
+    let unique = Set(RepositoryIconPresets.presets)
+    #expect(unique.count == RepositoryIconPresets.presets.count)
+  }
+
+  @Test func presetsHaveNoEmptyEntries() {
+    for symbol in RepositoryIconPresets.presets {
+      #expect(!symbol.isEmpty)
+    }
+  }
+
+  @Test func everyPresetResolvesToARealSFSymbolOnThisOS() {
+    // Catches a regression where a preset is added with a name like
+    // `rocket.fill` that *looks* plausible but doesn't actually exist
+    // (only `rocket` does, no `.fill` variant). A missing symbol
+    // would render as a blank tile in the picker grid — invisible
+    // bug. Run on the test machine's macOS, which is at least the
+    // project's minimum (macOS 26+ per CLAUDE.md).
+    let missing =
+      RepositoryIconPresets.presets
+      .filter { NSImage(systemSymbolName: $0, accessibilityDescription: nil) == nil }
+    #expect(missing.isEmpty, "Unrecognized SF Symbols in presets: \(missing)")
+  }
+}

--- a/supacodeTests/RepositoryIconSourceTests.swift
+++ b/supacodeTests/RepositoryIconSourceTests.swift
@@ -1,0 +1,117 @@
+import Foundation
+import Testing
+
+@testable import supacode
+
+struct RepositoryIconSourceTests {
+  // MARK: - storageString encoding
+
+  @Test func sfSymbolSerialisesBare() {
+    let icon = RepositoryIconSource.sfSymbol("folder.fill")
+    #expect(icon.storageString == "folder.fill")
+  }
+
+  @Test func bundledAssetUsesAssetMarker() {
+    let icon = RepositoryIconSource.bundledAsset("Docker")
+    #expect(icon.storageString == "@asset:Docker")
+  }
+
+  @Test func userImageUsesFileMarker() {
+    let icon = RepositoryIconSource.userImage(filename: "abc.png")
+    #expect(icon.storageString == "@file:abc.png")
+  }
+
+  // MARK: - parse
+
+  @Test func parseEmptyReturnsNil() {
+    #expect(RepositoryIconSource.parse("") == nil)
+    #expect(RepositoryIconSource.parse("   ") == nil)
+  }
+
+  @Test func parseBareStringIsSFSymbol() {
+    #expect(RepositoryIconSource.parse("folder") == .sfSymbol("folder"))
+  }
+
+  @Test func parseAssetMarker() {
+    #expect(RepositoryIconSource.parse("@asset:Docker") == .bundledAsset("Docker"))
+  }
+
+  @Test func parseFileMarker() {
+    #expect(RepositoryIconSource.parse("@file:abc.svg") == .userImage(filename: "abc.svg"))
+  }
+
+  @Test func parseTrimsWhitespace() {
+    #expect(RepositoryIconSource.parse("  folder.fill  ") == .sfSymbol("folder.fill"))
+  }
+
+  @Test func parsePreservesFilenameWithDots() {
+    // Filenames carry the extension; the parser must not strip dots.
+    let icon = RepositoryIconSource.parse("@file:logo.repo.svg")
+    #expect(icon == .userImage(filename: "logo.repo.svg"))
+  }
+
+  // MARK: - Round-trip
+
+  @Test func sfSymbolRoundTrip() {
+    let source = RepositoryIconSource.sfSymbol("hammer")
+    #expect(RepositoryIconSource.parse(source.storageString) == source)
+  }
+
+  @Test func bundledAssetRoundTrip() {
+    let source = RepositoryIconSource.bundledAsset("Visual Studio Code")
+    #expect(RepositoryIconSource.parse(source.storageString) == source)
+  }
+
+  @Test func userImageRoundTrip() {
+    let source = RepositoryIconSource.userImage(filename: "abc-123.png")
+    #expect(RepositoryIconSource.parse(source.storageString) == source)
+  }
+
+  // MARK: - Codable (single-value String)
+
+  @Test func encodesAsSingleString() throws {
+    let icon = RepositoryIconSource.sfSymbol("folder.fill")
+    let data = try JSONEncoder().encode(icon)
+    let decoded = try JSONDecoder().decode(String.self, from: data)
+    #expect(decoded == "folder.fill")
+  }
+
+  @Test func decodesFromSingleString() throws {
+    let raw = Data("\"@file:abc.png\"".utf8)
+    let decoded = try JSONDecoder().decode(RepositoryIconSource.self, from: raw)
+    #expect(decoded == .userImage(filename: "abc.png"))
+  }
+
+  @Test func decodingEmptyStringFails() {
+    let raw = Data("\"\"".utf8)
+    #expect(throws: DecodingError.self) {
+      try JSONDecoder().decode(RepositoryIconSource.self, from: raw)
+    }
+  }
+
+  // MARK: - isTintable
+
+  @Test func sfSymbolIsTintable() {
+    #expect(RepositoryIconSource.sfSymbol("folder").isTintable)
+  }
+
+  @Test func bundledAssetIsNotTintable() {
+    #expect(!RepositoryIconSource.bundledAsset("Docker").isTintable)
+  }
+
+  @Test func pngUserImageIsNotTintable() {
+    #expect(!RepositoryIconSource.userImage(filename: "abc.png").isTintable)
+  }
+
+  @Test func pngUserImageWithUppercaseExtensionIsNotTintable() {
+    #expect(!RepositoryIconSource.userImage(filename: "abc.PNG").isTintable)
+  }
+
+  @Test func svgUserImageIsTintable() {
+    #expect(RepositoryIconSource.userImage(filename: "abc.svg").isTintable)
+  }
+
+  @Test func svgUserImageWithUppercaseExtensionIsTintable() {
+    #expect(RepositoryIconSource.userImage(filename: "abc.SVG").isTintable)
+  }
+}

--- a/supacodeTests/RepositorySettingsAppearanceTests.swift
+++ b/supacodeTests/RepositorySettingsAppearanceTests.swift
@@ -179,24 +179,6 @@ struct RepositorySettingsAppearanceTests {
     await store.finish()
   }
 
-  @Test func importFailureSurfacesErrorMessage() async throws {
-    let store = makeStore(
-      iconAssetStore: RepositoryIconAssetStore(
-        importImage: { _, _ in throw RepositoryIconAssetStoreError.unsupportedExtension("jpeg") },
-        remove: { _, _ in },
-        exists: { _, _ in false }
-      )
-    )
-
-    await store.send(.importUserImage(URL(fileURLWithPath: "/tmp/source.jpeg")))
-    await store.receive(\.userImageImportFailed) {
-      $0.appearanceImportError = """
-        Repository icons must be PNG or SVG. JPEG files aren't supported.
-        """.trimmingCharacters(in: .whitespacesAndNewlines)
-    }
-    await store.finish()
-  }
-
   @Test func importGenericErrorSurfacesLocalizedDescription() async throws {
     struct Boom: LocalizedError { var errorDescription: String? { "boom" } }
     let store = makeStore(

--- a/supacodeTests/RepositorySettingsAppearanceTests.swift
+++ b/supacodeTests/RepositorySettingsAppearanceTests.swift
@@ -1,0 +1,308 @@
+import ComposableArchitecture
+import Dependencies
+import DependenciesTestSupport
+import Foundation
+import Sharing
+import Testing
+
+@testable import supacode
+
+@MainActor
+struct RepositorySettingsAppearanceTests {
+  // MARK: - Helpers
+
+  private func makeStore(
+    repositoryID: Repository.ID = "repo-1",
+    initialAppearance: RepositoryAppearance = .empty,
+    iconAssetStore: RepositoryIconAssetStore = .testNoOp,
+    appearancesURL: URL = URL(fileURLWithPath: "/tmp/appearances-\(UUID().uuidString).json"),
+    settingsStorage: SettingsTestStorage = SettingsTestStorage()
+  ) -> TestStore<RepositorySettingsFeature.State, RepositorySettingsFeature.Action> {
+    TestStore(
+      initialState: RepositorySettingsFeature.State(
+        rootURL: URL(fileURLWithPath: "/tmp/\(repositoryID)"),
+        repositoryID: repositoryID,
+        repositoryKind: .plain,
+        settings: .default,
+        userSettings: .default,
+        appearance: initialAppearance
+      )
+    ) {
+      RepositorySettingsFeature()
+    } withDependencies: {
+      $0.settingsFileStorage = settingsStorage.storage
+      $0.repositoryAppearancesFileURL = appearancesURL
+      $0.repositoryIconAssetStore = iconAssetStore
+    }
+  }
+
+  // MARK: - Color
+
+  @Test func setColorMutatesStateAndPersists() async throws {
+    let appearancesURL = URL(fileURLWithPath: "/tmp/appearances-\(UUID().uuidString).json")
+    let settingsStorage = SettingsTestStorage()
+    let store = makeStore(appearancesURL: appearancesURL, settingsStorage: settingsStorage)
+
+    await store.send(.setAppearanceColor(.blue)) {
+      $0.appearance.color = .blue
+    }
+    await store.finish()
+
+    let persisted = readAppearances(at: appearancesURL, storage: settingsStorage)
+    #expect(persisted["repo-1"]?.color == .blue)
+  }
+
+  @Test func setColorTwiceWithSameValueIsNoOp() async throws {
+    let store = makeStore(initialAppearance: RepositoryAppearance(icon: nil, color: .red))
+    await store.send(.setAppearanceColor(.red))
+    await store.finish()
+  }
+
+  @Test func clearColorDropsEntryWhenIconAlsoNil() async throws {
+    let appearancesURL = URL(fileURLWithPath: "/tmp/appearances-\(UUID().uuidString).json")
+    let settingsStorage = SettingsTestStorage()
+    let store = makeStore(
+      initialAppearance: RepositoryAppearance(icon: nil, color: .green),
+      appearancesURL: appearancesURL,
+      settingsStorage: settingsStorage
+    )
+
+    await store.send(.setAppearanceColor(nil)) {
+      $0.appearance.color = nil
+    }
+    await store.finish()
+
+    let persisted = readAppearances(at: appearancesURL, storage: settingsStorage)
+    #expect(persisted["repo-1"] == nil)
+  }
+
+  // MARK: - Icon
+
+  @Test func setIconMutatesStateAndPersists() async throws {
+    let appearancesURL = URL(fileURLWithPath: "/tmp/appearances-\(UUID().uuidString).json")
+    let settingsStorage = SettingsTestStorage()
+    let store = makeStore(appearancesURL: appearancesURL, settingsStorage: settingsStorage)
+
+    await store.send(.setAppearanceIcon(.sfSymbol("folder.fill"))) {
+      $0.appearance.icon = .sfSymbol("folder.fill")
+    }
+    await store.finish()
+
+    let persisted = readAppearances(at: appearancesURL, storage: settingsStorage)
+    #expect(persisted["repo-1"]?.icon == .sfSymbol("folder.fill"))
+  }
+
+  @Test func clearingUserImageIconRemovesFileFromDisk() async throws {
+    let removed = LockIsolated<[(String, URL)]>([])
+    let store = makeStore(
+      initialAppearance: RepositoryAppearance(
+        icon: .userImage(filename: "old.png"), color: .blue
+      ),
+      iconAssetStore: .testRecording(removed: removed)
+    )
+
+    await store.send(.setAppearanceIcon(nil)) {
+      $0.appearance.icon = nil
+    }
+    await store.finish()
+
+    #expect(removed.value.count == 1)
+    #expect(removed.value.first?.0 == "old.png")
+  }
+
+  @Test func replacingUserImageRemovesPreviousFile() async throws {
+    let removed = LockIsolated<[(String, URL)]>([])
+    let store = makeStore(
+      initialAppearance: RepositoryAppearance(
+        icon: .userImage(filename: "old.png"), color: nil
+      ),
+      iconAssetStore: .testRecording(removed: removed)
+    )
+
+    await store.send(.setAppearanceIcon(.sfSymbol("folder"))) {
+      $0.appearance.icon = .sfSymbol("folder")
+    }
+    await store.finish()
+
+    #expect(removed.value.count == 1)
+    #expect(removed.value.first?.0 == "old.png")
+  }
+
+  @Test func switchingFromSymbolToUserImageDoesNotTriggerRemoval() async throws {
+    let removed = LockIsolated<[(String, URL)]>([])
+    let store = makeStore(
+      initialAppearance: RepositoryAppearance(icon: .sfSymbol("folder"), color: nil),
+      iconAssetStore: .testRecording(removed: removed)
+    )
+
+    await store.send(.setAppearanceIcon(.userImage(filename: "new.png"))) {
+      $0.appearance.icon = .userImage(filename: "new.png")
+    }
+    await store.finish()
+
+    #expect(removed.value.isEmpty)
+  }
+
+  @Test func sameUserImageReassignmentDoesNotTriggerRemoval() async throws {
+    // Re-applying the same icon (e.g. an idempotent reducer flow) must
+    // not delete the asset out from under the new state.
+    let removed = LockIsolated<[(String, URL)]>([])
+    let initial = RepositoryAppearance(
+      icon: .userImage(filename: "stable.svg"), color: nil
+    )
+    let store = makeStore(initialAppearance: initial, iconAssetStore: .testRecording(removed: removed))
+
+    await store.send(.setAppearanceIcon(.userImage(filename: "stable.svg")))
+    await store.finish()
+
+    #expect(removed.value.isEmpty)
+  }
+
+  // MARK: - Import
+
+  @Test func importUserImageDispatchesImportedAction() async throws {
+    let store = makeStore(
+      iconAssetStore: RepositoryIconAssetStore(
+        importImage: { _, _ in "abc.svg" },
+        remove: { _, _ in },
+        exists: { _, _ in true }
+      )
+    )
+
+    await store.send(.importUserImage(URL(fileURLWithPath: "/tmp/source.svg")))
+    await store.receive(\.userImageImported) { _ in
+      // payload check below
+    }
+    await store.receive(\.setAppearanceIcon) {
+      $0.appearance.icon = .userImage(filename: "abc.svg")
+    }
+    await store.finish()
+  }
+
+  @Test func importFailureSurfacesErrorMessage() async throws {
+    let store = makeStore(
+      iconAssetStore: RepositoryIconAssetStore(
+        importImage: { _, _ in throw RepositoryIconAssetStoreError.unsupportedExtension("jpeg") },
+        remove: { _, _ in },
+        exists: { _, _ in false }
+      )
+    )
+
+    await store.send(.importUserImage(URL(fileURLWithPath: "/tmp/source.jpeg")))
+    await store.receive(\.userImageImportFailed) {
+      $0.appearanceImportError = """
+        Repository icons must be PNG or SVG. JPEG files aren't supported.
+        """.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+    await store.finish()
+  }
+
+  @Test func importGenericErrorSurfacesLocalizedDescription() async throws {
+    struct Boom: LocalizedError { var errorDescription: String? { "boom" } }
+    let store = makeStore(
+      iconAssetStore: RepositoryIconAssetStore(
+        importImage: { _, _ in throw Boom() },
+        remove: { _, _ in },
+        exists: { _, _ in false }
+      )
+    )
+
+    await store.send(.importUserImage(URL(fileURLWithPath: "/tmp/source.svg")))
+    await store.receive(\.userImageImportFailed) {
+      $0.appearanceImportError = "boom"
+    }
+    await store.finish()
+  }
+
+  @Test func dismissImportErrorClearsState() async throws {
+    let store = makeStore()
+    // Seed the error directly through the reducer surface.
+    await store.send(.userImageImportFailed("boom")) {
+      $0.appearanceImportError = "boom"
+    }
+    await store.send(.dismissAppearanceImportError) {
+      $0.appearanceImportError = nil
+    }
+  }
+
+  // MARK: - Reset
+
+  @Test func resetAppearanceClearsBothAndRemovesUserImage() async throws {
+    let removed = LockIsolated<[(String, URL)]>([])
+    let appearancesURL = URL(fileURLWithPath: "/tmp/appearances-\(UUID().uuidString).json")
+    let settingsStorage = SettingsTestStorage()
+    let store = makeStore(
+      initialAppearance: RepositoryAppearance(
+        icon: .userImage(filename: "abc.png"), color: .blue
+      ),
+      iconAssetStore: .testRecording(removed: removed),
+      appearancesURL: appearancesURL,
+      settingsStorage: settingsStorage
+    )
+
+    await store.send(.resetAppearance) {
+      $0.appearance = .empty
+    }
+    await store.finish()
+
+    #expect(removed.value.first?.0 == "abc.png")
+    let persisted = readAppearances(at: appearancesURL, storage: settingsStorage)
+    #expect(persisted["repo-1"] == nil)
+  }
+
+  @Test func resetAppearanceWhenAlreadyEmptyIsNoOp() async throws {
+    let removed = LockIsolated<[(String, URL)]>([])
+    let store = makeStore(iconAssetStore: .testRecording(removed: removed))
+    await store.send(.resetAppearance)
+    await store.finish()
+    #expect(removed.value.isEmpty)
+  }
+
+  // MARK: - appearanceLoaded
+
+  @Test func appearanceLoadedReplacesState() async throws {
+    let store = makeStore()
+    let loaded = RepositoryAppearance(icon: .sfSymbol("hammer"), color: .purple)
+    await store.send(.appearanceLoaded(loaded)) {
+      $0.appearance = loaded
+    }
+  }
+
+  // MARK: - Persistence helpers
+
+  private func readAppearances(
+    at url: URL, storage: SettingsTestStorage
+  ) -> [Repository.ID: RepositoryAppearance] {
+    guard let data = try? storage.storage.load(url) else { return [:] }
+    return (try? JSONDecoder().decode([Repository.ID: RepositoryAppearance].self, from: data))
+      ?? [:]
+  }
+}
+
+// MARK: - Test fixtures
+
+extension RepositoryIconAssetStore {
+  /// Silent test fixture: import always returns an empty filename and
+  /// remove/exists are no-ops. Use when the test doesn't care about
+  /// either side's effects.
+  fileprivate static let testNoOp = RepositoryIconAssetStore(
+    importImage: { _, _ in "" },
+    remove: { _, _ in },
+    exists: { _, _ in false }
+  )
+
+  /// Test fixture that records every `remove` call so a test can
+  /// assert on cleanup behavior without poking at the real
+  /// filesystem.
+  fileprivate static func testRecording(removed: LockIsolated<[(String, URL)]>)
+    -> RepositoryIconAssetStore
+  {
+    RepositoryIconAssetStore(
+      importImage: { _, _ in "" },
+      remove: { filename, root in
+        removed.withValue { $0.append((filename, root)) }
+      },
+      exists: { _, _ in false }
+    )
+  }
+}

--- a/supacodeTests/RepositorySettingsAppearanceTests.swift
+++ b/supacodeTests/RepositorySettingsAppearanceTests.swift
@@ -268,6 +268,43 @@ struct RepositorySettingsAppearanceTests {
     }
   }
 
+  // MARK: - Regression
+
+  @Test func pickingColorKeepsExistingIcon() async throws {
+    // Regression: appearance used to be loaded via `.task` async, which
+    // raced with the first click after reopening Settings — picking a
+    // color before `.task` finished would write `{icon: nil, color: x}`
+    // and wipe the previously-saved icon. The fix seeds appearance
+    // synchronously when the State is built, so the user's first click
+    // sees the right baseline. This test pins the new behavior: with
+    // an icon pre-set in initial state, setting a color must preserve
+    // the icon.
+    let store = makeStore(
+      initialAppearance: RepositoryAppearance(icon: .sfSymbol("hammer.fill"), color: nil)
+    )
+
+    await store.send(.setAppearanceColor(.blue)) {
+      $0.appearance.color = .blue
+    }
+
+    #expect(store.state.appearance.icon == .sfSymbol("hammer.fill"))
+    #expect(store.state.appearance.color == .blue)
+  }
+
+  @Test func pickingIconKeepsExistingColor() async throws {
+    // Mirror of the above for the symmetric case.
+    let store = makeStore(
+      initialAppearance: RepositoryAppearance(icon: nil, color: .red)
+    )
+
+    await store.send(.setAppearanceIcon(.sfSymbol("folder.fill"))) {
+      $0.appearance.icon = .sfSymbol("folder.fill")
+    }
+
+    #expect(store.state.appearance.color == .red)
+    #expect(store.state.appearance.icon == .sfSymbol("folder.fill"))
+  }
+
   // MARK: - Persistence helpers
 
   private func readAppearances(


### PR DESCRIPTION
## Summary

Each repository can now carry a user-pinned icon and color, surfaced
across the three places it shows up: the left sidebar, the shelf spine,
and the canvas card title bar. The goal is making it easy to tell repos
apart at a glance — a one-time setup per repo that pays off everywhere.

### What's pickable
- **Icon** — any SF Symbol (32 repo-flavored presets + free-form name
  entry), or a user-provided PNG / SVG.
- **Color** — one of 10 fixed system colors (Finder's 7 + mint / cyan /
  pink), or "no color".
- Both fields are independently optional. Repos without an entry render
  exactly as they did before this PR.

### Where it shows up
- **Sidebar row**: icon before the repo name (tinted when SVG / SF
  Symbol; PNG keeps its own colors), Finder-style color dot at the
  trailing edge.
- **Shelf spine**: the proximity-distance background tint swaps from
  `accentColor` to the repo color (ladder unchanged); the spine header
  gains a 14pt icon above the unread-notification dot.
- **Canvas card**: 12pt icon before the repo name in the title bar,
  repo color overlays the bar material as an always-on identity strip
  (focused cards get a slightly stronger tint).

### Architecture
- Single `@Shared([Repository.ID: RepositoryAppearance])` dictionary
  persisted at `~/.prowl/repository-appearances.json`. Sidebar, shelf,
  and canvas all read it directly via `@Shared` — no per-call client
  layer.
- User-imported PNG/SVG files live at
  `~/.prowl/repo/<name>/icons/<uuid>.<ext>` so they're cleaned up with
  the rest of the per-repo settings directory when a repo is removed.
- `RepositoryIconImage` is the single rendering site so tinting and
  fallback rules stay consistent across the three surfaces.
- Everything goes through explicit reducer actions
  (`setAppearanceColor`, `setAppearanceIcon`, `importUserImage`,
  `resetAppearance`, …) — no direct `store.appearance.* = …` writes
  in views, so the SwiftLint custom rule stays clean.

### Tests
30+ new test cases covering: palette stability, icon storage-string
round-trips for all three sources, codable forward-compat, file IO
golden paths and error surfaces, SharedKey load/save with empty-entry
pruning, and reducer flows for set/clear/import/reset/replace
including old-image cleanup semantics for every icon transition.

```
$ make test
passed_tests: 913
failed_tests: 0
```

### Mid-flight decisions
A few small implementation choices that diverge from or extend the
plan agreed in chat are recorded in `.agents/repo-icon-color-decisions.md`
(local-only, not in this PR). The most notable one: the canvas
title-bar repo tint sits *above* the `.bar` material rather than below
it, because the bar's 0.9 opacity would dilute a base-layer tint to
invisibility. Existing notification / selected-unfocused tints stay in
their original position so the look for repos with no appearance is
unchanged.

## Test plan

- [ ] Sidebar: assign icon + color to a git repo, see icon before the
      name and a Finder-style dot at the trailing edge. Hover the row;
      action buttons appear without hiding the dot.
- [ ] Sidebar: assign appearance to a `.plain` folder; same treatment.
- [ ] Sidebar: clear icon, clear color, reset all from Settings — row
      returns to the text-only baseline.
- [ ] Shelf: open multiple books with different repo colors; spine
      backgrounds use the repo color and the proximity ladder
      (selected most opaque, neighbors fade) still works. Hovering an
      unselected spine still bumps its tint.
- [ ] Shelf: header icon renders above the rotated title; notification
      dot still works.
- [ ] Canvas: card title bar shows icon and a subtle repo-color strip;
      focused card tint is slightly stronger; notification orange and
      selected-unfocused accent still render correctly.
- [ ] Settings sheet: SF Symbol picker, "Choose Image…" with PNG/SVG,
      "Clear Icon", color grid (10 swatches + "No color"), reset.
      Importing a JPEG surfaces an error banner.
- [ ] Replacing a user image deletes the previous file from
      `~/.prowl/repo/<name>/icons/`.
- [ ] Repos without an appearance entry are visually identical to
      before this PR.
