### PR TITLE
Animate repo header color dot on hover

### DIFF
--- a/supacode/Features/Repositories/Views/RepositorySectionView.swift
+++ b/supacode/Features/Repositories/Views/RepositorySectionView.swift
@@ -15,6 +15,7 @@ struct RepositorySectionView: View {
   let onRepositorySelected: () -> Void
   @Environment(\.colorScheme) private var colorScheme
   @Environment(\.resolvedKeybindings) private var resolvedKeybindings
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
   @State private var isHovering = false
   @Shared(.repositoryAppearances) private var repositoryAppearances
 
@@ -198,7 +199,15 @@ struct RepositorySectionView: View {
           }
       }
     }
-    .onHover { isHovering = $0 }
+    .onHover { hovering in
+      if reduceMotion {
+        isHovering = hovering
+      } else {
+        withAnimation(.easeOut(duration: 0.15)) {
+          isHovering = hovering
+        }
+      }
+    }
     .onTapGesture {
       onRepositorySelected()
     }


### PR DESCRIPTION
## Summary
- Hover on a sidebar repo header used to make the configured color dot snap left as the `…` / `+` / chevron buttons appeared, which felt jarring.
- Wrap the `isHovering` toggle in `withAnimation(.easeOut(duration: 0.15))` so the dot slides between its idle/hover positions while the buttons fade in/out via the default transition.
- Skip the animation entirely when `accessibilityReduceMotion` is on.

## Test plan
- [x] Hover and unhover a repo with a configured color: the dot glides smoothly, no snap.
- [x] Hover a repo without a color: buttons still appear/disappear with a gentle fade, no regression.
- [x] Enable System Settings → Accessibility → Display → Reduce Motion: hover state toggles instantly without animation.
- [x] `make check`
