### PR TITLE
Declare app icon bundle metadata

### DIFF
--- a/supacode/Info.plist
+++ b/supacode/Info.plist
@@ -28,6 +28,8 @@
 	<string>A program running within Prowl would like to use speech recognition.</string>
 	<key>NSSystemAdministrationUsageDescription</key>
 	<string>A program running within Prowl requires elevated privileges.</string>
+	<key>CFBundleIconName</key>
+	<string>AppIcon</string>
 	<key>SUFeedURL</key>
 	<string>https://github.com/onevcat/Prowl/releases/latest/download/appcast.xml</string>
 	<key>SUPublicEDKey</key>

--- a/supacodeTests/AppBundleMetadataTests.swift
+++ b/supacodeTests/AppBundleMetadataTests.swift
@@ -1,0 +1,18 @@
+import Foundation
+import Testing
+
+struct AppBundleMetadataTests {
+  @Test func appInfoPlistDeclaresAssetCatalogIconName() throws {
+    let testsDirectory = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+    let infoPlistURL =
+      testsDirectory
+      .deletingLastPathComponent()
+      .appending(path: "supacode/Info.plist")
+    let plistData = try Data(contentsOf: infoPlistURL)
+    let plist = try #require(
+      PropertyListSerialization.propertyList(from: plistData, format: nil) as? [String: Any]
+    )
+
+    #expect(plist["CFBundleIconName"] as? String == "AppIcon")
+  }
+}


### PR DESCRIPTION
## Summary
- declare `CFBundleIconName` as `AppIcon` in the app Info.plist template
- add a focused metadata test so the asset catalog icon name stays wired
- intentionally skip upstream's Icon Composer `.icon` resource because Prowl currently uses its own AppIcon asset catalog/release icon flow

## Verification
- `xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -only-testing:supacodeTests/AppBundleMetadataTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation 2>&1 | xcsift`
- `make check`
- `make build-app`
