### PR TITLE
Add notification jump and surface indicators

### DIFF
--- a/supacode/App/AppShortcuts.swift
+++ b/supacode/App/AppShortcuts.swift
@@ -94,6 +94,7 @@ enum AppShortcuts {
     static let openPullRequest = "open_pull_request"
     static let toggleLeftSidebar = "toggle_left_sidebar"
     static let refreshWorktrees = "refresh_worktrees"
+    static let jumpToLatestUnread = "jump_to_latest_unread"
     static let runScript = "run_script"
     static let stopScript = "stop_script"
     static let checkForUpdates = "check_for_updates"
@@ -180,6 +181,7 @@ enum AppShortcuts {
   static let openPullRequest = AppShortcut(key: "g", modifiers: [.command, .control])
   static let toggleLeftSidebar = AppShortcut(key: "s", modifiers: [.command, .control])
   static let refreshWorktrees = AppShortcut(key: "r", modifiers: [.command, .shift])
+  static let jumpToLatestUnread = AppShortcut(key: "u", modifiers: [.command, .option])
   static let runScript = AppShortcut(key: "r", modifiers: .command)
   static let stopRunScript = AppShortcut(key: ".", modifiers: .command)
   static let checkForUpdates = AppShortcut(key: "u", modifiers: [.command, .shift])
@@ -323,6 +325,7 @@ enum AppShortcuts {
   private static let reservedCustomCommandBindings: [ReservedCustomCommandBinding] = [
     .init(actionTitle: "Open Settings", shortcut: openSettings),
     .init(actionTitle: "Toggle Left Sidebar", shortcut: toggleLeftSidebar),
+    .init(actionTitle: "Jump to Latest Unread", shortcut: jumpToLatestUnread),
     .init(actionTitle: "Run Script", shortcut: runScript),
     .init(actionTitle: "Stop Script", shortcut: stopRunScript),
     .init(actionTitle: "Check for Updates", shortcut: checkForUpdates),
@@ -396,6 +399,12 @@ enum AppShortcuts {
       title: "Refresh Worktrees",
       scope: .configurableAppAction,
       shortcut: refreshWorktrees
+    ),
+    .init(
+      id: CommandID.jumpToLatestUnread,
+      title: "Jump to Latest Unread",
+      scope: .configurableAppAction,
+      shortcut: jumpToLatestUnread
     ),
     .init(
       id: CommandID.runScript,
@@ -840,6 +849,7 @@ enum AppShortcuts {
     toggleLeftSidebar,
     revealInSidebar,
     refreshWorktrees,
+    jumpToLatestUnread,
     runScript,
     stopRunScript,
     checkForUpdates,

--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -29,7 +29,14 @@ private enum GhosttyCLI {
 
 @MainActor
 final class SupacodeAppDelegate: NSObject, NSApplicationDelegate {
-  var appStore: StoreOf<AppFeature>?
+  var appStore: StoreOf<AppFeature>? {
+    didSet {
+      guard let appStore else { return }
+      setSystemNotificationTapHandler { [weak appStore] worktreeID, surfaceID in
+        appStore?.send(.systemNotificationTapped(worktreeID: worktreeID, surfaceID: surfaceID))
+      }
+    }
+  }
   var terminalManager: WorktreeTerminalManager?
   var cliSocketServer: CLISocketServer?
 
@@ -191,17 +198,7 @@ struct SupacodeApp: App {
       AppFeature()
         .logActions()
     } withDependencies: { values in
-      values.terminalClient = TerminalClient(
-        send: { command in
-          terminalManager.handleCommand(command)
-        },
-        events: {
-          terminalManager.eventStream()
-        },
-        canvasFocusedWorktreeID: {
-          terminalManager.canvasFocusedWorktreeID
-        }
-      )
+      values.terminalClient = Self.makeTerminalClient(terminalManager: terminalManager)
       values.worktreeInfoWatcher = WorktreeInfoWatcherClient(
         send: { command in
           worktreeInfoWatcher.handleCommand(command)
@@ -246,6 +243,29 @@ struct SupacodeApp: App {
     #if DEBUG
       DebugWindowManager.shared.configure(store: appStore)
     #endif
+  }
+
+  private static func makeTerminalClient(terminalManager: WorktreeTerminalManager) -> TerminalClient {
+    TerminalClient(
+      send: { command in
+        terminalManager.handleCommand(command)
+      },
+      events: {
+        terminalManager.eventStream()
+      },
+      canvasFocusedWorktreeID: {
+        terminalManager.canvasFocusedWorktreeID
+      },
+      latestUnreadNotification: {
+        terminalManager.latestUnreadNotificationLocation()
+      },
+      focusSurface: { worktreeID, surfaceID in
+        terminalManager.focusSurface(worktreeID: worktreeID, surfaceID: surfaceID)
+      },
+      markNotificationRead: { worktreeID, notificationID in
+        terminalManager.markNotificationRead(worktreeID: worktreeID, notificationID: notificationID)
+      }
+    )
   }
 
   private static func makeTargetResolver(

--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -264,6 +264,9 @@ struct SupacodeApp: App {
       },
       markNotificationRead: { worktreeID, notificationID in
         terminalManager.markNotificationRead(worktreeID: worktreeID, notificationID: notificationID)
+      },
+      markNotificationsReadForSurface: { worktreeID, surfaceID in
+        terminalManager.markNotificationsRead(worktreeID: worktreeID, surfaceID: surfaceID)
       }
     )
   }

--- a/supacode/Clients/Notifications/SystemNotificationClient.swift
+++ b/supacode/Clients/Notifications/SystemNotificationClient.swift
@@ -3,13 +3,34 @@ import ComposableArchitecture
 import Foundation
 import UserNotifications
 
+private nonisolated let notificationWorktreeIDKey = "prowl.worktreeID"
+private nonisolated let notificationSurfaceIDKey = "prowl.surfaceID"
+
+@MainActor
 private final class ForegroundSystemNotificationDelegate: NSObject, UNUserNotificationCenterDelegate {
+  var onNotificationTap: ((Worktree.ID, UUID) -> Void)?
+
   func userNotificationCenter(
     _ center: UNUserNotificationCenter,
     willPresent notification: UNNotification
   ) async -> UNNotificationPresentationOptions {
     await Task.yield()
     return [.badge, .sound, .banner]
+  }
+
+  func userNotificationCenter(
+    _ center: UNUserNotificationCenter,
+    didReceive response: UNNotificationResponse
+  ) async {
+    await Task.yield()
+    let userInfo = response.notification.request.content.userInfo
+    guard let worktreeID = userInfo[notificationWorktreeIDKey] as? String,
+      let rawSurfaceID = userInfo[notificationSurfaceIDKey] as? String,
+      let surfaceID = UUID(uuidString: rawSurfaceID)
+    else {
+      return
+    }
+    onNotificationTap?(worktreeID, surfaceID)
   }
 }
 
@@ -23,6 +44,12 @@ private func configuredNotificationCenter() -> UNUserNotificationCenter {
     center.delegate = foregroundSystemNotificationDelegate
   }
   return center
+}
+
+@MainActor
+func setSystemNotificationTapHandler(_ handler: @escaping @MainActor (Worktree.ID, UUID) -> Void) {
+  _ = configuredNotificationCenter()
+  foregroundSystemNotificationDelegate.onNotificationTap = handler
 }
 
 struct SystemNotificationClient {
@@ -39,7 +66,8 @@ struct SystemNotificationClient {
 
   var authorizationStatus: @MainActor @Sendable () async -> AuthorizationStatus
   var requestAuthorization: @MainActor @Sendable () async -> AuthorizationRequestResult
-  var send: @MainActor @Sendable (_ title: String, _ body: String) async -> Void
+  var send:
+    @MainActor @Sendable (_ title: String, _ body: String, _ worktreeID: Worktree.ID?, _ surfaceID: UUID?) async -> Void
   var openSettings: @MainActor @Sendable () async -> Void
 }
 
@@ -73,12 +101,18 @@ extension SystemNotificationClient: DependencyKey {
         )
       }
     },
-    send: { title, body in
+    send: { title, body, worktreeID, surfaceID in
       let center = configuredNotificationCenter()
       let content = UNMutableNotificationContent()
       content.title = title
       content.body = body
       content.sound = .default
+      if let worktreeID, let surfaceID {
+        content.userInfo = [
+          notificationWorktreeIDKey: worktreeID,
+          notificationSurfaceIDKey: surfaceID.uuidString,
+        ]
+      }
       let request = UNNotificationRequest(
         identifier: UUID().uuidString,
         content: content,
@@ -97,7 +131,7 @@ extension SystemNotificationClient: DependencyKey {
   static let testValue = SystemNotificationClient(
     authorizationStatus: { .notDetermined },
     requestAuthorization: { AuthorizationRequestResult(granted: false, errorMessage: nil) },
-    send: { _, _ in },
+    send: { _, _, _, _ in },
     openSettings: {}
   )
 }

--- a/supacode/Clients/Terminal/TerminalClient.swift
+++ b/supacode/Clients/Terminal/TerminalClient.swift
@@ -5,6 +5,9 @@ struct TerminalClient {
   var send: @MainActor @Sendable (Command) -> Void
   var events: @MainActor @Sendable () -> AsyncStream<Event>
   var canvasFocusedWorktreeID: @MainActor @Sendable () -> Worktree.ID?
+  var latestUnreadNotification: @MainActor @Sendable () -> NotificationLocation?
+  var focusSurface: @MainActor @Sendable (Worktree.ID, UUID) -> Bool
+  var markNotificationRead: @MainActor @Sendable (Worktree.ID, UUID) -> Void
 
   enum Command: Equatable {
     case createTab(Worktree, runSetupScriptIfNew: Bool)
@@ -49,7 +52,7 @@ struct TerminalClient {
 
   enum Event: Equatable {
     case customCommandSucceeded(worktreeID: Worktree.ID, name: String, durationMs: Int)
-    case notificationReceived(worktreeID: Worktree.ID, title: String, body: String)
+    case notificationReceived(worktreeID: Worktree.ID, surfaceID: UUID, title: String, body: String)
     case notificationIndicatorChanged(count: Int)
     case tabCreated(worktreeID: Worktree.ID)
     case tabClosed(worktreeID: Worktree.ID, remainingTabs: Int)
@@ -68,13 +71,19 @@ extension TerminalClient: DependencyKey {
   static let liveValue = TerminalClient(
     send: { _ in fatalError("TerminalClient.send not configured") },
     events: { fatalError("TerminalClient.events not configured") },
-    canvasFocusedWorktreeID: { nil }
+    canvasFocusedWorktreeID: { nil },
+    latestUnreadNotification: { nil },
+    focusSurface: { _, _ in false },
+    markNotificationRead: { _, _ in }
   )
 
   static let testValue = TerminalClient(
     send: { _ in },
     events: { AsyncStream { $0.finish() } },
-    canvasFocusedWorktreeID: { nil }
+    canvasFocusedWorktreeID: { nil },
+    latestUnreadNotification: { nil },
+    focusSurface: { _, _ in false },
+    markNotificationRead: { _, _ in }
   )
 }
 

--- a/supacode/Clients/Terminal/TerminalClient.swift
+++ b/supacode/Clients/Terminal/TerminalClient.swift
@@ -8,6 +8,7 @@ struct TerminalClient {
   var latestUnreadNotification: @MainActor @Sendable () -> NotificationLocation?
   var focusSurface: @MainActor @Sendable (Worktree.ID, UUID) -> Bool
   var markNotificationRead: @MainActor @Sendable (Worktree.ID, UUID) -> Void
+  var markNotificationsReadForSurface: @MainActor @Sendable (Worktree.ID, UUID) -> Void
 
   enum Command: Equatable {
     case createTab(Worktree, runSetupScriptIfNew: Bool)
@@ -74,7 +75,8 @@ extension TerminalClient: DependencyKey {
     canvasFocusedWorktreeID: { nil },
     latestUnreadNotification: { nil },
     focusSurface: { _, _ in false },
-    markNotificationRead: { _, _ in }
+    markNotificationRead: { _, _ in },
+    markNotificationsReadForSurface: { _, _ in }
   )
 
   static let testValue = TerminalClient(
@@ -83,7 +85,8 @@ extension TerminalClient: DependencyKey {
     canvasFocusedWorktreeID: { nil },
     latestUnreadNotification: { nil },
     focusSurface: { _, _ in false },
-    markNotificationRead: { _, _ in }
+    markNotificationRead: { _, _ in },
+    markNotificationsReadForSurface: { _, _ in }
   )
 }
 

--- a/supacode/Commands/WorktreeCommands.swift
+++ b/supacode/Commands/WorktreeCommands.swift
@@ -110,6 +110,12 @@ struct WorktreeCommands: Commands {
       }
       .modifier(KeyboardShortcutModifier(shortcut: keyboardShortcut(for: AppShortcuts.CommandID.refreshWorktrees)))
       .help(helpText(title: "Refresh Worktrees", commandID: AppShortcuts.CommandID.refreshWorktrees))
+      Button("Jump to Latest Unread") {
+        store.send(.jumpToLatestUnread)
+      }
+      .modifier(KeyboardShortcutModifier(shortcut: keyboardShortcut(for: AppShortcuts.CommandID.jumpToLatestUnread)))
+      .help(helpText(title: "Jump to Latest Unread", commandID: AppShortcuts.CommandID.jumpToLatestUnread))
+      .disabled(store.notificationIndicatorCount == 0)
       Divider()
       Button("Run Script") {
         runScriptAction?()

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -885,6 +885,7 @@ struct AppFeature {
           .send(.repositories(.selectWorktree(worktreeID, focusTerminal: true))),
           .run { _ in
             _ = await terminalClient.focusSurface(worktreeID, surfaceID)
+            await terminalClient.markNotificationsReadForSurface(worktreeID, surfaceID)
           }
         )
 
@@ -942,6 +943,9 @@ struct AppFeature {
 
       case .commandPalette(.delegate(.refreshWorktrees)):
         return .send(.repositories(.refreshWorktrees))
+
+      case .commandPalette(.delegate(.jumpToLatestUnread)):
+        return .send(.jumpToLatestUnread)
 
       case .commandPalette(.delegate(.installCLI)):
         return .send(.settings(.installCLIButtonTapped(showAlert: false)))

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -5,6 +5,7 @@ import PostHog
 import SwiftUI
 
 private let appLogger = SupaLogger("App")
+private let notificationJumpLogger = SupaLogger("NotificationJump")
 
 private enum CancelID {
   static let periodicRefresh = "app.periodicRefresh"
@@ -81,6 +82,7 @@ struct AppFeature {
     case openWorktreeFailed(OpenActionError)
     case requestQuit
     case newTerminal
+    case jumpToLatestUnread
     case runScript
     case runCustomCommand(Int)
     case runScriptDraftChanged(String)
@@ -95,6 +97,7 @@ struct AppFeature {
     case navigateSearchPrevious
     case endSearch
     case systemNotificationsPermissionFailed(errorMessage: String?)
+    case systemNotificationTapped(worktreeID: Worktree.ID, surfaceID: UUID)
     case alert(PresentationAction<Alert>)
     case terminalEvent(TerminalClient.Event)
   }
@@ -614,6 +617,24 @@ struct AppFeature {
           await terminalClient.send(.createTab(worktree, runSetupScriptIfNew: shouldRunSetupScript))
         }
 
+      case .jumpToLatestUnread:
+        guard let location = terminalClient.latestUnreadNotification() else {
+          notificationJumpLogger.debug("jumpToLatestUnread invoked with no unread notification.")
+          return .none
+        }
+        guard state.repositories.worktree(for: location.worktreeID) != nil else {
+          notificationJumpLogger.warning("Unread notification worktree vanished: \(location.worktreeID)")
+          return .none
+        }
+        analyticsClient.capture("notifications_jump_to_latest_unread", nil)
+        return .merge(
+          .send(.repositories(.selectWorktree(location.worktreeID, focusTerminal: true))),
+          .run { _ in
+            _ = await terminalClient.focusSurface(location.worktreeID, location.surfaceID)
+            await terminalClient.markNotificationRead(location.worktreeID, location.notificationID)
+          }
+        )
+
       case .runScript:
         guard let worktree = state.repositories.selectedTerminalWorktree else {
           return .none
@@ -855,6 +876,18 @@ struct AppFeature {
           .send(.settings(.showNotificationPermissionAlert(errorMessage: errorMessage)))
         )
 
+      case .systemNotificationTapped(let worktreeID, let surfaceID):
+        guard state.repositories.worktree(for: worktreeID) != nil else {
+          notificationJumpLogger.warning("Tapped notification worktree vanished: \(worktreeID)")
+          return .none
+        }
+        return .merge(
+          .send(.repositories(.selectWorktree(worktreeID, focusTerminal: true))),
+          .run { _ in
+            _ = await terminalClient.focusSurface(worktreeID, surfaceID)
+          }
+        )
+
       case .alert(.dismiss):
         state.alert = nil
         return .none
@@ -970,14 +1003,14 @@ struct AppFeature {
         let message = "\(name) succeeded in \(formatCustomCommandDuration(durationMs))"
         return .send(.repositories(.showToast(.success(message))))
 
-      case .terminalEvent(.notificationReceived(let worktreeID, let title, let body)):
+      case .terminalEvent(.notificationReceived(let worktreeID, let surfaceID, let title, let body)):
         var effects: [Effect<Action>] = [
           .send(.repositories(.worktreeOrdering(.worktreeNotificationReceived(worktreeID))))
         ]
         if state.settings.systemNotificationsEnabled {
           effects.append(
             .run { _ in
-              await systemNotificationClient.send(title, body)
+              await systemNotificationClient.send(title, body, worktreeID, surfaceID)
             }
           )
         }

--- a/supacode/Features/Canvas/Views/CanvasCardView.swift
+++ b/supacode/Features/Canvas/Views/CanvasCardView.swift
@@ -230,6 +230,7 @@ struct CanvasCardView: View {
       tree: tree,
       pinnedSize: cardSize,
       focusedSurfaceID: focusedSurfaceID,
+      hasNotification: { _ in false },
       action: onSplitOperation
     )
     .frame(width: cardSize.width, height: cardSize.height)

--- a/supacode/Features/CommandPalette/CommandPaletteItem.swift
+++ b/supacode/Features/CommandPalette/CommandPaletteItem.swift
@@ -31,6 +31,7 @@ struct CommandPaletteItem: Identifiable, Equatable {
     case archiveWorktree(Worktree.ID, Repository.ID)
     case viewArchivedWorktrees
     case refreshWorktrees
+    case jumpToLatestUnread
     case ghosttyCommand(String)
     case openPullRequest(Worktree.ID)
     case openRepositoryOnCodeHost(Worktree.ID)
@@ -52,7 +53,7 @@ struct CommandPaletteItem: Identifiable, Equatable {
   var isGlobal: Bool {
     switch kind {
     case .checkForUpdates, .openRepository, .openSettings, .newWorktree, .viewArchivedWorktrees,
-      .refreshWorktrees, .installCLI:
+      .refreshWorktrees, .installCLI, .jumpToLatestUnread:
       return true
     case .ghosttyCommand:
       return false
@@ -81,7 +82,7 @@ struct CommandPaletteItem: Identifiable, Equatable {
   var isRootAction: Bool {
     switch kind {
     case .checkForUpdates, .openRepository, .openSettings, .newWorktree, .viewArchivedWorktrees,
-      .refreshWorktrees, .installCLI:
+      .refreshWorktrees, .installCLI, .jumpToLatestUnread:
       return true
     case .ghosttyCommand:
       return false
@@ -120,6 +121,8 @@ struct CommandPaletteItem: Identifiable, Equatable {
       return AppShortcuts.CommandID.archivedWorktrees
     case .refreshWorktrees:
       return AppShortcuts.CommandID.refreshWorktrees
+    case .jumpToLatestUnread:
+      return AppShortcuts.CommandID.jumpToLatestUnread
     case .openPullRequest,
       .openRepositoryOnCodeHost:
       return AppShortcuts.CommandID.openPullRequest

--- a/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
+++ b/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
@@ -40,6 +40,7 @@ struct CommandPaletteFeature {
     case archiveWorktree(Worktree.ID, Repository.ID)
     case viewArchivedWorktrees
     case refreshWorktrees
+    case jumpToLatestUnread
     case ghosttyCommand(String)
     case openPullRequest(Worktree.ID)
     case markPullRequestReady(Worktree.ID)
@@ -207,6 +208,14 @@ struct CommandPaletteFeature {
         title: "Refresh Worktrees",
         subtitle: nil,
         kind: .refreshWorktrees
+      )
+    )
+    items.append(
+      CommandPaletteItem(
+        id: CommandPaletteItemID.globalJumpToLatestUnread,
+        title: "Jump to Latest Unread",
+        subtitle: nil,
+        kind: .jumpToLatestUnread
       )
     )
     items.append(
@@ -493,6 +502,7 @@ private enum CommandPaletteItemID {
   static let globalOpenRepository = "global.open-repository"
   static let globalNewWorktree = "global.new-worktree"
   static let globalRefreshWorktrees = "global.refresh-worktrees"
+  static let globalJumpToLatestUnread = "global.jump-to-latest-unread"
   static let globalViewArchivedWorktrees = "global.view-archived-worktrees"
   static let globalInstallCLI = "global.install-cli"
 
@@ -503,6 +513,7 @@ private enum CommandPaletteItemID {
       globalOpenRepository,
       globalNewWorktree,
       globalRefreshWorktrees,
+      globalJumpToLatestUnread,
       globalViewArchivedWorktrees,
       globalInstallCLI,
     ]
@@ -599,27 +610,16 @@ private func commandPaletteRecencyScore(
 }
 
 private func delegateAction(for kind: CommandPaletteItem.Kind) -> CommandPaletteFeature.Delegate {
+  if let appAction = appDelegateAction(for: kind) {
+    return appAction
+  }
   switch kind {
   case .worktreeSelect(let id):
     return .selectWorktree(id)
-  case .checkForUpdates:
-    return .checkForUpdates
-  case .openSettings:
-    return .openSettings
-  case .newWorktree:
-    return .newWorktree
-  case .openRepository:
-    return .openRepository
   case .removeWorktree(let worktreeID, let repositoryID):
     return .removeWorktree(worktreeID, repositoryID)
   case .archiveWorktree(let worktreeID, let repositoryID):
     return .archiveWorktree(worktreeID, repositoryID)
-  case .viewArchivedWorktrees:
-    return .viewArchivedWorktrees
-  case .refreshWorktrees:
-    return .refreshWorktrees
-  case .installCLI:
-    return .installCLI
   case .ghosttyCommand(let action):
     return .ghosttyCommand(action)
   case .changeFocusedTabIcon(let worktreeID):
@@ -640,6 +640,38 @@ private func delegateAction(for kind: CommandPaletteItem.Kind) -> CommandPalette
     case .debugSimulateUpdateFound:
       return .debugSimulateUpdateFound
   #endif
+  case .checkForUpdates,
+    .openSettings,
+    .newWorktree,
+    .openRepository,
+    .viewArchivedWorktrees,
+    .refreshWorktrees,
+    .jumpToLatestUnread,
+    .installCLI:
+    fatalError("appDelegateAction should handle app-level command palette actions")
+  }
+}
+
+private func appDelegateAction(for kind: CommandPaletteItem.Kind) -> CommandPaletteFeature.Delegate? {
+  switch kind {
+  case .checkForUpdates:
+    return .checkForUpdates
+  case .openSettings:
+    return .openSettings
+  case .newWorktree:
+    return .newWorktree
+  case .openRepository:
+    return .openRepository
+  case .viewArchivedWorktrees:
+    return .viewArchivedWorktrees
+  case .refreshWorktrees:
+    return .refreshWorktrees
+  case .jumpToLatestUnread:
+    return .jumpToLatestUnread
+  case .installCLI:
+    return .installCLI
+  default:
+    return nil
   }
 }
 
@@ -673,6 +705,7 @@ private func pullRequestDelegateAction(
     .archiveWorktree,
     .viewArchivedWorktrees,
     .refreshWorktrees,
+    .jumpToLatestUnread,
     .installCLI,
     .ghosttyCommand,
     .changeFocusedTabIcon:

--- a/supacode/Features/CommandPalette/Views/CommandPaletteOverlayView.swift
+++ b/supacode/Features/CommandPalette/Views/CommandPaletteOverlayView.swift
@@ -348,7 +348,7 @@ private struct CommandPaletteRowView: View {
   private var badge: String? {
     switch row.kind {
     case .checkForUpdates, .openRepository, .openSettings, .newWorktree, .viewArchivedWorktrees,
-      .refreshWorktrees, .installCLI, .ghosttyCommand,
+      .refreshWorktrees, .installCLI, .jumpToLatestUnread, .ghosttyCommand,
       .openPullRequest, .openRepositoryOnCodeHost, .markPullRequestReady, .mergePullRequest, .closePullRequest,
       .copyFailingJobURL,
       .copyCiFailureLogs,
@@ -379,6 +379,8 @@ private struct CommandPaletteRowView: View {
       return "archivebox"
     case .refreshWorktrees:
       return "arrow.clockwise"
+    case .jumpToLatestUnread:
+      return "bell.badge"
     case .ghosttyCommand:
       return "terminal"
     case .openPullRequest, .openRepositoryOnCodeHost:
@@ -419,7 +421,7 @@ private struct CommandPaletteRowView: View {
   private var emphasis: Bool {
     switch row.kind {
     case .checkForUpdates, .openRepository, .openSettings, .newWorktree, .viewArchivedWorktrees,
-      .refreshWorktrees, .installCLI, .ghosttyCommand,
+      .refreshWorktrees, .installCLI, .jumpToLatestUnread, .ghosttyCommand,
       .openPullRequest, .openRepositoryOnCodeHost, .markPullRequestReady, .mergePullRequest, .closePullRequest,
       .copyFailingJobURL,
       .copyCiFailureLogs,
@@ -515,6 +517,8 @@ private struct CommandPaletteRowView: View {
       base = "View Archived Worktrees"
     case .refreshWorktrees:
       base = "Refresh Worktrees"
+    case .jumpToLatestUnread:
+      base = "Jump to Latest Unread"
     case .ghosttyCommand:
       base = row.title
     case .removeWorktree:

--- a/supacode/Features/Shelf/Views/ShelfOpenBookView.swift
+++ b/supacode/Features/Shelf/Views/ShelfOpenBookView.swift
@@ -27,10 +27,14 @@ struct ShelfOpenBookView: View {
         TerminalTabContentStack(tabs: state.tabManager.tabs, selectedTabId: selectedId) { tabId in
           TerminalSplitTreeAXContainer(
             tree: state.splitTree(for: tabId),
-            focusedSurfaceID: state.focusedSurfaceId(in: tabId)
-          ) { operation in
-            state.performSplitOperation(operation, in: tabId)
-          }
+            focusedSurfaceID: state.focusedSurfaceId(in: tabId),
+            hasNotification: { surfaceID in
+              state.hasUnseenNotification(forSurfaceID: surfaceID)
+            },
+            action: { operation in
+              state.performSplitOperation(operation, in: tabId)
+            }
+          )
         }
       } else {
         EmptyTerminalPaneView(message: "No terminals open")

--- a/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
+++ b/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
@@ -226,8 +226,8 @@ final class WorktreeTerminalManager {
     state.isSelected = { [weak self] in
       self?.selectedWorktreeID == worktree.id
     }
-    state.onNotificationReceived = { [weak self] title, body in
-      self?.emit(.notificationReceived(worktreeID: worktree.id, title: title, body: body))
+    state.onNotificationReceived = { [weak self] surfaceID, title, body in
+      self?.emit(.notificationReceived(worktreeID: worktree.id, surfaceID: surfaceID, title: title, body: body))
     }
     state.onNotificationIndicatorChanged = { [weak self] in
       self?.emitNotificationIndicatorCountIfNeeded()
@@ -431,6 +431,39 @@ final class WorktreeTerminalManager {
 
   func hasUnseenNotifications(for worktreeID: Worktree.ID) -> Bool {
     states[worktreeID]?.hasUnseenNotification == true
+  }
+
+  func latestUnreadNotificationLocation() -> NotificationLocation? {
+    var bestLocation: NotificationLocation?
+    var bestCreatedAt: Date?
+    for (worktreeID, state) in states {
+      for notification in state.unreadNotifications() {
+        if let bestCreatedAt, bestCreatedAt >= notification.createdAt {
+          break
+        }
+        guard let tabID = state.tabID(containing: notification.surfaceId) else {
+          continue
+        }
+        bestLocation = NotificationLocation(
+          worktreeID: worktreeID,
+          tabID: tabID,
+          surfaceID: notification.surfaceId,
+          notificationID: notification.id
+        )
+        bestCreatedAt = notification.createdAt
+        break
+      }
+    }
+    return bestLocation
+  }
+
+  @discardableResult
+  func focusSurface(worktreeID: Worktree.ID, surfaceID: UUID) -> Bool {
+    states[worktreeID]?.focusSurface(id: surfaceID) == true
+  }
+
+  func markNotificationRead(worktreeID: Worktree.ID, notificationID: UUID) {
+    states[worktreeID]?.markNotificationRead(id: notificationID)
   }
 
   func surfaceBackgroundOpacity() -> Double {

--- a/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
+++ b/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
@@ -466,6 +466,10 @@ final class WorktreeTerminalManager {
     states[worktreeID]?.markNotificationRead(id: notificationID)
   }
 
+  func markNotificationsRead(worktreeID: Worktree.ID, surfaceID: UUID) {
+    states[worktreeID]?.markNotificationsRead(forSurfaceID: surfaceID)
+  }
+
   func surfaceBackgroundOpacity() -> Double {
     runtime?.backgroundOpacity() ?? 1.0
   }

--- a/supacode/Features/Terminal/Models/NotificationLocation.swift
+++ b/supacode/Features/Terminal/Models/NotificationLocation.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+struct NotificationLocation: Equatable, Sendable {
+  let worktreeID: Worktree.ID
+  let tabID: TerminalTabID
+  let surfaceID: UUID
+  let notificationID: UUID
+}

--- a/supacode/Features/Terminal/Models/WorktreeTerminalNotification.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalNotification.swift
@@ -5,13 +5,22 @@ struct WorktreeTerminalNotification: Identifiable, Equatable, Sendable {
   let surfaceId: UUID
   let title: String
   let body: String
+  let createdAt: Date
   var isRead: Bool
 
-  init(id: UUID = UUID(), surfaceId: UUID, title: String, body: String, isRead: Bool = false) {
+  init(
+    id: UUID = UUID(),
+    surfaceId: UUID,
+    title: String,
+    body: String,
+    createdAt: Date = .distantPast,
+    isRead: Bool = false
+  ) {
     self.id = id
     self.surfaceId = surfaceId
     self.title = title
     self.body = body
+    self.createdAt = createdAt
     self.isRead = isRead
   }
 

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -65,9 +65,22 @@ final class WorktreeTerminalState {
     notifications.contains { !$0.isRead }
   }
 
+  func hasUnseenNotification(forSurfaceID surfaceID: UUID) -> Bool {
+    notifications.contains { !$0.isRead && $0.surfaceId == surfaceID }
+  }
+
   func hasUnseenNotification(for tabId: TerminalTabID) -> Bool {
     let surfaceIds = trees[tabId]?.leaves().map(\.id) ?? []
     return notifications.contains { !$0.isRead && surfaceIds.contains($0.surfaceId) }
+  }
+
+  func unreadNotifications() -> [WorktreeTerminalNotification] {
+    notifications.filter { !$0.isRead }.sorted { left, right in
+      if left.createdAt != right.createdAt {
+        return left.createdAt > right.createdAt
+      }
+      return left.id.uuidString > right.id.uuidString
+    }
   }
 
   var canCloseFocusedTab: Bool {
@@ -84,7 +97,7 @@ final class WorktreeTerminalState {
   }
 
   var isSelected: () -> Bool = { false }
-  var onNotificationReceived: ((String, String) -> Void)?
+  var onNotificationReceived: ((UUID, String, String) -> Void)?
   var onNotificationIndicatorChanged: (() -> Void)?
   var onTabCreated: (() -> Void)?
   var onTabClosed: (() -> Void)?
@@ -943,6 +956,15 @@ final class WorktreeTerminalState {
     emitNotificationIndicatorIfNeeded(previousHasUnseen: previousHasUnseen)
   }
 
+  func markNotificationRead(id notificationID: WorktreeTerminalNotification.ID) {
+    let previousHasUnseen = hasUnseenNotification
+    guard let index = notifications.firstIndex(where: { $0.id == notificationID }) else {
+      return
+    }
+    notifications[index].isRead = true
+    emitNotificationIndicatorIfNeeded(previousHasUnseen: previousHasUnseen)
+  }
+
   func dismissNotification(_ notificationID: WorktreeTerminalNotification.ID) {
     let previousHasUnseen = hasUnseenNotification
     notifications.removeAll { $0.id == notificationID }
@@ -1300,13 +1322,14 @@ final class WorktreeTerminalState {
           surfaceId: surfaceId,
           title: trimmedTitle,
           body: trimmedBody,
+          createdAt: Date(),
           isRead: isRead
         ),
         at: 0
       )
       emitNotificationIndicatorIfNeeded(previousHasUnseen: previousHasUnseen)
     }
-    onNotificationReceived?(trimmedTitle, trimmedBody)
+    onNotificationReceived?(surfaceId, trimmedTitle, trimmedBody)
   }
 
   /// How recently the user must have typed for us to consider the exit user-initiated.
@@ -1585,11 +1608,15 @@ final class WorktreeTerminalState {
     tabIsRunningById.removeValue(forKey: tabId)
   }
 
-  private func tabId(containing surfaceId: UUID) -> TerminalTabID? {
+  func tabID(containing surfaceId: UUID) -> TerminalTabID? {
     for (tabId, tree) in trees where tree.find(id: surfaceId) != nil {
       return tabId
     }
     return nil
+  }
+
+  private func tabId(containing surfaceId: UUID) -> TerminalTabID? {
+    tabID(containing: surfaceId)
   }
 
   private func isFocusedSurface(_ surfaceId: UUID) -> Bool {

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabBarView.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabBarView.swift
@@ -12,6 +12,7 @@ struct TerminalTabBarView: View {
   let closeOthers: (TerminalTabID) -> Void
   let closeToRight: (TerminalTabID) -> Void
   let closeAll: () -> Void
+  let hasNotification: (TerminalTabID) -> Bool
   @Environment(\.controlActiveState)
   private var activeState
 
@@ -24,7 +25,8 @@ struct TerminalTabBarView: View {
         closeTab: closeTab,
         closeOthers: closeOthers,
         closeToRight: closeToRight,
-        closeAll: closeAll
+        closeAll: closeAll,
+        hasNotification: hasNotification
       )
       Spacer(minLength: 0)
       TerminalTabBarTrailingAccessories(

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabView.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabView.swift
@@ -7,6 +7,7 @@ struct TerminalTabView: View {
   let isDragging: Bool
   let tabIndex: Int
   let fixedWidth: CGFloat?
+  let hasNotification: Bool
   let onSelect: () -> Void
   let onClose: () -> Void
   @Binding var closeButtonGestureActive: Bool
@@ -41,14 +42,21 @@ struct TerminalTabView: View {
       .help("Open tab \(tab.title)")
       .accessibilityLabel(tab.title)
 
-      TerminalTabCloseButton(
-        isHoveringTab: isHovering,
-        isDragging: isDragging,
-        isShowingShortcutHint: showsShortcutHint,
-        closeAction: onClose,
-        closeButtonGestureActive: $closeButtonGestureActive,
-        isHoveringClose: $isHoveringClose
-      )
+      ZStack {
+        TabNotificationDot()
+          .opacity(isShowingNotificationDot ? 1 : 0)
+          .allowsHitTesting(false)
+        TerminalTabCloseButton(
+          isHoveringTab: isHovering,
+          isDragging: isDragging,
+          isShowingShortcutHint: showsShortcutHint,
+          closeAction: onClose,
+          closeButtonGestureActive: $closeButtonGestureActive,
+          isHoveringClose: $isHoveringClose
+        )
+      }
+      .animation(.easeInOut(duration: TerminalTabBarMetrics.hoverAnimationDuration), value: isHovering)
+      .animation(.easeInOut(duration: 0.2), value: hasNotification)
       .padding(.trailing, TerminalTabBarMetrics.tabHorizontalPadding)
     }
     .background {
@@ -79,6 +87,20 @@ struct TerminalTabView: View {
 
   private var showsShortcutHint: Bool {
     commandKeyObserver.isPressed && shortcutHint != nil
+  }
+
+  private var isShowingNotificationDot: Bool {
+    hasNotification && !isHovering && !isHoveringClose && !isDragging && !showsShortcutHint
+  }
+}
+
+private struct TabNotificationDot: View {
+  var body: some View {
+    Circle()
+      .fill(.orange)
+      .frame(width: 6, height: 6)
+      .frame(width: TerminalTabBarMetrics.closeButtonSize, height: TerminalTabBarMetrics.closeButtonSize)
+      .accessibilityLabel("Unread notifications")
   }
 }
 

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabsRowView.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabsRowView.swift
@@ -8,6 +8,7 @@ struct TerminalTabsRowView: View {
   @Binding var draggingStartLocation: CGFloat?
   @Binding var closeButtonGestureActive: Bool
   let fixedTabWidth: CGFloat?
+  let hasNotification: (TerminalTabID) -> Bool
   let changeTitle: (TerminalTabID) -> Void
   let changeIcon: (TerminalTabID) -> Void
   let closeTab: (TerminalTabID) -> Void
@@ -30,6 +31,7 @@ struct TerminalTabsRowView: View {
               isDragging: draggingTabId == id,
               tabIndex: index,
               fixedWidth: fixedTabWidth,
+              hasNotification: hasNotification(id),
               onSelect: {
                 manager.selectTab(id)
               },

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabsView.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabsView.swift
@@ -8,6 +8,7 @@ struct TerminalTabsView: View {
   let closeOthers: (TerminalTabID) -> Void
   let closeToRight: (TerminalTabID) -> Void
   let closeAll: () -> Void
+  let hasNotification: (TerminalTabID) -> Bool
 
   @State private var draggingTabId: TerminalTabID?
   @State private var draggingStartLocation: CGFloat?
@@ -30,6 +31,7 @@ struct TerminalTabsView: View {
             draggingStartLocation: $draggingStartLocation,
             closeButtonGestureActive: $closeButtonGestureActive,
             fixedTabWidth: effectiveTabWidth,
+            hasNotification: hasNotification,
             changeTitle: changeTitle,
             changeIcon: changeIcon,
             closeTab: closeTab,

--- a/supacode/Features/Terminal/Views/TerminalSplitTreeView.swift
+++ b/supacode/Features/Terminal/Views/TerminalSplitTreeView.swift
@@ -7,6 +7,7 @@ struct TerminalSplitTreeView: View {
   let tree: SplitTree<GhosttySurfaceView>
   var pinnedSize: CGSize?
   var focusedSurfaceID: UUID?
+  let hasNotification: (UUID) -> Bool
   let action: (Operation) -> Void
 
   private static let dragType = UTType(exportedAs: "com.onevcat.prowl.ghosttySurfaceId")
@@ -30,6 +31,7 @@ struct TerminalSplitTreeView: View {
         isRoot: node == tree.root,
         pinnedSize: pinnedSize,
         focusedSurfaceID: focusedSurfaceID,
+        hasNotification: hasNotification,
         action: action
       )
       .id(node.structuralIdentity)
@@ -47,6 +49,7 @@ struct TerminalSplitTreeView: View {
     var isRoot: Bool = false
     var pinnedSize: CGSize?
     var focusedSurfaceID: UUID?
+    let hasNotification: (UUID) -> Bool
     let action: (Operation) -> Void
 
     var body: some View {
@@ -56,6 +59,7 @@ struct TerminalSplitTreeView: View {
           surfaceView: leafView,
           isSplit: !isRoot,
           isFocused: leafView.id == focusedSurfaceID,
+          hasNotification: hasNotification(leafView.id),
           pinnedSize: pinnedSize,
           action: action
         )
@@ -85,6 +89,7 @@ struct TerminalSplitTreeView: View {
               node: split.left,
               pinnedSize: leftPinned,
               focusedSurfaceID: focusedSurfaceID,
+              hasNotification: hasNotification,
               action: action
             )
           },
@@ -93,6 +98,7 @@ struct TerminalSplitTreeView: View {
               node: split.right,
               pinnedSize: rightPinned,
               focusedSurfaceID: focusedSurfaceID,
+              hasNotification: hasNotification,
               action: action
             )
           },
@@ -119,6 +125,7 @@ struct TerminalSplitTreeView: View {
     let surfaceView: GhosttySurfaceView
     let isSplit: Bool
     var isFocused: Bool = true
+    let hasNotification: Bool
     var pinnedSize: CGSize?
     let action: (Operation) -> Void
 
@@ -156,6 +163,13 @@ struct TerminalSplitTreeView: View {
             if surfaceView.bridge.state.searchNeedle != nil {
               GhosttySurfaceSearchOverlay(surfaceView: surfaceView)
             }
+          }
+          .overlay(alignment: .topTrailing) {
+            SurfaceNotificationDot()
+              .padding(6)
+              .opacity(hasNotification ? 1 : 0)
+              .allowsHitTesting(false)
+              .animation(.easeInOut(duration: 0.2), value: hasNotification)
           }
           .overlay(alignment: .top) {
             if isSplit {
@@ -340,6 +354,18 @@ struct TerminalSplitTreeView: View {
   }
 }
 
+private struct SurfaceNotificationDot: View {
+  var body: some View {
+    Circle()
+      .fill(.orange)
+      .frame(width: 8, height: 8)
+      .overlay {
+        Circle().stroke(.background, lineWidth: 1)
+      }
+      .accessibilityLabel("Unread notifications")
+  }
+}
+
 // MARK: - Accessibility Container
 
 /// Wraps the SwiftUI split tree in an AppKit view so we can expose an ordered
@@ -347,6 +373,7 @@ struct TerminalSplitTreeView: View {
 struct TerminalSplitTreeAXContainer: NSViewRepresentable {
   let tree: SplitTree<GhosttySurfaceView>
   var focusedSurfaceID: UUID?
+  let hasNotification: (UUID) -> Bool
   let action: (TerminalSplitTreeView.Operation) -> Void
 
   func makeNSView(context: Context) -> TerminalSplitAXContainerView {
@@ -359,6 +386,7 @@ struct TerminalSplitTreeAXContainer: NSViewRepresentable {
         TerminalSplitTreeView(
           tree: tree,
           focusedSurfaceID: focusedSurfaceID,
+          hasNotification: hasNotification,
           action: action
         )
       ),

--- a/supacode/Features/Terminal/Views/WorktreeTerminalTabsView.swift
+++ b/supacode/Features/Terminal/Views/WorktreeTerminalTabsView.swift
@@ -39,16 +39,23 @@ struct WorktreeTerminalTabsView: View {
         },
         closeAll: {
           state.closeAllTabs()
+        },
+        hasNotification: { tabId in
+          state.hasUnseenNotification(for: tabId)
         }
       )
       if let selectedId = state.tabManager.selectedTabId {
         TerminalTabContentStack(tabs: state.tabManager.tabs, selectedTabId: selectedId) { tabId in
           TerminalSplitTreeAXContainer(
             tree: state.splitTree(for: tabId),
-            focusedSurfaceID: state.focusedSurfaceId(in: tabId)
-          ) { operation in
-            state.performSplitOperation(operation, in: tabId)
-          }
+            focusedSurfaceID: state.focusedSurfaceId(in: tabId),
+            hasNotification: { surfaceID in
+              state.hasUnseenNotification(forSurfaceID: surfaceID)
+            },
+            action: { operation in
+              state.performSplitOperation(operation, in: tabId)
+            }
+          )
         }
       } else {
         EmptyTerminalPaneView(message: "No terminals open")

--- a/supacodeTests/AppFeatureCommandPaletteTests.swift
+++ b/supacodeTests/AppFeatureCommandPaletteTests.swift
@@ -79,6 +79,15 @@ struct AppFeatureCommandPaletteTests {
     await store.receive(\.updates.checkForUpdates)
   }
 
+  @Test(.dependencies) func jumpToLatestUnreadDispatchesAppAction() async {
+    let store = TestStore(initialState: AppFeature.State()) {
+      AppFeature()
+    }
+
+    await store.send(.commandPalette(.delegate(.jumpToLatestUnread)))
+    await store.receive(\.jumpToLatestUnread)
+  }
+
   @Test(.dependencies) func ghosttyCommandDispatchesBindingActionToTerminalClient() async {
     let worktree = makeWorktree(
       id: "/tmp/repo-ghostty/wt-1",

--- a/supacodeTests/AppFeatureJumpToLatestUnreadTests.swift
+++ b/supacodeTests/AppFeatureJumpToLatestUnreadTests.swift
@@ -58,6 +58,7 @@ struct AppFeatureJumpToLatestUnreadTests {
     var repositoriesState = RepositoriesFeature.State(repositories: [repository])
     repositoriesState.snapshotPersistencePhase = .active
     let focusedSurfaces = LockIsolated<[(Worktree.ID, UUID)]>([])
+    let readSurfaces = LockIsolated<[(Worktree.ID, UUID)]>([])
     let store = TestStore(
       initialState: AppFeature.State(repositories: repositoriesState)
     ) {
@@ -66,6 +67,9 @@ struct AppFeatureJumpToLatestUnreadTests {
       $0.terminalClient.focusSurface = { worktreeID, targetSurfaceID in
         focusedSurfaces.withValue { $0.append((worktreeID, targetSurfaceID)) }
         return true
+      }
+      $0.terminalClient.markNotificationsReadForSurface = { worktreeID, targetSurfaceID in
+        readSurfaces.withValue { $0.append((worktreeID, targetSurfaceID)) }
       }
     }
     store.exhaustivity = .off
@@ -77,6 +81,7 @@ struct AppFeatureJumpToLatestUnreadTests {
     await store.finish()
 
     #expect(focusedSurfaces.value.map { "\($0.0)|\($0.1.uuidString)" } == ["\(worktree.id)|\(surfaceID.uuidString)"])
+    #expect(readSurfaces.value.map { "\($0.0)|\($0.1.uuidString)" } == ["\(worktree.id)|\(surfaceID.uuidString)"])
   }
 
   private func makeWorktree() -> Worktree {

--- a/supacodeTests/AppFeatureJumpToLatestUnreadTests.swift
+++ b/supacodeTests/AppFeatureJumpToLatestUnreadTests.swift
@@ -1,0 +1,100 @@
+import ComposableArchitecture
+import Foundation
+import IdentifiedCollections
+import Testing
+
+@testable import supacode
+
+@MainActor
+struct AppFeatureJumpToLatestUnreadTests {
+  @Test func jumpToLatestUnreadSelectsWorktreeAndFocusesSurface() async {
+    let worktree = makeWorktree()
+    let repository = makeRepository(worktrees: [worktree])
+    let tabID = TerminalTabID()
+    let surfaceID = UUID()
+    let notificationID = UUID()
+    var repositoriesState = RepositoriesFeature.State(repositories: [repository])
+    repositoriesState.snapshotPersistencePhase = .active
+    let focusedSurfaces = LockIsolated<[(Worktree.ID, UUID)]>([])
+    let readNotifications = LockIsolated<[(Worktree.ID, UUID)]>([])
+    let store = TestStore(
+      initialState: AppFeature.State(repositories: repositoriesState)
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.latestUnreadNotification = {
+        NotificationLocation(
+          worktreeID: worktree.id,
+          tabID: tabID,
+          surfaceID: surfaceID,
+          notificationID: notificationID
+        )
+      }
+      $0.terminalClient.focusSurface = { worktreeID, targetSurfaceID in
+        focusedSurfaces.withValue { $0.append((worktreeID, targetSurfaceID)) }
+        return true
+      }
+      $0.terminalClient.markNotificationRead = { worktreeID, targetNotificationID in
+        readNotifications.withValue { $0.append((worktreeID, targetNotificationID)) }
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.jumpToLatestUnread)
+    await store.receive(\.repositories.selectWorktree) {
+      $0.repositories.selection = .worktree(worktree.id)
+    }
+    await store.finish()
+
+    #expect(focusedSurfaces.value.map { "\($0.0)|\($0.1.uuidString)" } == ["\(worktree.id)|\(surfaceID.uuidString)"])
+    #expect(
+      readNotifications.value.map { "\($0.0)|\($0.1.uuidString)" } == ["\(worktree.id)|\(notificationID.uuidString)"])
+  }
+
+  @Test func systemNotificationTappedSelectsWorktreeAndFocusesSurface() async {
+    let worktree = makeWorktree()
+    let repository = makeRepository(worktrees: [worktree])
+    let surfaceID = UUID()
+    var repositoriesState = RepositoriesFeature.State(repositories: [repository])
+    repositoriesState.snapshotPersistencePhase = .active
+    let focusedSurfaces = LockIsolated<[(Worktree.ID, UUID)]>([])
+    let store = TestStore(
+      initialState: AppFeature.State(repositories: repositoriesState)
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.focusSurface = { worktreeID, targetSurfaceID in
+        focusedSurfaces.withValue { $0.append((worktreeID, targetSurfaceID)) }
+        return true
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.systemNotificationTapped(worktreeID: worktree.id, surfaceID: surfaceID))
+    await store.receive(\.repositories.selectWorktree) {
+      $0.repositories.selection = .worktree(worktree.id)
+    }
+    await store.finish()
+
+    #expect(focusedSurfaces.value.map { "\($0.0)|\($0.1.uuidString)" } == ["\(worktree.id)|\(surfaceID.uuidString)"])
+  }
+
+  private func makeWorktree() -> Worktree {
+    Worktree(
+      id: "/tmp/repo/wt-1",
+      name: "wt-1",
+      detail: "",
+      workingDirectory: URL(fileURLWithPath: "/tmp/repo/wt-1"),
+      repositoryRootURL: URL(fileURLWithPath: "/tmp/repo")
+    )
+  }
+
+  private func makeRepository(worktrees: [Worktree]) -> Repository {
+    Repository(
+      id: "/tmp/repo",
+      rootURL: URL(fileURLWithPath: "/tmp/repo"),
+      name: "repo",
+      worktrees: IdentifiedArray(uniqueElements: worktrees)
+    )
+  }
+}

--- a/supacodeTests/AppFeatureSystemNotificationTests.swift
+++ b/supacodeTests/AppFeatureSystemNotificationTests.swift
@@ -5,6 +5,13 @@ import Testing
 
 @testable import supacode
 
+private struct SystemNotificationSend: Equatable {
+  let title: String
+  let body: String
+  let worktreeID: Worktree.ID?
+  let surfaceID: UUID?
+}
+
 @MainActor
 struct AppFeatureSystemNotificationTests {
   @Test(.dependencies) func firstTimeDeniedTurnsSystemNotificationsBackOffWithAlert() async {
@@ -118,7 +125,8 @@ struct AppFeatureSystemNotificationTests {
   @Test(.dependencies) func notificationReceivedSendsSystemNotificationWhenEnabled() async {
     var globalSettings = GlobalSettings.default
     globalSettings.systemNotificationsEnabled = true
-    let sends = LockIsolated<[(String, String)]>([])
+    let surfaceID = UUID()
+    let sends = LockIsolated<[SystemNotificationSend]>([])
     let store = TestStore(
       initialState: AppFeature.State(
         settings: SettingsFeature.State(settings: globalSettings)
@@ -126,8 +134,17 @@ struct AppFeatureSystemNotificationTests {
     ) {
       AppFeature()
     } withDependencies: {
-      $0.systemNotificationClient.send = { title, body in
-        sends.withValue { $0.append((title, body)) }
+      $0.systemNotificationClient.send = { title, body, worktreeID, targetSurfaceID in
+        sends.withValue {
+          $0.append(
+            SystemNotificationSend(
+              title: title,
+              body: body,
+              worktreeID: worktreeID,
+              surfaceID: targetSurfaceID
+            )
+          )
+        }
       }
     }
     store.exhaustivity = .off
@@ -136,6 +153,7 @@ struct AppFeatureSystemNotificationTests {
       .terminalEvent(
         .notificationReceived(
           worktreeID: "/tmp/repo/wt-1",
+          surfaceID: surfaceID,
           title: "Done",
           body: "Build succeeded"
         )
@@ -144,8 +162,10 @@ struct AppFeatureSystemNotificationTests {
     await store.finish()
 
     #expect(sends.value.count == 1)
-    #expect(sends.value.first?.0 == "Done")
-    #expect(sends.value.first?.1 == "Build succeeded")
+    #expect(sends.value.first?.title == "Done")
+    #expect(sends.value.first?.body == "Build succeeded")
+    #expect(sends.value.first?.worktreeID == "/tmp/repo/wt-1")
+    #expect(sends.value.first?.surfaceID == surfaceID)
   }
 
   @Test(.dependencies) func notificationReceivedSkipsLocalSoundWhenSystemNotificationsEnabled() async {
@@ -170,6 +190,7 @@ struct AppFeatureSystemNotificationTests {
       .terminalEvent(
         .notificationReceived(
           worktreeID: "/tmp/repo/wt-1",
+          surfaceID: UUID(),
           title: "Done",
           body: "Build succeeded"
         )
@@ -196,7 +217,7 @@ struct AppFeatureSystemNotificationTests {
       $0.notificationSoundClient.play = {
         plays.withValue { $0 += 1 }
       }
-      $0.systemNotificationClient.send = { _, _ in
+      $0.systemNotificationClient.send = { _, _, _, _ in
         sends.withValue { $0 += 1 }
       }
     }
@@ -206,6 +227,7 @@ struct AppFeatureSystemNotificationTests {
       .terminalEvent(
         .notificationReceived(
           worktreeID: "/tmp/repo/wt-1",
+          surfaceID: UUID(),
           title: "Done",
           body: "Build succeeded"
         )

--- a/supacodeTests/CommandPaletteFeatureTests.swift
+++ b/supacodeTests/CommandPaletteFeatureTests.swift
@@ -16,6 +16,7 @@ struct CommandPaletteFeatureTests {
       "global.open-repository",
       "global.new-worktree",
       "global.refresh-worktrees",
+      "global.jump-to-latest-unread",
       "global.view-archived-worktrees",
       "global.install-cli",
     ]
@@ -27,6 +28,18 @@ struct CommandPaletteFeatureTests {
       ])
     #endif
     expectNoDifference(items.map(\.id), expectedIDs)
+  }
+
+  @Test func commandPaletteItems_includeJumpToLatestUnreadAction() {
+    let items = CommandPaletteFeature.commandPaletteItems(from: RepositoriesFeature.State())
+    let item = items.first { $0.id == "global.jump-to-latest-unread" }
+
+    #expect(item?.title == "Jump to Latest Unread")
+    #expect(item?.kind == .jumpToLatestUnread)
+    #expect(item?.appShortcutCommandID == AppShortcuts.CommandID.jumpToLatestUnread)
+
+    let filtered = CommandPaletteFeature.filterItems(items: items, query: "jump unread")
+    #expect(filtered.first?.id == "global.jump-to-latest-unread")
   }
 
   @Test func commandPaletteItems_skipsPendingAndDeletingWorktrees() {

--- a/supacodeTests/WorktreeTerminalManagerTests.swift
+++ b/supacodeTests/WorktreeTerminalManagerTests.swift
@@ -214,6 +214,99 @@ struct WorktreeTerminalManagerTests {
     #expect(manager.hasUnseenNotifications(for: worktree.id) == false)
   }
 
+  @Test func markNotificationReadOnlyAffectsMatchingID() {
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    let worktree = makeWorktree()
+    let state = manager.state(for: worktree)
+    let notificationA = UUID()
+    let notificationB = UUID()
+    let surfaceID = UUID()
+
+    state.notifications = [
+      makeNotification(id: notificationA, surfaceId: surfaceID, isRead: false),
+      makeNotification(id: notificationB, surfaceId: surfaceID, isRead: false),
+    ]
+
+    state.markNotificationRead(id: notificationB)
+
+    #expect(state.notifications.map(\.isRead) == [false, true])
+    #expect(manager.hasUnseenNotifications(for: worktree.id) == true)
+  }
+
+  @Test func latestUnreadNotificationLocationChoosesNewestFocusableAcrossWorktrees() {
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    let worktreeA = makeWorktree(id: "/tmp/repo/wt-a", name: "wt-a")
+    let worktreeB = makeWorktree(id: "/tmp/repo/wt-b", name: "wt-b")
+    let stateA = manager.state(for: worktreeA)
+    let stateB = manager.state(for: worktreeB)
+    let tabA = stateA.createTab()!
+    let tabB = stateB.createTab()!
+    let surfaceA = stateA.focusedSurfaceId(in: tabA)!
+    let surfaceB = stateB.focusedSurfaceId(in: tabB)!
+    let notificationA = UUID()
+    let notificationB = UUID()
+
+    stateA.notifications = [
+      makeNotification(
+        id: notificationA,
+        surfaceId: surfaceA,
+        createdAt: Date(timeIntervalSince1970: 10),
+        isRead: false
+      )
+    ]
+    stateB.notifications = [
+      makeNotification(
+        id: notificationB,
+        surfaceId: surfaceB,
+        createdAt: Date(timeIntervalSince1970: 20),
+        isRead: false
+      )
+    ]
+
+    #expect(
+      manager.latestUnreadNotificationLocation()
+        == NotificationLocation(
+          worktreeID: worktreeB.id,
+          tabID: tabB,
+          surfaceID: surfaceB,
+          notificationID: notificationB
+        )
+    )
+  }
+
+  @Test func latestUnreadNotificationLocationSkipsClosedSurfaces() {
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    let worktree = makeWorktree()
+    let state = manager.state(for: worktree)
+    let tabID = state.createTab()!
+    let surfaceID = state.focusedSurfaceId(in: tabID)!
+    let focusableNotification = UUID()
+
+    state.notifications = [
+      makeNotification(
+        surfaceId: UUID(),
+        createdAt: Date(timeIntervalSince1970: 20),
+        isRead: false
+      ),
+      makeNotification(
+        id: focusableNotification,
+        surfaceId: surfaceID,
+        createdAt: Date(timeIntervalSince1970: 10),
+        isRead: false
+      ),
+    ]
+
+    #expect(
+      manager.latestUnreadNotificationLocation()
+        == NotificationLocation(
+          worktreeID: worktree.id,
+          tabID: tabID,
+          surfaceID: surfaceID,
+          notificationID: focusableNotification
+        )
+    )
+  }
+
   @Test func setNotificationsDisabledMarksAllRead() {
     let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
     let worktree = makeWorktree()
@@ -314,12 +407,15 @@ struct WorktreeTerminalManagerTests {
     #expect(clearCount.value == 1)
   }
 
-  private func makeWorktree() -> Worktree {
+  private func makeWorktree(
+    id: Worktree.ID = "/tmp/repo/wt-1",
+    name: String = "wt-1"
+  ) -> Worktree {
     Worktree(
-      id: "/tmp/repo/wt-1",
-      name: "wt-1",
+      id: id,
+      name: name,
       detail: "detail",
-      workingDirectory: URL(fileURLWithPath: "/tmp/repo/wt-1"),
+      workingDirectory: URL(fileURLWithPath: id),
       repositoryRootURL: URL(fileURLWithPath: "/tmp/repo")
     )
   }
@@ -335,13 +431,17 @@ struct WorktreeTerminalManagerTests {
   }
 
   private func makeNotification(
+    id: UUID = UUID(),
     surfaceId: UUID = UUID(),
+    createdAt: Date = .distantPast,
     isRead: Bool
   ) -> WorktreeTerminalNotification {
     WorktreeTerminalNotification(
+      id: id,
       surfaceId: surfaceId,
       title: "Title",
       body: "Body",
+      createdAt: createdAt,
       isRead: isRead
     )
   }


### PR DESCRIPTION
## Summary
- add Jump to Latest Unread for the newest unread terminal notification using Cmd-Option-U
- carry source surface IDs through terminal and system notifications, including tap-to-focus support
- show unread dots on terminal tabs and split surfaces, with tests for newest focusable notification lookup

## Verification
- xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -only-testing:supacodeTests/WorktreeTerminalManagerTests -only-testing:supacodeTests/AppFeatureJumpToLatestUnreadTests -only-testing:supacodeTests/AppFeatureSystemNotificationTests -only-testing:supacodeTests/AppShortcutsTests -only-testing:supacodeTests/CommandFinishedNotificationTests -only-testing:supacodeTests/ToolbarNotificationGroupingTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation 2>&1 | xcsift
- make check
- make build-app

Upstream reference: supabitapp/supacode@072ad1e7 (#266)
