### PR TITLE
Adapt worktree loading detail polish

### DIFF
--- a/supacode/Domain/WorktreeLoadingInfo.swift
+++ b/supacode/Domain/WorktreeLoadingInfo.swift
@@ -2,8 +2,55 @@ struct WorktreeLoadingInfo: Hashable {
   let name: String
   let repositoryName: String?
   let state: WorktreeLoadingState
+  let isFolder: Bool
   let statusTitle: String?
   let statusDetail: String?
   let statusCommand: String?
   let statusLines: [String]
+
+  init(
+    name: String,
+    repositoryName: String?,
+    state: WorktreeLoadingState,
+    isFolder: Bool = false,
+    statusTitle: String?,
+    statusDetail: String?,
+    statusCommand: String?,
+    statusLines: [String]
+  ) {
+    self.name = name
+    self.repositoryName = repositoryName
+    self.state = state
+    self.isFolder = isFolder
+    self.statusTitle = statusTitle
+    self.statusDetail = statusDetail
+    self.statusCommand = statusCommand
+    self.statusLines = statusLines
+  }
+
+  var actionLabel: String {
+    switch state {
+    case .creating:
+      "Creating"
+    case .archiving:
+      "Archiving"
+    case .removing:
+      "Removing"
+    }
+  }
+
+  var statusSubtitle: String {
+    let tail = statusLines.suffix(5)
+    guard tail.isEmpty else {
+      return tail.joined(separator: "\n")
+    }
+    if let status = statusDetail ?? statusTitle {
+      return status
+    }
+    let noun = isFolder ? "folder" : "worktree"
+    if !isFolder, let repositoryName {
+      return "\(actionLabel) \(noun) in \(repositoryName)"
+    }
+    return "\(actionLabel) \(noun)..."
+  }
 }

