### PR TITLE
Improve Shelf book switch performance

### DIFF
--- a/doc-onevcat/shelf-jank-investigation.md
+++ b/doc-onevcat/shelf-jank-investigation.md
@@ -1,64 +1,76 @@
 # Shelf Book-Switch Jank Investigation
 
-Last updated: 2026-04-28
-Status: Closed for now — landed P0/P1 wins, no further structural change planned. Long-term signposts retained for future regressions.
+Last updated: 2026-04-29
+Status: Closed for now. The current branch keeps the fixes that improved trace data or UX without visible regressions, and drops the later experiments that introduced artifacts or reduced interaction quality.
 
 ## Summary
 
-When switching books quickly on the Shelf, the app showed visible jank: dropped frames, occasional multi-second main-thread blocks, and a sluggish feel. After ~9 traces and four code commits we landed two real fixes that eliminated the worst behaviour (Severe Hangs caused by an observability storm) and confirmed that the residual ~250 ms-per-click cost is rooted in SwiftUI animation/layout work that we cannot reduce without giving up the spine-flow animation entirely.
+Switching books quickly in Shelf mode showed visible frame drops, especially when switching with keyboard shortcuts. The first investigation pass found a large SwiftUI invalidation storm in the sidebar. The second pass narrowed the keyboard-path cost and simplified the Shelf spine layout.
 
-Final shipped state:
+The retained changes are:
 
-- `RepositorySectionView` no longer subscribes to `WorktreeTerminalManager.states` — body invocations dropped from ~7400/sec to ~850/sec under the same workload.
-- `orderedShelfBooks()` no longer rebuilds a `Dictionary` and a stack of `Set`s on every `ShelfView.body` call.
-- The redundant TCA-action animation transaction on Shelf-originated book switches was removed; the view-level `.animation(value: openBookID)` continues to drive the spine flow.
-- A long-term `OSSignposter` toolkit on `SupaLogger` plus a small set of body / lifecycle / NSView-representable signposts make future regressions much easier to localize on the Points of Interest timeline.
+- `RepositorySectionView` no longer reads `WorktreeTerminalManager.states` just to render the tab-count badge. The read moved into a leaf view so invalidation stops at the badge.
+- `orderedShelfBooks()` avoids per-body `Dictionary`, `Set`, and full `WorktreeRowModel` construction.
+- Shelf-originated book switches no longer send an extra TCA animation transaction on top of the view-level `openBookID` animation.
+- `CommandKeyObserver` only enters shortcut-hint mode for bare Command or bare Control, not every shortcut chord containing Command/Control.
+- The sidebar key-forwarding `.onKeyPress` modifier is not installed while Shelf is active. This removed the `EnvironmentWriter: KeyPressModifier` invalidation path from the Shelf switching trace.
+- Shelf spines are rendered from a single `ForEach`, removing the cross-list `matchedGeometryEffect` between left/right spine stacks.
+- The open-book opacity transition was removed. Trace improvement was small, but the user reported no visible UX regression, so it is kept as a low-risk cleanup.
+- Long-term signposts remain in place for future regressions.
 
-What we tried but rolled back:
+Experiments that were tried and rejected:
 
-- Removing `.id(worktree.id)` from `ShelfOpenBookView` (Phase 2). Behaved as designed (subtree no longer rebuilt) but produced no measurable hitch reduction; reverted to keep the codebase smaller and to preserve `.transition(.opacity)`.
-- Disabling the spine-flow animation entirely. Felt smooth in hand but did not actually reduce per-click work — it only removed the visual artefact. Reverted because the UX trade-off is not worth a perceptual-only win.
+- Removing `.id(worktree.id)` from `ShelfOpenBookView`. It was behaviorally safe but gave no measurable win.
+- Fully disabling or isolating the Shelf animation. It either only improved perception or caused visible terminal animation loss.
+- Rendering the terminal/open area in an overlay outside the spine layout animation. This created a black-edge artifact during spine movement and made several SwiftUI cause counters worse.
+- Removing context menus from closed-spine tab slots. This hurt interaction and did not improve hitches.
+
+## Final Trace Shape
+
+The final useful comparison line is run13/run15, after the keyboard-path and single-`ForEach` fixes. Hangs were treated as unreliable in this phase because they appeared and disappeared across similar runs; hitches and SwiftUI cause edges were more useful.
+
+| Run | Main change | Selects | All hitches/select | Select-window hitches/select | Key SwiftUI result |
+| --- | --- | ---: | ---: | ---: | --- |
+| run10 | Rejected terminal animation isolation experiment | 25 | 296.5 ms | not used | UX regression; terminal animation disappeared |
+| run11 | Bare Command/Control hint mode | 25 | 235.7 ms | 186.7 ms | `@Observable CommandKeyObserver.(Bool)` disappeared; `KeyPressModifier` fell to 116,284 source edges |
+| run12 | Disable sidebar key forwarding in Shelf | 29 | 196.1 ms | 151.7 ms | `EnvironmentWriter: KeyPressModifier` fell to 0; `WorktreeRowsView.body [skipped]` fell sharply |
+| run13 | Single `ForEach`, no matched geometry | 29 | 176.4 ms | 144.4 ms | `Layout: MatchedFrame` fell to 0; `LayoutChildGeometries` source edges fell from 111,421 to 4,279 |
+| run14 | Rejected terminal overlay | 29 | 167.1 ms | 136.3 ms | Small hitch win, but `AnimatableFrameAttribute`, responders, and opacity renderer all worsened; visible black edge |
+| run15 | Remove open-book opacity transition | 28 | 250.6 ms | 140.3 ms | Small select-window win; outside-window hitches dominated all-hitch total |
+| run16 | Rejected context-menu scoping | 27 | 180.6 ms | 145.1 ms | Interaction regression; `View Responders` worsened |
+
+`select-window hitches/select` is the preferred number for book-switch work because it only counts hitches between the first and last `reducer.selectWorktree` signpost. The "all hitches/select" number can be dominated by startup, recording, or unrelated post-workload spikes, as run15 shows.
 
 ## Problem
 
-Quickly clicking between books on the Shelf produced obvious frame drops. Initial Instruments capture (Animation Hitches template, Debug build) showed the situation was severe:
+Quickly switching between Shelf books produced obvious frame drops. Initial Instruments captures showed:
 
-- 1 Severe Hang (2.02 s) plus 11 Hangs of 600–1000 ms each
-- Main thread blocked for ~10.5 s out of a 25 s recording (~41 %)
-- 460 234 SwiftUI updates in 25 s — i.e. ~18 000 view updates per second under steady fast-clicking
+- severe hangs in early traces, including one multi-second main-thread block
+- hundreds of thousands of SwiftUI update/cause edges in short recordings
+- visible animation breakage during the 0.2 s spine-flow animation
 
-These numbers said the issue was not "one slow function" but a runaway invalidation pattern at the SwiftUI layer.
+The problem was not one slow reducer or one slow `NSViewRepresentable`. The reducer and Ghostty bridge signposts consistently measured in sub-millisecond ranges. The heavy work was mostly SwiftUI invalidation, layout, responder, and display-list work between our signposts.
 
 ## Investigation Timeline
 
-### 1. Static analysis (no instrumentation yet)
+### 1. Static Suspicions
 
-Before touching Instruments we inspected the Shelf view tree and the `RepositoriesFeature` reducer. Suspicions filed in priority order:
+The first static pass identified several plausible sources:
 
-1. `ShelfView.body` recomputes `orderedShelfBooks()` on every body call. The implementation builds a `Dictionary(uniqueKeysWithValues:)` from `repositories` and routes worktree ordering through `worktreeRowSections(in:)`, which constructs a full `WorktreeRowModel` and several intermediate `Set`s per repository.
-2. `.id(worktree.id)` on `ShelfOpenBookView` forces a full subtree teardown + rebuild on every book switch — including the Ghostty `NSViewRepresentable` wrappers.
-3. The animation is double-applied: `ShelfView` has `.animation(.easeInOut(duration: 0.2), value: openBookID)` AND book-click handlers do `store.send(..., animation: .easeInOut(duration: 0.2))`.
-4. Many spines each subscribe to `terminalManager.stateIfExists(for: book.id)`, which reads the entire `@Observable WorktreeTerminalManager.states` dictionary. Any terminal activity at all could fan out to every spine.
-5. The `matchedGeometryEffect` bridging the left and right `ForEach` branches forces SwiftUI to interpolate spine identity across two separate lists.
+1. `ShelfView.body` recomputes `orderedShelfBooks()` on every body call.
+2. `.id(worktree.id)` on `ShelfOpenBookView` might force expensive subtree teardown.
+3. Shelf book switching was applying animation twice: once in the TCA action send and once via `.animation(value: openBookID)`.
+4. Sidebar repository rows read `terminalManager.stateIfExists(...)` while rendering tab counts.
+5. The Shelf layout split spines across left/right `ForEach` lists and bridged identity with `matchedGeometryEffect`.
+6. Keyboard-based switching might be over-invalidating shortcut hint UI through `CommandKeyObserver` and `.onKeyPress`.
 
-Most of these turned out to be real but only some moved the needle.
+Most of these were real; only some moved user-visible performance.
 
-### 2. First Instruments capture and the smoking gun (Run 1, Debug)
+### 2. Sidebar Tab-Count Subscription Storm
 
-Animation Hitches + SwiftUI instrument template, Debug build, 25 s recording with rapid book clicking.
+Early `swiftui-causes` data showed `RepositorySectionView.body` and `@Observable WorktreeTerminalManager.(Dictionary<String, WorktreeTerminalState>)` as top offenders.
 
-Top "cause edges" in `swiftui-causes`:
-
-| Source | Cause edges |
-|---|---|
-| `Layout: AnimatableFrameAttribute` | 233 177 |
-| `@Observable WorktreeTerminalManager.(Dictionary<String, WorktreeTerminalState>)` | 196 968 |
-| `RepositorySectionView.body` | **184 681** |
-| `EnvironmentWriter: KeyPressModifier` | 164 594 |
-| `Layout: LayoutChildGeometries` | 124 230 |
-| `@Observable CommandKeyObserver.(Bool)` | 65 891 |
-
-`RepositorySectionView.body` running ~7400 times per second was the smoking gun. The cause was traced back to:
+The cause was:
 
 ```swift
 RepoHeaderRow(
@@ -68,240 +80,248 @@ RepoHeaderRow(
 )
 ```
 
-`openTabCount` iterates the repository's worktrees and calls `terminalManager.stateIfExists(...)` for each — so the body of *every* sidebar repository section subscribed to changes in `WorktreeTerminalManager.states` (which churns on any terminal activity), and *every* `tabManager.tabs` array within that. Any keystroke into a single terminal could fan out to the entire sidebar.
+`openTabCount` iterated worktrees and called `terminalManager.stateIfExists(...)` from the parent sidebar row. That subscribed every repository section body to the global terminal state dictionary, so unrelated terminal activity fanned out through the sidebar.
 
-### 3. P0 fixes (commit `0fe682cb`)
+Fixes landed in `0fe682cb`:
 
-Four changes landed together:
+- Move tab-count reads into `RepoHeaderTabCountBadge`.
+- Rewrite `orderedShelfBooks()` to use direct repository/worktree ordering.
+- Remove the redundant Shelf-originated action animation.
+- Add `SupaLogger` signpost helpers and focused Shelf/Ghostty signposts.
 
-- **P0-1**: Extract the tab-count badge into a dedicated leaf view `RepoHeaderTabCountBadge`. The leaf reads `terminalManager` itself; the parent `RepositorySectionView` no longer touches it. SwiftUI's invalidation graph stops at the badge subtree, leaving the rest of the sidebar untouched.
-- **P0-2**: Rewrite `orderedShelfBooks()` to use direct `IdentifiedArray` lookup (`repositories[id:]`) and route through the lighter `orderedWorktrees(in:)` rather than `worktreeRowSections(in:)`. Avoids per-repo `WorktreeRowModel` and `Set` allocations.
-- **P1-1**: Drop the redundant `animation:` parameter from Shelf-originated `store.send` calls. The view-level `.animation(value: openBookID)` already covers Shelf and left-nav-originated changes.
-- Also added `OSSignposter` to `SupaLogger` and instrumented the obvious suspects (reducer cases, focus/sync calls, book-click events).
+Result:
 
-Result in the next Release-build trace:
+| Metric | Before | After |
+| --- | ---: | ---: |
+| `RepositorySectionView.body` cause edges | 184,681 | 14,456 |
+| `WorktreeTerminalManager.states` cause edges | 196,968 | 14,456 |
+| Severe hangs from this storm | present | gone |
 
-| Metric | Before | After P0 | Δ |
-|---|---|---|---|
-| `RepositorySectionView.body` cause edges | 184 681 | 14 456 | **−92 %** |
-| `WorktreeTerminalManager.states` cause edges | 196 968 | 14 456 | **−93 %** |
-| Severe Hangs | 1 (2.02 s) | 0 | gone |
+This was the largest unambiguous win.
 
-Body-storm pattern eliminated. The 2 + second main-thread death observed at baseline never reappeared in any subsequent trace. **This is the unambiguous win of the entire investigation.**
+### 3. `.id(worktree.id)` Experiment
 
-### 4. The "still feels janky" plateau
+Hypothesis: the residual cost came from `ShelfOpenBookView` teardown/remount on every book switch.
 
-Despite P0 the user still felt visible jank. Subsequent Release traces showed:
+We tried migrating focus logic into `onChange(of: worktree.id, initial: true)` and removing the outer `.id(worktree.id)`. This behaved correctly, but trace data did not improve. The likely reason is that a deeper `.id(node.structuralIdentity)` in the terminal split tree already forces the relevant Ghostty surface wrapper lifecycle work.
 
-- Hitch budget remained roughly proportional to user clicks (~250–300 ms per click)
-- Hangs in the 600–1000 ms range still occurred under fast clicking
-- The dominant `swiftui-causes` work shifted to layout / animation / preferences:
-  - `Layout: AnimatableFrameAttribute` ~256 000
-  - `EnvironmentWriter: KeyPressModifier` ~240 000
-  - `Layout: LayoutChildGeometries` ~152 000
-  - `View Creation / Reuse` ~138 000
+Decision: reverted. The extra code was not worth keeping.
 
-These are SwiftUI-internal categories — nothing user-code we could optimize directly. We added more granular signposts to localize cost: `OpenBook.onAppear` / `onDisappear`, `Ghostty.makeNSView` / `updateNSView` / `dismantleNSView`, `ShelfView.body` / `ShelfSpineView.body` event counters.
+### 4. Animation Experiments
 
-The data was unambiguous and surprising:
+Disabling the root Shelf animation made the UI feel much smoother, but traces showed the work mostly remained. This clarified that animation was a perception amplifier: missed frames are much more visible when the spine is supposed to glide.
 
