### PR TITLE
Backport Ghostty text free ABI fix

### DIFF
--- a/doc-onevcat/fork-sync-ghostty.md
+++ b/doc-onevcat/fork-sync-ghostty.md
@@ -27,6 +27,11 @@ upstream tag, cherry-pick all of them.
    - Switches the foreground-group lookup from `proc_bsdinfo.e_tpgid` to
      `tcgetpgrp` on the pty fd, which is more reliable when the shell PID
      itself is not the controlling process.
+4. `48365577c1ae8e422c0dd90489921f07b9f79171` — `Backport Ghostty text free ABI fix`
+   - Backports upstream `ghostty-org/ghostty#12025` before an upstream tag that includes it exists.
+   - Keeps the public `ghostty_surface_free_text(ghostty_surface_t, ghostty_text_s*)`
+     API shape and fixes the Zig export to accept the unused surface parameter.
+   - Drop this patch when upgrading to an upstream tag that contains `4803d58`.
    - This is the commit the submodule currently points at.
 
 ## Upgrade To A New Ghostty Tag
@@ -58,4 +63,14 @@ Do not force-push `release/v*-patched` branches. If a cherry-pick needs repair, 
 
 ## Build Note
 
-On macOS 26.3.1 with Zig 0.15.2, native `zig build` can fail before running Ghostty's build script because Zig links the build runner with `-platform_version macos 26.3.1 26.4` and fails to resolve libSystem symbols. Direct `zig build-exe -target aarch64-macos.15.0 --sysroot "$(xcrun --sdk macosx --show-sdk-path)"` works, so this is a local Zig host-target/toolchain issue rather than a Ghostty patch syntax error. Re-run `make sync-ghostty` after the Zig toolchain issue is resolved.
+Build GhosttyKit with Xcode 26.3:
+
+```bash
+DEVELOPER_DIR=/Applications/Xcode-26.3.0.app/Contents/Developer make sync-ghostty
+```
+
+Build Prowl itself with the current Xcode, typically Xcode 26.4:
+
+```bash
+DEVELOPER_DIR=/Applications/Xcode-26.4.1.app/Contents/Developer make build-app
+```


### PR DESCRIPTION
## Summary

- Backport upstream `ghostty-org/ghostty#12025` into `onevcat/ghostty` `release/v1.3.1-patched` while waiting for an upstream tag that includes it.
- Advance `ThirdParty/ghostty` to `48365577c`, whose only Ghostty code change is making `ghostty_surface_free_text`'s Zig export accept the existing `(surface, text)` ABI.
- Document the temporary fork patch and the split build toolchain: GhosttyKit with Xcode 26.3, Prowl app with Xcode 26.4.

## Verification

- `DEVELOPER_DIR=/Applications/Xcode-26.3.0.app/Contents/Developer make sync-ghostty`
- `DEVELOPER_DIR=/Applications/Xcode-26.4.1.app/Contents/Developer make build-app`

## Notes

The Instruments trace showed leaked Zig `heap.CAllocator.alloc` buffers on the viewport-read path. The root cause matches upstream `ghostty-org/ghostty#12020`: the public header already declares `ghostty_surface_free_text(ghostty_surface_t, ghostty_text_s*)`, but the Zig export only accepted `*Text`, so the surface pointer was interpreted as the text pointer and the actual allocation was never deinitialized.

This PR keeps Prowl and the public Ghostty C API on the upstream-compatible two-argument call shape. When upgrading to a Ghostty tag that contains upstream commit `4803d58`, drop this temporary fork patch.
