### PR TITLE
Fix Ghostty key equivalent ownership

### DIFF
--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
@@ -1196,10 +1196,16 @@ final class GhosttySurfaceView: NSView, Identifiable {
     guard event.type == .keyDown else { return false }
     let isFontSizeShortcut = matchesFontSizeShortcut(event: event)
     guard let surface else { return false }
-    guard focused else { return false }
+    guard
+      Self.hasKeyEquivalentFocusOwnership(
+        cachedFocused: focused,
+        isActualFirstResponder: window?.firstResponder === self
+      )
+    else { return false }
 
     if UserCustomShortcutRegistry.shared.matches(event: event),
       let menu = NSApp.mainMenu,
+      Self.mainMenuHasMatchingItem(for: event, in: menu),
       menu.performKeyEquivalent(with: event)
     {
       return true
@@ -1208,6 +1214,7 @@ final class GhosttySurfaceView: NSView, Identifiable {
     if let bindingFlags = bindingFlags(for: event, surface: surface) {
       if shouldAttemptMenu(for: bindingFlags),
         let menu = NSApp.mainMenu,
+        Self.mainMenuHasMatchingItem(for: event, in: menu),
         menu.performKeyEquivalent(with: event)
       {
         return true
@@ -1437,6 +1444,39 @@ final class GhosttySurfaceView: NSView, Identifiable {
 
   @IBAction func changeTitle(_ sender: Any?) {
     performBindingAction("prompt_surface_title")
+  }
+
+  static func hasKeyEquivalentFocusOwnership(
+    cachedFocused: Bool,
+    isActualFirstResponder: Bool
+  ) -> Bool {
+    cachedFocused && isActualFirstResponder
+  }
+
+  static func mainMenuHasMatchingItem(for event: NSEvent, in menu: NSMenu) -> Bool {
+    guard let characters = event.charactersIgnoringModifiers?.lowercased(), !characters.isEmpty else { return false }
+    let shortcutMask: NSEvent.ModifierFlags = [.shift, .control, .option, .command]
+    let eventModifiers = event.modifierFlags.intersection(shortcutMask)
+
+    for item in menu.items {
+      if let submenu = item.submenu, mainMenuHasMatchingItem(for: event, in: submenu) {
+        return true
+      }
+
+      guard !item.keyEquivalent.isEmpty else { continue }
+      let itemKey = item.keyEquivalent
+      guard itemKey.lowercased() == characters else { continue }
+
+      var itemModifiers = item.keyEquivalentModifierMask.intersection(shortcutMask)
+      if itemKey != itemKey.lowercased() {
+        itemModifiers.insert(.shift)
+      }
+      if itemModifiers == eventModifiers {
+        return true
+      }
+    }
+
+    return false
   }
 
   private func shouldAttemptMenu(for flags: ghostty_binding_flags_e) -> Bool {

--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
@@ -1454,9 +1454,8 @@ final class GhosttySurfaceView: NSView, Identifiable {
   }
 
   static func mainMenuHasMatchingItem(for event: NSEvent, in menu: NSMenu) -> Bool {
-    guard let characters = event.charactersIgnoringModifiers?.lowercased(), !characters.isEmpty else { return false }
-    let shortcutMask: NSEvent.ModifierFlags = [.shift, .control, .option, .command]
-    let eventModifiers = event.modifierFlags.intersection(shortcutMask)
+    let eventEquivalents = normalizedEventKeyEquivalents(for: event)
+    guard !eventEquivalents.isEmpty else { return false }
 
     for item in menu.items {
       if let submenu = item.submenu, mainMenuHasMatchingItem(for: event, in: submenu) {
@@ -1464,19 +1463,63 @@ final class GhosttySurfaceView: NSView, Identifiable {
       }
 
       guard !item.keyEquivalent.isEmpty else { continue }
-      let itemKey = item.keyEquivalent
-      guard itemKey.lowercased() == characters else { continue }
-
-      var itemModifiers = item.keyEquivalentModifierMask.intersection(shortcutMask)
-      if itemKey != itemKey.lowercased() {
-        itemModifiers.insert(.shift)
-      }
-      if itemModifiers == eventModifiers {
+      guard let itemEquivalent = normalizedKeyEquivalent(
+        key: item.keyEquivalent,
+        modifiers: item.keyEquivalentModifierMask
+      ) else { continue }
+      if eventEquivalents.contains(where: { $0 == itemEquivalent }) {
         return true
       }
     }
 
     return false
+  }
+
+  private static let shortcutMask: NSEvent.ModifierFlags = [.shift, .control, .option, .command]
+
+  private static let shiftedKeyEquivalentBases: [Character: Character] = [
+    "~": "`", "!": "1", "@": "2", "#": "3", "$": "4", "%": "5", "^": "6", "&": "7",
+    "*": "8", "(": "9", ")": "0", "_": "-", "+": "=", "{": "[", "}": "]", "|": "\\",
+    ":": ";", "\"": "'", "<": ",", ">": ".", "?": "/",
+  ]
+
+  private struct KeyEquivalentSignature: Equatable {
+    var key: String
+    var modifiers: NSEvent.ModifierFlags
+  }
+
+  private static func normalizedEventKeyEquivalents(for event: NSEvent) -> [KeyEquivalentSignature] {
+    let eventModifiers = event.modifierFlags.intersection(shortcutMask)
+    return [event.charactersIgnoringModifiers, event.characters]
+      .compactMap { characters in
+        characters.flatMap { normalizedKeyEquivalent(key: $0, modifiers: eventModifiers) }
+      }
+      .reduce(into: []) { result, equivalent in
+        if !result.contains(equivalent) {
+          result.append(equivalent)
+        }
+      }
+  }
+
+  private static func normalizedKeyEquivalent(
+    key: String,
+    modifiers: NSEvent.ModifierFlags
+  ) -> KeyEquivalentSignature? {
+    guard !key.isEmpty else { return nil }
+
+    var normalizedKey = key.lowercased()
+    var normalizedModifiers = modifiers.intersection(shortcutMask)
+
+    if key.count == 1, let character = key.first {
+      if let base = shiftedKeyEquivalentBases[character] {
+        normalizedKey = String(base)
+        normalizedModifiers.insert(.shift)
+      } else if normalizedKey != key {
+        normalizedModifiers.insert(.shift)
+      }
+    }
+
+    return KeyEquivalentSignature(key: normalizedKey, modifiers: normalizedModifiers)
   }
 
   private func shouldAttemptMenu(for flags: ghostty_binding_flags_e) -> Bool {

--- a/supacodeTests/GhosttySurfaceViewTests.swift
+++ b/supacodeTests/GhosttySurfaceViewTests.swift
@@ -7,6 +7,64 @@ import Testing
 
 @MainActor
 struct GhosttySurfaceViewTests {
+  @Test func mainMenuExactMatchRejectsShiftVariantOfCommandComma() {
+    let menu = NSMenu()
+    let item = NSMenuItem(title: "Settings", action: nil, keyEquivalent: ",")
+    item.keyEquivalentModifierMask = [.command]
+    menu.addItem(item)
+
+    let event = makeKeyEvent(
+      characters: "<",
+      charactersIgnoringModifiers: ",",
+      modifiers: [.command, .shift],
+      keyCode: 43
+    )
+
+    #expect(!GhosttySurfaceView.mainMenuHasMatchingItem(for: event, in: menu))
+  }
+
+  @Test func mainMenuExactMatchAcceptsExactCommandComma() {
+    let menu = NSMenu()
+    let item = NSMenuItem(title: "Settings", action: nil, keyEquivalent: ",")
+    item.keyEquivalentModifierMask = [.command]
+    menu.addItem(item)
+
+    let event = makeKeyEvent(
+      characters: ",",
+      charactersIgnoringModifiers: ",",
+      modifiers: [.command],
+      keyCode: 43
+    )
+
+    #expect(GhosttySurfaceView.mainMenuHasMatchingItem(for: event, in: menu))
+  }
+
+  @Test func mainMenuExactMatchFindsSubmenuItems() {
+    let menu = NSMenu()
+    let parent = NSMenuItem(title: "View", action: nil, keyEquivalent: "")
+    let submenu = NSMenu()
+    let item = NSMenuItem(title: "Show Diff", action: nil, keyEquivalent: "y")
+    item.keyEquivalentModifierMask = [.command, .shift]
+    submenu.addItem(item)
+    parent.submenu = submenu
+    menu.addItem(parent)
+
+    let event = makeKeyEvent(
+      characters: "Y",
+      charactersIgnoringModifiers: "y",
+      modifiers: [.command, .shift],
+      keyCode: 16
+    )
+
+    #expect(GhosttySurfaceView.mainMenuHasMatchingItem(for: event, in: menu))
+  }
+
+  @Test func keyEquivalentFocusOwnershipRequiresActualFirstResponder() {
+    #expect(GhosttySurfaceView.hasKeyEquivalentFocusOwnership(cachedFocused: true, isActualFirstResponder: true))
+    #expect(!GhosttySurfaceView.hasKeyEquivalentFocusOwnership(cachedFocused: true, isActualFirstResponder: false))
+    #expect(!GhosttySurfaceView.hasKeyEquivalentFocusOwnership(cachedFocused: false, isActualFirstResponder: true))
+  }
+
   @Test func occlusionStateResendsDesiredValueAfterAttachmentChange() {
     var state = GhosttySurfaceView.OcclusionState()
 
@@ -370,5 +428,25 @@ struct GhosttySurfaceViewTests {
 
     #expect(!suppression.suppresses(keyCode: 49, timestamp: 11.1))
     #expect(suppression.isExpired(at: 11.1))
+  }
+
+  private func makeKeyEvent(
+    characters: String,
+    charactersIgnoringModifiers: String,
+    modifiers: NSEvent.ModifierFlags,
+    keyCode: UInt16
+  ) -> NSEvent {
+    NSEvent.keyEvent(
+      with: .keyDown,
+      location: .zero,
+      modifierFlags: modifiers,
+      timestamp: 1,
+      windowNumber: 0,
+      context: nil,
+      characters: characters,
+      charactersIgnoringModifiers: charactersIgnoringModifiers,
+      isARepeat: false,
+      keyCode: keyCode
+    )!
   }
 }

--- a/supacodeTests/GhosttySurfaceViewTests.swift
+++ b/supacodeTests/GhosttySurfaceViewTests.swift
@@ -7,13 +7,13 @@ import Testing
 
 @MainActor
 struct GhosttySurfaceViewTests {
-  @Test func mainMenuExactMatchRejectsShiftVariantOfCommandComma() {
+  @Test func mainMenuExactMatchRejectsShiftVariantOfCommandComma() throws {
     let menu = NSMenu()
     let item = NSMenuItem(title: "Settings", action: nil, keyEquivalent: ",")
     item.keyEquivalentModifierMask = [.command]
     menu.addItem(item)
 
-    let event = makeKeyEvent(
+    let event = try makeKeyEvent(
       characters: "<",
       charactersIgnoringModifiers: ",",
       modifiers: [.command, .shift],
@@ -23,13 +23,13 @@ struct GhosttySurfaceViewTests {
     #expect(!GhosttySurfaceView.mainMenuHasMatchingItem(for: event, in: menu))
   }
 
-  @Test func mainMenuExactMatchAcceptsExactCommandComma() {
+  @Test func mainMenuExactMatchAcceptsExactCommandComma() throws {
     let menu = NSMenu()
     let item = NSMenuItem(title: "Settings", action: nil, keyEquivalent: ",")
     item.keyEquivalentModifierMask = [.command]
     menu.addItem(item)
 
-    let event = makeKeyEvent(
+    let event = try makeKeyEvent(
       characters: ",",
       charactersIgnoringModifiers: ",",
       modifiers: [.command],
@@ -39,7 +39,39 @@ struct GhosttySurfaceViewTests {
     #expect(GhosttySurfaceView.mainMenuHasMatchingItem(for: event, in: menu))
   }
 
-  @Test func mainMenuExactMatchFindsSubmenuItems() {
+  @Test func mainMenuExactMatchAcceptsShiftedSymbolKeyEquivalent() throws {
+    let menu = NSMenu()
+    let item = NSMenuItem(title: "Help", action: nil, keyEquivalent: "?")
+    item.keyEquivalentModifierMask = [.command]
+    menu.addItem(item)
+
+    let event = try makeKeyEvent(
+      characters: "?",
+      charactersIgnoringModifiers: "/",
+      modifiers: [.command, .shift],
+      keyCode: 44
+    )
+
+    #expect(GhosttySurfaceView.mainMenuHasMatchingItem(for: event, in: menu))
+  }
+
+  @Test func mainMenuExactMatchRejectsUnshiftedVariantOfShiftedSymbolKeyEquivalent() throws {
+    let menu = NSMenu()
+    let item = NSMenuItem(title: "Help", action: nil, keyEquivalent: "?")
+    item.keyEquivalentModifierMask = [.command]
+    menu.addItem(item)
+
+    let event = try makeKeyEvent(
+      characters: "/",
+      charactersIgnoringModifiers: "/",
+      modifiers: [.command],
+      keyCode: 44
+    )
+
+    #expect(!GhosttySurfaceView.mainMenuHasMatchingItem(for: event, in: menu))
+  }
+
+  @Test func mainMenuExactMatchFindsSubmenuItems() throws {
     let menu = NSMenu()
     let parent = NSMenuItem(title: "View", action: nil, keyEquivalent: "")
     let submenu = NSMenu()
@@ -49,7 +81,7 @@ struct GhosttySurfaceViewTests {
     parent.submenu = submenu
     menu.addItem(parent)
 
-    let event = makeKeyEvent(
+    let event = try makeKeyEvent(
       characters: "Y",
       charactersIgnoringModifiers: "y",
       modifiers: [.command, .shift],
@@ -435,18 +467,20 @@ struct GhosttySurfaceViewTests {
     charactersIgnoringModifiers: String,
     modifiers: NSEvent.ModifierFlags,
     keyCode: UInt16
-  ) -> NSEvent {
-    NSEvent.keyEvent(
-      with: .keyDown,
-      location: .zero,
-      modifierFlags: modifiers,
-      timestamp: 1,
-      windowNumber: 0,
-      context: nil,
-      characters: characters,
-      charactersIgnoringModifiers: charactersIgnoringModifiers,
-      isARepeat: false,
-      keyCode: keyCode
-    )!
+  ) throws -> NSEvent {
+    try #require(
+      NSEvent.keyEvent(
+        with: .keyDown,
+        location: .zero,
+        modifierFlags: modifiers,
+        timestamp: 1,
+        windowNumber: 0,
+        context: nil,
+        characters: characters,
+        charactersIgnoringModifiers: charactersIgnoringModifiers,
+        isARepeat: false,
+        keyCode: keyCode
+      )
+    )
   }
 }


### PR DESCRIPTION
## Summary
- Require Ghostty surfaces to be the actual first responder before handling key equivalents.
- Only forward Ghostty-bound or user-custom shortcuts to the main menu when an exact menu item shortcut exists.
- Add regression coverage for shifted menu shortcut matching and focus ownership.

## Verification
- `xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -only-testing:supacodeTests/GhosttySurfaceViewTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation 2>&1 | xcsift`
- `make build-app`
