### PR TITLE
build: end the swift-format ↔ swiftlint trailing-comma ping-pong

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -10,6 +10,10 @@ disabled_rules:
   - file_length
   - closure_parameter_position
   - type_body_length
+  # swift-format owns trailing comma policy in this project. Letting
+  # swiftlint --fix add commas that swift-format then strips creates a
+  # check ↔ format ping-pong, so swiftlint stays out of trailing commas.
+  - trailing_comma
 
 opt_in_rules:
   - accessibility_label_for_image
@@ -20,9 +24,6 @@ opening_brace:
   ignore_multiline_function_signatures: true
   ignore_multiline_statement_conditions: true
   ignore_multiline_type_headers: true
-
-trailing_comma:
-  mandatory_comma: true
 
 cyclomatic_complexity:
   warning: 15

--- a/Makefile
+++ b/Makefile
@@ -307,7 +307,6 @@ format: # Format code with swift-format (local only)
 	swift-format -p --in-place --recursive --configuration ./.swift-format.json supacode supacodeTests
 
 lint: # Lint code with swiftlint
-	mise exec -- swiftlint --fix --quiet
 	mise exec -- swiftlint lint --quiet --config .swiftlint.yml
 
 check: format lint # Format and lint


### PR DESCRIPTION
## Why

Every `make check` run produced a flood of unrelated reformatting in files that hadn't been touched. The cause was a true rule conflict between the two formatters:

- `.swiftlint.yml` had `trailing_comma: mandatory_comma: true`, and `make lint` ran `swiftlint --fix --quiet` — which strictly **adds** trailing commas to multi-line collection literals.
- swift-format 602 (current pinned local + Swift 6.2 toolchain) actively **removes** trailing commas in multi-line collection literals whose last element is a multi-line function call. That behavior is a built-in of this version (the upstream `multilineTrailingCommaBehavior: alwaysUsed` setting only exists in 603+).

So `swift-format → swiftlint --fix` left files in state A (with commas), but any subsequent `swift-format` run flipped them to state B (without). Reproduced explicitly:

```text
HEAD                  d82134b... (no commas)
swiftlint --fix       a3f18a3... (commas added)
swift-format          d82134b... (commas stripped)
swiftlint --fix       a3f18a3... (commas added again)
... oscillates forever
```

Upstream supacode already untangled this in commit `6dec82f2 "Align trailing comma tooling"`, but that commit never made it into the fork.

## What

Mirrors the no-toolchain-bump portion of upstream's fix:

- **`.swiftlint.yml`**: add `trailing_comma` to `disabled_rules`, remove the `mandatory_comma` block. swift-format becomes the single authority on trailing commas.
- **`Makefile`**: drop `swiftlint --fix` from the `lint` target; lint is a pure check, formatting belongs to `make format` (i.e. swift-format).

Not adopting `multilineTrailingCommaBehavior: alwaysUsed` because the local swift-format (602.0.0) silently ignores the unknown key — the project's resulting style is "no trailing comma in this layout", which is the natural fixpoint of swift-format alone. If/when we upgrade swift-format to ≥603 we can revisit and re-align with upstream's "always" style.

## Verification

- `swift-format -p --in-place --recursive --configuration ./.swift-format.json supacode supacodeTests` — **0 files changed** (the codebase already matches the swift-format fixpoint, so no bulk sweep commit is needed).
- `swiftlint lint --quiet --config .swiftlint.yml` — passes (no new violations from removing `trailing_comma`).
- `make check` end-to-end — **0 diff** in the working tree afterwards.
- `make build-app` — succeeds.

## Test plan

- [x] `make check` is idempotent (running it twice in a row leaves working tree untouched).
- [x] `make build-app` passes.
- [x] Open a follow-up PR (or rebase #247 onto this) and confirm `make check` no longer drags unrelated files into the diff.
