### PR TITLE
fix(shelf): per-button tooltips on spine bottom controls

### DIFF
--- a/supacode/Features/Shelf/Views/ShelfSpineView.swift
+++ b/supacode/Features/Shelf/Views/ShelfSpineView.swift
@@ -39,6 +39,7 @@ struct ShelfSpineView: View {
 
   @State private var isHovering = false
   @Shared(.repositoryAppearances) private var repositoryAppearances
+  @Environment(GhosttyShortcutManager.self) private var ghosttyShortcuts
 
   var body: some View {
     VStack(spacing: 0) {
@@ -83,7 +84,6 @@ struct ShelfSpineView: View {
           .frame(width: 1)
       }
     }
-    .help(book.displayName)
   }
 
   /// Step-wise accent-alpha ladder keyed by `distanceFromOpen`. 100%
@@ -173,6 +173,7 @@ struct ShelfSpineView: View {
           ShelfSpineControlButton(
             systemImage: "plus",
             label: "New Tab",
+            shortcut: ghosttyShortcuts.display(for: "new_tab"),
             action: onNewTab
           )
         }
@@ -180,6 +181,7 @@ struct ShelfSpineView: View {
           ShelfSpineControlButton(
             systemImage: "square.split.2x1",
             label: "Split Vertically",
+            shortcut: ghosttyShortcuts.display(for: "new_split:right"),
             action: onSplitVertical
           )
         }
@@ -187,6 +189,7 @@ struct ShelfSpineView: View {
           ShelfSpineControlButton(
             systemImage: "square.split.1x2",
             label: "Split Horizontally",
+            shortcut: ghosttyShortcuts.display(for: "new_split:down"),
             action: onSplitHorizontal
           )
         }
@@ -212,6 +215,7 @@ struct ShelfSpineView: View {
     }
     .buttonStyle(.plain)
     .contextMenu { bookContextMenu }
+    .help(book.displayName)
   }
 
   @ViewBuilder
@@ -496,6 +500,7 @@ private struct ShelfSpineTabSlot: View {
 private struct ShelfSpineControlButton: View {
   let systemImage: String
   let label: String
+  let shortcut: String?
   let action: () -> Void
 
   var body: some View {
@@ -508,7 +513,12 @@ private struct ShelfSpineControlButton: View {
         .accessibilityHidden(true)
     }
     .buttonStyle(.plain)
-    .help(label)
+    .help(helpText)
+  }
+
+  private var helpText: String {
+    guard let shortcut else { return label }
+    return "\(label) (\(shortcut))"
   }
 }
 


### PR DESCRIPTION
## Summary
- Hovering the spine's `+` / Split Vertically / Split Horizontally buttons (and the per-tab slots) used to show the book's branch name because `.help(book.displayName)` was attached to the whole spine VStack, covering everything below it.
- Moved the book-level tooltip onto the header so the title/icon area still identifies the book (useful since the rotated title can be middle-truncated), and let each control render its own `.help` again.
- Bottom controls now match the horizontal tab bar's trailing accessories: `"New Tab (⌘T)"` style, with the shortcut pulled from `GhosttyShortcutManager` via `@Environment`.

## Test plan
- [ ] `make build-app` succeeds
- [ ] `make check` passes (lint + format)
- [ ] Hover over the three bottom buttons on the open book's spine — tooltip shows `New Tab (…)` / `Split Vertically (…)` / `Split Horizontally (…)`
- [ ] Hover over the spine header (icon + rotated title) — tooltip shows the book's display name
- [ ] Hover over a tab slot in the spine — tooltip shows the tab's title (existing behavior, no longer masked by the book-level help)
- [ ] Closed-book spines (the `+` only variant) still show `New Tab (…)` on hover