-| Signpost | Per-click avg / max |
-|---|---|
-| `reducer.selectWorktree` | 0.18 / 0.21 ms |
-| `OpenBook.onAppear` | 0.10 / 0.18 ms |
-| `Ghostty.makeNSView` | 0.33 / 0.60 ms |
-| `focusSelectedTab` | 0.05 / 0.10 ms |
-| `syncFocus` | 0.03 / 0.09 ms |
-| `applySurfaceActivity` | 0.03 / 0.10 ms |
+A later attempt to isolate book-switch animation around the spine stacks and disable it around the terminal area also failed product-wise. The terminal animation disappeared and the trace did not justify the UX loss.
 
-**Total instrumented user-code work over a 22 s recording with 32 clicks: ≈25 ms.** The remaining ~250 ms-per-click was happening *between* our signposts, entirely inside SwiftUI's layout / animation / display-list pipeline.
+Decision: keep the normal spine-flow animation.
 
-### 5. Phase 1 + Phase 2 — remove `.id(worktree.id)`
+### 5. Keyboard-Path Fixes
 
-Hypothesis: the residual cost is the SwiftUI subtree teardown / remount triggered by `.id`, even though our own `makeNSView` is fast. By switching to identity-stable view reuse and migrating the focus-sync logic into `.onChange(of: worktree.id, initial: true)`, the heavy SwiftUI bookkeeping (attribute graph, preference values, accessibility nodes) for the entire ShelfOpenBookView subtree should not run per click.
+The user reproduced the problem primarily with shortcuts. run8/run10 showed high `@Observable CommandKeyObserver.(Bool)` and `EnvironmentWriter: KeyPressModifier` cost.
 
-Implemented in two phases for safety:
+Two fixes were retained:
 
-- Phase 1: add the new `onChange` path with verification-only signposts, leave `.id` in place. Trace showed `OpenBook.onChange.worktreeID` firing 1:1 with `OpenBook.onAppear` — confirmed equivalence.
-- Phase 2: migrate logic, remove `.id`.
+- `CommandKeyObserver.shouldShowShortcuts(for:)` now returns true only for bare Command or bare Control, not shortcut chords such as Control+number or Command+Shift.
+- `SidebarListView` does not install its sidebar-to-terminal `.onKeyPress` forwarding modifier while Shelf is active.
 
-Pre-implementation we worried that `GhosttySurfaceScrollView` stores its `surfaceView` as `private let` — meaning if SwiftUI reused the wrapper across book switches via `updateNSView`, the wrapper would still display the previous book's surface. Inspection of `TerminalSplitTreeView.swift:27` showed there is already an inner `.id(node.structuralIdentity)` on `SubtreeView` that forces dismantle + make whenever the split tree changes. So the surface-binding bug was a non-issue in practice. The user confirmed visually.
+Results:
 
-Result: behaviourally clean, but **no measurable perf gain**:
+- run11 removed `@Observable CommandKeyObserver.(Bool)` from the hot SwiftUI causes.
+- run12 removed `EnvironmentWriter: KeyPressModifier` from the Shelf switching path entirely.
+- `WorktreeRowsView.body [skipped]` dropped from 26,466 in run11 to 2,853 in run12.
+- select-window hitches/select improved from 186.7 ms in run11 to 151.7 ms in run12.
 
-| Metric | With `.id` (Run 6) | Without `.id` (Run 8) |
-|---|---|---|
-| Hitches per click | 262 ms | 316 ms |
-| Hitch share of recording | 37 % | 39 % |
-| Severe Hangs | 0 | 4 (system-pressure variance) |
+The behavior trade-off is narrow: while Shelf is active and the sidebar has focus, ordinary typed characters are no longer forwarded into the selected terminal. Direct terminal input is unaffected.
 
-Phase 2 was reverted in commit `c9b852eb`'s parent state. Lesson: the inner `.id(node.structuralIdentity)` was already forcing the heavy work, the outer one was redundant overhead but not the dominant cost.
+### 6. Single-`ForEach` Shelf Layout
 
-### 6. Animation off — the perceptual experiment
+The original Shelf layout split spines into left and right stacks:
 
-Single-line change: `.animation(.easeInOut(duration: 0.2), value: openBookID)` → `.animation(nil, value: openBookID)`.
+```swift
+left spines
+open book area
+right spines
+```
 
-User reported: "去掉动画确实完全不卡了". But the trace told a different story:
+Because a book moved between the two `ForEach` subtrees when the open index changed, the code used `matchedGeometryEffect` to bridge identity.
 
-| Metric | Animation on (Run 8) | Animation off (Run 9) |
-|---|---|---|
-| Hitches per click | 316 ms | 256 ms |
-| Hangs | 5 | 20 |
-| Hang share of recording | 83 % | 51 % |
+The retained rewrite renders all spines from a single `ForEach(books)` and inserts the open book area after the open book. This lets normal SwiftUI diffing preserve spine identity without matched geometry.
 
-Per-click hitch barely moved. Total main-thread blocked time even *increased* in absolute terms, with many Hangs covering windows where multiple clicks landed inside one block.
+run13 results:
 
-The insight: **the spine-flow animation is the perceptual jank amplifier**, not the cause. When animation is running, every missed frame produces a visible "broken animation" artefact. When animation is off, the same amount of main-thread work just becomes a small response latency that the user reads as "instant click registered, slight delay before redraw" rather than "jank".
+| Metric | run12 | run13 |
+| --- | ---: | ---: |
+| select-window hitches/select | 151.7 ms | 144.4 ms |
+| SwiftUI cause rows | 1,303,129 | 1,026,467 |
+| `Layout: MatchedFrame` source | 18,030 | 0 |
+| `Layout: LayoutChildGeometries` source | 111,421 | 4,279 |
+| `View Responders` dest | 102,928 | 69,228 |
+| opacity renderer dest | 72,073 | 57,078 |
 
-Without further structural rewrites (e.g. lazy-rendered spines, single-`ForEach` layout to drop `matchedGeometryEffect`, or rendering spines with `Canvas` instead of one `View` each), the per-click work appears to be roughly constant.
+Decision: kept. The trace win was moderate and the user reported a clear subjective improvement.
 
-### 7. Final decision — Option C
+### 7. Terminal Overlay Experiment
 
-Restore everything that didn't have a measurable win:
+Hypothesis: keep spines animating, but remove the real terminal subtree from the animated `HStack`. Use a lightweight placeholder in the layout and render the terminal in an overlay at its final frame.
 
-- `.id(worktree.id)` back, focus logic back in `.onAppear`, Phase-2-only `onChange` path removed
-- Animation back to `.easeInOut(duration: 0.2)`
+run14 showed a small hitch win, but the approach had two problems:
 
-Keep what is unambiguously good:
+- Visual artifact: during spine movement the terminal overlay was already at the new position, while the old layout area exposed the window background, producing a black edge.
+- SwiftUI causes got worse:
+  - `AnimatableFrameAttribute` source increased from 135,581 to 164,827.
+  - `View Responders` dest increased from 69,228 to 75,033.
+  - opacity renderer dest increased from 57,078 to 70,036.
 
-- All four P0/P1 fixes
-- The `OSSignposter` toolkit on `SupaLogger` (`PointsOfInterest` category for stock-instrument visibility)
-- Body counters and lifecycle signposts as long-term observability — they cost nothing when no Instruments session is attached
+Decision: reverted. The small hitch improvement did not justify the artifact and added complexity.
 
-Net commits on `perf/shelf-jank-fixes`:
+### 8. Open-Book Opacity Transition Removal
 
-- `0fe682cb` perf(shelf): cut sidebar tab-count subscription storm and add signposts
-- `c9b852eb` chore(shelf): add long-term performance signposts
+Removing the explicit `.transition(.opacity)` from `openBookArea` produced only a small win:
 
-## What Worked vs What Didn't
+| Metric | run13 | run15 |
+| --- | ---: | ---: |
+| select-window hitches/select | 144.4 ms | 140.3 ms |
+| select-window max hitch | 125.0 ms | 116.7 ms |
+| `AnimatableFrameAttribute` source/select | 4,675 | 4,588 |
 
-| Change | Cost | Outcome |
-|---|---|---|
-| **P0-1**: leaf view for sidebar tab count | ~30 lines | RepositorySectionView body invocations −92 %, killed the Severe Hang completely. **Kept.** |
-| **P0-2**: rewrite `orderedShelfBooks()` | ~20 lines | Eliminated per-frame Dict/Set allocations on the ShelfView hot path. **Kept.** |
-| **P1-1**: drop redundant action animation | 4 line touch | Removed double-animation transactions. Marginal but free. **Kept.** |
-| `OSSignposter` toolkit + signposts | ~80 lines, multiple files | Made every subsequent investigation tractable. **Kept.** |
-| Phase 2: remove `.id(worktree.id)` | ~30 lines | No measurable perf gain; lost `.transition(.opacity)`. **Reverted.** |
-| Animation duration 0.2 s → 0.1 s | 1 line | Hitch per click 285 → 244 ms (−14 %). Not enough to justify UX change. **Reverted.** |
-| Animation off entirely | 1 line | Felt smooth but trace showed work was unchanged. UX trade-off not worth perceptual-only win. **Reverted.** |
+Several opacity-related SwiftUI causes did not improve after normalization, so this is not a major root-cause fix. However, the user reported no visible behavior regression, so it was kept as a simple low-risk improvement.
+
+### 9. Closed-Spine Tab Context Menu Experiment
+
+Hypothesis: closed spines did not need a full tab context menu, and removing it might reduce `View Responders` and the `TerminalTabContextMenu` view-list cost.
+
+Implementation: only the open spine retained full tab context menus.
+
+Result: rejected.
+
+- select-window hitches/select regressed from 140.3 ms to 145.1 ms.
+- `View Responders` dest/select worsened from 2,296 to 3,133.
+- The old `ModifiedContent<ShelfSpineTabSlot, TerminalTabContextMenu>` shape was replaced by `_ConditionalContent<ModifiedContent, ShelfSpineTabSlot>`, so SwiftUI still had view-list complexity.
+- Closed-spine right-click behavior got worse.
+
+Decision: reset away. Do not optimize context menus by conditionally changing the child view type.
+
+## What Worked vs What Did Not
+
+| Change | Outcome |
+| --- | --- |
+| Sidebar tab-count leaf view | Large win. Removed the biggest invalidation storm. Kept. |
+| Faster `orderedShelfBooks()` | Small/free hot-path cleanup. Kept. |
+| Remove redundant action animation | Small/free cleanup. Kept. |
+| Signpost toolkit and focused signposts | Made every later trace tractable. Kept. |
+| Bare Command/Control shortcut-hint mode | Clear win for keyboard switching. Kept. |
+| Disable sidebar `.onKeyPress` while Shelf is active | Clear win; removed `KeyPressModifier` from Shelf switching trace. Kept. |
+| Single `ForEach` Shelf layout | Moderate trace win and good subjective win. Kept. |
+| Remove open-book opacity transition | Small trace win, no observed UX cost. Kept. |
+| Remove outer `.id(worktree.id)` | No measurable win. Reverted. |
+| Disable/isolate animation | Either perceptual-only or visual regression. Reverted. |
+| Terminal overlay outside layout animation | Small hitch win but black-edge artifact and worse causes. Reverted. |
+| Closed-spine context-menu scoping | Worse trace and worse UX. Reset away. |
+
+## Current Conclusions
+
+1. **The worst problem was not the terminal.** Reducer work, Ghostty `makeNSView`, focus, and sync signposts are all tiny relative to the hitch windows.
+
+2. **The first major class was invalidation fan-out.** Sidebar tab counts, shortcut hints, and `.onKeyPress` environment machinery were multiplying work across unrelated views.
+
+3. **The second major class is SwiftUI layout animation.** After invalidation storms were removed, the dominant costs became `AnimatableFrameAttribute`, `External: Time`, `View Responders`, and display-list renderer effects. These are consequences of animating a dense interactive SwiftUI tree.
+
+4. **Hangs were too unstable to use as the deciding metric in later runs.** The same user-visible workload could show very different hang counts. Hitches and normalized SwiftUI cause edges were more reliable.
+
+5. **Animation changes must be judged by both trace and eye.** Disabling animation can feel much better while barely moving work. Conversely, moving terminal rendering out of layout improved hitches slightly but created visible artifacts.
+
+6. **Stable view shape matters.** The closed-spine context-menu experiment showed that replacing one expensive modifier with a conditional child shape can shift cost instead of reducing it.
 
 ## Methodology and Tooling Learned
 
 ### `xctrace` from the command line
 
-`/usr/bin/xctrace` is a stub; the real tool ships inside Xcode at `/Applications/Xcode-26.4.1.app/Contents/Developer/usr/bin/xctrace`. Trying to inspect a trace recorded by Xcode 26.x with the system stub produces `Cannot load existing document because of an error: Missing features` — silent and confusing. Always use the Xcode-bundled binary:
+`/usr/bin/xctrace` is a stub; use the Xcode-bundled tool. In this investigation the working path was:
 
 ```bash
 XCT="/Applications/Xcode-26.4.1.app/Contents/Developer/usr/bin/xctrace"
 
-# Discover what data is in the trace
 "$XCT" export --input run.trace --toc --output toc.xml
 
-# Pull a specific schema
+"$XCT" export --input run.trace \
+  --xpath '/trace-toc/run[@number="1"]/data/table[@schema="hitches"]' \
+  --output hitches.xml
+
 "$XCT" export --input run.trace \
   --xpath '/trace-toc/run[@number="1"]/data/table[@schema="potential-hangs"]' \
   --output hangs.xml
 
-# Filter further by attribute (e.g. signposts under PointsOfInterest)
 "$XCT" export --input run.trace \
   --xpath '/trace-toc/run[@number="1"]/data/table[@schema="os-signpost"][@category="PointsOfInterest"]' \
   --output poi.xml
+
+"$XCT" export --input run.trace \
+  --xpath '/trace-toc/run[@number="1"]/data/table[@schema="swiftui-causes"]' \
+  --output swiftui-causes.xml
 ```
 
-Useful schemas that consistently held data:
+The XML export interns values with `id`/`ref`. Aggregation scripts must resolve refs; a streaming parser is necessary for large `swiftui-causes` and `swiftui-updates` exports.
 
-- `potential-hangs` — main-thread block intervals with hang-type classification
-- `hitches` — per-frame hitch events, often with a narrative description
-- `os-signpost` — Begin/End/Event records, one table per attribute filter
-- `swiftui-causes` — view dependency graph edges, the most useful single source for finding invalidation storms
-- `swiftui-update-groups` — SwiftUI-internal update transactions with duration
+### Signposts
 
-The XML export uses an aggressive `id`/`ref` interning pattern. To aggregate counts you must build a per-trace `id → label` table from the first definition and then resolve refs. A simple Python script walks the rows in a single pass; the bigger files (1 GB+ for `swiftui-updates` on a 25 s recording) needed buffered streaming.
+`SupaLogger` emits signposts under subsystem `com.onevcat.prowl` and category `PointsOfInterest`. This category is visible in the stock Points of Interest instrument.
 
