### PR TITLE
Remove dead sidebar focus state

### DIFF
--- a/supacode/Features/Repositories/Views/SidebarListView.swift
+++ b/supacode/Features/Repositories/Views/SidebarListView.swift
@@ -1,6 +1,8 @@
 import ComposableArchitecture
 import SwiftUI
 
+// Uses LazyVStack rather than List for repository drag precision; keyboard
+// worktree navigation goes through Cmd+Ctrl+↑/↓ (`selectNextWorktree`).
 struct SidebarListView: View {
   enum RepositoryListHeaderAction: Equatable {
     case expandAll
@@ -33,7 +35,6 @@ struct SidebarListView: View {
   @Binding var expandedRepoIDs: Set<Repository.ID>
   @Binding var sidebarSelections: Set<SidebarSelection>
   let terminalManager: WorktreeTerminalManager
-  @FocusState private var isSidebarFocused: Bool
   @State private var isDragActive = false
   @State private var draggingRepositoryID: Repository.ID?
   @State private var targetedRepositoryDropDestination: Int?
@@ -122,7 +123,6 @@ struct SidebarListView: View {
         store.send(.repositoryManagement(.openRepositories(fileURLs)))
         return true
       }
-      .focused($isSidebarFocused)
       .onAppear {
         resetSidebarDrag()
       }
@@ -344,7 +344,6 @@ struct SidebarListView: View {
     // Give SwiftUI time to materialize newly expanded section rows before scrolling.
     await Task.yield()
     await Task.yield()
-    isSidebarFocused = true
     withAnimation(.easeOut(duration: 0.2)) {
       scrollProxy.scrollTo(SidebarScrollID.worktree(pendingSidebarReveal.worktreeID), anchor: .center)
     }


### PR DESCRIPTION
## Summary

- Drop `@FocusState isSidebarFocused`, its `.focused()` binding, and the
  setter inside `revealPendingSidebarWorktree`. The state had no readers,
  and SwiftUI's `@FocusState` does not steal first responder from the
  Ghostty surface NSView, so the binding never produced observable
  behavior — verified by typing into the terminal immediately after
  Reveal in Sidebar (`⌘⇧L`) without any focus reset.
- Add a one-line note on `SidebarListView` explaining that the
  `LazyVStack` choice is a deliberate tradeoff for repository drag
  precision (introduced in 304a2f8c), and that keyboard worktree
  navigation is served by `⌘⌃↑/↓` (`selectNextWorktree`).

Companion to closing #265 — that PR's premise (sidebar steals focus,
need to send it back to terminal with `→`) does not match actual runtime
behavior.

## Tests

- `make check`
- `make build-app`

## Manual Verification

- Press `⌘⇧L` to reveal the current worktree in the sidebar; confirm
  the terminal still accepts input without any extra interaction
  (unchanged from before).
- Press `⌘⌃↑` / `⌘⌃↓` to switch worktrees; confirm the keyboard
  navigation still works regardless of where the focus appears to be.
