### PR TITLE
Stop leaking task allocations per agent detection tick

### DIFF
--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -1635,9 +1635,13 @@ final class WorktreeTerminalState {
     let now = Date()
     let previous = surfaceAgentStates[surfaceID] ?? PaneAgentState(lastChangedAt: now)
     let viewportText = view.bridge.readViewportText() ?? ""
-    let raw = await Task.detached(priority: .utility) {
-      agent.detectState(in: viewportText)
-    }.value
+    // `detectState` is a `nonisolated` pure function that runs in well under a
+    // millisecond on a 24-line viewport, so the prior `Task.detached` hop
+    // bought nothing but allocator churn. In long sessions, each detection
+    // tick (300 ms or 2 s per surface) was leaving a task stack + closure
+    // capture behind that never reached ARC; over a 24 h session this added
+    // up to hundreds of MB of unreferenced allocations.
+    let raw = agent.detectState(in: viewportText)
     guard surfaces[surfaceID] != nil else { return }
 
     var lastClaudeWorkingAt = lastClaudeWorkingAtBySurface[surfaceID]


### PR DESCRIPTION
## Summary

- The 2026.5.11 active-agent detection loop wrapped a pure-function call in `Task.detached(priority: .utility) { ... }.value`, which left an unreferenced Swift task allocation (task stack + closure capture) behind on every detection tick.
- Inlining the call (the function is `nonisolated` and runs in well under a millisecond on a 24-line viewport) removes the unnecessary dispatch and stops the leak.

## Evidence

On a live 25 h Release build (PID 32587):

- `vmmap --summary` → `phys_footprint 970 MB`, `MALLOC_SMALL 80 MB resident + 549 MB swapped`.
- `heap` → **76,588 `Task stack` allocations** (38,314 × 1024 B paired with 38,274 × 320 B) and 14,037 unreferenced closure contexts.
- `leaks` → **98,504 leaks for 460 MB** of unreferenced memory.
- All four PostHog `memory_threshold_4096mb` samples we have are on `prowl@2026.5.11` (the release that shipped active-agent detection); installs that span M1 Pro / M2 Max / Mac17,8 / iMac21,1 all hit ≈ 100-200 MB / h linear growth.

The data, the timing of the regression, and the per-tick allocation pattern all point at this exact line. Linear: [CLAW-97](https://linear.app/onevcat/issue/CLAW-97/memory-leak-phys-footprint-grows-500-mbh-after-2026511-active-agents).

## Test plan

- [x] `make build-app`
- [x] `make check`
- [x] `xcodebuild test … ScreenHeuristicsTests AgentClassifierTests PaneAgentStateTests ActiveAgentsFeatureTests DetectedAgentTests` — all green
- [x] Local soak: Debug build, 5 long-running claude/codex surfaces, monitor `phys_footprint` for 30-60 min; expect near-flat instead of the ~100-200 MB / h slope seen on 5.11.