-### Animation Hitches template's signpost filter is hard-coded
-
-The stock Animation Hitches template includes an `os_signpost` instrument, but it's filtered to `subsystem == "com.apple.ConditionInducer.LowSeverity"` — i.e. only Apple's internal conditioning signposts. Our subsystem (`com.onevcat.prowl`) is not captured by default. Two ways to make app signposts visible in this template:
-
-1. Add a generic `os_signpost` instrument to the trace document and configure it manually (subsystem filter or empty).
-2. **Use the well-known `"PointsOfInterest"` category** for the signposter. The stock **Points of Interest** instrument is hard-coded to that category and shows app signposts without further configuration. This is what `SupaLogger` does now.
-
-We learned (1) the hard way in Run 3 and (2) when Run 4's "Points of Interest" lane stayed empty even with our signposts emitted.
-
-### Hangs vs Hitches
-
-These are not the same thing and Animation Hitches reports them in two different lanes:
-
-- A **Hang** is a contiguous main-thread block longer than the configured threshold (default 33 ms; surfaces as Microhang, Hang, or Severe Hang). Stack traces are sometimes attached.
-- A **Hitch** is one or more consecutive frames missing vsync. Multiple frames missed in a row collapse into one hitch event with a longer duration. Hitches do not require the main thread to be blocked — GPU / render-server / commit-phase issues all surface as hitches.
-
-A trace can have many Hitches and zero Hangs (frame production too slow to keep up with vsync but main thread always yielding within 33 ms — exactly what Run 4 looked like). It can also have many Hangs and very visible jank. The two metrics measure different aspects of "slow" and need to be read together.
-
-### Signpost begin/end with `inout` state
-
-`SupaLogger.interval(_:_:)` takes a closure, but TCA reducer cases bind `state` as `inout` and Swift cannot capture `inout` parameters in a non-escaping closure. The workaround is a manual `beginInterval` / `endInterval` token API:
+Reducer code that mutates `inout state` should use manual begin/end tokens:
 
 ```swift
 case .selectWorktree(let id, let focusTerminal):
   let token = repositoriesLogger.beginInterval("reducer.selectWorktree")
   defer { repositoriesLogger.endInterval(token) }
-  // ... mutate state directly ...
+  // mutate state
 ```
 
-The token wraps `OSSignpostIntervalState` so callers don't need to import `OSLog` themselves.
-
-### Signpost inside SwiftUI `body`
-
-`var body: some View` is implicitly `@ViewBuilder` and rejects `defer`. To count body invocations, an `Event` signpost via a discarded `let _ =` works:
+SwiftUI bodies can use event signposts:
 
 ```swift
 var body: some View {
   let _ = shelfLogger.event("ShelfView.body")
-  // ... view tree ...
+  // view tree
 }
 ```
 
-Body intervals (Begin/End) are not directly representable this way; use the SwiftUI instrument's "View Body" track instead when you need duration.
+### Hangs vs Hitches
 
-### `OSSignposter.emitEvent` doesn't always show up in `xctrace export`
+- A **Hang** is a main-thread block longer than the threshold.
+- A **Hitch** is one or more missed frames.
 
-In our traces, `Begin` and `End` rows from `interval(_:)` consistently appeared, but `emitEvent` (point signposts) sometimes didn't show in the exported `os-signpost` table even though they were visible in the Instruments UI. Worth knowing if a signpost count looks low — verify in the UI before assuming the call site didn't fire.
+They measure different failure modes. For this investigation, hitches normalized by `reducer.selectWorktree` count were the most useful metric.
 
-## Conclusions
+## Future Work
 
-1. **The single biggest win was finding the observability storm in `RepositorySectionView`**. Static analysis spotted the suspicious read; `swiftui-causes` confirmed it; the leaf-view fix dropped it ~92 % and eliminated the Severe Hang. This is what to look for first when SwiftUI feels uniformly slow under any state change.
+The current result is probably good enough. If Shelf book switching becomes a product priority again, the remaining useful directions are more structural:
 
-2. **`@Observable` types must be subscribed to with care.** Reading any property of an `@Observable` instance inside a parent `body` subscribes that body to *every change* on that property — and properties of type `Dictionary<…>` or `Set<…>` change on every insert / remove / mutate. For values that change frequently, push the read down into a leaf view that only renders that one value. The leaf still re-renders frequently, but the parent (and its other children) doesn't.
+- **Custom spine layout instead of animated `HStack` frame interpolation.** Compute spine positions directly and animate transforms/offsets with stable child identity. This is more invasive but targets `AnimatableFrameAttribute` directly.
+- **Reduce per-spine interactivity in a stable way.** Avoid conditional child types; consider stable lightweight wrappers if responder cost becomes a proven bottleneck.
+- **Lazy or virtualized spines.** Useful only if real users commonly have many more visible/open books than the current test set.
+- **Audit the inner terminal split-tree `.id(node.structuralIdentity)`.** This may be risky because `GhosttySurfaceScrollView` currently stores its surface view as immutable state; changing it needs a careful lifecycle audit.
+- **Canvas-rendered spines.** Potentially large reduction in SwiftUI view-tree work, but high implementation and accessibility cost.
 
-3. **Animation amplifies perceived jank far beyond its actual contribution to work.** The same ~250 ms of main-thread work feels broken when an animation is running through it and feels merely "slightly slow" when it isn't. Removing animation can be the right product call even when the trace numbers don't shift.
+Do not re-try these unless a new trace suggests a different result:
 
-4. **`.id(viewIdentity)` is not free.** Even when our own `makeNSView` body is fast, the SwiftUI bookkeeping around full subtree teardown (attribute graph, preferences, accessibility, transition orchestration) is real. But removing it may not yield measurable perf if there's another `.id` deeper in the tree forcing the same work — read the layout of `.id` modifiers across the whole subtree before assuming a removal will help.
-
-5. **Signposts pay for themselves on the second investigation.** They cost nothing when no Instruments session is attached and let us collapse 30 minutes of guess-and-trace into a single targeted measurement. Worth keeping permanently around hot paths.
-
-## Open Questions / Future Work
-
-If we ever decide to attack the residual ~250 ms-per-click cost (probably only worthwhile if user feedback escalates):
-
-- **Lazy-render spines**. We always render every spine even when many are off-screen. A `ScrollView` + `LazyHStack` could cap the work to the visible window.
-- **Single-`ForEach` Shelf layout**. Drop the cross-`ForEach` `matchedGeometryEffect` by laying out spines in one list and overlaying / inline-expanding the open book area at the right index. SwiftUI's normal list-diff would handle spine flow without identity reconciliation across two lists.
-- **`Canvas`-rendered spines**. Each spine is currently a `View` subtree with `Button`s, `ScrollView`, `.contextMenu`, `.help` etc. Cumulatively across ~10 spines this is a lot of view-tree work per click. A custom `Canvas`-based spine could cut SwiftUI's per-spine overhead by an order of magnitude — at the cost of having to reimplement hover, hit-testing, accessibility manually.
-- **Eliminate the inner `.id(node.structuralIdentity)`**. We never tested this. It might let the surface wrappers be reused across compatible split-tree shapes, but `GhosttySurfaceScrollView.surfaceView` is `let` so we'd have to make it mutable and audit all attach/detach lifecycle paths first.
-
-None of these are obviously worth doing today.
+- removing only the outer open-book `.id`
+- fully disabling Shelf animation
+- moving terminal content to a final-position overlay
+- conditionally removing closed-spine context menus
 
 ## Long-Term Observability Hooks
 
-After this investigation the following signposts are permanently emitted to the `com.onevcat.prowl` subsystem under the `PointsOfInterest` category. They are visible in Instruments by adding the stock **Points of Interest** instrument to any trace:
+Permanent signposts retained for future Shelf debugging:
 
-- Reducer paths: `reducer.selectWorktree`, `reducer.selectRepository` (intervals)
-- Terminal lifecycle: `Ghostty.makeNSView`, `Ghostty.updateNSView` (intervals); `Ghostty.dismantleNSView` (event)
-- Shelf focus / sync: `OpenBook.onAppear`, `OpenBook.onChange.selectedTabId`, `focusSelectedTab`, `syncFocus`, `applySurfaceActivity` (intervals); `OpenBook.onDisappear` (event)
-- View invalidation counters: `ShelfView.body`, `ShelfSpineView.body` (events)
-- User-input markers: `BookClick.SwitchBook`, `BookClick.TabSwitchSameBook`, `BookClick.NewTabSpine` (events)
+- Reducer paths: `reducer.selectWorktree`, `reducer.selectRepository`
+- Terminal lifecycle: `Ghostty.makeNSView`, `Ghostty.updateNSView`, `Ghostty.dismantleNSView`
+- Shelf focus/sync: `OpenBook.onAppear`, `OpenBook.onChange.selectedTabId`, `focusSelectedTab`, `syncFocus`, `applySurfaceActivity`, `OpenBook.onDisappear`
+- View counters: `ShelfView.body`, `ShelfSpineView.body`
+- User markers: `BookClick.SwitchBook`, `BookClick.TabSwitchSameBook`, `BookClick.NewTabSpine`
 
-For future Shelf perf debugging the recommended starting workflow is:
+Recommended future workflow:
 
-1. Record with Animation Hitches template
-2. Add the **Points of Interest** instrument to the document (one click)
-3. Reproduce the workload
-4. In the timeline, line up Hitches / Hangs against the Points of Interest lane to see which named work is on the critical path
+1. Record with Animation Hitches template.
+2. Add the Points of Interest instrument.
+3. Reproduce the workload.
+4. Export `hitches`, `os-signpost`, and `swiftui-causes`.
+5. Normalize hitches by `reducer.selectWorktree` count and inspect SwiftUI source/destination pairs.

