### PR TITLE
Refactor sidebar presentation drag handling

### DIFF
--- a/doc-onevcat/plans/2026-05-03-sidebar-container-refactor-plan.md
+++ b/doc-onevcat/plans/2026-05-03-sidebar-container-refactor-plan.md
@@ -12,7 +12,7 @@ This should fix the structural mismatch where the app treats repositories as reo
 
 - incorrect repository drag insertion indicators when dragging downward across expanded repositories
 - unstable bulk expand/collapse animations
-- potential sidebar flicker during drag when live terminal / notification / ordering updates arrive
+- potential sidebar flicker during drag when live terminal, notification, or ordering updates arrive
 
 ## Current Findings
 
@@ -56,7 +56,7 @@ SwiftUI is placing the indicator between list rows. It does not know that the ta
 
 The current `List` carries several behaviors at once:
 
-- special rows: Canvas, Shelf, archived worktrees, repository list header
+- archived worktree selection and repository list header
 - repository row selection for plain folders
 - worktree multi-selection
 - repository expand/collapse
@@ -65,7 +65,7 @@ The current `List` carries several behaviors at once:
 - reveal-in-sidebar via `ScrollViewReader.scrollTo`
 - native sidebar styling and accessibility
 
-This makes local fixes brittle because changing row structure affects selection, drag, animation, and scroll identity at the same time.
+Canvas, Shelf, and the footer are not `List` rows today; they are safe-area inset chrome around the list. The refactor should preserve that boundary unless a later design intentionally moves them into the scroll content.
 
 ### 3. Live state still reaches rows during drag
 
@@ -80,21 +80,29 @@ Remaining drag-time churn sources include:
 
 These are not necessarily the root cause of the drop-indicator bug, but they are credible contributors to #222-style flicker.
 
-## Recommended Direction
+## Revised Direction
 
 Use a custom sidebar scroll container rather than trying to keep the current flat `List` structure.
+
+Execution order matters: first stabilize the old `List` path with a reducer-level drag gate, then replace the visual structure. The drag gate is a hard prerequisite because it reduces #222 risk before the broader #249 rewrite starts.
 
 Recommended shape:
 
 ```text
-ScrollViewReader
-└── ScrollView
-    └── LazyVStack or VStack
-        ├── Special rows
-        ├── RepositoryContainerRow
-        │   ├── RepositoryHeaderRow
-        │   └── WorktreeRows
-        └── FailedRepositoryRow
+SidebarView chrome
+├── top safeAreaInset buttons
+│   ├── Canvas
+│   └── Shelf
+├── ScrollViewReader
+│   └── ScrollView
+│       └── LazyVStack or VStack
+│           ├── repository list header
+│           ├── RepositoryContainerRow
+│           │   ├── RepositoryHeaderRow
+│           │   └── WorktreeRows
+│           ├── FailedRepositoryRow
+│           └── ArchivedWorktreesRow
+└── bottom safeAreaInset footer
 ```
 
 Key property: repository containers are the only repository-level siblings in the outer stack. Expanded worktrees are children inside the container, not siblings beside it.
@@ -140,7 +148,7 @@ Cons:
 - must rebuild keyboard navigation, multi-selection, reorder, and accessibility affordances
 - more implementation work
 
-This is the recommended route for #249 if the goal is "fix the sidebar design once" rather than patch one symptom.
+This remains the recommended route for #249 if the goal is "fix the sidebar design once" rather than patch one symptom.
 
 ### Option C: Short-term drag-time freeze only
 
@@ -154,11 +162,47 @@ Cons:
 - does not fix repository insertion indicator because row boundaries remain wrong
 - leaves the main structural mismatch in place
 
-This can be kept as a subset of Option B, but it is not enough alone.
+This is now the mandatory M1 prerequisite for Option B, not a replacement for Option B.
+
+## Hard Requirements
+
+The refactor must preserve these behavior and state contracts.
+
+### Reducer actions and persistence
+
+- Keep the existing reducer actions and persistence paths for repository and worktree ordering unless a later implementation note explicitly proves a rename is worth it.
+- Preserve calls behind repository reorder, pinned worktree reorder, unpinned worktree reorder, and notification-driven reorder.
+- Treat failed repository reorder semantics as an explicit product decision:
+  - either failed repository rows are reorderable and their order persists through the same root ordering path
+  - or they are not reorderable and the UI gives consistent feedback with no insertion target around them
+
+### Expanded and collapsed state
+
+- Preserve `@Shared` write-back semantics for collapsed repository IDs.
+- Preserve cleanup of invalid collapsed IDs when repository IDs change.
+- Ensure bulk expand/collapse and single expand/collapse share the same model path.
+
+### Focused actions and selection synchronization
+
+- Preserve `SidebarView` focused values for `confirmWorktreeAction`, `archiveWorktreeAction`, `deleteWorktreeAction`, and `visibleHotkeyWorktreeRows`.
+- Preserve the `sidebarSelections -> setSidebarSelectedWorktreeIDs` synchronization currently owned by `SidebarView`.
+- Do not regress menu commands or numbered worktree hotkeys when replacing `List(selection:)`.
+
+### Existing row affordances
+
+- Preserve repository and worktree context menus.
+- Preserve drag previews.
+- Preserve current worktree row type-select behavior. Worktree rows currently use `.typeSelectEquivalent("")`; V1 should keep type-select effectively disabled for those rows.
+- Preserve root-level `dropDestination(for: URL.self)` on the sidebar container, including drops into blank sidebar space.
+
+### Ordered roots
+
+- Converge the current `orderedRoots.isEmpty` fallback and non-empty custom-order path into one presentation path.
+- The empty ordered-roots case is a valid user state and must have tests.
 
 ## Proposed Architecture
 
-### SidebarPresentationModel
+### SidebarPresentation
 
 Introduce a pure presentation model that flattens current repository state into explicit sidebar units.
 
