### PR TITLE
Fix Claude blocked detection for tall menus

### DIFF
--- a/supacode/Infrastructure/AgentDetection/ScreenHeuristics.swift
+++ b/supacode/Infrastructure/AgentDetection/ScreenHeuristics.swift
@@ -258,8 +258,7 @@ nonisolated private func claudeCurrentInteractionRegion(_ content: String) -> St
   }
 
   let lowerBound = max(lines.startIndex, promptIndex - 10)
-  let upperBound = min(lines.endIndex, promptIndex + 11)
-  return lines[lowerBound..<upperBound].joined(separator: "\n")
+  return lines[lowerBound..<lines.endIndex].joined(separator: "\n")
 }
 
 nonisolated private func hasClaudeBlockedPrompt(content: String, lower: String) -> Bool {

--- a/supacodeTests/ScreenHeuristicsTests.swift
+++ b/supacodeTests/ScreenHeuristicsTests.swift
@@ -118,6 +118,34 @@ struct ScreenHeuristicsTests {
     )
   }
 
+  @Test func claudeDetectsBlockedWhenFirstOptionSelectedInLongMenu() {
+    #expect(
+      DetectedAgent.claude.detectState(
+        in: """
+          需要决策：/release 跳进去发现 APK 没有链时，怎么走接？
+
+          ❯ 1. 自动 release: scripts/build-bridge.sh (Recommended)
+              /release 路径检及发现 APK 类失败链通，自动执行 build-bridge.sh 后继续。
+              便交不会进入入想运能走链。
+              缺点: /release 隐含使用 JDK + Android SDK
+              清看的语述置自动应才进。
+            2. Pre-flight 重新链: 不动动作
+              Step 1: 检查相关 /release 提示具子选定有应作 build-bridge.sh，从是
+              scripts/build-bridge.sh。
+              缺点: 严格、明确、不会有什么动作，但有手动确认。
+            3. Pre-flight 只检查: 例丁检发标
+              选择 APK 检证，看丁路否构建？[Y/n]
+              确即标当链全式动连验。
+            4. Type something.
+            5. Chat about this
+          ──────────────────────────────────────────────────────────────────────────────
+            [Opus 4.7 (1M context) | Max] █░░░░░░░░░ 8% | Prowl git:(branch*) | 2 CLAUDE.md
+            ⏵⏵ bypass permissions on (shift+tab to cycle)
+          """
+      ) == .blocked
+    )
+  }
+
   @Test func claudeDoesNotTreatHistoryInputAndBranchNameAsPermissionPrompt() {
     #expect(
       DetectedAgent.claude.detectState(


### PR DESCRIPTION
## Summary
- Extend `claudeCurrentInteractionRegion` down to the end of the recent buffer so footer markers like "Chat about this" / "Tab to amend" stay visible when `❯` is parked on the very first menu option.
- Add a regression test reproducing the long-menu scenario from #281 (Chinese-wrapped descriptions plus the Ghostty status bar pushed marker phrases past the previous `promptIndex + 11` cap, so the agent was misclassified as `.idle`).

## Why
The old `+11` look-ahead worked fine when the cursor sat on the bottom option (image 2 in the issue) but truncated the menu whenever the cursor was on option 1 of a tall menu (image 1). The lower bound is unchanged at `-10`, so stale prompts above the current `❯` are still ignored — the existing `claudeIgnoresStalePermissionPrompt*` tests cover that path and continue to pass.

Fixes #281.

## Test plan
- [x] `xcodebuild test … -only-testing:supacodeTests/ScreenHeuristicsTests` (all Claude/codex/etc. tests pass; new repro previously failed, now passes)
- [x] `make check`
- [x] `make build-app`