--- a/doc-onevcat/shelf-jank-investigation.md
+++ b/doc-onevcat/shelf-jank-investigation.md
@@ -1,0 +1,307 @@
+# Shelf Book-Switch Jank Investigation
+
+Last updated: 2026-04-28
+Status: Closed for now — landed P0/P1 wins, no further structural change planned. Long-term signposts retained for future regressions.
+
+## Summary
+
+When switching books quickly on the Shelf, the app showed visible jank: dropped frames, occasional multi-second main-thread blocks, and a sluggish feel. After ~9 traces and four code commits we landed two real fixes that eliminated the worst behaviour (Severe Hangs caused by an observability storm) and confirmed that the residual ~250 ms-per-click cost is rooted in SwiftUI animation/layout work that we cannot reduce without giving up the spine-flow animation entirely.
+
+Final shipped state:
+
+- `RepositorySectionView` no longer subscribes to `WorktreeTerminalManager.states` — body invocations dropped from ~7400/sec to ~850/sec under the same workload.
+- `orderedShelfBooks()` no longer rebuilds a `Dictionary` and a stack of `Set`s on every `ShelfView.body` call.
+- The redundant TCA-action animation transaction on Shelf-originated book switches was removed; the view-level `.animation(value: openBookID)` continues to drive the spine flow.
+- A long-term `OSSignposter` toolkit on `SupaLogger` plus a small set of body / lifecycle / NSView-representable signposts make future regressions much easier to localize on the Points of Interest timeline.
+
+What we tried but rolled back:
+
+- Removing `.id(worktree.id)` from `ShelfOpenBookView` (Phase 2). Behaved as designed (subtree no longer rebuilt) but produced no measurable hitch reduction; reverted to keep the codebase smaller and to preserve `.transition(.opacity)`.
+- Disabling the spine-flow animation entirely. Felt smooth in hand but did not actually reduce per-click work — it only removed the visual artefact. Reverted because the UX trade-off is not worth a perceptual-only win.
+
+## Problem
+
+Quickly clicking between books on the Shelf produced obvious frame drops. Initial Instruments capture (Animation Hitches template, Debug build) showed the situation was severe:
+
+- 1 Severe Hang (2.02 s) plus 11 Hangs of 600–1000 ms each
+- Main thread blocked for ~10.5 s out of a 25 s recording (~41 %)
+- 460 234 SwiftUI updates in 25 s — i.e. ~18 000 view updates per second under steady fast-clicking
+
+These numbers said the issue was not "one slow function" but a runaway invalidation pattern at the SwiftUI layer.
+
+## Investigation Timeline
+
+### 1. Static analysis (no instrumentation yet)
+
+Before touching Instruments we inspected the Shelf view tree and the `RepositoriesFeature` reducer. Suspicions filed in priority order:
+
+1. `ShelfView.body` recomputes `orderedShelfBooks()` on every body call. The implementation builds a `Dictionary(uniqueKeysWithValues:)` from `repositories` and routes worktree ordering through `worktreeRowSections(in:)`, which constructs a full `WorktreeRowModel` and several intermediate `Set`s per repository.
+2. `.id(worktree.id)` on `ShelfOpenBookView` forces a full subtree teardown + rebuild on every book switch — including the Ghostty `NSViewRepresentable` wrappers.
+3. The animation is double-applied: `ShelfView` has `.animation(.easeInOut(duration: 0.2), value: openBookID)` AND book-click handlers do `store.send(..., animation: .easeInOut(duration: 0.2))`.
+4. Many spines each subscribe to `terminalManager.stateIfExists(for: book.id)`, which reads the entire `@Observable WorktreeTerminalManager.states` dictionary. Any terminal activity at all could fan out to every spine.
+5. The `matchedGeometryEffect` bridging the left and right `ForEach` branches forces SwiftUI to interpolate spine identity across two separate lists.
+
+Most of these turned out to be real but only some moved the needle.
+
+### 2. First Instruments capture and the smoking gun (Run 1, Debug)
+
+Animation Hitches + SwiftUI instrument template, Debug build, 25 s recording with rapid book clicking.
+
+Top "cause edges" in `swiftui-causes`:
+
+| Source | Cause edges |
+|---|---|
+| `Layout: AnimatableFrameAttribute` | 233 177 |
+| `@Observable WorktreeTerminalManager.(Dictionary<String, WorktreeTerminalState>)` | 196 968 |
+| `RepositorySectionView.body` | **184 681** |
+| `EnvironmentWriter: KeyPressModifier` | 164 594 |
+| `Layout: LayoutChildGeometries` | 124 230 |
+| `@Observable CommandKeyObserver.(Bool)` | 65 891 |
+
+`RepositorySectionView.body` running ~7400 times per second was the smoking gun. The cause was traced back to:
+
+```swift
+RepoHeaderRow(
+  ...,
+  tabCount: Self.openTabCount(for: repository, terminalManager: terminalManager),
+  ...
+)
+```
+
+`openTabCount` iterates the repository's worktrees and calls `terminalManager.stateIfExists(...)` for each — so the body of *every* sidebar repository section subscribed to changes in `WorktreeTerminalManager.states` (which churns on any terminal activity), and *every* `tabManager.tabs` array within that. Any keystroke into a single terminal could fan out to the entire sidebar.
+
+### 3. P0 fixes (commit `0fe682cb`)
+
+Four changes landed together:
+
+- **P0-1**: Extract the tab-count badge into a dedicated leaf view `RepoHeaderTabCountBadge`. The leaf reads `terminalManager` itself; the parent `RepositorySectionView` no longer touches it. SwiftUI's invalidation graph stops at the badge subtree, leaving the rest of the sidebar untouched.
+- **P0-2**: Rewrite `orderedShelfBooks()` to use direct `IdentifiedArray` lookup (`repositories[id:]`) and route through the lighter `orderedWorktrees(in:)` rather than `worktreeRowSections(in:)`. Avoids per-repo `WorktreeRowModel` and `Set` allocations.
+- **P1-1**: Drop the redundant `animation:` parameter from Shelf-originated `store.send` calls. The view-level `.animation(value: openBookID)` already covers Shelf and left-nav-originated changes.
+- Also added `OSSignposter` to `SupaLogger` and instrumented the obvious suspects (reducer cases, focus/sync calls, book-click events).
+
+Result in the next Release-build trace:
+
+| Metric | Before | After P0 | Δ |
+|---|---|---|---|
+| `RepositorySectionView.body` cause edges | 184 681 | 14 456 | **−92 %** |
+| `WorktreeTerminalManager.states` cause edges | 196 968 | 14 456 | **−93 %** |
+| Severe Hangs | 1 (2.02 s) | 0 | gone |
+
+Body-storm pattern eliminated. The 2 + second main-thread death observed at baseline never reappeared in any subsequent trace. **This is the unambiguous win of the entire investigation.**
+
+### 4. The "still feels janky" plateau
+
+Despite P0 the user still felt visible jank. Subsequent Release traces showed:
+
+- Hitch budget remained roughly proportional to user clicks (~250–300 ms per click)
+- Hangs in the 600–1000 ms range still occurred under fast clicking
+- The dominant `swiftui-causes` work shifted to layout / animation / preferences:
+  - `Layout: AnimatableFrameAttribute` ~256 000
+  - `EnvironmentWriter: KeyPressModifier` ~240 000
+  - `Layout: LayoutChildGeometries` ~152 000
+  - `View Creation / Reuse` ~138 000
+
+These are SwiftUI-internal categories — nothing user-code we could optimize directly. We added more granular signposts to localize cost: `OpenBook.onAppear` / `onDisappear`, `Ghostty.makeNSView` / `updateNSView` / `dismantleNSView`, `ShelfView.body` / `ShelfSpineView.body` event counters.
+
+The data was unambiguous and surprising:
+
+| Signpost | Per-click avg / max |
+|---|---|
+| `reducer.selectWorktree` | 0.18 / 0.21 ms |
+| `OpenBook.onAppear` | 0.10 / 0.18 ms |
+| `Ghostty.makeNSView` | 0.33 / 0.60 ms |
+| `focusSelectedTab` | 0.05 / 0.10 ms |
+| `syncFocus` | 0.03 / 0.09 ms |
+| `applySurfaceActivity` | 0.03 / 0.10 ms |
+
+**Total instrumented user-code work over a 22 s recording with 32 clicks: ≈25 ms.** The remaining ~250 ms-per-click was happening *between* our signposts, entirely inside SwiftUI's layout / animation / display-list pipeline.
+
+### 5. Phase 1 + Phase 2 — remove `.id(worktree.id)`
+
+Hypothesis: the residual cost is the SwiftUI subtree teardown / remount triggered by `.id`, even though our own `makeNSView` is fast. By switching to identity-stable view reuse and migrating the focus-sync logic into `.onChange(of: worktree.id, initial: true)`, the heavy SwiftUI bookkeeping (attribute graph, preference values, accessibility nodes) for the entire ShelfOpenBookView subtree should not run per click.
+
+Implemented in two phases for safety:
+
+- Phase 1: add the new `onChange` path with verification-only signposts, leave `.id` in place. Trace showed `OpenBook.onChange.worktreeID` firing 1:1 with `OpenBook.onAppear` — confirmed equivalence.
+- Phase 2: migrate logic, remove `.id`.
+
+Pre-implementation we worried that `GhosttySurfaceScrollView` stores its `surfaceView` as `private let` — meaning if SwiftUI reused the wrapper across book switches via `updateNSView`, the wrapper would still display the previous book's surface. Inspection of `TerminalSplitTreeView.swift:27` showed there is already an inner `.id(node.structuralIdentity)` on `SubtreeView` that forces dismantle + make whenever the split tree changes. So the surface-binding bug was a non-issue in practice. The user confirmed visually.
+
+Result: behaviourally clean, but **no measurable perf gain**:
+
+| Metric | With `.id` (Run 6) | Without `.id` (Run 8) |
+|---|---|---|
+| Hitches per click | 262 ms | 316 ms |
+| Hitch share of recording | 37 % | 39 % |
+| Severe Hangs | 0 | 4 (system-pressure variance) |
+
+Phase 2 was reverted in commit `c9b852eb`'s parent state. Lesson: the inner `.id(node.structuralIdentity)` was already forcing the heavy work, the outer one was redundant overhead but not the dominant cost.
+
+### 6. Animation off — the perceptual experiment
+
+Single-line change: `.animation(.easeInOut(duration: 0.2), value: openBookID)` → `.animation(nil, value: openBookID)`.
+
+User reported: "去掉动画确实完全不卡了". But the trace told a different story:
+
+| Metric | Animation on (Run 8) | Animation off (Run 9) |
+|---|---|---|
+| Hitches per click | 316 ms | 256 ms |
+| Hangs | 5 | 20 |
+| Hang share of recording | 83 % | 51 % |
+
+Per-click hitch barely moved. Total main-thread blocked time even *increased* in absolute terms, with many Hangs covering windows where multiple clicks landed inside one block.
+
+The insight: **the spine-flow animation is the perceptual jank amplifier**, not the cause. When animation is running, every missed frame produces a visible "broken animation" artefact. When animation is off, the same amount of main-thread work just becomes a small response latency that the user reads as "instant click registered, slight delay before redraw" rather than "jank".
+
+Without further structural rewrites (e.g. lazy-rendered spines, single-`ForEach` layout to drop `matchedGeometryEffect`, or rendering spines with `Canvas` instead of one `View` each), the per-click work appears to be roughly constant.
+
+### 7. Final decision — Option C
+
+Restore everything that didn't have a measurable win:
+
+- `.id(worktree.id)` back, focus logic back in `.onAppear`, Phase-2-only `onChange` path removed
+- Animation back to `.easeInOut(duration: 0.2)`
+
+Keep what is unambiguously good:
+
+- All four P0/P1 fixes
+- The `OSSignposter` toolkit on `SupaLogger` (`PointsOfInterest` category for stock-instrument visibility)
+- Body counters and lifecycle signposts as long-term observability — they cost nothing when no Instruments session is attached
+
+Net commits on `perf/shelf-jank-fixes`:
+
+- `0fe682cb` perf(shelf): cut sidebar tab-count subscription storm and add signposts
+- `c9b852eb` chore(shelf): add long-term performance signposts
+
+## What Worked vs What Didn't
+
+| Change | Cost | Outcome |
+|---|---|---|
+| **P0-1**: leaf view for sidebar tab count | ~30 lines | RepositorySectionView body invocations −92 %, killed the Severe Hang completely. **Kept.** |
+| **P0-2**: rewrite `orderedShelfBooks()` | ~20 lines | Eliminated per-frame Dict/Set allocations on the ShelfView hot path. **Kept.** |
+| **P1-1**: drop redundant action animation | 4 line touch | Removed double-animation transactions. Marginal but free. **Kept.** |
+| `OSSignposter` toolkit + signposts | ~80 lines, multiple files | Made every subsequent investigation tractable. **Kept.** |
+| Phase 2: remove `.id(worktree.id)` | ~30 lines | No measurable perf gain; lost `.transition(.opacity)`. **Reverted.** |
+| Animation duration 0.2 s → 0.1 s | 1 line | Hitch per click 285 → 244 ms (−14 %). Not enough to justify UX change. **Reverted.** |
+| Animation off entirely | 1 line | Felt smooth but trace showed work was unchanged. UX trade-off not worth perceptual-only win. **Reverted.** |
+
+## Methodology and Tooling Learned
+
+### `xctrace` from the command line
+
+`/usr/bin/xctrace` is a stub; the real tool ships inside Xcode at `/Applications/Xcode-26.4.1.app/Contents/Developer/usr/bin/xctrace`. Trying to inspect a trace recorded by Xcode 26.x with the system stub produces `Cannot load existing document because of an error: Missing features` — silent and confusing. Always use the Xcode-bundled binary:
+
+```bash
+XCT="/Applications/Xcode-26.4.1.app/Contents/Developer/usr/bin/xctrace"
+
+# Discover what data is in the trace
+"$XCT" export --input run.trace --toc --output toc.xml
+
+# Pull a specific schema
+"$XCT" export --input run.trace \
+  --xpath '/trace-toc/run[@number="1"]/data/table[@schema="potential-hangs"]' \
+  --output hangs.xml
+
+# Filter further by attribute (e.g. signposts under PointsOfInterest)
+"$XCT" export --input run.trace \
+  --xpath '/trace-toc/run[@number="1"]/data/table[@schema="os-signpost"][@category="PointsOfInterest"]' \
+  --output poi.xml
+```
+
+Useful schemas that consistently held data:
+
+- `potential-hangs` — main-thread block intervals with hang-type classification
+- `hitches` — per-frame hitch events, often with a narrative description
+- `os-signpost` — Begin/End/Event records, one table per attribute filter
+- `swiftui-causes` — view dependency graph edges, the most useful single source for finding invalidation storms
+- `swiftui-update-groups` — SwiftUI-internal update transactions with duration
+
+The XML export uses an aggressive `id`/`ref` interning pattern. To aggregate counts you must build a per-trace `id → label` table from the first definition and then resolve refs. A simple Python script walks the rows in a single pass; the bigger files (1 GB+ for `swiftui-updates` on a 25 s recording) needed buffered streaming.
+
+### Animation Hitches template's signpost filter is hard-coded
+
+The stock Animation Hitches template includes an `os_signpost` instrument, but it's filtered to `subsystem == "com.apple.ConditionInducer.LowSeverity"` — i.e. only Apple's internal conditioning signposts. Our subsystem (`com.onevcat.prowl`) is not captured by default. Two ways to make app signposts visible in this template:
+
+1. Add a generic `os_signpost` instrument to the trace document and configure it manually (subsystem filter or empty).
+2. **Use the well-known `"PointsOfInterest"` category** for the signposter. The stock **Points of Interest** instrument is hard-coded to that category and shows app signposts without further configuration. This is what `SupaLogger` does now.
+
+We learned (1) the hard way in Run 3 and (2) when Run 4's "Points of Interest" lane stayed empty even with our signposts emitted.
+
+### Hangs vs Hitches
+
+These are not the same thing and Animation Hitches reports them in two different lanes:
+
+- A **Hang** is a contiguous main-thread block longer than the configured threshold (default 33 ms; surfaces as Microhang, Hang, or Severe Hang). Stack traces are sometimes attached.
+- A **Hitch** is one or more consecutive frames missing vsync. Multiple frames missed in a row collapse into one hitch event with a longer duration. Hitches do not require the main thread to be blocked — GPU / render-server / commit-phase issues all surface as hitches.
+
+A trace can have many Hitches and zero Hangs (frame production too slow to keep up with vsync but main thread always yielding within 33 ms — exactly what Run 4 looked like). It can also have many Hangs and very visible jank. The two metrics measure different aspects of "slow" and need to be read together.
+
+### Signpost begin/end with `inout` state
+
+`SupaLogger.interval(_:_:)` takes a closure, but TCA reducer cases bind `state` as `inout` and Swift cannot capture `inout` parameters in a non-escaping closure. The workaround is a manual `beginInterval` / `endInterval` token API:
+
+```swift
+case .selectWorktree(let id, let focusTerminal):
+  let token = repositoriesLogger.beginInterval("reducer.selectWorktree")
+  defer { repositoriesLogger.endInterval(token) }
+  // ... mutate state directly ...
+```
+
+The token wraps `OSSignpostIntervalState` so callers don't need to import `OSLog` themselves.
+
+### Signpost inside SwiftUI `body`
+
+`var body: some View` is implicitly `@ViewBuilder` and rejects `defer`. To count body invocations, an `Event` signpost via a discarded `let _ =` works:
+
+```swift
+var body: some View {
+  let _ = shelfLogger.event("ShelfView.body")
+  // ... view tree ...
+}
+```
+
+Body intervals (Begin/End) are not directly representable this way; use the SwiftUI instrument's "View Body" track instead when you need duration.
+
+### `OSSignposter.emitEvent` doesn't always show up in `xctrace export`
+
+In our traces, `Begin` and `End` rows from `interval(_:)` consistently appeared, but `emitEvent` (point signposts) sometimes didn't show in the exported `os-signpost` table even though they were visible in the Instruments UI. Worth knowing if a signpost count looks low — verify in the UI before assuming the call site didn't fire.
+
+## Conclusions
+
+1. **The single biggest win was finding the observability storm in `RepositorySectionView`**. Static analysis spotted the suspicious read; `swiftui-causes` confirmed it; the leaf-view fix dropped it ~92 % and eliminated the Severe Hang. This is what to look for first when SwiftUI feels uniformly slow under any state change.
+
+2. **`@Observable` types must be subscribed to with care.** Reading any property of an `@Observable` instance inside a parent `body` subscribes that body to *every change* on that property — and properties of type `Dictionary<…>` or `Set<…>` change on every insert / remove / mutate. For values that change frequently, push the read down into a leaf view that only renders that one value. The leaf still re-renders frequently, but the parent (and its other children) doesn't.
+
+3. **Animation amplifies perceived jank far beyond its actual contribution to work.** The same ~250 ms of main-thread work feels broken when an animation is running through it and feels merely "slightly slow" when it isn't. Removing animation can be the right product call even when the trace numbers don't shift.
+
+4. **`.id(viewIdentity)` is not free.** Even when our own `makeNSView` body is fast, the SwiftUI bookkeeping around full subtree teardown (attribute graph, preferences, accessibility, transition orchestration) is real. But removing it may not yield measurable perf if there's another `.id` deeper in the tree forcing the same work — read the layout of `.id` modifiers across the whole subtree before assuming a removal will help.
+
+5. **Signposts pay for themselves on the second investigation.** They cost nothing when no Instruments session is attached and let us collapse 30 minutes of guess-and-trace into a single targeted measurement. Worth keeping permanently around hot paths.
+
+## Open Questions / Future Work
+
+If we ever decide to attack the residual ~250 ms-per-click cost (probably only worthwhile if user feedback escalates):
+
+- **Lazy-render spines**. We always render every spine even when many are off-screen. A `ScrollView` + `LazyHStack` could cap the work to the visible window.
+- **Single-`ForEach` Shelf layout**. Drop the cross-`ForEach` `matchedGeometryEffect` by laying out spines in one list and overlaying / inline-expanding the open book area at the right index. SwiftUI's normal list-diff would handle spine flow without identity reconciliation across two lists.
+- **`Canvas`-rendered spines**. Each spine is currently a `View` subtree with `Button`s, `ScrollView`, `.contextMenu`, `.help` etc. Cumulatively across ~10 spines this is a lot of view-tree work per click. A custom `Canvas`-based spine could cut SwiftUI's per-spine overhead by an order of magnitude — at the cost of having to reimplement hover, hit-testing, accessibility manually.
+- **Eliminate the inner `.id(node.structuralIdentity)`**. We never tested this. It might let the surface wrappers be reused across compatible split-tree shapes, but `GhosttySurfaceScrollView.surfaceView` is `let` so we'd have to make it mutable and audit all attach/detach lifecycle paths first.
+
+None of these are obviously worth doing today.
+
+## Long-Term Observability Hooks
+
+After this investigation the following signposts are permanently emitted to the `com.onevcat.prowl` subsystem under the `PointsOfInterest` category. They are visible in Instruments by adding the stock **Points of Interest** instrument to any trace:
+
+- Reducer paths: `reducer.selectWorktree`, `reducer.selectRepository` (intervals)
+- Terminal lifecycle: `Ghostty.makeNSView`, `Ghostty.updateNSView` (intervals); `Ghostty.dismantleNSView` (event)
+- Shelf focus / sync: `OpenBook.onAppear`, `OpenBook.onChange.selectedTabId`, `focusSelectedTab`, `syncFocus`, `applySurfaceActivity` (intervals); `OpenBook.onDisappear` (event)
+- View invalidation counters: `ShelfView.body`, `ShelfSpineView.body` (events)
+- User-input markers: `BookClick.SwitchBook`, `BookClick.TabSwitchSameBook`, `BookClick.NewTabSpine` (events)
+
+For future Shelf perf debugging the recommended starting workflow is:
+
+1. Record with Animation Hitches template
+2. Add the **Points of Interest** instrument to the document (one click)
+3. Reproduce the workload
+4. In the timeline, line up Hitches / Hangs against the Points of Interest lane to see which named work is on the critical path

