### PR TITLE
Dim unfocused split panes

### DIFF
--- a/supacode/Features/Canvas/Views/CanvasCardView.swift
+++ b/supacode/Features/Canvas/Views/CanvasCardView.swift
@@ -16,6 +16,7 @@ struct CanvasCardView: View {
   /// PNG/SVG filenames against the per-repo icons directory.
   var repositoryRootURL: URL?
   let tree: SplitTree<GhosttySurfaceView>
+  let focusedSurfaceID: UUID?
   let isFocused: Bool
   let isSelected: Bool
   let hasUnseenNotification: Bool
@@ -225,9 +226,14 @@ struct CanvasCardView: View {
   }
 
   private var terminalContent: some View {
-    TerminalSplitTreeView(tree: tree, pinnedSize: cardSize, action: onSplitOperation)
-      .frame(width: cardSize.width, height: cardSize.height)
-      .allowsHitTesting(isFocused && !showsSelectionShield)
+    TerminalSplitTreeView(
+      tree: tree,
+      pinnedSize: cardSize,
+      focusedSurfaceID: focusedSurfaceID,
+      action: onSplitOperation
+    )
+    .frame(width: cardSize.width, height: cardSize.height)
+    .allowsHitTesting(isFocused && !showsSelectionShield)
   }
 
   private var selectionShield: some View {

--- a/supacode/Features/Canvas/Views/CanvasView.swift
+++ b/supacode/Features/Canvas/Views/CanvasView.swift
@@ -98,6 +98,7 @@ struct CanvasView: View {
                 repositoryColor: repositoryAppearance.color?.color,
                 repositoryRootURL: state.repositoryRootURL,
                 tree: tree,
+                focusedSurfaceID: state.focusedSurfaceId(in: tab.id),
                 isFocused: selectionState.primaryTabID == tab.id,
                 isSelected: selectionState.selectedTabIDs.contains(tab.id),
                 hasUnseenNotification: state.hasUnseenNotification(for: tab.id),

--- a/supacode/Features/Settings/Models/GlobalSettings.swift
+++ b/supacode/Features/Settings/Models/GlobalSettings.swift
@@ -27,6 +27,7 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
   var archivedAutoDeletePeriod: AutoDeletePeriod?
   var keybindingUserOverrides: KeybindingUserOverrideStore
   var defaultViewMode: DefaultViewMode
+  var dimUnfocusedSplits: Bool
 
   static let `default` = GlobalSettings(
     appearanceMode: .dark,
@@ -56,7 +57,8 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     archivedAutoDeletePeriod: nil,
     terminalFontSize: nil,
     keybindingUserOverrides: .empty,
-    defaultViewMode: .normal
+    defaultViewMode: .normal,
+    dimUnfocusedSplits: true
   )
 
   init(
@@ -87,7 +89,8 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     archivedAutoDeletePeriod: AutoDeletePeriod? = nil,
     terminalFontSize: Float32? = nil,
     keybindingUserOverrides: KeybindingUserOverrideStore = .empty,
-    defaultViewMode: DefaultViewMode = .normal
+    defaultViewMode: DefaultViewMode = .normal,
+    dimUnfocusedSplits: Bool = true
   ) {
     self.appearanceMode = appearanceMode
     self.defaultEditorID = defaultEditorID
@@ -117,6 +120,7 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     self.terminalFontSize = terminalFontSize
     self.keybindingUserOverrides = keybindingUserOverrides
     self.defaultViewMode = defaultViewMode
+    self.dimUnfocusedSplits = dimUnfocusedSplits
   }
 
   func encode(to encoder: any Encoder) throws {
@@ -149,6 +153,7 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     try container.encodeIfPresent(terminalFontSize, forKey: .terminalFontSize)
     try container.encode(keybindingUserOverrides, forKey: .keybindingUserOverrides)
     try container.encode(defaultViewMode, forKey: .defaultViewMode)
+    try container.encode(dimUnfocusedSplits, forKey: .dimUnfocusedSplits)
   }
 
   private enum CodingKeys: String, CodingKey {
@@ -180,6 +185,7 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     case terminalFontSize
     case keybindingUserOverrides
     case defaultViewMode
+    case dimUnfocusedSplits
     // Legacy key for migration
     case automaticallyArchiveMergedWorktrees
   }
@@ -272,5 +278,8 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     defaultViewMode =
       try container.decodeIfPresent(DefaultViewMode.self, forKey: .defaultViewMode)
       ?? Self.default.defaultViewMode
+    dimUnfocusedSplits =
+      try container.decodeIfPresent(Bool.self, forKey: .dimUnfocusedSplits)
+      ?? Self.default.dimUnfocusedSplits
   }
 }

--- a/supacode/Features/Settings/Reducer/SettingsFeature.swift
+++ b/supacode/Features/Settings/Reducer/SettingsFeature.swift
@@ -33,6 +33,7 @@ struct SettingsFeature {
     var terminalFontSize: Float32?
     var keybindingUserOverrides: KeybindingUserOverrideStore
     var defaultViewMode: DefaultViewMode
+    var dimUnfocusedSplits: Bool
     var cliInstallStatus: CLIInstallStatus = .notInstalled
     var cliInstallShowAlert: Bool = true
     var selection: SettingsSection? = .general
@@ -70,6 +71,7 @@ struct SettingsFeature {
       terminalFontSize = settings.terminalFontSize
       keybindingUserOverrides = settings.keybindingUserOverrides
       defaultViewMode = settings.defaultViewMode
+      dimUnfocusedSplits = settings.dimUnfocusedSplits
     }
 
     var globalSettings: GlobalSettings {
@@ -103,7 +105,8 @@ struct SettingsFeature {
         archivedAutoDeletePeriod: archivedAutoDeletePeriod,
         terminalFontSize: terminalFontSize,
         keybindingUserOverrides: keybindingUserOverrides,
-        defaultViewMode: defaultViewMode
+        defaultViewMode: defaultViewMode,
+        dimUnfocusedSplits: dimUnfocusedSplits
       )
     }
   }
@@ -204,6 +207,7 @@ struct SettingsFeature {
         state.terminalFontSize = normalizedSettings.terminalFontSize
         state.keybindingUserOverrides = normalizedSettings.keybindingUserOverrides
         state.defaultViewMode = normalizedSettings.defaultViewMode
+        state.dimUnfocusedSplits = normalizedSettings.dimUnfocusedSplits
         state.syncGlobalDefaults(from: normalizedSettings)
         return .send(.delegate(.settingsChanged(normalizedSettings)))
 

--- a/supacode/Features/Settings/Views/AppearanceSettingsView.swift
+++ b/supacode/Features/Settings/Views/AppearanceSettingsView.swift
@@ -46,6 +46,13 @@ struct AppearanceSettingsView: View {
           .font(.footnote)
           .foregroundStyle(.secondary)
         }
+        Section("Splits") {
+          Toggle(
+            "Dim unfocused split panes",
+            isOn: $store.dimUnfocusedSplits
+          )
+          .help("Fade split panes that aren't focused so the active one stands out.")
+        }
         Section("Default View") {
           Picker("Launch in", selection: $store.defaultViewMode) {
             ForEach(DefaultViewMode.allCases) { mode in

--- a/supacode/Features/Shelf/Views/ShelfOpenBookView.swift
+++ b/supacode/Features/Shelf/Views/ShelfOpenBookView.swift
@@ -25,7 +25,10 @@ struct ShelfOpenBookView: View {
     Group {
       if let selectedId = state.tabManager.selectedTabId {
         TerminalTabContentStack(tabs: state.tabManager.tabs, selectedTabId: selectedId) { tabId in
-          TerminalSplitTreeAXContainer(tree: state.splitTree(for: tabId)) { operation in
+          TerminalSplitTreeAXContainer(
+            tree: state.splitTree(for: tabId),
+            focusedSurfaceID: state.focusedSurfaceId(in: tabId)
+          ) { operation in
             state.performSplitOperation(operation, in: tabId)
           }
         }

--- a/supacode/Features/Terminal/Views/TerminalSplitTreeView.swift
+++ b/supacode/Features/Terminal/Views/TerminalSplitTreeView.swift
@@ -1,10 +1,12 @@
 import AppKit
+import Sharing
 import SwiftUI
 import UniformTypeIdentifiers
 
 struct TerminalSplitTreeView: View {
   let tree: SplitTree<GhosttySurfaceView>
   var pinnedSize: CGSize?
+  var focusedSurfaceID: UUID?
   let action: (Operation) -> Void
 
   private static let dragType = UTType(exportedAs: "com.onevcat.prowl.ghosttySurfaceId")
@@ -23,8 +25,14 @@ struct TerminalSplitTreeView: View {
 
   var body: some View {
     if let node = tree.visibleNode {
-      SubtreeView(node: node, isRoot: node == tree.root, pinnedSize: pinnedSize, action: action)
-        .id(node.structuralIdentity)
+      SubtreeView(
+        node: node,
+        isRoot: node == tree.root,
+        pinnedSize: pinnedSize,
+        focusedSurfaceID: focusedSurfaceID,
+        action: action
+      )
+      .id(node.structuralIdentity)
     }
   }
 
@@ -38,12 +46,19 @@ struct TerminalSplitTreeView: View {
     let node: SplitTree<GhosttySurfaceView>.Node
     var isRoot: Bool = false
     var pinnedSize: CGSize?
+    var focusedSurfaceID: UUID?
     let action: (Operation) -> Void
 
     var body: some View {
       switch node {
       case .leaf(let leafView):
-        LeafView(surfaceView: leafView, isSplit: !isRoot, pinnedSize: pinnedSize, action: action)
+        LeafView(
+          surfaceView: leafView,
+          isSplit: !isRoot,
+          isFocused: leafView.id == focusedSurfaceID,
+          pinnedSize: pinnedSize,
+          action: action
+        )
       case .split(let split):
         let splitViewDirection: SplitView<SubtreeView, SubtreeView>.Direction =
           switch split.direction {
@@ -63,13 +78,23 @@ struct TerminalSplitTreeView: View {
             set: {
               action(.resize(node: node, ratio: Double($0)))
             }),
-          dividerColor: .secondary,
+          dividerColor: Color(nsColor: .separatorColor),
           resizeIncrements: .init(width: 1, height: 1),
           left: {
-            SubtreeView(node: split.left, pinnedSize: leftPinned, action: action)
+            SubtreeView(
+              node: split.left,
+              pinnedSize: leftPinned,
+              focusedSurfaceID: focusedSurfaceID,
+              action: action
+            )
           },
           right: {
-            SubtreeView(node: split.right, pinnedSize: rightPinned, action: action)
+            SubtreeView(
+              node: split.right,
+              pinnedSize: rightPinned,
+              focusedSurfaceID: focusedSurfaceID,
+              action: action
+            )
           },
           onEqualize: {
             action(.equalize)
@@ -93,15 +118,37 @@ struct TerminalSplitTreeView: View {
   struct LeafView: View {
     let surfaceView: GhosttySurfaceView
     let isSplit: Bool
+    var isFocused: Bool = true
     var pinnedSize: CGSize?
     let action: (Operation) -> Void
 
     @State private var dropState: DropState = .idle
+    @Shared(.settingsFile) private var settingsFile: SettingsFile
+    @Environment(\.colorScheme) private var colorScheme
+
+    private var shouldDim: Bool {
+      isSplit && !isFocused && settingsFile.global.dimUnfocusedSplits
+    }
+
+    /// Lighter tint in light mode so the inactive pane reads as faded
+    /// rather than washed in grey; dark mode's deeper tint matches the
+    /// effect users see in Ghostty.app.
+    private var dimOpacity: Double {
+      colorScheme == .dark ? 0.3 : 0.12
+    }
 
     var body: some View {
       GeometryReader { geometry in
         GhosttyTerminalView(surfaceView: surfaceView, pinnedSize: pinnedSize)
           .frame(maxWidth: .infinity, maxHeight: .infinity)
+          .overlay {
+            // Mirrors Ghostty's `unfocused-split-fill`/`unfocused-split-opacity`:
+            // a translucent black tint fades the inactive pane.
+            Color.black
+              .opacity(shouldDim ? dimOpacity : 0)
+              .allowsHitTesting(false)
+              .animation(.easeOut(duration: 0.12), value: shouldDim)
+          }
           .overlay(alignment: .top) {
             GhosttySurfaceProgressOverlay(state: surfaceView.bridge.state)
           }
@@ -299,6 +346,7 @@ struct TerminalSplitTreeView: View {
 /// list of terminal panes to assistive technologies.
 struct TerminalSplitTreeAXContainer: NSViewRepresentable {
   let tree: SplitTree<GhosttySurfaceView>
+  var focusedSurfaceID: UUID?
   let action: (TerminalSplitTreeView.Operation) -> Void
 
   func makeNSView(context: Context) -> TerminalSplitAXContainerView {
@@ -307,7 +355,13 @@ struct TerminalSplitTreeAXContainer: NSViewRepresentable {
 
   func updateNSView(_ nsView: TerminalSplitAXContainerView, context: Context) {
     nsView.update(
-      rootView: AnyView(TerminalSplitTreeView(tree: tree, action: action)),
+      rootView: AnyView(
+        TerminalSplitTreeView(
+          tree: tree,
+          focusedSurfaceID: focusedSurfaceID,
+          action: action
+        )
+      ),
       panes: tree.visibleLeaves()
     )
   }

--- a/supacode/Features/Terminal/Views/WorktreeTerminalTabsView.swift
+++ b/supacode/Features/Terminal/Views/WorktreeTerminalTabsView.swift
@@ -43,7 +43,10 @@ struct WorktreeTerminalTabsView: View {
       )
       if let selectedId = state.tabManager.selectedTabId {
         TerminalTabContentStack(tabs: state.tabManager.tabs, selectedTabId: selectedId) { tabId in
-          TerminalSplitTreeAXContainer(tree: state.splitTree(for: tabId)) { operation in
+          TerminalSplitTreeAXContainer(
+            tree: state.splitTree(for: tabId),
+            focusedSurfaceID: state.focusedSurfaceId(in: tabId)
+          ) { operation in
             state.performSplitOperation(operation, in: tabId)
           }
         }


### PR DESCRIPTION
## Summary
- Adds a Ghostty-style dim overlay on inactive split panes so the active surface stands out at a glance. The mechanism mirrors `unfocused-split-fill`/`unfocused-split-opacity` from Ghostty.app: a translucent black tint laid on top of the terminal view (kept below progress/search/drag-handle overlays so those stay legible).
- Tint strength adapts to color scheme — `0.30` in dark mode, `0.12` in light mode — to avoid washing light-theme panes in grey while still giving dark mode the same depth as Ghostty's default.
- New Settings → Appearance → Splits → "Dim unfocused split panes" toggle, defaulting to on. Existing users who prefer the all-bright look can disable it; the value persists through `GlobalSettings` like every other appearance preference.
- Softens the split divider from `.secondary` to `NSColor.separatorColor` so the seam between panes feels neutral instead of busy alongside the new dim treatment.
- Wires `focusedSurfaceID` through `TerminalSplitTreeView` / `SubtreeView` / `LeafView` (and `TerminalSplitTreeAXContainer`), with all three call sites — `WorktreeTerminalTabsView`, `ShelfOpenBookView`, `CanvasCardView`/`CanvasView` — passing `state.focusedSurfaceId(in:)`.

## Test plan
- [x] `make check`
- [x] `make build-app`
- [x] Open a worktree, create a horizontal split, then a vertical one — confirm only the focused pane stays bright; click between panes to verify the active one swaps cleanly with a short fade.
- [x] Toggle Settings → Appearance → Splits → "Dim unfocused split panes" off, confirm all panes render at full brightness; toggle back on, confirm dim returns.
- [x] Switch the app between light and dark appearance and confirm the dim tint reads as faded (not washed grey) in both.
- [x] Switch to Canvas mode with multiple cards, each containing splits, and confirm dim reflects the focused surface inside each card regardless of which card is selected.
- [x] In a single-pane (no-split) terminal, confirm no dim is applied even when the window is unfocused.
- [x] Verify the split divider line reads as a subtle separator in both light and dark modes.
