### PR TITLE
chore(sentry): explicitly disable app hang tracking

### DIFF
--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -129,6 +129,7 @@ struct SupacodeApp: App {
           options.environment = environment
           if let releaseName { options.releaseName = releaseName }
           options.tracesSampleRate = 0.05
+          options.enableAppHangTracking = false
         }
       }
       if initialSettings.analyticsEnabled,


### PR DESCRIPTION
## Why

Commit b04b000d (`chore(sentry): remove App Hang tracking and its filter`) intended to turn off app hang reporting after we concluded that 90% of hang events leaf in kernel/runtime/SwiftUI internals with zero optimizable app code. The diff, however, only removed three lines from `supacode/App/supacodeApp.swift`:

```diff
- options.enableAppHangTracking = true
- options.appHangTimeoutInterval = 3
- options.beforeSend = SentryEventFilter.filterSystemHang
```

The Sentry Cocoa SDK defaults `enableAppHangTracking` to **true** (verified in the bundled `Sentry-Swift.h`: `/// @note The default is @c true.`). Net effect of that commit:

- ❌ tracking still ON (SDK default)
- ❌ threshold reverted from 3s to SDK default **2s** — more sensitive
- ❌ system-hang filter gone — system noise now goes straight to Sentry

Sentry confirms the regression: on `prowl@2026.4.25` issues `PROWL-MACOS-61..67` (one user, one event each) keep arriving with stacks like `NSHostingView._willUpdateConstraintsForSubtree` → `ViewGraph.sizeThatFits` → `CTLineCreateWithAttributedString` → `std::__hash_table::find`. Zero in-app frames — exactly what b04b000d set out to stop reporting.

## What

Explicit one-liner so we can't accidentally rely on the SDK default again:

```swift
options.enableAppHangTracking = false
```

Per b04b000d, hang diagnosis continues via MetricKit `MXHangDiagnosticPayload` (Xcode Organizer Hangs tab) and Instruments — not Sentry.

## Test plan

- [ ] Build & run; sanity-check Sentry still receives crashes / traces.
- [ ] After release, watch Sentry for new `App Hanging` issues — none should be created.
- [ ] Resolve the lingering `PROWL-MACOS-7/30/32/61–67` buckets in Sentry once the new build is out.
