### PR TITLE
Add sidebar repository expand toggle

### DIFF
--- a/supacode/Features/Repositories/Views/SidebarListView.swift
+++ b/supacode/Features/Repositories/Views/SidebarListView.swift
@@ -2,6 +2,33 @@ import ComposableArchitecture
 import SwiftUI
 
 struct SidebarListView: View {
+  enum RepositoryListHeaderAction: Equatable {
+    case expandAll
+    case collapseAll
+
+    var title: String {
+      switch self {
+      case .expandAll:
+        return "Expand All"
+      case .collapseAll:
+        return "Collapse All"
+      }
+    }
+
+    var systemImageName: String {
+      "chevron.right"
+    }
+
+    var rotation: Angle {
+      switch self {
+      case .expandAll:
+        return .zero
+      case .collapseAll:
+        return .degrees(90)
+      }
+    }
+  }
+
   @Bindable var store: StoreOf<RepositoriesFeature>
   @Binding var expandedRepoIDs: Set<Repository.ID>
   @Binding var sidebarSelections: Set<SidebarSelection>
@@ -13,6 +40,13 @@ struct SidebarListView: View {
     let state = store.state
     let hotkeyRows = state.orderedWorktreeRows(includingRepositoryIDs: expandedRepoIDs)
     let orderedRoots = state.orderedRepositoryRoots()
+    let expandableRepositoryIDs = Self.expandableRepositoryIDs(in: state.repositories)
+    let repositoryListHeaderAction = Self.repositoryListHeaderAction(
+      expandedRepoIDs: expandedRepoIDs,
+      expandableRepositoryIDs: expandableRepositoryIDs
+    )
+    let visibleRepositoryCount = orderedRoots.isEmpty ? state.repositories.count : orderedRoots.count
+    let showsRepositoryListHeader = Self.showsRepositoryListHeader(repositoryCount: visibleRepositoryCount)
     let selectedWorktreeIDs = Set(sidebarSelections.compactMap(\.worktreeID))
     let selection = Binding<Set<SidebarSelection>>(
       get: {
@@ -102,6 +136,14 @@ struct SidebarListView: View {
 
     ScrollViewReader { scrollProxy in
       List(selection: selection) {
+        if showsRepositoryListHeader {
+          repositoryListHeader(
+            action: repositoryListHeaderAction,
+            expandableRepositoryIDs: expandableRepositoryIDs
+          )
+          .listRowInsets(EdgeInsets())
+        }
+
         if orderedRoots.isEmpty {
           let repositories = store.repositories
           ForEach(Array(repositories.enumerated()), id: \.element.id) { index, repository in
@@ -240,6 +282,42 @@ struct SidebarListView: View {
     }
   }
 
+  private func repositoryListHeader(
+    action: RepositoryListHeaderAction,
+    expandableRepositoryIDs: Set<Repository.ID>
+  ) -> some View {
+    HStack(spacing: 8) {
+      Text("Repositories")
+        .font(.caption)
+        .foregroundStyle(.tertiary)
+        .frame(maxWidth: .infinity, alignment: .leading)
+      if !expandableRepositoryIDs.isEmpty {
+        Button {
+          withAnimation(.easeOut(duration: 0.2)) {
+            switch action {
+            case .expandAll:
+              expandedRepoIDs.formUnion(expandableRepositoryIDs)
+            case .collapseAll:
+              expandedRepoIDs.subtract(expandableRepositoryIDs)
+            }
+          }
+        } label: {
+          Label(action.title, systemImage: action.systemImageName)
+            .labelStyle(.iconOnly)
+            .frame(width: 20, height: 20)
+            .rotationEffect(action.rotation)
+            .contentShape(.rect)
+        }
+        .buttonStyle(.plain)
+        .foregroundStyle(.secondary)
+        .help(action.title)
+      }
+    }
+    .frame(maxWidth: .infinity, minHeight: 26, alignment: .center)
+    .padding(.top, 8)
+    .padding(.bottom, 4)
+  }
+
   @MainActor
   private func revealPendingSidebarWorktree(
     _ pendingSidebarReveal: PendingSidebarReveal?,
@@ -254,6 +332,29 @@ struct SidebarListView: View {
       scrollProxy.scrollTo(pendingSidebarReveal.worktreeID, anchor: .center)
     }
     store.send(.consumePendingSidebarReveal(pendingSidebarReveal.id))
+  }
+
+  static func expandableRepositoryIDs<Repositories: Sequence>(
+    in repositories: Repositories
+  ) -> Set<Repository.ID> where Repositories.Element == Repository {
+    Set(
+      repositories
+        .filter(\.capabilities.supportsWorktrees)
+        .map(\.id)
+    )
+  }
+
+  static func repositoryListHeaderAction(
+    expandedRepoIDs: Set<Repository.ID>,
+    expandableRepositoryIDs: Set<Repository.ID>
+  ) -> RepositoryListHeaderAction {
+    !expandedRepoIDs.isDisjoint(with: expandableRepositoryIDs)
+      ? .collapseAll
+      : .expandAll
+  }
+
+  static func showsRepositoryListHeader(repositoryCount: Int) -> Bool {
+    repositoryCount > 10
   }
 }
 

--- a/supacodeTests/RepositorySectionViewTests.swift
+++ b/supacodeTests/RepositorySectionViewTests.swift
@@ -6,6 +6,69 @@ import Testing
 
 @MainActor
 struct RepositorySectionViewTests {
+  @Test func sidebarHeaderActionCollapsesWhenAnyExpandableRepositoryIsOpen() {
+    let gitRepository = Repository(
+      id: "/tmp/git",
+      rootURL: URL(fileURLWithPath: "/tmp/git"),
+      name: "git",
+      kind: .git,
+      worktrees: []
+    )
+    let plainRepository = Repository(
+      id: "/tmp/plain",
+      rootURL: URL(fileURLWithPath: "/tmp/plain"),
+      name: "plain",
+      kind: .plain,
+      worktrees: []
+    )
+    let expandableIDs = SidebarListView.expandableRepositoryIDs(
+      in: [gitRepository, plainRepository]
+    )
+
+    #expect(expandableIDs == [gitRepository.id])
+    #expect(
+      SidebarListView.repositoryListHeaderAction(
+        expandedRepoIDs: [],
+        expandableRepositoryIDs: []
+      )
+        == .expandAll
+    )
+    #expect(
+      SidebarListView.repositoryListHeaderAction(
+        expandedRepoIDs: [],
+        expandableRepositoryIDs: expandableIDs
+      )
+        == .expandAll
+    )
+    #expect(
+      SidebarListView.repositoryListHeaderAction(
+        expandedRepoIDs: [gitRepository.id],
+        expandableRepositoryIDs: expandableIDs
+      )
+        == .collapseAll
+    )
+    #expect(
+      SidebarListView.repositoryListHeaderAction(
+        expandedRepoIDs: [gitRepository.id, plainRepository.id],
+        expandableRepositoryIDs: expandableIDs
+      )
+        == .collapseAll
+    )
+    #expect(
+      SidebarListView.repositoryListHeaderAction(
+        expandedRepoIDs: [plainRepository.id],
+        expandableRepositoryIDs: expandableIDs
+      )
+        == .expandAll
+    )
+  }
+
+  @Test func sidebarHeaderOnlyShowsForLongRepositoryLists() {
+    #expect(!SidebarListView.showsRepositoryListHeader(repositoryCount: 0))
+    #expect(!SidebarListView.showsRepositoryListHeader(repositoryCount: 10))
+    #expect(SidebarListView.showsRepositoryListHeader(repositoryCount: 11))
+  }
+
   @Test func openTabCountForGitRepositorySumsAllWorktrees() {
     let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
     let repositoryRootURL = URL(fileURLWithPath: "/tmp/repo")


### PR DESCRIPTION
## Summary

- Add a lightweight `Repositories` header above the sidebar repo list when the repo count is greater than 10.
- Add an icon-only expand/collapse-all control aligned with the repo rows.
- Prefer collapse behavior when any expandable repository is already open; expand only when all expandable repositories are collapsed.
- Keep plain folders out of the expandable repository set.

## Tests

- `make lint`
- `xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -only-testing:supacodeTests/RepositorySectionViewTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation 2>&1 | xcsift -f toon -w`
- `make build-app`

## Follow-up

Related sidebar animation refactor: #249
