### PR TITLE
refactor(command palette): introduce category + defaultSuggestion model

### DIFF
--- a/doc-onevcat/plans/2026-05-16-command-palette-architecture-plan.md
+++ b/doc-onevcat/plans/2026-05-16-command-palette-architecture-plan.md
@@ -1,0 +1,285 @@
+# Command Palette Architecture Refactor
+
+## Context
+
+The command palette (`supacode/Features/CommandPalette/`) ships ~24 commands today. We want to bring it to **60–80 commands** by surfacing view toggles (Canvas/Shelf/Sidebar/Active Agents), navigation actions (next/prev worktree, worktree history), terminal/tab/pane operations, and find-in-terminal — actions currently reachable only via hotkeys or menu items.
+
+Before adding commands, the existing architecture has three issues that would compound at scale:
+
+1. **Confusing visibility model.** Two booleans (`isGlobal`, `isRootAction`) collapse into a single bit of meaningful state. `isGlobal` is named as if it controls "appears in search", but every command participates in search regardless. `isRootAction` is a pure negative override — its only effect is to *hide* items from the empty-query suggestion list. The 8 app-level commands set both flags to `true`, so they never appear when the palette opens; opening Cmd+P shows a blank list in normal use.
+2. **No keyword aliases.** The fuzzy scorer only matches `title` and `subtitle`. `Toggle Sidebar` cannot be found by typing `sb`. At 60+ commands users will rely heavily on short queries — keyword support is load-bearing for discoverability.
+3. **High cost-per-command.** Adding one command requires changes in `CommandPaletteItem.Kind`, the builder in `CommandPaletteFeature.commandPaletteItems`, the delegate routing in `AppFeature`, and icon/badge rules in the overlay view. There's no factory to compress repetitive registration (e.g., commands that simply forward to an `AppShortcut`).
+
+This plan refactors the foundations first (PR1–PR3), then batches the actual command additions (PR4+).
+
+---
+
+## Design Overview
+
+### New `CommandPaletteItem` shape
+
+```swift
+struct CommandPaletteItem: Identifiable, Equatable {
+  let id: String
+  let title: String
+  let subtitle: String?
+  let kind: Kind
+  let priorityTier: Int
+  let category: Category          // NEW: required, drives section grouping
+  let keywords: [String]          // NEW: aliases that participate in fuzzy match
+  let defaultSuggestion: Bool     // NEW: replaces isGlobal + isRootAction
+}
+
+enum Category: String, CaseIterable {
+  case view          // Toggle Sidebar / Canvas / Shelf / Active Agents / Diff
+  case navigation    // Next/Prev worktree / tab / pane / shelf book / history
+  case worktree      // New / Refresh / Archive / Remove / Run / Stop / Open
+  case pullRequest   // Open / Merge / Close / Ready / CI actions
+  case terminal      // Font size / Find / Ghostty-bridged commands
+  case app           // Settings / Check Updates / Open Repository / Install CLI
+  #if DEBUG
+  case debug
+  #endif
+}
+```
+
+### Why a single `defaultSuggestion` bit (not three-state)
+
+A three-state enum (`alwaysSuggest / onSearch / contextual`) overlaps with what the builder already does. The current builder is context-aware — it only constructs PR commands when an open PR exists; it only adds the worktree icon-change command when a worktree is selected; it filters out unwanted Ghostty actions. **Contextuality lives in command construction**, not in the visibility flag.
+
+That means `defaultSuggestion: Bool` is sufficient and uniform: an item is suggested when (a) it was constructed (the builder decided the context is right) **and** (b) the static `defaultSuggestion` flag is true. PR commands appear in Suggested when a PR exists because the builder constructs them then, not because of any PR-specific filter in the suggestion logic.
+
+This satisfies the constraint *"don't special-case PR commands"* — the suggestion view is one filter + one sort.
+
+### Empty-query rendering (post-PR2)
+
+```
+┌──────────────────────────────────────────┐
+│  [search box]                            │
+├──────────────────────────────────────────┤
+│  Recent                                  │
+│    • Toggle Canvas              ⌘⌥↩     │
+│    • New Worktree               ⌘N      │
+│  Suggested                               │
+│    • Toggle Sidebar             ⌘⌃S     │
+│    • Check for Updates          ⌘⇧U     │
+│    • Open Settings              ⌘,      │
+│    • …                                   │
+└──────────────────────────────────────────┘
+```
+
+- **Cap at 8 rows total** (5 Recent + 3 Suggested, dynamic fill).
+- **Recent** = items with non-zero recency score, ordered by score desc.
+- **Suggested** = remaining items with `defaultSuggestion == true`, ordered by `priorityTier` then declaration order, dedup'd against Recent.
+- **Section headers only render on empty query.** When the user types, the scorer takes over: flat, fuzzy-ranked, no headers.
+
+### Keyword scoring
+
+`doScoreFuzzy` will score `title` and each entry in `keywords` independently and take the max. The matched label positions returned for highlighting always come from the `title` scoring run, even when a keyword scored higher — so the UI never paints highlights at indexes that don't exist in the visible string. Keywords are short labels (1–3 words), 0–5 per command, and not displayed.
+
+### Factory for `AppShortcut`-backed commands
+
+```swift
+extension CommandPaletteItem {
+  static func appShortcut(
+    id: String,
+    title: String,
+    category: Category,
+    keywords: [String] = [],
+    defaultSuggestion: Bool = true,
+    priorityTier: Int = defaultPriorityTier,
+    kind: Kind
+  ) -> CommandPaletteItem { ... }
+}
+```
+
+Most batch additions in PR4+ collapse to single-line calls like:
+
+```swift
+.appShortcut(
+  id: "view.toggle-sidebar",
+  title: "Toggle Sidebar",
+  category: .view,
+  keywords: ["sb", "hide", "left panel"],
+  kind: .toggleSidebar
+)
+```
+
+---
+
+## PR1 — Model Refactor (no behavior change)
+
+**Goal:** swap the two-flag model for `category` + `keywords` + `defaultSuggestion` without changing what the user sees. This PR is pure refactor; any UI/UX change goes to PR2.
+
+### Scope
+
+1. **Add `Category` enum** in `CommandPaletteItem.swift`. Six base cases plus `#if DEBUG case debug`.
+2. **Modify `CommandPaletteItem`**:
+   - Add `category: Category` (required init param)
+   - Add `keywords: [String]` (default `[]`)
+   - Add `defaultSuggestion: Bool` (required init param)
+   - Delete `isGlobal: Bool` computed property
+   - Delete `isRootAction: Bool` computed property
+3. **Update `commandPaletteItems` builder** (`CommandPaletteFeature.swift:168-266`) to pass `category` and `defaultSuggestion` for each construction site. Mapping table below — **`defaultSuggestion` must equal `current isGlobal && !isRootAction`** so empty-query behavior is byte-identical.
+4. **Update `filterItems`** (line 159–163): replace `items.filter(\.isGlobal).filter { !$0.isRootAction }` with `items.filter(\.defaultSuggestion)`.
+5. **Update `ghosttyCommandItems`** helper (line 737–749) to pass `category: .terminal, defaultSuggestion: false`.
+6. **Update tests** (`supacodeTests/CommandPaletteFeatureTests.swift`, `AppFeatureCommandPaletteTests.swift`): every `CommandPaletteItem(...)` construction needs the new fields. Existing assertions should still pass — that *is* the verification.
+
+### Command tagging table
+
+| Kind | Category | defaultSuggestion (= current `isGlobal && !isRootAction`) |
+|---|---|---|
+| `checkForUpdates` | `.app` | false |
+| `openSettings` | `.app` | false |
+| `openRepository` | `.app` | false |
+| `installCLI` | `.app` | false |
+| `newWorktree` | `.worktree` | false |
+| `refreshWorktrees` | `.worktree` | false |
+| `viewArchivedWorktrees` | `.worktree` | false |
+| `jumpToLatestUnread` | `.navigation` | false |
+| `worktreeSelect` | `.navigation` | false |
+| `removeWorktree` | `.worktree` | false |
+| `archiveWorktree` | `.worktree` | false |
+| `changeFocusedTabIcon` | `.worktree` | false |
+| `ghosttyCommand` | `.terminal` | false |
+| `openPullRequest` | `.pullRequest` | **true** |
+| `openRepositoryOnCodeHost` | `.pullRequest` | false |
+| `markPullRequestReady` | `.pullRequest` | **true** |
+| `mergePullRequest` | `.pullRequest` | **true** |
+| `closePullRequest` | `.pullRequest` | **true** |
+| `copyFailingJobURL` | `.pullRequest` | **true** |
+| `copyCiFailureLogs` | `.pullRequest` | **true** |
+| `rerunFailedJobs` | `.pullRequest` | **true** |
+| `openFailingCheckDetails` | `.pullRequest` | **true** |
+| `debugTestToast` | `.debug` | **true** |
+| `debugSimulateUpdateFound` | `.debug` | **true** |
+
+Result: in normal usage, empty Cmd+P still shows the same things it did before (nothing in the no-PR case; PR commands when a PR is open).
+
+### Verification
+
+- Existing `filterItems` test suite passes unchanged (the public observable behavior is identical).
+- Add one new test: `filterItems_emptyQuery_returnsOnlyDefaultSuggestionItems` asserting the post-refactor field reads correctly.
+- `make build-app` succeeds.
+- `make check` clean (formatting, swiftlint, swift-format).
+
+### Out of scope (deferred to PR2)
+
+- No change to which commands have `defaultSuggestion = true`. The 8 app-level commands stay hidden from empty palette in PR1.
+- No keyword data populated yet (`keywords: []` everywhere).
+- No section headers in the view.
+- No scorer changes.
+
+---
+
+## PR2 — Search & Empty-State UX
+
+**Goal:** make the palette useful on open, and let users search via short aliases.
+
+### Changes
+
+1. **Scorer**: extend `doScoreFuzzy` so each candidate scores against `[title] + keywords`, taking the max. Match highlight positions are always computed against `title`, never keywords.
+2. **`filterItems` empty-query path**: replace the simple `defaultSuggestion` filter + sort with a Recent/Suggested split (see Design Overview rendering box). Cap at 8 total.
+3. **`CommandPaletteOverlayView`**: add a tiny `Section` wrapper that renders headers — only when the active query is empty. When searching, headers disappear.
+4. **Flip `defaultSuggestion` to `true` for the 8 app-level commands.** Add starter keywords:
+   - `checkForUpdates` — `["update", "version"]`
+   - `openSettings` — `["preferences", "config"]`
+   - `openRepository` — `["repo", "add repo"]`
+   - `newWorktree` — `["worktree", "branch"]`
+   - `refreshWorktrees` — `["reload", "rescan"]`
+   - `viewArchivedWorktrees` — `["archive", "history"]`
+   - `jumpToLatestUnread` — `["unread", "bell", "notification"]`
+   - `installCLI` — `["cli", "command line", "terminal", "prowl"]`
+
+### Verification
+
+- New tests for keyword matching (`Toggle Sidebar` findable via `sb`, etc.).
+- New tests for Recent/Suggested split (8-cap, dedup, ordering by recency then priority).
+- New tests asserting headers render only when query is empty.
+- Manual smoke: open Cmd+P → see populated suggestions; type `sb` → see Toggle Sidebar (note: this command is added in PR4, so PR2's keyword tests use the 8 app-level commands' new keywords).
+
+---
+
+## PR3 — Factories
+
+**Goal:** make PR4+ command additions one-liners. No behavior change.
+
+### Additions
+
+1. **`CommandPaletteItem.appShortcut(id:title:category:keywords:defaultSuggestion:priorityTier:kind:)`** factory — handles the most common case where a command forwards to a hotkey already registered in `AppShortcuts`.
+2. **`CommandPaletteItem.ghosttyCommand(_:category:keywords:defaultSuggestion:)`** factory — consumes a `GhosttyCommand` value and returns a tagged item. Replaces `ghosttyCommandItems` inline construction.
+3. **`CommandPaletteItem.contextual(id:title:category:kind:)`** factory — for items that are constructed only when context allows (worktree commands, PR commands). `defaultSuggestion` defaults to `false` here.
+
+### Verification
+
+- Refactor existing builders in `commandPaletteItems` to use the new factories. Tests must still pass.
+- `make build-app` succeeds.
+
+---
+
+## PR4+ — Batch Command Additions
+
+Each PR adds one category's worth of commands. Suggested order (high → low priority based on user feedback):
+
+### PR4: View toggles + Diff
+
+- Toggle Sidebar (`⌘⌃S`)
+- Toggle Active Agents Panel (`⌘⌥P`)
+- Toggle Canvas (`⌘⌥↩`)
+- Toggle Shelf (`⌘⇧↩`)
+- Show Diff (`⌘⇧Y`)
+
+All `category: .view`, `defaultSuggestion: true`.
+
+### PR5: Navigation
+
+- Select Next / Previous Worktree (`⌘⌃↑/↓`)
+- Back / Forward Worktree History (`⌘⌥[` / `⌘⌥]`)
+- Open Worktree in Finder (`⌘O`)
+- Copy Worktree Path (`⌘⇧C`)
+- Reveal in Sidebar (`⌘⇧L`)
+
+All `category: .navigation`. Suggested = high-traffic only (Next/Prev Worktree, Jump to Unread already exists).
+
+### PR6: Worktree actions
+
+- Run Script (`⌘R`)
+- Stop Script (`⌘.`)
+- Pin / Unpin Worktree
+- Delete Worktree
+- Rename Branch (`⌘⇧M`)
+
+### PR7: Terminal / Tab / Pane
+
+Most pipe through Ghostty's existing actions — confirm each action key is exposed via `GhosttyCommand`. If exposed, register via the existing `.ghosttyCommand` factory; otherwise we may need a Ghostty-side patch (defer that conversation).
+
+- Select Tab 1-9, Prev/Next Tab, Prev/Next Pane, Pane Up/Down/Left/Right
+- Font size: increase / decrease / reset
+- Find / Find Next / Find Previous / Hide Find
+- New / Close Terminal / Close Tab
+
+### PR8: Shelf navigation
+
+- Select Next / Previous Shelf Book
+- Select Shelf Book 1-9
+
+### Stretch (no PR yet)
+
+- Repository context menu actions (Settings, Remove)
+- Bulk selection actions (Archive Selected, Delete Selected)
+- Confirm Worktree Action (`⌘↩`)
+
+---
+
+## Non-goals
+
+- **No registry pattern.** The centralized builder stays — moving to per-feature command contribution is a larger architectural shift that doesn't justify itself at this scale.
+- **No frequency tracking on top of recency.** The current exponential-decay recency model is good enough; adding a frequency counter is a measurable-impact-later question.
+- **No declarative "availability" framework.** Context conditions stay as `if` branches in the builder. Pulling them out would force every command kind to define an availability predicate, which is heavy for the current ~24 → ~80 jump.
+- **No virtualization.** SwiftUI `ForEach` in a `ScrollView` will handle 80 rows fine on macOS 26+.
+
+## Open questions (defer to PR2 design review)
+
+- Should `Recent` show a relative timestamp ("2m ago")? Probably not — adds visual noise for marginal value.
+- When a command becomes contextually applicable mid-session (e.g., a PR opens), should its priority in Suggested temporarily boost? Current plan: no — it just shows up because the builder includes it.
+- Should keywords be localized? Today the app is English-only; defer until we add localization.

