### PR TITLE
Focus terminal with sidebar right arrow

### DIFF
--- a/supacode/Features/Repositories/Views/SidebarListView.swift
+++ b/supacode/Features/Repositories/Views/SidebarListView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import ComposableArchitecture
 import SwiftUI
 
@@ -123,6 +124,21 @@ struct SidebarListView: View {
         return true
       }
       .focused($isSidebarFocused)
+      .background(
+        SidebarRightArrowMonitor(isSidebarFocused: isSidebarFocused) {
+          guard
+            let worktreeID = SidebarRightArrowFocusPolicy.targetWorktreeID(
+              selectedWorktreeID: store.selectedWorktreeID,
+              sidebarSelectedWorktreeIDs: state.sidebarSelectedWorktreeIDs
+            ),
+            let terminalState = terminalManager.stateIfExists(for: worktreeID)
+          else {
+            return false
+          }
+          terminalState.focusSelectedTab()
+          return true
+        }
+      )
       .onAppear {
         resetSidebarDrag()
       }
@@ -380,6 +396,78 @@ struct SidebarListView: View {
       selectedWorktreeIDs.insert(selectedWorktreeID)
     }
     return selectedWorktreeIDs
+  }
+}
+
+nonisolated enum SidebarRightArrowFocusPolicy {
+  static func targetWorktreeID(
+    selectedWorktreeID: Worktree.ID?,
+    sidebarSelectedWorktreeIDs: Set<Worktree.ID>
+  ) -> Worktree.ID? {
+    guard let selectedWorktreeID,
+      sidebarSelectedWorktreeIDs.count == 1,
+      sidebarSelectedWorktreeIDs.contains(selectedWorktreeID)
+    else {
+      return nil
+    }
+    return selectedWorktreeID
+  }
+}
+
+private struct SidebarRightArrowMonitor: NSViewRepresentable {
+  let isSidebarFocused: Bool
+  let handle: () -> Bool
+
+  func makeCoordinator() -> Coordinator {
+    Coordinator()
+  }
+
+  func makeNSView(context: Context) -> NSView {
+    let view = NSView(frame: .zero)
+    context.coordinator.update(isSidebarFocused: isSidebarFocused, handle: handle)
+    context.coordinator.install(host: view)
+    return view
+  }
+
+  func updateNSView(_ nsView: NSView, context: Context) {
+    context.coordinator.update(isSidebarFocused: isSidebarFocused, handle: handle)
+  }
+
+  static func dismantleNSView(_ nsView: NSView, coordinator: Coordinator) {
+    coordinator.uninstall()
+  }
+
+  @MainActor
+  final class Coordinator {
+    private var isSidebarFocused = false
+    private var handle: () -> Bool = { false }
+    private var monitor: Any?
+
+    func update(isSidebarFocused: Bool, handle: @escaping () -> Bool) {
+      self.isSidebarFocused = isSidebarFocused
+      self.handle = handle
+    }
+
+    func install(host: NSView) {
+      guard monitor == nil else { return }
+      monitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self, weak host] event in
+        guard event.specialKey == .rightArrow else { return event }
+        let userModifiers: NSEvent.ModifierFlags = [.command, .shift, .option, .control]
+        guard event.modifierFlags.isDisjoint(with: userModifiers) else { return event }
+        guard let host, event.window === host.window else { return event }
+        let consumed = MainActor.assumeIsolated {
+          (self?.isSidebarFocused ?? false) && (self?.handle() ?? false)
+        }
+        return consumed ? nil : event
+      }
+    }
+
+    func uninstall() {
+      if let monitor {
+        NSEvent.removeMonitor(monitor)
+      }
+      monitor = nil
+    }
   }
 }
 

--- a/supacodeTests/SidebarRightArrowFocusPolicyTests.swift
+++ b/supacodeTests/SidebarRightArrowFocusPolicyTests.swift
@@ -1,0 +1,35 @@
+import Testing
+
+@testable import supacode
+
+struct SidebarRightArrowFocusPolicyTests {
+  @Test func targetWorktreeRequiresSingleSidebarSelectionMatchingCurrentWorktree() {
+    #expect(
+      SidebarRightArrowFocusPolicy.targetWorktreeID(
+        selectedWorktreeID: "/tmp/repo/main",
+        sidebarSelectedWorktreeIDs: ["/tmp/repo/main"]
+      ) == "/tmp/repo/main"
+    )
+  }
+
+  @Test func targetWorktreeRejectsMultiSelectionAndMismatchedSelection() {
+    #expect(
+      SidebarRightArrowFocusPolicy.targetWorktreeID(
+        selectedWorktreeID: "/tmp/repo/main",
+        sidebarSelectedWorktreeIDs: ["/tmp/repo/main", "/tmp/repo/feature"]
+      ) == nil
+    )
+    #expect(
+      SidebarRightArrowFocusPolicy.targetWorktreeID(
+        selectedWorktreeID: "/tmp/repo/main",
+        sidebarSelectedWorktreeIDs: ["/tmp/repo/feature"]
+      ) == nil
+    )
+    #expect(
+      SidebarRightArrowFocusPolicy.targetWorktreeID(
+        selectedWorktreeID: nil,
+        sidebarSelectedWorktreeIDs: ["/tmp/repo/main"]
+      ) == nil
+    )
+  }
+}


### PR DESCRIPTION
## Summary
- add a sidebar-scoped right-arrow key monitor so `→` moves focus from the focused sidebar into the selected terminal
- keep the behavior constrained to a single sidebar worktree selection matching the current selected worktree
- ignore modified right-arrow shortcuts and scope the monitor to its host window

## Tests
- `xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -only-testing:supacodeTests/SidebarRightArrowFocusPolicyTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation | xcsift`
- `make check`
- `make build-app`

## Manual Verification
- Focus the sidebar with one selected worktree, press `→`, and verify the selected terminal tab receives focus.
- Press `→` with multiple sidebar worktrees selected and verify focus stays in the sidebar.
- Press modified right-arrow shortcuts such as `⌘→` and verify they are not consumed by the monitor.
