### PR TITLE
feat(tab-icon): pin Run Script and Custom Command icons over auto-detection

### DIFF
--- a/supacode/Clients/Terminal/TerminalClient.swift
+++ b/supacode/Clients/Terminal/TerminalClient.swift
@@ -13,14 +13,16 @@ struct TerminalClient {
       input: String,
       runSetupScriptIfNew: Bool,
       autoCloseOnSuccess: Bool,
-      customCommandName: String? = nil
+      customCommandName: String? = nil,
+      customCommandIcon: String? = nil
     )
     case createSplitWithInput(
       Worktree,
       direction: UserCustomSplitDirection,
       input: String,
       autoCloseOnSuccess: Bool,
-      customCommandName: String? = nil
+      customCommandName: String? = nil,
+      customCommandIcon: String? = nil
     )
     case createTabInDirectory(Worktree, directory: URL)
     case ensureInitialTab(Worktree, runSetupScriptIfNew: Bool, focusing: Bool)

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -645,6 +645,15 @@ struct AppFeature {
         let command = customCommand.command
         let closeOnSuccess = customCommand.closeOnSuccess
         let commandName = customCommand.resolvedTitle
+        // Treat the model's "terminal" placeholder (and an empty value)
+        // as "no icon configured", so the auto-detector can still brand
+        // the tab from the command itself. Anything else is a deliberate
+        // user pick and gets pinned for the duration of the run.
+        let commandIcon: String? = {
+          let trimmed = customCommand.systemImage.trimmingCharacters(in: .whitespacesAndNewlines)
+          guard !trimmed.isEmpty, trimmed != "terminal" else { return nil }
+          return trimmed
+        }()
         switch customCommand.execution {
         case .shellScript:
           return .run { _ in
@@ -654,7 +663,8 @@ struct AppFeature {
                 input: command,
                 runSetupScriptIfNew: false,
                 autoCloseOnSuccess: closeOnSuccess,
-                customCommandName: commandName
+                customCommandName: commandName,
+                customCommandIcon: commandIcon
               )
             )
           }
@@ -667,7 +677,8 @@ struct AppFeature {
                 direction: direction,
                 input: command,
                 autoCloseOnSuccess: closeOnSuccess,
-                customCommandName: commandName
+                customCommandName: commandName,
+                customCommandIcon: commandIcon
               )
             )
           }

--- a/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
+++ b/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
@@ -53,24 +53,28 @@ final class WorktreeTerminalManager {
     case .createTab(let worktree, let runSetupScriptIfNew):
       Task { createTabAsync(in: worktree, runSetupScriptIfNew: runSetupScriptIfNew) }
     case .createTabWithInput(
-      let worktree, let input, let runSetupScriptIfNew, let autoCloseOnSuccess, let customCommandName):
+      let worktree, let input, let runSetupScriptIfNew, let autoCloseOnSuccess, let customCommandName,
+      let customCommandIcon):
       Task {
         createTabAsync(
           in: worktree,
           runSetupScriptIfNew: runSetupScriptIfNew,
           initialInput: input,
           autoCloseOnSuccess: autoCloseOnSuccess,
-          customCommandName: customCommandName
+          customCommandName: customCommandName,
+          customCommandIcon: customCommandIcon
         )
       }
-    case .createSplitWithInput(let worktree, let direction, let input, let autoCloseOnSuccess, let customCommandName):
+    case .createSplitWithInput(
+      let worktree, let direction, let input, let autoCloseOnSuccess, let customCommandName, let customCommandIcon):
       Task {
         createSplitAsync(
           in: worktree,
           direction: direction,
           initialInput: input,
           autoCloseOnSuccess: autoCloseOnSuccess,
-          customCommandName: customCommandName
+          customCommandName: customCommandName,
+          customCommandIcon: customCommandIcon
         )
       }
     case .createTabInDirectory(let worktree, let directory):
@@ -268,7 +272,8 @@ final class WorktreeTerminalManager {
     initialInput: String? = nil,
     workingDirectory: URL? = nil,
     autoCloseOnSuccess: Bool = false,
-    customCommandName: String? = nil
+    customCommandName: String? = nil,
+    customCommandIcon: String? = nil
   ) {
     let state = state(for: worktree) { runSetupScriptIfNew }
     let setupScript: String?
@@ -293,6 +298,9 @@ final class WorktreeTerminalManager {
       if let customCommandName {
         state.markSurfaceForCustomCommand(surfaceId, name: customCommandName)
       }
+      if let customCommandIcon {
+        state.applyCustomCommandIcon(customCommandIcon, surfaceId: surfaceId)
+      }
     }
   }
 