--- a/supacode/App/CommandKeyObserver.swift
+++ b/supacode/App/CommandKeyObserver.swift
@@ -50,7 +50,8 @@ final class CommandKeyObserver {
   }
 
   nonisolated static func shouldShowShortcuts(for modifierFlags: NSEvent.ModifierFlags) -> Bool {
-    modifierFlags.contains(.command) || modifierFlags.contains(.control)
+    let modifiers = modifierFlags.intersection(.deviceIndependentFlagsMask)
+    return modifiers == .command || modifiers == .control
   }
 
   private func handleCommandKeyChange(isDown: Bool) {

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -10,6 +10,7 @@ nonisolated let worktreeCreationProgressLineLimit = 200
 nonisolated let worktreeCreationProgressUpdateStride = 20
 nonisolated let archiveScriptProgressLineLimit = 200
 private let secondsPerDay: Double = 86_400
+private let repositoriesLogger = SupaLogger("RepositoriesFeature")
 
 nonisolated struct WorktreeCreationProgressUpdateThrottle {
   private let stride: Int
@@ -792,6 +793,10 @@ struct RepositoriesFeature {
           return .none
 
         case .selectRepository(let repositoryID):
+          // `inout state` cannot be captured by a closure, so use the
+          // begin/end token API rather than the `interval` helper.
+          let selectRepoToken = repositoriesLogger.beginInterval("reducer.selectRepository")
+          defer { repositoriesLogger.endInterval(selectRepoToken) }
           guard let repositoryID, state.repositories[id: repositoryID] != nil else { return .none }
           state.selection = .repository(repositoryID)
           state.sidebarSelectedWorktreeIDs = []
@@ -802,6 +807,8 @@ struct RepositoriesFeature {
           return .send(.delegate(.selectedWorktreeChanged(state.selectedTerminalWorktree)))
 
         case .selectWorktree(let worktreeID, let focusTerminal):
+          let selectWtToken = repositoriesLogger.beginInterval("reducer.selectWorktree")
+          defer { repositoriesLogger.endInterval(selectWtToken) }
           setSingleWorktreeSelection(worktreeID, state: &state)
           if focusTerminal, let worktreeID {
             state.pendingTerminalFocusWorktreeIDs.insert(worktreeID)

--- a/supacode/Features/Repositories/Views/RepoHeaderRow.swift
+++ b/supacode/Features/Repositories/Views/RepoHeaderRow.swift
@@ -4,7 +4,6 @@ struct RepoHeaderRow: View {
   private static let debugHeaderLayers = false
   let name: String
   let isRemoving: Bool
-  let tabCount: Int
   /// User-pinned icon, when set. Renders before the repo name.
   /// `nil` keeps the historical text-only layout intact.
   let icon: RepositoryIconSource?
@@ -34,16 +33,6 @@ struct RepoHeaderRow: View {
           .font(.caption)
           .foregroundStyle(.tertiary)
       }
-      if tabCount > 0 {
-        Text("\(tabCount)")
-          .font(.caption2)
-          .monospacedDigit()
-          .foregroundStyle(.secondary)
-          .padding(.horizontal, 5)
-          .padding(.vertical, 1)
-          .background(.quaternary, in: .capsule)
-          .help("\(tabCount) active \(tabCount == 1 ? "tab" : "tabs")")
-      }
     }
     .background {
       if Self.debugHeaderLayers {
@@ -58,6 +47,37 @@ struct RepoHeaderRow: View {
   }
 }
 
+/// Leaf view that renders the open-tab count badge for a repository.
+///
+/// Lives in its own `View` so the read of `terminalManager` (an
+/// `@Observable` whose `states` dictionary churns whenever terminal
+/// activity happens) is isolated to this subtree. Without this split,
+/// `RepositorySectionView.body` would subscribe to every change in
+/// `terminalManager.states` on every re-evaluation — which under heavy
+/// terminal activity caused tens of thousands of body invocations per
+/// second across the sidebar.
+struct RepoHeaderTabCountBadge: View {
+  let repository: Repository
+  let terminalManager: WorktreeTerminalManager
+
+  var body: some View {
+    let count = RepositorySectionView.openTabCount(
+      for: repository,
+      terminalManager: terminalManager
+    )
+    if count > 0 {
+      Text("\(count)")
+        .font(.caption2)
+        .monospacedDigit()
+        .foregroundStyle(.secondary)
+        .padding(.horizontal, 5)
+        .padding(.vertical, 1)
+        .background(.quaternary, in: .capsule)
+        .help("\(count) active \(count == 1 ? "tab" : "tabs")")
+    }
+  }
+}
+
 // MARK: - Previews
 
 #Preview("RepoHeaderRow") {
@@ -65,7 +85,6 @@ struct RepoHeaderRow: View {
     RepoHeaderRow(
       name: "supacode",
       isRemoving: false,
-      tabCount: 3,
       icon: nil,
       iconTint: nil,
       repositoryRootURL: nil
@@ -73,7 +92,6 @@ struct RepoHeaderRow: View {
     RepoHeaderRow(
       name: "ghostty",
       isRemoving: false,
-      tabCount: 0,
       icon: .sfSymbol("folder.fill"),
       iconTint: .blue,
       repositoryRootURL: URL(fileURLWithPath: "/tmp/ghostty")
@@ -81,7 +99,6 @@ struct RepoHeaderRow: View {
     RepoHeaderRow(
       name: "removing-repo",
       isRemoving: true,
-      tabCount: 1,
       icon: .sfSymbol("hammer.fill"),
       iconTint: .orange,
       repositoryRootURL: URL(fileURLWithPath: "/tmp/removing")

--- a/supacode/Features/Repositories/Views/RepositorySectionView.swift
+++ b/supacode/Features/Repositories/Views/RepositorySectionView.swift
@@ -38,20 +38,27 @@ struct RepositorySectionView: View {
 
     let appearance = repositoryAppearances[repository.id] ?? .empty
     let header = HStack {
-      RepoHeaderRow(
-        name: repository.name,
-        isRemoving: isRemovingRepository,
-        tabCount: Self.openTabCount(
-          for: repository,
+      // Inner HStack groups the name row and the tab-count badge so they
+      // share the leading-aligned region of the outer header. Crucially
+      // the badge is its own leaf view (`RepoHeaderTabCountBadge`) — it
+      // owns the `terminalManager` read so this view never subscribes
+      // to the manager-wide states dictionary.
+      HStack {
+        RepoHeaderRow(
+          name: repository.name,
+          isRemoving: isRemovingRepository,
+          icon: appearance.icon,
+          iconTint: appearance.color?.color,
+          repositoryRootURL: repository.rootURL,
+          nameTooltip: repository.capabilities.supportsWorktrees
+            ? (isExpanded ? "Collapse" : "Expand")
+            : "Open terminal in folder"
+        )
+        RepoHeaderTabCountBadge(
+          repository: repository,
           terminalManager: terminalManager
-        ),
-        icon: appearance.icon,
-        iconTint: appearance.color?.color,
-        repositoryRootURL: repository.rootURL,
-        nameTooltip: repository.capabilities.supportsWorktrees
-          ? (isExpanded ? "Collapse" : "Expand")
-          : "Open terminal in folder"
-      )
+        )
+      }
       .frame(maxWidth: .infinity, alignment: .leading)
       .background {
         if Self.debugHeaderLayers {

--- a/supacode/Features/Repositories/Views/SidebarListView.swift
+++ b/supacode/Features/Repositories/Views/SidebarListView.swift
@@ -78,7 +78,9 @@ struct SidebarListView: View {
           return
         }
         sidebarSelections = Set(worktreeIDs.map(SidebarSelection.worktree))
-        if let selectedWorktreeID = state.selectedWorktreeID, worktreeIDs.contains(selectedWorktreeID) {
+        if let selectedWorktreeID = state.selectedWorktreeID,
+          worktreeIDs.contains(selectedWorktreeID)
+        {
           return
         }
         let nextPrimarySelection =
@@ -210,28 +212,14 @@ struct SidebarListView: View {
         store.send(.repositoryManagement(.openRepositories(fileURLs)))
         return true
       }
-      .onKeyPress { keyPress in
-        guard !keyPress.characters.isEmpty else { return .ignored }
-        let isNavigationKey =
-          keyPress.key == .upArrow
-          || keyPress.key == .downArrow
-          || keyPress.key == .leftArrow
-          || keyPress.key == .rightArrow
-          || keyPress.key == .home
-          || keyPress.key == .end
-          || keyPress.key == .pageUp
-          || keyPress.key == .pageDown
-        if isNavigationKey { return .ignored }
-        let hasCommandModifier = keyPress.modifiers.contains(.command)
-        if hasCommandModifier { return .ignored }
-        guard let worktreeID = store.selectedWorktreeID,
-          state.sidebarSelectedWorktreeIDs.count == 1,
-          state.sidebarSelectedWorktreeIDs.contains(worktreeID),
-          let terminalState = terminalManager.stateIfExists(for: worktreeID)
-        else { return .ignored }
-        terminalState.focusAndInsertText(keyPress.characters)
-        return .handled
-      }
+      .modifier(
+        SidebarKeyForwardingModifier(
+          isEnabled: !state.isShelfActive,
+          selectedWorktreeID: state.selectedWorktreeID,
+          sidebarSelectedWorktreeIDs: state.sidebarSelectedWorktreeIDs,
+          terminalManager: terminalManager
+        )
+      )
       .focused($isSidebarFocused)
       .task(id: pendingSidebarReveal?.id) {
         await revealPendingSidebarWorktree(pendingSidebarReveal, with: scrollProxy)
@@ -253,6 +241,48 @@ struct SidebarListView: View {
       scrollProxy.scrollTo(pendingSidebarReveal.worktreeID, anchor: .center)
     }
     store.send(.consumePendingSidebarReveal(pendingSidebarReveal.id))
+  }
+}
+
+private struct SidebarKeyForwardingModifier: ViewModifier {
+  let isEnabled: Bool
+  let selectedWorktreeID: Worktree.ID?
+  let sidebarSelectedWorktreeIDs: Set<Worktree.ID>
+  let terminalManager: WorktreeTerminalManager
+
+  @ViewBuilder
+  func body(content: Content) -> some View {
+    if isEnabled {
+      content
+        .onKeyPress { keyPress in
+          handleKeyPress(keyPress)
+        }
+    } else {
+      content
+    }
+  }
+
+  private func handleKeyPress(_ keyPress: KeyPress) -> KeyPress.Result {
+    guard !keyPress.characters.isEmpty else { return .ignored }
+    let isNavigationKey =
+      keyPress.key == .upArrow
+      || keyPress.key == .downArrow
+      || keyPress.key == .leftArrow
+      || keyPress.key == .rightArrow
+      || keyPress.key == .home
+      || keyPress.key == .end
+      || keyPress.key == .pageUp
+      || keyPress.key == .pageDown
+    if isNavigationKey { return .ignored }
+    let hasCommandModifier = keyPress.modifiers.contains(.command)
+    if hasCommandModifier { return .ignored }
+    guard let worktreeID = selectedWorktreeID,
+      sidebarSelectedWorktreeIDs.count == 1,
+      sidebarSelectedWorktreeIDs.contains(worktreeID),
+      let terminalState = terminalManager.stateIfExists(for: worktreeID)
+    else { return .ignored }
+    terminalState.focusAndInsertText(keyPress.characters)
+    return .handled
   }
 }
 

--- a/supacode/Features/Shelf/Models/ShelfBook.swift
+++ b/supacode/Features/Shelf/Models/ShelfBook.swift
@@ -1,4 +1,5 @@
 import Foundation
+import IdentifiedCollections
 
 /// A book on the Shelf — the unified abstraction over a Git worktree or
 /// a plain folder repository.
@@ -38,10 +39,18 @@ extension RepositoriesFeature.State {
   /// while in Shelf mode adds its ID here, which causes its spine to
   /// materialize (with the standard spine-flow animation).
   func orderedShelfBooks() -> [ShelfBook] {
-    let repositoriesByID = Dictionary(uniqueKeysWithValues: repositories.map { ($0.id, $0) })
+    // `ShelfView.body` re-runs on every TCA state change, so this method
+    // is on the per-frame hot path. The previous implementation built a
+    // `Dictionary(uniqueKeysWithValues:)` per call and routed worktree
+    // ordering through `worktreeRowSections(in:)` — which constructs a
+    // full `WorktreeRowModel` per worktree (PR/info lookups, icon
+    // resolution, etc.) plus several intermediate `Set` allocations per
+    // repository. None of that detail is needed by the Shelf, which only
+    // consumes id/name/branch. Use direct `IdentifiedArray` lookup and
+    // `orderedWorktrees(in:)` for the lighter ordering path.
     var books: [ShelfBook] = []
     for repositoryID in orderedRepositoryIDs() {
-      guard let repository = repositoriesByID[repositoryID] else { continue }
+      guard let repository = repositories[id: repositoryID] else { continue }
       if repository.kind == .plain {
         guard openedWorktreeIDs.contains(repository.id) else { continue }
         books.append(
@@ -55,15 +64,34 @@ extension RepositoriesFeature.State {
           ))
         continue
       }
-      for row in worktreeRows(in: repository) {
-        guard openedWorktreeIDs.contains(row.id) else { continue }
+      for worktree in orderedWorktrees(in: repository)
+      where openedWorktreeIDs.contains(worktree.id) {
         books.append(
           ShelfBook(
-            id: row.id,
+            id: worktree.id,
             repositoryID: repositoryID,
-            displayName: row.name,
+            displayName: worktree.name,
             projectName: repository.name,
-            branchName: row.name,
+            branchName: worktree.name,
+            kind: .worktree
+          ))
+      }
+      // Preserve prior behavior of `worktreeRowSections` which also
+      // surfaced any pending (in-creation) worktrees that had been
+      // marked opened. The list is typically empty so the cost is
+      // negligible — the win is avoiding `makePendingWorktreeRow` which
+      // builds a full `WorktreeRowModel` per entry.
+      for pending in pendingWorktrees
+      where pending.repositoryID == repositoryID
+        && openedWorktreeIDs.contains(pending.id)
+      {
+        books.append(
+          ShelfBook(
+            id: pending.id,
+            repositoryID: repositoryID,
+            displayName: pending.progress.titleText,
+            projectName: repository.name,
+            branchName: pending.progress.titleText,
             kind: .worktree
           ))
       }

--- a/supacode/Features/Shelf/Views/ShelfOpenBookView.swift
+++ b/supacode/Features/Shelf/Views/ShelfOpenBookView.swift
@@ -68,6 +68,13 @@ struct ShelfOpenBookView: View {
         state.syncFocus(windowIsKey: activity.isKeyWindow, windowIsVisible: activity.isVisible)
       }
     }
+    .onDisappear {
+      // Long-term diagnostic — pairs with `OpenBook.onAppear` so that
+      // any future regression in the per-book-switch teardown/remount
+      // cadence shows up as a count delta on the Points of Interest
+      // timeline.
+      shelfLogger.event("OpenBook.onDisappear")
+    }
     .onChange(of: state.tabManager.selectedTabId) { _, _ in
       shelfLogger.interval("OpenBook.onChange.selectedTabId") {
         if shouldAutoFocusTerminal {

--- a/supacode/Features/Shelf/Views/ShelfOpenBookView.swift
+++ b/supacode/Features/Shelf/Views/ShelfOpenBookView.swift
@@ -1,6 +1,8 @@
 import AppKit
 import SwiftUI
 
+private let shelfLogger = SupaLogger("Shelf")
+
 /// Renders the terminal content for the currently open book.
 ///
 /// Mirrors the terminal-content slice of `WorktreeTerminalTabsView` without
@@ -57,19 +59,23 @@ struct ShelfOpenBookView: View {
       }
     )
     .onAppear {
-      state.ensureInitialTab(focusing: false)
-      if shouldAutoFocusTerminal {
-        state.focusSelectedTab()
+      shelfLogger.interval("OpenBook.onAppear") {
+        state.ensureInitialTab(focusing: false)
+        if shouldAutoFocusTerminal {
+          state.focusSelectedTab()
+        }
+        let activity = resolvedWindowActivity
+        state.syncFocus(windowIsKey: activity.isKeyWindow, windowIsVisible: activity.isVisible)
       }
-      let activity = resolvedWindowActivity
-      state.syncFocus(windowIsKey: activity.isKeyWindow, windowIsVisible: activity.isVisible)
     }
     .onChange(of: state.tabManager.selectedTabId) { _, _ in
-      if shouldAutoFocusTerminal {
-        state.focusSelectedTab()
+      shelfLogger.interval("OpenBook.onChange.selectedTabId") {
+        if shouldAutoFocusTerminal {
+          state.focusSelectedTab()
+        }
+        let activity = resolvedWindowActivity
+        state.syncFocus(windowIsKey: activity.isKeyWindow, windowIsVisible: activity.isVisible)
       }
-      let activity = resolvedWindowActivity
-      state.syncFocus(windowIsKey: activity.isKeyWindow, windowIsVisible: activity.isVisible)
     }
   }
 

--- a/supacode/Features/Shelf/Views/ShelfSpineView.swift
+++ b/supacode/Features/Shelf/Views/ShelfSpineView.swift
@@ -1,6 +1,8 @@
 import Sharing
 import SwiftUI
 
+private let shelfLogger = SupaLogger("Shelf")
+
 /// Vertical spine rendering for a single book on the Shelf.
 ///
 /// Phase 3 scope: header with book-level notification dot, a vertical
@@ -42,6 +44,12 @@ struct ShelfSpineView: View {
   @Environment(GhosttyShortcutManager.self) private var ghosttyShortcuts
 
   var body: some View {
+    // Body-invocation counter signpost. With ~10 spines visible during
+    // a book switch, the trace can multiply this event count by spine
+    // count to estimate per-click body work. Emitted as a no-arg event
+    // (instant timeline marker) so it imposes no work even when
+    // Instruments isn't attached.
+    let _ = shelfLogger.event("ShelfSpineView.body")
     VStack(spacing: 0) {
       headerButton
       tabList

--- a/supacode/Features/Shelf/Views/ShelfView.swift
+++ b/supacode/Features/Shelf/Views/ShelfView.swift
@@ -29,10 +29,12 @@ struct ShelfView: View {
   @Environment(\.surfaceBackgroundOpacity) private var surfaceBackgroundOpacity
 
   var body: some View {
-    // Note: `body` is a `@ViewBuilder` getter so we can't add a
-    // `defer`-based signpost interval directly here. Body-level cost is
-    // already visible via the SwiftUI instrument's "View Body" track —
-    // signposts in this file focus on user-input moments instead.
+    // Body-invocation counter. The @ViewBuilder getter rules out a
+    // `defer`-based interval, but a fire-and-forget event marker is a
+    // simple expression and has no impact on the rendered tree. Each
+    // marker corresponds to one full body re-evaluation — useful for
+    // sanity-checking how often the root re-renders during animation.
+    let _ = shelfLogger.event("ShelfView.body")
     let state = store.state
     let books = state.orderedShelfBooks()
     let openBookID = state.openShelfBookID

--- a/supacode/Features/Shelf/Views/ShelfView.swift
+++ b/supacode/Features/Shelf/Views/ShelfView.swift
@@ -42,7 +42,6 @@ struct ShelfView: View {
         spine(book: book, index: index, openIndex: openIndex)
         if book.id == openBookID {
           openBookArea(for: book, state: state)
-            .transition(.opacity)
         }
       }
       if openBookID == nil {

--- a/supacode/Features/Shelf/Views/ShelfView.swift
+++ b/supacode/Features/Shelf/Views/ShelfView.swift
@@ -37,45 +37,25 @@ struct ShelfView: View {
       books.firstIndex(where: { $0.id == id })
     }
 
-    ZStack(alignment: .leading) {
-      spineFlow(books: books, openBookID: openBookID, openIndex: openIndex)
-      openBookOverlay(books: books, openIndex: openIndex, state: state)
-    }
-    .frame(maxWidth: .infinity, maxHeight: .infinity)
-    .background(Color(nsColor: .windowBackgroundColor).opacity(surfaceBackgroundOpacity))
-  }
-
-  @ViewBuilder
-  private func spineFlow(books: [ShelfBook], openBookID: ShelfBook.ID?, openIndex: Int?)
-    -> some View
-  {
     HStack(spacing: 0) {
       ForEach(Array(books.enumerated()), id: \.element.id) { index, book in
         spine(book: book, index: index, openIndex: openIndex)
         if book.id == openBookID {
-          terminalPlaceholder()
+          openBookArea(for: book, state: state)
+            .transition(.opacity)
         }
       }
       if openBookID == nil {
-        terminalPlaceholder()
+        emptyOpenArea()
       }
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .background(Color(nsColor: .windowBackgroundColor).opacity(surfaceBackgroundOpacity))
     // Animate on every openBookID change — covers both Shelf-originated
     // book switches (which also set their own TCA animation) and
     // left-nav-originated switches, so the spine flow is consistent
-    // regardless of entry point. The real terminal is rendered in a
-    // non-layout overlay, so this animation only moves spines and the
-    // lightweight placeholder.
+    // regardless of entry point.
     .animation(.easeInOut(duration: 0.2), value: openBookID)
-  }
-
-  @ViewBuilder
-  private func terminalPlaceholder() -> some View {
-    Color.clear
-      .frame(maxWidth: .infinity, maxHeight: .infinity)
-      .layoutPriority(1)
-      .accessibilityHidden(true)
   }
 
   @ViewBuilder
@@ -105,46 +85,6 @@ struct ShelfView: View {
         store.send(.repositoryManagement(.openRepositorySettings(book.repositoryID)))
       }
     )
-  }
-
-  @ViewBuilder
-  private func openBookOverlay(
-    books: [ShelfBook], openIndex: Int?, state: RepositoriesFeature.State
-  ) -> some View {
-    GeometryReader { proxy in
-      let frame = openBookOverlayFrame(in: proxy.size, bookCount: books.count, openIndex: openIndex)
-      openBookOverlayContent(books: books, openIndex: openIndex, state: state)
-        .frame(width: frame.width, height: proxy.size.height)
-        .clipped()
-        .offset(x: frame.minX)
-    }
-  }
-
-  private func openBookOverlayFrame(in size: CGSize, bookCount: Int, openIndex: Int?) -> (
-    minX: CGFloat, width: CGFloat
-  ) {
-    let leftSpineCount = openIndex.map { $0 + 1 } ?? bookCount
-    let rightSpineCount = openIndex.map { bookCount - $0 - 1 } ?? 0
-    let minX = CGFloat(leftSpineCount) * ShelfMetrics.spineWidth
-    let occupiedWidth = CGFloat(leftSpineCount + rightSpineCount) * ShelfMetrics.spineWidth
-    return (minX, max(0, size.width - occupiedWidth))
-  }
-
-  @ViewBuilder
-  private func openBookOverlayContent(
-    books: [ShelfBook],
-    openIndex: Int?,
-    state: RepositoriesFeature.State
-  ) -> some View {
-    if let openIndex {
-      openBookArea(for: books[openIndex], state: state)
-        .id(books[openIndex].id)
-        .transition(.opacity.animation(.easeInOut(duration: 0.12)))
-    } else {
-      emptyOpenArea()
-        .id("__empty__")
-        .transition(.opacity.animation(.easeInOut(duration: 0.12)))
-    }
   }
 
   /// Dispatch the open-book action only when `book` isn't already the open

--- a/supacode/Features/Shelf/Views/ShelfView.swift
+++ b/supacode/Features/Shelf/Views/ShelfView.swift
@@ -16,11 +16,6 @@ struct ShelfView: View {
   let terminalManager: WorktreeTerminalManager
   let createTab: () -> Void
 
-  /// Shared namespace so each spine's `matchedGeometryEffect` can bridge
-  /// the left-stack ForEach and the right-stack ForEach without breaking
-  /// visual identity while it moves between them.
-  @Namespace private var spineNamespace
-
   /// Mirrors the Ghostty `background-opacity` setting so the Shelf can
   /// honor the same window transparency as normal view mode. A previous
   /// plain `.background(.background)` defeated transparency entirely by
@@ -43,20 +38,14 @@ struct ShelfView: View {
     }
 
     HStack(spacing: 0) {
-      if let openIndex {
-        spineStack(books: Array(books[0...openIndex]), openIndex: openIndex, baseOffset: 0)
-        openBookArea(for: books[openIndex], state: state)
-          .transition(.opacity)
-        let rightStart = openIndex + 1
-        if rightStart < books.count {
-          spineStack(
-            books: Array(books[rightStart..<books.count]),
-            openIndex: openIndex,
-            baseOffset: rightStart
-          )
+      ForEach(Array(books.enumerated()), id: \.element.id) { index, book in
+        spine(book: book, index: index, openIndex: openIndex)
+        if book.id == openBookID {
+          openBookArea(for: book, state: state)
+            .transition(.opacity)
         }
-      } else {
-        spineStack(books: books, openIndex: nil, baseOffset: 0)
+      }
+      if openBookID == nil {
         emptyOpenArea()
       }
     }
@@ -69,42 +58,33 @@ struct ShelfView: View {
     .animation(.easeInOut(duration: 0.2), value: openBookID)
   }
 
-  /// `baseOffset` is the index of `books.first` within the full ordered
-  /// list, so we can reconstruct each spine's global index and compute
-  /// its distance to `openIndex` without re-scanning the full list.
   @ViewBuilder
-  private func spineStack(books: [ShelfBook], openIndex: Int?, baseOffset: Int) -> some View {
-    HStack(spacing: 0) {
-      ForEach(Array(books.enumerated()), id: \.element.id) { localIndex, book in
-        let globalIndex = baseOffset + localIndex
-        let distance = openIndex.map { abs(globalIndex - $0) }
-        let open = globalIndex == openIndex
-        ShelfSpineView(
-          book: book,
-          isOpen: open,
-          distanceFromOpen: distance,
-          terminalState: terminalManager.stateIfExists(for: book.id),
-          onOpenBook: { openBook(book, selectingTab: nil) },
-          onSelectTab: { tabID in openBook(book, selectingTab: tabID) },
-          onNewTab: {
-            // On a closed spine, `+` doubles as "pull this book out and
-            // start a fresh tab". Sequencing is fine because TCA runs
-            // reducers synchronously — `newTerminal` will observe the
-            // new `selectedTerminalWorktree` set by `selectWorktree`.
-            switchToBookIfNeeded(book)
-            createTab()
-          },
-          onSplitVertical: open ? { performSplit(direction: "new_split:right") } : nil,
-          onSplitHorizontal: open ? { performSplit(direction: "new_split:down") } : nil,
-          closeMenuTitle: closeMenuTitle(for: book),
-          onCloseBook: { closeBook(book) },
-          onOpenRepositorySettings: {
-            store.send(.repositoryManagement(.openRepositorySettings(book.repositoryID)))
-          }
-        )
-        .matchedGeometryEffect(id: book.id, in: spineNamespace)
+  private func spine(book: ShelfBook, index: Int, openIndex: Int?) -> some View {
+    let distance = openIndex.map { abs(index - $0) }
+    let open = index == openIndex
+    ShelfSpineView(
+      book: book,
+      isOpen: open,
+      distanceFromOpen: distance,
+      terminalState: terminalManager.stateIfExists(for: book.id),
+      onOpenBook: { openBook(book, selectingTab: nil) },
+      onSelectTab: { tabID in openBook(book, selectingTab: tabID) },
+      onNewTab: {
+        // On a closed spine, `+` doubles as "pull this book out and
+        // start a fresh tab". Sequencing is fine because TCA runs
+        // reducers synchronously — `newTerminal` will observe the
+        // new `selectedTerminalWorktree` set by `selectWorktree`.
+        switchToBookIfNeeded(book)
+        createTab()
+      },
+      onSplitVertical: open ? { performSplit(direction: "new_split:right") } : nil,
+      onSplitHorizontal: open ? { performSplit(direction: "new_split:down") } : nil,
+      closeMenuTitle: closeMenuTitle(for: book),
+      onCloseBook: { closeBook(book) },
+      onOpenRepositorySettings: {
+        store.send(.repositoryManagement(.openRepositorySettings(book.repositoryID)))
       }
-    }
+    )
   }
 
   /// Dispatch the open-book action only when `book` isn't already the open

--- a/supacode/Features/Shelf/Views/ShelfView.swift
+++ b/supacode/Features/Shelf/Views/ShelfView.swift
@@ -37,25 +37,45 @@ struct ShelfView: View {
       books.firstIndex(where: { $0.id == id })
     }
 
+    ZStack(alignment: .leading) {
+      spineFlow(books: books, openBookID: openBookID, openIndex: openIndex)
+      openBookOverlay(books: books, openIndex: openIndex, state: state)
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .background(Color(nsColor: .windowBackgroundColor).opacity(surfaceBackgroundOpacity))
+  }
+
+  @ViewBuilder
+  private func spineFlow(books: [ShelfBook], openBookID: ShelfBook.ID?, openIndex: Int?)
+    -> some View
+  {
     HStack(spacing: 0) {
       ForEach(Array(books.enumerated()), id: \.element.id) { index, book in
         spine(book: book, index: index, openIndex: openIndex)
         if book.id == openBookID {
-          openBookArea(for: book, state: state)
-            .transition(.opacity)
+          terminalPlaceholder()
         }
       }
       if openBookID == nil {
-        emptyOpenArea()
+        terminalPlaceholder()
       }
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)
-    .background(Color(nsColor: .windowBackgroundColor).opacity(surfaceBackgroundOpacity))
     // Animate on every openBookID change — covers both Shelf-originated
     // book switches (which also set their own TCA animation) and
     // left-nav-originated switches, so the spine flow is consistent
-    // regardless of entry point.
+    // regardless of entry point. The real terminal is rendered in a
+    // non-layout overlay, so this animation only moves spines and the
+    // lightweight placeholder.
     .animation(.easeInOut(duration: 0.2), value: openBookID)
+  }
+
+  @ViewBuilder
+  private func terminalPlaceholder() -> some View {
+    Color.clear
+      .frame(maxWidth: .infinity, maxHeight: .infinity)
+      .layoutPriority(1)
+      .accessibilityHidden(true)
   }
 
   @ViewBuilder
@@ -85,6 +105,46 @@ struct ShelfView: View {
         store.send(.repositoryManagement(.openRepositorySettings(book.repositoryID)))
       }
     )
+  }
+
+  @ViewBuilder
+  private func openBookOverlay(
+    books: [ShelfBook], openIndex: Int?, state: RepositoriesFeature.State
+  ) -> some View {
+    GeometryReader { proxy in
+      let frame = openBookOverlayFrame(in: proxy.size, bookCount: books.count, openIndex: openIndex)
+      openBookOverlayContent(books: books, openIndex: openIndex, state: state)
+        .frame(width: frame.width, height: proxy.size.height)
+        .clipped()
+        .offset(x: frame.minX)
+    }
+  }
+
+  private func openBookOverlayFrame(in size: CGSize, bookCount: Int, openIndex: Int?) -> (
+    minX: CGFloat, width: CGFloat
+  ) {
+    let leftSpineCount = openIndex.map { $0 + 1 } ?? bookCount
+    let rightSpineCount = openIndex.map { bookCount - $0 - 1 } ?? 0
+    let minX = CGFloat(leftSpineCount) * ShelfMetrics.spineWidth
+    let occupiedWidth = CGFloat(leftSpineCount + rightSpineCount) * ShelfMetrics.spineWidth
+    return (minX, max(0, size.width - occupiedWidth))
+  }
+
+  @ViewBuilder
+  private func openBookOverlayContent(
+    books: [ShelfBook],
+    openIndex: Int?,
+    state: RepositoriesFeature.State
+  ) -> some View {
+    if let openIndex {
+      openBookArea(for: books[openIndex], state: state)
+        .id(books[openIndex].id)
+        .transition(.opacity.animation(.easeInOut(duration: 0.12)))
+    } else {
+      emptyOpenArea()
+        .id("__empty__")
+        .transition(.opacity.animation(.easeInOut(duration: 0.12)))
+    }
   }
 
   /// Dispatch the open-book action only when `book` isn't already the open

--- a/supacode/Features/Shelf/Views/ShelfView.swift
+++ b/supacode/Features/Shelf/Views/ShelfView.swift
@@ -44,55 +44,46 @@ struct ShelfView: View {
 
     HStack(spacing: 0) {
       if let openIndex {
-        spineStack(
-          books: Array(books[0...openIndex]),
-          openIndex: openIndex,
-          baseOffset: 0,
-          animationValue: openBookID
-        )
+        spineStack(books: Array(books[0...openIndex]), openIndex: openIndex, baseOffset: 0)
         openBookArea(for: books[openIndex], state: state)
           .transition(.opacity)
-          .transaction { transaction in
-            transaction.animation = nil
-          }
         let rightStart = openIndex + 1
         if rightStart < books.count {
           spineStack(
             books: Array(books[rightStart..<books.count]),
             openIndex: openIndex,
-            baseOffset: rightStart,
-            animationValue: openBookID
+            baseOffset: rightStart
           )
         }
       } else {
-        spineStack(books: books, openIndex: nil, baseOffset: 0, animationValue: openBookID)
+        spineStack(books: books, openIndex: nil, baseOffset: 0)
         emptyOpenArea()
       }
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)
     .background(Color(nsColor: .windowBackgroundColor).opacity(surfaceBackgroundOpacity))
+    // Animate on every openBookID change — covers both Shelf-originated
+    // book switches (which also set their own TCA animation) and
+    // left-nav-originated switches, so the spine flow is consistent
+    // regardless of entry point.
+    .animation(.easeInOut(duration: 0.2), value: openBookID)
   }
 
   /// `baseOffset` is the index of `books.first` within the full ordered
   /// list, so we can reconstruct each spine's global index and compute
   /// its distance to `openIndex` without re-scanning the full list.
   @ViewBuilder
-  private func spineStack(
-    books: [ShelfBook],
-    openIndex: Int?,
-    baseOffset: Int,
-    animationValue: Worktree.ID?
-  ) -> some View {
+  private func spineStack(books: [ShelfBook], openIndex: Int?, baseOffset: Int) -> some View {
     HStack(spacing: 0) {
       ForEach(Array(books.enumerated()), id: \.element.id) { localIndex, book in
         let globalIndex = baseOffset + localIndex
         let distance = openIndex.map { abs(globalIndex - $0) }
         let open = globalIndex == openIndex
-        ShelfSpineContainer(
+        ShelfSpineView(
           book: book,
           isOpen: open,
           distanceFromOpen: distance,
-          terminalManager: terminalManager,
+          terminalState: terminalManager.stateIfExists(for: book.id),
           onOpenBook: { openBook(book, selectingTab: nil) },
           onSelectTab: { tabID in openBook(book, selectingTab: tabID) },
           onNewTab: {
@@ -114,11 +105,6 @@ struct ShelfView: View {
         .matchedGeometryEffect(id: book.id, in: spineNamespace)
       }
     }
-    // Keep the visual spine-flow animation scoped to the lightweight
-    // spine layer. The terminal content area is intentionally outside
-    // this transaction so Ghostty/AppKit representables do not inherit a
-    // book-switch animation.
-    .animation(.easeInOut(duration: 0.2), value: animationValue)
   }
 
   /// Dispatch the open-book action only when `book` isn't already the open
@@ -241,37 +227,5 @@ struct ShelfView: View {
       // manager seeds a default tab which we won't override.
       terminalManager.stateIfExists(for: book.id)?.tabManager.selectTab(tabID)
     }
-  }
-}
-
-private struct ShelfSpineContainer: View {
-  let book: ShelfBook
-  let isOpen: Bool
-  let distanceFromOpen: Int?
-  let terminalManager: WorktreeTerminalManager
-  let onOpenBook: () -> Void
-  let onSelectTab: (TerminalTabID) -> Void
-  let onNewTab: () -> Void
-  let onSplitVertical: (() -> Void)?
-  let onSplitHorizontal: (() -> Void)?
-  let closeMenuTitle: String
-  let onCloseBook: () -> Void
-  let onOpenRepositorySettings: () -> Void
-
-  var body: some View {
-    ShelfSpineView(
-      book: book,
-      isOpen: isOpen,
-      distanceFromOpen: distanceFromOpen,
-      terminalState: terminalManager.stateIfExists(for: book.id),
-      onOpenBook: onOpenBook,
-      onSelectTab: onSelectTab,
-      onNewTab: onNewTab,
-      onSplitVertical: onSplitVertical,
-      onSplitHorizontal: onSplitHorizontal,
-      closeMenuTitle: closeMenuTitle,
-      onCloseBook: onCloseBook,
-      onOpenRepositorySettings: onOpenRepositorySettings
-    )
   }
 }

--- a/supacode/Features/Shelf/Views/ShelfView.swift
+++ b/supacode/Features/Shelf/Views/ShelfView.swift
@@ -1,6 +1,8 @@
 import ComposableArchitecture
 import SwiftUI
 
+private let shelfLogger = SupaLogger("Shelf")
+
 /// Root view for Shelf presentation mode.
 ///
 /// Phase 3 layout: three horizontal segments — a left stack of passed
@@ -27,6 +29,10 @@ struct ShelfView: View {
   @Environment(\.surfaceBackgroundOpacity) private var surfaceBackgroundOpacity
 
   var body: some View {
+    // Note: `body` is a `@ViewBuilder` getter so we can't add a
+    // `defer`-based signpost interval directly here. Body-level cost is
+    // already visible via the SwiftUI instrument's "View Body" track —
+    // signposts in this file focus on user-input moments instead.
     let state = store.state
     let books = state.orderedShelfBooks()
     let openBookID = state.openShelfBookID
@@ -101,13 +107,21 @@ struct ShelfView: View {
 
   /// Dispatch the open-book action only when `book` isn't already the open
   /// one — idempotent helper for taps that imply a book change.
+  ///
+  /// No `animation:` is passed to `store.send` because the visible
+  /// spine-flow animation is already driven by the view-level
+  /// `.animation(.easeInOut(duration: 0.2), value: openBookID)` modifier
+  /// on the root container — wrapping the dispatch in another animation
+  /// transaction would double-run layout / transition machinery for the
+  /// same change.
   private func switchToBookIfNeeded(_ book: ShelfBook) {
     guard !isOpen(book) else { return }
+    shelfLogger.event("BookClick.NewTabSpine")
     switch book.kind {
     case .worktree:
-      store.send(.selectWorktree(book.id, focusTerminal: true), animation: .easeInOut(duration: 0.2))
+      store.send(.selectWorktree(book.id, focusTerminal: true))
     case .plainFolder:
-      store.send(.selectRepository(book.repositoryID), animation: .easeInOut(duration: 0.2))
+      store.send(.selectRepository(book.repositoryID))
     }
   }
 
@@ -190,17 +204,20 @@ struct ShelfView: View {
   private func openBook(_ book: ShelfBook, selectingTab tabID: TerminalTabID?) {
     let isAlreadyOpen = store.state.openShelfBookID == book.id
     if let tabID, isAlreadyOpen, let state = terminalManager.stateIfExists(for: book.id) {
+      shelfLogger.event("BookClick.TabSwitchSameBook")
       state.tabManager.selectTab(tabID)
       return
     }
-    // Animate the spine flow and terminal crossfade. The duration and
-    // curve mirror the Shelf design doc: ~200ms ease-in-out, snappy but
-    // legible so the user can read each spine's movement.
+    shelfLogger.event("BookClick.SwitchBook")
+    // The spine flow / terminal crossfade animation is already driven
+    // by the view-level `.animation(_:value: openBookID)` on the root
+    // container (~200ms ease-in-out per the Shelf design doc), so the
+    // dispatch itself does not pass an `animation:` argument here.
     switch book.kind {
     case .worktree:
-      store.send(.selectWorktree(book.id, focusTerminal: true), animation: .easeInOut(duration: 0.2))
+      store.send(.selectWorktree(book.id, focusTerminal: true))
     case .plainFolder:
-      store.send(.selectRepository(book.repositoryID), animation: .easeInOut(duration: 0.2))
+      store.send(.selectRepository(book.repositoryID))
     }
     if let tabID {
       // Apply tab selection eagerly; the target book's state already exists

--- a/supacode/Features/Shelf/Views/ShelfView.swift
+++ b/supacode/Features/Shelf/Views/ShelfView.swift
@@ -44,46 +44,55 @@ struct ShelfView: View {
 
     HStack(spacing: 0) {
       if let openIndex {
-        spineStack(books: Array(books[0...openIndex]), openIndex: openIndex, baseOffset: 0)
+        spineStack(
+          books: Array(books[0...openIndex]),
+          openIndex: openIndex,
+          baseOffset: 0,
+          animationValue: openBookID
+        )
         openBookArea(for: books[openIndex], state: state)
           .transition(.opacity)
+          .transaction { transaction in
+            transaction.animation = nil
+          }
         let rightStart = openIndex + 1
         if rightStart < books.count {
           spineStack(
             books: Array(books[rightStart..<books.count]),
             openIndex: openIndex,
-            baseOffset: rightStart
+            baseOffset: rightStart,
+            animationValue: openBookID
           )
         }
       } else {
-        spineStack(books: books, openIndex: nil, baseOffset: 0)
+        spineStack(books: books, openIndex: nil, baseOffset: 0, animationValue: openBookID)
         emptyOpenArea()
       }
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)
     .background(Color(nsColor: .windowBackgroundColor).opacity(surfaceBackgroundOpacity))
-    // Animate on every openBookID change — covers both Shelf-originated
-    // book switches (which also set their own TCA animation) and
-    // left-nav-originated switches, so the spine flow is consistent
-    // regardless of entry point.
-    .animation(.easeInOut(duration: 0.2), value: openBookID)
   }
 
   /// `baseOffset` is the index of `books.first` within the full ordered
   /// list, so we can reconstruct each spine's global index and compute
   /// its distance to `openIndex` without re-scanning the full list.
   @ViewBuilder
-  private func spineStack(books: [ShelfBook], openIndex: Int?, baseOffset: Int) -> some View {
+  private func spineStack(
+    books: [ShelfBook],
+    openIndex: Int?,
+    baseOffset: Int,
+    animationValue: Worktree.ID?
+  ) -> some View {
     HStack(spacing: 0) {
       ForEach(Array(books.enumerated()), id: \.element.id) { localIndex, book in
         let globalIndex = baseOffset + localIndex
         let distance = openIndex.map { abs(globalIndex - $0) }
         let open = globalIndex == openIndex
-        ShelfSpineView(
+        ShelfSpineContainer(
           book: book,
           isOpen: open,
           distanceFromOpen: distance,
-          terminalState: terminalManager.stateIfExists(for: book.id),
+          terminalManager: terminalManager,
           onOpenBook: { openBook(book, selectingTab: nil) },
           onSelectTab: { tabID in openBook(book, selectingTab: tabID) },
           onNewTab: {
@@ -105,6 +114,11 @@ struct ShelfView: View {
         .matchedGeometryEffect(id: book.id, in: spineNamespace)
       }
     }
+    // Keep the visual spine-flow animation scoped to the lightweight
+    // spine layer. The terminal content area is intentionally outside
+    // this transaction so Ghostty/AppKit representables do not inherit a
+    // book-switch animation.
+    .animation(.easeInOut(duration: 0.2), value: animationValue)
   }
 
   /// Dispatch the open-book action only when `book` isn't already the open
@@ -227,5 +241,37 @@ struct ShelfView: View {
       // manager seeds a default tab which we won't override.
       terminalManager.stateIfExists(for: book.id)?.tabManager.selectTab(tabID)
     }
+  }
+}
+
+private struct ShelfSpineContainer: View {
+  let book: ShelfBook
+  let isOpen: Bool
+  let distanceFromOpen: Int?
+  let terminalManager: WorktreeTerminalManager
+  let onOpenBook: () -> Void
+  let onSelectTab: (TerminalTabID) -> Void
+  let onNewTab: () -> Void
+  let onSplitVertical: (() -> Void)?
+  let onSplitHorizontal: (() -> Void)?
+  let closeMenuTitle: String
+  let onCloseBook: () -> Void
+  let onOpenRepositorySettings: () -> Void
+
+  var body: some View {
+    ShelfSpineView(
+      book: book,
+      isOpen: isOpen,
+      distanceFromOpen: distanceFromOpen,
+      terminalState: terminalManager.stateIfExists(for: book.id),
+      onOpenBook: onOpenBook,
+      onSelectTab: onSelectTab,
+      onNewTab: onNewTab,
+      onSplitVertical: onSplitVertical,
+      onSplitHorizontal: onSplitHorizontal,
+      closeMenuTitle: closeMenuTitle,
+      onCloseBook: onCloseBook,
+      onOpenRepositorySettings: onOpenRepositorySettings
+    )
   }
 }

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -315,8 +315,10 @@ final class WorktreeTerminalState {
   }
 
   func focusSelectedTab() {
-    guard let tabId = tabManager.selectedTabId else { return }
-    focusSurface(in: tabId)
+    terminalStateLogger.interval("focusSelectedTab") {
+      guard let tabId = tabManager.selectedTabId else { return }
+      focusSurface(in: tabId)
+    }
   }
 
   @discardableResult
@@ -345,12 +347,20 @@ final class WorktreeTerminalState {
   }
 
   func syncFocus(windowIsKey: Bool, windowIsVisible: Bool) {
-    lastWindowIsKey = windowIsKey
-    lastWindowIsVisible = windowIsVisible
-    applySurfaceActivity()
+    terminalStateLogger.interval("syncFocus") {
+      lastWindowIsKey = windowIsKey
+      lastWindowIsVisible = windowIsVisible
+      applySurfaceActivity()
+    }
   }
 
   private func applySurfaceActivity() {
+    terminalStateLogger.interval("applySurfaceActivity") {
+      applySurfaceActivityImpl()
+    }
+  }
+
+  private func applySurfaceActivityImpl() {
     let selectedTabId = tabManager.selectedTabId
     var surfaceToFocus: GhosttySurfaceView?
     for (tabId, tree) in trees {

--- a/supacode/Infrastructure/Ghostty/GhosttyTerminalView.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttyTerminalView.swift
@@ -11,24 +11,42 @@ struct GhosttyTerminalView: NSViewRepresentable {
   }
 
   func makeNSView(context: Context) -> GhosttySurfaceScrollView {
-    let view = GhosttySurfaceScrollView(surfaceView: surfaceView, hostKind: hostKind)
-    view.pinnedSize = pinnedSize
-    terminalHostLogger.info(
-      "[CanvasExit] hostMake wrapper=\(view.debugIdentifier) host=\(hostKind.rawValue) "
-        + "surface=\(surfaceView.debugIdentifierForLogging) "
-        + "pinned=\(pinnedSize != nil)"
-    )
-    return view
+    // Wrap in a signpost interval so the cost of NSView construction
+    // (allocating the scroll view, attaching the Metal-backed surface)
+    // shows up on the Points of Interest timeline. Frequency tells us
+    // how often `.id(worktree.id)` on `ShelfOpenBookView` is forcing a
+    // wholesale teardown/recreate on book switching — total time tells
+    // us if AppKit/Metal initialization is on the hot path.
+    return terminalHostLogger.interval("Ghostty.makeNSView") {
+      let view = GhosttySurfaceScrollView(surfaceView: surfaceView, hostKind: hostKind)
+      view.pinnedSize = pinnedSize
+      terminalHostLogger.info(
+        "[CanvasExit] hostMake wrapper=\(view.debugIdentifier) host=\(hostKind.rawValue) "
+          + "surface=\(surfaceView.debugIdentifierForLogging) "
+          + "pinned=\(pinnedSize != nil)"
+      )
+      return view
+    }
   }
 
   func updateNSView(_ view: GhosttySurfaceScrollView, context: Context) {
-    view.pinnedSize = pinnedSize
-    terminalHostLogger.info(
-      "[CanvasExit] hostUpdate wrapper=\(view.debugIdentifier) host=\(hostKind.rawValue) "
-        + "surface=\(surfaceView.debugIdentifierForLogging) "
-        + "pinned=\(pinnedSize != nil) "
-        + "attached=\(view.isSurfaceAttachedToDocumentView)"
-    )
-    view.ensureSurfaceAttached()
+    terminalHostLogger.interval("Ghostty.updateNSView") {
+      view.pinnedSize = pinnedSize
+      terminalHostLogger.info(
+        "[CanvasExit] hostUpdate wrapper=\(view.debugIdentifier) host=\(hostKind.rawValue) "
+          + "surface=\(surfaceView.debugIdentifierForLogging) "
+          + "pinned=\(pinnedSize != nil) "
+          + "attached=\(view.isSurfaceAttachedToDocumentView)"
+      )
+      view.ensureSurfaceAttached()
+    }
+  }
+
+  static func dismantleNSView(_ view: GhosttySurfaceScrollView, coordinator: Void) {
+    // Pairs with `Ghostty.makeNSView` on the timeline so the interval
+    // count of `make` minus `dismantle` gives a live count of attached
+    // surface wrappers — and frequency confirms whether each book
+    // switch tears down the wrapper layer.
+    terminalHostLogger.event("Ghostty.dismantleNSView")
   }
 }

--- a/supacode/Support/SupaLogger.swift
+++ b/supacode/Support/SupaLogger.swift
@@ -8,9 +8,16 @@ nonisolated struct SupaLogger: Sendable {
   /// Signposter for emitting `os_signpost` intervals/events visible in
   /// Instruments. Signposts are essentially zero-cost when no Instruments
   /// session is attached (a single TLS read), so they are always live —
-  /// no DEBUG gating. Intervals show up under the logger's category in
-  /// the os_signpost track of any trace template that includes it
-  /// (Animation Hitches and SwiftUI both do).
+  /// no DEBUG gating.
+  ///
+  /// The signposter uses the well-known `"PointsOfInterest"` category
+  /// regardless of the logger's own `category` so that intervals and
+  /// events automatically surface in Apple's **Points of Interest**
+  /// instrument (the discoverable, "just drag it in" track most people
+  /// will reach for). The signpost `name:` argument carries the actual
+  /// origin (e.g. `"OpenBook.onAppear"`, `"focusSelectedTab"`) so source
+  /// granularity is preserved — only the routing category differs from
+  /// the regular log channel.
   let signposter: OSSignposter
 
   init(_ category: String) {
@@ -19,7 +26,7 @@ nonisolated struct SupaLogger: Sendable {
     #if !DEBUG
       self.logger = Logger(subsystem: subsystem, category: category)
     #endif
-    self.signposter = OSSignposter(subsystem: subsystem, category: category)
+    self.signposter = OSSignposter(subsystem: subsystem, category: "PointsOfInterest")
   }
 
   func debug(_ message: String) {

--- a/supacode/Support/SupaLogger.swift
+++ b/supacode/Support/SupaLogger.swift
@@ -5,12 +5,21 @@ nonisolated struct SupaLogger: Sendable {
   #if !DEBUG
     private let logger: Logger
   #endif
+  /// Signposter for emitting `os_signpost` intervals/events visible in
+  /// Instruments. Signposts are essentially zero-cost when no Instruments
+  /// session is attached (a single TLS read), so they are always live —
+  /// no DEBUG gating. Intervals show up under the logger's category in
+  /// the os_signpost track of any trace template that includes it
+  /// (Animation Hitches and SwiftUI both do).
+  let signposter: OSSignposter
 
   init(_ category: String) {
     self.category = category
+    let subsystem = Bundle.main.bundleIdentifier ?? "com.onevcat.prowl"
     #if !DEBUG
-      self.logger = Logger(subsystem: Bundle.main.bundleIdentifier!, category: category)
+      self.logger = Logger(subsystem: subsystem, category: category)
     #endif
+    self.signposter = OSSignposter(subsystem: subsystem, category: category)
   }
 
   func debug(_ message: String) {
@@ -36,4 +45,45 @@ nonisolated struct SupaLogger: Sendable {
       logger.warning("\(message, privacy: .public)")
     #endif
   }
+
+  /// Wraps `body` in an `os_signpost` interval named `name`. The
+  /// interval renders as a labeled bar on the Instruments timeline,
+  /// making it trivial to correlate hotspots with hangs/hitches without
+  /// post-processing the trace XML.
+  func interval<T>(_ name: StaticString, _ body: () throws -> T) rethrows -> T {
+    let id = signposter.makeSignpostID()
+    let state = signposter.beginInterval(name, id: id)
+    defer { signposter.endInterval(name, state) }
+    return try body()
+  }
+
+  /// Manual begin/end pair for code paths that can't use the closure
+  /// form — e.g. inside a TCA reducer case where `inout state` cannot
+  /// be captured by a non-escaping closure. The returned `IntervalToken`
+  /// is opaque to callers, so they don't have to import `OSLog`
+  /// themselves.
+  func beginInterval(_ name: StaticString) -> IntervalToken {
+    let id = signposter.makeSignpostID()
+    let state = signposter.beginInterval(name, id: id)
+    return IntervalToken(name: name, state: state)
+  }
+
+  func endInterval(_ token: IntervalToken) {
+    signposter.endInterval(token.name, token.state)
+  }
+
+  /// Emits an instantaneous `os_signpost` event marker — useful for
+  /// marking discrete moments (e.g. "user clicked book") without an
+  /// associated duration.
+  func event(_ name: StaticString) {
+    signposter.emitEvent(name)
+  }
+}
+
+/// Opaque token bundling a signpost name and its interval state so
+/// callers can `beginInterval` / `endInterval` without depending on
+/// `OSLog` themselves.
+struct IntervalToken {
+  fileprivate let name: StaticString
+  fileprivate let state: OSSignpostIntervalState
 }

--- a/supacodeTests/CommandKeyObserverTests.swift
+++ b/supacodeTests/CommandKeyObserverTests.swift
@@ -4,14 +4,19 @@ import Testing
 @testable import supacode
 
 struct CommandKeyObserverTests {
-  @Test func shouldShowShortcutsForCommandOrControl() {
+  @Test func shouldShowShortcutsForBareCommandOrControl() {
     #expect(CommandKeyObserver.shouldShowShortcuts(for: [.command]))
     #expect(CommandKeyObserver.shouldShowShortcuts(for: [.control]))
-    #expect(CommandKeyObserver.shouldShowShortcuts(for: [.command, .shift]))
-    #expect(CommandKeyObserver.shouldShowShortcuts(for: [.control, .option]))
   }
 
-  @Test func shouldNotShowShortcutsForOtherModifiers() {
+  @Test func shouldNotShowShortcutsForShortcutCombinations() {
+    #expect(CommandKeyObserver.shouldShowShortcuts(for: [.command, .shift]) == false)
+    #expect(CommandKeyObserver.shouldShowShortcuts(for: [.control, .option]) == false)
+    #expect(CommandKeyObserver.shouldShowShortcuts(for: [.command, .control]) == false)
+    #expect(CommandKeyObserver.shouldShowShortcuts(for: [.command, .control, .shift]) == false)
+  }
+
+  @Test func shouldNotShowShortcutsForNonHintModifiers() {
     #expect(CommandKeyObserver.shouldShowShortcuts(for: []) == false)
     #expect(CommandKeyObserver.shouldShowShortcuts(for: [.shift]) == false)
     #expect(CommandKeyObserver.shouldShowShortcuts(for: [.option]) == false)


### PR DESCRIPTION
## Summary

This PR keeps the successful Shelf jank fixes from the investigation branch:

- limits shortcut-hint invalidation to bare Command/Control modifier presses
- disables sidebar key forwarding while Shelf is active, removing the `KeyPressModifier` invalidation path during book switching
- renders Shelf spines from a single `ForEach`, eliminating matched-geometry churn between left/right spine stacks
- removes the open-book opacity transition, which showed a small hitch improvement without noticeable UX regression
- adds/keeps signposts and investigation notes for future Shelf performance work

## Why

Book switching in Shelf mode was hitching heavily, especially when switching via keyboard shortcuts. Trace analysis showed a large SwiftUI invalidation storm from shortcut/key-press environment modifiers, followed by layout churn from the split spine rendering model.

The retained changes brought the most useful trace and UX improvements while avoiding the later experiments that introduced visible artifacts or degraded interaction.

## Validation

- `make build-app 2>&1 | xcsift -f toon`
- Compared Instruments traces through run15. The retained path removed `EnvironmentWriter: KeyPressModifier` from the Shelf switching trace, eliminated `Layout: MatchedFrame`, and reduced select-window hitch cost versus the earlier baseline.
