### PR TITLE
fix: improve sidebar branch name truncation

### DIFF
--- a/supacode/Features/Repositories/Views/WorktreeRow.swift
+++ b/supacode/Features/Repositories/Views/WorktreeRow.swift
@@ -73,7 +73,9 @@ struct WorktreeRow: View {
           .font(.body)
           .foregroundStyle(nameColor)
           .lineLimit(1)
-          .truncationMode(.tail)
+          .truncationMode(.middle)
+          .layoutPriority(1)
+          .help(name)
         Spacer(minLength: 4)
         if isHovered, pinAction != nil {
           Button {


### PR DESCRIPTION
## Summary
  - Use middle truncation for sidebar worktree branch names so long names keep both their prefix and suffix
  visible.
  - Add a tooltip that shows the full branch name on hover.