### PR TITLE
Document branch workflow for unrelated work

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,6 +118,7 @@ Reducer ← .terminalEvent(Event) ← AsyncStream<Event>
 
 - After a task, ensure the app builds: `make build-app`
 - When working on CLI code (`ProwlCLI/`, `ProwlCLITests/`, `Package.swift`), run `make build-cli`, `make test-cli-smoke`, and `make test-cli-integration` before committing.
+- When implementing a new feature or fixing a bug that is unrelated to the current branch's active work, first create a dedicated branch from the latest `origin/main`; then work, commit, push, and open a PR from that branch.
 - Automatically commit your changes and your changes only. Do not use `git add .`
 - Before you go on your task, check the current git branch name, if it's something generic like an animal name, name it accordingly. Do not do this for main branch
 - After implementing an execplan, always submit a PR if you're not in the main branch


### PR DESCRIPTION
## Summary

- document that unrelated feature or bugfix work should start from a dedicated branch based on latest `origin/main`
- require working, committing, pushing, and opening a PR from that branch

## Verification

- `make check`
- `make build-app`
