### PR TITLE
Honor Ghostty split-divider-color and prowl-split-divider-width

### DIFF
--- a/supacode/Features/Canvas/Views/CanvasCardView.swift
+++ b/supacode/Features/Canvas/Views/CanvasCardView.swift
@@ -18,6 +18,7 @@ struct CanvasCardView: View {
   let tree: SplitTree<GhosttySurfaceView>
   let activeSurfaceID: UUID?
   let unfocusedSplitOverlay: (fill: Color?, opacity: Double)
+  var splitDivider: (color: Color?, width: CGFloat?) = (nil, nil)
   let isFocused: Bool
   let isSelected: Bool
   let hasUnseenNotification: Bool
@@ -232,6 +233,7 @@ struct CanvasCardView: View {
       pinnedSize: cardSize,
       activeSurfaceID: activeSurfaceID,
       unfocusedSplitOverlay: unfocusedSplitOverlay,
+      splitDivider: splitDivider,
       hasNotification: { _ in false },
       action: onSplitOperation
     )

--- a/supacode/Features/Canvas/Views/CanvasView.swift
+++ b/supacode/Features/Canvas/Views/CanvasView.swift
@@ -91,6 +91,7 @@ struct CanvasView: View {
               let screenCenter = screenPosition(for: resized.center)
               let cardTotalHeight = resized.size.height + titleBarHeight
               let unfocusedSplitOverlay = terminalManager.unfocusedSplitOverlay()
+              let splitDivider = terminalManager.splitDividerAppearance()
 
               let repositoryAppearance = appearance(for: state.repositoryRootURL)
               let resolvedRepositoryName = repositoryDisplayName(for: state.repositoryRootURL)
@@ -103,6 +104,7 @@ struct CanvasView: View {
                 tree: tree,
                 activeSurfaceID: state.activeSurfaceID(for: tab.id),
                 unfocusedSplitOverlay: unfocusedSplitOverlay,
+                splitDivider: splitDivider,
                 isFocused: selectionState.primaryTabID == tab.id,
                 isSelected: selectionState.selectedTabIDs.contains(tab.id),
                 hasUnseenNotification: state.hasUnseenNotification(for: tab.id),

--- a/supacode/Features/Shelf/Views/ShelfOpenBookView.swift
+++ b/supacode/Features/Shelf/Views/ShelfOpenBookView.swift
@@ -25,6 +25,7 @@ struct ShelfOpenBookView: View {
     let state = manager.state(for: worktree) { shouldRunSetupScript }
     let _ = configReloadCounter
     let unfocusedSplitOverlay = manager.unfocusedSplitOverlay()
+    let splitDivider = manager.splitDividerAppearance()
     Group {
       if let selectedId = state.tabManager.selectedTabId {
         TerminalTabContentStack(tabs: state.tabManager.tabs, selectedTabId: selectedId) { tabId in
@@ -32,6 +33,7 @@ struct ShelfOpenBookView: View {
             tree: state.splitTree(for: tabId),
             activeSurfaceID: state.activeSurfaceID(for: tabId),
             unfocusedSplitOverlay: unfocusedSplitOverlay,
+            splitDivider: splitDivider,
             hasNotification: { surfaceID in
               state.hasUnseenNotification(forSurfaceID: surfaceID)
             },

--- a/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
+++ b/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
@@ -498,6 +498,11 @@ final class WorktreeTerminalManager {
     return (runtime.unfocusedSplitFill(), runtime.unfocusedSplitOverlayOpacity())
   }
 
+  func splitDividerAppearance() -> (color: Color?, width: CGFloat?) {
+    guard let runtime else { return (nil, nil) }
+    return (runtime.splitDividerColor(), runtime.splitDividerWidth())
+  }
+
   func syncPreferredFontSize(from worktreeID: Worktree.ID) {
     guard let state = states[worktreeID] else { return }
     let fontSize = state.focusedFontSize()

--- a/supacode/Features/Terminal/Views/SplitView.swift
+++ b/supacode/Features/Terminal/Views/SplitView.swift
@@ -10,7 +10,10 @@ struct SplitView<L: View, R: View>: View {
   let onEqualize: () -> Void
   let minSize: CGFloat = 10
   @Binding var split: CGFloat
-  private let splitterVisibleSize: CGFloat = 1
+  static var defaultVisibleSize: CGFloat { 1 }
+  // Visible thickness of the divider bar. The invisible hitbox stays constant
+  // so resize ergonomics don't depend on the visible thickness.
+  let splitterVisibleSize: CGFloat
   private let splitterInvisibleSize: CGFloat = 6
 
   var body: some View {
@@ -45,6 +48,7 @@ struct SplitView<L: View, R: View>: View {
     _ direction: Direction,
     _ split: Binding<CGFloat>,
     dividerColor: Color,
+    dividerVisibleSize: CGFloat = Self.defaultVisibleSize,
     resizeIncrements: CGSize = .init(width: 1, height: 1),
     @ViewBuilder left: (() -> L),
     @ViewBuilder right: (() -> R),
@@ -53,6 +57,7 @@ struct SplitView<L: View, R: View>: View {
     self.direction = direction
     self._split = split
     self.dividerColor = dividerColor
+    self.splitterVisibleSize = dividerVisibleSize
     self.resizeIncrements = resizeIncrements
     self.left = left()
     self.right = right()

--- a/supacode/Features/Terminal/Views/TerminalSplitTreeView.swift
+++ b/supacode/Features/Terminal/Views/TerminalSplitTreeView.swift
@@ -8,6 +8,7 @@ struct TerminalSplitTreeView: View {
   var pinnedSize: CGSize?
   var activeSurfaceID: UUID?
   var unfocusedSplitOverlay: (fill: Color?, opacity: Double)
+  var splitDivider: (color: Color?, width: CGFloat?) = (nil, nil)
   let hasNotification: (UUID) -> Bool
   let action: (Operation) -> Void
 
@@ -33,6 +34,7 @@ struct TerminalSplitTreeView: View {
         pinnedSize: pinnedSize,
         activeSurfaceID: activeSurfaceID,
         unfocusedSplitOverlay: unfocusedSplitOverlay,
+        splitDivider: splitDivider,
         hasNotification: hasNotification,
         action: action
       )
@@ -52,6 +54,7 @@ struct TerminalSplitTreeView: View {
     var pinnedSize: CGSize?
     var activeSurfaceID: UUID?
     var unfocusedSplitOverlay: (fill: Color?, opacity: Double)
+    var splitDivider: (color: Color?, width: CGFloat?) = (nil, nil)
     let hasNotification: (UUID) -> Bool
     let action: (Operation) -> Void
 
@@ -86,7 +89,8 @@ struct TerminalSplitTreeView: View {
             set: {
               action(.resize(node: node, ratio: Double($0)))
             }),
-          dividerColor: Color(nsColor: .separatorColor),
+          dividerColor: splitDivider.color ?? Color(nsColor: .separatorColor),
+          dividerVisibleSize: splitDivider.width ?? SplitView<SubtreeView, SubtreeView>.defaultVisibleSize,
           resizeIncrements: .init(width: 1, height: 1),
           left: {
             SubtreeView(
@@ -94,6 +98,7 @@ struct TerminalSplitTreeView: View {
               pinnedSize: leftPinned,
               activeSurfaceID: activeSurfaceID,
               unfocusedSplitOverlay: unfocusedSplitOverlay,
+              splitDivider: splitDivider,
               hasNotification: hasNotification,
               action: action
             )
@@ -104,6 +109,7 @@ struct TerminalSplitTreeView: View {
               pinnedSize: rightPinned,
               activeSurfaceID: activeSurfaceID,
               unfocusedSplitOverlay: unfocusedSplitOverlay,
+              splitDivider: splitDivider,
               hasNotification: hasNotification,
               action: action
             )
@@ -375,6 +381,7 @@ struct TerminalSplitTreeAXContainer: NSViewRepresentable {
   let tree: SplitTree<GhosttySurfaceView>
   var activeSurfaceID: UUID?
   var unfocusedSplitOverlay: (fill: Color?, opacity: Double)
+  var splitDivider: (color: Color?, width: CGFloat?) = (nil, nil)
   let hasNotification: (UUID) -> Bool
   let action: (TerminalSplitTreeView.Operation) -> Void
 
@@ -389,6 +396,7 @@ struct TerminalSplitTreeAXContainer: NSViewRepresentable {
           tree: tree,
           activeSurfaceID: activeSurfaceID,
           unfocusedSplitOverlay: unfocusedSplitOverlay,
+          splitDivider: splitDivider,
           hasNotification: hasNotification,
           action: action
         )

--- a/supacode/Features/Terminal/Views/WorktreeTerminalTabsView.swift
+++ b/supacode/Features/Terminal/Views/WorktreeTerminalTabsView.swift
@@ -14,6 +14,7 @@ struct WorktreeTerminalTabsView: View {
     let state = manager.state(for: worktree) { shouldRunSetupScript }
     let _ = configReloadCounter
     let unfocusedSplitOverlay = manager.unfocusedSplitOverlay()
+    let splitDivider = manager.splitDividerAppearance()
     VStack(spacing: 0) {
       TerminalTabBarView(
         manager: state.tabManager,
@@ -53,6 +54,7 @@ struct WorktreeTerminalTabsView: View {
             tree: state.splitTree(for: tabId),
             activeSurfaceID: state.activeSurfaceID(for: tabId),
             unfocusedSplitOverlay: unfocusedSplitOverlay,
+            splitDivider: splitDivider,
             hasNotification: { surfaceID in
               state.hasUnseenNotification(forSurfaceID: surfaceID)
             },

--- a/supacode/Infrastructure/Ghostty/GhosttyRuntime.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttyRuntime.swift
@@ -968,6 +968,59 @@ final class GhosttyRuntime {
     return nil
   }
 
+  func splitDividerColor() -> Color? {
+    guard let config else { return nil }
+    var color = ghostty_config_color_s()
+    let key = "split-divider-color"
+    guard ghostty_config_get(config, &color, key, UInt(key.lengthOfBytes(using: .utf8))) else {
+      return nil
+    }
+    return Color(nsColor: NSColor(ghostty: color))
+  }
+
+  /// Reads a Prowl-specific override for the visible divider thickness from the
+  /// primary Ghostty config file (the one returned by `ghostty_config_open_path`).
+  /// Ghostty itself has no such option (and its own divider size is hardcoded),
+  /// so we layer a `prowl-split-divider-width = N` directive on top of the
+  /// user's existing Ghostty config to avoid carrying another fork patch.
+  func splitDividerWidth() -> CGFloat? {
+    Self.parseProwlSplitDividerWidth(at: Self.ghosttyConfigPath())
+  }
+
+  nonisolated static func ghosttyConfigPath() -> String? {
+    let configStr = ghostty_config_open_path()
+    defer { ghostty_string_free(configStr) }
+    guard let ptr = configStr.ptr, configStr.len > 0 else { return nil }
+    let path = String(data: Data(bytes: ptr, count: Int(configStr.len)), encoding: .utf8)
+    guard let path, !path.isEmpty else { return nil }
+    return path
+  }
+
+  nonisolated static func parseProwlSplitDividerWidth(at path: String?) -> CGFloat? {
+    guard let path else { return nil }
+    guard let contents = try? String(contentsOfFile: path, encoding: .utf8) else { return nil }
+    return parseProwlSplitDividerWidth(from: contents)
+  }
+
+  nonisolated static func parseProwlSplitDividerWidth(from contents: String) -> CGFloat? {
+    let key = "prowl-split-divider-width"
+    var resolved: CGFloat?
+    for rawLine in contents.split(whereSeparator: \.isNewline) {
+      let trimmed = rawLine.trimmingCharacters(in: .whitespaces)
+      guard !trimmed.isEmpty, !trimmed.hasPrefix("#") else { continue }
+      guard let equalsIndex = trimmed.firstIndex(of: "=") else { continue }
+      let lhs = trimmed[..<equalsIndex].trimmingCharacters(in: .whitespaces)
+      guard lhs == key else { continue }
+      let rhs = trimmed[trimmed.index(after: equalsIndex)...].trimmingCharacters(in: .whitespaces)
+      guard let value = Double(rhs) else { continue }
+      // Clamp to a sane visible range — 0 disables the visible bar while
+      // keeping the invisible hit area, large values are capped to prevent
+      // accidental absurdities from a typo.
+      resolved = CGFloat(min(max(value, 0), 32))
+    }
+    return resolved
+  }
+
   func backgroundColor() -> NSColor {
     backgroundColorFromConfig() ?? NSColor.windowBackgroundColor
   }

--- a/supacodeTests/GhosttyRuntimeSplitDividerWidthTests.swift
+++ b/supacodeTests/GhosttyRuntimeSplitDividerWidthTests.swift
@@ -1,0 +1,86 @@
+import CoreGraphics
+import Testing
+
+@testable import supacode
+
+struct GhosttyRuntimeSplitDividerWidthTests {
+  @Test func parsesBareIntegerValue() {
+    let parsed = GhosttyRuntime.parseProwlSplitDividerWidth(
+      from: """
+        font-size = 14
+        prowl-split-divider-width = 3
+        background = #000000
+        """)
+
+    #expect(parsed == 3)
+  }
+
+  @Test func parsesDecimalValue() {
+    let parsed = GhosttyRuntime.parseProwlSplitDividerWidth(
+      from: "prowl-split-divider-width = 1.5\n")
+
+    #expect(parsed == 1.5)
+  }
+
+  @Test func toleratesExtraWhitespaceAroundEquals() {
+    let parsed = GhosttyRuntime.parseProwlSplitDividerWidth(
+      from: "   prowl-split-divider-width   =    2   ")
+
+    #expect(parsed == 2)
+  }
+
+  @Test func ignoresCommentedDirective() {
+    let parsed = GhosttyRuntime.parseProwlSplitDividerWidth(
+      from: "# prowl-split-divider-width = 5")
+
+    #expect(parsed == nil)
+  }
+
+  @Test func returnsNilWhenKeyAbsent() {
+    let parsed = GhosttyRuntime.parseProwlSplitDividerWidth(
+      from: """
+        font-size = 14
+        background = #000000
+        """)
+
+    #expect(parsed == nil)
+  }
+
+  @Test func ignoresNonNumericValue() {
+    let parsed = GhosttyRuntime.parseProwlSplitDividerWidth(
+      from: "prowl-split-divider-width = wide")
+
+    #expect(parsed == nil)
+  }
+
+  @Test func lastDeclarationWins() {
+    let parsed = GhosttyRuntime.parseProwlSplitDividerWidth(
+      from: """
+        prowl-split-divider-width = 1
+        prowl-split-divider-width = 4
+        """)
+
+    #expect(parsed == 4)
+  }
+
+  @Test func clampsExcessiveValues() {
+    let parsed = GhosttyRuntime.parseProwlSplitDividerWidth(
+      from: "prowl-split-divider-width = 9999")
+
+    #expect(parsed == 32)
+  }
+
+  @Test func clampsNegativeValuesToZero() {
+    let parsed = GhosttyRuntime.parseProwlSplitDividerWidth(
+      from: "prowl-split-divider-width = -3")
+
+    #expect(parsed == 0)
+  }
+
+  @Test func ignoresUnrelatedProwlPrefixedKeys() {
+    let parsed = GhosttyRuntime.parseProwlSplitDividerWidth(
+      from: "prowl-split-divider-color = #ff0000")
+
+    #expect(parsed == nil)
+  }
+}


### PR DESCRIPTION
## Summary

Closes #278. Brings the split-pane divider in line with the rest of the Ghostty appearance pipeline so user themes can restyle it.

- **Color**: Reads Ghostty's existing `split-divider-color` via `ghostty_config_get` (same path as `unfocused-split-fill`/`unfocused-split-opacity`). Falls back to `NSColor.separatorColor`.
- **Width**: Ghostty hardcodes the visible divider size and has no config for it, so adding a Prowl key would require another fork patch. To keep the Ghostty patch set minimal, Prowl instead parses `prowl-split-divider-width = N` directly from the primary Ghostty config file (`ghostty_config_open_path()`). Values are clamped to `0…32` pt; the invisible hit area is unchanged.

Both values flow through `WorktreeTerminalManager.splitDividerAppearance()` to `TerminalSplitTreeView` and feed `SplitView`. The new `dividerVisibleSize` argument on `SplitView` defaults to the previous `1` pt so existing callers are untouched.

## Test plan

- [x] `make build-app`
- [x] `make check`
- [x] `xcodebuild test -only-testing:supacodeTests/GhosttyRuntimeSplitDividerWidthTests` (10/10 passing)
- [x] Manually: set `split-divider-color = #ff5733` and `prowl-split-divider-width = 4` in `~/Library/Application Support/com.mitchellh.ghostty/config`, restart Prowl, confirm the divider in both Tab view and Canvas card updates.