@@ -171,9 +215,9 @@ struct SidebarPresentation: Equatable {
 
 enum SidebarItem: Equatable, Identifiable {
   case listHeader(SidebarListHeaderModel)
-  case special(SidebarSpecialRowModel)
   case repository(SidebarRepositoryContainerModel)
   case failedRepository(FailedRepositoryModel)
+  case archivedWorktrees(ArchivedWorktreesRowModel)
 }
 
 struct SidebarRepositoryContainerModel: Equatable, Identifiable {
@@ -189,25 +233,31 @@ struct SidebarRepositoryContainerModel: Equatable, Identifiable {
 
 Rules:
 
+- build `SidebarPresentation` from reducer/state-side pure functions or equivalent helpers
 - outer `items` contains one item per repository, not one item per row
 - worktree sections remain inside the repository container
-- presentation construction should be pure and unit-tested
-- live terminal state should not be part of the broad presentation model unless required for layout identity
+- presentation construction is pure and unit-tested
+- high-frequency terminal notification/task/run-script state stays in leaf views, not in broad presentation state
+- Canvas, Shelf, and footer chrome remain outside `SidebarPresentation` in V1
 
 ### Selection
 
 Replace `List(selection:)` with explicit selection handling.
 
-Keep `RepositoriesFeature.State.selection` and `sidebarSelectedWorktreeIDs` as the source of truth, but route clicks through helper functions:
+Keep `RepositoriesFeature.State.selection` and `sidebarSelectedWorktreeIDs` as the source of truth, but route clicks through helper functions.
 
-- repository header click:
-  - plain folder: select repository
-  - git repository: toggle expand by default, or select repository if a future repository-detail mode needs it
-- worktree row click:
-  - normal click: select worktree and focus terminal
-  - Cmd-click: toggle multi-selection
-  - Shift-click: optional follow-up, only if current behavior supports it through `List`
-- Canvas / Shelf / Archived rows: dispatch existing actions
+Compatibility matrix:
+
+| Interaction | State behavior | Focus behavior |
+| --- | --- | --- |
+| Canvas button | Selects Canvas and clears incompatible sidebar worktree selection. | Does not focus a terminal. |
+| Shelf button | Selects Shelf and clears incompatible sidebar worktree selection. | Does not focus a terminal. |
+| Archived worktrees row | Selects archived worktrees and clears incompatible worktree selection. | Does not focus a terminal. |
+| Git repository header click | Toggles expanded state by default. | Does not focus a terminal. |
+| Plain folder repository click | Selects the repository. | Does not focus a terminal unless current behavior already does. |
+| Worktree row normal click | Selects one worktree and updates sidebar selected worktree IDs to that one ID. | Focuses the terminal for the selected worktree. |
+| Worktree row Cmd-click | Toggles membership in sidebar selected worktree IDs, preserving multi-select priority. | Does not steal focus unless the resulting primary selection changes by existing rules. |
+| Empty sidebar selection | Clears sidebar selected worktree IDs. | Does not focus a terminal. |
 
 Selection visuals should be explicit in `RepositoryHeaderRow` and `WorktreeRow`, not inherited from `List`.
 
@@ -227,7 +277,7 @@ Required V1 behavior:
 - command shortcuts still select worktrees
 - selected row is scrolled into view on reveal
 - focus returns to terminal after single worktree selection
-- sidebar focus does not accidentally forward text while Canvas / Shelf rules say it should not
+- sidebar focus does not accidentally forward text while Canvas, Shelf, or Archived rules say it should not
 
 ### Repository Reorder
 
@@ -238,7 +288,7 @@ Suggested approach:
 - make `RepositoryContainerRow` draggable with repository ID payload
 - render a custom repository insertion indicator between repository containers
 - compute drop destination as a repository index
-- dispatch existing `.worktreeOrdering(.repositoriesMoved(offsets, destination))` or a new clearer action such as `.repositoriesReordered([Repository.ID])`
+- dispatch existing repository-ordering actions or a new reducer action that delegates to the same persistence path
 
 The custom indicator should always render at repository container boundaries:
 
@@ -267,7 +317,7 @@ Cross-repository worktree drag can stay out of scope. The current model does not
 
 ### Drag-Time Freeze
 
-Add a small sidebar drag state to suppress non-essential row churn.
+Add sidebar drag state at reducer level and use it in both the old and new sidebar paths.
 
 During any sidebar drag:
 
@@ -275,6 +325,13 @@ During any sidebar drag:
 - hide pull request / notification popover affordances that resize rows
 - suppress row-ID animations caused by notification-driven reorder
 - defer "move notified worktree to top" until drag ends, or apply it without animation after drop
+
+Reducer behavior:
+
+- drag begin records that sidebar drag is active
+- `worktreeNotificationReceived` while drag is active records pending reorder IDs instead of mutating row order immediately
+- drag end flushes pending notification reorders in deterministic order, dropping stale worktree IDs
+- `moveNotifiedWorktreeToTop == false` remains a no-op
 
 This addresses #222 without requiring every live data read to stop.
 
@@ -295,16 +352,16 @@ Rules:
 
 - repository container: `SidebarScrollID.repository(repositoryID)`
 - worktree row: `SidebarScrollID.worktree(worktreeID)`
-- special rows: `SidebarScrollID.canvas`, etc.
+- archived worktrees row: `SidebarScrollID.archivedWorktrees`
 
 When revealing a collapsed worktree:
 
 1. expand its repository
-2. yield for layout materialization
+2. wait for an event-driven row availability signal
 3. scroll to `SidebarScrollID.worktree(worktreeID)`
 4. consume pending reveal
 
-This matches the current two-yield approach but removes dependency on `List` row materialization.
+Do not rely on a fixed number of `Task.yield()` calls in the new architecture. The implementation can use a scroll target registry, preference key, or equivalent view materialization signal.
 
 ### Accessibility
 
@@ -328,7 +385,37 @@ If full native `List` accessibility cannot be matched in V1, document the gap an
   - sidebar multi-selection
   - reveal-in-sidebar
 - Add signposts around sidebar presentation build and drag state transitions if trace work is needed.
-- Keep current `List` code untouched until presentation tests exist.
+- Establish `LazyVStack` vs `VStack` decision metrics before replacing the list:
+  - expand/collapse latency for 10+ repositories
+  - frame stability during repository drag
+  - CPU peak during drag and bulk expand/collapse
+  - body recomputation count for repository container and worktree row views
+- Keep current `List` code untouched until M1 and presentation tests exist.
+
+### M1: Stabilize Old `List` Drag Behavior
+
+Files likely involved:
+
+- `supacode/Features/Repositories/Reducer/RepositoriesFeature.swift`
+- `supacode/Features/Repositories/Reducer/RepositoriesFeature+WorktreeOrdering.swift`
+- `supacode/Features/Repositories/Views/SidebarListView.swift`
+- `supacodeTests/RepositoriesFeatureTests.swift`
+
+Deliver:
+
+- reducer-level sidebar drag state
+- view action for drag begin/end from the old `List` path
+- delayed or no-animation handling for notification-driven reorder during drag
+- deterministic pending reorder flush on drag end
+
+Tests:
+
+- notification during sidebar drag does not mutate visible worktree order immediately
+- drag end applies the pending notification reorder in deterministic order
+- multiple notifications during one drag produce stable ordering
+- stale pending worktree IDs are ignored
+- `moveNotifiedWorktreeToTop == false` remains a no-op
+- persistence is called only when the reorder is actually applied
 
 ### Phase 1: Pure Presentation and Reorder Mapping
 
@@ -343,13 +430,18 @@ Deliver:
 - pure sidebar presentation builder
 - stable scroll IDs
 - pure drop-destination mapping for repository and worktree reorder
-- tests for:
-  - expanded repository keeps one outer item with child rows
-  - failed repositories preserve order
-  - plain folders produce repository containers with no worktree children
-  - pinned/main/pending/unpinned sections are preserved
-  - repository drop destinations map to expected order
-  - worktree drop destinations map within pinned/unpinned sections
+- one unified presentation path for empty and non-empty ordered roots
+- explicit failed repository row reorder semantics
+
+Tests:
+
+- expanded repository keeps one outer item with child rows
+- failed repositories preserve the chosen reorder semantics
+- plain folders produce repository containers with no worktree children
+- pinned/main/pending/unpinned sections are preserved
+- empty ordered roots and custom ordered roots produce equivalent presentation rules
+- repository drop destinations map to expected order
+- worktree drop destinations map within pinned/unpinned sections
 
 ### Phase 2: New Container Views Behind a Switch
 
@@ -366,23 +458,28 @@ Deliver:
 - render the new container sidebar behind a local compile-time or private runtime switch
 - no reducer changes except new presentation helpers if needed
 - preserve row styling visually before enabling custom drag/drop
+- preserve root-level URL drop for files dragged into blank sidebar space
+- preserve context menus and drag previews
 
 This phase should be screenshot/manual verified before deleting the old `List` path.
 
-### Phase 3: Explicit Selection and Reveal
+### Phase 3: Explicit Selection, Focus, and Reveal
 
 Deliver:
 
 - click handling for repository and worktree rows
 - explicit selection visuals
-- multi-selection behavior matching current sidebar expectations
-- reveal-in-sidebar via new scroll IDs
+- multi-selection behavior matching the compatibility matrix
+- `sidebarSelections -> setSidebarSelectedWorktreeIDs` synchronization
+- focused actions and hotkey row values
+- reveal-in-sidebar via new scroll IDs and row availability events
 - focused terminal handoff after single worktree selection
 
 Tests:
 
-- pure selection helper tests if logic is factored out
-- existing reducer selection tests should keep passing
+- pure selection helper tests
+- reducer tests for sidebar selected worktree synchronization
+- focused action manual checklist for confirm/archive/delete and numbered hotkeys
 
 ### Phase 4: Custom Repository Reorder
 
@@ -390,14 +487,14 @@ Deliver:
 
 - repository drag payload
 - custom repo-level insertion indicator
-- drop handling that dispatches repository reorder
+- drop handling that dispatches repository reorder through the existing persistence path
 - drag-time UI freeze for non-essential row affordances
 
 Manual verification:
 
 - dragging a repository upward shows indicator below the target repository container when appropriate
 - dragging a repository downward never shows the indicator between target header and target worktree rows
-- failed repository rows either reorder correctly or are explicitly non-reorderable
+- failed repository rows follow the documented reorder semantics
 
 ### Phase 5: Custom Worktree Reorder
 
@@ -429,6 +526,9 @@ Deliver:
 Automated:
 
 - `SidebarPresentationTests`
+- reducer tests for sidebar drag gate and notification reorder concurrency
+- reducer tests for expanded/collapsed state write-back and invalid collapsed ID cleanup
+- reducer tests for sidebar selected worktree synchronization
 - existing `RepositoriesFeatureTests` ordering tests
 - existing `RepositorySectionViewTests` migrated or renamed
 - `make check`
@@ -437,16 +537,23 @@ Automated:
 Manual:
 
 1. Select a plain folder repository row.
-2. Select a git repository worktree row and confirm terminal focus.
-3. Cmd-click multiple worktree rows and confirm bulk archive/delete commands still target selected rows.
-4. Expand/collapse one repository.
-5. Bulk expand/collapse at least 10 repositories.
-6. Drag repository upward and downward across expanded repositories.
-7. Drag pinned worktrees within a repository.
-8. Drag unpinned worktrees within a repository.
-9. Trigger reveal-in-sidebar from Canvas or command.
-10. Verify Canvas / Shelf / Archived rows remain selectable.
-11. Verify notification/task/run-script indicators update without moving rows during a drag.
+2. Click a git repository header and confirm it expands/collapses without selecting a worktree.
+3. Select a git repository worktree row and confirm terminal focus.
+4. Cmd-click multiple worktree rows and confirm bulk archive/delete commands still target selected rows.
+5. Verify confirm/archive/delete menu commands target the same worktrees as before.
+6. Verify numbered worktree hotkeys use visible sidebar rows.
+7. Expand/collapse one repository.
+8. Bulk expand/collapse at least 10 repositories.
+9. Drag repository upward and downward across expanded repositories.
+10. Drag pinned worktrees within a repository.
+11. Drag unpinned worktrees within a repository.
+12. Trigger reveal-in-sidebar from Canvas or command.
+13. Verify Canvas / Shelf / Archived interactions remain correct.
+14. Verify notification/task/run-script indicators update without moving rows during a drag.
+15. Drop a repository URL onto a visible row and onto blank sidebar space.
+16. Verify repository and worktree context menus.
+17. Verify drag previews.
+18. Verify worktree rows do not gain type-select behavior in V1.
 
 ## Risks
 
@@ -477,7 +584,7 @@ Risk: replacing the sidebar in one PR touches selection, animation, and drag.
 Mitigation:
 
 - stage behind a private switch until visual behavior is verified
-- land presentation model tests first
+- land M1 and presentation model tests first
 - keep reducer actions and persistence shape stable
 
 ### Performance regressions
@@ -488,7 +595,7 @@ Mitigation:
 
 - start with `LazyVStack`
 - switch only repository containers to non-lazy child stacks if expand/collapse animation needs it
-- measure with the existing signpost / Instruments workflow if the sidebar feels worse
+- decide using the Phase 0 metrics rather than visual impression alone
 
 ## Recommendation
 
@@ -498,11 +605,13 @@ Do not attempt to fix the repository insertion indicator through reducer index c
 
 The safest execution path is:
 
-1. pure presentation model and tests
-2. render-only new sidebar path
-3. explicit selection/reveal
-4. custom repository reorder
-5. custom worktree reorder
-6. remove old `List` path
+1. baseline metrics and manual guardrails
+2. M1 old `List` drag gate and reducer concurrency tests
+3. pure presentation model and tests
+4. render-only new sidebar path
+5. explicit selection, focus, and reveal
+6. custom repository reorder
+7. custom worktree reorder
+8. remove old `List` path
 
 This is larger than a tactical #222 fix, but it addresses the underlying sidebar design mismatch and gives future sidebar features a cleaner foundation.

--- a/doc-onevcat/plans/2026-05-03-sidebar-container-refactor-plan.md
+++ b/doc-onevcat/plans/2026-05-03-sidebar-container-refactor-plan.md
@@ -1,0 +1,508 @@
+# Sidebar Container Refactor Plan
+
+Status: planning
+Issue: [#249](https://github.com/onevcat/Prowl/issues/249)
+Related: [#222](https://github.com/onevcat/Prowl/issues/222)
+
+## Goal
+
+Refactor the repository sidebar so each repository behaves as one stable visual and drag unit, while worktrees remain selectable, reorderable, and efficient to update.
+
+This should fix the structural mismatch where the app treats repositories as reorderable units but SwiftUI `List` sees repository headers and worktree rows as separate rows. That mismatch shows up as:
+
+- incorrect repository drag insertion indicators when dragging downward across expanded repositories
+- unstable bulk expand/collapse animations
+- potential sidebar flicker during drag when live terminal / notification / ordering updates arrive
+
+## Current Findings
+
+### 1. Repository sections are not actual list rows
+
+`SidebarListView` renders repositories through an outer `ForEach(...).onMove`.
+
+`RepositorySectionView` then returns:
+
+```swift
+Group {
+  header
+    .tag(SidebarSelection.repository(repository.id))
+  if isExpanded {
+    WorktreeRowsView(...)
+  }
+}
+```
+
+In practice, the outer data model says "repository row", but `List` receives separate rows:
+
+```text
+Repository A header
+  Repository A worktree
+  Repository A worktree
+Repository B header
+  Repository B worktree
+```
+
+This explains the observed downward-drag indicator bug:
+
+```text
+Target Repo header
+o-----------
+Target Repo worktree
+```
+
+SwiftUI is placing the indicator between list rows. It does not know that the target repository header and its worktree rows should be treated as one repository-level drop zone.
+
+### 2. `List(selection:)` is doing too much
+
+The current `List` carries several behaviors at once:
+
+- special rows: Canvas, Shelf, archived worktrees, repository list header
+- repository row selection for plain folders
+- worktree multi-selection
+- repository expand/collapse
+- native repository reorder
+- native worktree reorder for pinned and unpinned groups
+- reveal-in-sidebar via `ScrollViewReader.scrollTo`
+- native sidebar styling and accessibility
+
+This makes local fixes brittle because changing row structure affects selection, drag, animation, and scroll identity at the same time.
+
+### 3. Live state still reaches rows during drag
+
+Some expensive state reads have already been isolated, such as moving repository tab-count reads into `RepoHeaderTabCountBadge`.
+
+Remaining drag-time churn sources include:
+
+- `WorktreeRowsView` animates changes to `rowIDs`
+- each worktree row reads terminal notification/task/run-script state
+- notification-driven reorder can call `withAnimation(.snappy)` and mutate `worktreeOrderByRepository`
+- row hover/action UI changes while a drag session is active
+
+These are not necessarily the root cause of the drop-indicator bug, but they are credible contributors to #222-style flicker.
+
+## Recommended Direction
+
+Use a custom sidebar scroll container rather than trying to keep the current flat `List` structure.
+
+Recommended shape:
+
+```text
+ScrollViewReader
+└── ScrollView
+    └── LazyVStack or VStack
+        ├── Special rows
+        ├── RepositoryContainerRow
+        │   ├── RepositoryHeaderRow
+        │   └── WorktreeRows
+        └── FailedRepositoryRow
+```
+
+Key property: repository containers are the only repository-level siblings in the outer stack. Expanded worktrees are children inside the container, not siblings beside it.
+
+This aligns UI boundaries with model boundaries:
+
+- repository reorder indicators target repository containers
+- expand/collapse animates inside a container
+- worktree reorder indicators target worktree rows inside one container
+- live worktree updates do not change the outer repository list shape
+
+## Options Considered
+
+### Option A: Keep `List`, wrap worktrees inside one repository row
+
+Pros:
+
+- preserves some native sidebar styling
+- repository-level `onMove` might remain mostly native
+
+Cons:
+
+- nested selectable worktree rows inside a single `List` row no longer participate naturally in `List(selection:)`
+- worktree-level `onMove` becomes awkward inside a row
+- native selection and keyboard behavior still need replacement
+- likely keeps a hard-to-debug mix of native and custom drag logic
+
+This option reduces the indicator bug but does not cleanly solve the broader sidebar design.
+
+### Option B: Move fully to `ScrollView` + explicit rows
+
+Pros:
+
+- model and visual structure match
+- repo and worktree drag/drop can be made explicit and testable
+- selection, focus, and reveal behavior are owned by our code instead of `List` side effects
+- easier to freeze drag-time updates intentionally
+- eliminates `List` cell reuse as a class of expand/collapse animation bugs
+
+Cons:
+
+- must replace native `List(selection:)`
+- must rebuild keyboard navigation, multi-selection, reorder, and accessibility affordances
+- more implementation work
+
+This is the recommended route for #249 if the goal is "fix the sidebar design once" rather than patch one symptom.
+
+### Option C: Short-term drag-time freeze only
+
+Pros:
+
+- small
+- may help #222 flicker
+
+Cons:
+
+- does not fix repository insertion indicator because row boundaries remain wrong
+- leaves the main structural mismatch in place
+
+This can be kept as a subset of Option B, but it is not enough alone.
+
+## Proposed Architecture
+
+### SidebarPresentationModel
+
+Introduce a pure presentation model that flattens current repository state into explicit sidebar units.
+
+Suggested model:
+
+```swift
+struct SidebarPresentation: Equatable {
+  var items: [SidebarItem]
+}
+
+enum SidebarItem: Equatable, Identifiable {
+  case listHeader(SidebarListHeaderModel)
+  case special(SidebarSpecialRowModel)
+  case repository(SidebarRepositoryContainerModel)
+  case failedRepository(FailedRepositoryModel)
+}
+
+struct SidebarRepositoryContainerModel: Equatable, Identifiable {
+  var repositoryID: Repository.ID
+  var title: String
+  var rootURL: URL
+  var kind: Repository.Kind
+  var isExpanded: Bool
+  var isRemoving: Bool
+  var worktreeSections: WorktreeRowSections
+}
+```
+
+Rules:
+
+- outer `items` contains one item per repository, not one item per row
+- worktree sections remain inside the repository container
+- presentation construction should be pure and unit-tested
+- live terminal state should not be part of the broad presentation model unless required for layout identity
+
+### Selection
+
+Replace `List(selection:)` with explicit selection handling.
+
+Keep `RepositoriesFeature.State.selection` and `sidebarSelectedWorktreeIDs` as the source of truth, but route clicks through helper functions:
+
+- repository header click:
+  - plain folder: select repository
+  - git repository: toggle expand by default, or select repository if a future repository-detail mode needs it
+- worktree row click:
+  - normal click: select worktree and focus terminal
+  - Cmd-click: toggle multi-selection
+  - Shift-click: optional follow-up, only if current behavior supports it through `List`
+- Canvas / Shelf / Archived rows: dispatch existing actions
+
+Selection visuals should be explicit in `RepositoryHeaderRow` and `WorktreeRow`, not inherited from `List`.
+
+### Keyboard Navigation
+
+Preserve the existing command actions first:
+
+- `selectNextWorktree`
+- `selectPreviousWorktree`
+- `revealSelectedWorktreeInSidebar`
+- numbered hotkeys
+
+Do not try to rebuild full Finder-like keyboard navigation in the first pass unless it is currently user-visible and relied upon.
+
+Required V1 behavior:
+
+- command shortcuts still select worktrees
+- selected row is scrolled into view on reveal
+- focus returns to terminal after single worktree selection
+- sidebar focus does not accidentally forward text while Canvas / Shelf rules say it should not
+
+### Repository Reorder
+
+Replace `ForEach(...).onMove` with explicit repository drag/drop.
+
+Suggested approach:
+
+- make `RepositoryContainerRow` draggable with repository ID payload
+- render a custom repository insertion indicator between repository containers
+- compute drop destination as a repository index
+- dispatch existing `.worktreeOrdering(.repositoriesMoved(offsets, destination))` or a new clearer action such as `.repositoriesReordered([Repository.ID])`
+
+The custom indicator should always render at repository container boundaries:
+
+```text
+Target Repo header
+  Target Repo worktree
+o-----------
+```
+
+This directly fixes the current downward-drag indicator bug.
+
+### Worktree Reorder
+
+Keep worktree reorder scoped inside one repository container.
+
+Suggested approach:
+
+- worktree rows are draggable with worktree ID payload
+- pinned and unpinned sections keep separate drop zones
+- main and pending rows remain non-movable
+- drop destination maps to existing reducer actions:
+  - `.pinnedWorktreesMoved(repositoryID, offsets, destination)`
+  - `.unpinnedWorktreesMoved(repositoryID, offsets, destination)`
+
+Cross-repository worktree drag can stay out of scope. The current model does not appear to support moving worktrees between repositories.
+
+### Drag-Time Freeze
+
+Add a small sidebar drag state to suppress non-essential row churn.
+
+During any sidebar drag:
+
+- freeze hover-only row actions
+- hide pull request / notification popover affordances that resize rows
+- suppress row-ID animations caused by notification-driven reorder
+- defer "move notified worktree to top" until drag ends, or apply it without animation after drop
+
+This addresses #222 without requiring every live data read to stop.
+
+### Expand / Collapse
+
+Move expand/collapse animation into `RepositoryContainerRow`.
+
+Rules:
+
+- outer repository container identity must not change when worktrees appear/disappear
+- single repo expand/collapse animates child rows inside the container
+- bulk expand/collapse updates many containers, but the outer stack still has stable repository items
+- avoid animating row identity and live status changes in the same transaction
+
+### Reveal In Sidebar
+
+`ScrollViewReader.scrollTo` can still work, but scroll IDs must be explicit:
+
+- repository container: `SidebarScrollID.repository(repositoryID)`
+- worktree row: `SidebarScrollID.worktree(worktreeID)`
+- special rows: `SidebarScrollID.canvas`, etc.
+
+When revealing a collapsed worktree:
+
+1. expand its repository
+2. yield for layout materialization
+3. scroll to `SidebarScrollID.worktree(worktreeID)`
+4. consume pending reveal
+
+This matches the current two-yield approach but removes dependency on `List` row materialization.
+
+### Accessibility
+
+Minimum accessibility requirements:
+
+- repository headers expose button/row labels and expanded state
+- worktree rows expose selection state
+- drag handles or rows expose reorder affordance where AppKit/SwiftUI can support it
+- Canvas / Shelf / Archived rows keep meaningful labels
+
+If full native `List` accessibility cannot be matched in V1, document the gap and keep keyboard command coverage strong.
+
+## Implementation Plan
+
+### Phase 0: Baseline and Guardrails
+
+- Add a short manual repro checklist for:
+  - repository drag up/down over expanded target
+  - bulk expand/collapse with many repositories
+  - worktree reorder in pinned/unpinned groups
+  - sidebar multi-selection
+  - reveal-in-sidebar
+- Add signposts around sidebar presentation build and drag state transitions if trace work is needed.
+- Keep current `List` code untouched until presentation tests exist.
+
+### Phase 1: Pure Presentation and Reorder Mapping
+
+Files likely involved:
+
+- `supacode/Features/Repositories/Models/SidebarPresentation.swift` (new)
+- `supacodeTests/SidebarPresentationTests.swift` (new)
+- existing reducer ordering tests
+
+Deliver:
+
+- pure sidebar presentation builder
+- stable scroll IDs
+- pure drop-destination mapping for repository and worktree reorder
+- tests for:
+  - expanded repository keeps one outer item with child rows
+  - failed repositories preserve order
+  - plain folders produce repository containers with no worktree children
+  - pinned/main/pending/unpinned sections are preserved
+  - repository drop destinations map to expected order
+  - worktree drop destinations map within pinned/unpinned sections
+
+### Phase 2: New Container Views Behind a Switch
+
+Files likely involved:
+
+- `SidebarListView.swift`
+- `RepositorySectionView.swift`
+- `WorktreeRowsView.swift`
+- new `SidebarContainerListView.swift`
+- new `RepositoryContainerRow.swift`
+
+Deliver:
+
+- render the new container sidebar behind a local compile-time or private runtime switch
+- no reducer changes except new presentation helpers if needed
+- preserve row styling visually before enabling custom drag/drop
+
+This phase should be screenshot/manual verified before deleting the old `List` path.
+
+### Phase 3: Explicit Selection and Reveal
+
+Deliver:
+
+- click handling for repository and worktree rows
+- explicit selection visuals
+- multi-selection behavior matching current sidebar expectations
+- reveal-in-sidebar via new scroll IDs
+- focused terminal handoff after single worktree selection
+
+Tests:
+
+- pure selection helper tests if logic is factored out
+- existing reducer selection tests should keep passing
+
+### Phase 4: Custom Repository Reorder
+
+Deliver:
+
+- repository drag payload
+- custom repo-level insertion indicator
+- drop handling that dispatches repository reorder
+- drag-time UI freeze for non-essential row affordances
+
+Manual verification:
+
+- dragging a repository upward shows indicator below the target repository container when appropriate
+- dragging a repository downward never shows the indicator between target header and target worktree rows
+- failed repository rows either reorder correctly or are explicitly non-reorderable
+
+### Phase 5: Custom Worktree Reorder
+
+Deliver:
+
+- pinned/unpinned scoped worktree drop zones
+- custom worktree insertion indicator
+- main/pending rows stay non-movable
+- existing persistence paths remain unchanged
+
+Manual verification:
+
+- pinned worktree reorder persists
+- unpinned worktree reorder persists
+- dragging over main/pending rows does not create invalid moves
+
+### Phase 6: Remove Old `List` Path and Polish
+
+Deliver:
+
+- delete old `List(selection:)` implementation
+- remove obsolete `RepositorySectionView` / `WorktreeRowsView` pieces or fold them into new components
+- final accessibility pass
+- final animation pass for bulk expand/collapse
+- update issue #249 with final implementation notes
+
+## Verification Matrix
+
+Automated:
+
+- `SidebarPresentationTests`
+- existing `RepositoriesFeatureTests` ordering tests
+- existing `RepositorySectionViewTests` migrated or renamed
+- `make check`
+- `make build-app`
+
+Manual:
+
+1. Select a plain folder repository row.
+2. Select a git repository worktree row and confirm terminal focus.
+3. Cmd-click multiple worktree rows and confirm bulk archive/delete commands still target selected rows.
+4. Expand/collapse one repository.
+5. Bulk expand/collapse at least 10 repositories.
+6. Drag repository upward and downward across expanded repositories.
+7. Drag pinned worktrees within a repository.
+8. Drag unpinned worktrees within a repository.
+9. Trigger reveal-in-sidebar from Canvas or command.
+10. Verify Canvas / Shelf / Archived rows remain selectable.
+11. Verify notification/task/run-script indicators update without moving rows during a drag.
+
+## Risks
+
+### Native `List` behavior loss
+
+Risk: custom scroll rows may lose some free AppKit sidebar behavior.
+
+Mitigation:
+
+- preserve command-based navigation first
+- add explicit accessibility labels/traits
+- keep manual keyboard/accessibility checklist
+
+### Reorder implementation complexity
+
+Risk: custom drag/drop can become more complex than native `.onMove`.
+
+Mitigation:
+
+- keep pure drop-index mapping tested
+- keep repository reorder and worktree reorder separate
+- defer cross-repository worktree moves
+
+### UI regressions from broad rewrite
+
+Risk: replacing the sidebar in one PR touches selection, animation, and drag.
+
+Mitigation:
+
+- stage behind a private switch until visual behavior is verified
+- land presentation model tests first
+- keep reducer actions and persistence shape stable
+
+### Performance regressions
+
+Risk: replacing lazy `List` with `VStack` could render too much.
+
+Mitigation:
+
+- start with `LazyVStack`
+- switch only repository containers to non-lazy child stacks if expand/collapse animation needs it
+- measure with the existing signpost / Instruments workflow if the sidebar feels worse
+
+## Recommendation
+
+Proceed with Option B as the #249 plan: a custom `ScrollView` sidebar with repository containers as outer items.
+
+Do not attempt to fix the repository insertion indicator through reducer index changes. The indicator is a symptom of the current `List` row structure, not the persisted ordering logic.
+
+The safest execution path is:
+
+1. pure presentation model and tests
+2. render-only new sidebar path
+3. explicit selection/reveal
+4. custom repository reorder
+5. custom worktree reorder
+6. remove old `List` path
+
+This is larger than a tactical #222 fix, but it addresses the underlying sidebar design mismatch and gives future sidebar features a cleaner foundation.

--- a/supacode/Features/Repositories/Models/SidebarPresentation.swift
+++ b/supacode/Features/Repositories/Models/SidebarPresentation.swift
@@ -59,6 +59,12 @@ enum SidebarPresentationItemID: Equatable, Hashable {
   case archivedWorktrees
 }
 
+enum SidebarScrollID: Equatable, Hashable {
+  case repository(Repository.ID)
+  case worktree(Worktree.ID)
+  case archivedWorktrees
+}
+
 struct SidebarListHeaderModel: Equatable, Identifiable {
   let id = SidebarPresentationItemID.listHeader
   var repositoryCount: Int

--- a/supacode/Features/Repositories/Models/SidebarPresentation.swift
+++ b/supacode/Features/Repositories/Models/SidebarPresentation.swift
@@ -1,0 +1,196 @@
+import Foundation
+
+struct SidebarPresentation: Equatable {
+  var items: [SidebarItem]
+
+  static func showsListHeader(repositoryCount: Int) -> Bool {
+    repositoryCount > 10
+  }
+
+  var repositoryOrderIDs: [Repository.ID] {
+    items.compactMap(\.repositoryOrderID)
+  }
+
+  func repositoryOrderAfterMove(
+    fromOffsets source: IndexSet,
+    toOffset destination: Int
+  ) -> [Repository.ID] {
+    var orderedIDs = repositoryOrderIDs
+    orderedIDs.moveElements(fromOffsets: source, toOffset: destination)
+    return orderedIDs
+  }
+}
+
+enum SidebarItem: Equatable, Identifiable {
+  case listHeader(SidebarListHeaderModel)
+  case repository(SidebarRepositoryContainerModel)
+  case failedRepository(FailedRepositoryModel)
+  case archivedWorktrees(ArchivedWorktreesRowModel)
+
+  var id: SidebarPresentationItemID {
+    switch self {
+    case .listHeader:
+      return .listHeader
+    case .repository(let model):
+      return .repository(model.id)
+    case .failedRepository(let model):
+      return .failedRepository(model.id)
+    case .archivedWorktrees:
+      return .archivedWorktrees
+    }
+  }
+
+  var repositoryOrderID: Repository.ID? {
+    switch self {
+    case .repository(let model):
+      return model.id
+    case .failedRepository(let model) where model.isReorderable:
+      return model.id
+    case .listHeader, .failedRepository, .archivedWorktrees:
+      return nil
+    }
+  }
+}
+
+enum SidebarPresentationItemID: Equatable, Hashable {
+  case listHeader
+  case repository(Repository.ID)
+  case failedRepository(Repository.ID)
+  case archivedWorktrees
+}
+
+struct SidebarListHeaderModel: Equatable, Identifiable {
+  let id = SidebarPresentationItemID.listHeader
+  var repositoryCount: Int
+}
+
+struct SidebarRepositoryContainerModel: Equatable, Identifiable {
+  var id: Repository.ID { repositoryID }
+
+  var repositoryID: Repository.ID
+  var title: String
+  var rootURL: URL
+  var kind: Repository.Kind
+  var isExpanded: Bool
+  var isRemoving: Bool
+  var worktreeSections: WorktreeRowSections
+}
+
+struct FailedRepositoryModel: Equatable, Identifiable {
+  var id: Repository.ID
+  var name: String
+  var path: String
+  var failureMessage: String
+  var isReorderable: Bool
+}
+
+struct ArchivedWorktreesRowModel: Equatable, Identifiable {
+  let id = SidebarPresentationItemID.archivedWorktrees
+  var count: Int
+}
+
+enum SidebarWorktreeSection: Equatable {
+  case pinned
+  case unpinned
+}
+
+struct SidebarWorktreeDropTarget: Equatable {
+  var repositoryID: Repository.ID
+  var section: SidebarWorktreeSection
+  var source: IndexSet
+  var destination: Int
+
+  var action: RepositoriesFeature.WorktreeOrderingAction {
+    switch section {
+    case .pinned:
+      return .pinnedWorktreesMoved(repositoryID: repositoryID, source, destination)
+    case .unpinned:
+      return .unpinnedWorktreesMoved(repositoryID: repositoryID, source, destination)
+    }
+  }
+}
+
+extension RepositoriesFeature.State {
+  func sidebarPresentation(
+    expandedRepositoryIDs: Set<Repository.ID>,
+    includesArchivedWorktreesRow: Bool = false
+  ) -> SidebarPresentation {
+    let repositoriesByID = Dictionary(uniqueKeysWithValues: repositories.map { ($0.id, $0) })
+    let roots = sidebarPresentationRoots()
+    let repositoryCount = roots.count
+    var items: [SidebarItem] = []
+
+    if SidebarPresentation.showsListHeader(repositoryCount: repositoryCount) {
+      items.append(.listHeader(SidebarListHeaderModel(repositoryCount: repositoryCount)))
+    }
+
+    for rootURL in roots {
+      let standardizedRootURL = rootURL.standardizedFileURL
+      let repositoryID = standardizedRootURL.path(percentEncoded: false)
+      if let failureMessage = loadFailuresByID[repositoryID] {
+        let path = standardizedRootURL.path(percentEncoded: false)
+        items.append(
+          .failedRepository(
+            FailedRepositoryModel(
+              id: repositoryID,
+              name: Repository.name(for: standardizedRootURL),
+              path: path,
+              failureMessage: failureMessage,
+              isReorderable: true
+            )
+          )
+        )
+      } else if let repository = repositoriesByID[repositoryID] {
+        let isExpanded = expandedRepositoryIDs.contains(repository.id)
+        items.append(
+          .repository(
+            SidebarRepositoryContainerModel(
+              repositoryID: repository.id,
+              title: repository.name,
+              rootURL: repository.rootURL,
+              kind: repository.kind,
+              isExpanded: isExpanded,
+              isRemoving: isRemovingRepository(repository),
+              worktreeSections: isExpanded ? worktreeRowSections(in: repository) : .empty
+            )
+          )
+        )
+      }
+    }
+
+    if includesArchivedWorktreesRow, !archivedWorktrees.isEmpty {
+      items.append(.archivedWorktrees(ArchivedWorktreesRowModel(count: archivedWorktrees.count)))
+    }
+
+    return SidebarPresentation(items: items)
+  }
+
+  private func sidebarPresentationRoots() -> [URL] {
+    let orderedRoots = orderedRepositoryRoots()
+    if !orderedRoots.isEmpty {
+      return orderedRoots
+    }
+    return repositories.map(\.rootURL)
+  }
+}
+
+extension WorktreeRowSections {
+  static let empty = WorktreeRowSections(
+    main: nil,
+    pinned: [],
+    pending: [],
+    unpinned: []
+  )
+}
+
+extension Array {
+  fileprivate mutating func moveElements(fromOffsets source: IndexSet, toOffset destination: Int) {
+    let sourceIndexes = source.sorted()
+    let movedElements = sourceIndexes.map { self[$0] }
+    for index in sourceIndexes.reversed() {
+      remove(at: index)
+    }
+    let removedBeforeDestination = sourceIndexes.filter { $0 < destination }.count
+    insert(contentsOf: movedElements, at: destination - removedBeforeDestination)
+  }
+}

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+WorktreeOrdering.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+WorktreeOrdering.swift
@@ -142,32 +142,46 @@ extension RepositoriesFeature {
       return .merge(effects)
 
     case .worktreeNotificationReceived(let worktreeID):
-      guard let repositoryID = state.repositoryID(containing: worktreeID),
-        let repository = state.repositories[id: repositoryID],
-        let worktree = repository.worktrees[id: worktreeID]
-      else {
+      guard notificationReorderTarget(for: worktreeID, state: state) != nil else {
         return .none
       }
-      if state.isWorktreeArchived(worktree.id) {
+      if state.isSidebarDragActive {
+        state.pendingSidebarNotifyReorderIDs.removeAll { $0 == worktreeID }
+        state.pendingSidebarNotifyReorderIDs.append(worktreeID)
         return .none
       }
-      if state.moveNotifiedWorktreeToTop, !state.isMainWorktree(worktree), !state.isWorktreePinned(worktree) {
-        let reordered = reorderedUnpinnedWorktreeIDs(
-          for: worktreeID,
-          in: repository,
-          state: state
-        )
-        if state.worktreeOrderByRepository[repositoryID] != reordered {
-          withAnimation(.snappy(duration: 0.2)) {
-            state.worktreeOrderByRepository[repositoryID] = reordered
-          }
-          let worktreeOrderByRepository = state.worktreeOrderByRepository
-          return .run { _ in
-            await repositoryPersistence.saveWorktreeOrderByRepository(worktreeOrderByRepository)
-          }
-        }
+      guard applyNotificationReorder(for: worktreeID, state: &state, animated: true) else {
+        return .none
       }
-      return .none
+      let worktreeOrderByRepository = state.worktreeOrderByRepository
+      return .run { _ in
+        await repositoryPersistence.saveWorktreeOrderByRepository(worktreeOrderByRepository)
+      }
+
+    case .setSidebarDragActive(let isActive):
+      guard state.isSidebarDragActive != isActive else {
+        return .none
+      }
+      state.isSidebarDragActive = isActive
+      guard !isActive else {
+        return .none
+      }
+      let pendingWorktreeIDs = state.pendingSidebarNotifyReorderIDs
+      state.pendingSidebarNotifyReorderIDs = []
+      guard !pendingWorktreeIDs.isEmpty else {
+        return .none
+      }
+      var didReorder = false
+      for worktreeID in pendingWorktreeIDs {
+        didReorder = applyNotificationReorder(for: worktreeID, state: &state, animated: false) || didReorder
+      }
+      guard didReorder else {
+        return .none
+      }
+      let worktreeOrderByRepository = state.worktreeOrderByRepository
+      return .run { _ in
+        await repositoryPersistence.saveWorktreeOrderByRepository(worktreeOrderByRepository)
+      }
 
     case .setMoveNotifiedWorktreeToTop(let isEnabled):
       state.moveNotifiedWorktreeToTop = isEnabled
@@ -183,4 +197,47 @@ extension RepositoriesFeature {
       return reduceWorktreeOrdering(state: &state, action: action)
     }
   }
+}
+
+private func notificationReorderTarget(
+  for worktreeID: Worktree.ID,
+  state: RepositoriesFeature.State
+) -> (repositoryID: Repository.ID, repository: Repository)? {
+  guard state.moveNotifiedWorktreeToTop,
+    let repositoryID = state.repositoryID(containing: worktreeID),
+    let repository = state.repositories[id: repositoryID],
+    let worktree = repository.worktrees[id: worktreeID],
+    !state.isWorktreeArchived(worktree.id),
+    !state.isMainWorktree(worktree),
+    !state.isWorktreePinned(worktree)
+  else {
+    return nil
+  }
+  return (repositoryID, repository)
+}
+
+private func applyNotificationReorder(
+  for worktreeID: Worktree.ID,
+  state: inout RepositoriesFeature.State,
+  animated: Bool
+) -> Bool {
+  guard let target = notificationReorderTarget(for: worktreeID, state: state) else {
+    return false
+  }
+  let reordered = reorderedUnpinnedWorktreeIDs(
+    for: worktreeID,
+    in: target.repository,
+    state: state
+  )
+  guard state.worktreeOrderByRepository[target.repositoryID] != reordered else {
+    return false
+  }
+  if animated {
+    withAnimation(.snappy(duration: 0.2)) {
+      state.worktreeOrderByRepository[target.repositoryID] = reordered
+    }
+  } else {
+    state.worktreeOrderByRepository[target.repositoryID] = reordered
+  }
+  return true
 }

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -146,6 +146,7 @@ struct RepositoriesFeature {
     case pinWorktree(Worktree.ID)
     case unpinWorktree(Worktree.ID)
     case worktreeNotificationReceived(Worktree.ID)
+    case setSidebarDragActive(Bool)
     case setMoveNotifiedWorktreeToTop(Bool)
   }
 
@@ -235,6 +236,8 @@ struct RepositoriesFeature {
     var sidebarSelectedWorktreeIDs: Set<Worktree.ID> = []
     var nextPendingSidebarRevealID = 0
     var pendingSidebarReveal: PendingSidebarReveal?
+    var isSidebarDragActive = false
+    var pendingSidebarNotifyReorderIDs: [Worktree.ID] = []
     @Shared(.appStorage("sidebarCollapsedRepositoryIDs")) var collapsedRepositoryIDs: [Repository.ID] = []
     @Presents var worktreeCreationPrompt: WorktreeCreationPromptFeature.State?
     @Presents var alert: AlertState<Alert>?
@@ -1977,7 +1980,7 @@ extension RepositoriesFeature.State {
   }
 }
 
-struct WorktreeRowSections {
+struct WorktreeRowSections: Equatable {
   let main: WorktreeRowModel?
   let pinned: [WorktreeRowModel]
   let pending: [WorktreeRowModel]

--- a/supacode/Features/Repositories/Views/RepoDisplayName.swift
+++ b/supacode/Features/Repositories/Views/RepoDisplayName.swift
@@ -16,6 +16,8 @@ struct RepoDisplayName: View {
 
   var body: some View {
     Text(customTitle ?? fallbackName)
+      .lineLimit(1)
+      .truncationMode(.tail)
       .help(tooltip ?? "")
   }
 }

--- a/supacode/Features/Repositories/Views/RepositorySectionView.swift
+++ b/supacode/Features/Repositories/Views/RepositorySectionView.swift
@@ -36,8 +36,6 @@ struct RepositorySectionView: View {
         }
       }
     }
-    let isDragging = isDragActive
-
     let appearance = repositoryAppearances[repository.id] ?? .empty
     let header = HStack {
       // Inner HStack groups the name row and the tab-count badge so they
@@ -73,7 +71,7 @@ struct RepositorySectionView: View {
             }
         }
       }
-      if isRemovingRepository && !isDragging {
+      if isRemovingRepository {
         ProgressView()
           .controlSize(.small)
           .background {
@@ -94,7 +92,7 @@ struct RepositorySectionView: View {
           .help(color.displayName)
           .accessibilityLabel(Text("Repo color: \(color.displayName)"))
       }
-      if isHovering && !isDragging {
+      if isHovering {
         Menu {
           Button("Repo Settings") {
             openRepoSettings()

--- a/supacode/Features/Repositories/Views/RepositorySectionView.swift
+++ b/supacode/Features/Repositories/Views/RepositorySectionView.swift
@@ -12,6 +12,7 @@ struct RepositorySectionView: View {
   @Binding var expandedRepoIDs: Set<Repository.ID>
   @Bindable var store: StoreOf<RepositoriesFeature>
   let terminalManager: WorktreeTerminalManager
+  let onRepositorySelected: () -> Void
   @Environment(\.colorScheme) private var colorScheme
   @Environment(\.resolvedKeybindings) private var resolvedKeybindings
   @State private var isHovering = false
@@ -21,6 +22,7 @@ struct RepositorySectionView: View {
     let state = store.state
     let isExpanded = expandedRepoIDs.contains(repository.id)
     let isRemovingRepository = state.isRemovingRepository(repository)
+    let isSelected = state.selection == .repository(repository.id)
     let openRepoSettings = {
       _ = store.send(.repositoryManagement(.openRepositorySettings(repository.id)))
     }
@@ -184,7 +186,11 @@ struct RepositorySectionView: View {
     .padding(.bottom, hasTopSpacing && !repository.capabilities.supportsWorktrees ? 4 : 0)
     .contentShape(.interaction, .rect)
     .background {
-      if Self.debugHeaderLayers {
+      if isSelected {
+        RoundedRectangle(cornerRadius: 5)
+          .fill(Color.accentColor.opacity(0.18))
+          .padding(.horizontal, 6)
+      } else if Self.debugHeaderLayers {
         Rectangle()
           .fill(.red.opacity(0.12))
           .overlay {
@@ -194,6 +200,10 @@ struct RepositorySectionView: View {
       }
     }
     .onHover { isHovering = $0 }
+    .onTapGesture {
+      onRepositorySelected()
+    }
+    .accessibilityAddTraits(.isButton)
     .contentShape(.rect)
     .contextMenu {
       Button("Repo Settings") {
@@ -211,7 +221,7 @@ struct RepositorySectionView: View {
     .environment(\.colorScheme, colorScheme)
     .preferredColorScheme(colorScheme)
 
-    Group {
+    VStack(spacing: 0) {
       header
         .tag(SidebarSelection.repository(repository.id))
       if isExpanded {
@@ -225,6 +235,7 @@ struct RepositorySectionView: View {
         )
       }
     }
+    .id(SidebarScrollID.repository(repository.id))
   }
 
   private var headerCellHeight: CGFloat {

--- a/supacode/Features/Repositories/Views/RepositorySectionView.swift
+++ b/supacode/Features/Repositories/Views/RepositorySectionView.swift
@@ -182,6 +182,7 @@ struct RepositorySectionView: View {
       }
     }
     .frame(maxWidth: .infinity, minHeight: headerCellHeight, maxHeight: .infinity, alignment: .center)
+    .padding(.horizontal, 12)
     .padding(.top, hasTopSpacing ? 4 : 0)
     .padding(.bottom, hasTopSpacing && !repository.capabilities.supportsWorktrees ? 4 : 0)
     .contentShape(.interaction, .rect)

--- a/supacode/Features/Repositories/Views/RepositorySectionView.swift
+++ b/supacode/Features/Repositories/Views/RepositorySectionView.swift
@@ -49,7 +49,7 @@ struct RepositorySectionView: View {
           customTitle: store.repositoryCustomTitles[repository.id],
           isRemoving: isRemovingRepository,
           icon: appearance.icon,
-          iconTint: appearance.color?.color,
+          iconTint: appearance.color?.color ?? .accentColor,
           repositoryRootURL: repository.rootURL,
           nameTooltip: repository.capabilities.supportsWorktrees
             ? (isExpanded ? "Collapse" : "Expand")

--- a/supacode/Features/Repositories/Views/SidebarDragSupport.swift
+++ b/supacode/Features/Repositories/Views/SidebarDragSupport.swift
@@ -50,6 +50,7 @@ enum SidebarDragProvider {
 }
 
 struct SidebarRepositoryDropDelegate: DropDelegate {
+  let isEnabled: Bool
   let destination: (DropInfo) -> Int
   let repositoryOrderIDs: [Repository.ID]
   @Binding var targetedDestination: Int?
@@ -57,6 +58,10 @@ struct SidebarRepositoryDropDelegate: DropDelegate {
   let onDragEnded: () -> Void
 
   func dropEntered(info: DropInfo) {
+    guard isEnabled else {
+      targetedDestination = nil
+      return
+    }
     targetedDestination = destination(info)
   }
 
@@ -65,11 +70,19 @@ struct SidebarRepositoryDropDelegate: DropDelegate {
   }
 
   func dropUpdated(info: DropInfo) -> DropProposal? {
+    guard isEnabled else {
+      targetedDestination = nil
+      return nil
+    }
     targetedDestination = destination(info)
     return DropProposal(operation: .move)
   }
 
   func performDrop(info: DropInfo) -> Bool {
+    guard isEnabled else {
+      targetedDestination = nil
+      return false
+    }
     let dropDestination = destination(info)
     targetedDestination = nil
     guard let provider = info.itemProviders(for: [.prowlSidebarDragPayload]).first else {
@@ -96,6 +109,7 @@ struct SidebarRepositoryDropDelegate: DropDelegate {
 }
 
 struct SidebarWorktreeDropDelegate: DropDelegate {
+  let isEnabled: Bool
   let destination: (DropInfo) -> Int
   let sectionIDs: [Worktree.ID]
   @Binding var targetedDestination: Int?
@@ -103,6 +117,10 @@ struct SidebarWorktreeDropDelegate: DropDelegate {
   let onDragEnded: () -> Void
 
   func dropEntered(info: DropInfo) {
+    guard isEnabled else {
+      targetedDestination = nil
+      return
+    }
     targetedDestination = destination(info)
   }
 
@@ -111,11 +129,19 @@ struct SidebarWorktreeDropDelegate: DropDelegate {
   }
 
   func dropUpdated(info: DropInfo) -> DropProposal? {
+    guard isEnabled else {
+      targetedDestination = nil
+      return nil
+    }
     targetedDestination = destination(info)
     return DropProposal(operation: .move)
   }
 
   func performDrop(info: DropInfo) -> Bool {
+    guard isEnabled else {
+      targetedDestination = nil
+      return false
+    }
     let dropDestination = destination(info)
     targetedDestination = nil
     guard let provider = info.itemProviders(for: [.prowlSidebarDragPayload]).first else {
@@ -294,22 +320,19 @@ private struct SidebarRepositoryDropTargetModifier: ViewModifier {
 
   @ViewBuilder
   func body(content: Content) -> some View {
-    if isEnabled {
-      content.onDrop(
-        of: [.prowlSidebarDragPayload],
-        delegate: SidebarRepositoryDropDelegate(
-          destination: { info in
-            info.location.y < 24 ? index : index + 1
-          },
-          repositoryOrderIDs: repositoryOrderIDs,
-          targetedDestination: $targetedDestination,
-          onDrop: actions.onDrop,
-          onDragEnded: actions.onDragEnded
-        )
+    content.onDrop(
+      of: [.prowlSidebarDragPayload],
+      delegate: SidebarRepositoryDropDelegate(
+        isEnabled: isEnabled,
+        destination: { info in
+          info.location.y < 24 ? index : index + 1
+        },
+        repositoryOrderIDs: repositoryOrderIDs,
+        targetedDestination: $targetedDestination,
+        onDrop: actions.onDrop,
+        onDragEnded: actions.onDragEnded
       )
-    } else {
-      content
-    }
+    )
   }
 }
 
@@ -322,21 +345,18 @@ private struct SidebarWorktreeDropTargetModifier: ViewModifier {
 
   @ViewBuilder
   func body(content: Content) -> some View {
-    if isEnabled {
-      content.onDrop(
-        of: [.prowlSidebarDragPayload],
-        delegate: SidebarWorktreeDropDelegate(
-          destination: { info in
-            info.location.y < 18 ? index : index + 1
-          },
-          sectionIDs: rowIDs,
-          targetedDestination: $targetedDestination,
-          onDrop: actions.onDrop,
-          onDragEnded: actions.onDragEnded
-        )
+    content.onDrop(
+      of: [.prowlSidebarDragPayload],
+      delegate: SidebarWorktreeDropDelegate(
+        isEnabled: isEnabled,
+        destination: { info in
+          info.location.y < 18 ? index : index + 1
+        },
+        sectionIDs: rowIDs,
+        targetedDestination: $targetedDestination,
+        onDrop: actions.onDrop,
+        onDragEnded: actions.onDragEnded
       )
-    } else {
-      content
-    }
+    )
   }
 }

--- a/supacode/Features/Repositories/Views/SidebarDragSupport.swift
+++ b/supacode/Features/Repositories/Views/SidebarDragSupport.swift
@@ -54,8 +54,7 @@ struct SidebarRepositoryDropDelegate: DropDelegate {
   let destination: (DropInfo) -> Int
   let repositoryOrderIDs: [Repository.ID]
   @Binding var targetedDestination: Int?
-  let onDrop: (IndexSet, Int) -> Void
-  let onDragEnded: () -> Void
+  let actions: SidebarDropTargetActions
 
   func dropEntered(info: DropInfo) {
     guard isEnabled else {
@@ -85,25 +84,38 @@ struct SidebarRepositoryDropDelegate: DropDelegate {
     }
     let dropDestination = destination(info)
     targetedDestination = nil
+    if let repositoryID = actions.draggedItemID {
+      return performDrop(repositoryID: repositoryID, dropDestination: dropDestination)
+    }
     guard let provider = info.itemProviders(for: [.prowlSidebarDragPayload]).first else {
-      onDragEnded()
+      actions.onDragEnded()
       return false
     }
     provider.loadDataRepresentation(forTypeIdentifier: UTType.prowlSidebarDragPayload.identifier) { data, _ in
       guard let data,
-        let repositoryID = SidebarDragProvider.repositoryID(from: data),
-        let source = repositoryOrderIDs.firstIndex(of: repositoryID),
-        source != dropDestination,
-        source + 1 != dropDestination
+        let repositoryID = SidebarDragProvider.repositoryID(from: data)
       else {
-        Task { @MainActor in onDragEnded() }
+        Task { @MainActor in actions.onDragEnded() }
         return
       }
       Task { @MainActor in
-        onDrop(IndexSet(integer: source), dropDestination)
-        onDragEnded()
+        _ = performDrop(repositoryID: repositoryID, dropDestination: dropDestination)
       }
     }
+    return true
+  }
+
+  @MainActor
+  private func performDrop(repositoryID: Repository.ID, dropDestination: Int) -> Bool {
+    guard let source = repositoryOrderIDs.firstIndex(of: repositoryID),
+      source != dropDestination,
+      source + 1 != dropDestination
+    else {
+      actions.onDragEnded()
+      return false
+    }
+    actions.onDrop(IndexSet(integer: source), dropDestination)
+    actions.onDragEnded()
     return true
   }
 }
@@ -113,8 +125,7 @@ struct SidebarWorktreeDropDelegate: DropDelegate {
   let destination: (DropInfo) -> Int
   let sectionIDs: [Worktree.ID]
   @Binding var targetedDestination: Int?
-  let onDrop: (IndexSet, Int) -> Void
-  let onDragEnded: () -> Void
+  let actions: SidebarDropTargetActions
 
   func dropEntered(info: DropInfo) {
     guard isEnabled else {
@@ -144,25 +155,38 @@ struct SidebarWorktreeDropDelegate: DropDelegate {
     }
     let dropDestination = destination(info)
     targetedDestination = nil
+    if let worktreeID = actions.draggedItemID {
+      return performDrop(worktreeID: worktreeID, dropDestination: dropDestination)
+    }
     guard let provider = info.itemProviders(for: [.prowlSidebarDragPayload]).first else {
-      onDragEnded()
+      actions.onDragEnded()
       return false
     }
     provider.loadDataRepresentation(forTypeIdentifier: UTType.prowlSidebarDragPayload.identifier) { data, _ in
       guard let data,
-        let worktreeID = SidebarDragProvider.worktreeID(from: data),
-        let source = sectionIDs.firstIndex(of: worktreeID),
-        source != dropDestination,
-        source + 1 != dropDestination
+        let worktreeID = SidebarDragProvider.worktreeID(from: data)
       else {
-        Task { @MainActor in onDragEnded() }
+        Task { @MainActor in actions.onDragEnded() }
         return
       }
       Task { @MainActor in
-        onDrop(IndexSet(integer: source), dropDestination)
-        onDragEnded()
+        _ = performDrop(worktreeID: worktreeID, dropDestination: dropDestination)
       }
     }
+    return true
+  }
+
+  @MainActor
+  private func performDrop(worktreeID: Worktree.ID, dropDestination: Int) -> Bool {
+    guard let source = sectionIDs.firstIndex(of: worktreeID),
+      source != dropDestination,
+      source + 1 != dropDestination
+    else {
+      actions.onDragEnded()
+      return false
+    }
+    actions.onDrop(IndexSet(integer: source), dropDestination)
+    actions.onDragEnded()
     return true
   }
 }
@@ -211,6 +235,7 @@ enum SidebarDropIndicatorEdge: Equatable {
 }
 
 struct SidebarDropTargetActions {
+  var draggedItemID: String?
   let onDrop: (IndexSet, Int) -> Void
   let onDragEnded: () -> Void
 }
@@ -329,8 +354,7 @@ private struct SidebarRepositoryDropTargetModifier: ViewModifier {
         },
         repositoryOrderIDs: repositoryOrderIDs,
         targetedDestination: $targetedDestination,
-        onDrop: actions.onDrop,
-        onDragEnded: actions.onDragEnded
+        actions: actions
       )
     )
   }
@@ -354,8 +378,7 @@ private struct SidebarWorktreeDropTargetModifier: ViewModifier {
         },
         sectionIDs: rowIDs,
         targetedDestination: $targetedDestination,
-        onDrop: actions.onDrop,
-        onDragEnded: actions.onDragEnded
+        actions: actions
       )
     )
   }

--- a/supacode/Features/Repositories/Views/SidebarDragSupport.swift
+++ b/supacode/Features/Repositories/Views/SidebarDragSupport.swift
@@ -114,8 +114,8 @@ struct SidebarRepositoryDropDelegate: DropDelegate {
       actions.onDragEnded()
       return false
     }
-    actions.onDrop(IndexSet(integer: source), dropDestination)
     actions.onDragEnded()
+    actions.onDrop(IndexSet(integer: source), dropDestination)
     return true
   }
 }
@@ -185,8 +185,8 @@ struct SidebarWorktreeDropDelegate: DropDelegate {
       actions.onDragEnded()
       return false
     }
-    actions.onDrop(IndexSet(integer: source), dropDestination)
     actions.onDragEnded()
+    actions.onDrop(IndexSet(integer: source), dropDestination)
     return true
   }
 }

--- a/supacode/Features/Repositories/Views/SidebarDragSupport.swift
+++ b/supacode/Features/Repositories/Views/SidebarDragSupport.swift
@@ -27,7 +27,7 @@ enum SidebarDragProvider {
 
   private nonisolated static func itemProvider(payload: String) -> NSItemProvider {
     let provider = NSItemProvider()
-    let loadHandler: (@escaping (Data?, (any Error)?) -> Void) -> Progress? = { completion in
+    let loadHandler: @Sendable (@escaping @Sendable (Data?, (any Error)?) -> Void) -> Progress? = { completion in
       completion(Data(payload.utf8), nil)
       return nil
     }
@@ -161,31 +161,62 @@ struct SidebarDropIndicator: View {
   }
 }
 
+enum SidebarDropIndicatorEdge: Equatable {
+  case none
+  case top
+  case bottom
+
+  static func edge(
+    targetedDestination: Int?,
+    rowIndex: Int,
+    rowCount: Int
+  ) -> Self {
+    guard let targetedDestination else {
+      return .none
+    }
+    if targetedDestination == rowIndex {
+      return .top
+    }
+    if rowIndex == rowCount - 1, targetedDestination == rowCount {
+      return .bottom
+    }
+    return .none
+  }
+}
+
+struct SidebarDropTargetActions {
+  let onDrop: (IndexSet, Int) -> Void
+  let onDragEnded: () -> Void
+}
+
 extension View {
   func repositoryDropTarget(
     index: Int,
     repositoryOrderIDs: [Repository.ID],
+    isEnabled: Bool,
     targetedDestination: Binding<Int?>,
-    onDrop: @escaping (IndexSet, Int) -> Void,
-    onDragEnded: @escaping () -> Void
+    actions: SidebarDropTargetActions
   ) -> some View {
-    self
+    let edge = SidebarDropIndicatorEdge.edge(
+      targetedDestination: targetedDestination.wrappedValue,
+      rowIndex: index,
+      rowCount: repositoryOrderIDs.count
+    )
+    return
+      self
       .overlay(alignment: .top) {
-        SidebarDropIndicator(isVisible: targetedDestination.wrappedValue == index)
+        SidebarDropIndicator(isVisible: edge == .top)
       }
       .overlay(alignment: .bottom) {
-        SidebarDropIndicator(isVisible: targetedDestination.wrappedValue == index + 1)
+        SidebarDropIndicator(isVisible: edge == .bottom)
       }
-      .onDrop(
-        of: [.prowlSidebarDragPayload],
-        delegate: SidebarRepositoryDropDelegate(
-          destination: { info in
-            info.location.y < 24 ? index : index + 1
-          },
+      .modifier(
+        SidebarRepositoryDropTargetModifier(
+          isEnabled: isEnabled,
+          index: index,
           repositoryOrderIDs: repositoryOrderIDs,
           targetedDestination: targetedDestination,
-          onDrop: onDrop,
-          onDragEnded: onDragEnded
+          actions: actions
         )
       )
   }
@@ -193,27 +224,30 @@ extension View {
   func worktreeDropTarget(
     index: Int,
     rowIDs: [Worktree.ID],
+    isEnabled: Bool,
     targetedDestination: Binding<Int?>,
-    onDrop: @escaping (IndexSet, Int) -> Void,
-    onDragEnded: @escaping () -> Void
+    actions: SidebarDropTargetActions
   ) -> some View {
-    self
+    let edge = SidebarDropIndicatorEdge.edge(
+      targetedDestination: targetedDestination.wrappedValue,
+      rowIndex: index,
+      rowCount: rowIDs.count
+    )
+    return
+      self
       .overlay(alignment: .top) {
-        SidebarDropIndicator(isVisible: targetedDestination.wrappedValue == index, horizontalPadding: 28)
+        SidebarDropIndicator(isVisible: edge == .top, horizontalPadding: 28)
       }
       .overlay(alignment: .bottom) {
-        SidebarDropIndicator(isVisible: targetedDestination.wrappedValue == index + 1, horizontalPadding: 28)
+        SidebarDropIndicator(isVisible: edge == .bottom, horizontalPadding: 28)
       }
-      .onDrop(
-        of: [.prowlSidebarDragPayload],
-        delegate: SidebarWorktreeDropDelegate(
-          destination: { info in
-            info.location.y < 18 ? index : index + 1
-          },
-          sectionIDs: rowIDs,
+      .modifier(
+        SidebarWorktreeDropTargetModifier(
+          isEnabled: isEnabled,
+          index: index,
+          rowIDs: rowIDs,
           targetedDestination: targetedDestination,
-          onDrop: onDrop,
-          onDragEnded: onDragEnded
+          actions: actions
         )
       )
   }
@@ -247,6 +281,62 @@ extension View {
       }
     } else {
       self
+    }
+  }
+}
+
+private struct SidebarRepositoryDropTargetModifier: ViewModifier {
+  let isEnabled: Bool
+  let index: Int
+  let repositoryOrderIDs: [Repository.ID]
+  @Binding var targetedDestination: Int?
+  let actions: SidebarDropTargetActions
+
+  @ViewBuilder
+  func body(content: Content) -> some View {
+    if isEnabled {
+      content.onDrop(
+        of: [.prowlSidebarDragPayload],
+        delegate: SidebarRepositoryDropDelegate(
+          destination: { info in
+            info.location.y < 24 ? index : index + 1
+          },
+          repositoryOrderIDs: repositoryOrderIDs,
+          targetedDestination: $targetedDestination,
+          onDrop: actions.onDrop,
+          onDragEnded: actions.onDragEnded
+        )
+      )
+    } else {
+      content
+    }
+  }
+}
+
+private struct SidebarWorktreeDropTargetModifier: ViewModifier {
+  let isEnabled: Bool
+  let index: Int
+  let rowIDs: [Worktree.ID]
+  @Binding var targetedDestination: Int?
+  let actions: SidebarDropTargetActions
+
+  @ViewBuilder
+  func body(content: Content) -> some View {
+    if isEnabled {
+      content.onDrop(
+        of: [.prowlSidebarDragPayload],
+        delegate: SidebarWorktreeDropDelegate(
+          destination: { info in
+            info.location.y < 18 ? index : index + 1
+          },
+          sectionIDs: rowIDs,
+          targetedDestination: $targetedDestination,
+          onDrop: actions.onDrop,
+          onDragEnded: actions.onDragEnded
+        )
+      )
+    } else {
+      content
     }
   }
 }

--- a/supacode/Features/Repositories/Views/SidebarDragSupport.swift
+++ b/supacode/Features/Repositories/Views/SidebarDragSupport.swift
@@ -2,26 +2,50 @@ import SwiftUI
 import UniformTypeIdentifiers
 
 extension UTType {
-  static let prowlSidebarRepositoryID = UTType(exportedAs: "com.onevcat.prowl.sidebar.repository-id")
-  static let prowlSidebarWorktreeID = UTType(exportedAs: "com.onevcat.prowl.sidebar.worktree-id")
+  nonisolated static let prowlSidebarDragPayload = UTType.plainText
 }
 
 enum SidebarDragProvider {
-  static func repository(id: Repository.ID) -> NSItemProvider {
-    itemProvider(id: id, type: .prowlSidebarRepositoryID)
+  private nonisolated static let repositoryPrefix = "prowl-sidebar-repository:"
+  private nonisolated static let worktreePrefix = "prowl-sidebar-worktree:"
+
+  nonisolated static func repository(id: Repository.ID) -> NSItemProvider {
+    itemProvider(payload: repositoryPrefix + id)
   }
 
-  static func worktree(id: Worktree.ID) -> NSItemProvider {
-    itemProvider(id: id, type: .prowlSidebarWorktreeID)
+  nonisolated static func worktree(id: Worktree.ID) -> NSItemProvider {
+    itemProvider(payload: worktreePrefix + id)
   }
 
-  private static func itemProvider(id: String, type: UTType) -> NSItemProvider {
+  nonisolated static func repositoryID(from data: Data) -> Repository.ID? {
+    payload(from: data, prefix: repositoryPrefix)
+  }
+
+  nonisolated static func worktreeID(from data: Data) -> Worktree.ID? {
+    payload(from: data, prefix: worktreePrefix)
+  }
+
+  private nonisolated static func itemProvider(payload: String) -> NSItemProvider {
     let provider = NSItemProvider()
-    provider.registerDataRepresentation(forTypeIdentifier: type.identifier, visibility: .all) { completion in
-      completion(Data(id.utf8), nil)
+    let loadHandler: (@escaping (Data?, (any Error)?) -> Void) -> Progress? = { completion in
+      completion(Data(payload.utf8), nil)
       return nil
     }
+    provider.registerDataRepresentation(
+      forTypeIdentifier: UTType.prowlSidebarDragPayload.identifier,
+      visibility: .all,
+      loadHandler: loadHandler
+    )
     return provider
+  }
+
+  private nonisolated static func payload(from data: Data, prefix: String) -> String? {
+    guard let payload = String(data: data, encoding: .utf8),
+      payload.hasPrefix(prefix)
+    else {
+      return nil
+    }
+    return String(payload.dropFirst(prefix.count))
   }
 }
 
@@ -48,13 +72,13 @@ struct SidebarRepositoryDropDelegate: DropDelegate {
   func performDrop(info: DropInfo) -> Bool {
     let dropDestination = destination(info)
     targetedDestination = nil
-    guard let provider = info.itemProviders(for: [.prowlSidebarRepositoryID]).first else {
+    guard let provider = info.itemProviders(for: [.prowlSidebarDragPayload]).first else {
       onDragEnded()
       return false
     }
-    provider.loadDataRepresentation(forTypeIdentifier: UTType.prowlSidebarRepositoryID.identifier) { data, _ in
+    provider.loadDataRepresentation(forTypeIdentifier: UTType.prowlSidebarDragPayload.identifier) { data, _ in
       guard let data,
-        let repositoryID = String(data: data, encoding: .utf8),
+        let repositoryID = SidebarDragProvider.repositoryID(from: data),
         let source = repositoryOrderIDs.firstIndex(of: repositoryID),
         source != dropDestination,
         source + 1 != dropDestination
@@ -94,13 +118,13 @@ struct SidebarWorktreeDropDelegate: DropDelegate {
   func performDrop(info: DropInfo) -> Bool {
     let dropDestination = destination(info)
     targetedDestination = nil
-    guard let provider = info.itemProviders(for: [.prowlSidebarWorktreeID]).first else {
+    guard let provider = info.itemProviders(for: [.prowlSidebarDragPayload]).first else {
       onDragEnded()
       return false
     }
-    provider.loadDataRepresentation(forTypeIdentifier: UTType.prowlSidebarWorktreeID.identifier) { data, _ in
+    provider.loadDataRepresentation(forTypeIdentifier: UTType.prowlSidebarDragPayload.identifier) { data, _ in
       guard let data,
-        let worktreeID = String(data: data, encoding: .utf8),
+        let worktreeID = SidebarDragProvider.worktreeID(from: data),
         let source = sectionIDs.firstIndex(of: worktreeID),
         source != dropDestination,
         source + 1 != dropDestination
@@ -152,24 +176,18 @@ extension View {
       .overlay(alignment: .bottom) {
         SidebarDropIndicator(isVisible: targetedDestination.wrappedValue == index + 1)
       }
-      .background {
-        GeometryReader { proxy in
-          Color.clear
-            .onDrop(
-              of: [.prowlSidebarRepositoryID],
-              delegate: SidebarRepositoryDropDelegate(
-                destination: { info in
-                  info.location.y < proxy.size.height / 2 ? index : index + 1
-                },
-                repositoryOrderIDs: repositoryOrderIDs,
-                targetedDestination: targetedDestination,
-                onDrop: onDrop,
-                onDragEnded: onDragEnded
-              )
-            )
-            .accessibilityHidden(true)
-        }
-      }
+      .onDrop(
+        of: [.prowlSidebarDragPayload],
+        delegate: SidebarRepositoryDropDelegate(
+          destination: { info in
+            info.location.y < 24 ? index : index + 1
+          },
+          repositoryOrderIDs: repositoryOrderIDs,
+          targetedDestination: targetedDestination,
+          onDrop: onDrop,
+          onDragEnded: onDragEnded
+        )
+      )
   }
 
   func worktreeDropTarget(
@@ -186,24 +204,18 @@ extension View {
       .overlay(alignment: .bottom) {
         SidebarDropIndicator(isVisible: targetedDestination.wrappedValue == index + 1, horizontalPadding: 28)
       }
-      .background {
-        GeometryReader { proxy in
-          Color.clear
-            .onDrop(
-              of: [.prowlSidebarWorktreeID],
-              delegate: SidebarWorktreeDropDelegate(
-                destination: { info in
-                  info.location.y < proxy.size.height / 2 ? index : index + 1
-                },
-                sectionIDs: rowIDs,
-                targetedDestination: targetedDestination,
-                onDrop: onDrop,
-                onDragEnded: onDragEnded
-              )
-            )
-            .accessibilityHidden(true)
-        }
-      }
+      .onDrop(
+        of: [.prowlSidebarDragPayload],
+        delegate: SidebarWorktreeDropDelegate(
+          destination: { info in
+            info.location.y < 18 ? index : index + 1
+          },
+          sectionIDs: rowIDs,
+          targetedDestination: targetedDestination,
+          onDrop: onDrop,
+          onDragEnded: onDragEnded
+        )
+      )
   }
 
   @ViewBuilder

--- a/supacode/Features/Repositories/Views/SidebarDragSupport.swift
+++ b/supacode/Features/Repositories/Views/SidebarDragSupport.swift
@@ -26,27 +26,27 @@ enum SidebarDragProvider {
 }
 
 struct SidebarRepositoryDropDelegate: DropDelegate {
-  let destination: Int
+  let destination: (DropInfo) -> Int
   let repositoryOrderIDs: [Repository.ID]
   @Binding var targetedDestination: Int?
   let onDrop: (IndexSet, Int) -> Void
   let onDragEnded: () -> Void
 
   func dropEntered(info: DropInfo) {
-    targetedDestination = destination
+    targetedDestination = destination(info)
   }
 
   func dropExited(info: DropInfo) {
-    if targetedDestination == destination {
-      targetedDestination = nil
-    }
+    targetedDestination = nil
   }
 
   func dropUpdated(info: DropInfo) -> DropProposal? {
-    DropProposal(operation: .move)
+    targetedDestination = destination(info)
+    return DropProposal(operation: .move)
   }
 
   func performDrop(info: DropInfo) -> Bool {
+    let dropDestination = destination(info)
     targetedDestination = nil
     guard let provider = info.itemProviders(for: [.prowlSidebarRepositoryID]).first else {
       onDragEnded()
@@ -56,14 +56,14 @@ struct SidebarRepositoryDropDelegate: DropDelegate {
       guard let data,
         let repositoryID = String(data: data, encoding: .utf8),
         let source = repositoryOrderIDs.firstIndex(of: repositoryID),
-        source != destination,
-        source + 1 != destination
+        source != dropDestination,
+        source + 1 != dropDestination
       else {
         Task { @MainActor in onDragEnded() }
         return
       }
       Task { @MainActor in
-        onDrop(IndexSet(integer: source), destination)
+        onDrop(IndexSet(integer: source), dropDestination)
         onDragEnded()
       }
     }
@@ -72,27 +72,27 @@ struct SidebarRepositoryDropDelegate: DropDelegate {
 }
 
 struct SidebarWorktreeDropDelegate: DropDelegate {
-  let destination: Int
+  let destination: (DropInfo) -> Int
   let sectionIDs: [Worktree.ID]
   @Binding var targetedDestination: Int?
   let onDrop: (IndexSet, Int) -> Void
   let onDragEnded: () -> Void
 
   func dropEntered(info: DropInfo) {
-    targetedDestination = destination
+    targetedDestination = destination(info)
   }
 
   func dropExited(info: DropInfo) {
-    if targetedDestination == destination {
-      targetedDestination = nil
-    }
+    targetedDestination = nil
   }
 
   func dropUpdated(info: DropInfo) -> DropProposal? {
-    DropProposal(operation: .move)
+    targetedDestination = destination(info)
+    return DropProposal(operation: .move)
   }
 
   func performDrop(info: DropInfo) -> Bool {
+    let dropDestination = destination(info)
     targetedDestination = nil
     guard let provider = info.itemProviders(for: [.prowlSidebarWorktreeID]).first else {
       onDragEnded()
@@ -102,14 +102,14 @@ struct SidebarWorktreeDropDelegate: DropDelegate {
       guard let data,
         let worktreeID = String(data: data, encoding: .utf8),
         let source = sectionIDs.firstIndex(of: worktreeID),
-        source != destination,
-        source + 1 != destination
+        source != dropDestination,
+        source + 1 != dropDestination
       else {
         Task { @MainActor in onDragEnded() }
         return
       }
       Task { @MainActor in
-        onDrop(IndexSet(integer: source), destination)
+        onDrop(IndexSet(integer: source), dropDestination)
         onDragEnded()
       }
     }
@@ -138,6 +138,74 @@ struct SidebarDropIndicator: View {
 }
 
 extension View {
+  func repositoryDropTarget(
+    index: Int,
+    repositoryOrderIDs: [Repository.ID],
+    targetedDestination: Binding<Int?>,
+    onDrop: @escaping (IndexSet, Int) -> Void,
+    onDragEnded: @escaping () -> Void
+  ) -> some View {
+    self
+      .overlay(alignment: .top) {
+        SidebarDropIndicator(isVisible: targetedDestination.wrappedValue == index)
+      }
+      .overlay(alignment: .bottom) {
+        SidebarDropIndicator(isVisible: targetedDestination.wrappedValue == index + 1)
+      }
+      .background {
+        GeometryReader { proxy in
+          Color.clear
+            .onDrop(
+              of: [.prowlSidebarRepositoryID],
+              delegate: SidebarRepositoryDropDelegate(
+                destination: { info in
+                  info.location.y < proxy.size.height / 2 ? index : index + 1
+                },
+                repositoryOrderIDs: repositoryOrderIDs,
+                targetedDestination: targetedDestination,
+                onDrop: onDrop,
+                onDragEnded: onDragEnded
+              )
+            )
+            .accessibilityHidden(true)
+        }
+      }
+  }
+
+  func worktreeDropTarget(
+    index: Int,
+    rowIDs: [Worktree.ID],
+    targetedDestination: Binding<Int?>,
+    onDrop: @escaping (IndexSet, Int) -> Void,
+    onDragEnded: @escaping () -> Void
+  ) -> some View {
+    self
+      .overlay(alignment: .top) {
+        SidebarDropIndicator(isVisible: targetedDestination.wrappedValue == index, horizontalPadding: 28)
+      }
+      .overlay(alignment: .bottom) {
+        SidebarDropIndicator(isVisible: targetedDestination.wrappedValue == index + 1, horizontalPadding: 28)
+      }
+      .background {
+        GeometryReader { proxy in
+          Color.clear
+            .onDrop(
+              of: [.prowlSidebarWorktreeID],
+              delegate: SidebarWorktreeDropDelegate(
+                destination: { info in
+                  info.location.y < proxy.size.height / 2 ? index : index + 1
+                },
+                sectionIDs: rowIDs,
+                targetedDestination: targetedDestination,
+                onDrop: onDrop,
+                onDragEnded: onDragEnded
+              )
+            )
+            .accessibilityHidden(true)
+        }
+      }
+  }
+
   @ViewBuilder
   func draggableRepository(
     id: Repository.ID,

--- a/supacode/Features/Repositories/Views/SidebarDragSupport.swift
+++ b/supacode/Features/Repositories/Views/SidebarDragSupport.swift
@@ -1,0 +1,172 @@
+import SwiftUI
+import UniformTypeIdentifiers
+
+extension UTType {
+  static let prowlSidebarRepositoryID = UTType(exportedAs: "com.onevcat.prowl.sidebar.repository-id")
+  static let prowlSidebarWorktreeID = UTType(exportedAs: "com.onevcat.prowl.sidebar.worktree-id")
+}
+
+enum SidebarDragProvider {
+  static func repository(id: Repository.ID) -> NSItemProvider {
+    itemProvider(id: id, type: .prowlSidebarRepositoryID)
+  }
+
+  static func worktree(id: Worktree.ID) -> NSItemProvider {
+    itemProvider(id: id, type: .prowlSidebarWorktreeID)
+  }
+
+  private static func itemProvider(id: String, type: UTType) -> NSItemProvider {
+    let provider = NSItemProvider()
+    provider.registerDataRepresentation(forTypeIdentifier: type.identifier, visibility: .all) { completion in
+      completion(Data(id.utf8), nil)
+      return nil
+    }
+    return provider
+  }
+}
+
+struct SidebarRepositoryDropDelegate: DropDelegate {
+  let destination: Int
+  let repositoryOrderIDs: [Repository.ID]
+  @Binding var targetedDestination: Int?
+  let onDrop: (IndexSet, Int) -> Void
+  let onDragEnded: () -> Void
+
+  func dropEntered(info: DropInfo) {
+    targetedDestination = destination
+  }
+
+  func dropExited(info: DropInfo) {
+    if targetedDestination == destination {
+      targetedDestination = nil
+    }
+  }
+
+  func dropUpdated(info: DropInfo) -> DropProposal? {
+    DropProposal(operation: .move)
+  }
+
+  func performDrop(info: DropInfo) -> Bool {
+    targetedDestination = nil
+    guard let provider = info.itemProviders(for: [.prowlSidebarRepositoryID]).first else {
+      onDragEnded()
+      return false
+    }
+    provider.loadDataRepresentation(forTypeIdentifier: UTType.prowlSidebarRepositoryID.identifier) { data, _ in
+      guard let data,
+        let repositoryID = String(data: data, encoding: .utf8),
+        let source = repositoryOrderIDs.firstIndex(of: repositoryID),
+        source != destination,
+        source + 1 != destination
+      else {
+        Task { @MainActor in onDragEnded() }
+        return
+      }
+      Task { @MainActor in
+        onDrop(IndexSet(integer: source), destination)
+        onDragEnded()
+      }
+    }
+    return true
+  }
+}
+
+struct SidebarWorktreeDropDelegate: DropDelegate {
+  let destination: Int
+  let sectionIDs: [Worktree.ID]
+  @Binding var targetedDestination: Int?
+  let onDrop: (IndexSet, Int) -> Void
+  let onDragEnded: () -> Void
+
+  func dropEntered(info: DropInfo) {
+    targetedDestination = destination
+  }
+
+  func dropExited(info: DropInfo) {
+    if targetedDestination == destination {
+      targetedDestination = nil
+    }
+  }
+
+  func dropUpdated(info: DropInfo) -> DropProposal? {
+    DropProposal(operation: .move)
+  }
+
+  func performDrop(info: DropInfo) -> Bool {
+    targetedDestination = nil
+    guard let provider = info.itemProviders(for: [.prowlSidebarWorktreeID]).first else {
+      onDragEnded()
+      return false
+    }
+    provider.loadDataRepresentation(forTypeIdentifier: UTType.prowlSidebarWorktreeID.identifier) { data, _ in
+      guard let data,
+        let worktreeID = String(data: data, encoding: .utf8),
+        let source = sectionIDs.firstIndex(of: worktreeID),
+        source != destination,
+        source + 1 != destination
+      else {
+        Task { @MainActor in onDragEnded() }
+        return
+      }
+      Task { @MainActor in
+        onDrop(IndexSet(integer: source), destination)
+        onDragEnded()
+      }
+    }
+    return true
+  }
+}
+
+struct SidebarDropIndicator: View {
+  let isVisible: Bool
+  var horizontalPadding: CGFloat = 12
+
+  var body: some View {
+    ZStack {
+      if isVisible {
+        Capsule()
+          .fill(Color.accentColor)
+          .frame(height: 2)
+          .padding(.horizontal, horizontalPadding)
+          .transition(.opacity)
+      }
+    }
+    .frame(maxWidth: .infinity)
+    .frame(height: 6)
+    .accessibilityHidden(true)
+  }
+}
+
+extension View {
+  @ViewBuilder
+  func draggableRepository(
+    id: Repository.ID,
+    isEnabled: Bool,
+    beginDrag: @escaping () -> Void
+  ) -> some View {
+    if isEnabled {
+      self.onDrag {
+        beginDrag()
+        return SidebarDragProvider.repository(id: id)
+      }
+    } else {
+      self
+    }
+  }
+
+  @ViewBuilder
+  func draggableWorktree(
+    id: Worktree.ID,
+    isEnabled: Bool,
+    beginDrag: @escaping () -> Void
+  ) -> some View {
+    if isEnabled {
+      self.onDrag {
+        beginDrag()
+        return SidebarDragProvider.worktree(id: id)
+      }
+    } else {
+      self
+    }
+  }
+}

--- a/supacode/Features/Repositories/Views/SidebarListView.swift
+++ b/supacode/Features/Repositories/Views/SidebarListView.swift
@@ -35,6 +35,7 @@ struct SidebarListView: View {
   let terminalManager: WorktreeTerminalManager
   @FocusState private var isSidebarFocused: Bool
   @State private var isDragActive = false
+  @State private var draggingRepositoryID: Repository.ID?
   @State private var targetedRepositoryDropDestination: Int?
 
   var body: some View {
@@ -204,7 +205,9 @@ struct SidebarListView: View {
           .draggableRepository(
             id: model.repositoryID,
             isEnabled: !model.isRemoving,
-            beginDrag: beginSidebarDrag
+            beginDrag: {
+              beginSidebarDrag(repositoryID: model.repositoryID)
+            }
           )
         }
 
@@ -233,7 +236,9 @@ struct SidebarListView: View {
         .draggableRepository(
           id: model.id,
           isEnabled: model.isReorderable,
-          beginDrag: beginSidebarDrag
+          beginDrag: {
+            beginSidebarDrag(repositoryID: model.id)
+          }
         )
 
       case .listHeader, .archivedWorktrees:
@@ -246,28 +251,34 @@ struct SidebarListView: View {
       isEnabled: isDragActive,
       targetedDestination: $targetedRepositoryDropDestination,
       actions: SidebarDropTargetActions(
+        draggedItemID: draggingRepositoryID,
         onDrop: { offsets, destination in
-          store.send(.worktreeOrdering(.repositoriesMoved(offsets, destination)))
+          withAnimation(.easeOut(duration: 0.2)) {
+            _ = store.send(.worktreeOrdering(.repositoriesMoved(offsets, destination)))
+          }
         },
         onDragEnded: endSidebarDrag
       )
     )
   }
 
-  private func beginSidebarDrag() {
+  private func beginSidebarDrag(repositoryID: Repository.ID) {
     guard !isDragActive else { return }
+    draggingRepositoryID = repositoryID
     isDragActive = true
     store.send(.worktreeOrdering(.setSidebarDragActive(true)))
   }
 
   private func endSidebarDrag() {
     targetedRepositoryDropDestination = nil
+    draggingRepositoryID = nil
     isDragActive = false
     store.send(.worktreeOrdering(.setSidebarDragActive(false)))
   }
 
   private func resetSidebarDrag() {
     targetedRepositoryDropDestination = nil
+    draggingRepositoryID = nil
     isDragActive = false
     store.send(.worktreeOrdering(.setSidebarDragActive(false)))
   }

--- a/supacode/Features/Repositories/Views/SidebarListView.swift
+++ b/supacode/Features/Repositories/Views/SidebarListView.swift
@@ -243,11 +243,14 @@ struct SidebarListView: View {
     .repositoryDropTarget(
       index: index,
       repositoryOrderIDs: repositoryOrderIDs,
+      isEnabled: isDragActive,
       targetedDestination: $targetedRepositoryDropDestination,
-      onDrop: { offsets, destination in
-        store.send(.worktreeOrdering(.repositoriesMoved(offsets, destination)))
-      },
-      onDragEnded: endSidebarDrag
+      actions: SidebarDropTargetActions(
+        onDrop: { offsets, destination in
+          store.send(.worktreeOrdering(.repositoriesMoved(offsets, destination)))
+        },
+        onDragEnded: endSidebarDrag
+      )
     )
   }
 

--- a/supacode/Features/Repositories/Views/SidebarListView.swift
+++ b/supacode/Features/Repositories/Views/SidebarListView.swift
@@ -173,8 +173,9 @@ struct SidebarListView: View {
       }
     }
     .frame(maxWidth: .infinity, minHeight: 26, alignment: .center)
-    .padding(.horizontal, 12)
-    .padding(.top, 8)
+    .padding(.leading, 12)
+    .padding(.trailing, 4)
+    .padding(.top, 2)
     .padding(.bottom, 4)
   }
 

--- a/supacode/Features/Repositories/Views/SidebarListView.swift
+++ b/supacode/Features/Repositories/Views/SidebarListView.swift
@@ -173,6 +173,7 @@ struct SidebarListView: View {
       }
     }
     .frame(maxWidth: .infinity, minHeight: 26, alignment: .center)
+    .padding(.horizontal, 12)
     .padding(.top, 8)
     .padding(.bottom, 4)
   }

--- a/supacode/Features/Repositories/Views/SidebarListView.swift
+++ b/supacode/Features/Repositories/Views/SidebarListView.swift
@@ -174,7 +174,7 @@ struct SidebarListView: View {
     }
     .frame(maxWidth: .infinity, minHeight: 26, alignment: .center)
     .padding(.leading, 12)
-    .padding(.trailing, 4)
+    .padding(.trailing, 8)
     .padding(.top, 2)
     .padding(.bottom, 4)
   }

--- a/supacode/Features/Repositories/Views/SidebarListView.swift
+++ b/supacode/Features/Repositories/Views/SidebarListView.swift
@@ -39,14 +39,19 @@ struct SidebarListView: View {
   var body: some View {
     let state = store.state
     let hotkeyRows = state.orderedWorktreeRows(includingRepositoryIDs: expandedRepoIDs)
-    let orderedRoots = state.orderedRepositoryRoots()
+    let presentation = state.sidebarPresentation(expandedRepositoryIDs: expandedRepoIDs)
     let expandableRepositoryIDs = Self.expandableRepositoryIDs(in: state.repositories)
     let repositoryListHeaderAction = Self.repositoryListHeaderAction(
       expandedRepoIDs: expandedRepoIDs,
       expandableRepositoryIDs: expandableRepositoryIDs
     )
-    let visibleRepositoryCount = orderedRoots.isEmpty ? state.repositories.count : orderedRoots.count
-    let showsRepositoryListHeader = Self.showsRepositoryListHeader(repositoryCount: visibleRepositoryCount)
+    let repositoryItems = presentation.items.filter(\.isRepositoryOrderItem)
+    let showsRepositoryListHeader = presentation.items.contains { item in
+      if case .listHeader = item {
+        return true
+      }
+      return false
+    }
     let selectedWorktreeIDs = Set(sidebarSelections.compactMap(\.worktreeID))
     let selection = Binding<Set<SidebarSelection>>(
       get: {
@@ -131,7 +136,6 @@ struct SidebarListView: View {
         }
       }
     )
-    let repositoriesByID = Dictionary(uniqueKeysWithValues: store.repositories.map { ($0.id, $0) })
     let pendingSidebarReveal = state.pendingSidebarReveal
 
     ScrollViewReader { scrollProxy in
@@ -144,75 +148,17 @@ struct SidebarListView: View {
           .listRowInsets(EdgeInsets())
         }
 
-        if orderedRoots.isEmpty {
-          let repositories = store.repositories
-          ForEach(Array(repositories.enumerated()), id: \.element.id) { index, repository in
-            RepositorySectionView(
-              repository: repository,
-              hasTopSpacing: index > 0,
-              isDragActive: isDragActive,
-              hotkeyRows: hotkeyRows,
-              selectedWorktreeIDs: selectedWorktreeIDs,
-              expandedRepoIDs: $expandedRepoIDs,
-              store: store,
-              terminalManager: terminalManager
-            )
-            .listRowInsets(EdgeInsets())
-          }
-        } else {
-          let orderedRows = Array(orderedRoots.enumerated()).map { index, rootURL in
-            (
-              index: index,
-              rootURL: rootURL,
-              repositoryID: rootURL.standardizedFileURL.path(percentEncoded: false)
-            )
-          }
-          ForEach(orderedRows, id: \.repositoryID) { row in
-            let index = row.index
-            let rootURL = row.rootURL
-            let repositoryID = row.repositoryID
-            if let failureMessage = state.loadFailuresByID[repositoryID] {
-              let name = Repository.name(for: rootURL.standardizedFileURL)
-              let path = rootURL.standardizedFileURL.path(percentEncoded: false)
-              FailedRepositoryRow(
-                name: name,
-                path: path,
-                showFailure: {
-                  let message = "\(path)\n\n\(failureMessage)"
-                  store.send(.presentAlert(title: "Unable to load \(name)", message: message))
-                },
-                removeRepository: {
-                  store.send(.repositoryManagement(.removeFailedRepository(repositoryID)))
-                }
-              )
-              .padding(.horizontal, 12)
-              .overlay(alignment: .top) {
-                if index > 0 {
-                  Rectangle()
-                    .fill(.secondary)
-                    .frame(height: 1)
-                    .frame(maxWidth: .infinity)
-                    .accessibilityHidden(true)
-                }
-              }
-              .listRowInsets(EdgeInsets())
-            } else if let repository = repositoriesByID[repositoryID] {
-              RepositorySectionView(
-                repository: repository,
-                hasTopSpacing: index > 0,
-                isDragActive: isDragActive,
-                hotkeyRows: hotkeyRows,
-                selectedWorktreeIDs: selectedWorktreeIDs,
-                expandedRepoIDs: $expandedRepoIDs,
-                store: store,
-                terminalManager: terminalManager
-              )
-              .listRowInsets(EdgeInsets())
-            }
-          }
-          .onMove { offsets, destination in
-            store.send(.worktreeOrdering(.repositoriesMoved(offsets, destination)))
-          }
+        ForEach(Array(repositoryItems.enumerated()), id: \.element.id) { index, item in
+          repositoryItemView(
+            item,
+            index: index,
+            hotkeyRows: hotkeyRows,
+            selectedWorktreeIDs: selectedWorktreeIDs
+          )
+          .listRowInsets(EdgeInsets())
+        }
+        .onMove { offsets, destination in
+          store.send(.worktreeOrdering(.repositoriesMoved(offsets, destination)))
         }
       }
       .listStyle(.sidebar)
@@ -222,17 +168,20 @@ struct SidebarListView: View {
         if case .ended = session.phase {
           if isDragActive {
             isDragActive = false
+            store.send(.worktreeOrdering(.setSidebarDragActive(false)))
           }
           return
         }
         if case .dataTransferCompleted = session.phase {
           if isDragActive {
             isDragActive = false
+            store.send(.worktreeOrdering(.setSidebarDragActive(false)))
           }
           return
         }
         if !isDragActive {
           isDragActive = true
+          store.send(.worktreeOrdering(.setSidebarDragActive(true)))
         }
       }
       .safeAreaInset(edge: .top) {
@@ -318,6 +267,56 @@ struct SidebarListView: View {
     .padding(.bottom, 4)
   }
 
+  @ViewBuilder
+  private func repositoryItemView(
+    _ item: SidebarItem,
+    index: Int,
+    hotkeyRows: [WorktreeRowModel],
+    selectedWorktreeIDs: Set<Worktree.ID>
+  ) -> some View {
+    switch item {
+    case .repository(let model):
+      if let repository = store.state.repositories[id: model.repositoryID] {
+        RepositorySectionView(
+          repository: repository,
+          hasTopSpacing: index > 0,
+          isDragActive: isDragActive,
+          hotkeyRows: hotkeyRows,
+          selectedWorktreeIDs: selectedWorktreeIDs,
+          expandedRepoIDs: $expandedRepoIDs,
+          store: store,
+          terminalManager: terminalManager
+        )
+      }
+
+    case .failedRepository(let model):
+      FailedRepositoryRow(
+        name: model.name,
+        path: model.path,
+        showFailure: {
+          let message = "\(model.path)\n\n\(model.failureMessage)"
+          store.send(.presentAlert(title: "Unable to load \(model.name)", message: message))
+        },
+        removeRepository: {
+          store.send(.repositoryManagement(.removeFailedRepository(model.id)))
+        }
+      )
+      .padding(.horizontal, 12)
+      .overlay(alignment: .top) {
+        if index > 0 {
+          Rectangle()
+            .fill(.secondary)
+            .frame(height: 1)
+            .frame(maxWidth: .infinity)
+            .accessibilityHidden(true)
+        }
+      }
+
+    case .listHeader, .archivedWorktrees:
+      EmptyView()
+    }
+  }
+
   @MainActor
   private func revealPendingSidebarWorktree(
     _ pendingSidebarReveal: PendingSidebarReveal?,
@@ -354,7 +353,13 @@ struct SidebarListView: View {
   }
 
   static func showsRepositoryListHeader(repositoryCount: Int) -> Bool {
-    repositoryCount > 10
+    SidebarPresentation.showsListHeader(repositoryCount: repositoryCount)
+  }
+}
+
+extension SidebarItem {
+  fileprivate var isRepositoryOrderItem: Bool {
+    repositoryOrderID != nil
   }
 }
 

--- a/supacode/Features/Repositories/Views/SidebarListView.swift
+++ b/supacode/Features/Repositories/Views/SidebarListView.swift
@@ -67,21 +67,14 @@ struct SidebarListView: View {
           }
 
           ForEach(Array(repositoryItems.enumerated()), id: \.element.id) { index, item in
-            repositoryDropZone(
-              destination: index,
-              repositoryOrderIDs: presentation.repositoryOrderIDs
-            )
             repositoryItemView(
               item,
               index: index,
+              repositoryOrderIDs: presentation.repositoryOrderIDs,
               hotkeyRows: hotkeyRows,
               selectedWorktreeIDs: selectedWorktreeIDs
             )
           }
-          repositoryDropZone(
-            destination: repositoryItems.count,
-            repositoryOrderIDs: presentation.repositoryOrderIDs
-          )
         }
         .padding(.vertical, 2)
       }
@@ -95,9 +88,7 @@ struct SidebarListView: View {
         }
         if case .dataTransferCompleted = session.phase {
           endSidebarDrag()
-          return
         }
-        beginSidebarDrag()
       }
       .safeAreaInset(edge: .top) {
         HStack(spacing: 4) {
@@ -186,82 +177,75 @@ struct SidebarListView: View {
   private func repositoryItemView(
     _ item: SidebarItem,
     index: Int,
+    repositoryOrderIDs: [Repository.ID],
     hotkeyRows: [WorktreeRowModel],
     selectedWorktreeIDs: Set<Worktree.ID>
   ) -> some View {
-    switch item {
-    case .repository(let model):
-      if let repository = store.state.repositories[id: model.repositoryID] {
-        RepositorySectionView(
-          repository: repository,
-          hasTopSpacing: index > 0,
-          isDragActive: isDragActive,
-          hotkeyRows: hotkeyRows,
-          selectedWorktreeIDs: selectedWorktreeIDs,
-          expandedRepoIDs: $expandedRepoIDs,
-          store: store,
-          terminalManager: terminalManager,
-          onRepositorySelected: {
-            selectRepository(repository)
+    Group {
+      switch item {
+      case .repository(let model):
+        if let repository = store.state.repositories[id: model.repositoryID] {
+          RepositorySectionView(
+            repository: repository,
+            hasTopSpacing: index > 0,
+            isDragActive: isDragActive,
+            hotkeyRows: hotkeyRows,
+            selectedWorktreeIDs: selectedWorktreeIDs,
+            expandedRepoIDs: $expandedRepoIDs,
+            store: store,
+            terminalManager: terminalManager,
+            onRepositorySelected: {
+              selectRepository(repository)
+            }
+          )
+          .draggableRepository(
+            id: model.repositoryID,
+            isEnabled: !model.isRemoving,
+            beginDrag: beginSidebarDrag
+          )
+        }
+
+      case .failedRepository(let model):
+        FailedRepositoryRow(
+          name: model.name,
+          path: model.path,
+          showFailure: {
+            let message = "\(model.path)\n\n\(model.failureMessage)"
+            store.send(.presentAlert(title: "Unable to load \(model.name)", message: message))
+          },
+          removeRepository: {
+            store.send(.repositoryManagement(.removeFailedRepository(model.id)))
           }
         )
+        .padding(.horizontal, 12)
+        .overlay(alignment: .top) {
+          if index > 0 {
+            Rectangle()
+              .fill(.secondary)
+              .frame(height: 1)
+              .frame(maxWidth: .infinity)
+              .accessibilityHidden(true)
+          }
+        }
         .draggableRepository(
-          id: model.repositoryID,
-          isEnabled: !model.isRemoving,
+          id: model.id,
+          isEnabled: model.isReorderable,
           beginDrag: beginSidebarDrag
         )
-      }
 
-    case .failedRepository(let model):
-      FailedRepositoryRow(
-        name: model.name,
-        path: model.path,
-        showFailure: {
-          let message = "\(model.path)\n\n\(model.failureMessage)"
-          store.send(.presentAlert(title: "Unable to load \(model.name)", message: message))
-        },
-        removeRepository: {
-          store.send(.repositoryManagement(.removeFailedRepository(model.id)))
-        }
-      )
-      .padding(.horizontal, 12)
-      .overlay(alignment: .top) {
-        if index > 0 {
-          Rectangle()
-            .fill(.secondary)
-            .frame(height: 1)
-            .frame(maxWidth: .infinity)
-            .accessibilityHidden(true)
-        }
+      case .listHeader, .archivedWorktrees:
+        EmptyView()
       }
-      .draggableRepository(
-        id: model.id,
-        isEnabled: model.isReorderable,
-        beginDrag: beginSidebarDrag
-      )
-
-    case .listHeader, .archivedWorktrees:
-      EmptyView()
     }
-  }
-
-  private func repositoryDropZone(
-    destination: Int,
-    repositoryOrderIDs: [Repository.ID]
-  ) -> some View {
-    SidebarDropIndicator(isVisible: targetedRepositoryDropDestination == destination)
-      .onDrop(
-        of: [.prowlSidebarRepositoryID],
-        delegate: SidebarRepositoryDropDelegate(
-          destination: destination,
-          repositoryOrderIDs: repositoryOrderIDs,
-          targetedDestination: $targetedRepositoryDropDestination,
-          onDrop: { offsets, destination in
-            store.send(.worktreeOrdering(.repositoriesMoved(offsets, destination)))
-          },
-          onDragEnded: endSidebarDrag
-        )
-      )
+    .repositoryDropTarget(
+      index: index,
+      repositoryOrderIDs: repositoryOrderIDs,
+      targetedDestination: $targetedRepositoryDropDestination,
+      onDrop: { offsets, destination in
+        store.send(.worktreeOrdering(.repositoriesMoved(offsets, destination)))
+      },
+      onDragEnded: endSidebarDrag
+    )
   }
 
   private func beginSidebarDrag() {

--- a/supacode/Features/Repositories/Views/SidebarListView.swift
+++ b/supacode/Features/Repositories/Views/SidebarListView.swift
@@ -35,6 +35,7 @@ struct SidebarListView: View {
   let terminalManager: WorktreeTerminalManager
   @FocusState private var isSidebarFocused: Bool
   @State private var isDragActive = false
+  @State private var targetedRepositoryDropDestination: Int?
 
   var body: some View {
     let state = store.state
@@ -52,137 +53,51 @@ struct SidebarListView: View {
       }
       return false
     }
-    let selectedWorktreeIDs = Set(sidebarSelections.compactMap(\.worktreeID))
-    let selection = Binding<Set<SidebarSelection>>(
-      get: {
-        var nextSelections = sidebarSelections
-        if state.isShowingCanvas {
-          nextSelections = [.canvas]
-        } else if state.isShowingArchivedWorktrees {
-          nextSelections = [.archivedWorktrees]
-        } else {
-          nextSelections.remove(.archivedWorktrees)
-          nextSelections.remove(.canvas)
-          if let selectedRepository = state.selectedRepository, selectedRepository.kind == .plain {
-            nextSelections = [.repository(selectedRepository.id)]
-          } else if let selectedWorktreeID = state.selectedWorktreeID {
-            nextSelections.insert(.worktree(selectedWorktreeID))
-          }
-        }
-        return nextSelections
-      },
-      set: { newValue in
-        let nextSelections = newValue
-        let repositorySelections: [Repository.ID] = nextSelections.compactMap { selection in
-          guard case .repository(let repositoryID) = selection else { return nil }
-          return repositoryID
-        }
-
-        if nextSelections.contains(.canvas) {
-          sidebarSelections = [.canvas]
-          store.send(.selectCanvas)
-          return
-        }
-
-        if nextSelections.contains(.archivedWorktrees) {
-          sidebarSelections = [.archivedWorktrees]
-          store.send(.selectArchivedWorktrees)
-          return
-        }
-
-        if let repositoryID = repositorySelections.first {
-          guard let repository = state.repositories[id: repositoryID] else {
-            return
-          }
-          if repository.capabilities.supportsWorktrees {
-            withAnimation(.easeOut(duration: 0.2)) {
-              if expandedRepoIDs.contains(repositoryID) {
-                expandedRepoIDs.remove(repositoryID)
-              } else {
-                expandedRepoIDs.insert(repositoryID)
-              }
-            }
-            sidebarSelections = []
-          } else {
-            sidebarSelections = [.repository(repositoryID)]
-            store.send(.selectRepository(repositoryID))
-            focusTerminalAfterSidebarSelection(worktreeID: store.state.selectedTerminalWorktree?.id)
-          }
-          return
-        }
-
-        let worktreeIDs = Set(nextSelections.compactMap(\.worktreeID))
-        guard !worktreeIDs.isEmpty else {
-          sidebarSelections = []
-          store.send(.selectWorktree(nil))
-          return
-        }
-        let shouldFocusTerminal = worktreeIDs.count == 1
-        sidebarSelections = Set(worktreeIDs.map(SidebarSelection.worktree))
-        if let selectedWorktreeID = state.selectedWorktreeID,
-          worktreeIDs.contains(selectedWorktreeID)
-        {
-          if shouldFocusTerminal {
-            focusTerminalAfterSidebarSelection(worktreeID: selectedWorktreeID)
-          }
-          return
-        }
-        let nextPrimarySelection =
-          hotkeyRows.map(\.id).first(where: worktreeIDs.contains)
-          ?? worktreeIDs.first
-        store.send(.selectWorktree(nextPrimarySelection, focusTerminal: shouldFocusTerminal))
-        if shouldFocusTerminal {
-          focusTerminalAfterSidebarSelection(worktreeID: nextPrimarySelection)
-        }
-      }
-    )
+    let selectedWorktreeIDs = Self.selectedWorktreeIDs(in: state)
     let pendingSidebarReveal = state.pendingSidebarReveal
 
     ScrollViewReader { scrollProxy in
-      List(selection: selection) {
-        if showsRepositoryListHeader {
-          repositoryListHeader(
-            action: repositoryListHeaderAction,
-            expandableRepositoryIDs: expandableRepositoryIDs
-          )
-          .listRowInsets(EdgeInsets())
-        }
+      ScrollView {
+        LazyVStack(spacing: 0) {
+          if showsRepositoryListHeader {
+            repositoryListHeader(
+              action: repositoryListHeaderAction,
+              expandableRepositoryIDs: expandableRepositoryIDs
+            )
+          }
 
-        ForEach(Array(repositoryItems.enumerated()), id: \.element.id) { index, item in
-          repositoryItemView(
-            item,
-            index: index,
-            hotkeyRows: hotkeyRows,
-            selectedWorktreeIDs: selectedWorktreeIDs
+          ForEach(Array(repositoryItems.enumerated()), id: \.element.id) { index, item in
+            repositoryDropZone(
+              destination: index,
+              repositoryOrderIDs: presentation.repositoryOrderIDs
+            )
+            repositoryItemView(
+              item,
+              index: index,
+              hotkeyRows: hotkeyRows,
+              selectedWorktreeIDs: selectedWorktreeIDs
+            )
+          }
+          repositoryDropZone(
+            destination: repositoryItems.count,
+            repositoryOrderIDs: presentation.repositoryOrderIDs
           )
-          .listRowInsets(EdgeInsets())
         }
-        .onMove { offsets, destination in
-          store.send(.worktreeOrdering(.repositoriesMoved(offsets, destination)))
-        }
+        .padding(.vertical, 2)
       }
-      .listStyle(.sidebar)
       .scrollIndicators(.never)
       .frame(minWidth: 220)
+      .background(.bar)
       .onDragSessionUpdated { session in
         if case .ended = session.phase {
-          if isDragActive {
-            isDragActive = false
-            store.send(.worktreeOrdering(.setSidebarDragActive(false)))
-          }
+          endSidebarDrag()
           return
         }
         if case .dataTransferCompleted = session.phase {
-          if isDragActive {
-            isDragActive = false
-            store.send(.worktreeOrdering(.setSidebarDragActive(false)))
-          }
+          endSidebarDrag()
           return
         }
-        if !isDragActive {
-          isDragActive = true
-          store.send(.worktreeOrdering(.setSidebarDragActive(true)))
-        }
+        beginSidebarDrag()
       }
       .safeAreaInset(edge: .top) {
         HStack(spacing: 4) {
@@ -285,7 +200,15 @@ struct SidebarListView: View {
           selectedWorktreeIDs: selectedWorktreeIDs,
           expandedRepoIDs: $expandedRepoIDs,
           store: store,
-          terminalManager: terminalManager
+          terminalManager: terminalManager,
+          onRepositorySelected: {
+            selectRepository(repository)
+          }
+        )
+        .draggableRepository(
+          id: model.repositoryID,
+          isEnabled: !model.isRemoving,
+          beginDrag: beginSidebarDrag
         )
       }
 
@@ -311,9 +234,63 @@ struct SidebarListView: View {
             .accessibilityHidden(true)
         }
       }
+      .draggableRepository(
+        id: model.id,
+        isEnabled: model.isReorderable,
+        beginDrag: beginSidebarDrag
+      )
 
     case .listHeader, .archivedWorktrees:
       EmptyView()
+    }
+  }
+
+  private func repositoryDropZone(
+    destination: Int,
+    repositoryOrderIDs: [Repository.ID]
+  ) -> some View {
+    SidebarDropIndicator(isVisible: targetedRepositoryDropDestination == destination)
+      .onDrop(
+        of: [.prowlSidebarRepositoryID],
+        delegate: SidebarRepositoryDropDelegate(
+          destination: destination,
+          repositoryOrderIDs: repositoryOrderIDs,
+          targetedDestination: $targetedRepositoryDropDestination,
+          onDrop: { offsets, destination in
+            store.send(.worktreeOrdering(.repositoriesMoved(offsets, destination)))
+          },
+          onDragEnded: endSidebarDrag
+        )
+      )
+  }
+
+  private func beginSidebarDrag() {
+    guard !isDragActive else { return }
+    isDragActive = true
+    store.send(.worktreeOrdering(.setSidebarDragActive(true)))
+  }
+
+  private func endSidebarDrag() {
+    targetedRepositoryDropDestination = nil
+    guard isDragActive else { return }
+    isDragActive = false
+    store.send(.worktreeOrdering(.setSidebarDragActive(false)))
+  }
+
+  private func selectRepository(_ repository: Repository) {
+    if repository.capabilities.supportsWorktrees {
+      withAnimation(.easeOut(duration: 0.2)) {
+        if expandedRepoIDs.contains(repository.id) {
+          expandedRepoIDs.remove(repository.id)
+        } else {
+          expandedRepoIDs.insert(repository.id)
+        }
+      }
+      sidebarSelections = []
+    } else {
+      sidebarSelections = [.repository(repository.id)]
+      store.send(.selectRepository(repository.id))
+      focusTerminalAfterSidebarSelection(worktreeID: store.state.selectedTerminalWorktree?.id)
     }
   }
 
@@ -328,7 +305,7 @@ struct SidebarListView: View {
     await Task.yield()
     isSidebarFocused = true
     withAnimation(.easeOut(duration: 0.2)) {
-      scrollProxy.scrollTo(pendingSidebarReveal.worktreeID, anchor: .center)
+      scrollProxy.scrollTo(SidebarScrollID.worktree(pendingSidebarReveal.worktreeID), anchor: .center)
     }
     store.send(.consumePendingSidebarReveal(pendingSidebarReveal.id))
   }
@@ -354,6 +331,14 @@ struct SidebarListView: View {
 
   static func showsRepositoryListHeader(repositoryCount: Int) -> Bool {
     SidebarPresentation.showsListHeader(repositoryCount: repositoryCount)
+  }
+
+  static func selectedWorktreeIDs(in state: RepositoriesFeature.State) -> Set<Worktree.ID> {
+    var selectedWorktreeIDs = state.sidebarSelectedWorktreeIDs
+    if let selectedWorktreeID = state.selectedWorktreeID {
+      selectedWorktreeIDs.insert(selectedWorktreeID)
+    }
+    return selectedWorktreeIDs
   }
 }
 

--- a/supacode/Features/Repositories/Views/SidebarListView.swift
+++ b/supacode/Features/Repositories/Views/SidebarListView.swift
@@ -118,6 +118,9 @@ struct SidebarListView: View {
         return true
       }
       .focused($isSidebarFocused)
+      .onAppear {
+        resetSidebarDrag()
+      }
       .task(id: pendingSidebarReveal?.id) {
         await revealPendingSidebarWorktree(pendingSidebarReveal, with: scrollProxy)
       }
@@ -256,7 +259,12 @@ struct SidebarListView: View {
 
   private func endSidebarDrag() {
     targetedRepositoryDropDestination = nil
-    guard isDragActive else { return }
+    isDragActive = false
+    store.send(.worktreeOrdering(.setSidebarDragActive(false)))
+  }
+
+  private func resetSidebarDrag() {
+    targetedRepositoryDropDestination = nil
     isDragActive = false
     store.send(.worktreeOrdering(.setSidebarDragActive(false)))
   }

--- a/supacode/Features/Repositories/Views/SidebarListView.swift
+++ b/supacode/Features/Repositories/Views/SidebarListView.swift
@@ -174,7 +174,7 @@ struct SidebarListView: View {
     }
     .frame(maxWidth: .infinity, minHeight: 26, alignment: .center)
     .padding(.leading, 12)
-    .padding(.trailing, 8)
+    .padding(.trailing, 7)
     .padding(.top, 2)
     .padding(.bottom, 4)
   }

--- a/supacode/Features/Repositories/Views/WorktreeRow.swift
+++ b/supacode/Features/Repositories/Views/WorktreeRow.swift
@@ -73,6 +73,7 @@ struct WorktreeRow: View {
           .font(.body)
           .foregroundStyle(nameColor)
           .lineLimit(1)
+          .truncationMode(.tail)
         Spacer(minLength: 4)
         if isHovered, pinAction != nil {
           Button {

--- a/supacode/Features/Repositories/Views/WorktreeRowsView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeRowsView.swift
@@ -107,6 +107,7 @@ struct WorktreeRowsView: View {
         isEnabled: isWorktreeDragActive,
         targetedDestination: targetedDestination,
         actions: SidebarDropTargetActions(
+          draggedItemID: draggingWorktreeIDs.first,
           onDrop: { offsets, destination in
             moveWorktrees(section: section, offsets: offsets, destination: destination)
           },
@@ -139,10 +140,12 @@ struct WorktreeRowsView: View {
     Group {
       if row.isRemovable, let worktree = store.state.worktree(for: row.id), !isRepositoryRemoving {
         baseRow
-          .contextMenu {
-            ContextMenuHighlightActivator {
+          .overlay {
+            ContextMenuActivationOverlay {
               scheduleContextMenuHighlight(for: row.id)
             }
+          }
+          .contextMenu {
             rowContextMenu(worktree: worktree, row: row)
           }
       } else {
@@ -519,11 +522,38 @@ struct WorktreeRowsView: View {
   }
 }
 
-private struct ContextMenuHighlightActivator: View {
+private struct ContextMenuActivationOverlay: NSViewRepresentable {
   let activate: () -> Void
 
-  var body: some View {
-    EmptyView()
-      .onAppear(perform: activate)
+  func makeNSView(context: Context) -> RightClickForwardingView {
+    let view = RightClickForwardingView()
+    view.activate = activate
+    return view
+  }
+
+  func updateNSView(_ nsView: RightClickForwardingView, context: Context) {
+    nsView.activate = activate
+  }
+
+  final class RightClickForwardingView: NSView {
+    var activate: (() -> Void)?
+    private var isForwardingRightClick = false
+
+    override func hitTest(_ point: NSPoint) -> NSView? {
+      guard !isForwardingRightClick,
+        NSApp.currentEvent?.type == .rightMouseDown
+      else {
+        return nil
+      }
+      return bounds.contains(point) ? self : nil
+    }
+
+    override func rightMouseDown(with event: NSEvent) {
+      activate?()
+      guard let window else { return }
+      isForwardingRightClick = true
+      window.sendEvent(event)
+      isForwardingRightClick = false
+    }
   }
 }

--- a/supacode/Features/Repositories/Views/WorktreeRowsView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeRowsView.swift
@@ -14,6 +14,7 @@ struct WorktreeRowsView: View {
   @Environment(\.resolvedKeybindings) private var resolvedKeybindings
   @State private var draggingWorktreeIDs: Set<Worktree.ID> = []
   @State private var hoveredWorktreeID: Worktree.ID?
+  @State private var contextMenuHighlightedWorktreeID: Worktree.ID?
   @State private var targetedPinnedDropDestination: Int?
   @State private var targetedUnpinnedDropDestination: Int?
 
@@ -40,6 +41,9 @@ struct WorktreeRowsView: View {
       shortcutIndexByID: shortcutIndexByID
     )
     .animation(isSidebarDragActive ? nil : .easeOut(duration: 0.2), value: rowIDs)
+    .onReceive(NotificationCenter.default.publisher(for: NSMenu.didEndTrackingNotification)) { _ in
+      contextMenuHighlightedWorktreeID = nil
+    }
   }
 
   @ViewBuilder
@@ -134,9 +138,13 @@ struct WorktreeRowsView: View {
       .contentShape(Rectangle())
     Group {
       if row.isRemovable, let worktree = store.state.worktree(for: row.id), !isRepositoryRemoving {
-        baseRow.contextMenu {
-          rowContextMenu(worktree: worktree, row: row)
-        }
+        baseRow
+          .contextMenu {
+            ContextMenuHighlightActivator {
+              scheduleContextMenuHighlight(for: row.id)
+            }
+            rowContextMenu(worktree: worktree, row: row)
+          }
       } else {
         baseRow
       }
@@ -324,6 +332,7 @@ struct WorktreeRowsView: View {
 
   private func worktreeRowView(_ row: WorktreeRowModel, config: WorktreeRowViewConfig) -> some View {
     let isSelected = selectedWorktreeIDs.contains(row.id)
+    let showsContextMenuHighlight = contextMenuHighlightedWorktreeID == row.id && !isSelected
     let taskStatus = terminalManager.taskStatus(for: row.id)
     let isRunScriptRunning = terminalManager.isRunScriptRunning(for: row.id)
     let isWorktreeDragActive = !draggingWorktreeIDs.isEmpty
@@ -359,8 +368,22 @@ struct WorktreeRowsView: View {
           .padding(.horizontal, 6)
       }
     }
+    .overlay {
+      if showsContextMenuHighlight {
+        RoundedRectangle(cornerRadius: 5)
+          .stroke(Color.accentColor, lineWidth: 2)
+          .padding(.horizontal, 6)
+      }
+    }
     .transition(.opacity)
     .moveDisabled(config.moveDisabled)
+  }
+
+  private func scheduleContextMenuHighlight(for worktreeID: Worktree.ID) {
+    guard !selectedWorktreeIDs.contains(worktreeID) else { return }
+    Task { @MainActor in
+      contextMenuHighlightedWorktreeID = worktreeID
+    }
   }
 
   @ViewBuilder
@@ -493,5 +516,14 @@ struct WorktreeRowsView: View {
       }
     }
     return row.name
+  }
+}
+
+private struct ContextMenuHighlightActivator: View {
+  let activate: () -> Void
+
+  var body: some View {
+    EmptyView()
+      .onAppear(perform: activate)
   }
 }

--- a/supacode/Features/Repositories/Views/WorktreeRowsView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeRowsView.swift
@@ -363,7 +363,7 @@ struct WorktreeRowsView: View {
     .tag(SidebarSelection.worktree(row.id))
     .id(SidebarScrollID.worktree(row.id))
     .typeSelectEquivalent("")
-    .padding(.leading, 20)
+    .padding(.leading, 14)
     .padding(.trailing, 8)
     .background {
       if isSelected {

--- a/supacode/Features/Repositories/Views/WorktreeRowsView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeRowsView.swift
@@ -89,6 +89,7 @@ struct WorktreeRowsView: View {
     shortcutIndexByID: [Worktree.ID: Int]
   ) -> some View {
     let rowIDs = rows.map(\.id)
+    let isWorktreeDragActive = !draggingWorktreeIDs.isEmpty
     ForEach(Array(rows.enumerated()), id: \.element.id) { index, row in
       rowView(
         row,
@@ -99,11 +100,14 @@ struct WorktreeRowsView: View {
       .worktreeDropTarget(
         index: index,
         rowIDs: rowIDs,
+        isEnabled: isWorktreeDragActive,
         targetedDestination: targetedDestination,
-        onDrop: { offsets, destination in
-          moveWorktrees(section: section, offsets: offsets, destination: destination)
-        },
-        onDragEnded: endWorktreeDrag
+        actions: SidebarDropTargetActions(
+          onDrop: { offsets, destination in
+            moveWorktrees(section: section, offsets: offsets, destination: destination)
+          },
+          onDragEnded: endWorktreeDrag
+        )
       )
     }
   }
@@ -116,69 +120,27 @@ struct WorktreeRowsView: View {
     shortcutHint: String?
   ) -> some View {
     let isWorktreeDragActive = !draggingWorktreeIDs.isEmpty
-    let showsNotificationIndicator = terminalManager.hasUnseenNotifications(for: row.id)
-    let displayName =
-      if row.isDeleting {
-        "\(row.name) (deleting...)"
-      } else if row.isArchiving {
-        "\(row.name) (archiving...)"
-      } else {
-        row.name
-      }
-    let canShowRowActions = row.isRemovable && !isRepositoryRemoving && !isWorktreeDragActive
-    let pinAction: (() -> Void)? =
-      canShowRowActions && !row.isMainWorktree
-      ? { togglePin(for: row.id, isPinned: row.isPinned) }
-      : nil
-    let archiveAction: (() -> Void)? =
-      canShowRowActions && !row.isMainWorktree
-      ? { archiveWorktree(row.id) }
-      : nil
-    let notifications = terminalManager.stateIfExists(for: row.id)?.notifications ?? []
-    let onFocusNotification: (WorktreeTerminalNotification) -> Void = { notification in
-      guard let terminalState = terminalManager.stateIfExists(for: row.id) else {
-        return
-      }
-      _ = terminalState.focusSurface(id: notification.surfaceId)
-    }
-    let onDiffTap: (() -> Void)? = {
-      guard let worktree = store.state.worktree(for: row.id) else { return }
-      DiffWindowManager.shared.show(
-        worktreeURL: worktree.workingDirectory,
-        branchName: worktree.name,
-        resolvedKeybindings: resolvedKeybindings
-      )
-    }
-    let onStopRunScript: (() -> Void)? =
-      terminalManager.isRunScriptRunning(for: row.id)
-      ? { _ = terminalManager.stateIfExists(for: row.id)?.stopRunScript() }
-      : nil
-    let config = WorktreeRowViewConfig(
-      displayName: displayName,
-      worktreeName: worktreeName(for: row),
-      isHovered: !isWorktreeDragActive && hoveredWorktreeID == row.id,
-      showsNotificationIndicator: !isWorktreeDragActive && showsNotificationIndicator,
-      notifications: isWorktreeDragActive ? [] : notifications,
-      onFocusNotification: onFocusNotification,
-      shortcutHint: shortcutHint,
-      pinAction: pinAction,
-      archiveAction: archiveAction,
-      onDiffTap: onDiffTap,
-      onStopRunScript: onStopRunScript,
+    let config = rowConfig(
+      for: row,
+      isRepositoryRemoving: isRepositoryRemoving,
+      isWorktreeDragActive: isWorktreeDragActive,
       moveDisabled: moveDisabled,
+      shortcutHint: shortcutHint
     )
     let baseRow = worktreeRowView(row, config: config)
+      .disabled(isRepositoryRemoving)
+      .contentShape(.dragPreview, .rect)
+      .contentShape(.interaction, .rect)
+      .contentShape(Rectangle())
     Group {
       if row.isRemovable, let worktree = store.state.worktree(for: row.id), !isRepositoryRemoving {
         baseRow.contextMenu {
           rowContextMenu(worktree: worktree, row: row)
         }
       } else {
-        baseRow.disabled(isRepositoryRemoving)
+        baseRow
       }
     }
-    .contentShape(.dragPreview, .rect)
-    .contentShape(.interaction, .rect)
     .onTapGesture {
       selectWorktreeRow(row.id)
     }
@@ -216,6 +178,66 @@ struct WorktreeRowsView: View {
     }
   }
 
+  private func rowConfig(
+    for row: WorktreeRowModel,
+    isRepositoryRemoving: Bool,
+    isWorktreeDragActive: Bool,
+    moveDisabled: Bool,
+    shortcutHint: String?
+  ) -> WorktreeRowViewConfig {
+    let displayName =
+      if row.isDeleting {
+        "\(row.name) (deleting...)"
+      } else if row.isArchiving {
+        "\(row.name) (archiving...)"
+      } else {
+        row.name
+      }
+    let showsNotificationIndicator = terminalManager.hasUnseenNotifications(for: row.id)
+    let notifications = terminalManager.stateIfExists(for: row.id)?.notifications ?? []
+    let canShowRowActions = row.isRemovable && !isRepositoryRemoving && !isWorktreeDragActive
+    return WorktreeRowViewConfig(
+      displayName: displayName,
+      worktreeName: worktreeName(for: row),
+      isHovered: !isWorktreeDragActive && hoveredWorktreeID == row.id,
+      showsNotificationIndicator: !isWorktreeDragActive && showsNotificationIndicator,
+      notifications: isWorktreeDragActive ? [] : notifications,
+      onFocusNotification: focusNotificationHandler(for: row.id),
+      shortcutHint: shortcutHint,
+      pinAction: canShowRowActions && !row.isMainWorktree ? { togglePin(for: row.id, isPinned: row.isPinned) } : nil,
+      archiveAction: canShowRowActions && !row.isMainWorktree ? { archiveWorktree(row.id) } : nil,
+      onDiffTap: diffTapHandler(for: row.id),
+      onStopRunScript: stopRunScriptHandler(for: row.id),
+      moveDisabled: moveDisabled,
+    )
+  }
+
+  private func focusNotificationHandler(for worktreeID: Worktree.ID) -> (WorktreeTerminalNotification) -> Void {
+    { notification in
+      guard let terminalState = terminalManager.stateIfExists(for: worktreeID) else {
+        return
+      }
+      _ = terminalState.focusSurface(id: notification.surfaceId)
+    }
+  }
+
+  private func diffTapHandler(for worktreeID: Worktree.ID) -> (() -> Void)? {
+    {
+      guard let worktree = store.state.worktree(for: worktreeID) else { return }
+      DiffWindowManager.shared.show(
+        worktreeURL: worktree.workingDirectory,
+        branchName: worktree.name,
+        resolvedKeybindings: resolvedKeybindings
+      )
+    }
+  }
+
+  private func stopRunScriptHandler(for worktreeID: Worktree.ID) -> (() -> Void)? {
+    terminalManager.isRunScriptRunning(for: worktreeID)
+      ? { _ = terminalManager.stateIfExists(for: worktreeID)?.stopRunScript() }
+      : nil
+  }
+
   private func handleWorktreeDragSession(
     draggedIDs: Set<Worktree.ID>,
     didEnd: Bool
@@ -224,7 +246,7 @@ struct WorktreeRowsView: View {
       endWorktreeDrag()
       return
     }
-    if draggedIDs != draggingWorktreeIDs {
+    if !draggedIDs.isEmpty, draggedIDs != draggingWorktreeIDs {
       draggingWorktreeIDs = draggedIDs
     }
   }

--- a/supacode/Features/Repositories/Views/WorktreeRowsView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeRowsView.swift
@@ -115,7 +115,7 @@ struct WorktreeRowsView: View {
     moveDisabled: Bool,
     shortcutHint: String?
   ) -> some View {
-    let isSidebarDragActive = store.state.isSidebarDragActive
+    let isWorktreeDragActive = !draggingWorktreeIDs.isEmpty
     let showsNotificationIndicator = terminalManager.hasUnseenNotifications(for: row.id)
     let displayName =
       if row.isDeleting {
@@ -125,7 +125,7 @@ struct WorktreeRowsView: View {
       } else {
         row.name
       }
-    let canShowRowActions = row.isRemovable && !isRepositoryRemoving && !isSidebarDragActive
+    let canShowRowActions = row.isRemovable && !isRepositoryRemoving && !isWorktreeDragActive
     let pinAction: (() -> Void)? =
       canShowRowActions && !row.isMainWorktree
       ? { togglePin(for: row.id, isPinned: row.isPinned) }
@@ -156,9 +156,9 @@ struct WorktreeRowsView: View {
     let config = WorktreeRowViewConfig(
       displayName: displayName,
       worktreeName: worktreeName(for: row),
-      isHovered: !isSidebarDragActive && hoveredWorktreeID == row.id,
-      showsNotificationIndicator: !isSidebarDragActive && showsNotificationIndicator,
-      notifications: isSidebarDragActive ? [] : notifications,
+      isHovered: !isWorktreeDragActive && hoveredWorktreeID == row.id,
+      showsNotificationIndicator: !isWorktreeDragActive && showsNotificationIndicator,
+      notifications: isWorktreeDragActive ? [] : notifications,
       onFocusNotification: onFocusNotification,
       shortcutHint: shortcutHint,
       pinAction: pinAction,
@@ -304,12 +304,12 @@ struct WorktreeRowsView: View {
     let isSelected = selectedWorktreeIDs.contains(row.id)
     let taskStatus = terminalManager.taskStatus(for: row.id)
     let isRunScriptRunning = terminalManager.isRunScriptRunning(for: row.id)
-    let isSidebarDragActive = store.state.isSidebarDragActive
+    let isWorktreeDragActive = !draggingWorktreeIDs.isEmpty
     return WorktreeRow(
       name: config.displayName,
       worktreeName: config.worktreeName,
       info: row.info,
-      showsPullRequestInfo: !isSidebarDragActive && !draggingWorktreeIDs.contains(row.id),
+      showsPullRequestInfo: !isWorktreeDragActive,
       isHovered: config.isHovered,
       isPinned: row.isPinned,
       isMainWorktree: row.isMainWorktree,

--- a/supacode/Features/Repositories/Views/WorktreeRowsView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeRowsView.swift
@@ -90,25 +90,22 @@ struct WorktreeRowsView: View {
   ) -> some View {
     let rowIDs = rows.map(\.id)
     ForEach(Array(rows.enumerated()), id: \.element.id) { index, row in
-      worktreeDropZone(
-        destination: index,
-        rowIDs: rowIDs,
-        targetedDestination: targetedDestination,
-        section: section
-      )
       rowView(
         row,
         isRepositoryRemoving: isRepositoryRemoving,
         moveDisabled: isRepositoryRemoving || row.isDeleting || row.isArchiving,
         shortcutHint: worktreeShortcutHint(for: shortcutIndexByID[row.id])
       )
+      .worktreeDropTarget(
+        index: index,
+        rowIDs: rowIDs,
+        targetedDestination: targetedDestination,
+        onDrop: { offsets, destination in
+          moveWorktrees(section: section, offsets: offsets, destination: destination)
+        },
+        onDragEnded: endWorktreeDrag
+      )
     }
-    worktreeDropZone(
-      destination: rows.count,
-      rowIDs: rowIDs,
-      targetedDestination: targetedDestination,
-      section: section
-    )
   }
 
   @ViewBuilder
@@ -224,38 +221,12 @@ struct WorktreeRowsView: View {
     didEnd: Bool
   ) {
     if didEnd {
-      draggingWorktreeIDs = []
+      endWorktreeDrag()
       return
     }
     if draggedIDs != draggingWorktreeIDs {
       draggingWorktreeIDs = draggedIDs
     }
-  }
-
-  private func worktreeDropZone(
-    destination: Int,
-    rowIDs: [Worktree.ID],
-    targetedDestination: Binding<Int?>,
-    section: SidebarWorktreeSection
-  ) -> some View {
-    SidebarDropIndicator(isVisible: targetedDestination.wrappedValue == destination, horizontalPadding: 28)
-      .onDrop(
-        of: [.prowlSidebarWorktreeID],
-        delegate: SidebarWorktreeDropDelegate(
-          destination: destination,
-          sectionIDs: rowIDs,
-          targetedDestination: targetedDestination,
-          onDrop: { offsets, destination in
-            switch section {
-            case .pinned:
-              store.send(.worktreeOrdering(.pinnedWorktreesMoved(repositoryID: repository.id, offsets, destination)))
-            case .unpinned:
-              store.send(.worktreeOrdering(.unpinnedWorktreesMoved(repositoryID: repository.id, offsets, destination)))
-            }
-          },
-          onDragEnded: endWorktreeDrag
-        )
-      )
   }
 
   private func selectWorktreeRow(_ worktreeID: Worktree.ID) {
@@ -299,6 +270,19 @@ struct WorktreeRowsView: View {
     targetedPinnedDropDestination = nil
     targetedUnpinnedDropDestination = nil
     store.send(.worktreeOrdering(.setSidebarDragActive(false)))
+  }
+
+  private func moveWorktrees(
+    section: SidebarWorktreeSection,
+    offsets: IndexSet,
+    destination: Int
+  ) {
+    switch section {
+    case .pinned:
+      store.send(.worktreeOrdering(.pinnedWorktreesMoved(repositoryID: repository.id, offsets, destination)))
+    case .unpinned:
+      store.send(.worktreeOrdering(.unpinnedWorktreesMoved(repositoryID: repository.id, offsets, destination)))
+    }
   }
 
   private struct WorktreeRowViewConfig {

--- a/supacode/Features/Repositories/Views/WorktreeRowsView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeRowsView.swift
@@ -363,7 +363,8 @@ struct WorktreeRowsView: View {
     .tag(SidebarSelection.worktree(row.id))
     .id(SidebarScrollID.worktree(row.id))
     .typeSelectEquivalent("")
-    .padding(.horizontal, 8)
+    .padding(.leading, 20)
+    .padding(.trailing, 8)
     .background {
       if isSelected {
         RoundedRectangle(cornerRadius: 5)

--- a/supacode/Features/Repositories/Views/WorktreeRowsView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeRowsView.swift
@@ -14,6 +14,8 @@ struct WorktreeRowsView: View {
   @Environment(\.resolvedKeybindings) private var resolvedKeybindings
   @State private var draggingWorktreeIDs: Set<Worktree.ID> = []
   @State private var hoveredWorktreeID: Worktree.ID?
+  @State private var targetedPinnedDropDestination: Int?
+  @State private var targetedUnpinnedDropDestination: Int?
 
   var body: some View {
     if isExpanded {
@@ -35,7 +37,6 @@ struct WorktreeRowsView: View {
     return rowsGroup(
       sections: sections,
       isRepositoryRemoving: isRepositoryRemoving,
-      showShortcutHints: showShortcutHints,
       shortcutIndexByID: shortcutIndexByID
     )
     .animation(isSidebarDragActive ? nil : .easeOut(duration: 0.2), value: rowIDs)
@@ -45,7 +46,6 @@ struct WorktreeRowsView: View {
   private func rowsGroup(
     sections: WorktreeRowSections,
     isRepositoryRemoving: Bool,
-    showShortcutHints: Bool,
     shortcutIndexByID: [Worktree.ID: Int]
   ) -> some View {
     if let row = sections.main {
@@ -53,39 +53,62 @@ struct WorktreeRowsView: View {
         row,
         isRepositoryRemoving: isRepositoryRemoving,
         moveDisabled: true,
-        shortcutHint: showShortcutHints ? worktreeShortcutHint(for: shortcutIndexByID[row.id]) : nil
+        shortcutHint: worktreeShortcutHint(for: shortcutIndexByID[row.id])
       )
     }
-    ForEach(sections.pinned) { row in
-      rowView(
-        row,
-        isRepositoryRemoving: isRepositoryRemoving,
-        moveDisabled: isRepositoryRemoving || row.isDeleting || row.isArchiving,
-        shortcutHint: showShortcutHints ? worktreeShortcutHint(for: shortcutIndexByID[row.id]) : nil
-      )
-    }
-    .onMove { offsets, destination in
-      store.send(.worktreeOrdering(.pinnedWorktreesMoved(repositoryID: repository.id, offsets, destination)))
-    }
+    movableRowsGroup(
+      rows: sections.pinned,
+      section: .pinned,
+      targetedDestination: $targetedPinnedDropDestination,
+      isRepositoryRemoving: isRepositoryRemoving,
+      shortcutIndexByID: shortcutIndexByID
+    )
     ForEach(sections.pending) { row in
       rowView(
         row,
         isRepositoryRemoving: isRepositoryRemoving,
         moveDisabled: true,
-        shortcutHint: showShortcutHints ? worktreeShortcutHint(for: shortcutIndexByID[row.id]) : nil
+        shortcutHint: worktreeShortcutHint(for: shortcutIndexByID[row.id])
       )
     }
-    ForEach(sections.unpinned) { row in
+    movableRowsGroup(
+      rows: sections.unpinned,
+      section: .unpinned,
+      targetedDestination: $targetedUnpinnedDropDestination,
+      isRepositoryRemoving: isRepositoryRemoving,
+      shortcutIndexByID: shortcutIndexByID
+    )
+  }
+
+  @ViewBuilder
+  private func movableRowsGroup(
+    rows: [WorktreeRowModel],
+    section: SidebarWorktreeSection,
+    targetedDestination: Binding<Int?>,
+    isRepositoryRemoving: Bool,
+    shortcutIndexByID: [Worktree.ID: Int]
+  ) -> some View {
+    let rowIDs = rows.map(\.id)
+    ForEach(Array(rows.enumerated()), id: \.element.id) { index, row in
+      worktreeDropZone(
+        destination: index,
+        rowIDs: rowIDs,
+        targetedDestination: targetedDestination,
+        section: section
+      )
       rowView(
         row,
         isRepositoryRemoving: isRepositoryRemoving,
         moveDisabled: isRepositoryRemoving || row.isDeleting || row.isArchiving,
-        shortcutHint: showShortcutHints ? worktreeShortcutHint(for: shortcutIndexByID[row.id]) : nil
+        shortcutHint: worktreeShortcutHint(for: shortcutIndexByID[row.id])
       )
     }
-    .onMove { offsets, destination in
-      store.send(.worktreeOrdering(.unpinnedWorktreesMoved(repositoryID: repository.id, offsets, destination)))
-    }
+    worktreeDropZone(
+      destination: rows.count,
+      rowIDs: rowIDs,
+      targetedDestination: targetedDestination,
+      section: section
+    )
   }
 
   @ViewBuilder
@@ -159,6 +182,18 @@ struct WorktreeRowsView: View {
     }
     .contentShape(.dragPreview, .rect)
     .contentShape(.interaction, .rect)
+    .onTapGesture {
+      selectWorktreeRow(row.id)
+    }
+    .accessibilityAddTraits(.isButton)
+    .draggableWorktree(
+      id: row.id,
+      isEnabled: !moveDisabled,
+      beginDrag: {
+        draggingWorktreeIDs = [row.id]
+        store.send(.worktreeOrdering(.setSidebarDragActive(true)))
+      }
+    )
     .environment(\.colorScheme, colorScheme)
     .preferredColorScheme(colorScheme)
     .onHover { hovering in
@@ -169,23 +204,101 @@ struct WorktreeRowsView: View {
       }
     }
     .onDragSessionUpdated { session in
-      let draggedIDs = Set(session.draggedItemIDs(for: Worktree.ID.self))
-      if case .ended = session.phase {
-        if !draggingWorktreeIDs.isEmpty {
-          draggingWorktreeIDs = []
+      let didEnd =
+        if case .ended = session.phase {
+          true
+        } else if case .dataTransferCompleted = session.phase {
+          true
+        } else {
+          false
         }
+      handleWorktreeDragSession(
+        draggedIDs: Set(session.draggedItemIDs(for: Worktree.ID.self)),
+        didEnd: didEnd
+      )
+    }
+  }
+
+  private func handleWorktreeDragSession(
+    draggedIDs: Set<Worktree.ID>,
+    didEnd: Bool
+  ) {
+    if didEnd {
+      draggingWorktreeIDs = []
+      return
+    }
+    if draggedIDs != draggingWorktreeIDs {
+      draggingWorktreeIDs = draggedIDs
+    }
+  }
+
+  private func worktreeDropZone(
+    destination: Int,
+    rowIDs: [Worktree.ID],
+    targetedDestination: Binding<Int?>,
+    section: SidebarWorktreeSection
+  ) -> some View {
+    SidebarDropIndicator(isVisible: targetedDestination.wrappedValue == destination, horizontalPadding: 28)
+      .onDrop(
+        of: [.prowlSidebarWorktreeID],
+        delegate: SidebarWorktreeDropDelegate(
+          destination: destination,
+          sectionIDs: rowIDs,
+          targetedDestination: targetedDestination,
+          onDrop: { offsets, destination in
+            switch section {
+            case .pinned:
+              store.send(.worktreeOrdering(.pinnedWorktreesMoved(repositoryID: repository.id, offsets, destination)))
+            case .unpinned:
+              store.send(.worktreeOrdering(.unpinnedWorktreesMoved(repositoryID: repository.id, offsets, destination)))
+            }
+          },
+          onDragEnded: endWorktreeDrag
+        )
+      )
+  }
+
+  private func selectWorktreeRow(_ worktreeID: Worktree.ID) {
+    if commandKeyObserver.isPressed {
+      var nextSelection = selectedWorktreeIDs
+      if nextSelection.contains(worktreeID) {
+        nextSelection.remove(worktreeID)
+      } else {
+        nextSelection.insert(worktreeID)
+      }
+      guard !nextSelection.isEmpty else {
+        store.send(.selectWorktree(nil))
         return
       }
-      if case .dataTransferCompleted = session.phase {
-        if !draggingWorktreeIDs.isEmpty {
-          draggingWorktreeIDs = []
+      let primarySelection =
+        hotkeyRows.map(\.id).first(where: nextSelection.contains)
+        ?? nextSelection.first
+      store.send(.selectWorktree(primarySelection, focusTerminal: false))
+      store.send(.setSidebarSelectedWorktreeIDs(nextSelection))
+      return
+    }
+
+    store.send(.selectWorktree(worktreeID, focusTerminal: true))
+    focusTerminalAfterSelection(worktreeID: worktreeID)
+  }
+
+  private func focusTerminalAfterSelection(worktreeID: Worktree.ID) {
+    Task { @MainActor [terminalManager] in
+      for _ in 0..<4 {
+        await Task.yield()
+        if let terminalState = terminalManager.stateIfExists(for: worktreeID) {
+          terminalState.focusSelectedTab()
+          return
         }
-        return
-      }
-      if draggedIDs != draggingWorktreeIDs {
-        draggingWorktreeIDs = draggedIDs
       }
     }
+  }
+
+  private func endWorktreeDrag() {
+    draggingWorktreeIDs = []
+    targetedPinnedDropDestination = nil
+    targetedUnpinnedDropDestination = nil
+    store.send(.worktreeOrdering(.setSidebarDragActive(false)))
   }
 
   private struct WorktreeRowViewConfig {
@@ -230,10 +343,16 @@ struct WorktreeRowsView: View {
       onStopRunScript: config.onStopRunScript,
     )
     .tag(SidebarSelection.worktree(row.id))
-    .id(row.id)
+    .id(SidebarScrollID.worktree(row.id))
     .typeSelectEquivalent("")
-    .listRowInsets(EdgeInsets())
-    .listRowSeparator(.hidden)
+    .padding(.horizontal, 8)
+    .background {
+      if isSelected {
+        RoundedRectangle(cornerRadius: 5)
+          .fill(Color.accentColor.opacity(0.18))
+          .padding(.horizontal, 6)
+      }
+    }
     .transition(.opacity)
     .moveDisabled(config.moveDisabled)
   }

--- a/supacode/Features/Repositories/Views/WorktreeRowsView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeRowsView.swift
@@ -25,6 +25,7 @@ struct WorktreeRowsView: View {
     let state = store.state
     let sections = state.worktreeRowSections(in: repository)
     let isRepositoryRemoving = state.isRemovingRepository(repository)
+    let isSidebarDragActive = state.isSidebarDragActive
     let showShortcutHints = commandKeyObserver.isPressed
     let allRows = showShortcutHints ? hotkeyRows : []
     let shortcutIndexByID = Dictionary(
@@ -37,7 +38,7 @@ struct WorktreeRowsView: View {
       showShortcutHints: showShortcutHints,
       shortcutIndexByID: shortcutIndexByID
     )
-    .animation(.easeOut(duration: 0.2), value: rowIDs)
+    .animation(isSidebarDragActive ? nil : .easeOut(duration: 0.2), value: rowIDs)
   }
 
   @ViewBuilder
@@ -94,6 +95,7 @@ struct WorktreeRowsView: View {
     moveDisabled: Bool,
     shortcutHint: String?
   ) -> some View {
+    let isSidebarDragActive = store.state.isSidebarDragActive
     let showsNotificationIndicator = terminalManager.hasUnseenNotifications(for: row.id)
     let displayName =
       if row.isDeleting {
@@ -103,7 +105,7 @@ struct WorktreeRowsView: View {
       } else {
         row.name
       }
-    let canShowRowActions = row.isRemovable && !isRepositoryRemoving
+    let canShowRowActions = row.isRemovable && !isRepositoryRemoving && !isSidebarDragActive
     let pinAction: (() -> Void)? =
       canShowRowActions && !row.isMainWorktree
       ? { togglePin(for: row.id, isPinned: row.isPinned) }
@@ -134,9 +136,9 @@ struct WorktreeRowsView: View {
     let config = WorktreeRowViewConfig(
       displayName: displayName,
       worktreeName: worktreeName(for: row),
-      isHovered: hoveredWorktreeID == row.id,
-      showsNotificationIndicator: showsNotificationIndicator,
-      notifications: notifications,
+      isHovered: !isSidebarDragActive && hoveredWorktreeID == row.id,
+      showsNotificationIndicator: !isSidebarDragActive && showsNotificationIndicator,
+      notifications: isSidebarDragActive ? [] : notifications,
       onFocusNotification: onFocusNotification,
       shortcutHint: shortcutHint,
       pinAction: pinAction,
@@ -205,11 +207,12 @@ struct WorktreeRowsView: View {
     let isSelected = selectedWorktreeIDs.contains(row.id)
     let taskStatus = terminalManager.taskStatus(for: row.id)
     let isRunScriptRunning = terminalManager.isRunScriptRunning(for: row.id)
+    let isSidebarDragActive = store.state.isSidebarDragActive
     return WorktreeRow(
       name: config.displayName,
       worktreeName: config.worktreeName,
       info: row.info,
-      showsPullRequestInfo: !draggingWorktreeIDs.contains(row.id),
+      showsPullRequestInfo: !isSidebarDragActive && !draggingWorktreeIDs.contains(row.id),
       isHovered: config.isHovered,
       isPinned: row.isPinned,
       isMainWorktree: row.isMainWorktree,

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -2577,6 +2577,115 @@ struct RepositoriesFeatureTests {
     #expect(store.state.statusToast == nil)
   }
 
+  @Test func worktreeNotificationDuringSidebarDragDefersReorder() async {
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let featureA = makeWorktree(id: "/tmp/repo/a", name: "a", repoRoot: repoRoot)
+    let featureB = makeWorktree(id: "/tmp/repo/b", name: "b", repoRoot: repoRoot)
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree, featureA, featureB])
+    var state = makeState(repositories: [repository])
+    state.worktreeOrderByRepository[repoRoot] = [featureA.id, featureB.id]
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    }
+
+    await store.send(.worktreeOrdering(.setSidebarDragActive(true))) {
+      $0.isSidebarDragActive = true
+    }
+    await store.send(.worktreeOrdering(.worktreeNotificationReceived(featureB.id))) {
+      $0.pendingSidebarNotifyReorderIDs = [featureB.id]
+    }
+    #expect(store.state.worktreeOrderByRepository[repoRoot] == [featureA.id, featureB.id])
+  }
+
+  @Test func endingSidebarDragAppliesPendingNotificationReordersInOrder() async {
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let featureA = makeWorktree(id: "/tmp/repo/a", name: "a", repoRoot: repoRoot)
+    let featureB = makeWorktree(id: "/tmp/repo/b", name: "b", repoRoot: repoRoot)
+    let featureC = makeWorktree(id: "/tmp/repo/c", name: "c", repoRoot: repoRoot)
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree, featureA, featureB, featureC])
+    var state = makeState(repositories: [repository])
+    state.isSidebarDragActive = true
+    state.pendingSidebarNotifyReorderIDs = [featureA.id, featureC.id, featureB.id]
+    state.worktreeOrderByRepository[repoRoot] = [featureA.id, featureB.id, featureC.id]
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    }
+
+    await store.send(.worktreeOrdering(.setSidebarDragActive(false))) {
+      $0.isSidebarDragActive = false
+      $0.pendingSidebarNotifyReorderIDs = []
+      $0.worktreeOrderByRepository[repoRoot] = [featureB.id, featureC.id, featureA.id]
+    }
+  }
+
+  @Test func repeatedNotificationDuringSidebarDragKeepsLatestPosition() async {
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let featureA = makeWorktree(id: "/tmp/repo/a", name: "a", repoRoot: repoRoot)
+    let featureB = makeWorktree(id: "/tmp/repo/b", name: "b", repoRoot: repoRoot)
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree, featureA, featureB])
+    var state = makeState(repositories: [repository])
+    state.isSidebarDragActive = true
+    state.worktreeOrderByRepository[repoRoot] = [featureA.id, featureB.id]
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    }
+
+    await store.send(.worktreeOrdering(.worktreeNotificationReceived(featureA.id))) {
+      $0.pendingSidebarNotifyReorderIDs = [featureA.id]
+    }
+    await store.send(.worktreeOrdering(.worktreeNotificationReceived(featureB.id))) {
+      $0.pendingSidebarNotifyReorderIDs = [featureA.id, featureB.id]
+    }
+    await store.send(.worktreeOrdering(.worktreeNotificationReceived(featureA.id))) {
+      $0.pendingSidebarNotifyReorderIDs = [featureB.id, featureA.id]
+    }
+    await store.send(.worktreeOrdering(.setSidebarDragActive(false))) {
+      $0.isSidebarDragActive = false
+      $0.pendingSidebarNotifyReorderIDs = []
+      $0.worktreeOrderByRepository[repoRoot] = [featureA.id, featureB.id]
+    }
+  }
+
+  @Test func stalePendingNotificationReordersAreIgnoredWhenDragEnds() async {
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let featureA = makeWorktree(id: "/tmp/repo/a", name: "a", repoRoot: repoRoot)
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree, featureA])
+    var state = makeState(repositories: [repository])
+    state.isSidebarDragActive = true
+    state.pendingSidebarNotifyReorderIDs = ["/tmp/repo/stale", featureA.id]
+    state.worktreeOrderByRepository[repoRoot] = [featureA.id]
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    }
+
+    await store.send(.worktreeOrdering(.setSidebarDragActive(false))) {
+      $0.isSidebarDragActive = false
+      $0.pendingSidebarNotifyReorderIDs = []
+    }
+  }
+
+  @Test func notificationDuringSidebarDragDoesNotRecordWhenMoveToTopDisabled() async {
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let featureA = makeWorktree(id: "/tmp/repo/a", name: "a", repoRoot: repoRoot)
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree, featureA])
+    var state = makeState(repositories: [repository])
+    state.isSidebarDragActive = true
+    state.moveNotifiedWorktreeToTop = false
+    state.worktreeOrderByRepository[repoRoot] = [featureA.id]
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    }
+
+    await store.send(.worktreeOrdering(.worktreeNotificationReceived(featureA.id)))
+    #expect(store.state.pendingSidebarNotifyReorderIDs.isEmpty)
+    #expect(store.state.worktreeOrderByRepository[repoRoot] == [featureA.id])
+  }
+
   @Test func setMoveNotifiedWorktreeToTopUpdatesState() async {
     var state = makeState(repositories: [])
     state.moveNotifiedWorktreeToTop = true

--- a/supacodeTests/RepositorySectionViewTests.swift
+++ b/supacodeTests/RepositorySectionViewTests.swift
@@ -69,6 +69,28 @@ struct RepositorySectionViewTests {
     #expect(SidebarListView.showsRepositoryListHeader(repositoryCount: 11))
   }
 
+  @Test func explicitSelectionIncludesPrimarySelectedWorktree() {
+    let worktree = Worktree(
+      id: "/tmp/repo/wt",
+      name: "wt",
+      detail: "detail",
+      workingDirectory: URL(fileURLWithPath: "/tmp/repo/wt"),
+      repositoryRootURL: URL(fileURLWithPath: "/tmp/repo")
+    )
+    let repository = Repository(
+      id: "/tmp/repo",
+      rootURL: URL(fileURLWithPath: "/tmp/repo"),
+      name: "repo",
+      kind: .git,
+      worktrees: [worktree]
+    )
+    var state = RepositoriesFeature.State()
+    state.repositories = [repository]
+    state.selection = .worktree(worktree.id)
+
+    #expect(SidebarListView.selectedWorktreeIDs(in: state) == [worktree.id])
+  }
+
   @Test func openTabCountForGitRepositorySumsAllWorktrees() {
     let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
     let repositoryRootURL = URL(fileURLWithPath: "/tmp/repo")

--- a/supacodeTests/SidebarDragSupportTests.swift
+++ b/supacodeTests/SidebarDragSupportTests.swift
@@ -1,0 +1,54 @@
+import Testing
+
+@testable import supacode
+
+struct SidebarDragSupportTests {
+  @Test func dropIndicatorOnlyDrawsOneEdgeForInteriorDestinations() {
+    #expect(
+      SidebarDropIndicatorEdge.edge(
+        targetedDestination: 1,
+        rowIndex: 0,
+        rowCount: 3
+      )
+        == .none
+    )
+    #expect(
+      SidebarDropIndicatorEdge.edge(
+        targetedDestination: 1,
+        rowIndex: 1,
+        rowCount: 3
+      )
+        == .top
+    )
+  }
+
+  @Test func dropIndicatorDrawsTopAndFinalBottomBoundaries() {
+    #expect(
+      SidebarDropIndicatorEdge.edge(
+        targetedDestination: 0,
+        rowIndex: 0,
+        rowCount: 3
+      )
+        == .top
+    )
+    #expect(
+      SidebarDropIndicatorEdge.edge(
+        targetedDestination: 3,
+        rowIndex: 2,
+        rowCount: 3
+      )
+        == .bottom
+    )
+  }
+
+  @Test func dropIndicatorHidesWithoutTarget() {
+    #expect(
+      SidebarDropIndicatorEdge.edge(
+        targetedDestination: nil,
+        rowIndex: 1,
+        rowCount: 3
+      )
+        == .none
+    )
+  }
+}

--- a/supacodeTests/SidebarPresentationTests.swift
+++ b/supacodeTests/SidebarPresentationTests.swift
@@ -1,0 +1,197 @@
+import Foundation
+import IdentifiedCollections
+import Testing
+
+@testable import supacode
+
+@MainActor
+struct SidebarPresentationTests {
+  @Test func expandedRepositoryIsOneOuterItemWithChildRows() {
+    let repoRoot = "/tmp/repo"
+    let main = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let feature = makeWorktree(id: "/tmp/repo/feature", name: "feature", repoRoot: repoRoot)
+    let repository = makeRepository(id: repoRoot, worktrees: [main, feature])
+    let state = makeState(repositories: [repository])
+
+    let presentation = state.sidebarPresentation(expandedRepositoryIDs: [repository.id])
+
+    #expect(presentation.items.count == 1)
+    guard case .repository(let model) = presentation.items.first else {
+      Issue.record("Expected repository container")
+      return
+    }
+    #expect(model.id == repository.id)
+    #expect(model.isExpanded)
+    #expect(model.worktreeSections.allRows.map(\.id) == [main.id, feature.id])
+  }
+
+  @Test func collapsedRepositoryKeepsContainerButHidesChildRows() {
+    let repoRoot = "/tmp/repo"
+    let main = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let feature = makeWorktree(id: "/tmp/repo/feature", name: "feature", repoRoot: repoRoot)
+    let repository = makeRepository(id: repoRoot, worktrees: [main, feature])
+    let state = makeState(repositories: [repository])
+
+    let presentation = state.sidebarPresentation(expandedRepositoryIDs: [])
+
+    guard case .repository(let model) = presentation.items.first else {
+      Issue.record("Expected repository container")
+      return
+    }
+    #expect(!model.isExpanded)
+    #expect(model.worktreeSections.allRows.isEmpty)
+  }
+
+  @Test func failedRepositoriesParticipateInRootOrder() {
+    let repoA = makeRepository(id: "/tmp/a", worktrees: [])
+    var state = makeState(repositories: [repoA])
+    state.repositoryRoots = [
+      URL(fileURLWithPath: "/tmp/missing"),
+      repoA.rootURL,
+    ]
+    state.repositoryOrderIDs = ["/tmp/missing", repoA.id]
+    state.loadFailuresByID["/tmp/missing"] = "missing"
+
+    let presentation = state.sidebarPresentation(expandedRepositoryIDs: [repoA.id])
+
+    #expect(presentation.repositoryOrderIDs == ["/tmp/missing", repoA.id])
+    #expect(
+      presentation.repositoryOrderAfterMove(fromOffsets: IndexSet(integer: 0), toOffset: 2) == [
+        repoA.id, "/tmp/missing",
+      ])
+    guard case .failedRepository(let failed) = presentation.items.first else {
+      Issue.record("Expected failed repository first")
+      return
+    }
+    #expect(failed.id == "/tmp/missing")
+    #expect(failed.isReorderable)
+  }
+
+  @Test func plainFolderProducesContainerWithoutWorktreeChildren() {
+    let repository = makeRepository(id: "/tmp/plain", kind: .plain, worktrees: [])
+    let state = makeState(repositories: [repository])
+
+    let presentation = state.sidebarPresentation(expandedRepositoryIDs: [repository.id])
+
+    guard case .repository(let model) = presentation.items.first else {
+      Issue.record("Expected repository container")
+      return
+    }
+    #expect(model.kind == .plain)
+    #expect(model.worktreeSections.allRows.isEmpty)
+  }
+
+  @Test func worktreeSectionsPreservePinnedMainPendingAndUnpinnedRows() {
+    let repoRoot = "/tmp/repo"
+    let main = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let pinned = makeWorktree(id: "/tmp/repo/pinned", name: "pinned", repoRoot: repoRoot)
+    let unpinned = makeWorktree(id: "/tmp/repo/unpinned", name: "unpinned", repoRoot: repoRoot)
+    let repository = makeRepository(id: repoRoot, worktrees: [main, pinned, unpinned])
+    var state = makeState(repositories: [repository])
+    state.pinnedWorktreeIDs = [pinned.id]
+    state.pendingWorktrees = [
+      PendingWorktree(
+        id: "/tmp/repo/pending",
+        repositoryID: repository.id,
+        progress: WorktreeCreationProgress(stage: .choosingWorktreeName, worktreeName: "pending")
+      )
+    ]
+    state.worktreeOrderByRepository[repository.id] = [unpinned.id]
+
+    let presentation = state.sidebarPresentation(expandedRepositoryIDs: [repository.id])
+
+    guard case .repository(let model) = presentation.items.first else {
+      Issue.record("Expected repository container")
+      return
+    }
+    #expect(model.worktreeSections.main?.id == main.id)
+    #expect(model.worktreeSections.pinned.map(\.id) == [pinned.id])
+    #expect(model.worktreeSections.pending.map(\.id) == ["/tmp/repo/pending"])
+    #expect(model.worktreeSections.unpinned.map(\.id) == [unpinned.id])
+  }
+
+  @Test func emptyOrderedRootsStillBuildsRepositoryPresentation() {
+    let repoA = makeRepository(id: "/tmp/a", worktrees: [])
+    let repoB = makeRepository(id: "/tmp/b", worktrees: [])
+    var state = RepositoriesFeature.State()
+    state.repositories = [repoA, repoB]
+
+    let presentation = state.sidebarPresentation(expandedRepositoryIDs: [repoA.id, repoB.id])
+
+    #expect(presentation.repositoryOrderIDs == [repoA.id, repoB.id])
+  }
+
+  @Test func customOrderedRootsUseSamePresentationRules() {
+    let repoA = makeRepository(id: "/tmp/a", worktrees: [])
+    let repoB = makeRepository(id: "/tmp/b", worktrees: [])
+    var state = makeState(repositories: [repoA, repoB])
+    state.repositoryOrderIDs = [repoB.id, repoA.id]
+
+    let presentation = state.sidebarPresentation(expandedRepositoryIDs: [repoA.id, repoB.id])
+
+    #expect(presentation.repositoryOrderIDs == [repoB.id, repoA.id])
+  }
+
+  @Test func worktreeDropDestinationsMapToExistingOrderingActions() {
+    let pinned = SidebarWorktreeDropTarget(
+      repositoryID: "/tmp/repo",
+      section: .pinned,
+      source: IndexSet(integer: 1),
+      destination: 0
+    )
+    let unpinned = SidebarWorktreeDropTarget(
+      repositoryID: "/tmp/repo",
+      section: .unpinned,
+      source: IndexSet(integer: 0),
+      destination: 2
+    )
+
+    #expect(
+      pinned.action
+        == RepositoriesFeature.WorktreeOrderingAction.pinnedWorktreesMoved(
+          repositoryID: "/tmp/repo",
+          IndexSet(integer: 1),
+          0
+        )
+    )
+    #expect(
+      unpinned.action
+        == RepositoriesFeature.WorktreeOrderingAction.unpinnedWorktreesMoved(
+          repositoryID: "/tmp/repo",
+          IndexSet(integer: 0),
+          2
+        )
+    )
+  }
+
+  private func makeWorktree(id: String, name: String, repoRoot: String) -> Worktree {
+    Worktree(
+      id: id,
+      name: name,
+      detail: "detail",
+      workingDirectory: URL(fileURLWithPath: id),
+      repositoryRootURL: URL(fileURLWithPath: repoRoot)
+    )
+  }
+
+  private func makeRepository(
+    id: String,
+    kind: Repository.Kind = .git,
+    worktrees: [Worktree]
+  ) -> Repository {
+    Repository(
+      id: id,
+      rootURL: URL(fileURLWithPath: id),
+      name: URL(fileURLWithPath: id).lastPathComponent,
+      kind: kind,
+      worktrees: IdentifiedArray(uniqueElements: worktrees)
+    )
+  }
+
+  private func makeState(repositories: [Repository]) -> RepositoriesFeature.State {
+    var state = RepositoriesFeature.State()
+    state.repositories = IdentifiedArray(uniqueElements: repositories)
+    state.repositoryRoots = repositories.map(\.rootURL)
+    return state
+  }
+}


### PR DESCRIPTION
## Summary

- keep the sidebar container refactor plan in `doc-onevcat/plans/2026-05-03-sidebar-container-refactor-plan.md`
- add reducer-level sidebar drag state so notification-driven worktree reordering is deferred while a sidebar drag is active
- add a pure `SidebarPresentation` model with repository containers, failed repository rows, stable repository order mapping, and worktree drop action mapping
- replace the sidebar's native `List(selection:)` body with a `ScrollView` / `LazyVStack` container where repositories are stable outer rows and worktrees are children inside each repository container
- add custom repository and worktree drag/drop support with explicit insertion indicators at container or section boundaries
- use plain-text internal drag payloads for SwiftUI drop compatibility, and draw drop indicators as overlays on existing rows so they do not affect sidebar layout
- keep PR/notification/hover display independent from the reducer-level drag gate so failed/cancelled drags cannot freeze sidebar row affordances
- keep drop targets mounted throughout drag sessions while filtering delegate responses by active local drag type, render only one insertion indicator per boundary, keep long labels single-line truncated on hover, restore full-row worktree context menu hit areas, align the repository list header inset with repository rows, and indent worktree rows within repository sections
- clear local drag state synchronously from the active dragged item before applying drop reordering; repository moves use a short animation
- show a temporary accent focus ring when opening a context menu on an unselected worktree row

## Notes

This PR now covers the first user-visible container phase: expanded repositories are rendered as one stable visual unit, and repository drag indicators are custom-drawn at repository container boundaries instead of between a header and its child worktree rows. Worktree reorder remains supported for pinned and unpinned sections via custom row drop targets.

Remaining follow-up work should focus on polishing keyboard/accessibility parity beyond the current command shortcuts and replacing the fixed-yield reveal materialization with an event-driven row-availability signal.

## Verification

- `xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -only-testing:supacodeTests/SidebarDragSupportTests -only-testing:supacodeTests/RepositorySectionViewTests -only-testing:supacodeTests/RepositoriesFeatureTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation 2>&1 | xcsift -f toon -w`
- `make check`
- `make build-app 2>&1 | xcsift -f toon -w`

Refs #249