@@ -301,7 +309,8 @@ final class WorktreeTerminalManager {
     direction: UserCustomSplitDirection,
     initialInput: String,
     autoCloseOnSuccess: Bool,
-    customCommandName: String? = nil
+    customCommandName: String? = nil,
+    customCommandIcon: String? = nil
   ) {
     let state = state(for: worktree)
     guard
@@ -317,6 +326,9 @@ final class WorktreeTerminalManager {
     }
     if let customCommandName {
       state.markSurfaceForCustomCommand(newSurfaceId, name: customCommandName)
+    }
+    if let customCommandIcon {
+      state.applyCustomCommandIcon(customCommandIcon, surfaceId: newSurfaceId)
     }
   }
 

--- a/supacode/Features/Terminal/Models/TerminalTabItem.swift
+++ b/supacode/Features/Terminal/Models/TerminalTabItem.swift
@@ -7,6 +7,12 @@ struct TerminalTabItem: Identifiable, Equatable, Sendable {
   var isDirty: Bool
   var isTitleLocked: Bool
   var isIconLocked: Bool
+  /// `true` while a Run Script or Custom Command's configured icon owns
+  /// this tab's icon slot. Sits between auto-detected command icons and
+  /// `isIconLocked` (user picker) in the precedence chain: blocks
+  /// `CommandIconMap`-driven overrides so the play / configured glyph
+  /// doesn't get clobbered mid-run, but yields to a user-set lock.
+  var isScriptIconActive: Bool
 
   init(
     id: TerminalTabID = TerminalTabID(),
@@ -14,7 +20,8 @@ struct TerminalTabItem: Identifiable, Equatable, Sendable {
     icon: String?,
     isDirty: Bool = false,
     isTitleLocked: Bool = false,
-    isIconLocked: Bool = false
+    isIconLocked: Bool = false,
+    isScriptIconActive: Bool = false
   ) {
     self.id = id
     self.title = title
@@ -22,5 +29,6 @@ struct TerminalTabItem: Identifiable, Equatable, Sendable {
     self.isDirty = isDirty
     self.isTitleLocked = isTitleLocked
     self.isIconLocked = isIconLocked
+    self.isScriptIconActive = isScriptIconActive
   }
 }

--- a/supacode/Features/Terminal/Models/TerminalTabItem.swift
+++ b/supacode/Features/Terminal/Models/TerminalTabItem.swift
@@ -1,18 +1,30 @@
 import Foundation
 
+/// Who currently owns a tab's icon slot. The precedence chain runs
+/// `auto < script < user`: stronger owners block weaker writes.
+///
+/// - `auto`: nobody has claimed the icon — `CommandIconMap` and other
+///   auto-detection paths are free to overwrite it.
+/// - `script`: Run Script's `play.fill` or a Custom Command's configured
+///   icon. Survives auto-detection so the glyph doesn't flash mid-run.
+/// - `user`: the icon picker. Wins over everything until cleared.
+///
+/// Avoid naming a case `.none` — it collides with `Optional.none` in
+/// expressions like `tab?.iconLock == .none`, where Swift would infer
+/// the right-hand side as the optional sentinel rather than this case.
+enum TerminalTabIconLock: Equatable, Sendable {
+  case auto
+  case script
+  case user
+}
+
 struct TerminalTabItem: Identifiable, Equatable, Sendable {
   let id: TerminalTabID
   var title: String
   var icon: String?
   var isDirty: Bool
   var isTitleLocked: Bool
-  var isIconLocked: Bool
-  /// `true` while a Run Script or Custom Command's configured icon owns
-  /// this tab's icon slot. Sits between auto-detected command icons and
-  /// `isIconLocked` (user picker) in the precedence chain: blocks
-  /// `CommandIconMap`-driven overrides so the play / configured glyph
-  /// doesn't get clobbered mid-run, but yields to a user-set lock.
-  var isScriptIconActive: Bool
+  var iconLock: TerminalTabIconLock
 
   init(
     id: TerminalTabID = TerminalTabID(),
@@ -20,15 +32,13 @@ struct TerminalTabItem: Identifiable, Equatable, Sendable {
     icon: String?,
     isDirty: Bool = false,
     isTitleLocked: Bool = false,
-    isIconLocked: Bool = false,
-    isScriptIconActive: Bool = false
+    iconLock: TerminalTabIconLock = .auto
   ) {
     self.id = id
     self.title = title
     self.icon = icon
     self.isDirty = isDirty
     self.isTitleLocked = isTitleLocked
-    self.isIconLocked = isIconLocked
-    self.isScriptIconActive = isScriptIconActive
+    self.iconLock = iconLock
   }
 }

--- a/supacode/Features/Terminal/Models/TerminalTabManager.swift
+++ b/supacode/Features/Terminal/Models/TerminalTabManager.swift
@@ -41,37 +41,36 @@ final class TerminalTabManager {
     tabs[index].isTitleLocked = false
   }
 
+  /// Auto-detection write path (e.g. `CommandIconMap`). Only applies
+  /// when nothing has claimed the icon slot.
   func updateIcon(_ id: TerminalTabID, icon: String?) {
     guard let index = tabs.firstIndex(where: { $0.id == id }) else { return }
-    guard !tabs[index].isIconLocked, !tabs[index].isScriptIconActive else { return }
+    guard tabs[index].iconLock == .auto else { return }
     tabs[index].icon = icon
   }
 
+  /// User picker path. Always wins, transitioning the slot to `.user`.
   func overrideIcon(_ id: TerminalTabID, icon: String) {
     guard let index = tabs.firstIndex(where: { $0.id == id }) else { return }
     tabs[index].icon = icon
-    tabs[index].isIconLocked = true
-    // User-set lock supersedes any active script-command override so the
-    // precedence chain (user > script > auto) can't ambiguously stack.
-    tabs[index].isScriptIconActive = false
+    tabs[index].iconLock = .user
   }
 
+  /// "Reset to default" from the icon picker. Drops back to `.none`
+  /// so the next auto-detected match can take over.
   func clearIconOverride(_ id: TerminalTabID) {
     guard let index = tabs.firstIndex(where: { $0.id == id }) else { return }
-    tabs[index].isIconLocked = false
-    // Reset to default also drops the script-level pin so the next
-    // auto-detection can take over.
-    tabs[index].isScriptIconActive = false
+    tabs[index].iconLock = .auto
   }
 
-  /// Apply a Run Script / Custom Command icon and mark it as the active
-  /// "script" override. No-op when the user has already locked an icon
-  /// — manual lock always wins.
+  /// Run Script / Custom Command write path. Pins the icon to `.script`
+  /// — strong enough to block auto-detection, weak enough to yield to
+  /// a user-set `.user` lock.
   func setScriptIcon(_ id: TerminalTabID, icon: String) {
     guard let index = tabs.firstIndex(where: { $0.id == id }) else { return }
-    guard !tabs[index].isIconLocked else { return }
+    guard tabs[index].iconLock != .user else { return }
     tabs[index].icon = icon
-    tabs[index].isScriptIconActive = true
+    tabs[index].iconLock = .script
   }
 
   func updateDirty(_ id: TerminalTabID, isDirty: Bool) {

--- a/supacode/Features/Terminal/Models/TerminalTabManager.swift
+++ b/supacode/Features/Terminal/Models/TerminalTabManager.swift
@@ -43,7 +43,7 @@ final class TerminalTabManager {
 
   func updateIcon(_ id: TerminalTabID, icon: String?) {
     guard let index = tabs.firstIndex(where: { $0.id == id }) else { return }
-    guard !tabs[index].isIconLocked else { return }
+    guard !tabs[index].isIconLocked, !tabs[index].isScriptIconActive else { return }
     tabs[index].icon = icon
   }
 
@@ -51,11 +51,27 @@ final class TerminalTabManager {
     guard let index = tabs.firstIndex(where: { $0.id == id }) else { return }
     tabs[index].icon = icon
     tabs[index].isIconLocked = true
+    // User-set lock supersedes any active script-command override so the
+    // precedence chain (user > script > auto) can't ambiguously stack.
+    tabs[index].isScriptIconActive = false
   }
 
   func clearIconOverride(_ id: TerminalTabID) {
     guard let index = tabs.firstIndex(where: { $0.id == id }) else { return }
     tabs[index].isIconLocked = false
+    // Reset to default also drops the script-level pin so the next
+    // auto-detection can take over.
+    tabs[index].isScriptIconActive = false
+  }
+
+  /// Apply a Run Script / Custom Command icon and mark it as the active
+  /// "script" override. No-op when the user has already locked an icon
+  /// — manual lock always wins.
+  func setScriptIcon(_ id: TerminalTabID, icon: String) {
+    guard let index = tabs.firstIndex(where: { $0.id == id }) else { return }
+    guard !tabs[index].isIconLocked else { return }
+    tabs[index].icon = icon
+    tabs[index].isScriptIconActive = true
   }
 
   func updateDirty(_ id: TerminalTabID, isDirty: Bool) {

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -259,6 +259,12 @@ final class WorktreeTerminalState {
         workingDirectoryOverride: nil
       )
     )
+    if let tabId {
+      // Lock in the play glyph as a script-level override so OSC-2
+      // titles emitted by the script (e.g. `npm run dev`) can't swap
+      // the icon out from under it.
+      tabManager.setScriptIcon(tabId, icon: "play.fill")
+    }
     setRunScriptTabId(tabId)
     return tabId
   }
@@ -560,6 +566,17 @@ final class WorktreeTerminalState {
   /// so a success toast can be emitted when that surface's next command exits with code 0.
   func markSurfaceForCustomCommand(_ surfaceId: UUID, name: String) {
     pendingCustomCommands[surfaceId] = name
+  }
+
+  /// Pin a Custom Command's configured icon onto its host tab so the
+  /// auto-detector can't swap it out when the script's OSC-2 title
+  /// matches a known command. Yields to a user-set icon lock — manual
+  /// picker selections always win.
+  func applyCustomCommandIcon(_ icon: String, surfaceId: UUID) {
+    let trimmed = icon.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return }
+    guard let tabId = tabId(containing: surfaceId) else { return }
+    tabManager.setScriptIcon(tabId, icon: trimmed)
   }
 
   // Short delay lets the user see the final output before the pane disappears.
@@ -1495,10 +1512,11 @@ final class WorktreeTerminalState {
     return false
   }
 
-  /// Apply an already-resolved icon to the tab. Honours focus and
-  /// user-icon-lock; encodes the icon through `storageString` so
-  /// `assetName`-bearing entries pick up the `@asset:` marker the
-  /// renderers parse via `ResolvedTabIcon`.
+  /// Apply an already-resolved icon to the tab. Honours focus, the user
+  /// icon lock, and the Run Script / Custom Command override; encodes
+  /// the icon through `storageString` so `assetName`-bearing entries
+  /// pick up the `@asset:` marker the renderers parse via
+  /// `ResolvedTabIcon`.
   private func applyResolvedIcon(
     _ icon: TabIconSource,
     surfaceId: UUID,
@@ -1510,7 +1528,7 @@ final class WorktreeTerminalState {
     // user is currently looking at.
     guard focusedSurfaceIdByTab[tabId] == surfaceId else { return }
     guard let tab = tabManager.tabs.first(where: { $0.id == tabId }) else { return }
-    guard !tab.isIconLocked else { return }
+    guard !tab.isIconLocked, !tab.isScriptIconActive else { return }
     let serialised = icon.storageString
     guard tab.icon != serialised else { return }
     tabManager.updateIcon(tabId, icon: serialised)

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -752,9 +752,9 @@ final class WorktreeTerminalState {
       }
       // Skip title/icon for blocking-script tabs as they are transient.
       // Persist the icon only when the user has explicitly overridden it; otherwise
-      // restore should pick up the current default ("terminal").
+      // restore should pick up the current default ("terminal") or auto-detection.
       let isBlockingScriptTab = tab.id == runScriptTabId
-      let snapshotIcon: String? = (isBlockingScriptTab || !tab.isIconLocked) ? nil : tab.icon
+      let snapshotIcon: String? = (isBlockingScriptTab || tab.iconLock != .user) ? nil : tab.icon
       snapshotTabs.append(
         TerminalLayoutSnapshotPayload.SnapshotTab(
           tabID: tab.id.rawValue.uuidString,
@@ -848,7 +848,7 @@ final class WorktreeTerminalState {
           title: entry.snapshotTab.title ?? "\(worktree.name) \(index + 1)",
           icon: entry.snapshotTab.icon ?? "terminal",
           isTitleLocked: entry.snapshotTab.title != nil,
-          isIconLocked: entry.snapshotTab.icon != nil
+          iconLock: entry.snapshotTab.icon != nil ? .user : .auto
         )
       )
     }
@@ -1528,7 +1528,7 @@ final class WorktreeTerminalState {
     // user is currently looking at.
     guard focusedSurfaceIdByTab[tabId] == surfaceId else { return }
     guard let tab = tabManager.tabs.first(where: { $0.id == tabId }) else { return }
-    guard !tab.isIconLocked, !tab.isScriptIconActive else { return }
+    guard tab.iconLock == .auto else { return }
     let serialised = icon.storageString
     guard tab.icon != serialised else { return }
     tabManager.updateIcon(tabId, icon: serialised)

--- a/supacodeTests/AppFeatureCustomCommandTests.swift
+++ b/supacodeTests/AppFeatureCustomCommandTests.swift
@@ -42,7 +42,8 @@ struct AppFeatureCustomCommandTests {
           input: "swift test",
           runSetupScriptIfNew: false,
           autoCloseOnSuccess: false,
-          customCommandName: "Test"
+          customCommandName: "Test",
+          customCommandIcon: "checkmark.circle"
         ),
       ],
     )
@@ -119,7 +120,8 @@ struct AppFeatureCustomCommandTests {
           direction: .down,
           input: "tail -f logs",
           autoCloseOnSuccess: false,
-          customCommandName: "Tail"
+          customCommandName: "Tail",
+          customCommandIcon: "doc.text"
         ),
       ],
     )
@@ -171,14 +173,16 @@ struct AppFeatureCustomCommandTests {
           input: "make build",
           runSetupScriptIfNew: false,
           autoCloseOnSuccess: true,
-          customCommandName: "Build"
+          customCommandName: "Build",
+          customCommandIcon: "hammer"
         ),
         .createSplitWithInput(
           worktree,
           direction: .right,
           input: "make lint",
           autoCloseOnSuccess: true,
-          customCommandName: "Lint"
+          customCommandName: "Lint",
+          customCommandIcon: "checkmark"
         ),
       ],
     )
@@ -286,7 +290,95 @@ struct AppFeatureCustomCommandTests {
           input: "echo five",
           runSetupScriptIfNew: false,
           autoCloseOnSuccess: false,
-          customCommandName: "Five"
+          customCommandName: "Five",
+          customCommandIcon: "5.circle"
+        ),
+      ],
+    )
+  }
+
+  @Test(.dependencies) func defaultTerminalIconIsTreatedAsUnsetForAutoDetection() async {
+    let worktree = makeWorktree()
+    let sent = LockIsolated<[TerminalClient.Command]>([])
+    var state = AppFeature.State(
+      repositories: makeRepositoriesState(worktree: worktree),
+      settings: SettingsFeature.State()
+    )
+    state.selectedCustomCommands = [
+      UserCustomCommand(
+        title: "Default",
+        systemImage: "terminal",
+        command: "npm test",
+        execution: .shellScript,
+        shortcut: nil,
+      ),
+    ]
+
+    let store = TestStore(initialState: state) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in
+        sent.withValue { $0.append(command) }
+      }
+    }
+
+    await store.send(.runCustomCommand(0))
+    await store.finish()
+
+    // The model's "terminal" placeholder should not be pinned as a
+    // script icon — the auto-detector should remain free to brand the
+    // tab from the executed command itself.
+    #expect(
+      sent.value == [
+        .createTabWithInput(
+          worktree,
+          input: "npm test",
+          runSetupScriptIfNew: false,
+          autoCloseOnSuccess: false,
+          customCommandName: "Default",
+          customCommandIcon: nil
+        ),
+      ],
+    )
+  }
+
+  @Test(.dependencies) func emptyIconIsTreatedAsUnsetForAutoDetection() async {
+    let worktree = makeWorktree()
+    let sent = LockIsolated<[TerminalClient.Command]>([])
+    var state = AppFeature.State(
+      repositories: makeRepositoriesState(worktree: worktree),
+      settings: SettingsFeature.State()
+    )
+    state.selectedCustomCommands = [
+      UserCustomCommand(
+        title: "Blank",
+        systemImage: "   ",
+        command: "swift test",
+        execution: .shellScript,
+        shortcut: nil,
+      ),
+    ]
+
+    let store = TestStore(initialState: state) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in
+        sent.withValue { $0.append(command) }
+      }
+    }
+
+    await store.send(.runCustomCommand(0))
+    await store.finish()
+
+    #expect(
+      sent.value == [
+        .createTabWithInput(
+          worktree,
+          input: "swift test",
+          runSetupScriptIfNew: false,
+          autoCloseOnSuccess: false,
+          customCommandName: "Blank",
+          customCommandIcon: nil
         ),
       ],
     )

