### PR TITLE
Use phase animator for progress bar sweep

### DIFF
--- a/supacode/Features/Terminal/Views/GhosttySurfaceProgressBar.swift
+++ b/supacode/Features/Terminal/Views/GhosttySurfaceProgressBar.swift
@@ -5,8 +5,6 @@ struct GhosttySurfaceProgressBar: View {
   let progressState: ghostty_action_progress_report_state_e
   let progressValue: Int?
 
-  @State private var position: CGFloat = 0
-
   var body: some View {
     let color: Color =
       switch progressState {
@@ -52,18 +50,11 @@ struct GhosttySurfaceProgressBar: View {
             Rectangle()
               .fill(color)
               .frame(width: geometry.size.width * 0.25, height: geometry.size.height)
-              .offset(x: position * (geometry.size.width * 0.75))
-          }
-          .onAppear {
-            withAnimation(
-              .easeInOut(duration: 1.2)
-                .repeatForever(autoreverses: true)
-            ) {
-              position = 1
-            }
-          }
-          .onDisappear {
-            position = 0
+              .phaseAnimator([false, true]) { content, moved in
+                content.offset(x: moved ? geometry.size.width * 0.75 : 0)
+              } animation: { _ in
+                .easeInOut(duration: 1.2)
+              }
           }
         }
       }


### PR DESCRIPTION
## Summary
- adapt the applicable animation part of upstream #265 by replacing the Ghostty indeterminate progress bar's `repeatForever` state driver with `phaseAnimator`
- remove the transient `position` state so SwiftUI can manage the phase timeline directly

Skipped from upstream because Prowl's current fork structure differs:
- cross-repo script dot tint is not applicable: Prowl tracks run-script state as a per-worktree boolean and renders a fixed green stop/play indicator, not upstream's per-script tint map
- upstream sidebar `PingDot`/`ShimmerModifier` changes do not apply: those views/modifiers are absent in this fork after sidebar refactors

## Verification
- `rg -n "repeatForever|@State private var position" supacode/Features/Terminal/Views/GhosttySurfaceProgressBar.swift` returns no matches
- `make check`
- `make build-app`
