### PR TITLE
Fix GitHub PR repo resolution

### DIFF
--- a/supacode/Clients/Github/GithubCLIClient.swift
+++ b/supacode/Clients/Github/GithubCLIClient.swift
@@ -45,9 +45,9 @@ struct GithubCLIClient: Sendable {
   var resolveRemoteInfo: @Sendable (URL) async -> GithubRemoteInfo?
   var latestRun: @Sendable (URL, String) async throws -> GithubWorkflowRun?
   var batchPullRequests: @Sendable (String, String, String, [String]) async throws -> [String: GithubPullRequest]
-  var mergePullRequest: @Sendable (URL, GithubRemoteInfo?, Int, PullRequestMergeStrategy) async throws -> Void
-  var closePullRequest: @Sendable (URL, GithubRemoteInfo?, Int) async throws -> Void
-  var markPullRequestReady: @Sendable (URL, GithubRemoteInfo?, Int) async throws -> Void
+  var mergePullRequest: @Sendable (URL, GithubRemoteInfo, Int, PullRequestMergeStrategy) async throws -> Void
+  var closePullRequest: @Sendable (URL, GithubRemoteInfo, Int) async throws -> Void
+  var markPullRequestReady: @Sendable (URL, GithubRemoteInfo, Int) async throws -> Void
   var rerunFailedJobs: @Sendable (URL, Int) async throws -> Void
   var failedRunLogs: @Sendable (URL, Int) async throws -> String
   var runLogs: @Sendable (URL, Int) async throws -> String
@@ -299,7 +299,7 @@ nonisolated private func batchPullRequestsFetcher(
 nonisolated private func mergePullRequestFetcher(
   shell: ShellClient,
   resolver: GithubCLIExecutableResolver
-) -> @Sendable (URL, GithubRemoteInfo?, Int, PullRequestMergeStrategy) async throws -> Void {
+) -> @Sendable (URL, GithubRemoteInfo, Int, PullRequestMergeStrategy) async throws -> Void {
   { repoRoot, remoteInfo, pullRequestNumber, strategy in
     _ = try await runGh(
       shell: shell,
@@ -318,7 +318,7 @@ nonisolated private func mergePullRequestFetcher(
 nonisolated private func closePullRequestFetcher(
   shell: ShellClient,
   resolver: GithubCLIExecutableResolver
-) -> @Sendable (URL, GithubRemoteInfo?, Int) async throws -> Void {
+) -> @Sendable (URL, GithubRemoteInfo, Int) async throws -> Void {
   { repoRoot, remoteInfo, pullRequestNumber in
     _ = try await runGh(
       shell: shell,
@@ -336,7 +336,7 @@ nonisolated private func closePullRequestFetcher(
 nonisolated private func markPullRequestReadyFetcher(
   shell: ShellClient,
   resolver: GithubCLIExecutableResolver
-) -> @Sendable (URL, GithubRemoteInfo?, Int) async throws -> Void {
+) -> @Sendable (URL, GithubRemoteInfo, Int) async throws -> Void {
   { repoRoot, remoteInfo, pullRequestNumber in
     _ = try await runGh(
       shell: shell,
@@ -351,11 +351,8 @@ nonisolated private func markPullRequestReadyFetcher(
   }
 }
 
-nonisolated private func repoArgument(_ remoteInfo: GithubRemoteInfo?) -> [String] {
-  guard let remoteInfo else {
-    return []
-  }
-  return ["--repo", "\(remoteInfo.host)/\(remoteInfo.owner)/\(remoteInfo.repo)"]
+nonisolated private func repoArgument(_ remoteInfo: GithubRemoteInfo) -> [String] {
+  ["--repo", "\(remoteInfo.host)/\(remoteInfo.owner)/\(remoteInfo.repo)"]
 }
 
 nonisolated private func rerunFailedJobsFetcher(

--- a/supacode/Clients/Github/GithubCLIClient.swift
+++ b/supacode/Clients/Github/GithubCLIClient.swift
@@ -42,11 +42,12 @@ extension GithubAuthStatusResponse.GithubAuthAccount: Decodable {
 
 struct GithubCLIClient: Sendable {
   var defaultBranch: @Sendable (URL) async throws -> String
+  var resolveRemoteInfo: @Sendable (URL) async -> GithubRemoteInfo?
   var latestRun: @Sendable (URL, String) async throws -> GithubWorkflowRun?
   var batchPullRequests: @Sendable (String, String, String, [String]) async throws -> [String: GithubPullRequest]
-  var mergePullRequest: @Sendable (URL, Int, PullRequestMergeStrategy) async throws -> Void
-  var closePullRequest: @Sendable (URL, Int) async throws -> Void
-  var markPullRequestReady: @Sendable (URL, Int) async throws -> Void
+  var mergePullRequest: @Sendable (URL, GithubRemoteInfo?, Int, PullRequestMergeStrategy) async throws -> Void
+  var closePullRequest: @Sendable (URL, GithubRemoteInfo?, Int) async throws -> Void
+  var markPullRequestReady: @Sendable (URL, GithubRemoteInfo?, Int) async throws -> Void
   var rerunFailedJobs: @Sendable (URL, Int) async throws -> Void
   var failedRunLogs: @Sendable (URL, Int) async throws -> String
   var runLogs: @Sendable (URL, Int) async throws -> String
@@ -61,6 +62,7 @@ extension GithubCLIClient: DependencyKey {
     let resolver = GithubCLIExecutableResolver()
     return GithubCLIClient(
       defaultBranch: defaultBranchFetcher(shell: shell, resolver: resolver),
+      resolveRemoteInfo: resolveRemoteInfoFetcher(shell: shell, resolver: resolver),
       latestRun: latestRunFetcher(shell: shell, resolver: resolver),
       batchPullRequests: batchPullRequestsFetcher(shell: shell, resolver: resolver),
       mergePullRequest: mergePullRequestFetcher(shell: shell, resolver: resolver),
@@ -76,11 +78,12 @@ extension GithubCLIClient: DependencyKey {
 
   static let testValue = GithubCLIClient(
     defaultBranch: { _ in "main" },
+    resolveRemoteInfo: { _ in nil },
     latestRun: { _, _ in nil },
     batchPullRequests: { _, _, _, _ in [:] },
-    mergePullRequest: { _, _, _ in },
-    closePullRequest: { _, _ in },
-    markPullRequestReady: { _, _ in },
+    mergePullRequest: { _, _, _, _ in },
+    closePullRequest: { _, _, _ in },
+    markPullRequestReady: { _, _, _ in },
     rerunFailedJobs: { _, _ in },
     failedRunLogs: { _, _ in "" },
     runLogs: { _, _ in "" },
@@ -100,6 +103,23 @@ private struct GithubPullRequestsRequest: Sendable {
   let host: String
   let owner: String
   let repo: String
+}
+
+nonisolated private struct GithubRepoViewRemoteInfoResponse: Decodable, Sendable {
+  let owner: Owner
+  let name: String
+  let url: String
+
+  nonisolated var remoteInfo: GithubRemoteInfo? {
+    guard let host = URL(string: url)?.host else {
+      return nil
+    }
+    return GithubRemoteInfo(host: host, owner: owner.login, repo: name)
+  }
+
+  nonisolated struct Owner: Decodable, Sendable {
+    let login: String
+  }
 }
 
 private actor GithubCLIExecutableResolver {
@@ -197,6 +217,27 @@ nonisolated private func defaultBranchFetcher(
   }
 }
 
+nonisolated private func resolveRemoteInfoFetcher(
+  shell: ShellClient,
+  resolver: GithubCLIExecutableResolver
+) -> @Sendable (URL) async -> GithubRemoteInfo? {
+  { repoRoot in
+    do {
+      let output = try await runGh(
+        shell: shell,
+        resolver: resolver,
+        arguments: ["repo", "view", "--json", "owner,name,url"],
+        repoRoot: repoRoot
+      )
+      let data = Data(output.utf8)
+      let response = try JSONDecoder().decode(GithubRepoViewRemoteInfoResponse.self, from: data)
+      return response.remoteInfo
+    } catch {
+      return nil
+    }
+  }
+}
+
 nonisolated private func latestRunFetcher(
   shell: ShellClient,
   resolver: GithubCLIExecutableResolver
@@ -258,8 +299,8 @@ nonisolated private func batchPullRequestsFetcher(
 nonisolated private func mergePullRequestFetcher(
   shell: ShellClient,
   resolver: GithubCLIExecutableResolver
-) -> @Sendable (URL, Int, PullRequestMergeStrategy) async throws -> Void {
-  { repoRoot, pullRequestNumber, strategy in
+) -> @Sendable (URL, GithubRemoteInfo?, Int, PullRequestMergeStrategy) async throws -> Void {
+  { repoRoot, remoteInfo, pullRequestNumber, strategy in
     _ = try await runGh(
       shell: shell,
       resolver: resolver,
@@ -268,7 +309,7 @@ nonisolated private func mergePullRequestFetcher(
         "merge",
         "\(pullRequestNumber)",
         "--\(strategy.ghArgument)",
-      ],
+      ] + repoArgument(remoteInfo),
       repoRoot: repoRoot
     )
   }
@@ -277,8 +318,8 @@ nonisolated private func mergePullRequestFetcher(
 nonisolated private func closePullRequestFetcher(
   shell: ShellClient,
   resolver: GithubCLIExecutableResolver
-) -> @Sendable (URL, Int) async throws -> Void {
-  { repoRoot, pullRequestNumber in
+) -> @Sendable (URL, GithubRemoteInfo?, Int) async throws -> Void {
+  { repoRoot, remoteInfo, pullRequestNumber in
     _ = try await runGh(
       shell: shell,
       resolver: resolver,
@@ -286,7 +327,7 @@ nonisolated private func closePullRequestFetcher(
         "pr",
         "close",
         "\(pullRequestNumber)",
-      ],
+      ] + repoArgument(remoteInfo),
       repoRoot: repoRoot
     )
   }
@@ -295,8 +336,8 @@ nonisolated private func closePullRequestFetcher(
 nonisolated private func markPullRequestReadyFetcher(
   shell: ShellClient,
   resolver: GithubCLIExecutableResolver
-) -> @Sendable (URL, Int) async throws -> Void {
-  { repoRoot, pullRequestNumber in
+) -> @Sendable (URL, GithubRemoteInfo?, Int) async throws -> Void {
+  { repoRoot, remoteInfo, pullRequestNumber in
     _ = try await runGh(
       shell: shell,
       resolver: resolver,
@@ -304,10 +345,17 @@ nonisolated private func markPullRequestReadyFetcher(
         "pr",
         "ready",
         "\(pullRequestNumber)",
-      ],
+      ] + repoArgument(remoteInfo),
       repoRoot: repoRoot
     )
   }
+}
+
+nonisolated private func repoArgument(_ remoteInfo: GithubRemoteInfo?) -> [String] {
+  guard let remoteInfo else {
+    return []
+  }
+  return ["--repo", "\(remoteInfo.host)/\(remoteInfo.owner)/\(remoteInfo.repo)"]
 }
 
 nonisolated private func rerunFailedJobsFetcher(

--- a/supacode/Clients/Github/GithubGraphQLPullRequestResponse.swift
+++ b/supacode/Clients/Github/GithubGraphQLPullRequestResponse.swift
@@ -20,6 +20,8 @@ nonisolated struct GithubGraphQLPullRequestResponse: Decodable {
       if !upstreamCandidates.isEmpty {
         candidates = upstreamCandidates
       } else {
+        // Without an upstream-repository match, same-name base branches are likely from unrelated
+        // fork workflows and can shadow the local worktree branch this app is trying to resolve.
         let forkCandidates = connection.nodes.filter {
           $0.headRepository != nil && $0.doesNotTargetSameBranch(branch)
         }

--- a/supacode/Clients/Github/GithubGraphQLPullRequestResponse.swift
+++ b/supacode/Clients/Github/GithubGraphQLPullRequestResponse.swift
@@ -16,10 +16,22 @@ nonisolated struct GithubGraphQLPullRequestResponse: Decodable {
         continue
       }
       let upstreamCandidates = connection.nodes.filter { $0.matches(owner: normalizedOwner, repo: normalizedRepo) }
-      let candidates =
-        upstreamCandidates.isEmpty
-        ? connection.nodes.filter { $0.headRepository != nil }
-        : upstreamCandidates
+      let candidates: [PullRequestNode]
+      if !upstreamCandidates.isEmpty {
+        candidates = upstreamCandidates
+      } else {
+        let forkCandidates = connection.nodes.filter {
+          $0.headRepository != nil && $0.doesNotTargetSameBranch(branch)
+        }
+        candidates =
+          if !forkCandidates.isEmpty {
+            forkCandidates
+          } else {
+            connection.nodes.filter {
+              $0.headRepository == nil && $0.doesNotTargetSameBranch(branch)
+            }
+          }
+      }
       if let node = candidates.max(by: { left, right in
         let leftRank = left.stateRank
         let rightRank = right.stateRank
@@ -132,6 +144,13 @@ nonisolated struct GithubGraphQLPullRequestResponse: Decodable {
       }
       return headRepository.owner.login.lowercased() == owner
         && headRepository.name.lowercased() == repo
+    }
+
+    func doesNotTargetSameBranch(_ branch: String) -> Bool {
+      guard let baseRefName else {
+        return true
+      }
+      return baseRefName != branch
     }
   }
 

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+GithubIntegration.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+GithubIntegration.swift
@@ -2,8 +2,11 @@ import AppKit
 import ComposableArchitecture
 import Foundation
 
+private let unresolvedGithubRepositoryMessage =
+  "Prowl could not determine which GitHub repository owns this pull request. Check the repository remote and try again."
+
 extension RepositoriesFeature {
-  func resolveGithubRemoteInfo(
+  static func resolveGithubRemoteInfo(
     repositoryRootURL: URL,
     githubCLI: GithubCLIClient,
     gitClient: GitClientDependency
@@ -338,11 +341,18 @@ extension RepositoriesFeature {
           }
           await send(.showToast(.inProgress("Marking PR ready…")))
           do {
-            let remoteInfo = await resolveGithubRemoteInfo(
-              repositoryRootURL: repoRoot,
-              githubCLI: githubCLI,
-              gitClient: gitClient
-            )
+            guard
+              let remoteInfo = await Self.resolveGithubRemoteInfo(
+                repositoryRootURL: repoRoot,
+                githubCLI: githubCLI,
+                gitClient: gitClient
+              )
+            else {
+              await send(.dismissToast)
+              await send(
+                .presentAlert(title: "GitHub repository not resolved", message: unresolvedGithubRepositoryMessage))
+              return
+            }
             try await githubCLI.markPullRequestReady(worktreeRoot, remoteInfo, pullRequest.number)
             await send(.showToast(.success("Pull request marked ready")))
             await send(.githubIntegration(.delayedPullRequestRefresh(worktreeID)))
@@ -376,11 +386,18 @@ extension RepositoriesFeature {
           let strategy = repositorySettings.pullRequestMergeStrategy ?? settingsFile.global.pullRequestMergeStrategy
           await send(.showToast(.inProgress("Merging pull request…")))
           do {
-            let remoteInfo = await resolveGithubRemoteInfo(
-              repositoryRootURL: repoRoot,
-              githubCLI: githubCLI,
-              gitClient: gitClient
-            )
+            guard
+              let remoteInfo = await Self.resolveGithubRemoteInfo(
+                repositoryRootURL: repoRoot,
+                githubCLI: githubCLI,
+                gitClient: gitClient
+              )
+            else {
+              await send(.dismissToast)
+              await send(
+                .presentAlert(title: "GitHub repository not resolved", message: unresolvedGithubRepositoryMessage))
+              return
+            }
             try await githubCLI.mergePullRequest(worktreeRoot, remoteInfo, pullRequest.number, strategy)
             await send(.showToast(.success("Pull request merged")))
             await send(.worktreeInfoEvent(pullRequestRefresh))
@@ -412,11 +429,18 @@ extension RepositoriesFeature {
           }
           await send(.showToast(.inProgress("Closing pull request…")))
           do {
-            let remoteInfo = await resolveGithubRemoteInfo(
-              repositoryRootURL: repoRoot,
-              githubCLI: githubCLI,
-              gitClient: gitClient
-            )
+            guard
+              let remoteInfo = await Self.resolveGithubRemoteInfo(
+                repositoryRootURL: repoRoot,
+                githubCLI: githubCLI,
+                gitClient: gitClient
+              )
+            else {
+              await send(.dismissToast)
+              await send(
+                .presentAlert(title: "GitHub repository not resolved", message: unresolvedGithubRepositoryMessage))
+              return
+            }
             try await githubCLI.closePullRequest(worktreeRoot, remoteInfo, pullRequest.number)
             await send(.showToast(.success("Pull request closed")))
             await send(.worktreeInfoEvent(pullRequestRefresh))

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+GithubIntegration.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+GithubIntegration.swift
@@ -3,6 +3,19 @@ import ComposableArchitecture
 import Foundation
 
 extension RepositoriesFeature {
+  func resolveGithubRemoteInfo(
+    repositoryRootURL: URL,
+    githubCLI: GithubCLIClient,
+    gitClient: GitClientDependency
+  ) async -> GithubRemoteInfo? {
+    if let remoteInfo = await githubCLI.resolveRemoteInfo(repositoryRootURL) {
+      return remoteInfo
+    }
+    return await gitClient.remoteInfo(repositoryRootURL)
+  }
+}
+
+extension RepositoriesFeature {
   // swiftlint:disable:next cyclomatic_complexity function_body_length
   func reduceGithubIntegration(
     state: inout State,
@@ -312,6 +325,7 @@ extension RepositoriesFeature {
       case .markReadyForReview:
         let githubCLI = githubCLI
         let githubIntegration = githubIntegration
+        let gitClient = gitClient
         return .run { send in
           guard await githubIntegration.isAvailable() else {
             await send(
@@ -324,7 +338,12 @@ extension RepositoriesFeature {
           }
           await send(.showToast(.inProgress("Marking PR ready…")))
           do {
-            try await githubCLI.markPullRequestReady(worktreeRoot, pullRequest.number)
+            let remoteInfo = await resolveGithubRemoteInfo(
+              repositoryRootURL: repoRoot,
+              githubCLI: githubCLI,
+              gitClient: gitClient
+            )
+            try await githubCLI.markPullRequestReady(worktreeRoot, remoteInfo, pullRequest.number)
             await send(.showToast(.success("Pull request marked ready")))
             await send(.githubIntegration(.delayedPullRequestRefresh(worktreeID)))
           } catch {
@@ -341,6 +360,7 @@ extension RepositoriesFeature {
       case .merge:
         let githubCLI = githubCLI
         let githubIntegration = githubIntegration
+        let gitClient = gitClient
         return .run { send in
           guard await githubIntegration.isAvailable() else {
             await send(
@@ -356,7 +376,12 @@ extension RepositoriesFeature {
           let strategy = repositorySettings.pullRequestMergeStrategy ?? settingsFile.global.pullRequestMergeStrategy
           await send(.showToast(.inProgress("Merging pull request…")))
           do {
-            try await githubCLI.mergePullRequest(worktreeRoot, pullRequest.number, strategy)
+            let remoteInfo = await resolveGithubRemoteInfo(
+              repositoryRootURL: repoRoot,
+              githubCLI: githubCLI,
+              gitClient: gitClient
+            )
+            try await githubCLI.mergePullRequest(worktreeRoot, remoteInfo, pullRequest.number, strategy)
             await send(.showToast(.success("Pull request merged")))
             await send(.worktreeInfoEvent(pullRequestRefresh))
             await send(.githubIntegration(.delayedPullRequestRefresh(worktreeID)))
@@ -374,6 +399,7 @@ extension RepositoriesFeature {
       case .close:
         let githubCLI = githubCLI
         let githubIntegration = githubIntegration
+        let gitClient = gitClient
         return .run { send in
           guard await githubIntegration.isAvailable() else {
             await send(
@@ -386,7 +412,12 @@ extension RepositoriesFeature {
           }
           await send(.showToast(.inProgress("Closing pull request…")))
           do {
-            try await githubCLI.closePullRequest(worktreeRoot, pullRequest.number)
+            let remoteInfo = await resolveGithubRemoteInfo(
+              repositoryRootURL: repoRoot,
+              githubCLI: githubCLI,
+              gitClient: gitClient
+            )
+            try await githubCLI.closePullRequest(worktreeRoot, remoteInfo, pullRequest.number)
             await send(.showToast(.success("Pull request closed")))
             await send(.worktreeInfoEvent(pullRequestRefresh))
             await send(.githubIntegration(.delayedPullRequestRefresh(worktreeID)))

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -1153,7 +1153,7 @@ struct RepositoriesFeature {
     let githubCLI = githubCLI
     return .run { send in
       guard
-        let remoteInfo = await resolveGithubRemoteInfo(
+        let remoteInfo = await Self.resolveGithubRemoteInfo(
           repositoryRootURL: repositoryRootURL,
           githubCLI: githubCLI,
           gitClient: gitClient

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -1152,7 +1152,13 @@ struct RepositoriesFeature {
     let gitClient = gitClient
     let githubCLI = githubCLI
     return .run { send in
-      guard let remoteInfo = await gitClient.remoteInfo(repositoryRootURL) else {
+      guard
+        let remoteInfo = await resolveGithubRemoteInfo(
+          repositoryRootURL: repositoryRootURL,
+          githubCLI: githubCLI,
+          gitClient: gitClient
+        )
+      else {
         await send(.githubIntegration(.repositoryPullRequestRefreshCompleted(repositoryID)))
         return
       }

--- a/supacodeTests/GithubBatchPullRequestsTests.swift
+++ b/supacodeTests/GithubBatchPullRequestsTests.swift
@@ -108,7 +108,7 @@ struct GithubBatchPullRequestsTests {
     #expect(prs["feature-a"]?.title == "Fork PR")
   }
 
-  @Test func ignoresNilHeadRepositoryInFallback() throws {
+  @Test func fallsBackToMergedPullRequestWithDeletedFork() throws {
     let json = """
       {
         "data": {
@@ -117,8 +117,8 @@ struct GithubBatchPullRequestsTests {
               "nodes": [
                 {
                   "number": 7,
-                  "title": "Head Missing",
-                  "state": "OPEN",
+                  "title": "Deleted Fork",
+                  "state": "MERGED",
                   "additions": 1,
                   "deletions": 0,
                   "isDraft": false,
@@ -127,18 +127,62 @@ struct GithubBatchPullRequestsTests {
                   "url": "https://github.com/octo/repo/pull/7",
                   "headRefName": "feature-a",
                   "headRepository": null
+                }
+              ]
+            }
+          }
+        }
+      }
+      """
+    let data = Data(json.utf8)
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+    let response = try decoder.decode(GithubGraphQLPullRequestResponse.self, from: data)
+    let prs = response.pullRequestsByBranch(
+      aliasMap: ["branch0": "feature-a"],
+      owner: "octo",
+      repo: "repo"
+    )
+    #expect(prs["feature-a"]?.number == 7)
+    #expect(prs["feature-a"]?.title == "Deleted Fork")
+  }
+
+  @Test func forkFallbackIgnoresSameBaseBranchMatches() throws {
+    let json = """
+      {
+        "data": {
+          "repository": {
+            "branch0": {
+              "nodes": [
+                {
+                  "number": 12,
+                  "title": "Same Branch Candidate",
+                  "state": "OPEN",
+                  "additions": 1,
+                  "deletions": 0,
+                  "isDraft": false,
+                  "reviewDecision": null,
+                  "updatedAt": "2025-01-03T00:00:00Z",
+                  "url": "https://github.com/fork/repo/pull/12",
+                  "headRefName": "feature-a",
+                  "baseRefName": "feature-a",
+                  "headRepository": {
+                    "name": "repo",
+                    "owner": { "login": "fork" }
+                  }
                 },
                 {
-                  "number": 8,
-                  "title": "Fork PR",
+                  "number": 13,
+                  "title": "Fork PR From Feature",
                   "state": "OPEN",
                   "additions": 1,
                   "deletions": 0,
                   "isDraft": false,
                   "reviewDecision": null,
                   "updatedAt": "2025-01-01T00:00:00Z",
-                  "url": "https://github.com/fork/repo/pull/8",
+                  "url": "https://github.com/fork/repo/pull/13",
                   "headRefName": "feature-a",
+                  "baseRefName": "main",
                   "headRepository": {
                     "name": "repo",
                     "owner": { "login": "fork" }
@@ -159,7 +203,8 @@ struct GithubBatchPullRequestsTests {
       owner: "octo",
       repo: "repo"
     )
-    #expect(prs["feature-a"]?.number == 8)
+    #expect(prs["feature-a"]?.number == 13)
+    #expect(prs["feature-a"]?.title == "Fork PR From Feature")
   }
 
   @Test func prefersOpenOverMergedEvenIfOlder() throws {

--- a/supacodeTests/GithubCLIClientTests.swift
+++ b/supacodeTests/GithubCLIClientTests.swift
@@ -48,7 +48,96 @@ actor GithubBatchShellProbe {
   }
 }
 
+actor GithubCommandProbe {
+  struct Call: Equatable {
+    let arguments: [String]
+    let currentDirectoryURL: URL?
+  }
+
+  private var calls: [Call] = []
+
+  func record(arguments: [String], currentDirectoryURL: URL?) {
+    calls.append(Call(arguments: arguments, currentDirectoryURL: currentDirectoryURL))
+  }
+
+  func snapshot() -> [Call] {
+    calls
+  }
+}
+
 struct GithubCLIClientTests {
+  @Test func resolveRemoteInfoUsesGhRepoView() async throws {
+    let repoRoot = URL(fileURLWithPath: "/tmp/fork")
+    let probe = GithubCommandProbe()
+    let shell = ShellClient(
+      run: { executableURL, _, _ in
+        if executableURL.lastPathComponent == "which" {
+          return ShellOutput(stdout: "/usr/bin/gh", stderr: "", exitCode: 0)
+        }
+        return ShellOutput(stdout: "", stderr: "", exitCode: 0)
+      },
+      runLoginImpl: { executableURL, arguments, currentDirectoryURL, _ in
+        guard executableURL.lastPathComponent == "gh" else {
+          return ShellOutput(stdout: "", stderr: "", exitCode: 0)
+        }
+        await probe.record(arguments: arguments, currentDirectoryURL: currentDirectoryURL)
+        return ShellOutput(
+          stdout: #"{"owner":{"login":"supabitapp"},"name":"supacode","url":"https://github.com/supabitapp/supacode"}"#,
+          stderr: "",
+          exitCode: 0
+        )
+      }
+    )
+    let client = GithubCLIClient.live(shell: shell)
+
+    let remoteInfo = try await client.resolveRemoteInfo(repoRoot)
+
+    #expect(remoteInfo == GithubRemoteInfo(host: "github.com", owner: "supabitapp", repo: "supacode"))
+    let calls = await probe.snapshot()
+    #expect(
+      calls == [
+        GithubCommandProbe.Call(
+          arguments: ["repo", "view", "--json", "owner,name,url"],
+          currentDirectoryURL: repoRoot
+        )
+      ])
+  }
+
+  @Test func pullRequestMutationsUseResolvedRemoteInfo() async throws {
+    let repoRoot = URL(fileURLWithPath: "/tmp/fork")
+    let remoteInfo = GithubRemoteInfo(host: "github.enterprise.test", owner: "octo", repo: "repo")
+    let probe = GithubCommandProbe()
+    let shell = ShellClient(
+      run: { executableURL, _, _ in
+        if executableURL.lastPathComponent == "which" {
+          return ShellOutput(stdout: "/usr/bin/gh", stderr: "", exitCode: 0)
+        }
+        return ShellOutput(stdout: "", stderr: "", exitCode: 0)
+      },
+      runLoginImpl: { executableURL, arguments, currentDirectoryURL, _ in
+        guard executableURL.lastPathComponent == "gh" else {
+          return ShellOutput(stdout: "", stderr: "", exitCode: 0)
+        }
+        await probe.record(arguments: arguments, currentDirectoryURL: currentDirectoryURL)
+        return ShellOutput(stdout: "", stderr: "", exitCode: 0)
+      }
+    )
+    let client = GithubCLIClient.live(shell: shell)
+
+    try await client.mergePullRequest(repoRoot, remoteInfo, 12, .squash)
+    try await client.closePullRequest(repoRoot, remoteInfo, 13)
+    try await client.markPullRequestReady(repoRoot, remoteInfo, 14)
+
+    let calls = await probe.snapshot()
+    #expect(
+      calls.map(\.arguments) == [
+        ["pr", "merge", "12", "--squash", "--repo", "github.enterprise.test/octo/repo"],
+        ["pr", "close", "13", "--repo", "github.enterprise.test/octo/repo"],
+        ["pr", "ready", "14", "--repo", "github.enterprise.test/octo/repo"],
+      ])
+    #expect(calls.allSatisfy { $0.currentDirectoryURL == repoRoot })
+  }
+
   @Test func batchPullRequestsCapsConcurrencyAtThree() async throws {
     let probe = GithubBatchShellProbe()
     let shell = ShellClient(

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -3306,7 +3306,7 @@ struct RepositoriesFeatureTests {
       RepositoriesFeature()
     } withDependencies: {
       $0.githubIntegration.isAvailable = { true }
-      $0.githubCLI.mergePullRequest = { _, number, _ in
+      $0.githubCLI.mergePullRequest = { _, _, number, _ in
         mergedNumbers.withValue { $0.append(number) }
       }
     }
@@ -3356,7 +3356,7 @@ struct RepositoriesFeatureTests {
       RepositoriesFeature()
     } withDependencies: {
       $0.githubIntegration.isAvailable = { true }
-      $0.githubCLI.mergePullRequest = { _, _, strategy in
+      $0.githubCLI.mergePullRequest = { _, _, _, strategy in
         mergedStrategies.withValue { $0.append(strategy) }
       }
     }
@@ -3371,6 +3371,57 @@ struct RepositoriesFeatureTests {
     }
     await store.receive(\.worktreeInfoEvent)
     #expect(mergedStrategies.value == [.squash])
+    await store.finish()
+  }
+
+  @Test func pullRequestActionMergeUsesResolvedRemoteInfo() async {
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let featureWorktree = makeWorktree(
+      id: "\(repoRoot)/feature",
+      name: "feature",
+      repoRoot: repoRoot
+    )
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree, featureWorktree])
+    let openPullRequest = makePullRequest(state: "OPEN", headRefName: featureWorktree.name, number: 12)
+    let upstreamRemoteInfo = GithubRemoteInfo(host: "github.com", owner: "supabitapp", repo: "supacode")
+    var state = makeState(repositories: [repository])
+    state.githubIntegrationAvailability = .disabled
+    state.worktreeInfoByID[featureWorktree.id] = WorktreeInfoEntry(
+      addedLines: nil,
+      removedLines: nil,
+      pullRequest: openPullRequest
+    )
+    let mutationRemoteInfos = LockIsolated<[GithubRemoteInfo?]>([])
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.githubIntegration.isAvailable = { true }
+      $0.githubCLI.resolveRemoteInfo = { root in
+        #expect(root == URL(fileURLWithPath: repoRoot))
+        return upstreamRemoteInfo
+      }
+      $0.gitClient.remoteInfo = { _ in
+        Issue.record("git remoteInfo should not be used when gh repo view succeeds")
+        return nil
+      }
+      $0.githubCLI.mergePullRequest = { root, remoteInfo, number, _ in
+        #expect(root == featureWorktree.workingDirectory)
+        #expect(number == 12)
+        mutationRemoteInfos.withValue { $0.append(remoteInfo) }
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.githubIntegration(.pullRequestAction(featureWorktree.id, .merge)))
+    await store.receive(\.showToast) {
+      $0.statusToast = .inProgress("Merging pull request…")
+    }
+    await store.receive(\.showToast) {
+      $0.statusToast = .success("Pull request merged")
+    }
+    await store.receive(\.worktreeInfoEvent)
+    #expect(mutationRemoteInfos.value == [upstreamRemoteInfo])
     await store.finish()
   }
 
@@ -3396,7 +3447,7 @@ struct RepositoriesFeatureTests {
       RepositoriesFeature()
     } withDependencies: {
       $0.githubIntegration.isAvailable = { true }
-      $0.githubCLI.closePullRequest = { _, number in
+      $0.githubCLI.closePullRequest = { _, _, number in
         closedNumbers.withValue { $0.append(number) }
       }
     }
@@ -3586,6 +3637,58 @@ struct RepositoriesFeatureTests {
     await store.receive(\.githubIntegration.repositoryPullRequestRefreshCompleted) {
       $0.inFlightPullRequestRefreshRepositoryIDs = []
     }
+    await store.finish()
+  }
+
+  @Test func worktreeInfoEventRepositoryPullRequestRefreshPrefersResolvedRemoteInfo() async {
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let featureWorktree = makeWorktree(
+      id: "\(repoRoot)/feature",
+      name: "feature",
+      repoRoot: repoRoot
+    )
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree, featureWorktree])
+    let upstreamRemoteInfo = GithubRemoteInfo(host: "github.com", owner: "supabitapp", repo: "supacode")
+    let requestedRemoteInfos = LockIsolated<[GithubRemoteInfo]>([])
+    var initialState = makeState(repositories: [repository])
+    initialState.githubIntegrationAvailability = .available
+    let store = TestStore(initialState: initialState) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.githubCLI.resolveRemoteInfo = { root in
+        #expect(root == URL(fileURLWithPath: repoRoot))
+        return upstreamRemoteInfo
+      }
+      $0.gitClient.remoteInfo = { _ in
+        Issue.record("git remoteInfo should not be used when gh repo view succeeds")
+        return nil
+      }
+      $0.githubCLI.batchPullRequests = { host, owner, repo, branches in
+        #expect(branches == ["main", "feature"])
+        requestedRemoteInfos.withValue {
+          $0.append(GithubRemoteInfo(host: host, owner: owner, repo: repo))
+        }
+        return [:]
+      }
+    }
+
+    await store.send(
+      .worktreeInfoEvent(
+        .repositoryPullRequestRefresh(
+          repositoryRootURL: URL(fileURLWithPath: repoRoot),
+          worktreeIDs: [mainWorktree.id, featureWorktree.id]
+        )
+      )
+    )
+    await store.receive(\.githubIntegration.repositoryPullRequestRefreshRequested) {
+      $0.inFlightPullRequestRefreshRepositoryIDs = [repository.id]
+    }
+    await store.receive(\.githubIntegration.repositoryPullRequestsLoaded)
+    await store.receive(\.githubIntegration.repositoryPullRequestRefreshCompleted) {
+      $0.inFlightPullRequestRefreshRepositoryIDs = []
+    }
+    #expect(requestedRemoteInfos.value == [upstreamRemoteInfo])
     await store.finish()
   }
 

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -3301,11 +3301,13 @@ struct RepositoriesFeatureTests {
       removedLines: nil,
       pullRequest: openPullRequest
     )
+    let upstreamRemoteInfo = GithubRemoteInfo(host: "github.com", owner: "supabitapp", repo: "supacode")
     let mergedNumbers = LockIsolated<[Int]>([])
     let store = TestStore(initialState: state) {
       RepositoriesFeature()
     } withDependencies: {
       $0.githubIntegration.isAvailable = { true }
+      $0.githubCLI.resolveRemoteInfo = { _ in upstreamRemoteInfo }
       $0.githubCLI.mergePullRequest = { _, _, number, _ in
         mergedNumbers.withValue { $0.append(number) }
       }
@@ -3343,6 +3345,7 @@ struct RepositoriesFeatureTests {
       removedLines: nil,
       pullRequest: openPullRequest
     )
+    let upstreamRemoteInfo = GithubRemoteInfo(host: "github.com", owner: "supabitapp", repo: "supacode")
     let mergedStrategies = LockIsolated<[PullRequestMergeStrategy]>([])
     @Shared(.settingsFile) var settingsFile
     $settingsFile.withLock {
@@ -3356,6 +3359,7 @@ struct RepositoriesFeatureTests {
       RepositoriesFeature()
     } withDependencies: {
       $0.githubIntegration.isAvailable = { true }
+      $0.githubCLI.resolveRemoteInfo = { _ in upstreamRemoteInfo }
       $0.githubCLI.mergePullRequest = { _, _, _, strategy in
         mergedStrategies.withValue { $0.append(strategy) }
       }
@@ -3425,6 +3429,61 @@ struct RepositoriesFeatureTests {
     await store.finish()
   }
 
+  @Test func pullRequestActionMergeRequiresResolvedRemoteInfo() async {
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let featureWorktree = makeWorktree(
+      id: "\(repoRoot)/feature",
+      name: "feature",
+      repoRoot: repoRoot
+    )
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree, featureWorktree])
+    let openPullRequest = makePullRequest(state: "OPEN", headRefName: featureWorktree.name, number: 12)
+    var state = makeState(repositories: [repository])
+    state.githubIntegrationAvailability = .disabled
+    state.worktreeInfoByID[featureWorktree.id] = WorktreeInfoEntry(
+      addedLines: nil,
+      removedLines: nil,
+      pullRequest: openPullRequest
+    )
+    let mergeAttempts = LockIsolated(0)
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.githubIntegration.isAvailable = { true }
+      $0.githubCLI.resolveRemoteInfo = { _ in nil }
+      $0.gitClient.remoteInfo = { _ in nil }
+      $0.githubCLI.mergePullRequest = { _, _, _, _ in
+        mergeAttempts.withValue { $0 += 1 }
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.githubIntegration(.pullRequestAction(featureWorktree.id, .merge)))
+    await store.receive(\.showToast) {
+      $0.statusToast = .inProgress("Merging pull request…")
+    }
+    await store.receive(\.dismissToast) {
+      $0.statusToast = nil
+    }
+    await store.receive(\.presentAlert) {
+      $0.alert = AlertState<RepositoriesFeature.Alert> {
+        TextState("GitHub repository not resolved")
+      } actions: {
+        ButtonState(role: .cancel) {
+          TextState("OK")
+        }
+      } message: {
+        TextState(
+          "Prowl could not determine which GitHub repository owns this pull request. "
+            + "Check the repository remote and try again."
+        )
+      }
+    }
+    #expect(mergeAttempts.value == 0)
+    await store.finish()
+  }
+
   @Test func pullRequestActionCloseRefreshesImmediately() async {
     let repoRoot = "/tmp/repo"
     let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
@@ -3442,11 +3501,13 @@ struct RepositoriesFeatureTests {
       removedLines: nil,
       pullRequest: openPullRequest
     )
+    let upstreamRemoteInfo = GithubRemoteInfo(host: "github.com", owner: "supabitapp", repo: "supacode")
     let closedNumbers = LockIsolated<[Int]>([])
     let store = TestStore(initialState: state) {
       RepositoriesFeature()
     } withDependencies: {
       $0.githubIntegration.isAvailable = { true }
+      $0.githubCLI.resolveRemoteInfo = { _ in upstreamRemoteInfo }
       $0.githubCLI.closePullRequest = { _, _, number in
         closedNumbers.withValue { $0.append(number) }
       }


### PR DESCRIPTION
## Summary
- resolve GitHub PR repository ownership with `gh repo view` before falling back to git remote parsing
- pass resolved repo info to `gh pr merge`, `gh pr close`, and `gh pr ready` via `--repo`
- tighten batch PR matching for fork clones, same-branch false positives, and deleted fork heads

## Tests
- `xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -only-testing:supacodeTests/GithubCLIClientTests -only-testing:supacodeTests/GithubBatchPullRequestsTests -only-testing:supacodeTests/RepositoriesFeatureTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation 2>&1 | xcsift`
- `make check`
- `make build-app`
