### PR TITLE
Tag Sentry events with the PostHog install identifier

### DIFF
--- a/supacode.xcodeproj/xcshareddata/xcschemes/supacode.xcscheme
+++ b/supacode.xcodeproj/xcshareddata/xcschemes/supacode.xcscheme
@@ -64,7 +64,7 @@
       </BuildableProductRunnable>
    </LaunchAction>
    <ProfileAction
-      buildConfiguration = "Release"
+      buildConfiguration = "Debug"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"

--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -122,6 +122,10 @@ struct SupacodeApp: App {
           options.tracesSampleRate = 0.05
           options.enableAppHangTracking = false
         }
+        // Match the Sentry user id to the PostHog distinct id so an event in
+        // one system can be traced to the same install in the other.
+        let sentryUser = Sentry.User(userId: InstallIdentifier.current)
+        SentrySDK.setUser(sentryUser)
       }
       if initialSettings.analyticsEnabled,
         let apiKey = infoPlistSecret(infoDictionary, key: "ProwlPostHogAPIKey"),


### PR DESCRIPTION
## Summary

- Set Sentry's `user.id` to `InstallIdentifier.current` so a single install carries the same UUID in both PostHog (`distinct_id`) and Sentry (`user.id`).
- Without this, cross-referencing a PostHog event (e.g. `memory_threshold_4096mb`) to its Sentry breadcrumbs required pivoting through device + release tags, which often returned zero matches.

## Test plan

- [x] `make build-app`
- [x] `make check`
- [x] Local install: launch a Debug build, capture a Sentry event, and verify the event's `user.id` equals the value of the `com.onevcat.prowl.installIdentifier` UserDefaults key.
