### PR TITLE
Align inactive split dimming with Ghostty config

### DIFF
--- a/supacode/Features/Canvas/Views/CanvasCardView.swift
+++ b/supacode/Features/Canvas/Views/CanvasCardView.swift
@@ -16,7 +16,8 @@ struct CanvasCardView: View {
   /// PNG/SVG filenames against the per-repo icons directory.
   var repositoryRootURL: URL?
   let tree: SplitTree<GhosttySurfaceView>
-  let focusedSurfaceID: UUID?
+  let activeSurfaceID: UUID?
+  let unfocusedSplitOverlay: (fill: Color?, opacity: Double)
   let isFocused: Bool
   let isSelected: Bool
   let hasUnseenNotification: Bool
@@ -229,7 +230,8 @@ struct CanvasCardView: View {
     TerminalSplitTreeView(
       tree: tree,
       pinnedSize: cardSize,
-      focusedSurfaceID: focusedSurfaceID,
+      activeSurfaceID: activeSurfaceID,
+      unfocusedSplitOverlay: unfocusedSplitOverlay,
       action: onSplitOperation
     )
     .frame(width: cardSize.width, height: cardSize.height)

--- a/supacode/Features/Canvas/Views/CanvasView.swift
+++ b/supacode/Features/Canvas/Views/CanvasView.swift
@@ -26,6 +26,7 @@ struct CanvasView: View {
   @State private var hasPerformedInitialFit = false
   @State private var viewportSize: CGSize = .zero
   @State private var showsCanvasHelp = false
+  @State private var configReloadCounter = 0
 
   private let minCardWidth: CGFloat = 300
   private let minCardHeight: CGFloat = 200
@@ -43,6 +44,7 @@ struct CanvasView: View {
       for: AppShortcuts.CommandID.selectAllCanvasCards,
       in: resolvedKeybindings
     )
+    let _ = configReloadCounter
     CanvasScrollContainer(
       offset: $canvasOffset,
       lastOffset: $lastCanvasOffset,
@@ -88,6 +90,7 @@ struct CanvasView: View {
               let resized = resizedFrame(for: tab.id, baseLayout: baseLayout)
               let screenCenter = screenPosition(for: resized.center)
               let cardTotalHeight = resized.size.height + titleBarHeight
+              let unfocusedSplitOverlay = terminalManager.unfocusedSplitOverlay()
 
               let repositoryAppearance = appearance(for: state.repositoryRootURL)
               let resolvedRepositoryName = repositoryDisplayName(for: state.repositoryRootURL)
@@ -98,7 +101,8 @@ struct CanvasView: View {
                 repositoryColor: repositoryAppearance.color?.color,
                 repositoryRootURL: state.repositoryRootURL,
                 tree: tree,
-                focusedSurfaceID: state.focusedSurfaceId(in: tab.id),
+                activeSurfaceID: state.activeSurfaceID(for: tab.id),
+                unfocusedSplitOverlay: unfocusedSplitOverlay,
                 isFocused: selectionState.primaryTabID == tab.id,
                 isSelected: selectionState.selectedTabIDs.contains(tab.id),
                 hasUnseenNotification: state.hasUnseenNotification(for: tab.id),
@@ -201,6 +205,9 @@ struct CanvasView: View {
       return .handled
     }
     .task { activateCanvas() }
+    .onReceive(NotificationCenter.default.publisher(for: .ghosttyRuntimeConfigDidChange)) { _ in
+      configReloadCounter &+= 1
+    }
     .onDisappear { deactivateCanvas() }
   }
 

--- a/supacode/Features/Shelf/Views/ShelfOpenBookView.swift
+++ b/supacode/Features/Shelf/Views/ShelfOpenBookView.swift
@@ -19,18 +19,23 @@ struct ShelfOpenBookView: View {
   let forceAutoFocus: Bool
 
   @State private var windowActivity = WindowActivityState.inactive
+  @State private var configReloadCounter = 0
 
   var body: some View {
     let state = manager.state(for: worktree) { shouldRunSetupScript }
+    let _ = configReloadCounter
+    let unfocusedSplitOverlay = manager.unfocusedSplitOverlay()
     Group {
       if let selectedId = state.tabManager.selectedTabId {
         TerminalTabContentStack(tabs: state.tabManager.tabs, selectedTabId: selectedId) { tabId in
           TerminalSplitTreeAXContainer(
             tree: state.splitTree(for: tabId),
-            focusedSurfaceID: state.focusedSurfaceId(in: tabId)
-          ) { operation in
-            state.performSplitOperation(operation, in: tabId)
-          }
+            activeSurfaceID: state.activeSurfaceID(for: tabId),
+            unfocusedSplitOverlay: unfocusedSplitOverlay,
+            action: { operation in
+              state.performSplitOperation(operation, in: tabId)
+            }
+          )
         }
       } else {
         EmptyTerminalPaneView(message: "No terminals open")
@@ -86,6 +91,9 @@ struct ShelfOpenBookView: View {
         let activity = resolvedWindowActivity
         state.syncFocus(windowIsKey: activity.isKeyWindow, windowIsVisible: activity.isVisible)
       }
+    }
+    .onReceive(NotificationCenter.default.publisher(for: .ghosttyRuntimeConfigDidChange)) { _ in
+      configReloadCounter &+= 1
     }
   }
 

--- a/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
+++ b/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Observation
 import Sharing
+import SwiftUI
 
 private let terminalLogger = SupaLogger("Terminal")
 private let layoutRestoreFailureMessage = "Saved terminal layout was invalid and has been reset"
@@ -435,6 +436,11 @@ final class WorktreeTerminalManager {
 
   func surfaceBackgroundOpacity() -> Double {
     runtime?.backgroundOpacity() ?? 1.0
+  }
+
+  func unfocusedSplitOverlay() -> (fill: Color?, opacity: Double) {
+    guard let runtime else { return (nil, 0) }
+    return (runtime.unfocusedSplitFill(), runtime.unfocusedSplitOverlayOpacity())
   }
 
   func syncPreferredFontSize(from worktreeID: Worktree.ID) {

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -576,6 +576,10 @@ final class WorktreeTerminalState {
     focusedSurfaceIdByTab[tabId]
   }
 
+  func activeSurfaceID(for tabId: TerminalTabID) -> UUID? {
+    focusedSurfaceIdByTab[tabId]
+  }
+
   /// Marks a surface so that its next successful `command_finished` event (exit 0)
   /// will trigger a one-shot close of that surface.
   func markSurfaceForAutoClose(_ surfaceId: UUID) {
@@ -1090,10 +1094,7 @@ final class WorktreeTerminalState {
   private func configureSurfaceCallbacks(for view: GhosttySurfaceView, tabId: TerminalTabID) {
     view.onFocusChange = { [weak self, weak view] focused in
       guard let self, let view, focused else { return }
-      self.focusedSurfaceIdByTab[tabId] = view.id
-      self.markNotificationsRead(forSurfaceID: view.id)
-      self.updateTabTitle(for: tabId)
-      self.emitFocusChangedIfNeeded(view.id)
+      self.recordActiveSurface(view, in: tabId)
       self.emitTaskStatusIfChanged()
     }
     view.onKeyInput = { [weak self, weak view] in
@@ -1279,12 +1280,16 @@ final class WorktreeTerminalState {
 
   private func focusSurface(_ surface: GhosttySurfaceView, in tabId: TerminalTabID) {
     let previousSurface = focusedSurfaceIdByTab[tabId].flatMap { surfaces[$0] }
-    focusedSurfaceIdByTab[tabId] = surface.id
-    markNotificationsRead(forSurfaceID: surface.id)
-    updateTabTitle(for: tabId)
+    recordActiveSurface(surface, in: tabId)
     guard tabId == tabManager.selectedTabId else { return }
     let fromSurface = (previousSurface === surface) ? nil : previousSurface
     GhosttySurfaceView.moveFocus(to: surface, from: fromSurface)
+  }
+
+  private func recordActiveSurface(_ surface: GhosttySurfaceView, in tabId: TerminalTabID) {
+    focusedSurfaceIdByTab[tabId] = surface.id
+    markNotificationsRead(forSurfaceID: surface.id)
+    updateTabTitle(for: tabId)
     emitFocusChangedIfNeeded(surface.id)
   }
 

--- a/supacode/Features/Terminal/Views/TerminalSplitTreeView.swift
+++ b/supacode/Features/Terminal/Views/TerminalSplitTreeView.swift
@@ -6,7 +6,8 @@ import UniformTypeIdentifiers
 struct TerminalSplitTreeView: View {
   let tree: SplitTree<GhosttySurfaceView>
   var pinnedSize: CGSize?
-  var focusedSurfaceID: UUID?
+  var activeSurfaceID: UUID?
+  var unfocusedSplitOverlay: (fill: Color?, opacity: Double)
   let action: (Operation) -> Void
 
   private static let dragType = UTType(exportedAs: "com.onevcat.prowl.ghosttySurfaceId")
@@ -29,7 +30,8 @@ struct TerminalSplitTreeView: View {
         node: node,
         isRoot: node == tree.root,
         pinnedSize: pinnedSize,
-        focusedSurfaceID: focusedSurfaceID,
+        activeSurfaceID: activeSurfaceID,
+        unfocusedSplitOverlay: unfocusedSplitOverlay,
         action: action
       )
       .id(node.structuralIdentity)
@@ -46,7 +48,8 @@ struct TerminalSplitTreeView: View {
     let node: SplitTree<GhosttySurfaceView>.Node
     var isRoot: Bool = false
     var pinnedSize: CGSize?
-    var focusedSurfaceID: UUID?
+    var activeSurfaceID: UUID?
+    var unfocusedSplitOverlay: (fill: Color?, opacity: Double)
     let action: (Operation) -> Void
 
     var body: some View {
@@ -55,7 +58,8 @@ struct TerminalSplitTreeView: View {
         LeafView(
           surfaceView: leafView,
           isSplit: !isRoot,
-          isFocused: leafView.id == focusedSurfaceID,
+          isFocused: leafView.id == activeSurfaceID,
+          unfocusedSplitOverlay: unfocusedSplitOverlay,
           pinnedSize: pinnedSize,
           action: action
         )
@@ -84,7 +88,8 @@ struct TerminalSplitTreeView: View {
             SubtreeView(
               node: split.left,
               pinnedSize: leftPinned,
-              focusedSurfaceID: focusedSurfaceID,
+              activeSurfaceID: activeSurfaceID,
+              unfocusedSplitOverlay: unfocusedSplitOverlay,
               action: action
             )
           },
@@ -92,7 +97,8 @@ struct TerminalSplitTreeView: View {
             SubtreeView(
               node: split.right,
               pinnedSize: rightPinned,
-              focusedSurfaceID: focusedSurfaceID,
+              activeSurfaceID: activeSurfaceID,
+              unfocusedSplitOverlay: unfocusedSplitOverlay,
               action: action
             )
           },
@@ -119,22 +125,19 @@ struct TerminalSplitTreeView: View {
     let surfaceView: GhosttySurfaceView
     let isSplit: Bool
     var isFocused: Bool = true
+    var unfocusedSplitOverlay: (fill: Color?, opacity: Double)
     var pinnedSize: CGSize?
     let action: (Operation) -> Void
 
     @State private var dropState: DropState = .idle
     @Shared(.settingsFile) private var settingsFile: SettingsFile
-    @Environment(\.colorScheme) private var colorScheme
 
     private var shouldDim: Bool {
-      isSplit && !isFocused && settingsFile.global.dimUnfocusedSplits
-    }
-
-    /// Lighter tint in light mode so the inactive pane reads as faded
-    /// rather than washed in grey; dark mode's deeper tint matches the
-    /// effect users see in Ghostty.app.
-    private var dimOpacity: Double {
-      colorScheme == .dark ? 0.3 : 0.12
+      isSplit
+        && !isFocused
+        && settingsFile.global.dimUnfocusedSplits
+        && unfocusedSplitOverlay.fill != nil
+        && unfocusedSplitOverlay.opacity > 0
     }
 
     var body: some View {
@@ -142,10 +145,8 @@ struct TerminalSplitTreeView: View {
         GhosttyTerminalView(surfaceView: surfaceView, pinnedSize: pinnedSize)
           .frame(maxWidth: .infinity, maxHeight: .infinity)
           .overlay {
-            // Mirrors Ghostty's `unfocused-split-fill`/`unfocused-split-opacity`:
-            // a translucent black tint fades the inactive pane.
-            Color.black
-              .opacity(shouldDim ? dimOpacity : 0)
+            unfocusedSplitOverlay.fill
+              .opacity(shouldDim ? unfocusedSplitOverlay.opacity : 0)
               .allowsHitTesting(false)
               .animation(.easeOut(duration: 0.12), value: shouldDim)
           }
@@ -346,7 +347,8 @@ struct TerminalSplitTreeView: View {
 /// list of terminal panes to assistive technologies.
 struct TerminalSplitTreeAXContainer: NSViewRepresentable {
   let tree: SplitTree<GhosttySurfaceView>
-  var focusedSurfaceID: UUID?
+  var activeSurfaceID: UUID?
+  var unfocusedSplitOverlay: (fill: Color?, opacity: Double)
   let action: (TerminalSplitTreeView.Operation) -> Void
 
   func makeNSView(context: Context) -> TerminalSplitAXContainerView {
@@ -358,7 +360,8 @@ struct TerminalSplitTreeAXContainer: NSViewRepresentable {
       rootView: AnyView(
         TerminalSplitTreeView(
           tree: tree,
-          focusedSurfaceID: focusedSurfaceID,
+          activeSurfaceID: activeSurfaceID,
+          unfocusedSplitOverlay: unfocusedSplitOverlay,
           action: action
         )
       ),

--- a/supacode/Features/Terminal/Views/WorktreeTerminalTabsView.swift
+++ b/supacode/Features/Terminal/Views/WorktreeTerminalTabsView.swift
@@ -8,9 +8,12 @@ struct WorktreeTerminalTabsView: View {
   let forceAutoFocus: Bool
   let createTab: () -> Void
   @State private var windowActivity = WindowActivityState.inactive
+  @State private var configReloadCounter = 0
 
   var body: some View {
     let state = manager.state(for: worktree) { shouldRunSetupScript }
+    let _ = configReloadCounter
+    let unfocusedSplitOverlay = manager.unfocusedSplitOverlay()
     VStack(spacing: 0) {
       TerminalTabBarView(
         manager: state.tabManager,
@@ -45,10 +48,12 @@ struct WorktreeTerminalTabsView: View {
         TerminalTabContentStack(tabs: state.tabManager.tabs, selectedTabId: selectedId) { tabId in
           TerminalSplitTreeAXContainer(
             tree: state.splitTree(for: tabId),
-            focusedSurfaceID: state.focusedSurfaceId(in: tabId)
-          ) { operation in
-            state.performSplitOperation(operation, in: tabId)
-          }
+            activeSurfaceID: state.activeSurfaceID(for: tabId),
+            unfocusedSplitOverlay: unfocusedSplitOverlay,
+            action: { operation in
+              state.performSplitOperation(operation, in: tabId)
+            }
+          )
         }
       } else {
         EmptyTerminalPaneView(message: "No terminals open")
@@ -93,6 +98,9 @@ struct WorktreeTerminalTabsView: View {
       }
       let activity = resolvedWindowActivity
       state.syncFocus(windowIsKey: activity.isKeyWindow, windowIsVisible: activity.isVisible)
+    }
+    .onReceive(NotificationCenter.default.publisher(for: .ghosttyRuntimeConfigDidChange)) { _ in
+      configReloadCounter &+= 1
     }
   }
 

--- a/supacode/Infrastructure/Ghostty/GhosttyRuntime.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttyRuntime.swift
@@ -943,6 +943,31 @@ final class GhosttyRuntime {
     return min(max(value, 0.001), 1)
   }
 
+  func unfocusedSplitOverlayOpacity() -> Double {
+    guard let config else { return 0 }
+    var value: Double = 0.85
+    let key = "unfocused-split-opacity"
+    _ = ghostty_config_get(config, &value, key, UInt(key.lengthOfBytes(using: .utf8)))
+    return min(max(1 - value, 0), 1)
+  }
+
+  func unfocusedSplitFill() -> Color? {
+    guard let config else { return nil }
+    var color = ghostty_config_color_s()
+    let fillKey = "unfocused-split-fill"
+    if ghostty_config_get(config, &color, fillKey, UInt(fillKey.lengthOfBytes(using: .utf8))) {
+      return Color(nsColor: NSColor(ghostty: color))
+    }
+    let backgroundKey = "background"
+    if ghostty_config_get(config, &color, backgroundKey, UInt(backgroundKey.lengthOfBytes(using: .utf8))) {
+      return Color(nsColor: NSColor(ghostty: color))
+    }
+    ghosttyLogger.warning(
+      "Ghostty config missing both 'unfocused-split-fill' and 'background'; skipping unfocused split overlay."
+    )
+    return nil
+  }
+
   func backgroundColor() -> NSColor {
     backgroundColorFromConfig() ?? NSColor.windowBackgroundColor
   }

--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
@@ -1463,10 +1463,12 @@ final class GhosttySurfaceView: NSView, Identifiable {
       }
 
       guard !item.keyEquivalent.isEmpty else { continue }
-      guard let itemEquivalent = normalizedKeyEquivalent(
-        key: item.keyEquivalent,
-        modifiers: item.keyEquivalentModifierMask
-      ) else { continue }
+      guard
+        let itemEquivalent = normalizedKeyEquivalent(
+          key: item.keyEquivalent,
+          modifiers: item.keyEquivalentModifierMask
+        )
+      else { continue }
       if eventEquivalents.contains(where: { $0 == itemEquivalent }) {
         return true
       }

--- a/supacodeTests/SplitTreeTests.swift
+++ b/supacodeTests/SplitTreeTests.swift
@@ -5,6 +5,39 @@ import Testing
 
 @MainActor
 struct SplitTreeTests {
+  @Test func activeSurfaceTracksClickAndGotoSplitPaths() throws {
+    let state = makeWorktreeTerminalState()
+    let tabId = try #require(state.createTab())
+    let firstID = try #require(state.focusedSurfaceId(in: tabId))
+    let first = try #require(state.surfaceView(for: firstID))
+
+    #expect(state.performSplitAction(.newSplit(direction: .right), for: firstID))
+    let secondID = try #require(state.focusedSurfaceId(in: tabId))
+    let second = try #require(state.surfaceView(for: secondID))
+
+    var emissions: [UUID] = []
+    state.onFocusChanged = { emissions.append($0) }
+
+    #expect(state.activeSurfaceID(for: tabId) == second.id)
+
+    first.onFocusChange?(true)
+    #expect(state.activeSurfaceID(for: tabId) == first.id)
+
+    first.onFocusChange?(true)
+    #expect(state.activeSurfaceID(for: tabId) == first.id)
+
+    #expect(state.performSplitAction(.gotoSplit(direction: .next), for: first.id))
+    #expect(state.activeSurfaceID(for: tabId) == second.id)
+
+    #expect(state.focusSurface(id: second.id))
+    #expect(state.activeSurfaceID(for: tabId) == second.id)
+
+    second.onFocusChange?(false)
+    #expect(state.activeSurfaceID(for: tabId) == second.id)
+
+    #expect(emissions == [first.id, second.id])
+  }
+
   @Test func focusTargetAfterClosingUsesNextForLeftmostLeaf() throws {
     let first = SplitTreeTestView()
     let second = SplitTreeTestView()
@@ -43,6 +76,19 @@ struct SplitTreeTests {
 
     #expect(visibleLeaves.count == 1)
     #expect(visibleLeaves.first === second)
+  }
+
+  private func makeWorktreeTerminalState() -> WorktreeTerminalState {
+    WorktreeTerminalState(
+      runtime: GhosttyRuntime(),
+      worktree: Worktree(
+        id: "/tmp/repo/wt-1",
+        name: "wt-1",
+        detail: "",
+        workingDirectory: URL(fileURLWithPath: "/tmp/repo/wt-1"),
+        repositoryRootURL: URL(fileURLWithPath: "/tmp/repo")
+      )
+    )
   }
 }
 


### PR DESCRIPTION
## Summary
- route click focus and explicit split focus through a shared active-surface path
- read unfocused split overlay fill and opacity from Ghostty runtime config instead of hardcoding the tint
- refresh normal tab, Shelf, and Canvas split overlays when Ghostty runtime config changes

## Verification
- xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -only-testing:supacodeTests/SplitTreeTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation 2>&1 | xcsift
- make check
- make build-app

Upstream reference: supabitapp/supacode@4d19b068 (#260)
