### PR TITLE
Adapt window title and quit confirmation

### DIFF
--- a/supacode/App/ContentView.swift
+++ b/supacode/App/ContentView.swift
@@ -100,12 +100,6 @@ struct ContentView: View {
       )
     }
     .background(WindowTabbingDisabler())
-    .navigationTitle(
-      WindowTitle.compute(
-        repositories: store.repositories,
-        terminalManager: terminalManager
-      )
-    )
   }
 
   private func toggleLeftSidebar() {

--- a/supacode/App/ContentView.swift
+++ b/supacode/App/ContentView.swift
@@ -100,6 +100,12 @@ struct ContentView: View {
       )
     }
     .background(WindowTabbingDisabler())
+    .navigationTitle(
+      WindowTitle.compute(
+        repositories: store.repositories,
+        terminalManager: terminalManager
+      )
+    )
   }
 
   private func toggleLeftSidebar() {

--- a/supacode/App/WindowSurfacing.swift
+++ b/supacode/App/WindowSurfacing.swift
@@ -1,0 +1,34 @@
+import AppKit
+
+enum WindowID {
+  static let main = "main"
+  static let settings = "settings"
+}
+
+extension NSApplication {
+  @MainActor
+  @discardableResult
+  func surfaceMainWindow() -> Bool {
+    guard let window = mainWindowCandidate() else {
+      activate(ignoringOtherApps: true)
+      return false
+    }
+    if window.isMiniaturized {
+      window.deminiaturize(nil)
+    }
+    activate(ignoringOtherApps: true)
+    window.makeKeyAndOrderFront(nil)
+    return true
+  }
+
+  private func mainWindowCandidate() -> NSWindow? {
+    if let window = windows.first(where: { $0.identifier?.rawValue == WindowID.main }) {
+      return window
+    }
+    let candidates = windows.filter { !($0 is NSPanel) }
+    if let window = candidates.first(where: { $0.identifier?.rawValue != WindowID.settings }) {
+      return window
+    }
+    return candidates.first
+  }
+}

--- a/supacode/App/WindowTabbingDisabler.swift
+++ b/supacode/App/WindowTabbingDisabler.swift
@@ -20,7 +20,8 @@ final class WindowTabbingView: NSView, NSWindowDelegate {
   func disallowTabbing() {
     guard let window else { return }
     window.tabbingMode = .disallowed
-    window.identifier = NSUserInterfaceItemIdentifier("main")
+    window.identifier = NSUserInterfaceItemIdentifier(WindowID.main)
+    window.isExcludedFromWindowsMenu = true
     if window.delegate !== self {
       window.delegate = self
     }

--- a/supacode/App/WindowTitle.swift
+++ b/supacode/App/WindowTitle.swift
@@ -59,9 +59,13 @@ enum WindowTitle {
     else {
       return appName
     }
+    // No active tab → drop worktree context so the title doesn't outlive the last tab.
+    guard let tab = selectedTabTitle(in: terminalState(worktreeID)) else {
+      return appName
+    }
     return format(
       repository: repositoryDisplayTitle(repositoryID: repositoryID, repositories: repositories),
-      tab: selectedTabTitle(in: terminalState(worktreeID))
+      tab: tab
     )
   }
 

--- a/supacode/App/WindowTitle.swift
+++ b/supacode/App/WindowTitle.swift
@@ -1,0 +1,106 @@
+import Foundation
+import IdentifiedCollections
+
+enum WindowTitle {
+  static let appName = "Prowl"
+  static let archivedWorktreesTitle = "Archived Worktrees"
+  static let canvasTitle = "Canvas"
+
+  static func format(repository: String, tab: String?) -> String {
+    guard let tab, !tab.isEmpty else { return repository }
+    return "\(repository) · \(tab)"
+  }
+
+  @MainActor
+  static func compute(
+    repositories: RepositoriesFeature.State,
+    terminalManager: WorktreeTerminalManager
+  ) -> String {
+    compute(
+      repositories: repositories,
+      terminalState: { terminalManager.stateIfExists(for: $0) }
+    )
+  }
+
+  @MainActor
+  static func compute(
+    repositories: RepositoriesFeature.State,
+    terminalState: (Worktree.ID) -> WorktreeTerminalState?
+  ) -> String {
+    switch repositories.selection {
+    case .archivedWorktrees:
+      return archivedWorktreesTitle
+    case .canvas:
+      return canvasTitle
+    case .repository(let repositoryID):
+      return repositoryTitle(repositoryID: repositoryID, repositories: repositories, terminalState: terminalState)
+    case .worktree(let worktreeID):
+      return worktreeTitle(worktreeID: worktreeID, repositories: repositories, terminalState: terminalState)
+    case nil:
+      return appName
+    }
+  }
+
+  static func sanitize(_ raw: String) -> String? {
+    let scalars = raw.unicodeScalars.filter { !CharacterSet.controlCharacters.contains($0) }
+    let trimmed = String(String.UnicodeScalarView(scalars))
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+    return trimmed.isEmpty ? nil : trimmed
+  }
+
+  @MainActor
+  private static func worktreeTitle(
+    worktreeID: Worktree.ID,
+    repositories: RepositoriesFeature.State,
+    terminalState: (Worktree.ID) -> WorktreeTerminalState?
+  ) -> String {
+    guard let repositoryID = repositories.repositoryID(containing: worktreeID),
+      repositories.repositories[id: repositoryID] != nil
+    else {
+      return appName
+    }
+    return format(
+      repository: repositoryDisplayTitle(repositoryID: repositoryID, repositories: repositories),
+      tab: selectedTabTitle(in: terminalState(worktreeID))
+    )
+  }
+
+  @MainActor
+  private static func repositoryTitle(
+    repositoryID: Repository.ID,
+    repositories: RepositoriesFeature.State,
+    terminalState: (Worktree.ID) -> WorktreeTerminalState?
+  ) -> String {
+    guard repositories.repositories[id: repositoryID] != nil else {
+      return appName
+    }
+    return format(
+      repository: repositoryDisplayTitle(repositoryID: repositoryID, repositories: repositories),
+      tab: selectedTabTitle(in: terminalState(repositoryID))
+    )
+  }
+
+  private static func repositoryDisplayTitle(
+    repositoryID: Repository.ID,
+    repositories: RepositoriesFeature.State
+  ) -> String {
+    if let customTitle = repositories.repositoryCustomTitles[repositoryID]?
+      .trimmingCharacters(in: .whitespacesAndNewlines),
+      !customTitle.isEmpty
+    {
+      return customTitle
+    }
+    return repositories.repositories[id: repositoryID]?.name ?? appName
+  }
+
+  @MainActor
+  private static func selectedTabTitle(in state: WorktreeTerminalState?) -> String? {
+    guard let state,
+      let selectedTabID = state.tabManager.selectedTabId,
+      let tab = state.tabManager.tabs.first(where: { $0.id == selectedTabID })
+    else {
+      return nil
+    }
+    return sanitize(tab.title)
+  }
+}

--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -43,13 +43,16 @@ final class SupacodeAppDelegate: NSObject, NSApplicationDelegate {
 
   func applicationDidBecomeActive(_ notification: Notification) {
     let app = NSApplication.shared
-    guard !app.windows.contains(where: \.isVisible) else { return }
-    _ = showMainWindow(from: app)
+    let hasVisibleMainWindow = app.windows.contains { window in
+      window.isVisible && !(window is NSPanel)
+    }
+    guard !hasVisibleMainWindow else { return }
+    app.surfaceMainWindow()
   }
 
   func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
     if flag { return true }
-    return showMainWindow(from: sender) ? false : true
+    return !sender.surfaceMainWindow()
   }
 
   func applicationWillTerminate(_ notification: Notification) {
@@ -63,25 +66,6 @@ final class SupacodeAppDelegate: NSObject, NSApplicationDelegate {
     false
   }
 
-  private func mainWindow(from sender: NSApplication) -> NSWindow? {
-    if let window = sender.windows.first(where: { $0.identifier?.rawValue == "main" }) {
-      return window
-    }
-    if let window = sender.windows.first(where: { $0.identifier?.rawValue != "settings" }) {
-      return window
-    }
-    return sender.windows.first
-  }
-
-  private func showMainWindow(from sender: NSApplication) -> Bool {
-    guard let window = mainWindow(from: sender) else { return false }
-    if window.isMiniaturized {
-      window.deminiaturize(nil)
-    }
-    sender.activate(ignoringOtherApps: true)
-    window.makeKeyAndOrderFront(nil)
-    return true
-  }
 }
 
 @main
@@ -582,30 +566,11 @@ struct SupacodeApp: App {
   }
 
   private static func bringMainWindowToFront() -> Bool {
-    let app = NSApplication.shared
-    guard let window = mainWindow(from: app) else {
-      return false
-    }
-    if window.isMiniaturized {
-      window.deminiaturize(nil)
-    }
-    app.activate(ignoringOtherApps: true)
-    window.makeKeyAndOrderFront(nil)
-    return true
-  }
-
-  private static func mainWindow(from app: NSApplication) -> NSWindow? {
-    if let window = app.windows.first(where: { $0.identifier?.rawValue == "main" }) {
-      return window
-    }
-    if let window = app.windows.first(where: { $0.identifier?.rawValue != "settings" }) {
-      return window
-    }
-    return app.windows.first
+    NSApplication.shared.surfaceMainWindow()
   }
 
   var body: some Scene {
-    Window("Prowl", id: "main") {
+    Window("Prowl", id: WindowID.main) {
       GhosttyColorSchemeSyncView(
         ghostty: ghostty,
         preferredColorScheme: store.settings.appearanceMode.colorScheme

--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -598,8 +598,11 @@ struct SupacodeApp: App {
         SidebarCommands(store: store)
         TerminalCommands(ghosttyShortcuts: ghosttyShortcuts)
         WindowCommands(
+          store: store,
+          terminalManager: terminalManager,
           ghosttyShortcuts: ghosttyShortcuts,
-          resolvedKeybindings: store.resolvedKeybindings
+          resolvedKeybindings: store.resolvedKeybindings,
+          settingsWindowManager: SettingsWindowManager.shared
         )
       }
       CommandGroup(after: .textEditing) {

--- a/supacode/CLIService/OpenCommandHandler.swift
+++ b/supacode/CLIService/OpenCommandHandler.swift
@@ -397,13 +397,7 @@ final class OpenCommandHandler: CommandHandler {
   }
 
   private func bringAppToFront() {
-    NSApplication.shared.activate(ignoringOtherApps: true)
-    if let window = NSApplication.shared.windows.first(where: { $0.identifier?.rawValue == "main" }) {
-      if window.isMiniaturized {
-        window.deminiaturize(nil)
-      }
-      window.makeKeyAndOrderFront(nil)
-    }
+    NSApplication.shared.surfaceMainWindow()
   }
 
   private func waitForRepositoriesReadyIfNeeded() async {

--- a/supacode/Clients/AppLifecycle/AppLifecycleClient.swift
+++ b/supacode/Clients/AppLifecycle/AppLifecycleClient.swift
@@ -1,0 +1,30 @@
+import AppKit
+import ComposableArchitecture
+
+struct AppLifecycleClient: Sendable {
+  var surfaceMainWindow: @MainActor @Sendable () -> Bool
+  var terminate: @MainActor @Sendable () -> Void
+}
+
+extension AppLifecycleClient: DependencyKey {
+  static let liveValue = AppLifecycleClient(
+    surfaceMainWindow: {
+      NSApplication.shared.surfaceMainWindow()
+    },
+    terminate: {
+      NSApplication.shared.terminate(nil)
+    }
+  )
+
+  static let testValue = AppLifecycleClient(
+    surfaceMainWindow: { false },
+    terminate: {}
+  )
+}
+
+extension DependencyValues {
+  var appLifecycleClient: AppLifecycleClient {
+    get { self[AppLifecycleClient.self] }
+    set { self[AppLifecycleClient.self] = newValue }
+  }
+}

--- a/supacode/Commands/WindowCommands.swift
+++ b/supacode/Commands/WindowCommands.swift
@@ -1,8 +1,13 @@
+import ComposableArchitecture
 import SwiftUI
 
 struct WindowCommands: Commands {
+  @Bindable var store: StoreOf<AppFeature>
+  let terminalManager: WorktreeTerminalManager
   let ghosttyShortcuts: GhosttyShortcutManager
   let resolvedKeybindings: ResolvedKeybindingMap
+  @Bindable var settingsWindowManager: SettingsWindowManager
+  @Dependency(SettingsWindowClient.self) private var settingsWindowClient
   @FocusedValue(\.closeTabAction) private var closeTabAction
   @FocusedValue(\.closeSurfaceAction) private var closeSurfaceAction
   @FocusedValue(\.selectPreviousTerminalTabAction) private var selectPreviousTerminalTabAction
@@ -34,13 +39,13 @@ struct WindowCommands: Commands {
       )
     }
 
-    CommandGroup(replacing: .windowArrangement) {
-      Button("Prowl") {
-        NSApp.surfaceMainWindow()
-      }
-      .help("Show main window")
-      Divider()
+    let mainWindowTitle = WindowTitle.compute(
+      repositories: store.repositories,
+      terminalManager: terminalManager
+    )
+    let isSettingsOpen = settingsWindowManager.isOpen
 
+    CommandGroup(replacing: .windowArrangement) {
       Button("Select Previous Tab") {
         selectPreviousTerminalTabAction?()
       }
@@ -123,6 +128,20 @@ struct WindowCommands: Commands {
           )
         )
         .disabled(selectTerminalPaneRightAction == nil)
+      }
+
+      Divider()
+
+      Button(mainWindowTitle) {
+        NSApp.surfaceMainWindow()
+      }
+      .help("Show main window")
+
+      if isSettingsOpen {
+        Button("Settings") {
+          settingsWindowClient.show()
+        }
+        .help("Show Settings window")
       }
     }
   }

--- a/supacode/Commands/WindowCommands.swift
+++ b/supacode/Commands/WindowCommands.swift
@@ -36,10 +36,7 @@ struct WindowCommands: Commands {
 
     CommandGroup(replacing: .windowArrangement) {
       Button("Prowl") {
-        if let window = NSApp.windows.first(where: { $0.identifier?.rawValue == "main" }) {
-          window.makeKeyAndOrderFront(nil)
-          NSApp.activate(ignoringOtherApps: true)
-        }
+        NSApp.surfaceMainWindow()
       }
       .help("Show main window")
       Divider()

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -109,6 +109,7 @@ struct AppFeature {
   @Dependency(RepositoryPersistenceClient.self) private var repositoryPersistence
   @Dependency(WorkspaceClient.self) private var workspaceClient
   @Dependency(SettingsWindowClient.self) private var settingsWindowClient
+  @Dependency(AppLifecycleClient.self) private var appLifecycleClient
   @Dependency(NotificationSoundClient.self) private var notificationSoundClient
   @Dependency(SystemNotificationClient.self) private var systemNotificationClient
   @Dependency(TerminalClient.self) private var terminalClient
@@ -578,31 +579,26 @@ struct AppFeature {
         return .none
 
       case .requestQuit:
-        #if !DEBUG
-          guard state.settings.confirmBeforeQuit else {
-            analyticsClient.capture("app_quit", appQuitProperties(launchedAt: state.launchedAt))
-            return .run { @MainActor _ in
-              NSApplication.shared.terminate(nil)
-            }
-          }
-          state.alert = AlertState {
-            TextState("Quit Prowl?")
-          } actions: {
-            ButtonState(action: .confirmQuit) {
-              TextState("Quit")
-            }
-            ButtonState(role: .cancel, action: .dismiss) {
-              TextState("Cancel")
-            }
-          } message: {
-            TextState("This will close all terminal sessions.")
-          }
-          return .none
-        #else
+        guard state.settings.confirmBeforeQuit else {
+          analyticsClient.capture("app_quit", appQuitProperties(launchedAt: state.launchedAt))
           return .run { @MainActor _ in
-            NSApplication.shared.terminate(nil)
+            appLifecycleClient.terminate()
           }
-        #endif
+        }
+        _ = appLifecycleClient.surfaceMainWindow()
+        state.alert = AlertState {
+          TextState("Quit Prowl?")
+        } actions: {
+          ButtonState(action: .confirmQuit) {
+            TextState("Quit")
+          }
+          ButtonState(role: .cancel, action: .dismiss) {
+            TextState("Cancel")
+          }
+        } message: {
+          TextState("This will close all terminal sessions.")
+        }
+        return .none
 
       case .newTerminal:
         guard let worktree = state.repositories.selectedTerminalWorktree else {
@@ -863,7 +859,7 @@ struct AppFeature {
         analyticsClient.capture("app_quit", appQuitProperties(launchedAt: state.launchedAt))
         state.alert = nil
         return .run { @MainActor _ in
-          NSApplication.shared.terminate(nil)
+          appLifecycleClient.terminate()
         }
 
       case .alert:

--- a/supacode/Features/Repositories/Views/WorktreeDetailView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailView.swift
@@ -62,7 +62,7 @@ struct WorktreeDetailView: View {
       selectedTerminalWorktree: selectedTerminalWorktree,
       selectedWorktreeSummaries: selectedWorktreeSummaries
     )
-    .navigationTitle(repositories.isShowingCanvas ? "Canvas" : "")
+    .navigationTitle(WindowTitle.compute(repositories: repositories, terminalManager: terminalManager))
     .toolbar(removing: repositories.isShowingCanvas ? nil : .title)
     .toolbar {
       if repositories.isShowingCanvas {

--- a/supacode/Features/Settings/BusinessLogic/SettingsWindowManager.swift
+++ b/supacode/Features/Settings/BusinessLogic/SettingsWindowManager.swift
@@ -3,13 +3,17 @@ import ComposableArchitecture
 import SwiftUI
 
 @MainActor
+@Observable
 final class SettingsWindowManager {
-  static let shared = SettingsWindowManager()
+  @ObservationIgnored static let shared = SettingsWindowManager()
 
-  private var settingsWindow: NSWindow?
-  private var store: StoreOf<AppFeature>?
-  private var ghosttyShortcuts: GhosttyShortcutManager?
-  private var commandKeyObserver: CommandKeyObserver?
+  private(set) var isOpen: Bool = false
+
+  @ObservationIgnored private var settingsWindow: NSWindow?
+  @ObservationIgnored private var store: StoreOf<AppFeature>?
+  @ObservationIgnored private var ghosttyShortcuts: GhosttyShortcutManager?
+  @ObservationIgnored private var commandKeyObserver: CommandKeyObserver?
+  @ObservationIgnored private var willCloseObserver: NSObjectProtocol?
 
   private init() {}
 
@@ -29,6 +33,7 @@ final class SettingsWindowManager {
         existingWindow.deminiaturize(nil)
       }
       existingWindow.makeKeyAndOrderFront(nil)
+      isOpen = true
       return
     }
 
@@ -41,9 +46,9 @@ final class SettingsWindowManager {
     let hostingController = NSHostingController(rootView: settingsView)
 
     let window = NSWindow(contentViewController: hostingController)
-    window.title = ""
+    window.title = "Settings"
     window.titleVisibility = .hidden
-    window.identifier = NSUserInterfaceItemIdentifier("settings")
+    window.identifier = NSUserInterfaceItemIdentifier(WindowID.settings)
     window.styleMask = [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView]
     window.tabbingMode = .disallowed
     window.titlebarAppearsTransparent = true
@@ -53,12 +58,24 @@ final class SettingsWindowManager {
       window.toolbar?.showsBaselineSeparator = false
     }
     window.isReleasedWhenClosed = false
+    window.isExcludedFromWindowsMenu = true
     window.setContentSize(NSSize(width: 800, height: 600))
     window.minSize = NSSize(width: 750, height: 500)
+
+    willCloseObserver = NotificationCenter.default.addObserver(
+      forName: NSWindow.willCloseNotification,
+      object: window,
+      queue: .main
+    ) { [weak self] _ in
+      MainActor.assumeIsolated {
+        self?.isOpen = false
+      }
+    }
 
     window.center()
     window.makeKeyAndOrderFront(nil)
 
     settingsWindow = window
+    isOpen = true
   }
 }

--- a/supacodeTests/AppFeatureQuitTests.swift
+++ b/supacodeTests/AppFeatureQuitTests.swift
@@ -1,0 +1,64 @@
+import ComposableArchitecture
+import DependenciesTestSupport
+import Foundation
+import Testing
+
+@testable import supacode
+
+@MainActor
+struct AppFeatureQuitTests {
+  @Test(.dependencies) func requestQuitWithConfirmationSurfacesMainWindowAndShowsAlert() async {
+    var settings = SettingsFeature.State()
+    settings.confirmBeforeQuit = true
+    let surfaced = LockIsolated(false)
+    let store = TestStore(
+      initialState: AppFeature.State(settings: settings)
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.appLifecycleClient.surfaceMainWindow = {
+        surfaced.setValue(true)
+        return true
+      }
+    }
+
+    await store.send(.requestQuit) {
+      $0.alert = AlertState {
+        TextState("Quit Prowl?")
+      } actions: {
+        ButtonState(action: .confirmQuit) {
+          TextState("Quit")
+        }
+        ButtonState(role: .cancel, action: .dismiss) {
+          TextState("Cancel")
+        }
+      } message: {
+        TextState("This will close all terminal sessions.")
+      }
+    }
+
+    #expect(surfaced.value)
+  }
+
+  @Test(.dependencies) func requestQuitWithoutConfirmationTerminatesThroughLifecycleClient() async {
+    var settings = SettingsFeature.State()
+    settings.confirmBeforeQuit = false
+    let terminated = LockIsolated(false)
+    let store = TestStore(
+      initialState: AppFeature.State(settings: settings)
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.date.now = Date(timeIntervalSince1970: 1_000)
+      $0.appLifecycleClient.terminate = {
+        terminated.setValue(true)
+      }
+    }
+
+    await store.send(.requestQuit)
+    await store.finish()
+
+    #expect(terminated.value)
+    #expect(store.state.alert == nil)
+  }
+}

--- a/supacodeTests/WindowTitleTests.swift
+++ b/supacodeTests/WindowTitleTests.swift
@@ -1,0 +1,73 @@
+import ComposableArchitecture
+import Foundation
+import IdentifiedCollections
+import Testing
+
+@testable import supacode
+
+@MainActor
+struct WindowTitleTests {
+  @Test func formatIncludesTabWhenPresent() {
+    #expect(WindowTitle.format(repository: "Prowl", tab: "codex") == "Prowl · codex")
+  }
+
+  @Test func formatDropsEmptyTab() {
+    #expect(WindowTitle.format(repository: "Prowl", tab: nil) == "Prowl")
+    #expect(WindowTitle.format(repository: "Prowl", tab: "") == "Prowl")
+  }
+
+  @Test func sanitizeRemovesControlCharacters() {
+    #expect(WindowTitle.sanitize("codex\nsecret\u{1B}") == "codexsecret")
+    #expect(WindowTitle.sanitize("\n\t\u{07}") == nil)
+  }
+
+  @Test func computeUsesAppTitleWithoutSelection() {
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    #expect(WindowTitle.compute(repositories: RepositoriesFeature.State(), terminalManager: manager) == "Prowl")
+  }
+
+  @Test func computeUsesViewTitlesForCanvasAndArchive() {
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    var state = RepositoriesFeature.State()
+
+    state.selection = .canvas
+    #expect(WindowTitle.compute(repositories: state, terminalManager: manager) == "Canvas")
+
+    state.selection = .archivedWorktrees
+    #expect(WindowTitle.compute(repositories: state, terminalManager: manager) == "Archived Worktrees")
+  }
+
+  @Test func computeUsesCustomRepositoryTitleAndSelectedTabTitle() {
+    let rootURL = URL(fileURLWithPath: "/tmp/repo")
+    let worktree = makeWorktree(rootURL: rootURL)
+    let repository = Repository(
+      id: rootURL.path(percentEncoded: false),
+      rootURL: rootURL,
+      name: "repo",
+      worktrees: IdentifiedArray(uniqueElements: [worktree])
+    )
+    var state = RepositoriesFeature.State(repositories: [repository])
+    state.selection = .worktree(worktree.id)
+    state.repositoryCustomTitles[repository.id] = "Prowl"
+
+    let terminalState = WorktreeTerminalState(runtime: GhosttyRuntime(), worktree: worktree)
+    _ = terminalState.tabManager.createTab(title: "codex\nhidden", icon: nil)
+
+    #expect(
+      WindowTitle.compute(
+        repositories: state,
+        terminalState: { id in id == worktree.id ? terminalState : nil }
+      ) == "Prowl · codexhidden"
+    )
+  }
+
+  private func makeWorktree(rootURL: URL) -> Worktree {
+    Worktree(
+      id: rootURL.appendingPathComponent("main").path(percentEncoded: false),
+      name: "main",
+      detail: "detail",
+      workingDirectory: rootURL.appendingPathComponent("main"),
+      repositoryRootURL: rootURL
+    )
+  }
+}

--- a/supacodeTests/WindowTitleTests.swift
+++ b/supacodeTests/WindowTitleTests.swift
@@ -37,6 +37,37 @@ struct WindowTitleTests {
     #expect(WindowTitle.compute(repositories: state, terminalManager: manager) == "Archived Worktrees")
   }
 
+  @Test func computeFallsBackToAppNameWhenWorktreeHasNoActiveTab() {
+    let rootURL = URL(fileURLWithPath: "/tmp/repo")
+    let worktree = makeWorktree(rootURL: rootURL)
+    let repository = Repository(
+      id: rootURL.path(percentEncoded: false),
+      rootURL: rootURL,
+      name: "repo",
+      worktrees: IdentifiedArray(uniqueElements: [worktree])
+    )
+    var state = RepositoriesFeature.State(repositories: [repository])
+    state.selection = .worktree(worktree.id)
+
+    let terminalState = WorktreeTerminalState(runtime: GhosttyRuntime(), worktree: worktree)
+    let tabId = terminalState.tabManager.createTab(title: "codex", icon: nil)
+    terminalState.tabManager.closeTab(tabId)
+
+    #expect(
+      WindowTitle.compute(
+        repositories: state,
+        terminalState: { id in id == worktree.id ? terminalState : nil }
+      ) == "Prowl"
+    )
+
+    #expect(
+      WindowTitle.compute(
+        repositories: state,
+        terminalState: { _ in nil }
+      ) == "Prowl"
+    )
+  }
+
   @Test func computeUsesCustomRepositoryTitleAndSelectedTabTitle() {
     let rootURL = URL(fileURLWithPath: "/tmp/repo")
     let worktree = makeWorktree(rootURL: rootURL)


### PR DESCRIPTION
## Summary
- add dynamic main-window titles for repository, worktree, canvas, archive, and selected terminal tab state
- centralize main-window surfacing so app reopen, CLI open, Window menu, and quit confirmation target the real main window instead of Settings/panels
- route quit termination through an injectable app lifecycle client so confirmation behavior is testable in DEBUG too

## Tests
- `xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -only-testing:supacodeTests/WindowTitleTests -only-testing:supacodeTests/AppFeatureQuitTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation | xcsift`
- `make check`
- `make build-app`
