### PR TITLE
Cancel superseded test workflow runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - main
   pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: macos-26


### PR DESCRIPTION
## Summary
- add concurrency to the fork's test workflow so superseded PR/main runs are canceled
- intentionally skip upstream release-tip/warm-cache/inspect-dependencies changes because those workflows are absent or release strategy differs in Prowl

## Verification
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/test.yml"); puts "yaml ok"'`
