### PR TITLE
Fix initial Ghostty color scheme sync

### DIFF
--- a/supacode/App/GhosttyColorSchemeSyncView.swift
+++ b/supacode/App/GhosttyColorSchemeSyncView.swift
@@ -3,21 +3,34 @@ import SwiftUI
 struct GhosttyColorSchemeSyncView<Content: View>: View {
   @Environment(\.colorScheme) private var colorScheme
   let ghostty: GhosttyRuntime
+  let preferredColorScheme: ColorScheme?
   let content: Content
 
-  init(ghostty: GhosttyRuntime, @ViewBuilder content: () -> Content) {
+  init(
+    ghostty: GhosttyRuntime,
+    preferredColorScheme: ColorScheme? = nil,
+    @ViewBuilder content: () -> Content
+  ) {
     self.ghostty = ghostty
+    self.preferredColorScheme = preferredColorScheme
     self.content = content()
   }
 
   var body: some View {
     content
       .task {
-        apply(colorScheme)
+        apply(effectiveColorScheme)
       }
       .onChange(of: colorScheme) { _, newValue in
-        apply(newValue)
+        apply(preferredColorScheme ?? newValue)
       }
+      .onChange(of: preferredColorScheme) { _, newValue in
+        apply(newValue ?? colorScheme)
+      }
+  }
+
+  private var effectiveColorScheme: ColorScheme {
+    preferredColorScheme ?? colorScheme
   }
 
   private func apply(_ scheme: ColorScheme) {

--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -167,7 +167,7 @@ struct SupacodeApp: App {
         preconditionFailure("ghostty_init failed")
       }
     }
-    let runtime = GhosttyRuntime()
+    let runtime = GhosttyRuntime(initialColorScheme: initialSettings.appearanceMode.colorScheme)
     _ghostty = State(initialValue: runtime)
     let shortcuts = GhosttyShortcutManager(runtime: runtime)
     _ghosttyShortcuts = State(initialValue: shortcuts)
@@ -605,7 +605,10 @@ struct SupacodeApp: App {
 
   var body: some Scene {
     Window("Prowl", id: "main") {
-      GhosttyColorSchemeSyncView(ghostty: ghostty) {
+      GhosttyColorSchemeSyncView(
+        ghostty: ghostty,
+        preferredColorScheme: store.settings.appearanceMode.colorScheme
+      ) {
         ContentView(store: store, terminalManager: terminalManager)
           .environment(ghosttyShortcuts)
           .environment(commandKeyObserver)

--- a/supacode/Infrastructure/Ghostty/GhosttyRuntime.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttyRuntime.swift
@@ -48,7 +48,7 @@ final class GhosttyRuntime {
   var onConfigChange: (() -> Void)?
   var onQuit: (() -> Void)?
 
-  init() {
+  init(initialColorScheme: ColorScheme? = nil) {
     guard let config = Self.loadConfig() else {
       preconditionFailure("ghostty_config_new failed")
     }
@@ -81,9 +81,16 @@ final class GhosttyRuntime {
       preconditionFailure("ghostty_app_new failed")
     }
     self.app = app
+    if let initialColorScheme {
+      setColorScheme(initialColorScheme)
+    }
 
     Self.shared = self
     registerNotificationObservers()
+  }
+
+  var appliedColorSchemeForTesting: ColorScheme? {
+    currentColorScheme
   }
 
   private func registerNotificationObservers() {

--- a/supacodeTests/GhosttyRuntimeColorSchemeTests.swift
+++ b/supacodeTests/GhosttyRuntimeColorSchemeTests.swift
@@ -1,0 +1,19 @@
+import SwiftUI
+import Testing
+
+@testable import supacode
+
+@MainActor
+struct GhosttyRuntimeColorSchemeTests {
+  @Test func initialColorSchemeIsAppliedBeforeSurfacesAreRegistered() {
+    let runtime = GhosttyRuntime(initialColorScheme: .dark)
+
+    #expect(runtime.appliedColorSchemeForTesting == .dark)
+  }
+
+  @Test func missingInitialColorSchemeLeavesRuntimeUnspecified() {
+    let runtime = GhosttyRuntime()
+
+    #expect(runtime.appliedColorSchemeForTesting == nil)
+  }
+}


### PR DESCRIPTION
## Summary

- Apply the saved Prowl appearance mode to `GhosttyRuntime` during app startup, before restored terminal surfaces can be created.
- Keep `GhosttyColorSchemeSyncView` anchored to the explicit app preference when Light or Dark is selected, while still following the environment for System mode.
- Add coverage for the runtime's initial color scheme behavior.

## Root Cause

`GhosttyRuntime` was initialized without Prowl's persisted appearance mode. During startup, restored terminal surfaces could be created before SwiftUI propagated `.preferredColorScheme`, so Ghostty could choose the system Light/Dark branch instead of the app-selected branch.

## Validation

- `xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -only-testing:supacodeTests/GhosttyRuntimeColorSchemeTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation`
- `make build-app`