--- a/supacodeTests/TerminalTabManagerTests.swift
+++ b/supacodeTests/TerminalTabManagerTests.swift
@@ -89,4 +89,50 @@ struct TerminalTabManagerTests {
     manager.updateIcon(tabId, icon: "play.fill")
     #expect(manager.tabs.first?.icon == "play.fill")
   }
+
+  @Test func setScriptIconAppliesAndFlags() {
+    let manager = TerminalTabManager()
+    let tabId = manager.createTab(title: "one", icon: "terminal")
+    manager.setScriptIcon(tabId, icon: "play.fill")
+    #expect(manager.tabs.first?.icon == "play.fill")
+    #expect(manager.tabs.first?.isScriptIconActive == true)
+    #expect(manager.tabs.first?.isIconLocked == false)
+  }
+
+  @Test func updateIconRespectsScriptIconActive() {
+    let manager = TerminalTabManager()
+    let tabId = manager.createTab(title: "one", icon: "terminal")
+    manager.setScriptIcon(tabId, icon: "play.fill")
+    manager.updateIcon(tabId, icon: "@asset:Npm")
+    #expect(manager.tabs.first?.icon == "play.fill")
+  }
+
+  @Test func userOverrideClearsScriptIconActive() {
+    let manager = TerminalTabManager()
+    let tabId = manager.createTab(title: "one", icon: "terminal")
+    manager.setScriptIcon(tabId, icon: "play.fill")
+    manager.overrideIcon(tabId, icon: "sparkles")
+    #expect(manager.tabs.first?.icon == "sparkles")
+    #expect(manager.tabs.first?.isIconLocked == true)
+    #expect(manager.tabs.first?.isScriptIconActive == false)
+  }
+
+  @Test func setScriptIconYieldsToUserLock() {
+    let manager = TerminalTabManager()
+    let tabId = manager.createTab(title: "one", icon: "terminal")
+    manager.overrideIcon(tabId, icon: "sparkles")
+    manager.setScriptIcon(tabId, icon: "play.fill")
+    #expect(manager.tabs.first?.icon == "sparkles")
+    #expect(manager.tabs.first?.isScriptIconActive == false)
+  }
+
+  @Test func clearIconOverrideAlsoClearsScriptIconActive() {
+    let manager = TerminalTabManager()
+    let tabId = manager.createTab(title: "one", icon: "terminal")
+    manager.setScriptIcon(tabId, icon: "play.fill")
+    manager.clearIconOverride(tabId)
+    #expect(manager.tabs.first?.isScriptIconActive == false)
+    manager.updateIcon(tabId, icon: "@asset:Npm")
+    #expect(manager.tabs.first?.icon == "@asset:Npm")
+  }
 }

