### PR TITLE
Move Add Repository to sidebar header with onboarding hint

### DIFF
--- a/supacode/Features/Repositories/Models/SidebarPresentation.swift
+++ b/supacode/Features/Repositories/Models/SidebarPresentation.swift
@@ -4,7 +4,7 @@ struct SidebarPresentation: Equatable {
   var items: [SidebarItem]
 
   static func showsListHeader(repositoryCount: Int) -> Bool {
-    repositoryCount > 10
+    true
   }
 
   var repositoryOrderIDs: [Repository.ID] {

--- a/supacode/Features/Repositories/Views/EmptyStateView.swift
+++ b/supacode/Features/Repositories/Views/EmptyStateView.swift
@@ -38,8 +38,8 @@ struct EmptyStateView: View {
 
   private func promptText(shortcutDisplay: String?) -> String {
     if let shortcutDisplay {
-      return "Press \(shortcutDisplay) or click Open Repository to choose a folder."
+      return "Press \(shortcutDisplay) or click Open Repository to add a repository."
     }
-    return "Click Open Repository to choose a folder."
+    return "Click Open Repository to add a repository."
   }
 }

--- a/supacode/Features/Repositories/Views/EmptyStateView.swift
+++ b/supacode/Features/Repositories/Views/EmptyStateView.swift
@@ -7,18 +7,20 @@ struct EmptyStateView: View {
 
   var body: some View {
     let shortcutDisplay = AppShortcuts.display(for: AppShortcuts.CommandID.openRepository, in: resolvedKeybindings)
-    VStack {
+    VStack(spacing: 16) {
       Image(systemName: "tray")
         .font(.title2)
         .accessibilityHidden(true)
+        .padding(.bottom, 4)
       Text("Open a repository or folder")
         .font(.headline)
       Text(promptText(shortcutDisplay: shortcutDisplay))
         .font(.subheadline)
         .foregroundStyle(.secondary)
-      Button("Open Repository...") {
+      Button("Add Repository...") {
         store.send(.setOpenPanelPresented(true))
       }
+      .padding(.top, 4)
       .modifier(
         KeyboardShortcutModifier(
           shortcut: resolvedKeybindings.keyboardShortcut(for: AppShortcuts.CommandID.openRepository)
@@ -26,11 +28,12 @@ struct EmptyStateView: View {
       )
       .help(
         AppShortcuts.helpText(
-          title: "Open Repository",
+          title: "Add Repository",
           commandID: AppShortcuts.CommandID.openRepository,
           in: resolvedKeybindings
         ))
     }
+    .padding(24)
     .frame(maxWidth: .infinity, maxHeight: .infinity)
     .background(Color(nsColor: .windowBackgroundColor))
     .multilineTextAlignment(.center)
@@ -38,8 +41,8 @@ struct EmptyStateView: View {
 
   private func promptText(shortcutDisplay: String?) -> String {
     if let shortcutDisplay {
-      return "Press \(shortcutDisplay) or click Open Repository to add a repository."
+      return "Press \(shortcutDisplay) or click Add Repository to add one."
     }
-    return "Click Open Repository to add a repository."
+    return "Click Add Repository to add one."
   }
 }

--- a/supacode/Features/Repositories/Views/EmptyStateView.swift
+++ b/supacode/Features/Repositories/Views/EmptyStateView.swift
@@ -7,20 +7,14 @@ struct EmptyStateView: View {
 
   var body: some View {
     let shortcutDisplay = AppShortcuts.display(for: AppShortcuts.CommandID.openRepository, in: resolvedKeybindings)
-    VStack(spacing: 16) {
-      Image(systemName: "tray")
-        .font(.title2)
-        .accessibilityHidden(true)
-        .padding(.bottom, 4)
-      Text("Open a repository or folder")
-        .font(.headline)
+    ContentUnavailableView {
+      Label("Open a repository or folder", systemImage: "tray")
+    } description: {
       Text(promptText(shortcutDisplay: shortcutDisplay))
-        .font(.subheadline)
-        .foregroundStyle(.secondary)
+    } actions: {
       Button("Add Repository...") {
         store.send(.setOpenPanelPresented(true))
       }
-      .padding(.top, 4)
       .modifier(
         KeyboardShortcutModifier(
           shortcut: resolvedKeybindings.keyboardShortcut(for: AppShortcuts.CommandID.openRepository)
@@ -33,10 +27,8 @@ struct EmptyStateView: View {
           in: resolvedKeybindings
         ))
     }
-    .padding(24)
     .frame(maxWidth: .infinity, maxHeight: .infinity)
     .background(Color(nsColor: .windowBackgroundColor))
-    .multilineTextAlignment(.center)
   }
 
   private func promptText(shortcutDisplay: String?) -> String {

--- a/supacode/Features/Repositories/Views/SidebarFooterView.swift
+++ b/supacode/Features/Repositories/Views/SidebarFooterView.swift
@@ -5,30 +5,10 @@ struct SidebarFooterView: View {
   let store: StoreOf<RepositoriesFeature>
   @Environment(\.surfaceBottomChromeBackgroundOpacity) private var surfaceBottomChromeBackgroundOpacity
   @Environment(\.openURL) private var openURL
-  @Environment(CommandKeyObserver.self) private var commandKeyObserver
   @Environment(\.resolvedKeybindings) private var resolvedKeybindings
 
   var body: some View {
     HStack {
-      Button {
-        store.send(.setOpenPanelPresented(true))
-      } label: {
-        HStack(spacing: 6) {
-          Label("Add Repository", systemImage: "folder.badge.plus")
-            .font(.callout)
-          if commandKeyObserver.isPressed,
-            let shortcut = shortcutDisplay(for: AppShortcuts.CommandID.openRepository)
-          {
-            ShortcutHintView(text: shortcut, color: .secondary)
-          }
-        }
-      }
-      .help(
-        AppShortcuts.helpText(
-          title: "Add Repository",
-          commandID: AppShortcuts.CommandID.openRepository,
-          in: resolvedKeybindings
-        ))
       Spacer()
       Menu {
         Button("Homepage", systemImage: "house") {
@@ -109,9 +89,5 @@ struct SidebarFooterView: View {
     .overlay(alignment: .top) {
       Divider()
     }
-  }
-
-  private func shortcutDisplay(for commandID: String) -> String? {
-    AppShortcuts.display(for: commandID, in: resolvedKeybindings)
   }
 }

--- a/supacode/Features/Repositories/Views/SidebarFooterView.swift
+++ b/supacode/Features/Repositories/Views/SidebarFooterView.swift
@@ -9,7 +9,6 @@ struct SidebarFooterView: View {
 
   var body: some View {
     HStack {
-      Spacer()
       Menu {
         Button("Homepage", systemImage: "house") {
           if let url = URL(string: "https://prowl.onev.cat/") {
@@ -36,6 +35,7 @@ struct SidebarFooterView: View {
       }
       .menuIndicator(.hidden)
       .help("Help")
+      Spacer()
       Button {
         store.send(.refreshWorktrees)
       } label: {

--- a/supacode/Features/Repositories/Views/SidebarListView.swift
+++ b/supacode/Features/Repositories/Views/SidebarListView.swift
@@ -200,7 +200,7 @@ struct SidebarListView: View {
       Text("Add your first repository")
         .font(.caption)
         .foregroundStyle(.secondary)
-      Image(systemName: "arrow.turn.up.right")
+      Image(systemName: "arrow.turn.right.up")
         .font(.caption.weight(.semibold))
         .foregroundStyle(.secondary)
         .symbolEffect(.pulse, options: .repeating)

--- a/supacode/Features/Repositories/Views/SidebarListView.swift
+++ b/supacode/Features/Repositories/Views/SidebarListView.swift
@@ -67,6 +67,10 @@ struct SidebarListView: View {
             )
           }
 
+          if repositoryItems.isEmpty {
+            emptyRepositoryHint()
+          }
+
           ForEach(Array(repositoryItems.enumerated()), id: \.element.id) { index, item in
             repositoryItemView(
               item,
@@ -145,11 +149,22 @@ struct SidebarListView: View {
     action: RepositoryListHeaderAction,
     expandableRepositoryIDs: Set<Repository.ID>
   ) -> some View {
-    HStack(spacing: 8) {
+    HStack(spacing: 4) {
       Text("Repositories")
         .font(.caption)
         .foregroundStyle(.tertiary)
         .frame(maxWidth: .infinity, alignment: .leading)
+      Button {
+        store.send(.setOpenPanelPresented(true))
+      } label: {
+        Label("Add Repository", systemImage: "plus")
+          .labelStyle(.iconOnly)
+          .frame(width: 20, height: 20)
+          .contentShape(.rect)
+      }
+      .buttonStyle(.plain)
+      .foregroundStyle(.secondary)
+      .help("Add Repository")
       if !expandableRepositoryIDs.isEmpty {
         Button {
           withAnimation(.easeOut(duration: 0.2)) {
@@ -177,6 +192,24 @@ struct SidebarListView: View {
     .padding(.trailing, 7)
     .padding(.top, 2)
     .padding(.bottom, 4)
+  }
+
+  private func emptyRepositoryHint() -> some View {
+    HStack(spacing: 6) {
+      Spacer(minLength: 0)
+      Text("Add your first repository")
+        .font(.caption)
+        .foregroundStyle(.secondary)
+      Image(systemName: "arrow.turn.up.right")
+        .font(.caption.weight(.semibold))
+        .foregroundStyle(.secondary)
+        .symbolEffect(.pulse, options: .repeating)
+        .accessibilityHidden(true)
+    }
+    .padding(.leading, 12)
+    .padding(.trailing, 14)
+    .padding(.top, 2)
+    .padding(.bottom, 6)
   }
 
   @ViewBuilder

--- a/supacode/Features/Shelf/Views/ShelfView.swift
+++ b/supacode/Features/Shelf/Views/ShelfView.swift
@@ -166,17 +166,11 @@ struct ShelfView: View {
 
   @ViewBuilder
   private func emptyOpenArea() -> some View {
-    VStack(spacing: 10) {
-      Image(systemName: "books.vertical")
-        .font(.system(size: 40))
-        .foregroundStyle(.secondary)
-        .accessibilityHidden(true)
-      Text("No worktree selected")
-        .font(.headline)
-      Text("Click a worktree to open it.")
-        .font(.callout)
-        .foregroundStyle(.secondary)
-    }
+    ContentUnavailableView(
+      "No worktree selected",
+      systemImage: "books.vertical",
+      description: Text("Click a worktree to open it.")
+    )
     .frame(maxWidth: .infinity, maxHeight: .infinity)
   }
 

--- a/supacodeTests/RepositorySectionViewTests.swift
+++ b/supacodeTests/RepositorySectionViewTests.swift
@@ -63,9 +63,9 @@ struct RepositorySectionViewTests {
     )
   }
 
-  @Test func sidebarHeaderOnlyShowsForLongRepositoryLists() {
-    #expect(!SidebarListView.showsRepositoryListHeader(repositoryCount: 0))
-    #expect(!SidebarListView.showsRepositoryListHeader(repositoryCount: 10))
+  @Test func sidebarHeaderAlwaysShows() {
+    #expect(SidebarListView.showsRepositoryListHeader(repositoryCount: 0))
+    #expect(SidebarListView.showsRepositoryListHeader(repositoryCount: 1))
     #expect(SidebarListView.showsRepositoryListHeader(repositoryCount: 11))
   }
 

--- a/supacodeTests/SidebarPresentationTests.swift
+++ b/supacodeTests/SidebarPresentationTests.swift
@@ -15,8 +15,9 @@ struct SidebarPresentationTests {
 
     let presentation = state.sidebarPresentation(expandedRepositoryIDs: [repository.id])
 
-    #expect(presentation.items.count == 1)
-    guard case .repository(let model) = presentation.items.first else {
+    let repositoryItems = presentation.repositoryRowItems
+    #expect(repositoryItems.count == 1)
+    guard case .repository(let model) = repositoryItems.first else {
       Issue.record("Expected repository container")
       return
     }
@@ -34,7 +35,7 @@ struct SidebarPresentationTests {
 
     let presentation = state.sidebarPresentation(expandedRepositoryIDs: [])
 
-    guard case .repository(let model) = presentation.items.first else {
+    guard case .repository(let model) = presentation.repositoryRowItems.first else {
       Issue.record("Expected repository container")
       return
     }
@@ -59,7 +60,7 @@ struct SidebarPresentationTests {
       presentation.repositoryOrderAfterMove(fromOffsets: IndexSet(integer: 0), toOffset: 2) == [
         repoA.id, "/tmp/missing",
       ])
-    guard case .failedRepository(let failed) = presentation.items.first else {
+    guard case .failedRepository(let failed) = presentation.repositoryRowItems.first else {
       Issue.record("Expected failed repository first")
       return
     }
@@ -73,7 +74,7 @@ struct SidebarPresentationTests {
 
     let presentation = state.sidebarPresentation(expandedRepositoryIDs: [repository.id])
 
-    guard case .repository(let model) = presentation.items.first else {
+    guard case .repository(let model) = presentation.repositoryRowItems.first else {
       Issue.record("Expected repository container")
       return
     }
@@ -100,7 +101,7 @@ struct SidebarPresentationTests {
 
     let presentation = state.sidebarPresentation(expandedRepositoryIDs: [repository.id])
 
-    guard case .repository(let model) = presentation.items.first else {
+    guard case .repository(let model) = presentation.repositoryRowItems.first else {
       Issue.record("Expected repository container")
       return
     }
@@ -193,5 +194,11 @@ struct SidebarPresentationTests {
     state.repositories = IdentifiedArray(uniqueElements: repositories)
     state.repositoryRoots = repositories.map(\.rootURL)
     return state
+  }
+}
+
+extension SidebarPresentation {
+  fileprivate var repositoryRowItems: [SidebarItem] {
+    items.filter { $0.repositoryOrderID != nil }
   }
 }


### PR DESCRIPTION
## Summary

- Show the "Repositories" header in the side nav unconditionally; previously it only appeared once a user had more than 10 repos, leaving the section unlabeled in the common case.
- Move the Add Repository action from the sidebar footer to a `+` icon-button next to the existing expand/collapse chevron in the header. The footer no longer carries it (and dropped the `commandKeyObserver`-based shortcut chip with it — the action is too low-frequency to warrant the hint there).
- Render an empty-state hint row right under the header — `arrow.turn.up.right` with a pulsing symbol effect plus "Add your first repository" — when there are zero repositories, guiding new users toward the new `+` button.
- Tighten the main `EmptyStateView` copy so it talks about *adding* a repository (matching the new sidebar affordance), still using the dynamic `openRepository` shortcut so user keybinding overrides keep showing through.

## Test plan

- [x] `make check`
- [x] `make test`
- [x] `make build-app`
- [x] Manual: launch with no repositories — sidebar shows "Repositories" + `+` + pulsing arrow hint; main window shows updated empty state copy with the resolved shortcut.
- [x] Manual: with one or more repositories — header shows "Repositories" + `+` + chevron; clicking `+` opens the Add Repository panel; empty hint disappears.
- [x] Manual: footer still has Help / Refresh / Archived / Settings, right-aligned.