--- a/supacode/Features/CommandPalette/CommandPaletteItem.swift
+++ b/supacode/Features/CommandPalette/CommandPaletteItem.swift
@@ -6,18 +6,27 @@ struct CommandPaletteItem: Identifiable, Equatable {
   let subtitle: String?
   let kind: Kind
   let priorityTier: Int
+  let category: Category
+  let keywords: [String]
+  let defaultSuggestion: Bool
 
   init(
     id: String,
     title: String,
     subtitle: String?,
     kind: Kind,
+    category: Category,
+    defaultSuggestion: Bool,
+    keywords: [String] = [],
     priorityTier: Int = defaultPriorityTier
   ) {
     self.id = id
     self.title = title
     self.subtitle = subtitle
     self.kind = kind
+    self.category = category
+    self.defaultSuggestion = defaultSuggestion
+    self.keywords = keywords
     self.priorityTier = priorityTier
   }
 
@@ -50,61 +59,16 @@ struct CommandPaletteItem: Identifiable, Equatable {
     #endif
   }
 
-  var isGlobal: Bool {
-    switch kind {
-    case .checkForUpdates, .openRepository, .openSettings, .newWorktree, .viewArchivedWorktrees,
-      .refreshWorktrees, .installCLI, .jumpToLatestUnread:
-      return true
-    case .ghosttyCommand:
-      return false
-    case .openPullRequest,
-      .markPullRequestReady,
-      .mergePullRequest,
-      .closePullRequest,
-      .copyFailingJobURL,
-      .copyCiFailureLogs,
-      .rerunFailedJobs,
-      .openFailingCheckDetails:
-      return true
-    case .worktreeSelect,
-      .removeWorktree,
-      .archiveWorktree,
-      .changeFocusedTabIcon,
-      .openRepositoryOnCodeHost:
-      return false
+  enum Category: String, CaseIterable, Equatable {
+    case view
+    case navigation
+    case worktree
+    case pullRequest
+    case terminal
+    case app
     #if DEBUG
-      case .debugTestToast, .debugSimulateUpdateFound:
-        return true
+      case debug
     #endif
-    }
-  }
-
-  var isRootAction: Bool {
-    switch kind {
-    case .checkForUpdates, .openRepository, .openSettings, .newWorktree, .viewArchivedWorktrees,
-      .refreshWorktrees, .installCLI, .jumpToLatestUnread:
-      return true
-    case .ghosttyCommand:
-      return false
-    case .openPullRequest,
-      .openRepositoryOnCodeHost,
-      .markPullRequestReady,
-      .mergePullRequest,
-      .closePullRequest,
-      .copyFailingJobURL,
-      .copyCiFailureLogs,
-      .rerunFailedJobs,
-      .openFailingCheckDetails,
-      .worktreeSelect,
-      .removeWorktree,
-      .archiveWorktree,
-      .changeFocusedTabIcon:
-      return false
-    #if DEBUG
-      case .debugTestToast, .debugSimulateUpdateFound:
-        return false
-    #endif
-    }
   }
 
   var appShortcutCommandID: String? {

--- a/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
+++ b/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
@@ -156,9 +156,8 @@ struct CommandPaletteFeature {
     now: Date = .now
   ) -> [CommandPaletteItem] {
     let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
-    let globalItems = items.filter(\.isGlobal)
     guard !trimmed.isEmpty else {
-      let visibleItems = globalItems.filter { !$0.isRootAction }
+      let visibleItems = items.filter(\.defaultSuggestion)
       return prioritizeItems(items: visibleItems, recencyByID: recencyByID, now: now)
     }
     let scorer = CommandPaletteFuzzyScorer(query: trimmed, recencyByID: recencyByID, now: now)
@@ -172,75 +171,16 @@ struct CommandPaletteFeature {
     let showsNewWorktreeAction =
       repositories.repositories.isEmpty
       || repositories.repositories.contains { $0.capabilities.supportsWorktrees }
-    var items: [CommandPaletteItem] = [
-      CommandPaletteItem(
-        id: CommandPaletteItemID.globalCheckForUpdates,
-        title: "Check for Updates",
-        subtitle: nil,
-        kind: .checkForUpdates
-      ),
-      CommandPaletteItem(
-        id: CommandPaletteItemID.globalOpenSettings,
-        title: "Open Settings",
-        subtitle: nil,
-        kind: .openSettings
-      ),
-      CommandPaletteItem(
-        id: CommandPaletteItemID.globalOpenRepository,
-        title: "Open Repository",
-        subtitle: nil,
-        kind: .openRepository
-      ),
-    ]
-    if showsNewWorktreeAction {
-      items.append(
-        CommandPaletteItem(
-          id: CommandPaletteItemID.globalNewWorktree,
-          title: "New Worktree",
-          subtitle: nil,
-          kind: .newWorktree
-        )
-      )
-    }
-    items.append(
-      CommandPaletteItem(
-        id: CommandPaletteItemID.globalRefreshWorktrees,
-        title: "Refresh Worktrees",
-        subtitle: nil,
-        kind: .refreshWorktrees
-      )
-    )
-    items.append(
-      CommandPaletteItem(
-        id: CommandPaletteItemID.globalJumpToLatestUnread,
-        title: "Jump to Latest Unread",
-        subtitle: nil,
-        kind: .jumpToLatestUnread
-      )
-    )
-    items.append(
-      CommandPaletteItem(
-        id: CommandPaletteItemID.globalViewArchivedWorktrees,
-        title: "View Archived Worktrees",
-        subtitle: nil,
-        kind: .viewArchivedWorktrees
-      )
-    )
-    items.append(
-      CommandPaletteItem(
-        id: CommandPaletteItemID.globalInstallCLI,
-        title: "Install Command Line Tool",
-        subtitle: nil,
-        kind: .installCLI
-      )
-    )
+    var items = globalCommandItems(showsNewWorktreeAction: showsNewWorktreeAction)
     if let terminalWorktree = repositories.selectedTerminalWorktree {
       items.append(
         CommandPaletteItem(
           id: CommandPaletteItemID.changeFocusedTabIcon(terminalWorktree.id),
           title: "Change Tab Icon...",
           subtitle: terminalWorktree.name,
-          kind: .changeFocusedTabIcon(terminalWorktree.id)
+          kind: .changeFocusedTabIcon(terminalWorktree.id),
+          category: .worktree,
+          defaultSuggestion: false
         )
       )
       items.append(contentsOf: ghosttyCommandItems(ghosttyCommands))
@@ -258,7 +198,9 @@ struct CommandPaletteFeature {
           id: CommandPaletteItemID.worktreeSelect(row.id),
           title: title,
           subtitle: nil,
-          kind: .worktreeSelect(row.id)
+          kind: .worktreeSelect(row.id),
+          category: .navigation,
+          defaultSuggestion: false
         )
       )
     }
@@ -278,6 +220,88 @@ struct CommandPaletteFeature {
     }
     return ids
   }
+}
+
+private func globalCommandItems(showsNewWorktreeAction: Bool) -> [CommandPaletteItem] {
+  var items: [CommandPaletteItem] = [
+    CommandPaletteItem(
+      id: CommandPaletteItemID.globalCheckForUpdates,
+      title: "Check for Updates",
+      subtitle: nil,
+      kind: .checkForUpdates,
+      category: .app,
+      defaultSuggestion: false
+    ),
+    CommandPaletteItem(
+      id: CommandPaletteItemID.globalOpenSettings,
+      title: "Open Settings",
+      subtitle: nil,
+      kind: .openSettings,
+      category: .app,
+      defaultSuggestion: false
+    ),
+    CommandPaletteItem(
+      id: CommandPaletteItemID.globalOpenRepository,
+      title: "Open Repository",
+      subtitle: nil,
+      kind: .openRepository,
+      category: .app,
+      defaultSuggestion: false
+    ),
+  ]
+  if showsNewWorktreeAction {
+    items.append(
+      CommandPaletteItem(
+        id: CommandPaletteItemID.globalNewWorktree,
+        title: "New Worktree",
+        subtitle: nil,
+        kind: .newWorktree,
+        category: .worktree,
+        defaultSuggestion: false
+      )
+    )
+  }
+  items.append(
+    CommandPaletteItem(
+      id: CommandPaletteItemID.globalRefreshWorktrees,
+      title: "Refresh Worktrees",
+      subtitle: nil,
+      kind: .refreshWorktrees,
+      category: .worktree,
+      defaultSuggestion: false
+    )
+  )
+  items.append(
+    CommandPaletteItem(
+      id: CommandPaletteItemID.globalJumpToLatestUnread,
+      title: "Jump to Latest Unread",
+      subtitle: nil,
+      kind: .jumpToLatestUnread,
+      category: .navigation,
+      defaultSuggestion: false
+    )
+  )
+  items.append(
+    CommandPaletteItem(
+      id: CommandPaletteItemID.globalViewArchivedWorktrees,
+      title: "View Archived Worktrees",
+      subtitle: nil,
+      kind: .viewArchivedWorktrees,
+      category: .worktree,
+      defaultSuggestion: false
+    )
+  )
+  items.append(
+    CommandPaletteItem(
+      id: CommandPaletteItemID.globalInstallCLI,
+      title: "Install Command Line Tool",
+      subtitle: nil,
+      kind: .installCLI,
+      category: .app,
+      defaultSuggestion: false
+    )
+  )
+  return items
 }
 
 private func selectedCodeHostItems(
@@ -316,6 +340,8 @@ private func selectedCodeHostItems(
       title: "Open Repository on \(codeHost.displayName)",
       subtitle: repository.name,
       kind: .openRepositoryOnCodeHost(selectedWorktreeID),
+      category: .pullRequest,
+      defaultSuggestion: false,
       priorityTier: 2
     )
   ]
@@ -327,74 +353,10 @@ private func pullRequestItems(
   repositoryID: Repository.ID,
   codeHost: CodeHost
 ) -> [CommandPaletteItem] {
-  let state = pullRequest.state.uppercased()
-  let isOpen = state == "OPEN"
-  let isDraft = pullRequest.isDraft
+  let isOpen = pullRequest.state.uppercased() == "OPEN"
   let mergeReadiness = PullRequestMergeReadiness(pullRequest: pullRequest)
-  let checks = pullRequest.statusCheckRollup?.checks ?? []
-  let breakdown = PullRequestCheckBreakdown(checks: checks)
-  let hasFailingChecks = breakdown.failed > 0
-  let canMerge = isOpen && !isDraft && !mergeReadiness.isBlocking
-
-  func makeReadyItem() -> CommandPaletteItem? {
-    guard isOpen && isDraft else { return nil }
-    return CommandPaletteItem(
-      id: CommandPaletteItemID.pullRequestReady(repositoryID),
-      title: "Mark PR Ready for Review",
-      subtitle: pullRequest.title,
-      kind: .markPullRequestReady(worktreeID),
-      priorityTier: 0
-    )
-  }
-
-  func makeFailingItems() -> [CommandPaletteItem] {
-    guard isOpen && hasFailingChecks else { return [] }
-    let hasFailingCheckWithDetails = checks.contains { $0.checkState == .failure && $0.detailsUrl != nil }
-    let leadingTier = isDraft ? 1 : 0
-    let followupTier = leadingTier + 1
-    var failingItems: [CommandPaletteItem] = []
-    if hasFailingCheckWithDetails {
-      failingItems.append(
-        CommandPaletteItem(
-          id: CommandPaletteItemID.pullRequestCopyFailingJobURL(repositoryID),
-          title: "Copy failing job URL",
-          subtitle: pullRequest.title,
-          kind: .copyFailingJobURL(worktreeID),
-          priorityTier: leadingTier
-        )
-      )
-    }
-    failingItems.append(
-      CommandPaletteItem(
-        id: CommandPaletteItemID.pullRequestCopyCiLogs(repositoryID),
-        title: "Copy CI Failure Logs",
-        subtitle: pullRequest.title,
-        kind: .copyCiFailureLogs(worktreeID),
-        priorityTier: hasFailingCheckWithDetails ? followupTier : leadingTier
-      )
-    )
-    failingItems.append(
-      CommandPaletteItem(
-        id: CommandPaletteItemID.pullRequestRerunFailedJobs(repositoryID),
-        title: "Re-run Failed Jobs",
-        subtitle: pullRequest.title,
-        kind: .rerunFailedJobs(worktreeID),
-        priorityTier: followupTier
-      )
-    )
-    if hasFailingCheckWithDetails {
-      failingItems.append(
-        CommandPaletteItem(
-          id: CommandPaletteItemID.pullRequestOpenFailingCheck(repositoryID),
-          title: "Open Failing Check Details",
-          subtitle: pullRequest.title,
-          kind: .openFailingCheckDetails(worktreeID),
-          priorityTier: followupTier
-        )
-      )
-    }
-    return failingItems
-  }
+  let breakdown = PullRequestCheckBreakdown(checks: pullRequest.statusCheckRollup?.checks ?? [])
+  let canMerge = isOpen && !pullRequest.isDraft && !mergeReadiness.isBlocking
 
   var items: [CommandPaletteItem] = [
     CommandPaletteItem(
@@ -402,15 +364,27 @@ private func pullRequestItems(
       title: "Open Pull Request on \(codeHost.displayName)",
       subtitle: pullRequest.title,
       kind: .openPullRequest(worktreeID),
+      category: .pullRequest,
+      defaultSuggestion: true,
       priorityTier: 2
     )
   ]
 
-  if let readyItem = makeReadyItem() {
+  if let readyItem = makeReadyPullRequestItem(
+    pullRequest: pullRequest,
+    repositoryID: repositoryID,
+    worktreeID: worktreeID
+  ) {
     items.append(readyItem)
   }
 
-  items.append(contentsOf: makeFailingItems())
+  items.append(
+    contentsOf: makeFailingPullRequestItems(
+      pullRequest: pullRequest,
+      repositoryID: repositoryID,
+      worktreeID: worktreeID
+    )
+  )
 
   if let mergeItem = makeMergePullRequestItem(
     canMerge: canMerge,
@@ -433,6 +407,88 @@ private func pullRequestItems(
   return items
 }
 
+private func makeReadyPullRequestItem(
+  pullRequest: GithubPullRequest,
+  repositoryID: Repository.ID,
+  worktreeID: Worktree.ID
+) -> CommandPaletteItem? {
+  let isOpen = pullRequest.state.uppercased() == "OPEN"
+  guard isOpen && pullRequest.isDraft else { return nil }
+  return CommandPaletteItem(
+    id: CommandPaletteItemID.pullRequestReady(repositoryID),
+    title: "Mark PR Ready for Review",
+    subtitle: pullRequest.title,
+    kind: .markPullRequestReady(worktreeID),
+    category: .pullRequest,
+    defaultSuggestion: true,
+    priorityTier: 0
+  )
+}
+
+private func makeFailingPullRequestItems(
+  pullRequest: GithubPullRequest,
+  repositoryID: Repository.ID,
+  worktreeID: Worktree.ID
+) -> [CommandPaletteItem] {
+  let isOpen = pullRequest.state.uppercased() == "OPEN"
+  let checks = pullRequest.statusCheckRollup?.checks ?? []
+  let hasFailingChecks = PullRequestCheckBreakdown(checks: checks).failed > 0
+  guard isOpen && hasFailingChecks else { return [] }
+  let hasFailingCheckWithDetails = checks.contains { $0.checkState == .failure && $0.detailsUrl != nil }
+  let leadingTier = pullRequest.isDraft ? 1 : 0
+  let followupTier = leadingTier + 1
+  var failingItems: [CommandPaletteItem] = []
+  if hasFailingCheckWithDetails {
+    failingItems.append(
+      CommandPaletteItem(
+        id: CommandPaletteItemID.pullRequestCopyFailingJobURL(repositoryID),
+        title: "Copy failing job URL",
+        subtitle: pullRequest.title,
+        kind: .copyFailingJobURL(worktreeID),
+        category: .pullRequest,
+        defaultSuggestion: true,
+        priorityTier: leadingTier
+      )
+    )
+  }
+  failingItems.append(
+    CommandPaletteItem(
+      id: CommandPaletteItemID.pullRequestCopyCiLogs(repositoryID),
+      title: "Copy CI Failure Logs",
+      subtitle: pullRequest.title,
+      kind: .copyCiFailureLogs(worktreeID),
+      category: .pullRequest,
+      defaultSuggestion: true,
+      priorityTier: hasFailingCheckWithDetails ? followupTier : leadingTier
+    )
+  )
+  failingItems.append(
+    CommandPaletteItem(
+      id: CommandPaletteItemID.pullRequestRerunFailedJobs(repositoryID),
+      title: "Re-run Failed Jobs",
+      subtitle: pullRequest.title,
+      kind: .rerunFailedJobs(worktreeID),
+      category: .pullRequest,
+      defaultSuggestion: true,
+      priorityTier: followupTier
+    )
+  )
+  if hasFailingCheckWithDetails {
+    failingItems.append(
+      CommandPaletteItem(
+        id: CommandPaletteItemID.pullRequestOpenFailingCheck(repositoryID),
+        title: "Open Failing Check Details",
+        subtitle: pullRequest.title,
+        kind: .openFailingCheckDetails(worktreeID),
+        category: .pullRequest,
+        defaultSuggestion: true,
+        priorityTier: followupTier
+      )
+    )
+  }
+  return failingItems
+}
+
 private func makeMergePullRequestItem(
   canMerge: Bool,
   breakdown: PullRequestCheckBreakdown,
@@ -450,6 +506,8 @@ private func makeMergePullRequestItem(
     title: "Merge PR",
     subtitle: "Merge Ready - \(successfulChecksLabel)",
     kind: .mergePullRequest(worktreeID),
+    category: .pullRequest,
+    defaultSuggestion: true,
     priorityTier: 0
   )
 }
@@ -466,6 +524,8 @@ private func makeClosePullRequestItem(
     title: "Close PR",
     subtitle: pullRequestTitle,
     kind: .closePullRequest(worktreeID),
+    category: .pullRequest,
+    defaultSuggestion: true,
     priorityTier: 1
   )
 }
@@ -477,19 +537,25 @@ private func makeClosePullRequestItem(
         id: "debug.toast.inProgress",
         title: "[Debug] Toast: In Progress",
         subtitle: "Simulates an in-progress toast",
-        kind: .debugTestToast(.inProgress("Merging pull request…"))
+        kind: .debugTestToast(.inProgress("Merging pull request…")),
+        category: .debug,
+        defaultSuggestion: true
       ),
       CommandPaletteItem(
         id: "debug.toast.success",
         title: "[Debug] Toast: Success",
         subtitle: "Simulates a success toast",
-        kind: .debugTestToast(.success("Pull request merged"))
+        kind: .debugTestToast(.success("Pull request merged")),
+        category: .debug,
+        defaultSuggestion: true
       ),
       CommandPaletteItem(
         id: "debug.update.simulate-found",
         title: "[Debug] Simulate Update Found",
         subtitle: "Shows the toolbar update badge without querying Sparkle",
-        kind: .debugSimulateUpdateFound
+        kind: .debugSimulateUpdateFound,
+        category: .debug,
+        defaultSuggestion: true
       ),
     ]
   }
@@ -743,6 +809,8 @@ private func ghosttyCommandItems(_ commands: [GhosttyCommand]) -> [CommandPalett
       title: command.title,
       subtitle: subtitle.isEmpty ? nil : subtitle,
       kind: .ghosttyCommand(command.action),
+      category: .terminal,
+      defaultSuggestion: false,
       priorityTier: CommandPaletteItem.defaultPriorityTier + 100
     )
   }

--- a/supacodeTests/AppShortcutsTests.swift
+++ b/supacodeTests/AppShortcutsTests.swift
@@ -351,7 +351,9 @@ struct AppShortcutsTests {
       id: "settings",
       title: "Open Settings",
       subtitle: nil,
-      kind: .openSettings
+      kind: .openSettings,
+      category: .app,
+      defaultSuggestion: false
     )
     expectNoDifference(paletteItem.appShortcutLabel(in: resolved), "⌘;")
 
@@ -381,7 +383,9 @@ struct AppShortcutsTests {
       id: "settings",
       title: "Open Settings",
       subtitle: nil,
-      kind: .openSettings
+      kind: .openSettings,
+      category: .app,
+      defaultSuggestion: false
     )
     #expect(paletteItem.appShortcutLabel(in: resolved) == nil)
 
@@ -440,7 +444,9 @@ struct AppShortcutsTests {
       id: "settings",
       title: "Open Settings",
       subtitle: nil,
-      kind: .openSettings
+      kind: .openSettings,
+      category: .app,
+      defaultSuggestion: false
     )
     expectNoDifference(paletteItem.appShortcutLabel(in: resolved), "⌘1")
 

--- a/supacodeTests/CommandPaletteFeatureTests.swift
+++ b/supacodeTests/CommandPaletteFeatureTests.swift
@@ -248,13 +248,13 @@ struct CommandPaletteFeatureTests {
   }
 
   @Test func emptyQueryHidesGhosttyCommands() {
-    let ghosttyItem = CommandPaletteItem(
+    let ghosttyItem = makeItem(
       id: "ghostty.goto_split:right|Focus Split Right",
       title: "Focus Split Right",
       subtitle: nil,
       kind: .ghosttyCommand("goto_split:right")
     )
-    let prAction = CommandPaletteItem(
+    let prAction = makeItem(
       id: "pr.open",
       title: "Open PR on GitHub",
       subtitle: "PR title",
@@ -466,31 +466,31 @@ struct CommandPaletteFeatureTests {
   }
 
   @Test func showsGlobalItemsWhenQueryEmpty() {
-    let openSettings = CommandPaletteItem(
+    let openSettings = makeItem(
       id: "global.open-settings",
       title: "Open Settings",
       subtitle: nil,
       kind: .openSettings
     )
-    let newWorktree = CommandPaletteItem(
+    let newWorktree = makeItem(
       id: "global.new-worktree",
       title: "New Worktree",
       subtitle: nil,
       kind: .newWorktree
     )
-    let selectFox = CommandPaletteItem(
+    let selectFox = makeItem(
       id: "worktree.fox.select",
       title: "Repo / fox",
       subtitle: "main",
       kind: .worktreeSelect("wt-fox")
     )
-    let archiveFox = CommandPaletteItem(
+    let archiveFox = makeItem(
       id: "worktree.fox.archive",
       title: "Repo / fox",
       subtitle: "Archive Worktree - main",
       kind: .archiveWorktree("wt-fox", "repo-fox")
     )
-    let removeFox = CommandPaletteItem(
+    let removeFox = makeItem(
       id: "worktree.fox.remove",
       title: "Repo / fox",
       subtitle: "Remove Worktree - main",
@@ -521,13 +521,13 @@ struct CommandPaletteFeatureTests {
   }
 
   @Test func queryRanksByFuzzyScoreAcrossAllItems() {
-    let openSettings = CommandPaletteItem(
+    let openSettings = makeItem(
       id: "global.open-settings",
       title: "Open Settings",
       subtitle: nil,
       kind: .openSettings
     )
-    let selectSettings = CommandPaletteItem(
+    let selectSettings = makeItem(
       id: "worktree.settings.select",
       title: "Repo / settings",
       subtitle: "main",
@@ -541,13 +541,13 @@ struct CommandPaletteFeatureTests {
   }
 
   @Test func fuzzyRanksPrefixAndShorterLabelFirst() {
-    let short = CommandPaletteItem(
+    let short = makeItem(
       id: "worktree.set.select",
       title: "Set",
       subtitle: nil,
       kind: .worktreeSelect("wt-set")
     )
-    let long = CommandPaletteItem(
+    let long = makeItem(
       id: "worktree.settings.select",
       title: "Settings",
       subtitle: nil,
@@ -561,7 +561,7 @@ struct CommandPaletteFeatureTests {
   }
 
   @Test func fuzzyMatchesSubtitleWhenLabelDoesNot() {
-    let item = CommandPaletteItem(
+    let item = makeItem(
       id: "worktree.fox.select",
       title: "Repo / fox",
       subtitle: "main",
@@ -575,7 +575,7 @@ struct CommandPaletteFeatureTests {
   }
 
   @Test func fuzzyMatchesMultiplePieces() {
-    let item = CommandPaletteItem(
+    let item = makeItem(
       id: "worktree.fox.select",
       title: "Repo / fox",
       subtitle: "main",
@@ -730,13 +730,13 @@ struct CommandPaletteFeatureTests {
 
   @Test func recencyBreaksFuzzyTiesWithinGroup() {
     let now = Date(timeIntervalSince1970: 1_000_000)
-    let recent = CommandPaletteItem(
+    let recent = makeItem(
       id: "global.recent",
       title: "Open",
       subtitle: nil,
       kind: .openRepository
     )
-    let older = CommandPaletteItem(
+    let older = makeItem(
       id: "global.older",
       title: "Open",
       subtitle: nil,
@@ -759,13 +759,13 @@ struct CommandPaletteFeatureTests {
   }
 
   @Test func supacodeItemsBeatGhosttyItemsWhenScoresTie() {
-    let supacodeItem = CommandPaletteItem(
+    let supacodeItem = makeItem(
       id: "global.open-settings",
       title: "Open Settings",
       subtitle: nil,
       kind: .openSettings
     )
-    let ghosttyItem = CommandPaletteItem(
+    let ghosttyItem = makeItem(
       id: "ghostty.open-settings|Open Settings",
       title: "Open Settings",
       subtitle: nil,
@@ -785,13 +785,13 @@ struct CommandPaletteFeatureTests {
   // MARK: - Unified Ranking Tests
 
   @Test func worktreeOutranksGlobalWhenBetterMatch() {
-    let checkForUpdates = CommandPaletteItem(
+    let checkForUpdates = makeItem(
       id: "global.check-for-updates",
       title: "Check for Updates",
       subtitle: nil,
       kind: .checkForUpdates
     )
-    let worktreeFox = CommandPaletteItem(
+    let worktreeFox = makeItem(
       id: "worktree.fox.select",
       title: "Repo / fox",
       subtitle: nil,
@@ -805,13 +805,13 @@ struct CommandPaletteFeatureTests {
   }
 
   @Test func worktreeExactPrefixOutranksGlobalSubstringMatch() {
-    let openSettings = CommandPaletteItem(
+    let openSettings = makeItem(
       id: "global.open-settings",
       title: "Open Settings",
       subtitle: nil,
       kind: .openSettings
     )
-    let worktreeOpen = CommandPaletteItem(
+    let worktreeOpen = makeItem(
       id: "worktree.open.select",
       title: "open",
       subtitle: nil,
@@ -826,19 +826,19 @@ struct CommandPaletteFeatureTests {
   }
 
   @Test func globalAndWorktreeItemsInterleavedByScore() {
-    let openRepo = CommandPaletteItem(
+    let openRepo = makeItem(
       id: "global.open-repository",
       title: "Open Repository",
       subtitle: nil,
       kind: .openRepository
     )
-    let worktreeRepo = CommandPaletteItem(
+    let worktreeRepo = makeItem(
       id: "worktree.repo.select",
       title: "repo",
       subtitle: nil,
       kind: .worktreeSelect("wt-repo")
     )
-    let refreshWorktrees = CommandPaletteItem(
+    let refreshWorktrees = makeItem(
       id: "global.refresh-worktrees",
       title: "Refresh Worktrees",
       subtitle: nil,
@@ -856,13 +856,13 @@ struct CommandPaletteFeatureTests {
   }
 
   @Test func nonMatchingItemsExcludedRegardlessOfType() {
-    let checkForUpdates = CommandPaletteItem(
+    let checkForUpdates = makeItem(
       id: "global.check-for-updates",
       title: "Check for Updates",
       subtitle: nil,
       kind: .checkForUpdates
     )
-    let worktreeFox = CommandPaletteItem(
+    let worktreeFox = makeItem(
       id: "worktree.fox.select",
       title: "Repo / fox",
       subtitle: nil,
@@ -876,19 +876,19 @@ struct CommandPaletteFeatureTests {
   }
 
   @Test func multipleWorktreesCanAppearBeforeGlobalItems() {
-    let openSettings = CommandPaletteItem(
+    let openSettings = makeItem(
       id: "global.open-settings",
       title: "Open Settings",
       subtitle: nil,
       kind: .openSettings
     )
-    let worktreeAlpha = CommandPaletteItem(
+    let worktreeAlpha = makeItem(
       id: "worktree.alpha.select",
       title: "set",
       subtitle: nil,
       kind: .worktreeSelect("wt-alpha")
     )
-    let worktreeBeta = CommandPaletteItem(
+    let worktreeBeta = makeItem(
       id: "worktree.beta.select",
       title: "sett",
       subtitle: nil,
@@ -906,14 +906,14 @@ struct CommandPaletteFeatureTests {
   }
 
   @Test func priorityTierBreaksTiesAcrossItemTypes() {
-    let prAction = CommandPaletteItem(
+    let prAction = makeItem(
       id: "pr.merge",
       title: "Merge PR",
       subtitle: "Ready",
       kind: .mergePullRequest("wt-1"),
       priorityTier: 0
     )
-    let worktreeMerge = CommandPaletteItem(
+    let worktreeMerge = makeItem(
       id: "worktree.merge.select",
       title: "Merge",
       subtitle: nil,
@@ -933,13 +933,13 @@ struct CommandPaletteFeatureTests {
 
   @Test func recencyBreaksTiesAcrossItemTypes() {
     let now = Date(timeIntervalSince1970: 1_000_000)
-    let globalItem = CommandPaletteItem(
+    let globalItem = makeItem(
       id: "global.open-settings",
       title: "Open Settings",
       subtitle: nil,
       kind: .openSettings
     )
-    let worktreeItem = CommandPaletteItem(
+    let worktreeItem = makeItem(
       id: "worktree.settings.select",
       title: "Repo / settings",
       subtitle: nil,
@@ -961,13 +961,13 @@ struct CommandPaletteFeatureTests {
   }
 
   @Test func worktreeWithLabelMatchOutranksGlobalWithDescriptionMatch() {
-    let globalItem = CommandPaletteItem(
+    let globalItem = makeItem(
       id: "global.pr.open",
       title: "Open PR on GitHub",
       subtitle: "deploy-fixes",
       kind: .openPullRequest("wt-1")
     )
-    let worktreeItem = CommandPaletteItem(
+    let worktreeItem = makeItem(
       id: "worktree.deploy.select",
       title: "Repo / deploy-fixes",
       subtitle: nil,
@@ -983,13 +983,13 @@ struct CommandPaletteFeatureTests {
   }
 
   @Test func shorterWorktreeLabelWinsOverLongerGlobalLabel() {
-    let globalItem = CommandPaletteItem(
+    let globalItem = makeItem(
       id: "global.new-worktree",
       title: "New Worktree",
       subtitle: nil,
       kind: .newWorktree
     )
-    let worktreeItem = CommandPaletteItem(
+    let worktreeItem = makeItem(
       id: "worktree.new.select",
       title: "new",
       subtitle: nil,
@@ -1005,19 +1005,19 @@ struct CommandPaletteFeatureTests {
   }
 
   @Test func emptyQueryStillHidesRootActionsAndWorktrees() {
-    let checkForUpdates = CommandPaletteItem(
+    let checkForUpdates = makeItem(
       id: "global.check-for-updates",
       title: "Check for Updates",
       subtitle: nil,
       kind: .checkForUpdates
     )
-    let worktreeFox = CommandPaletteItem(
+    let worktreeFox = makeItem(
       id: "worktree.fox.select",
       title: "Repo / fox",
       subtitle: nil,
       kind: .worktreeSelect("wt-fox")
     )
-    let prAction = CommandPaletteItem(
+    let prAction = makeItem(
       id: "pr.open",
       title: "Open PR on GitHub",
       subtitle: "PR title",
@@ -1036,13 +1036,13 @@ struct CommandPaletteFeatureTests {
   }
 
   @Test func whitespaceOnlyQueryTreatedAsEmpty() {
-    let checkForUpdates = CommandPaletteItem(
+    let checkForUpdates = makeItem(
       id: "global.check-for-updates",
       title: "Check for Updates",
       subtitle: nil,
       kind: .checkForUpdates
     )
-    let worktreeFox = CommandPaletteItem(
+    let worktreeFox = makeItem(
       id: "worktree.fox.select",
       title: "Repo / fox",
       subtitle: nil,
@@ -1062,13 +1062,13 @@ struct CommandPaletteFeatureTests {
   }
 
   @Test func inputOrderDoesNotAffectScoreBasedRanking() {
-    let globalItem = CommandPaletteItem(
+    let globalItem = makeItem(
       id: "global.open-settings",
       title: "Open Settings",
       subtitle: nil,
       kind: .openSettings
     )
-    let worktreeItem = CommandPaletteItem(
+    let worktreeItem = makeItem(
       id: "worktree.open.select",
       title: "open",
       subtitle: nil,
@@ -1092,7 +1092,7 @@ struct CommandPaletteFeatureTests {
     state.isPresented = true
     state.query = "bear"
     state.selectedIndex = 1
-    let item = CommandPaletteItem(
+    let item = makeItem(
       id: "global.open-repository",
       title: "Open Repository",
       subtitle: nil,
@@ -1115,7 +1115,7 @@ struct CommandPaletteFeatureTests {
 
   @Test func activateGhosttyCommandDispatchesDelegate() async {
     let now = Date(timeIntervalSince1970: 7_654_321)
-    let item = CommandPaletteItem(
+    let item = makeItem(
       id: "ghostty.goto_split:right|Focus Split Right",
       title: "Focus Split Right",
       subtitle: nil,
@@ -1168,6 +1168,63 @@ private func makeRepository(
     kind: kind,
     worktrees: IdentifiedArray(uniqueElements: worktrees)
   )
+}
+
+private func makeItem(
+  id: String,
+  title: String,
+  subtitle: String?,
+  kind: CommandPaletteItem.Kind,
+  priorityTier: Int = CommandPaletteItem.defaultPriorityTier
+) -> CommandPaletteItem {
+  CommandPaletteItem(
+    id: id,
+    title: title,
+    subtitle: subtitle,
+    kind: kind,
+    category: testCategory(for: kind),
+    defaultSuggestion: testDefaultSuggestion(for: kind),
+    priorityTier: priorityTier
+  )
+}
+
+private func testCategory(for kind: CommandPaletteItem.Kind) -> CommandPaletteItem.Category {
+  switch kind {
+  case .checkForUpdates, .openSettings, .openRepository, .installCLI:
+    return .app
+  case .newWorktree, .refreshWorktrees, .viewArchivedWorktrees,
+    .removeWorktree, .archiveWorktree, .changeFocusedTabIcon:
+    return .worktree
+  case .jumpToLatestUnread, .worktreeSelect:
+    return .navigation
+  case .openPullRequest, .openRepositoryOnCodeHost, .markPullRequestReady,
+    .mergePullRequest, .closePullRequest, .copyFailingJobURL, .copyCiFailureLogs,
+    .rerunFailedJobs, .openFailingCheckDetails:
+    return .pullRequest
+  case .ghosttyCommand:
+    return .terminal
+  #if DEBUG
+    case .debugTestToast, .debugSimulateUpdateFound:
+      return .debug
+  #endif
+  }
+}
+
+private func testDefaultSuggestion(for kind: CommandPaletteItem.Kind) -> Bool {
+  switch kind {
+  case .openPullRequest, .markPullRequestReady, .mergePullRequest, .closePullRequest,
+    .copyFailingJobURL, .copyCiFailureLogs, .rerunFailedJobs, .openFailingCheckDetails:
+    return true
+  case .checkForUpdates, .openSettings, .openRepository, .installCLI,
+    .newWorktree, .refreshWorktrees, .viewArchivedWorktrees, .jumpToLatestUnread,
+    .worktreeSelect, .removeWorktree, .archiveWorktree, .changeFocusedTabIcon,
+    .ghosttyCommand, .openRepositoryOnCodeHost:
+    return false
+  #if DEBUG
+    case .debugTestToast, .debugSimulateUpdateFound:
+      return true
+  #endif
+  }
 }
 
 private func makePullRequest(

--- a/supacodeTests/CommandPaletteFeatureTests.swift
+++ b/supacodeTests/CommandPaletteFeatureTests.swift
@@ -247,6 +247,28 @@ struct CommandPaletteFeatureTests {
     #expect(searchedItems.contains(where: { $0.id == changeIconItem?.id }))
   }
 
+  @Test func filterItemsEmptyQueryHonorsDefaultSuggestionFlagOnly() {
+    let suggested = CommandPaletteItem(
+      id: "suggested",
+      title: "Suggested",
+      subtitle: nil,
+      kind: .openSettings,
+      category: .app,
+      defaultSuggestion: true
+    )
+    let hidden = CommandPaletteItem(
+      id: "hidden",
+      title: "Hidden",
+      subtitle: nil,
+      kind: .openSettings,
+      category: .app,
+      defaultSuggestion: false
+    )
+
+    let result = CommandPaletteFeature.filterItems(items: [suggested, hidden], query: "")
+    expectNoDifference(result.map(\.id), [suggested.id])
+  }
+
   @Test func emptyQueryHidesGhosttyCommands() {
     let ghosttyItem = makeItem(
       id: "ghostty.goto_split:right|Focus Split Right",


### PR DESCRIPTION
## Summary

PR1 of a four-PR plan to make the command palette ready for ~60-80 commands (currently ~24). This is a pure refactor — observable behavior is unchanged.

- Replaces the confusing two-flag visibility model (`isGlobal` + `isRootAction`) with a single explicit `defaultSuggestion: Bool`. The old flags collapsed into one bit of meaningful state: both were set on the 8 app-level commands so they could never appear when the palette opened with no query.
- Adds `CommandPaletteItem.Category` (`view` / `navigation` / `worktree` / `pullRequest` / `terminal` / `app` / `debug`). Not yet rendered — laying the field for PR2 to surface section headers in the empty-query view.
- Extracts a few private helpers from `commandPaletteItems` and `pullRequestItems` so the bodies stay under SwiftLint's function-length limit after the per-item fields grew.

Adds `doc-onevcat/plans/2026-05-16-command-palette-architecture-plan.md` describing the full PR1 → PR2 → PR3 → PR4+ sequence.

### What's deferred to later PRs

- **PR2:** keyword aliases + Recent/Suggested split on empty query + section headers + flipping app-level commands to `defaultSuggestion: true` so they actually appear when Cmd+P opens.
- **PR3:** `CommandPaletteItem.appShortcut(...)` factory so PR4+ command additions become one-liners.
- **PR4+:** batch-register the missing commands (Toggle Sidebar/Canvas/Shelf/Active Agents, navigation, terminal/pane/find, etc.).

## Test plan

- [x] `make build-app` — green
- [x] `make check` (swift-format + swiftlint strict) — green
- [x] `xcodebuild test` against `CommandPaletteFeatureTests`, `AppFeatureCommandPaletteTests`, `AppShortcutsTests` — all pass
- [ ] Manual smoke: open Cmd+P → empty list with no PR (unchanged); open with PR → PR commands listed (unchanged); type any query → fuzzy ranking unchanged
