### PR TITLE
[codex] Fix command palette query focus

### DIFF
--- a/supacode/Clients/Terminal/TerminalClient.swift
+++ b/supacode/Clients/Terminal/TerminalClient.swift
@@ -41,6 +41,7 @@ struct TerminalClient {
     case navigateSearchNext(Worktree)
     case navigateSearchPrevious(Worktree)
     case endSearch(Worktree)
+    case focusSelectedTab(Worktree)
     case prune(Set<Worktree.ID>)
     case setNotificationsEnabled(Bool)
     case setCommandFinishedNotification(enabled: Bool, threshold: Int)

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -124,6 +124,13 @@ struct AppFeature {
     return ["session_duration_seconds": seconds]
   }
 
+  private func restoreTerminalFocusEffect(for worktree: Worktree?) -> Effect<Action> {
+    guard let worktree else { return .none }
+    return .run { _ in
+      await terminalClient.send(.focusSelectedTab(worktree))
+    }
+  }
+
   static func sessionDurationSeconds(launchedAt: Date?, now: Date) -> Int? {
     guard let launchedAt else { return nil }
     return max(0, Int(now.timeIntervalSince(launchedAt)))
@@ -932,11 +939,22 @@ struct AppFeature {
       case .updates:
         return .none
 
+      case .commandPalette(.setPresented(false)):
+        guard state.commandPalette.isPresented else { return .none }
+        return restoreTerminalFocusEffect(for: state.repositories.selectedTerminalWorktree)
+
+      case .commandPalette(.togglePresented):
+        guard state.commandPalette.isPresented else { return .none }
+        return restoreTerminalFocusEffect(for: state.repositories.selectedTerminalWorktree)
+
       case .commandPalette(.delegate(.selectWorktree(let worktreeID))):
         return .send(.repositories(.selectWorktree(worktreeID)))
 
       case .commandPalette(.delegate(.checkForUpdates)):
-        return .send(.updates(.checkForUpdates))
+        return .merge(
+          .send(.updates(.checkForUpdates)),
+          restoreTerminalFocusEffect(for: state.repositories.selectedTerminalWorktree)
+        )
 
       case .commandPalette(.delegate(.openSettings)):
         return .merge(
@@ -962,7 +980,10 @@ struct AppFeature {
         return .send(.repositories(.selectArchivedWorktrees))
 
       case .commandPalette(.delegate(.refreshWorktrees)):
-        return .send(.repositories(.refreshWorktrees))
+        return .merge(
+          .send(.repositories(.refreshWorktrees)),
+          restoreTerminalFocusEffect(for: state.repositories.selectedTerminalWorktree)
+        )
 
       case .commandPalette(.delegate(.jumpToLatestUnread)):
         return .send(.jumpToLatestUnread)
@@ -1014,7 +1035,10 @@ struct AppFeature {
 
       #if DEBUG
         case .commandPalette(.delegate(.debugTestToast(let toast))):
-          return .send(.repositories(.showToast(toast)))
+          return .merge(
+            .send(.repositories(.showToast(toast))),
+            restoreTerminalFocusEffect(for: state.repositories.selectedTerminalWorktree)
+          )
 
         case .commandPalette(.delegate(.debugSimulateUpdateFound)):
           return .send(.updates(.debugSimulateUpdateFound))

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -124,11 +124,38 @@ struct AppFeature {
     return ["session_duration_seconds": seconds]
   }
 
-  private func restoreTerminalFocusEffect(for worktree: Worktree?) -> Effect<Action> {
-    guard let worktree else { return .none }
+  private func restoreCommandPaletteTerminalFocusEffect(repositories: RepositoriesFeature.State) -> Effect<Action> {
+    guard let worktree = commandPaletteTerminalFocusTarget(repositories: repositories) else { return .none }
     return .run { _ in
       await terminalClient.send(.focusSelectedTab(worktree))
     }
+  }
+
+  private func commandPaletteTerminalFocusTarget(repositories: RepositoriesFeature.State) -> Worktree? {
+    if let worktree = repositories.selectedTerminalWorktree {
+      return worktree
+    }
+    guard repositories.isShowingCanvas,
+      let worktreeID = terminalClient.canvasFocusedWorktreeID()
+    else {
+      return nil
+    }
+    if let worktree = repositories.worktree(for: worktreeID) {
+      return worktree
+    }
+    guard let repository = repositories.repositories[id: worktreeID],
+      repository.capabilities.supportsRunnableFolderActions,
+      !repository.capabilities.supportsWorktrees
+    else {
+      return nil
+    }
+    return Worktree(
+      id: repository.id,
+      name: repository.name,
+      detail: repository.rootURL.path(percentEncoded: false),
+      workingDirectory: repository.rootURL,
+      repositoryRootURL: repository.rootURL
+    )
   }
 
   static func sessionDurationSeconds(launchedAt: Date?, now: Date) -> Int? {
@@ -941,11 +968,11 @@ struct AppFeature {
 
       case .commandPalette(.setPresented(false)):
         guard state.commandPalette.isPresented else { return .none }
-        return restoreTerminalFocusEffect(for: state.repositories.selectedTerminalWorktree)
+        return restoreCommandPaletteTerminalFocusEffect(repositories: state.repositories)
 
       case .commandPalette(.togglePresented):
         guard state.commandPalette.isPresented else { return .none }
-        return restoreTerminalFocusEffect(for: state.repositories.selectedTerminalWorktree)
+        return restoreCommandPaletteTerminalFocusEffect(repositories: state.repositories)
 
       case .commandPalette(.delegate(.selectWorktree(let worktreeID))):
         return .send(.repositories(.selectWorktree(worktreeID)))
@@ -953,7 +980,7 @@ struct AppFeature {
       case .commandPalette(.delegate(.checkForUpdates)):
         return .merge(
           .send(.updates(.checkForUpdates)),
-          restoreTerminalFocusEffect(for: state.repositories.selectedTerminalWorktree)
+          restoreCommandPaletteTerminalFocusEffect(repositories: state.repositories)
         )
 
       case .commandPalette(.delegate(.openSettings)):
@@ -982,7 +1009,7 @@ struct AppFeature {
       case .commandPalette(.delegate(.refreshWorktrees)):
         return .merge(
           .send(.repositories(.refreshWorktrees)),
-          restoreTerminalFocusEffect(for: state.repositories.selectedTerminalWorktree)
+          restoreCommandPaletteTerminalFocusEffect(repositories: state.repositories)
         )
 
       case .commandPalette(.delegate(.jumpToLatestUnread)):
@@ -1037,7 +1064,7 @@ struct AppFeature {
         case .commandPalette(.delegate(.debugTestToast(let toast))):
           return .merge(
             .send(.repositories(.showToast(toast))),
-            restoreTerminalFocusEffect(for: state.repositories.selectedTerminalWorktree)
+            restoreCommandPaletteTerminalFocusEffect(repositories: state.repositories)
           )
 
         case .commandPalette(.delegate(.debugSimulateUpdateFound)):

--- a/supacode/Features/CommandPalette/Views/CommandPaletteOverlayView.swift
+++ b/supacode/Features/CommandPalette/Views/CommandPaletteOverlayView.swift
@@ -7,7 +7,8 @@ struct CommandPaletteOverlayView: View {
   @Bindable var store: StoreOf<CommandPaletteFeature>
   let items: [CommandPaletteItem]
   let resolvedKeybindings: ResolvedKeybindingMap
-  @FocusState private var isQueryFocused: Bool
+  @State private var isQueryFocused = false
+  @State private var queryFocusTask: Task<Void, Never>?
   @State private var hoveredID: CommandPaletteItem.ID?
   @State private var filteredItems: [CommandPaletteItem] = []
 
@@ -37,7 +38,7 @@ struct CommandPaletteOverlayView: View {
                 items: filteredItems,
                 resolvedKeybindings: resolvedKeybindings,
                 hoveredID: $hoveredID,
-                isQueryFocused: _isQueryFocused,
+                isQueryFocused: isQueryFocused,
                 onEvent: { event in
                   switch event {
                   case .exit:
@@ -54,7 +55,7 @@ struct CommandPaletteOverlayView: View {
               )
               .zIndex(1)
               .task {
-                isQueryFocused = store.isPresented
+                focusQueryField()
               }
 
               Spacer(minLength: 0)
@@ -70,11 +71,14 @@ struct CommandPaletteOverlayView: View {
       }
     }
     .onChange(of: store.isPresented) { _, newValue in
-      isQueryFocused = newValue
       if newValue {
         let updatedItems = refreshFilteredItems(items: items)
         updateSelection(rows: updatedItems)
+        focusQueryField()
       } else {
+        queryFocusTask?.cancel()
+        queryFocusTask = nil
+        isQueryFocused = false
         hoveredID = nil
       }
     }
@@ -147,6 +151,26 @@ struct CommandPaletteOverlayView: View {
     filteredItems = updatedItems
     return updatedItems
   }
+
+  private func focusQueryField() {
+    queryFocusTask?.cancel()
+    isQueryFocused = false
+    queryFocusTask = Task { @MainActor in
+      let delays: [Duration?] = [nil, .milliseconds(50), .milliseconds(150)]
+      for delay in delays {
+        if let delay {
+          try? await ContinuousClock().sleep(for: delay)
+        } else {
+          await Task.yield()
+        }
+        guard !Task.isCancelled else { return }
+        isQueryFocused = false
+        await Task.yield()
+        guard !Task.isCancelled else { return }
+        isQueryFocused = true
+      }
+    }
+  }
 }
 
 private struct CommandPaletteCard: View {
@@ -157,7 +181,7 @@ private struct CommandPaletteCard: View {
   let items: [CommandPaletteItem]
   let resolvedKeybindings: ResolvedKeybindingMap
   @Binding var hoveredID: CommandPaletteItem.ID?
-  let isQueryFocused: FocusState<Bool>
+  let isQueryFocused: Bool
   let onEvent: (CommandPaletteKeyboardEvent) -> Void
   let activate: (CommandPaletteItem.ID) -> Void
 
@@ -221,17 +245,17 @@ private struct CommandPaletteQuery: View {
   static let fieldHeight: CGFloat = 48
 
   @Binding var query: String
+  let isTextFieldFocused: Bool
   var onEvent: ((CommandPaletteKeyboardEvent) -> Void)?
-  @FocusState private var isTextFieldFocused: Bool
 
   init(
     query: Binding<String>,
-    isTextFieldFocused: FocusState<Bool>,
+    isTextFieldFocused: Bool,
     onEvent: ((CommandPaletteKeyboardEvent) -> Void)? = nil
   ) {
     _query = query
+    self.isTextFieldFocused = isTextFieldFocused
     self.onEvent = onEvent
-    _isTextFieldFocused = isTextFieldFocused
   }
 
   var body: some View {
@@ -270,20 +294,120 @@ private struct CommandPaletteQuery: View {
       .frame(width: 0, height: 0)
       .accessibilityHidden(true)
 
-      TextField("Search for actions or branches...", text: $query)
-        .padding()
-        .font(.title3.weight(.light))
-        .frame(height: Self.fieldHeight)
-        .textFieldStyle(.plain)
-        .focused($isTextFieldFocused)
-        .onChange(of: isTextFieldFocused) { _, focused in
-          if !focused {
-            onEvent?(.exit)
-          }
+      CommandPaletteQueryTextField(
+        query: $query,
+        isFocused: isTextFieldFocused,
+        onEvent: { event in
+          onEvent?(event)
         }
-        .onExitCommand { onEvent?(.exit) }
-        .onMoveCommand { onEvent?(.move($0)) }
-        .onSubmit { onEvent?(.submit) }
+      )
+      .padding()
+      .frame(height: Self.fieldHeight)
+    }
+  }
+}
+
+private struct CommandPaletteQueryTextField: NSViewRepresentable {
+  @Binding var query: String
+  let isFocused: Bool
+  let onEvent: (CommandPaletteKeyboardEvent) -> Void
+
+  func makeCoordinator() -> Coordinator {
+    Coordinator(query: $query, onEvent: onEvent)
+  }
+
+  func makeNSView(context: Context) -> QueryField {
+    let field = QueryField()
+    field.delegate = context.coordinator
+    field.onEvent = onEvent
+    field.placeholderString = "Search for actions or branches..."
+    field.isBordered = false
+    field.drawsBackground = false
+    field.focusRingType = .none
+    let titleFont = NSFont.preferredFont(forTextStyle: .title3)
+    field.font = NSFont.systemFont(ofSize: titleFont.pointSize, weight: .light)
+    field.usesSingleLineMode = true
+    field.lineBreakMode = .byTruncatingTail
+    return field
+  }
+
+  func updateNSView(_ nsView: QueryField, context: Context) {
+    context.coordinator.query = $query
+    context.coordinator.onEvent = onEvent
+    nsView.onEvent = onEvent
+    if nsView.stringValue != query {
+      nsView.stringValue = query
+    }
+    if isFocused, !Self.isFocused(nsView) {
+      nsView.window?.makeFirstResponder(nsView)
+    }
+  }
+
+  private static func isFocused(_ field: NSTextField) -> Bool {
+    guard let window = field.window else { return false }
+    return window.firstResponder === field || window.firstResponder === field.currentEditor()
+  }
+
+  final class Coordinator: NSObject, NSTextFieldDelegate {
+    var query: Binding<String>
+    var onEvent: (CommandPaletteKeyboardEvent) -> Void
+
+    init(query: Binding<String>, onEvent: @escaping (CommandPaletteKeyboardEvent) -> Void) {
+      self.query = query
+      self.onEvent = onEvent
+    }
+
+    func controlTextDidChange(_ notification: Notification) {
+      guard let field = notification.object as? NSTextField else { return }
+      query.wrappedValue = field.stringValue
+    }
+
+    func control(
+      _ control: NSControl,
+      textView: NSTextView,
+      doCommandBy commandSelector: Selector
+    ) -> Bool {
+      switch commandSelector {
+      case #selector(NSResponder.cancelOperation(_:)):
+        onEvent(.exit)
+      case #selector(NSResponder.insertNewline(_:)):
+        onEvent(.submit)
+      case #selector(NSResponder.moveUp(_:)):
+        onEvent(.move(.up))
+      case #selector(NSResponder.moveDown(_:)):
+        onEvent(.move(.down))
+      default:
+        return false
+      }
+      return true
+    }
+  }
+
+  final class QueryField: NSTextField {
+    var onEvent: ((CommandPaletteKeyboardEvent) -> Void)?
+
+    override func cancelOperation(_ sender: Any?) {
+      onEvent?(.exit)
+    }
+
+    override func keyDown(with event: NSEvent) {
+      if event.keyCode == 36 || event.keyCode == 76 {
+        onEvent?(.submit)
+        return
+      }
+      if event.modifierFlags.contains(.control) {
+        switch event.charactersIgnoringModifiers?.lowercased() {
+        case "p":
+          onEvent?(.move(.up))
+          return
+        case "n":
+          onEvent?(.move(.down))
+          return
+        default:
+          break
+        }
+      }
+      super.keyDown(with: event)
     }
   }
 }

--- a/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
+++ b/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
@@ -105,6 +105,8 @@ final class WorktreeTerminalManager {
       _ = closeFocusedTab(in: worktree)
     case .closeFocusedSurface(let worktree):
       _ = closeFocusedSurface(in: worktree)
+    case .focusSelectedTab(let worktree):
+      state(for: worktree).focusSelectedTab()
     default:
       return false
     }

--- a/supacodeTests/AppFeatureCommandPaletteTests.swift
+++ b/supacodeTests/AppFeatureCommandPaletteTests.swift
@@ -8,6 +8,151 @@ import Testing
 
 @MainActor
 struct AppFeatureCommandPaletteTests {
+  @Test(.dependencies) func closingCommandPaletteRestoresSelectedTerminalFocus() async {
+    let worktree = makeWorktree(
+      id: "/tmp/repo-focus/wt-1",
+      name: "wt-1",
+      repoRoot: "/tmp/repo-focus"
+    )
+    let repository = makeRepository(id: "/tmp/repo-focus", worktrees: [worktree])
+    var repositoriesState = RepositoriesFeature.State()
+    repositoriesState.repositories = [repository]
+    repositoriesState.selection = .worktree(worktree.id)
+    var state = AppFeature.State(
+      repositories: repositoriesState,
+      settings: SettingsFeature.State()
+    )
+    state.commandPalette.isPresented = true
+    let sent = LockIsolated<[TerminalClient.Command]>([])
+    let store = TestStore(initialState: state) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in
+        sent.withValue { $0.append(command) }
+      }
+    }
+
+    await store.send(.commandPalette(.setPresented(false))) {
+      $0.commandPalette.isPresented = false
+    }
+    await store.finish()
+
+    #expect(sent.value == [.focusSelectedTab(worktree)])
+  }
+
+  @Test(.dependencies) func togglingPresentedCommandPaletteClosedRestoresSelectedTerminalFocus() async {
+    let worktree = makeWorktree(
+      id: "/tmp/repo-toggle-focus/wt-1",
+      name: "wt-1",
+      repoRoot: "/tmp/repo-toggle-focus"
+    )
+    let repository = makeRepository(id: "/tmp/repo-toggle-focus", worktrees: [worktree])
+    var repositoriesState = RepositoriesFeature.State()
+    repositoriesState.repositories = [repository]
+    repositoriesState.selection = .worktree(worktree.id)
+    var state = AppFeature.State(
+      repositories: repositoriesState,
+      settings: SettingsFeature.State()
+    )
+    state.commandPalette.isPresented = true
+    let sent = LockIsolated<[TerminalClient.Command]>([])
+    let store = TestStore(initialState: state) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in
+        sent.withValue { $0.append(command) }
+      }
+    }
+
+    await store.send(.commandPalette(.togglePresented)) {
+      $0.commandPalette.isPresented = false
+    }
+    await store.finish()
+
+    #expect(sent.value == [.focusSelectedTab(worktree)])
+  }
+
+  @Test(.dependencies) func closingCommandPaletteDoesNotRestoreFocusWithoutSelectedTerminal() async {
+    var state = AppFeature.State()
+    state.commandPalette.isPresented = true
+    let sent = LockIsolated<[TerminalClient.Command]>([])
+    let store = TestStore(initialState: state) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in
+        sent.withValue { $0.append(command) }
+      }
+    }
+
+    await store.send(.commandPalette(.setPresented(false))) {
+      $0.commandPalette.isPresented = false
+    }
+    await store.finish()
+
+    #expect(sent.value.isEmpty)
+  }
+
+  @Test(.dependencies) func passiveCommandPaletteCommandRestoresSelectedTerminalFocus() async {
+    let worktree = makeWorktree(
+      id: "/tmp/repo-passive/wt-1",
+      name: "wt-1",
+      repoRoot: "/tmp/repo-passive"
+    )
+    let repository = makeRepository(id: "/tmp/repo-passive", worktrees: [worktree])
+    var repositoriesState = RepositoriesFeature.State()
+    repositoriesState.repositories = [repository]
+    repositoriesState.selection = .worktree(worktree.id)
+    let sent = LockIsolated<[TerminalClient.Command]>([])
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: repositoriesState,
+        settings: SettingsFeature.State()
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in
+        sent.withValue { $0.append(command) }
+      }
+    }
+
+    await store.send(.commandPalette(.delegate(.checkForUpdates)))
+    await store.receive(\.updates.checkForUpdates)
+    await store.finish()
+
+    #expect(sent.value == [.focusSelectedTab(worktree)])
+  }
+
+  @Test(.dependencies) func selectingWorktreeDoesNotRestorePreviousTerminalFocus() async {
+    let worktree = makeWorktree(
+      id: "/tmp/repo-select/wt-1",
+      name: "wt-1",
+      repoRoot: "/tmp/repo-select"
+    )
+    let repository = makeRepository(id: "/tmp/repo-select", worktrees: [worktree])
+    var repositoriesState = RepositoriesFeature.State()
+    repositoriesState.repositories = [repository]
+    let sent = LockIsolated<[TerminalClient.Command]>([])
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: repositoriesState,
+        settings: SettingsFeature.State()
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in
+        sent.withValue { $0.append(command) }
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.commandPalette(.delegate(.selectWorktree(worktree.id))))
+    await store.finish()
+
+    #expect(!sent.value.contains(.focusSelectedTab(worktree)))
+  }
+
   @Test(.dependencies) func openSettingsShowsWindow() async {
     let shown = LockIsolated(false)
     var state = AppFeature.State()

--- a/supacodeTests/AppFeatureCommandPaletteTests.swift
+++ b/supacodeTests/AppFeatureCommandPaletteTests.swift
@@ -92,6 +92,71 @@ struct AppFeatureCommandPaletteTests {
     #expect(sent.value.isEmpty)
   }
 
+  @Test(.dependencies) func closingCommandPaletteInCanvasRestoresCanvasFocusedTerminalFocus() async {
+    let worktree = makeWorktree(
+      id: "/tmp/repo-canvas-focus/wt-1",
+      name: "wt-1",
+      repoRoot: "/tmp/repo-canvas-focus"
+    )
+    let repository = makeRepository(id: "/tmp/repo-canvas-focus", worktrees: [worktree])
+    var repositoriesState = RepositoriesFeature.State()
+    repositoriesState.repositories = [repository]
+    repositoriesState.selection = .canvas
+    var state = AppFeature.State(
+      repositories: repositoriesState,
+      settings: SettingsFeature.State()
+    )
+    state.commandPalette.isPresented = true
+    let sent = LockIsolated<[TerminalClient.Command]>([])
+    let store = TestStore(initialState: state) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.canvasFocusedWorktreeID = { worktree.id }
+      $0.terminalClient.send = { command in
+        sent.withValue { $0.append(command) }
+      }
+    }
+
+    await store.send(.commandPalette(.setPresented(false))) {
+      $0.commandPalette.isPresented = false
+    }
+    await store.finish()
+
+    #expect(sent.value == [.focusSelectedTab(worktree)])
+  }
+
+  @Test(.dependencies) func passiveCommandPaletteCommandInCanvasRestoresCanvasFocusedTerminalFocus() async {
+    let worktree = makeWorktree(
+      id: "/tmp/repo-canvas-passive/wt-1",
+      name: "wt-1",
+      repoRoot: "/tmp/repo-canvas-passive"
+    )
+    let repository = makeRepository(id: "/tmp/repo-canvas-passive", worktrees: [worktree])
+    var repositoriesState = RepositoriesFeature.State()
+    repositoriesState.repositories = [repository]
+    repositoriesState.selection = .canvas
+    let sent = LockIsolated<[TerminalClient.Command]>([])
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: repositoriesState,
+        settings: SettingsFeature.State()
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.canvasFocusedWorktreeID = { worktree.id }
+      $0.terminalClient.send = { command in
+        sent.withValue { $0.append(command) }
+      }
+    }
+
+    await store.send(.commandPalette(.delegate(.checkForUpdates)))
+    await store.receive(\.updates.checkForUpdates)
+    await store.finish()
+
+    #expect(sent.value == [.focusSelectedTab(worktree)])
+  }
+
   @Test(.dependencies) func passiveCommandPaletteCommandRestoresSelectedTerminalFocus() async {
     let worktree = makeWorktree(
       id: "/tmp/repo-passive/wt-1",


### PR DESCRIPTION
## Summary
- Replaces the fragile SwiftUI `@FocusState` query focus handoff with a thin AppKit-backed query field, following the existing terminal search overlay pattern.
- Reasserts query focus shortly after the palette appears so the macOS 26.5/Tahoe `Cmd+P` menu-command path cannot leave the terminal as first responder.
- Keeps the existing hidden shortcut buttons for Up/Down and Ctrl-P/Ctrl-N as a fallback path, while the AppKit field also handles Escape, Return, Up/Down, and Ctrl-P/Ctrl-N when focused.
- Restores focus to the selected terminal when the palette is dismissed without switching terminals, including Escape, repeated `Cmd+P`, and passive command actions such as check-for-updates/refresh/debug toast.
- In Canvas mode, restores focus to the last Canvas-focused terminal card via `terminalClient.canvasFocusedWorktreeID()`.

## Root Cause Evidence
The reproduced behavior on macOS 26.5 is specific:
- `Cmd+P` opens the palette.
- The original palette still received navigation keys: Up/Down moved the selection.
- The query field had no insertion cursor, and typed text continued going to the terminal behind it.
- Clicking the query field made the original implementation work.
- `Cmd+Shift+P` worked in the original implementation.

That points away from shortcut delivery or overlay presentation, and toward the query field failing to become first responder after the `Cmd+P` open path. Earlier attempts also ruled out Ghostty keybind routing and upstream menu identity alignment as sufficient fixes.

One intermediate AppKit field version made things worse because it replaced the existing keyboard shortcut fallback and closed the palette on text-field focus churn. This version intentionally avoids that: it preserves the fallback shortcut buttons and does not use blur as a dismiss signal.

## Regression Check
- Filtering, selection updates, item activation, row clicks, and recency ordering still use the existing Command Palette reducer and view code paths.
- Up/Down and Ctrl-P/Ctrl-N hidden shortcut buttons are preserved as fallback keyboard routing.
- The query changed surface is limited to query focus and query text input plumbing.
- Terminal focus restoration is routed through `TerminalClient.Command.focusSelectedTab`.
- Normal/Shelf restore uses `selectedTerminalWorktree`; Canvas restore uses `canvasFocusedWorktreeID`; worktree selection explicitly does not restore the previous terminal focus.

## Validation
- `xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -only-testing:supacodeTests/AppShortcutsTests -only-testing:supacodeTests/CommandPaletteFeatureTests -only-testing:supacodeTests/AppFeatureCommandPaletteTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation 2>&1 | xcsift -f toon`
- `make build-app 2>&1 | xcsift -f toon`

## Manual Verification
- On macOS 26.5, focus a terminal, press `Cmd+P`, type a query, and verify the text appears in the Command Palette field rather than the terminal.
- Verify `Cmd+P` then Up/Down changes palette selection.
- Verify `Cmd+P` then clicking the query field still allows typing.
- Verify `Cmd+Shift+P` opens the palette and accepts typing.
- Verify Escape dismisses the palette and returns typing focus to the previous terminal in Normal, Shelf, and Canvas modes.
- Verify repeated `Cmd+P` dismisses the palette and returns typing focus to the previous terminal in Normal, Shelf, and Canvas modes.
- Verify choosing a passive command, such as debug toast, dismisses the palette and returns typing focus to the previous terminal in Normal, Shelf, and Canvas modes.
- Verify choosing a worktree does not restore focus to the previous terminal.