--- a/supacode/Features/Repositories/Views/WorktreeDetailView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailView.swift
@@ -668,11 +668,13 @@ struct WorktreeDetailView: View {
   ) -> WorktreeLoadingInfo? {
     guard let selectedRow else { return nil }
     let repositoryName = repositories.repositoryName(for: selectedRow.repositoryID)
+    let isFolder = repositories.repositories[id: selectedRow.repositoryID]?.kind == .plain
     if selectedRow.isDeleting {
       return WorktreeLoadingInfo(
         name: selectedRow.name,
         repositoryName: repositoryName,
         state: .removing,
+        isFolder: isFolder,
         statusTitle: nil,
         statusDetail: nil,
         statusCommand: nil,

--- a/supacode/Features/Repositories/Views/WorktreeLoadingView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeLoadingView.swift
@@ -3,96 +3,36 @@ import SwiftUI
 struct WorktreeLoadingView: View {
   let info: WorktreeLoadingInfo
   @Environment(\.surfaceBackgroundOpacity) private var surfaceBackgroundOpacity
-  private let bottomAnchorID = "worktree-loading-bottom"
 
   var body: some View {
-    let actionLabel =
-      if info.state == .creating {
-        "Creating"
-      } else if info.state == .archiving {
-        "Archiving"
-      } else {
-        "Removing"
-      }
-    let fallbackStatus =
-      if let repositoryName = info.repositoryName {
-        "\(actionLabel) worktree in \(repositoryName)"
-      } else {
-        "\(actionLabel) worktree..."
-      }
-    let statusLine = info.statusDetail ?? info.statusTitle ?? fallbackStatus
     let statusCommand = info.statusCommand
-    VStack(spacing: 10) {
+    VStack(spacing: 12) {
       ProgressView()
+        .controlSize(.large)
       Text(info.name)
-        .font(.headline)
-        .multilineTextAlignment(.center)
-      if info.statusLines.isEmpty {
-        Text(statusLine)
+        .font(.title3)
+        .lineLimit(1)
+        .truncationMode(.middle)
+      if let statusCommand {
+        Text(statusCommand)
           .font(.subheadline)
+          .monospaced()
           .foregroundStyle(.secondary)
-          .multilineTextAlignment(.center)
-        if let statusCommand {
-          Text(statusCommand)
-            .font(.caption)
-            .monospaced()
-            .foregroundStyle(.secondary)
-            .multilineTextAlignment(.center)
-        }
-      } else {
-        ScrollViewReader { scrollProxy in
-          ScrollView {
-            VStack(alignment: .leading, spacing: 4) {
-              if let statusCommand {
-                Text(statusCommand)
-                  .font(.caption)
-                  .monospaced()
-                  .foregroundStyle(.secondary)
-                  .multilineTextAlignment(.leading)
-                  .frame(maxWidth: .infinity, alignment: .leading)
-              }
-              ForEach(Array(info.statusLines.enumerated()), id: \.offset) { _, line in
-                Text(line)
-                  .font(.caption)
-                  .monospaced()
-                  .foregroundStyle(.secondary)
-                  .multilineTextAlignment(.leading)
-                  .frame(maxWidth: .infinity, alignment: .leading)
-              }
-              Color.clear
-                .frame(height: 1)
-                .id(bottomAnchorID)
-            }
-            .padding(12)
-          }
-          .frame(maxWidth: 560, minHeight: 180, maxHeight: 380)
-          .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
-          .overlay {
-            RoundedRectangle(cornerRadius: 14, style: .continuous)
-              .strokeBorder(.quaternary, lineWidth: 1)
-          }
-          .onAppear {
-            scrollToBottom(using: scrollProxy, animated: false)
-          }
-          .onChange(of: info.statusLines) { _, _ in
-            scrollToBottom(using: scrollProxy, animated: true)
-          }
-        }
+          .lineLimit(1)
+          .truncationMode(.middle)
       }
+      Text(info.statusSubtitle)
+        .font(.subheadline)
+        .monospaced()
+        .foregroundStyle(.tertiary)
+        .lineLimit(5, reservesSpace: true)
+        .truncationMode(.head)
+        .contentTransition(.opacity)
+        .animation(.easeInOut, value: info.statusSubtitle)
     }
-    .frame(maxWidth: 640)
-    .padding(.horizontal, 16)
+    .multilineTextAlignment(.center)
+    .padding(.horizontal, 24)
     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
     .background(Color(nsColor: .windowBackgroundColor).opacity(surfaceBackgroundOpacity))
-  }
-
-  private func scrollToBottom(using proxy: ScrollViewProxy, animated: Bool) {
-    if animated {
-      withAnimation(.easeOut(duration: 0.12)) {
-        proxy.scrollTo(bottomAnchorID, anchor: .bottom)
-      }
-    } else {
-      proxy.scrollTo(bottomAnchorID, anchor: .bottom)
-    }
   }
 }

--- a/supacodeTests/WorktreeLoadingInfoTests.swift
+++ b/supacodeTests/WorktreeLoadingInfoTests.swift
@@ -1,0 +1,48 @@
+import Testing
+
+@testable import supacode
+
+struct WorktreeLoadingInfoTests {
+  @Test func statusSubtitleUsesLatestFiveOutputLines() {
+    let info = WorktreeLoadingInfo(
+      name: "feature",
+      repositoryName: "Prowl",
+      state: .creating,
+      statusTitle: "Creating worktree",
+      statusDetail: "Preparing worktree",
+      statusCommand: "git worktree add",
+      statusLines: ["one", "two", "three", "four", "five", "six"]
+    )
+
+    #expect(info.statusSubtitle == "two\nthree\nfour\nfive\nsix")
+  }
+
+  @Test func statusSubtitleFallsBackToProgressDetailBeforeTitle() {
+    let info = WorktreeLoadingInfo(
+      name: "feature",
+      repositoryName: "Prowl",
+      state: .creating,
+      statusTitle: "Creating worktree",
+      statusDetail: "Preparing worktree",
+      statusCommand: nil,
+      statusLines: []
+    )
+
+    #expect(info.statusSubtitle == "Preparing worktree")
+  }
+
+  @Test func removingPlainFolderUsesFolderNounWithoutRepositorySuffix() {
+    let info = WorktreeLoadingInfo(
+      name: "Documents",
+      repositoryName: "Documents",
+      state: .removing,
+      isFolder: true,
+      statusTitle: nil,
+      statusDetail: nil,
+      statusCommand: nil,
+      statusLines: []
+    )
+
+    #expect(info.statusSubtitle == "Removing folder...")
+  }
+}


### PR DESCRIPTION
## Summary
- adapt the upstream #258 loading overlay polish to Prowl's current repository/detail structure
- centralize loading subtitle text so streaming output shows the latest five lines without a nested scroll region
- treat plain-folder removal as folder removal in loading copy while preserving Prowl's archive-progress path

Skipped from upstream because Prowl already has fork-specific replacements:
- sidebar add button and icon sizing now live in the refactored sidebar views
- empty repository state already uses `ContentUnavailableView`
- detail title already has `DetailToolbarTitle` branch/folder semantics and shortcut-aware rename behavior

## Tests
- `xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -only-testing:supacodeTests/WorktreeLoadingInfoTests -only-testing:supacodeTests/DetailToolbarTitleTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation | xcsift`
- `make check`
- `make build-app`