--- a/supacodeTests/TerminalTabManagerTests.swift
+++ b/supacodeTests/TerminalTabManagerTests.swift
@@ -69,7 +69,7 @@ struct TerminalTabManagerTests {
     let tabId = manager.createTab(title: "one", icon: "terminal")
     manager.overrideIcon(tabId, icon: "sparkles")
     #expect(manager.tabs.first?.icon == "sparkles")
-    #expect(manager.tabs.first?.isIconLocked == true)
+    #expect(manager.tabs.first?.iconLock == .user)
   }
 
   @Test func updateIconRespectsLock() {
@@ -85,7 +85,7 @@ struct TerminalTabManagerTests {
     let tabId = manager.createTab(title: "one", icon: "terminal")
     manager.overrideIcon(tabId, icon: "sparkles")
     manager.clearIconOverride(tabId)
-    #expect(manager.tabs.first?.isIconLocked == false)
+    #expect(manager.tabs.first?.iconLock == .auto)
     manager.updateIcon(tabId, icon: "play.fill")
     #expect(manager.tabs.first?.icon == "play.fill")
   }
@@ -95,11 +95,10 @@ struct TerminalTabManagerTests {
     let tabId = manager.createTab(title: "one", icon: "terminal")
     manager.setScriptIcon(tabId, icon: "play.fill")
     #expect(manager.tabs.first?.icon == "play.fill")
-    #expect(manager.tabs.first?.isScriptIconActive == true)
-    #expect(manager.tabs.first?.isIconLocked == false)
+    #expect(manager.tabs.first?.iconLock == .script)
   }
 
-  @Test func updateIconRespectsScriptIconActive() {
+  @Test func updateIconYieldsToScriptLock() {
     let manager = TerminalTabManager()
     let tabId = manager.createTab(title: "one", icon: "terminal")
     manager.setScriptIcon(tabId, icon: "play.fill")
@@ -107,14 +106,13 @@ struct TerminalTabManagerTests {
     #expect(manager.tabs.first?.icon == "play.fill")
   }
 
-  @Test func userOverrideClearsScriptIconActive() {
+  @Test func userOverrideSupersedesScriptLock() {
     let manager = TerminalTabManager()
     let tabId = manager.createTab(title: "one", icon: "terminal")
     manager.setScriptIcon(tabId, icon: "play.fill")
     manager.overrideIcon(tabId, icon: "sparkles")
     #expect(manager.tabs.first?.icon == "sparkles")
-    #expect(manager.tabs.first?.isIconLocked == true)
-    #expect(manager.tabs.first?.isScriptIconActive == false)
+    #expect(manager.tabs.first?.iconLock == .user)
   }
 
   @Test func setScriptIconYieldsToUserLock() {
@@ -123,15 +121,15 @@ struct TerminalTabManagerTests {
     manager.overrideIcon(tabId, icon: "sparkles")
     manager.setScriptIcon(tabId, icon: "play.fill")
     #expect(manager.tabs.first?.icon == "sparkles")
-    #expect(manager.tabs.first?.isScriptIconActive == false)
+    #expect(manager.tabs.first?.iconLock == .user)
   }
 
-  @Test func clearIconOverrideAlsoClearsScriptIconActive() {
+  @Test func clearIconOverrideReleasesScriptLock() {
     let manager = TerminalTabManager()
     let tabId = manager.createTab(title: "one", icon: "terminal")
     manager.setScriptIcon(tabId, icon: "play.fill")
     manager.clearIconOverride(tabId)
-    #expect(manager.tabs.first?.isScriptIconActive == false)
+    #expect(manager.tabs.first?.iconLock == .auto)
     manager.updateIcon(tabId, icon: "@asset:Npm")
     #expect(manager.tabs.first?.icon == "@asset:Npm")
   }


### PR DESCRIPTION
## Summary
- Add a new icon-precedence level (auto-detected < script/custom-command < user picker) via a `TerminalTabItem.isScriptIconActive` flag, so the play glyph and Custom Command icons can't be clobbered by `CommandIconMap` mid-run.
- Run Script tabs now keep `play.fill` for the lifetime of the tab (no more single-frame flash before the command icon takes over).
- Custom Commands gain auto icon support: `TerminalClient.Command.createTabWithInput` / `createSplitWithInput` carry a new `customCommandIcon: String?`, populated from `customCommand.systemImage`. The model's `"terminal"` placeholder and empty/whitespace values are treated as "unset" so untouched commands still get full auto-detection.
- User-set icons (`overrideIcon` via picker) continue to win over everything; resetting via the picker clears the script flag so auto-detection can take back over.

## Test plan
- [x] `make build-app` passes
- [x] `make check` passes
- [x] `make test` (929 tests, including 6 new `TerminalTabManagerTests` and 2 new `AppFeatureCustomCommandTests`)
- [x] Smoke: configure a `Run Script` that runs e.g. `npm run dev` — expect the tab to keep the play icon for the whole run instead of flashing then switching to the npm icon.
- [x] Smoke: configure a Custom Command with `systemImage = "wrench.and.screwdriver.fill"` running `swift test` — tab adopts the wrench icon, doesn't switch to swift mid-run.
- [x] Smoke: configure a Custom Command with the default `terminal` icon running `npm test` — tab uses auto-detected npm icon (i.e. behaves as before).
- [x] Smoke: with a script icon active, open the icon picker and pick something custom — manual choice wins; then "reset to default" → auto-detection takes over again.
