### PR TITLE
Add persistent custom tab titles

### DIFF
--- a/supacode/CLIService/TargetResolver.swift
+++ b/supacode/CLIService/TargetResolver.swift
@@ -260,7 +260,7 @@ enum TargetResolutionSnapshotBuilder {
         guard let snapshot else { return nil }
         return TargetResolutionSnapshot.Tab(
           id: tab.id.rawValue,
-          title: tab.title,
+          title: tab.displayTitle,
           selected: tab.id == selectedTabID,
           panes: snapshot.panes,
           focusedPaneID: snapshot.focusedPaneID

--- a/supacode/Features/Canvas/Views/CanvasView.swift
+++ b/supacode/Features/Canvas/Views/CanvasView.swift
@@ -93,7 +93,7 @@ struct CanvasView: View {
               let resolvedRepositoryName = repositoryDisplayName(for: state.repositoryRootURL)
               CanvasCardView(
                 repositoryName: resolvedRepositoryName,
-                worktreeName: tab.title,
+                worktreeName: tab.displayTitle,
                 repositoryIcon: repositoryAppearance.icon,
                 repositoryColor: repositoryAppearance.color?.color,
                 repositoryRootURL: state.repositoryRootURL,

--- a/supacode/Features/Shelf/Views/ShelfSpineView.swift
+++ b/supacode/Features/Shelf/Views/ShelfSpineView.swift
@@ -270,7 +270,7 @@ struct ShelfSpineView: View {
           tabId: tab.id,
           tabs: terminalState.tabManager.tabs,
           actions: TerminalTabContextMenuActions(
-            changeTitle: { terminalState.promptChangeTabTitle($0) },
+            renameTab: { terminalState.promptChangeTabTitle($0) },
             changeIcon: { terminalState.presentIconPicker(for: $0) },
             closeTab: { terminalState.closeTab($0) },
             closeOthers: { terminalState.closeOtherTabs(keeping: $0) },
@@ -449,7 +449,7 @@ private struct ShelfSpineTabSlot: View {
     .onHover { hovering in
       isHovering = hovering
     }
-    .help(tab.title)
+    .help(tab.displayTitle)
   }
 
   /// When ⌘ is held AND this tab has a `Cmd+N` hotkey, swap the icon

--- a/supacode/Features/Terminal/Models/TerminalLayoutSnapshotPayload.swift
+++ b/supacode/Features/Terminal/Models/TerminalLayoutSnapshotPayload.swift
@@ -1,7 +1,8 @@
 import Foundation
 
 nonisolated struct TerminalLayoutSnapshotPayload: Codable, Equatable, Sendable {
-  nonisolated static let currentVersion = 1
+  nonisolated static let currentVersion = 2
+  nonisolated static let minSupportedVersion = 1
   nonisolated static let maxSnapshotFileBytes = 2 * 1024 * 1024
   nonisolated static let maxWorktrees = 128
   nonisolated static let maxTabsPerWorktree = 128
@@ -32,11 +33,47 @@ nonisolated struct TerminalLayoutSnapshotPayload: Codable, Equatable, Sendable {
     guard let payload = try? decoder.decode(Self.self, from: data) else {
       return nil
     }
-    return payload.isValid ? payload : nil
+    let migrated = payload.migratedToCurrentVersion()
+    return migrated.isValid ? migrated : nil
+  }
+
+  /// Upgrade v1 payloads to the current schema.
+  ///
+  /// In v1 the `title` field on `SnapshotTab` doubled as both the live shell
+  /// title (which was frozen on restore) and the user's overridden title — they
+  /// were indistinguishable on disk. After v2 the user override moves to
+  /// `customTitle`, so promoting a v1 `title` to `customTitle` preserves what
+  /// the user actually saw across the upgrade. The downside (a previously
+  /// non-overridden tab now looks "pinned") is something the user can clear via
+  /// the new inline rename.
+  func migratedToCurrentVersion() -> TerminalLayoutSnapshotPayload {
+    guard version < Self.currentVersion else { return self }
+    let migratedWorktrees = worktrees.map { worktree -> SnapshotWorktree in
+      let migratedTabs = worktree.tabs.map { tab -> SnapshotTab in
+        guard tab.customTitle == nil, let title = tab.title else { return tab }
+        return SnapshotTab(
+          tabID: tab.tabID,
+          title: nil,
+          customTitle: title,
+          icon: tab.icon,
+          splitRoot: tab.splitRoot
+        )
+      }
+      return SnapshotWorktree(
+        worktreeID: worktree.worktreeID,
+        selectedTabID: worktree.selectedTabID,
+        tabs: migratedTabs
+      )
+    }
+    return TerminalLayoutSnapshotPayload(
+      version: Self.currentVersion,
+      selectedWorktreeID: selectedWorktreeID,
+      worktrees: migratedWorktrees
+    )
   }
 
   var isValid: Bool {
-    guard version == Self.currentVersion else {
+    guard (Self.minSupportedVersion...Self.currentVersion).contains(version) else {
       return false
     }
     guard !worktrees.isEmpty, worktrees.count <= Self.maxWorktrees else {

--- a/supacode/Features/Terminal/Models/TerminalLayoutSnapshotPayload.swift
+++ b/supacode/Features/Terminal/Models/TerminalLayoutSnapshotPayload.swift
@@ -100,11 +100,29 @@ extension TerminalLayoutSnapshotPayload {
   nonisolated struct SnapshotTab: Codable, Equatable, Sendable {
     let tabID: String
     let title: String?
+    let customTitle: String?
     let icon: String?
     let splitRoot: SnapshotSplitNode
 
+    init(
+      tabID: String,
+      title: String?,
+      customTitle: String? = nil,
+      icon: String?,
+      splitRoot: SnapshotSplitNode
+    ) {
+      self.tabID = tabID
+      self.title = title
+      self.customTitle = customTitle
+      self.icon = icon
+      self.splitRoot = splitRoot
+    }
+
     func isValid(maxSplitNodesPerTab: Int, maxSplitDepth: Int) -> Bool {
       guard hasContent(tabID) else {
+        return false
+      }
+      if let customTitle, !hasContent(customTitle) {
         return false
       }
       var nodeCount = 0

--- a/supacode/Features/Terminal/Models/TerminalTabItem.swift
+++ b/supacode/Features/Terminal/Models/TerminalTabItem.swift
@@ -21,14 +21,18 @@ enum TerminalTabIconLock: Equatable, Sendable {
 struct TerminalTabItem: Identifiable, Equatable, Sendable {
   let id: TerminalTabID
   var title: String
+  var customTitle: String?
   var icon: String?
   var isDirty: Bool
   var isTitleLocked: Bool
   var iconLock: TerminalTabIconLock
 
+  var displayTitle: String { customTitle ?? title }
+
   init(
     id: TerminalTabID = TerminalTabID(),
     title: String,
+    customTitle: String? = nil,
     icon: String?,
     isDirty: Bool = false,
     isTitleLocked: Bool = false,
@@ -36,6 +40,7 @@ struct TerminalTabItem: Identifiable, Equatable, Sendable {
   ) {
     self.id = id
     self.title = title
+    self.customTitle = customTitle
     self.icon = icon
     self.isDirty = isDirty
     self.isTitleLocked = isTitleLocked

--- a/supacode/Features/Terminal/Models/TerminalTabManager.swift
+++ b/supacode/Features/Terminal/Models/TerminalTabManager.swift
@@ -1,10 +1,17 @@
+import Foundation
 import Observation
 
 @MainActor
 @Observable
 final class TerminalTabManager {
-  var tabs: [TerminalTabItem] = []
+  var tabs: [TerminalTabItem] = [] {
+    didSet {
+      guard let editingTabID, !tabs.contains(where: { $0.id == editingTabID }) else { return }
+      self.editingTabID = nil
+    }
+  }
   var selectedTabId: TerminalTabID?
+  private(set) var editingTabID: TerminalTabID?
 
   func createTab(title: String, icon: String?, isTitleLocked: Bool = false) -> TerminalTabID {
     let tab = TerminalTabItem(title: title, icon: icon, isTitleLocked: isTitleLocked)
@@ -31,14 +38,27 @@ final class TerminalTabManager {
   }
 
   func overrideTitle(_ id: TerminalTabID, title: String) {
-    guard let index = tabs.firstIndex(where: { $0.id == id }) else { return }
-    tabs[index].title = title
-    tabs[index].isTitleLocked = true
+    setCustomTitle(id, title: title)
   }
 
   func clearTitleOverride(_ id: TerminalTabID) {
+    setCustomTitle(id, title: "")
+  }
+
+  func setCustomTitle(_ id: TerminalTabID, title: String) {
     guard let index = tabs.firstIndex(where: { $0.id == id }) else { return }
-    tabs[index].isTitleLocked = false
+    guard !tabs[index].isTitleLocked else { return }
+    let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
+    tabs[index].customTitle = trimmed.isEmpty ? nil : trimmed
+  }
+
+  func beginTabRename(_ id: TerminalTabID) {
+    guard tabs.contains(where: { $0.id == id && !$0.isTitleLocked }) else { return }
+    editingTabID = id
+  }
+
+  func endTabRename() {
+    editingTabID = nil
   }
 
   /// Auto-detection write path (e.g. `CommandIconMap`). Only applies

--- a/supacode/Features/Terminal/Models/TerminalTabManager.swift
+++ b/supacode/Features/Terminal/Models/TerminalTabManager.swift
@@ -37,14 +37,6 @@ final class TerminalTabManager {
     tabs[index].title = title
   }
 
-  func overrideTitle(_ id: TerminalTabID, title: String) {
-    setCustomTitle(id, title: title)
-  }
-
-  func clearTitleOverride(_ id: TerminalTabID) {
-    setCustomTitle(id, title: "")
-  }
-
   func setCustomTitle(_ id: TerminalTabID, title: String) {
     guard let index = tabs.firstIndex(where: { $0.id == id }) else { return }
     guard !tabs[index].isTitleLocked else { return }

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -783,6 +783,7 @@ final class WorktreeTerminalState {
         TerminalLayoutSnapshotPayload.SnapshotTab(
           tabID: tab.id.rawValue.uuidString,
           title: isBlockingScriptTab ? nil : tab.title,
+          customTitle: isBlockingScriptTab ? nil : tab.customTitle,
           icon: snapshotIcon,
           splitRoot: splitRoot
         )
@@ -870,8 +871,9 @@ final class WorktreeTerminalState {
         TerminalTabItem(
           id: entry.tabID,
           title: entry.snapshotTab.title ?? "\(worktree.name) \(index + 1)",
+          customTitle: entry.snapshotTab.customTitle,
           icon: entry.snapshotTab.icon ?? "terminal",
-          isTitleLocked: entry.snapshotTab.title != nil,
+          isTitleLocked: false,
           iconLock: entry.snapshotTab.icon != nil ? .user : .auto
         )
       )
@@ -1236,7 +1238,7 @@ final class WorktreeTerminalState {
     alert.alertStyle = .informational
 
     let textField = NSTextField(frame: NSRect(x: 0, y: 0, width: 250, height: 24))
-    textField.stringValue = tabManager.tabs[tabIndex].title
+    textField.stringValue = tabManager.tabs[tabIndex].displayTitle
     alert.accessoryView = textField
 
     alert.addButton(withTitle: "OK")
@@ -1248,12 +1250,7 @@ final class WorktreeTerminalState {
         guard response == .alertFirstButtonReturn else { return }
         guard let self else { return }
         let newTitle = textField.stringValue
-        if newTitle.isEmpty {
-          self.tabManager.clearTitleOverride(tabId)
-          self.updateTabTitle(for: tabId)
-        } else {
-          self.tabManager.overrideTitle(tabId, title: newTitle)
-        }
+        self.tabManager.setCustomTitle(tabId, title: newTitle)
       }
     }
   }
@@ -1857,13 +1854,13 @@ extension WorktreeTerminalState {
           context: GHOSTTY_SURFACE_CONTEXT_TAB
         ).workingDirectory?.path(percentEncoded: false)
 
-        let title = paneTitle(surfaceID: paneID, fallbackTabTitle: tab.title)
+        let title = paneTitle(surfaceID: paneID, fallbackTabTitle: tab.displayTitle)
         return CLITerminalPaneSnapshot(id: paneID, title: title, cwd: cwd)
       }
 
       return CLITerminalTabSnapshot(
         id: tab.id.rawValue,
-        title: tab.title,
+        title: tab.displayTitle,
         selected: tab.id == selectedTabID,
         focusedPaneID: focusedSurfaceIdByTab[tab.id],
         panes: panes

--- a/supacode/Features/Terminal/TabBar/TerminalTabBarMetrics.swift
+++ b/supacode/Features/Terminal/TabBar/TerminalTabBarMetrics.swift
@@ -25,4 +25,6 @@ enum TerminalTabBarMetrics {
   static let selectionAnimationDuration: Double = 0.15
   static let reorderAnimationDuration: Double = 0.3
   static let reorderAnimationBounce: Double = 0.15
+  static let renameFieldCornerRadius: CGFloat = 4
+  static let renameFieldInset: CGFloat = 4
 }

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabBarView.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabBarView.swift
@@ -6,7 +6,7 @@ struct TerminalTabBarView: View {
   let splitHorizontally: () -> Void
   let splitVertically: () -> Void
   let canSplit: Bool
-  let changeTitle: (TerminalTabID) -> Void
+  let renameTab: (TerminalTabID) -> Void
   let changeIcon: (TerminalTabID) -> Void
   let closeTab: (TerminalTabID) -> Void
   let closeOthers: (TerminalTabID) -> Void
@@ -19,7 +19,7 @@ struct TerminalTabBarView: View {
     HStack(spacing: 0) {
       TerminalTabsView(
         manager: manager,
-        changeTitle: changeTitle,
+        renameTab: renameTab,
         changeIcon: changeIcon,
         closeTab: closeTab,
         closeOthers: closeOthers,

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabContextMenu.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabContextMenu.swift
@@ -23,8 +23,10 @@ struct TerminalTabContextMenu: ViewModifier {
 
   func body(content: Content) -> some View {
     content.contextMenu {
-      Button("Change Tab Title...") {
-        actions.changeTitle(tabId)
+      if let currentTab, !currentTab.isTitleLocked {
+        Button("Rename Tab") {
+          actions.renameTab(tabId)
+        }
       }
 
       Button("Change Tab Icon...") {
@@ -56,5 +58,9 @@ struct TerminalTabContextMenu: ViewModifier {
   private var isLastTab: Bool {
     guard let last = tabs.last else { return true }
     return last.id == tabId
+  }
+
+  private var currentTab: TerminalTabItem? {
+    tabs.first { $0.id == tabId }
   }
 }

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabContextMenuActions.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabContextMenuActions.swift
@@ -1,5 +1,5 @@
 struct TerminalTabContextMenuActions {
-  let changeTitle: (TerminalTabID) -> Void
+  let renameTab: (TerminalTabID) -> Void
   let changeIcon: (TerminalTabID) -> Void
   let closeTab: (TerminalTabID) -> Void
   let closeOthers: (TerminalTabID) -> Void

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabLabelView.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabLabelView.swift
@@ -11,21 +11,7 @@ struct TerminalTabLabelView: View {
   var body: some View {
     HStack(spacing: TerminalTabBarMetrics.contentSpacing) {
       if tab.isDirty || tab.icon != nil {
-        ZStack {
-          if tab.isDirty {
-            ProgressView()
-              .controlSize(.small)
-              .tint(isActive ? TerminalTabBarColors.activeText : TerminalTabBarColors.inactiveText)
-          } else if let icon = tab.icon {
-            TabIconImage(rawName: icon, pointSize: 12)
-              .foregroundStyle(isActive ? TerminalTabBarColors.activeText : TerminalTabBarColors.inactiveText)
-          }
-        }
-        .frame(
-          width: TerminalTabBarMetrics.closeButtonSize,
-          height: TerminalTabBarMetrics.closeButtonSize
-        )
-        .accessibilityHidden(true)
+        TerminalTabIconBadge(tab: tab, isActive: isActive)
       }
       Text(tab.displayTitle)
         .font(.caption)
@@ -42,5 +28,28 @@ struct TerminalTabLabelView: View {
     .contentShape(.rect)
     .padding(.horizontal, TerminalTabBarMetrics.tabHorizontalPadding)
     .padding(.trailing, TerminalTabBarMetrics.closeButtonSize + TerminalTabBarMetrics.contentSpacing)
+  }
+}
+
+struct TerminalTabIconBadge: View {
+  let tab: TerminalTabItem
+  let isActive: Bool
+
+  var body: some View {
+    ZStack {
+      if tab.isDirty {
+        ProgressView()
+          .controlSize(.small)
+          .tint(isActive ? TerminalTabBarColors.activeText : TerminalTabBarColors.inactiveText)
+      } else if let icon = tab.icon {
+        TabIconImage(rawName: icon, pointSize: 12)
+          .foregroundStyle(isActive ? TerminalTabBarColors.activeText : TerminalTabBarColors.inactiveText)
+      }
+    }
+    .frame(
+      width: TerminalTabBarMetrics.closeButtonSize,
+      height: TerminalTabBarMetrics.closeButtonSize
+    )
+    .accessibilityHidden(true)
   }
 }

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabLabelView.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabLabelView.swift
@@ -27,7 +27,7 @@ struct TerminalTabLabelView: View {
         )
         .accessibilityHidden(true)
       }
-      Text(tab.title)
+      Text(tab.displayTitle)
         .font(.caption)
         .lineLimit(1)
         .foregroundStyle(isActive ? TerminalTabBarColors.activeText : TerminalTabBarColors.inactiveText)

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabView.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabView.swift
@@ -9,11 +9,19 @@ struct TerminalTabView: View {
   let fixedWidth: CGFloat?
   let onSelect: () -> Void
   let onClose: () -> Void
+  let onRename: (String) -> Void
   @Binding var closeButtonGestureActive: Bool
+  let isEditing: Bool
+  let onBeginRename: () -> Void
+  let onEndRename: () -> Void
 
   @State private var isHovering = false
   @State private var isHoveringClose = false
   @State private var isPressing = false
+  @State private var editingTitle = ""
+  @State private var initialEditingTitle = ""
+  @State private var cancelOnExit = false
+  @FocusState private var isFieldFocused: Bool
   @Environment(CommandKeyObserver.self) private var commandKeyObserver
   @Environment(\.resolvedKeybindings) private var resolvedKeybindings
 
@@ -38,8 +46,10 @@ struct TerminalTabView: View {
       )
       .frame(width: fixedWidth)
       .contentShape(.rect)
-      .help("Open tab \(tab.title)")
-      .accessibilityLabel(tab.title)
+      .help("Open tab \(tab.displayTitle)")
+      .accessibilityLabel(tab.displayTitle)
+      .allowsHitTesting(!isEditing)
+      .opacity(isEditing ? 0 : 1)
 
       TerminalTabCloseButton(
         isHoveringTab: isHovering,
@@ -50,6 +60,33 @@ struct TerminalTabView: View {
         isHoveringClose: $isHoveringClose
       )
       .padding(.trailing, TerminalTabBarMetrics.tabHorizontalPadding)
+      .opacity(isEditing ? 0 : 1)
+      .allowsHitTesting(!isEditing)
+    }
+    .overlay {
+      if isEditing {
+        TextField("", text: $editingTitle)
+          .textFieldStyle(.plain)
+          .font(.caption)
+          .focused($isFieldFocused)
+          .foregroundStyle(TerminalTabBarColors.activeText)
+          .accessibilityLabel("Rename tab")
+          .padding(.horizontal, TerminalTabBarMetrics.tabHorizontalPadding)
+          .padding(
+            .trailing,
+            TerminalTabBarMetrics.closeButtonSize + TerminalTabBarMetrics.contentSpacing
+          )
+          .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+          .onSubmit { onEndRename() }
+          .onExitCommand {
+            cancelOnExit = true
+            onEndRename()
+          }
+          .onChange(of: isFieldFocused) { _, focused in
+            guard !focused, isEditing else { return }
+            onEndRename()
+          }
+      }
     }
     .background {
       TerminalTabBackground(
@@ -66,6 +103,30 @@ struct TerminalTabView: View {
     .contentShape(.rect)
     .onHover { hovering in
       isHovering = hovering
+    }
+    .simultaneousGesture(
+      TapGesture(count: 2).onEnded {
+        guard !tab.isTitleLocked else { return }
+        onBeginRename()
+      }
+    )
+    .onChange(of: isEditing) { _, editing in
+      if editing {
+        editingTitle = tab.displayTitle
+        initialEditingTitle = tab.displayTitle
+        cancelOnExit = false
+        isFieldFocused = true
+      } else if cancelOnExit {
+        cancelOnExit = false
+      } else if editingTitle != initialEditingTitle {
+        onRename(editingTitle)
+      }
+    }
+    .onDisappear {
+      guard isEditing else { return }
+      defer { onEndRename() }
+      guard !cancelOnExit, editingTitle != initialEditingTitle else { return }
+      onRename(editingTitle)
     }
     .zIndex(isActive ? 2 : (isDragging ? 3 : 0))
     .overlay {

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabView.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabView.swift
@@ -79,11 +79,24 @@ struct TerminalTabView: View {
           .focused($isFieldFocused)
           .foregroundStyle(TerminalTabBarColors.activeText)
           .accessibilityLabel("Rename tab")
-          .padding(.horizontal, TerminalTabBarMetrics.tabHorizontalPadding)
-          .padding(
-            .trailing,
-            TerminalTabBarMetrics.closeButtonSize + TerminalTabBarMetrics.contentSpacing
+          .padding(.horizontal, TerminalTabBarMetrics.contentSpacing)
+          .background(
+            RoundedRectangle(
+              cornerRadius: TerminalTabBarMetrics.renameFieldCornerRadius,
+              style: .continuous
+            )
+            .fill(Color(nsColor: .textBackgroundColor))
+            .overlay(
+              RoundedRectangle(
+                cornerRadius: TerminalTabBarMetrics.renameFieldCornerRadius,
+                style: .continuous
+              )
+              .strokeBorder(Color.accentColor, lineWidth: 1.5)
+            )
           )
+          .padding(.leading, TerminalTabBarMetrics.tabHorizontalPadding - TerminalTabBarMetrics.contentSpacing)
+          .padding(.trailing, TerminalTabBarMetrics.closeButtonSize + TerminalTabBarMetrics.contentSpacing)
+          .padding(.vertical, TerminalTabBarMetrics.renameFieldInset)
           .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
           .onSubmit { onEndRename() }
           .onExitCommand {
@@ -124,17 +137,16 @@ struct TerminalTabView: View {
         initialEditingTitle = tab.displayTitle
         cancelOnExit = false
         isFieldFocused = true
+        // The field editor only attaches after SwiftUI promotes the TextField
+        // to first responder, so defer selectAll one hop to land on it.
+        DispatchQueue.main.async {
+          NSApp.sendAction(#selector(NSText.selectAll(_:)), to: nil, from: nil)
+        }
       } else if cancelOnExit {
         cancelOnExit = false
       } else if editingTitle != initialEditingTitle {
         onRename(editingTitle)
       }
-    }
-    .onDisappear {
-      guard isEditing else { return }
-      defer { onEndRename() }
-      guard !cancelOnExit, editingTitle != initialEditingTitle else { return }
-      onRename(editingTitle)
     }
     .zIndex(isActive ? 2 : (isDragging ? 3 : 0))
     .overlay {

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabView.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabView.swift
@@ -11,6 +11,7 @@ struct TerminalTabView: View {
   let onSelect: () -> Void
   let onClose: () -> Void
   let onRename: (String) -> Void
+  let onChangeIcon: () -> Void
   @Binding var closeButtonGestureActive: Bool
   let isEditing: Bool
   let onBeginRename: () -> Void
@@ -72,34 +73,39 @@ struct TerminalTabView: View {
     }
     .overlay {
       if isEditing {
-        RenameTextField(
-          text: $editingTitle,
-          onCommit: { onEndRename() },
-          onCancel: {
-            cancelOnExit = true
-            onEndRename()
+        HStack(spacing: TerminalTabBarMetrics.contentSpacing) {
+          if tab.isDirty || tab.icon != nil {
+            TerminalTabIconBadge(tab: tab, isActive: isActive)
           }
-        )
-        .padding(.horizontal, TerminalTabBarMetrics.contentSpacing)
-        .background(
-          RoundedRectangle(
-            cornerRadius: TerminalTabBarMetrics.renameFieldCornerRadius,
-            style: .continuous
+          RenameTextField(
+            text: $editingTitle,
+            onCommit: { onEndRename() },
+            onCancel: {
+              cancelOnExit = true
+              onEndRename()
+            }
           )
-          .fill(Color(nsColor: .textBackgroundColor))
-          .overlay(
+          .padding(.horizontal, TerminalTabBarMetrics.contentSpacing)
+          .background(
             RoundedRectangle(
               cornerRadius: TerminalTabBarMetrics.renameFieldCornerRadius,
               style: .continuous
             )
-            .strokeBorder(Color.accentColor, lineWidth: 1.5)
+            .fill(Color(nsColor: .textBackgroundColor))
+            .overlay(
+              RoundedRectangle(
+                cornerRadius: TerminalTabBarMetrics.renameFieldCornerRadius,
+                style: .continuous
+              )
+              .strokeBorder(Color.accentColor, lineWidth: 1.5)
+            )
           )
-        )
-        .padding(.leading, TerminalTabBarMetrics.tabHorizontalPadding - TerminalTabBarMetrics.contentSpacing)
+          .accessibilityLabel("Rename tab")
+        }
+        .padding(.leading, TerminalTabBarMetrics.tabHorizontalPadding)
         .padding(.trailing, TerminalTabBarMetrics.closeButtonSize + TerminalTabBarMetrics.contentSpacing)
         .padding(.vertical, TerminalTabBarMetrics.renameFieldInset)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
-        .accessibilityLabel("Rename tab")
       }
     }
     .background {
@@ -119,9 +125,12 @@ struct TerminalTabView: View {
       isHovering = hovering
     }
     .simultaneousGesture(
-      TapGesture(count: 2).onEnded {
-        guard !tab.isTitleLocked else { return }
-        onBeginRename()
+      SpatialTapGesture(count: 2, coordinateSpace: .local).onEnded { value in
+        if isInIconHitArea(value.location) {
+          onChangeIcon()
+        } else if !tab.isTitleLocked {
+          onBeginRename()
+        }
       }
     )
     .onChange(of: isEditing) { _, editing in
@@ -151,6 +160,16 @@ struct TerminalTabView: View {
 
   private var isShowingNotificationDot: Bool {
     hasNotification && !isHovering && !isHoveringClose && !isDragging && !showsShortcutHint
+  }
+
+  /// Hit zone for the icon in tab-local coordinates. Covers the leading
+  /// padding plus the icon column, so a double-click anywhere on the icon
+  /// (or the empty strip just to its left) opens the icon picker. The rest
+  /// of the tab routes to inline rename.
+  private func isInIconHitArea(_ point: CGPoint) -> Bool {
+    guard tab.isDirty || tab.icon != nil else { return false }
+    let maxX = TerminalTabBarMetrics.tabHorizontalPadding + TerminalTabBarMetrics.closeButtonSize
+    return point.x >= 0 && point.x <= maxX
   }
 }
 

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabView.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabView.swift
@@ -22,7 +22,6 @@ struct TerminalTabView: View {
   @State private var editingTitle = ""
   @State private var initialEditingTitle = ""
   @State private var cancelOnExit = false
-  @FocusState private var isFieldFocused: Bool
   @Environment(CommandKeyObserver.self) private var commandKeyObserver
   @Environment(\.resolvedKeybindings) private var resolvedKeybindings
 
@@ -73,40 +72,34 @@ struct TerminalTabView: View {
     }
     .overlay {
       if isEditing {
-        TextField("", text: $editingTitle)
-          .textFieldStyle(.plain)
-          .font(.caption)
-          .focused($isFieldFocused)
-          .foregroundStyle(TerminalTabBarColors.activeText)
-          .accessibilityLabel("Rename tab")
-          .padding(.horizontal, TerminalTabBarMetrics.contentSpacing)
-          .background(
+        RenameTextField(
+          text: $editingTitle,
+          onCommit: { onEndRename() },
+          onCancel: {
+            cancelOnExit = true
+            onEndRename()
+          }
+        )
+        .padding(.horizontal, TerminalTabBarMetrics.contentSpacing)
+        .background(
+          RoundedRectangle(
+            cornerRadius: TerminalTabBarMetrics.renameFieldCornerRadius,
+            style: .continuous
+          )
+          .fill(Color(nsColor: .textBackgroundColor))
+          .overlay(
             RoundedRectangle(
               cornerRadius: TerminalTabBarMetrics.renameFieldCornerRadius,
               style: .continuous
             )
-            .fill(Color(nsColor: .textBackgroundColor))
-            .overlay(
-              RoundedRectangle(
-                cornerRadius: TerminalTabBarMetrics.renameFieldCornerRadius,
-                style: .continuous
-              )
-              .strokeBorder(Color.accentColor, lineWidth: 1.5)
-            )
+            .strokeBorder(Color.accentColor, lineWidth: 1.5)
           )
-          .padding(.leading, TerminalTabBarMetrics.tabHorizontalPadding - TerminalTabBarMetrics.contentSpacing)
-          .padding(.trailing, TerminalTabBarMetrics.closeButtonSize + TerminalTabBarMetrics.contentSpacing)
-          .padding(.vertical, TerminalTabBarMetrics.renameFieldInset)
-          .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
-          .onSubmit { onEndRename() }
-          .onExitCommand {
-            cancelOnExit = true
-            onEndRename()
-          }
-          .onChange(of: isFieldFocused) { _, focused in
-            guard !focused, isEditing else { return }
-            onEndRename()
-          }
+        )
+        .padding(.leading, TerminalTabBarMetrics.tabHorizontalPadding - TerminalTabBarMetrics.contentSpacing)
+        .padding(.trailing, TerminalTabBarMetrics.closeButtonSize + TerminalTabBarMetrics.contentSpacing)
+        .padding(.vertical, TerminalTabBarMetrics.renameFieldInset)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+        .accessibilityLabel("Rename tab")
       }
     }
     .background {
@@ -136,12 +129,6 @@ struct TerminalTabView: View {
         editingTitle = tab.displayTitle
         initialEditingTitle = tab.displayTitle
         cancelOnExit = false
-        isFieldFocused = true
-        // The field editor only attaches after SwiftUI promotes the TextField
-        // to first responder, so defer selectAll one hop to land on it.
-        DispatchQueue.main.async {
-          NSApp.sendAction(#selector(NSText.selectAll(_:)), to: nil, from: nil)
-        }
       } else if cancelOnExit {
         cancelOnExit = false
       } else if editingTitle != initialEditingTitle {
@@ -216,4 +203,97 @@ private final class MiddleClickNSView: NSView {
   }
 
   override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
+}
+
+/// Inline rename field for tabs.
+///
+/// SwiftUI's `TextField` + `@FocusState` plus `NSApp.sendAction(selectAll:)`
+/// is unreliable here: the focus promotion spans multiple runloop ticks, and
+/// `sendAction` along the responder chain reaches whatever owns the chain
+/// first — typically the active GhosttySurface, which happily selects every
+/// glyph in the terminal instead of the tab title. Owning the `NSTextField`
+/// directly lets us drive `selectAll` on its own field editor without
+/// fighting SwiftUI's focus timing.
+private struct RenameTextField: NSViewRepresentable {
+  @Binding var text: String
+  let onCommit: () -> Void
+  let onCancel: () -> Void
+
+  func makeCoordinator() -> Coordinator { Coordinator(parent: self) }
+
+  func makeNSView(context: Context) -> RenameNSTextField {
+    let field = RenameNSTextField()
+    field.font = NSFont.systemFont(ofSize: NSFont.smallSystemFontSize)
+    field.textColor = .labelColor
+    field.isBordered = false
+    field.drawsBackground = false
+    field.focusRingType = .none
+    field.cell?.usesSingleLineMode = true
+    field.cell?.wraps = false
+    field.cell?.isScrollable = true
+    field.lineBreakMode = .byClipping
+    field.stringValue = text
+    field.delegate = context.coordinator
+    field.setContentHuggingPriority(.defaultLow, for: .horizontal)
+    field.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+    return field
+  }
+
+  func updateNSView(_ nsView: RenameNSTextField, context: Context) {
+    context.coordinator.parent = self
+    if nsView.stringValue != text {
+      nsView.stringValue = text
+    }
+  }
+
+  final class Coordinator: NSObject, NSTextFieldDelegate {
+    var parent: RenameTextField
+    private var hasResolved = false
+
+    init(parent: RenameTextField) { self.parent = parent }
+
+    func controlTextDidChange(_ obj: Notification) {
+      guard let field = obj.object as? NSTextField else { return }
+      parent.text = field.stringValue
+    }
+
+    func control(
+      _ control: NSControl,
+      textView: NSTextView,
+      doCommandBy commandSelector: Selector
+    ) -> Bool {
+      switch commandSelector {
+      case #selector(NSResponder.cancelOperation(_:)):
+        hasResolved = true
+        parent.onCancel()
+        return true
+      case #selector(NSResponder.insertNewline(_:)):
+        hasResolved = true
+        parent.onCommit()
+        return true
+      default:
+        return false
+      }
+    }
+
+    func controlTextDidEndEditing(_ obj: Notification) {
+      guard !hasResolved else { return }
+      hasResolved = true
+      parent.onCommit()
+    }
+  }
+}
+
+private final class RenameNSTextField: NSTextField {
+  override func viewDidMoveToWindow() {
+    super.viewDidMoveToWindow()
+    guard window != nil else { return }
+    // Defer one runloop hop so AppKit finishes mounting the field before we
+    // request first-responder; otherwise `currentEditor()` returns nil.
+    DispatchQueue.main.async { [weak self] in
+      guard let self, let window = self.window else { return }
+      window.makeFirstResponder(self)
+      self.currentEditor()?.selectAll(nil)
+    }
+  }
 }

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabsRowView.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabsRowView.swift
@@ -8,7 +8,7 @@ struct TerminalTabsRowView: View {
   @Binding var draggingStartLocation: CGFloat?
   @Binding var closeButtonGestureActive: Bool
   let fixedTabWidth: CGFloat?
-  let changeTitle: (TerminalTabID) -> Void
+  let renameTab: (TerminalTabID) -> Void
   let changeIcon: (TerminalTabID) -> Void
   let closeTab: (TerminalTabID) -> Void
   let closeOthers: (TerminalTabID) -> Void
@@ -36,7 +36,18 @@ struct TerminalTabsRowView: View {
               onClose: {
                 closeTab(id)
               },
-              closeButtonGestureActive: $closeButtonGestureActive
+              onRename: { newTitle in
+                manager.setCustomTitle(id, title: newTitle)
+              },
+              closeButtonGestureActive: $closeButtonGestureActive,
+              isEditing: manager.editingTabID == id,
+              onBeginRename: {
+                manager.beginTabRename(id)
+              },
+              onEndRename: {
+                guard manager.editingTabID == id else { return }
+                manager.endTabRename()
+              }
             )
             .background(
               TerminalTabMeasurementView(
@@ -51,7 +62,7 @@ struct TerminalTabsRowView: View {
               tabId: id,
               tabs: manager.tabs,
               actions: TerminalTabContextMenuActions(
-                changeTitle: changeTitle,
+                renameTab: renameTab,
                 changeIcon: changeIcon,
                 closeTab: closeTab,
                 closeOthers: closeOthers,

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabsRowView.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabsRowView.swift
@@ -41,6 +41,9 @@ struct TerminalTabsRowView: View {
               onRename: { newTitle in
                 manager.setCustomTitle(id, title: newTitle)
               },
+              onChangeIcon: {
+                changeIcon(id)
+              },
               closeButtonGestureActive: $closeButtonGestureActive,
               isEditing: manager.editingTabID == id,
               onBeginRename: {

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabsView.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabsView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct TerminalTabsView: View {
   @Bindable var manager: TerminalTabManager
-  let changeTitle: (TerminalTabID) -> Void
+  let renameTab: (TerminalTabID) -> Void
   let changeIcon: (TerminalTabID) -> Void
   let closeTab: (TerminalTabID) -> Void
   let closeOthers: (TerminalTabID) -> Void
@@ -30,7 +30,7 @@ struct TerminalTabsView: View {
             draggingStartLocation: $draggingStartLocation,
             closeButtonGestureActive: $closeButtonGestureActive,
             fixedTabWidth: effectiveTabWidth,
-            changeTitle: changeTitle,
+            renameTab: renameTab,
             changeIcon: changeIcon,
             closeTab: closeTab,
             closeOthers: closeOthers,

--- a/supacode/Features/Terminal/Views/WorktreeTerminalTabsView.swift
+++ b/supacode/Features/Terminal/Views/WorktreeTerminalTabsView.swift
@@ -22,8 +22,8 @@ struct WorktreeTerminalTabsView: View {
           _ = state.performBindingActionOnFocusedSurface("new_split:right")
         },
         canSplit: state.tabManager.selectedTabId != nil,
-        changeTitle: { tabId in
-          state.promptChangeTabTitle(tabId)
+        renameTab: { tabId in
+          state.tabManager.beginTabRename(tabId)
         },
         changeIcon: { tabId in
           state.presentIconPicker(for: tabId)

--- a/supacodeTests/TerminalLayoutSnapshotPayloadTests.swift
+++ b/supacodeTests/TerminalLayoutSnapshotPayloadTests.swift
@@ -273,6 +273,68 @@ struct TerminalLayoutSnapshotPayloadTests {
     #expect(decodedTab?.icon == nil)
   }
 
+  @Test func decodeValidatedMigratesV1TitleIntoCustomTitle() {
+    let json = #"""
+      {
+        "version": 1,
+        "worktrees": [
+          {
+            "worktreeID": "wt-1",
+            "selectedTabID": "tab-1",
+            "tabs": [
+              {
+                "tabID": "tab-1",
+                "title": "Frozen Title",
+                "splitRoot": {
+                  "kind": "leaf",
+                  "surfaceID": "surface-1"
+                }
+              }
+            ]
+          }
+        ]
+      }
+      """#
+    let data = Data(json.utf8)
+
+    let decoded = TerminalLayoutSnapshotPayload.decodeValidated(from: data)
+    #expect(decoded?.version == TerminalLayoutSnapshotPayload.currentVersion)
+    let decodedTab = decoded?.worktrees.first?.tabs.first
+    #expect(decodedTab?.title == nil)
+    #expect(decodedTab?.customTitle == "Frozen Title")
+  }
+
+  @Test func decodeValidatedV1MigrationLeavesExistingCustomTitleAlone() {
+    let json = #"""
+      {
+        "version": 1,
+        "worktrees": [
+          {
+            "worktreeID": "wt-1",
+            "selectedTabID": "tab-1",
+            "tabs": [
+              {
+                "tabID": "tab-1",
+                "title": "Live",
+                "customTitle": "Pinned",
+                "splitRoot": {
+                  "kind": "leaf",
+                  "surfaceID": "surface-1"
+                }
+              }
+            ]
+          }
+        ]
+      }
+      """#
+    let data = Data(json.utf8)
+
+    let decoded = TerminalLayoutSnapshotPayload.decodeValidated(from: data)
+    let decodedTab = decoded?.worktrees.first?.tabs.first
+    #expect(decodedTab?.title == "Live")
+    #expect(decodedTab?.customTitle == "Pinned")
+  }
+
   @Test func decodeValidatedBackwardCompatibleWithoutTitleAndIcon() {
     let json = #"""
       {

--- a/supacodeTests/TerminalLayoutSnapshotPayloadTests.swift
+++ b/supacodeTests/TerminalLayoutSnapshotPayloadTests.swift
@@ -12,6 +12,16 @@ struct TerminalLayoutSnapshotPayloadTests {
     #expect(decoded == payload)
   }
 
+  @Test func decodeValidatedRoundTripsTabCustomTitle() throws {
+    let payload = makePayload(title: "live", customTitle: "Pinned")
+    let data = try JSONEncoder().encode(payload)
+
+    let decoded = TerminalLayoutSnapshotPayload.decodeValidated(from: data)
+
+    #expect(decoded == payload)
+    #expect(decoded?.worktrees.first?.tabs.first?.customTitle == "Pinned")
+  }
+
   @Test func decodeValidatedRoundTripsLeafCwdPath() throws {
     let payload = makePayload(splitRoot: .leaf(surfaceID: "surface-1", cwdPath: "/tmp/repo/wt-1/src"))
     let data = try JSONEncoder().encode(payload)
@@ -309,6 +319,8 @@ private func makePayload(
   version: Int = TerminalLayoutSnapshotPayload.currentVersion,
   worktreeID: String = "wt-1",
   tabID: String = "tab-1",
+  title: String? = nil,
+  customTitle: String? = nil,
   splitRoot: TerminalLayoutSnapshotPayload.SnapshotSplitNode = .leaf(surfaceID: "surface-1")
 ) -> TerminalLayoutSnapshotPayload {
   TerminalLayoutSnapshotPayload(
@@ -318,7 +330,7 @@ private func makePayload(
         worktreeID: worktreeID,
         selectedTabID: tabID,
         tabs: [
-          makeTab(tabID: tabID, splitRoot: splitRoot)
+          makeTab(tabID: tabID, title: title, customTitle: customTitle, splitRoot: splitRoot)
         ]
       )
     ]
@@ -340,12 +352,14 @@ private func makeWorktree(
 private func makeTab(
   tabID: String,
   title: String? = nil,
+  customTitle: String? = nil,
   icon: String? = nil,
   splitRoot: TerminalLayoutSnapshotPayload.SnapshotSplitNode = .leaf(surfaceID: "surface-1")
 ) -> TerminalLayoutSnapshotPayload.SnapshotTab {
   TerminalLayoutSnapshotPayload.SnapshotTab(
     tabID: tabID,
     title: title,
+    customTitle: customTitle,
     icon: icon,
     splitRoot: splitRoot
   )

--- a/supacodeTests/TerminalTabManagerTests.swift
+++ b/supacodeTests/TerminalTabManagerTests.swift
@@ -4,6 +4,50 @@ import Testing
 
 @MainActor
 struct TerminalTabManagerTests {
+  @Test func customTitleOverridesDisplayTitleWithoutFreezingLiveTitle() {
+    let manager = TerminalTabManager()
+    let tabId = manager.createTab(title: "shell", icon: nil)
+
+    manager.setCustomTitle(tabId, title: "  build  ")
+    manager.updateTitle(tabId, title: "npm test")
+
+    #expect(manager.tabs.first?.title == "npm test")
+    #expect(manager.tabs.first?.customTitle == "build")
+    #expect(manager.tabs.first?.displayTitle == "build")
+  }
+
+  @Test func clearingCustomTitleRestoresLiveShellTitle() {
+    let manager = TerminalTabManager()
+    let tabId = manager.createTab(title: "shell", icon: nil)
+
+    manager.setCustomTitle(tabId, title: "build")
+    manager.updateTitle(tabId, title: "npm test")
+    manager.setCustomTitle(tabId, title: "   ")
+
+    #expect(manager.tabs.first?.customTitle == nil)
+    #expect(manager.tabs.first?.displayTitle == "npm test")
+  }
+
+  @Test func customTitleIgnoresLockedTabs() {
+    let manager = TerminalTabManager()
+    let tabId = manager.createTab(title: "RUN SCRIPT", icon: "play.fill", isTitleLocked: true)
+
+    manager.setCustomTitle(tabId, title: "build")
+
+    #expect(manager.tabs.first?.customTitle == nil)
+    #expect(manager.tabs.first?.displayTitle == "RUN SCRIPT")
+  }
+
+  @Test func editingTabIDIsDroppedWhenTabCloses() {
+    let manager = TerminalTabManager()
+    let tabId = manager.createTab(title: "one", icon: nil)
+
+    manager.beginTabRename(tabId)
+    manager.closeTab(tabId)
+
+    #expect(manager.editingTabID == nil)
+  }
+
   @Test func createTabInsertsAfterSelection() {
     let manager = TerminalTabManager()
     let first = manager.createTab(title: "one", icon: nil)

--- a/supacodeTests/WorktreeTerminalManagerTests.swift
+++ b/supacodeTests/WorktreeTerminalManagerTests.swift
@@ -246,6 +246,49 @@ struct WorktreeTerminalManagerTests {
     #expect(manager.hasUnseenNotifications(for: worktree.id) == false)
   }
 
+  @Test func makeLayoutSnapshotPersistsCustomTabTitle() throws {
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    let worktree = makeWorktree()
+    let state = manager.state(for: worktree)
+    let tabID = try #require(state.createTab())
+
+    state.tabManager.updateTitle(tabID, title: "npm test")
+    state.tabManager.setCustomTitle(tabID, title: "Build")
+
+    let snapshot = try #require(state.makeLayoutSnapshotWorktree())
+
+    #expect(snapshot.tabs.first?.title == "npm test")
+    #expect(snapshot.tabs.first?.customTitle == "Build")
+  }
+
+  @Test func applyLayoutSnapshotRestoresCustomTabTitle() throws {
+    let tabID = UUID()
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    let worktree = makeWorktree()
+    let state = manager.state(for: worktree)
+    let snapshot = TerminalLayoutSnapshotPayload.SnapshotWorktree(
+      worktreeID: worktree.id,
+      selectedTabID: tabID.uuidString,
+      tabs: [
+        TerminalLayoutSnapshotPayload.SnapshotTab(
+          tabID: tabID.uuidString,
+          title: "npm test",
+          customTitle: "Build",
+          icon: nil,
+          splitRoot: .leaf(surfaceID: UUID().uuidString)
+        )
+      ]
+    )
+
+    #expect(state.applyLayoutSnapshot(snapshot))
+    let restored = try #require(state.tabManager.tabs.first)
+
+    #expect(restored.title == "npm test")
+    #expect(restored.customTitle == "Build")
+    #expect(restored.displayTitle == "Build")
+    #expect(restored.isTitleLocked == false)
+  }
+
   @Test func restoreLayoutSnapshotFailClosedClearsSnapshotWhenWorktreeMissing() async {
     let clearCount = LockIsolated(0)
     let snapshot = TerminalLayoutSnapshotPayload(


### PR DESCRIPTION
## Summary
- split live shell titles from user custom tab titles with `customTitle` / `displayTitle`
- add inline rename for the normal tab bar while keeping Shelf rename on the existing modal path
- persist and restore custom tab titles in terminal layout snapshots, and surface display titles in Canvas/Shelf/CLI snapshots

## Verification
- xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -only-testing:supacodeTests/TerminalTabManagerTests -only-testing:supacodeTests/TerminalLayoutSnapshotPayloadTests -only-testing:supacodeTests/TerminalLayoutPersistenceClientTests -only-testing:supacodeTests/WorktreeTerminalManagerTests -only-testing:supacodeTests/TerminalLayoutSnapshotTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation 2>&1 | xcsift
- make check
- make build-app

Upstream reference: supabitapp/supacode@6615f49c (#269)
