### PR TITLE
Add icon to Check for Updates menu item

### DIFF
--- a/supacode/Commands/UpdateCommands.swift
+++ b/supacode/Commands/UpdateCommands.swift
@@ -7,7 +7,7 @@ struct UpdateCommands: Commands {
 
   var body: some Commands {
     CommandGroup(after: .appInfo) {
-      Button("Check for Updates...") {
+      Button("Check for Updates...", systemImage: "arrow.down.circle") {
         store.send(.checkForUpdates)
       }
       .modifier(KeyboardShortcutModifier(shortcut: keyboardShortcut(for: AppShortcuts.CommandID.checkForUpdates)))


### PR DESCRIPTION
## Background

I really enjoy using Prowl as a macOS app. While using it, I noticed that the `Check for Updates...` item in the app menu did not have a leading icon, while the `About Prowl` item above it does. The visual mismatch felt a little uncomfortable in daily use, so this PR adds an icon to make the menu feel more polished and consistent. I hope this helps make Prowl a little better.

## Summary

- Add an SF Symbol icon to the app menu's `Check for Updates...` command.
- Use `arrow.down.circle` to match Prowl's existing update icon language.
- Keep the command behavior, shortcut, and help text unchanged.

## Screenshots

| Before | After |
| --- | --- |
| ![Before: Check for Updates without icon](https://github.com/user-attachments/assets/207a48b7-c0ae-46a1-b24f-22dccf60418c) | ![After: Check for Updates with icon](https://github.com/user-attachments/assets/55cbb003-e82b-4d04-af11-68149ff50f71) |

## Testing

- Built and ran the Debug app locally.
- Verified the Prowl app menu now shows `arrow.down.circle` before `Check for Updates...`.
- Verified the menu item still uses the existing `⇧⌘U` shortcut and triggers the same update check action.
