### PR TITLE
Add worktree history navigation

### DIFF
--- a/supacode/App/AppShortcuts.swift
+++ b/supacode/App/AppShortcuts.swift
@@ -238,12 +238,8 @@ enum AppShortcuts {
   static let selectPreviousWorktree = AppShortcut(
     keyEquivalent: .upArrow, ghosttyKeyName: "arrow_up", modifiers: [.command, .control]
   )
-  static let worktreeHistoryBack = AppShortcut(
-    keyEquivalent: .leftArrow, ghosttyKeyName: "arrow_left", modifiers: [.command, .option, .control]
-  )
-  static let worktreeHistoryForward = AppShortcut(
-    keyEquivalent: .rightArrow, ghosttyKeyName: "arrow_right", modifiers: [.command, .option, .control]
-  )
+  static let worktreeHistoryBack = AppShortcut(key: "[", modifiers: [.command, .option])
+  static let worktreeHistoryForward = AppShortcut(key: "]", modifiers: [.command, .option])
   static let selectWorktree1 = AppShortcut(key: "1", modifiers: [.control])
   static let selectWorktree2 = AppShortcut(key: "2", modifiers: [.control])
   static let selectWorktree3 = AppShortcut(key: "3", modifiers: [.control])

--- a/supacode/App/AppShortcuts.swift
+++ b/supacode/App/AppShortcuts.swift
@@ -115,6 +115,8 @@ enum AppShortcuts {
     static let archivedWorktrees = "archived_worktrees"
     static let selectNextWorktree = "select_next_worktree"
     static let selectPreviousWorktree = "select_previous_worktree"
+    static let worktreeHistoryBack = "worktree_history_back"
+    static let worktreeHistoryForward = "worktree_history_forward"
     static let selectWorktree1 = "select_worktree_1"
     static let selectWorktree2 = "select_worktree_2"
     static let selectWorktree3 = "select_worktree_3"
@@ -235,6 +237,12 @@ enum AppShortcuts {
   )
   static let selectPreviousWorktree = AppShortcut(
     keyEquivalent: .upArrow, ghosttyKeyName: "arrow_up", modifiers: [.command, .control]
+  )
+  static let worktreeHistoryBack = AppShortcut(
+    keyEquivalent: .leftArrow, ghosttyKeyName: "arrow_left", modifiers: [.command, .option, .control]
+  )
+  static let worktreeHistoryForward = AppShortcut(
+    keyEquivalent: .rightArrow, ghosttyKeyName: "arrow_right", modifiers: [.command, .option, .control]
   )
   static let selectWorktree1 = AppShortcut(key: "1", modifiers: [.control])
   static let selectWorktree2 = AppShortcut(key: "2", modifiers: [.control])
@@ -522,6 +530,18 @@ enum AppShortcuts {
       title: "Select Previous Worktree (Tab in Shelf View)",
       scope: .configurableAppAction,
       shortcut: selectPreviousWorktree
+    ),
+    .init(
+      id: CommandID.worktreeHistoryBack,
+      title: "Back in Worktree History",
+      scope: .configurableAppAction,
+      shortcut: worktreeHistoryBack
+    ),
+    .init(
+      id: CommandID.worktreeHistoryForward,
+      title: "Forward in Worktree History",
+      scope: .configurableAppAction,
+      shortcut: worktreeHistoryForward
     ),
     .init(
       id: CommandID.selectWorktree1,
@@ -860,6 +880,8 @@ enum AppShortcuts {
     archivedWorktrees,
     selectNextWorktree,
     selectPreviousWorktree,
+    worktreeHistoryBack,
+    worktreeHistoryForward,
     selectWorktree1,
     selectWorktree2,
     selectWorktree3,

--- a/supacode/Commands/WorktreeCommands.swift
+++ b/supacode/Commands/WorktreeCommands.swift
@@ -41,6 +41,22 @@ struct WorktreeCommands: Commands {
       )
       .help(helpText(title: "Select Previous Worktree", commandID: AppShortcuts.CommandID.selectPreviousWorktree))
       .disabled(orderedRows.isEmpty)
+      Button("Back in Worktree History") {
+        store.send(.repositories(.worktreeHistoryBack))
+      }
+      .modifier(
+        KeyboardShortcutModifier(shortcut: keyboardShortcut(for: AppShortcuts.CommandID.worktreeHistoryBack))
+      )
+      .help(helpText(title: "Back in Worktree History", commandID: AppShortcuts.CommandID.worktreeHistoryBack))
+      .disabled(!repositories.canNavigateWorktreeHistoryBackward)
+      Button("Forward in Worktree History") {
+        store.send(.repositories(.worktreeHistoryForward))
+      }
+      .modifier(
+        KeyboardShortcutModifier(shortcut: keyboardShortcut(for: AppShortcuts.CommandID.worktreeHistoryForward))
+      )
+      .help(helpText(title: "Forward in Worktree History", commandID: AppShortcuts.CommandID.worktreeHistoryForward))
+      .disabled(!repositories.canNavigateWorktreeHistoryForward)
       Divider()
       ForEach(worktreeMenuEntries(orderedRows: orderedRows)) { entry in
         worktreeMenuButton(entry: entry)

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+WorktreeCreation.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+WorktreeCreation.swift
@@ -257,7 +257,7 @@ extension RepositoriesFeature {
           progress: WorktreeCreationProgress(stage: .loadingLocalBranches)
         )
       )
-      setSingleWorktreeSelection(pendingID, state: &state)
+      setSingleWorktreeSelection(pendingID, state: &state, recordHistory: true)
       let existingNames = Set(repository.worktrees.map { $0.name.lowercased() })
       let createWorktreeStream = gitClient.createWorktreeStream
       let isValidBranchName = gitClient.isValidBranchName
@@ -558,7 +558,7 @@ extension RepositoriesFeature {
       state.pendingTerminalFocusWorktreeIDs.insert(worktree.id)
       removePendingWorktree(pendingID, state: &state)
       if state.selection == .worktree(pendingID) {
-        setSingleWorktreeSelection(worktree.id, state: &state)
+        setSingleWorktreeSelection(worktree.id, state: &state, recordHistory: false)
       }
       insertWorktree(worktree, repositoryID: repositoryID, state: &state)
       return .merge(

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -304,7 +304,7 @@ struct RepositoriesFeature {
     case markWorktreeClosed(Worktree.ID)
     case setSidebarSelectedWorktreeIDs(Set<Worktree.ID>)
     case selectRepository(Repository.ID?)
-    case selectWorktree(Worktree.ID?, focusTerminal: Bool = false)
+    case selectWorktree(Worktree.ID?, focusTerminal: Bool = false, recordHistory: Bool = true)
     case selectNextWorktree
     case selectPreviousWorktree
     case worktreeHistoryBack
@@ -870,10 +870,10 @@ struct RepositoriesFeature {
           }
           return .send(.delegate(.selectedWorktreeChanged(state.selectedTerminalWorktree)))
 
-        case .selectWorktree(let worktreeID, let focusTerminal):
+        case .selectWorktree(let worktreeID, let focusTerminal, let recordHistory):
           let selectWtToken = repositoriesLogger.beginInterval("reducer.selectWorktree")
           defer { repositoriesLogger.endInterval(selectWtToken) }
-          setSingleWorktreeSelection(worktreeID, state: &state, recordHistory: true)
+          setSingleWorktreeSelection(worktreeID, state: &state, recordHistory: recordHistory)
           if focusTerminal, let worktreeID {
             state.pendingTerminalFocusWorktreeIDs.insert(worktreeID)
           }
@@ -1553,11 +1553,13 @@ extension RepositoriesFeature.State {
   }
 
   var canNavigateWorktreeHistoryBackward: Bool {
-    canNavigateWorktreeHistory(stack: worktreeHistoryBackStack)
+    guard canUseWorktreeHistory else { return false }
+    return canNavigateWorktreeHistory(stack: worktreeHistoryBackStack)
   }
 
   var canNavigateWorktreeHistoryForward: Bool {
-    canNavigateWorktreeHistory(stack: worktreeHistoryForwardStack)
+    guard canUseWorktreeHistory else { return false }
+    return canNavigateWorktreeHistory(stack: worktreeHistoryForwardStack)
   }
 
   var selectedRepositoryID: Repository.ID? {
@@ -1631,6 +1633,10 @@ extension RepositoriesFeature.State {
 
   var isShowingShelf: Bool {
     isShelfActive
+  }
+
+  private var canUseWorktreeHistory: Bool {
+    !isShowingShelf && !isShowingCanvas
   }
 
   var archivedWorktreeIDSet: Set<Worktree.ID> {
@@ -2435,7 +2441,7 @@ func shelfBookSelectionEffect(
 ) -> Effect<RepositoriesFeature.Action> {
   switch book.kind {
   case .worktree:
-    return .send(.selectWorktree(book.id, focusTerminal: true))
+    return .send(.selectWorktree(book.id, focusTerminal: true, recordHistory: false))
   case .plainFolder:
     return .send(.selectRepository(book.repositoryID))
   }
@@ -2484,6 +2490,7 @@ private func navigateWorktreeHistory(
   direction: WorktreeHistoryDirection,
   state: inout RepositoriesFeature.State
 ) -> Effect<RepositoriesFeature.Action> {
+  guard !state.isShowingShelf, !state.isShowingCanvas else { return .none }
   guard let currentID = state.selectedWorktreeID else { return .none }
   var sourceStack =
     direction == .backward
@@ -2516,6 +2523,7 @@ private func recordWorktreeHistoryTransition(
   to nextID: Worktree.ID?,
   state: inout RepositoriesFeature.State
 ) {
+  guard !state.isShowingShelf, !state.isShowingCanvas else { return }
   guard let previousID, let nextID, previousID != nextID else { return }
   guard isSelectionValid(previousID, state: state), isSelectionValid(nextID, state: state) else { return }
   pushWorktreeHistoryID(previousID, onto: &state.worktreeHistoryBackStack)

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -216,6 +216,8 @@ struct RepositoriesFeature {
     var preCanvasWorktreeID: Worktree.ID?
     var preCanvasTerminalTargetID: Worktree.ID?
     var isShelfActive: Bool = false
+    var worktreeHistoryBackStack: [Worktree.ID] = []
+    var worktreeHistoryForwardStack: [Worktree.ID] = []
     /// IDs of worktrees (and plain-folder repositories) that have been
     /// "opened" at least once in this session — i.e., had their
     /// terminal state created by a user selection or CLI activation.
@@ -305,6 +307,8 @@ struct RepositoriesFeature {
     case selectWorktree(Worktree.ID?, focusTerminal: Bool = false)
     case selectNextWorktree
     case selectPreviousWorktree
+    case worktreeHistoryBack
+    case worktreeHistoryForward
     case revealSelectedWorktreeInSidebar
     case consumePendingSidebarReveal(Int)
     case requestRenameBranch(Worktree.ID, String)
@@ -869,7 +873,7 @@ struct RepositoriesFeature {
         case .selectWorktree(let worktreeID, let focusTerminal):
           let selectWtToken = repositoriesLogger.beginInterval("reducer.selectWorktree")
           defer { repositoriesLogger.endInterval(selectWtToken) }
-          setSingleWorktreeSelection(worktreeID, state: &state)
+          setSingleWorktreeSelection(worktreeID, state: &state, recordHistory: true)
           if focusTerminal, let worktreeID {
             state.pendingTerminalFocusWorktreeIDs.insert(worktreeID)
           }
@@ -899,6 +903,12 @@ struct RepositoriesFeature {
           }
           guard let id = state.worktreeID(byOffset: -1) else { return .none }
           return .send(.selectWorktree(id))
+
+        case .worktreeHistoryBack:
+          return navigateWorktreeHistory(direction: .backward, state: &state)
+
+        case .worktreeHistoryForward:
+          return navigateWorktreeHistory(direction: .forward, state: &state)
 
         case .revealSelectedWorktreeInSidebar:
           guard let worktreeID = state.selectedWorktreeID,
@@ -1542,6 +1552,14 @@ extension RepositoriesFeature.State {
     selection?.worktreeID
   }
 
+  var canNavigateWorktreeHistoryBackward: Bool {
+    canNavigateWorktreeHistory(stack: worktreeHistoryBackStack)
+  }
+
+  var canNavigateWorktreeHistoryForward: Bool {
+    canNavigateWorktreeHistory(stack: worktreeHistoryForwardStack)
+  }
+
   var selectedRepositoryID: Repository.ID? {
     guard case .repository(let repositoryID) = selection else { return nil }
     return repositoryID
@@ -1621,6 +1639,12 @@ extension RepositoriesFeature.State {
 
   func isWorktreeArchived(_ id: Worktree.ID) -> Bool {
     archivedWorktreeIDSet.contains(id)
+  }
+
+  private func canNavigateWorktreeHistory(stack: [Worktree.ID]) -> Bool {
+    stack.reversed().contains { id in
+      id != selectedWorktreeID && isSelectionValid(id, state: self)
+    }
   }
 
   func worktreeInfo(for worktreeID: Worktree.ID) -> WorktreeInfoEntry? {
@@ -2344,8 +2368,10 @@ func restoreSelection(
   guard state.selection == .worktree(pendingID) else { return }
   setSingleWorktreeSelection(
     isSelectionValid(id, state: state) ? id : nil,
-    state: &state
+    state: &state,
+    recordHistory: false
   )
+  pruneWorktreeHistoryTails(state: &state)
 }
 
 func isSelectionValid(
@@ -2433,13 +2459,103 @@ private func isSidebarSelectionValid(
 
 func setSingleWorktreeSelection(
   _ worktreeID: Worktree.ID?,
-  state: inout RepositoriesFeature.State
+  state: inout RepositoriesFeature.State,
+  recordHistory: Bool = false
 ) {
+  if recordHistory {
+    recordWorktreeHistoryTransition(from: state.selectedWorktreeID, to: worktreeID, state: &state)
+  }
   state.selection = worktreeID.map(SidebarSelection.worktree)
   if let worktreeID {
     state.sidebarSelectedWorktreeIDs = [worktreeID]
   } else {
     state.sidebarSelectedWorktreeIDs = []
+  }
+}
+
+private enum WorktreeHistoryDirection {
+  case backward
+  case forward
+}
+
+private let worktreeHistoryStackLimit = 50
+
+private func navigateWorktreeHistory(
+  direction: WorktreeHistoryDirection,
+  state: inout RepositoriesFeature.State
+) -> Effect<RepositoriesFeature.Action> {
+  guard let currentID = state.selectedWorktreeID else { return .none }
+  var sourceStack =
+    direction == .backward
+    ? state.worktreeHistoryBackStack
+    : state.worktreeHistoryForwardStack
+  guard let destinationID = popValidWorktreeHistoryDestination(from: &sourceStack, currentID: currentID, state: state)
+  else {
+    if direction == .backward {
+      state.worktreeHistoryBackStack = sourceStack
+    } else {
+      state.worktreeHistoryForwardStack = sourceStack
+    }
+    return .none
+  }
+
+  if direction == .backward {
+    state.worktreeHistoryBackStack = sourceStack
+    pushWorktreeHistoryID(currentID, onto: &state.worktreeHistoryForwardStack)
+  } else {
+    state.worktreeHistoryForwardStack = sourceStack
+    pushWorktreeHistoryID(currentID, onto: &state.worktreeHistoryBackStack)
+  }
+  setSingleWorktreeSelection(destinationID, state: &state, recordHistory: false)
+  state.openedWorktreeIDs.insert(destinationID)
+  return .send(.delegate(.selectedWorktreeChanged(state.worktree(for: destinationID))))
+}
+
+private func recordWorktreeHistoryTransition(
+  from previousID: Worktree.ID?,
+  to nextID: Worktree.ID?,
+  state: inout RepositoriesFeature.State
+) {
+  guard let previousID, let nextID, previousID != nextID else { return }
+  guard isSelectionValid(previousID, state: state), isSelectionValid(nextID, state: state) else { return }
+  pushWorktreeHistoryID(previousID, onto: &state.worktreeHistoryBackStack)
+  state.worktreeHistoryForwardStack = []
+}
+
+private func popValidWorktreeHistoryDestination(
+  from stack: inout [Worktree.ID],
+  currentID: Worktree.ID,
+  state: RepositoriesFeature.State
+) -> Worktree.ID? {
+  while let candidateID = stack.popLast() {
+    guard candidateID != currentID, isSelectionValid(candidateID, state: state) else {
+      continue
+    }
+    return candidateID
+  }
+  return nil
+}
+
+private func pushWorktreeHistoryID(_ id: Worktree.ID, onto stack: inout [Worktree.ID]) {
+  stack.append(id)
+  if stack.count > worktreeHistoryStackLimit {
+    stack.removeFirst(stack.count - worktreeHistoryStackLimit)
+  }
+}
+
+private func pruneWorktreeHistoryTails(state: inout RepositoriesFeature.State) {
+  pruneWorktreeHistoryTail(stack: &state.worktreeHistoryBackStack, state: state)
+  pruneWorktreeHistoryTail(stack: &state.worktreeHistoryForwardStack, state: state)
+}
+
+private func pruneWorktreeHistoryTail(
+  stack: inout [Worktree.ID],
+  state: RepositoriesFeature.State
+) {
+  while let last = stack.last,
+    last == state.selectedWorktreeID || !isSelectionValid(last, state: state)
+  {
+    stack.removeLast()
   }
 }
 

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -707,6 +707,7 @@ struct RepositoriesFeature {
 
         case .selectArchivedWorktrees:
           state.isShelfActive = false
+          recordWorktreeHistoryTransition(from: state.selectedWorktreeID, to: nil, state: &state)
           state.selection = .archivedWorktrees
           state.sidebarSelectedWorktreeIDs = []
           return .send(.delegate(.selectedWorktreeChanged(nil)))
@@ -862,6 +863,7 @@ struct RepositoriesFeature {
           let selectRepoToken = repositoriesLogger.beginInterval("reducer.selectRepository")
           defer { repositoriesLogger.endInterval(selectRepoToken) }
           guard let repositoryID, state.repositories[id: repositoryID] != nil else { return .none }
+          recordWorktreeHistoryTransition(from: state.selectedWorktreeID, to: nil, state: &state)
           state.selection = .repository(repositoryID)
           state.sidebarSelectedWorktreeIDs = []
           if state.repositories[id: repositoryID]?.kind == .plain {
@@ -1636,7 +1638,11 @@ extension RepositoriesFeature.State {
   }
 
   private var canUseWorktreeHistory: Bool {
-    !isShowingShelf && !isShowingCanvas
+    // History navigation only makes sense when a worktree is the current
+    // anchor. With selection on `.repository`, `.archivedWorktrees`, or `nil`,
+    // there is no "current" position to step away from, so the menu items
+    // (and their shortcuts) must be disabled.
+    !isShowingShelf && !isShowingCanvas && selectedWorktreeID != nil
   }
 
   var archivedWorktreeIDSet: Set<Worktree.ID> {
@@ -2523,11 +2529,21 @@ private func recordWorktreeHistoryTransition(
   to nextID: Worktree.ID?,
   state: inout RepositoriesFeature.State
 ) {
+  // Shelf / Canvas are mode switches, not worktree navigation — leave
+  // history frozen so users can resume Back/Forward where they left off.
   guard !state.isShowingShelf, !state.isShowingCanvas else { return }
-  guard let previousID, let nextID, previousID != nextID else { return }
-  guard isSelectionValid(previousID, state: state), isSelectionValid(nextID, state: state) else { return }
-  pushWorktreeHistoryID(previousID, onto: &state.worktreeHistoryBackStack)
+  // No-op transitions (same worktree, or both endpoints nil) leave history alone.
+  if previousID == nextID { return }
+  // Any user-initiated selection change invalidates the redo path. Crucially
+  // this also fires when the user navigates to/from .repository or
+  // .archivedWorktrees (one or both IDs nil), so a stale forward stack
+  // can't carry over into an unrelated path.
   state.worktreeHistoryForwardStack = []
+  // Only push onto the back stack when leaving a still-valid worktree; we
+  // don't want non-worktree selections (repository / archived) showing up
+  // as Back targets.
+  guard let previousID, isSelectionValid(previousID, state: state) else { return }
+  pushWorktreeHistoryID(previousID, onto: &state.worktreeHistoryBackStack)
 }
 
 private func popValidWorktreeHistoryDestination(

--- a/supacode/Features/Settings/Views/ShortcutsSettingsView.swift
+++ b/supacode/Features/Settings/Views/ShortcutsSettingsView.swift
@@ -906,6 +906,8 @@ private enum ShortcutGroup: String, CaseIterable, Identifiable {
     switch commandID {
     case AppShortcuts.CommandID.selectNextWorktree,
       AppShortcuts.CommandID.selectPreviousWorktree,
+      AppShortcuts.CommandID.worktreeHistoryBack,
+      AppShortcuts.CommandID.worktreeHistoryForward,
       AppShortcuts.CommandID.renameBranch,
       AppShortcuts.CommandID.selectWorktree1,
       AppShortcuts.CommandID.selectWorktree2,

--- a/supacodeTests/AppFeatureArchivedSelectionTests.swift
+++ b/supacodeTests/AppFeatureArchivedSelectionTests.swift
@@ -42,6 +42,7 @@ struct AppFeatureArchivedSelectionTests {
     }
 
     await store.send(.repositories(.selectArchivedWorktrees)) {
+      $0.repositories.worktreeHistoryBackStack = [worktree.id]
       $0.repositories.selection = .archivedWorktrees
     }
     await store.receive(\.repositories.delegate.selectedWorktreeChanged)

--- a/supacodeTests/KeybindingSchemaTests.swift
+++ b/supacodeTests/KeybindingSchemaTests.swift
@@ -56,8 +56,12 @@ struct KeybindingSchemaTests {
   @Test func worktreeHistoryShortcutsDoNotConflictWithShelfBookNavigation() {
     #expect(AppShortcuts.worktreeHistoryBack != AppShortcuts.selectPreviousShelfBook)
     #expect(AppShortcuts.worktreeHistoryForward != AppShortcuts.selectNextShelfBook)
-    #expect(AppShortcuts.worktreeHistoryBack.display == "⌘⌥⌃←")
-    #expect(AppShortcuts.worktreeHistoryForward.display == "⌘⌥⌃→")
+    #expect(AppShortcuts.worktreeHistoryBack != AppShortcuts.selectPreviousTerminalPane)
+    #expect(AppShortcuts.worktreeHistoryForward != AppShortcuts.selectNextTerminalPane)
+    #expect(AppShortcuts.worktreeHistoryBack != AppShortcuts.selectPreviousTerminalTab)
+    #expect(AppShortcuts.worktreeHistoryForward != AppShortcuts.selectNextTerminalTab)
+    #expect(AppShortcuts.worktreeHistoryBack.display == "⌘⌥[")
+    #expect(AppShortcuts.worktreeHistoryForward.display == "⌘⌥]")
   }
 
   @Test func resolverAppliesUserOverrideOverMigratedOverride() {

--- a/supacodeTests/KeybindingSchemaTests.swift
+++ b/supacodeTests/KeybindingSchemaTests.swift
@@ -53,6 +53,13 @@ struct KeybindingSchemaTests {
     #expect(selectAllCanvasCards?.conflictPolicy == .localOnly)
   }
 
+  @Test func worktreeHistoryShortcutsDoNotConflictWithShelfBookNavigation() {
+    #expect(AppShortcuts.worktreeHistoryBack != AppShortcuts.selectPreviousShelfBook)
+    #expect(AppShortcuts.worktreeHistoryForward != AppShortcuts.selectNextShelfBook)
+    #expect(AppShortcuts.worktreeHistoryBack.display == "⌘⌥⌃←")
+    #expect(AppShortcuts.worktreeHistoryForward.display == "⌘⌥⌃→")
+  }
+
   @Test func resolverAppliesUserOverrideOverMigratedOverride() {
     let schema = KeybindingSchemaDocument(
       version: 1,

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -960,6 +960,7 @@ struct RepositoriesFeatureTests {
     }
 
     await store.send(.selectRepository(repository.id)) {
+      $0.worktreeHistoryBackStack = [worktree.id]
       $0.selection = .repository(repository.id)
       $0.sidebarSelectedWorktreeIDs = []
     }
@@ -1087,6 +1088,7 @@ struct RepositoriesFeatureTests {
     }
 
     await store.send(.selectArchivedWorktrees) {
+      $0.worktreeHistoryBackStack = [worktree1.id]
       $0.selection = .archivedWorktrees
       $0.sidebarSelectedWorktreeIDs = []
     }
@@ -4333,6 +4335,111 @@ struct RepositoriesFeatureTests {
     state.repositories = [makeRepository(id: "/tmp/repo", worktrees: [wt1, wt2])]
     state.worktreeHistoryBackStack = [wt2.id, "/tmp/gone"]
     #expect(state.canNavigateWorktreeHistoryBackward)
+  }
+
+  @Test func canNavigateWorktreeHistoryDisabledWhenSelectionIsNotAWorktree() {
+    let wt1 = makeWorktree(id: "/tmp/wt1", name: "alpha")
+    let wt2 = makeWorktree(id: "/tmp/wt2", name: "beta")
+    let repository = makeRepository(id: "/tmp/repo", worktrees: [wt1, wt2])
+    var state = makeState(repositories: [repository])
+    state.worktreeHistoryBackStack = [wt1.id]
+    state.worktreeHistoryForwardStack = [wt2.id]
+
+    state.selection = .repository(repository.id)
+    #expect(!state.canNavigateWorktreeHistoryBackward)
+    #expect(!state.canNavigateWorktreeHistoryForward)
+
+    state.selection = .archivedWorktrees
+    #expect(!state.canNavigateWorktreeHistoryBackward)
+    #expect(!state.canNavigateWorktreeHistoryForward)
+
+    state.selection = nil
+    #expect(!state.canNavigateWorktreeHistoryBackward)
+    #expect(!state.canNavigateWorktreeHistoryForward)
+
+    state.selection = .worktree(wt1.id)
+    #expect(state.canNavigateWorktreeHistoryForward)
+  }
+
+  @Test func selectRepositoryPushesWorktreeOntoBackStackAndClearsForwardStack() async {
+    let wt1 = makeWorktree(id: "/tmp/wt1", name: "alpha")
+    let wt2 = makeWorktree(id: "/tmp/wt2", name: "beta")
+    let repository = makeRepository(id: "/tmp/repo", worktrees: [wt1, wt2])
+    var state = makeState(repositories: [repository])
+    state.selection = .worktree(wt1.id)
+    state.sidebarSelectedWorktreeIDs = [wt1.id]
+    state.worktreeHistoryForwardStack = [wt2.id]
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    }
+
+    await store.send(.selectRepository(repository.id)) {
+      $0.worktreeHistoryBackStack = [wt1.id]
+      $0.worktreeHistoryForwardStack = []
+      $0.selection = .repository(repository.id)
+      $0.sidebarSelectedWorktreeIDs = []
+    }
+    await store.receive(\.delegate.selectedWorktreeChanged)
+  }
+
+  @Test func selectArchivedWorktreesPushesWorktreeOntoBackStackAndClearsForwardStack() async {
+    let wt1 = makeWorktree(id: "/tmp/wt1", name: "alpha")
+    let wt2 = makeWorktree(id: "/tmp/wt2", name: "beta")
+    let repository = makeRepository(id: "/tmp/repo", worktrees: [wt1, wt2])
+    var state = makeState(repositories: [repository])
+    state.selection = .worktree(wt1.id)
+    state.sidebarSelectedWorktreeIDs = [wt1.id]
+    state.worktreeHistoryForwardStack = [wt2.id]
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    }
+
+    await store.send(.selectArchivedWorktrees) {
+      $0.worktreeHistoryBackStack = [wt1.id]
+      $0.worktreeHistoryForwardStack = []
+      $0.selection = .archivedWorktrees
+      $0.sidebarSelectedWorktreeIDs = []
+    }
+    await store.receive(\.delegate.selectedWorktreeChanged)
+  }
+
+  @Test func reselectingWorktreeAfterRepositoryDoesNotResurrectStaleForwardEntry() async {
+    // Reproduces the scenario from the Copilot review: after the user
+    // navigates Back and then leaves the worktree view through a
+    // non-worktree selection, the stale forward target must not survive
+    // the next worktree selection.
+    let wt1 = makeWorktree(id: "/tmp/wt1", name: "alpha")
+    let wt2 = makeWorktree(id: "/tmp/wt2", name: "beta")
+    let wt3 = makeWorktree(id: "/tmp/wt3", name: "gamma")
+    let repository = makeRepository(id: "/tmp/repo", worktrees: [wt1, wt2, wt3])
+    var state = makeState(repositories: [repository])
+    // User landed on wt2 via Back, leaving wt3 in the forward stack.
+    state.selection = .worktree(wt2.id)
+    state.worktreeHistoryBackStack = [wt1.id]
+    state.worktreeHistoryForwardStack = [wt3.id]
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    }
+
+    // Detour through repository view.
+    await store.send(.selectRepository(repository.id)) {
+      $0.worktreeHistoryBackStack = [wt1.id, wt2.id]
+      $0.worktreeHistoryForwardStack = []
+      $0.selection = .repository(repository.id)
+      $0.sidebarSelectedWorktreeIDs = []
+    }
+    await store.receive(\.delegate.selectedWorktreeChanged)
+
+    // Reselect a worktree — no leftover forward target should remain.
+    await store.send(.selectWorktree(wt2.id)) {
+      $0.selection = .worktree(wt2.id)
+      $0.sidebarSelectedWorktreeIDs = [wt2.id]
+      $0.openedWorktreeIDs = [wt2.id]
+    }
+    await store.receive(\.delegate.selectedWorktreeChanged)
+
+    #expect(!store.state.canNavigateWorktreeHistoryForward)
+    #expect(store.state.canNavigateWorktreeHistoryBackward)
   }
 
   private func makeWorktree(

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -944,6 +944,7 @@ struct RepositoriesFeatureTests {
       $0.selection = .worktree(wt2.id)
       $0.sidebarSelectedWorktreeIDs = [wt2.id]
       $0.openedWorktreeIDs = [wt2.id]
+      $0.worktreeHistoryBackStack = [wt1.id]
     }
     await store.receive(\.delegate.selectedWorktreeChanged)
   }
@@ -4025,6 +4026,7 @@ struct RepositoriesFeatureTests {
       $0.selection = .worktree(wt1.id)
       $0.sidebarSelectedWorktreeIDs = [wt1.id]
       $0.openedWorktreeIDs = [wt1.id]
+      $0.worktreeHistoryBackStack = [wt2.id]
     }
     await store.receive(\.delegate.selectedWorktreeChanged)
   }
@@ -4044,6 +4046,7 @@ struct RepositoriesFeatureTests {
       $0.selection = .worktree(wt2.id)
       $0.sidebarSelectedWorktreeIDs = [wt2.id]
       $0.openedWorktreeIDs = [wt2.id]
+      $0.worktreeHistoryBackStack = [wt1.id]
     }
     await store.receive(\.delegate.selectedWorktreeChanged)
   }
@@ -4082,6 +4085,7 @@ struct RepositoriesFeatureTests {
       $0.selection = .worktree(wt2.id)
       $0.sidebarSelectedWorktreeIDs = [wt2.id]
       $0.openedWorktreeIDs = [wt2.id]
+      $0.worktreeHistoryBackStack = [wt1.id]
     }
     await store.receive(\.delegate.selectedWorktreeChanged)
   }
@@ -4148,6 +4152,7 @@ struct RepositoriesFeatureTests {
       $0.selection = .worktree(wt3.id)
       $0.sidebarSelectedWorktreeIDs = [wt3.id]
       $0.openedWorktreeIDs = [wt3.id]
+      $0.worktreeHistoryBackStack = [wt1.id]
     }
     await store.receive(\.delegate.selectedWorktreeChanged)
   }
@@ -4171,6 +4176,7 @@ struct RepositoriesFeatureTests {
       $0.selection = .worktree(wt1.id)
       $0.sidebarSelectedWorktreeIDs = [wt1.id]
       $0.openedWorktreeIDs = [wt1.id]
+      $0.worktreeHistoryBackStack = [wt3.id]
     }
     await store.receive(\.delegate.selectedWorktreeChanged)
   }
@@ -4220,8 +4226,113 @@ struct RepositoriesFeatureTests {
       $0.selection = .worktree(wt1.id)
       $0.sidebarSelectedWorktreeIDs = [wt1.id]
       $0.openedWorktreeIDs = [wt1.id]
+      $0.worktreeHistoryBackStack = [wt3.id]
     }
     await store.receive(\.delegate.selectedWorktreeChanged)
+  }
+
+  // MARK: - Worktree History Back/Forward
+
+  @Test func selectingDifferentWorktreePushesPreviousOntoBackStack() async {
+    let wt1 = makeWorktree(id: "/tmp/wt1", name: "alpha")
+    let wt2 = makeWorktree(id: "/tmp/wt2", name: "beta")
+    let repository = makeRepository(id: "/tmp/repo", worktrees: [wt1, wt2])
+    var state = makeState(repositories: [repository])
+    state.selection = .worktree(wt1.id)
+    state.worktreeHistoryForwardStack = [wt2.id]
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    }
+
+    await store.send(.selectWorktree(wt2.id)) {
+      $0.selection = .worktree(wt2.id)
+      $0.sidebarSelectedWorktreeIDs = [wt2.id]
+      $0.openedWorktreeIDs = [wt2.id]
+      $0.worktreeHistoryBackStack = [wt1.id]
+      $0.worktreeHistoryForwardStack = []
+    }
+    await store.receive(\.delegate.selectedWorktreeChanged)
+  }
+
+  @Test func worktreeHistoryBackPopsPreviousAndPushesCurrentToForward() async {
+    let wt1 = makeWorktree(id: "/tmp/wt1", name: "alpha")
+    let wt2 = makeWorktree(id: "/tmp/wt2", name: "beta")
+    let repository = makeRepository(id: "/tmp/repo", worktrees: [wt1, wt2])
+    var state = makeState(repositories: [repository])
+    state.selection = .worktree(wt2.id)
+    state.worktreeHistoryBackStack = [wt1.id]
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    }
+
+    await store.send(.worktreeHistoryBack) {
+      $0.selection = .worktree(wt1.id)
+      $0.sidebarSelectedWorktreeIDs = [wt1.id]
+      $0.openedWorktreeIDs = [wt1.id]
+      $0.worktreeHistoryBackStack = []
+      $0.worktreeHistoryForwardStack = [wt2.id]
+    }
+    await store.receive(\.delegate.selectedWorktreeChanged)
+  }
+
+  @Test func worktreeHistoryForwardPopsNextAndPushesCurrentToBack() async {
+    let wt1 = makeWorktree(id: "/tmp/wt1", name: "alpha")
+    let wt2 = makeWorktree(id: "/tmp/wt2", name: "beta")
+    let repository = makeRepository(id: "/tmp/repo", worktrees: [wt1, wt2])
+    var state = makeState(repositories: [repository])
+    state.selection = .worktree(wt1.id)
+    state.worktreeHistoryForwardStack = [wt2.id]
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    }
+
+    await store.send(.worktreeHistoryForward) {
+      $0.selection = .worktree(wt2.id)
+      $0.sidebarSelectedWorktreeIDs = [wt2.id]
+      $0.openedWorktreeIDs = [wt2.id]
+      $0.worktreeHistoryBackStack = [wt1.id]
+      $0.worktreeHistoryForwardStack = []
+    }
+    await store.receive(\.delegate.selectedWorktreeChanged)
+  }
+
+  @Test func worktreeHistoryBackSkipsStaleEntriesUntilValidIDFound() async {
+    let wt1 = makeWorktree(id: "/tmp/wt1", name: "alpha")
+    let wt3 = makeWorktree(id: "/tmp/wt3", name: "gamma")
+    let repository = makeRepository(id: "/tmp/repo", worktrees: [wt1, wt3])
+    var state = makeState(repositories: [repository])
+    state.selection = .worktree(wt3.id)
+    state.worktreeHistoryBackStack = [wt1.id, "/tmp/wt2-deleted"]
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    }
+
+    await store.send(.worktreeHistoryBack) {
+      $0.selection = .worktree(wt1.id)
+      $0.sidebarSelectedWorktreeIDs = [wt1.id]
+      $0.openedWorktreeIDs = [wt1.id]
+      $0.worktreeHistoryBackStack = []
+      $0.worktreeHistoryForwardStack = [wt3.id]
+    }
+    await store.receive(\.delegate.selectedWorktreeChanged)
+  }
+
+  @Test func canNavigateBackwardFiltersStaleAndSelfReferentialEntries() {
+    let wt1 = makeWorktree(id: "/tmp/wt1", name: "alpha")
+    let repository = makeRepository(id: "/tmp/repo", worktrees: [wt1])
+    var state = makeState(repositories: [repository])
+    state.selection = .worktree(wt1.id)
+
+    state.worktreeHistoryBackStack = ["/tmp/gone-a", "/tmp/gone-b"]
+    #expect(!state.canNavigateWorktreeHistoryBackward)
+
+    state.worktreeHistoryBackStack = [wt1.id]
+    #expect(!state.canNavigateWorktreeHistoryBackward)
+
+    let wt2 = makeWorktree(id: "/tmp/wt2", name: "beta")
+    state.repositories = [makeRepository(id: "/tmp/repo", worktrees: [wt1, wt2])]
+    state.worktreeHistoryBackStack = [wt2.id, "/tmp/gone"]
+    #expect(state.canNavigateWorktreeHistoryBackward)
   }
 
   private func makeWorktree(

--- a/supacodeTests/ShelfFeatureTests.swift
+++ b/supacodeTests/ShelfFeatureTests.swift
@@ -801,6 +801,7 @@ struct ShelfFeatureTests {
 
     await store.send(.selectArchivedWorktrees) {
       $0.isShelfActive = false
+      $0.worktreeHistoryBackStack = [worktree.id]
       $0.selection = .archivedWorktrees
       $0.sidebarSelectedWorktreeIDs = []
     }

--- a/supacodeTests/ShelfFeatureTests.swift
+++ b/supacodeTests/ShelfFeatureTests.swift
@@ -442,6 +442,41 @@ struct ShelfFeatureTests {
     #expect(sentCommands.value == [.performBindingAction(wt1, action: "previous_tab")])
   }
 
+  @Test(.dependencies) func worktreeHistoryIsUnavailableWhileShelfIsActive() async {
+    let fixture = threeWorktreeFixture()
+    var state = RepositoriesFeature.State(repositories: [fixture.repo])
+    state.selection = .worktree(fixture.worktrees[1].id)
+    state.isShelfActive = true
+    state.worktreeHistoryBackStack = [fixture.worktrees[0].id]
+    state.worktreeHistoryForwardStack = [fixture.worktrees[2].id]
+    #expect(!state.canNavigateWorktreeHistoryBackward)
+    #expect(!state.canNavigateWorktreeHistoryForward)
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    }
+
+    await store.send(.worktreeHistoryBack)
+    await store.send(.worktreeHistoryForward)
+    await store.finish()
+  }
+
+  @Test(.dependencies) func worktreeHistoryIsUnavailableWhileCanvasIsActive() async {
+    let fixture = threeWorktreeFixture()
+    var state = RepositoriesFeature.State(repositories: [fixture.repo])
+    state.selection = .canvas
+    state.worktreeHistoryBackStack = [fixture.worktrees[0].id]
+    state.worktreeHistoryForwardStack = [fixture.worktrees[2].id]
+    #expect(!state.canNavigateWorktreeHistoryBackward)
+    #expect(!state.canNavigateWorktreeHistoryForward)
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    }
+
+    await store.send(.worktreeHistoryBack)
+    await store.send(.worktreeHistoryForward)
+    await store.finish()
+  }
+
   @Test(.dependencies) func selectNextWorktreeOutsideShelfStillCyclesWorktrees() async {
     let rootURL = URL(fileURLWithPath: "/tmp/repo")
     let wt1 = Worktree(
@@ -477,6 +512,7 @@ struct ShelfFeatureTests {
       $0.selection = .worktree(wt2.id)
       $0.sidebarSelectedWorktreeIDs = [wt2.id]
       $0.openedWorktreeIDs = [wt2.id]
+      $0.worktreeHistoryBackStack = [wt1.id]
     }
     await store.receive(\.delegate.selectedWorktreeChanged)
     await store.finish()


### PR DESCRIPTION
## Summary

- Add browser-style back/forward history for worktree selection in the standard sidebar/detail navigation mode.
- Keep worktree history disabled while Shelf or Canvas is active, since those views are the higher-level session navigation surfaces.
- Register Worktrees menu commands and configurable shortcuts.
- Use `⌘⌥[` / `⌘⌥]` for Back/Forward, matching macOS-style navigation and avoiding the existing `⌘[` / `⌘]`, `⌘⇧[` / `⌘⇧]`, and Shelf shortcuts.

## Verification

- `xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -only-testing:supacodeTests/ShelfFeatureTests -only-testing:supacodeTests/KeybindingSchemaTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation 2>&1 | xcsift`
- `xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -only-testing:supacodeTests/RepositoriesFeatureTests -only-testing:supacodeTests/KeybindingSchemaTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation 2>&1 | xcsift`
- `make check`
- `make build-app`
- `make test`
