### PR TITLE
Hold Cmd-W on terminal layer through Shelf book switch

### DIFF
--- a/supacode/Commands/WindowCommands.swift
+++ b/supacode/Commands/WindowCommands.swift
@@ -22,10 +22,13 @@ struct WindowCommands: Commands {
   var body: some Commands {
     let closeSurfaceHotkey = ghosttyShortcuts.keyboardShortcut(for: "close_surface")
     let closeTabHotkey = ghosttyShortcuts.keyboardShortcut(for: "close_tab")
+    let shelfHasOpenBooks =
+      store.repositories.isShelfActive && !store.repositories.openedWorktreeIDs.isEmpty
     let closeWindowShortcut = WindowCloseShortcutPolicy.closeWindowShortcut(
       closeSurfaceShortcut: closeSurfaceHotkey,
       closeTabShortcut: closeTabHotkey,
-      hasTerminalCloseTarget: closeTabAction != nil || closeSurfaceAction != nil
+      hasTerminalCloseTarget: closeTabAction != nil || closeSurfaceAction != nil,
+      shelfHasOpenBooks: shelfHasOpenBooks
     )
 
     CommandGroup(replacing: .saveItem) {
@@ -151,9 +154,16 @@ enum WindowCloseShortcutPolicy {
   static func closeWindowShortcut(
     closeSurfaceShortcut: KeyboardShortcut?,
     closeTabShortcut: KeyboardShortcut?,
-    hasTerminalCloseTarget: Bool
+    hasTerminalCloseTarget: Bool,
+    shelfHasOpenBooks: Bool = false
   ) -> KeyboardShortcut? {
-    if hasTerminalCloseTarget && (isCommandW(closeSurfaceShortcut) || isCommandW(closeTabShortcut)) {
+    // `shelfHasOpenBooks` keeps Cmd+W with the terminal layer through the brief
+    // gap between closing a book's last tab and Shelf advancing to the next
+    // book. Without it, `hasTerminalCloseTarget` momentarily flips false during
+    // that transition, which would let an auto-repeated Cmd+W press fall
+    // through to the "Close Window" menu shortcut and shut the window.
+    let terminalOwnsCommandW = hasTerminalCloseTarget || shelfHasOpenBooks
+    if terminalOwnsCommandW && (isCommandW(closeSurfaceShortcut) || isCommandW(closeTabShortcut)) {
       return nil
     }
     return KeyboardShortcut("w")

--- a/supacodeTests/WindowCloseShortcutPolicyTests.swift
+++ b/supacodeTests/WindowCloseShortcutPolicyTests.swift
@@ -45,4 +45,44 @@ struct WindowCloseShortcutPolicyTests {
     #expect(shortcut?.key == "w")
     #expect(shortcut?.modifiers == .command)
   }
+
+  // Closing the last tab of a Shelf book momentarily clears every focused
+  // close target while the Shelf advances to the next book. If Close Window
+  // is allowed to claim Cmd+W in that window, the next auto-repeated press
+  // shuts the whole window. While Shelf still has at least one open book,
+  // Cmd+W must stay with the terminal layer.
+  @Test func closeWindowYieldsCommandWDuringShelfBookSwitchEvenWithoutFocusedTarget() {
+    let shortcut = WindowCloseShortcutPolicy.closeWindowShortcut(
+      closeSurfaceShortcut: KeyboardShortcut("w"),
+      closeTabShortcut: nil,
+      hasTerminalCloseTarget: false,
+      shelfHasOpenBooks: true
+    )
+
+    #expect(shortcut == nil)
+  }
+
+  @Test func closeWindowKeepsCommandWWhenShelfIsEmptyEvenWithoutFocusedTarget() {
+    let shortcut = WindowCloseShortcutPolicy.closeWindowShortcut(
+      closeSurfaceShortcut: KeyboardShortcut("w"),
+      closeTabShortcut: nil,
+      hasTerminalCloseTarget: false,
+      shelfHasOpenBooks: false
+    )
+
+    #expect(shortcut?.key == "w")
+    #expect(shortcut?.modifiers == .command)
+  }
+
+  @Test func closeWindowKeepsCommandWWhenShelfHasBooksButTerminalUsesDifferentShortcut() {
+    let shortcut = WindowCloseShortcutPolicy.closeWindowShortcut(
+      closeSurfaceShortcut: KeyboardShortcut("w", modifiers: [.option, .command]),
+      closeTabShortcut: nil,
+      hasTerminalCloseTarget: false,
+      shelfHasOpenBooks: true
+    )
+
+    #expect(shortcut?.key == "w")
+    #expect(shortcut?.modifiers == .command)
+  }
 }


### PR DESCRIPTION
## Summary
- Closing the last tab of a Shelf book leaves every focused close target nil for a frame while the reducer advances to the next book. `WindowCloseShortcutPolicy` saw `hasTerminalCloseTarget` flip false in that gap and surrendered Cmd+W to "Close Window", so an auto-repeated Cmd+W shut the whole window mid-transition. Same-book multi-tab Cmd+W never hit this because `canCloseFocusedTab` stays true between presses.
- Pass a new `shelfHasOpenBooks` signal (`isShelfActive && !openedWorktreeIDs.isEmpty`) into the policy; while it's true, the terminal layer keeps Cmd+W ownership across the transition. Once the Shelf empties, Close Window reclaims the shortcut as before.

## Test plan
- [x] `make build-app`
- [x] `xcodebuild test -only-testing:supacodeTests/WindowCloseShortcutPolicyTests` (4 existing + 3 new pass)
- [x] `xcodebuild test -only-testing:supacodeTests/ShelfFeatureTests -only-testing:supacodeTests/WorktreeTerminalManagerTests` (no regressions)
- [x] `make check`
- [x] Manual: open ≥2 books on the Shelf, hold Cmd+W to chew through tabs across book boundaries, confirm the window does not close during the book switch
