### PR TITLE
feat(command palette): Recent/Suggested empty-query view + keyword aliases

### DIFF
--- a/supacode/Features/CommandPalette/CommandPaletteItem.swift
+++ b/supacode/Features/CommandPalette/CommandPaletteItem.swift
@@ -1,3 +1,13 @@
+struct CommandPaletteSuggestions: Equatable {
+  static let maxItems = 8
+
+  let recent: [CommandPaletteItem]
+  let suggested: [CommandPaletteItem]
+
+  var allItems: [CommandPaletteItem] { recent + suggested }
+  var isEmpty: Bool { recent.isEmpty && suggested.isEmpty }
+}
+
 struct CommandPaletteItem: Identifiable, Equatable {
   static let defaultPriorityTier = 100
 

--- a/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
+++ b/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
@@ -149,6 +149,42 @@ struct CommandPaletteFeature {
     }
   }
 
+  static func suggestions(
+    items: [CommandPaletteItem],
+    recencyByID: [CommandPaletteItem.ID: TimeInterval] = [:],
+    now: Date = .now
+  ) -> CommandPaletteSuggestions {
+    let recencyScored: [(item: CommandPaletteItem, score: Double)] = items.compactMap { item in
+      let score = commandPaletteRecencyScore(item, recencyByID: recencyByID, now: now)
+      return score > 0 ? (item, score) : nil
+    }
+    let recent = Array(
+      recencyScored
+        .sorted { $0.score > $1.score }
+        .prefix(CommandPaletteSuggestions.maxItems)
+        .map(\.item)
+    )
+
+    let recentIDs = Set(recent.map(\.id))
+    let suggestedCandidates = items.enumerated().compactMap { idx, item -> (item: CommandPaletteItem, idx: Int)? in
+      guard item.defaultSuggestion, !recentIDs.contains(item.id) else { return nil }
+      return (item, idx)
+    }
+    let suggested = Array(
+      suggestedCandidates
+        .sorted { left, right in
+          if left.item.priorityTier != right.item.priorityTier {
+            return left.item.priorityTier < right.item.priorityTier
+          }
+          return left.idx < right.idx
+        }
+        .prefix(CommandPaletteSuggestions.maxItems - recent.count)
+        .map(\.item)
+    )
+
+    return CommandPaletteSuggestions(recent: recent, suggested: suggested)
+  }
+
   static func filterItems(
     items: [CommandPaletteItem],
     query: String,
@@ -157,8 +193,7 @@ struct CommandPaletteFeature {
   ) -> [CommandPaletteItem] {
     let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !trimmed.isEmpty else {
-      let visibleItems = items.filter(\.defaultSuggestion)
-      return prioritizeItems(items: visibleItems, recencyByID: recencyByID, now: now)
+      return suggestions(items: items, recencyByID: recencyByID, now: now).allItems
     }
     let scorer = CommandPaletteFuzzyScorer(query: trimmed, recencyByID: recencyByID, now: now)
     return scorer.rankedItems(from: items)
@@ -230,7 +265,8 @@ private func globalCommandItems(showsNewWorktreeAction: Bool) -> [CommandPalette
       subtitle: nil,
       kind: .checkForUpdates,
       category: .app,
-      defaultSuggestion: false
+      defaultSuggestion: true,
+      keywords: ["update", "version"]
     ),
     CommandPaletteItem(
       id: CommandPaletteItemID.globalOpenSettings,
@@ -238,7 +274,8 @@ private func globalCommandItems(showsNewWorktreeAction: Bool) -> [CommandPalette
       subtitle: nil,
       kind: .openSettings,
       category: .app,
-      defaultSuggestion: false
+      defaultSuggestion: true,
+      keywords: ["preferences", "config"]
     ),
     CommandPaletteItem(
       id: CommandPaletteItemID.globalOpenRepository,
@@ -246,7 +283,8 @@ private func globalCommandItems(showsNewWorktreeAction: Bool) -> [CommandPalette
       subtitle: nil,
       kind: .openRepository,
       category: .app,
-      defaultSuggestion: false
+      defaultSuggestion: true,
+      keywords: ["repo", "add repo"]
     ),
   ]
   if showsNewWorktreeAction {
@@ -257,7 +295,8 @@ private func globalCommandItems(showsNewWorktreeAction: Bool) -> [CommandPalette
         subtitle: nil,
         kind: .newWorktree,
         category: .worktree,
-        defaultSuggestion: false
+        defaultSuggestion: true,
+        keywords: ["worktree", "branch"]
       )
     )
   }
@@ -268,7 +307,8 @@ private func globalCommandItems(showsNewWorktreeAction: Bool) -> [CommandPalette
       subtitle: nil,
       kind: .refreshWorktrees,
       category: .worktree,
-      defaultSuggestion: false
+      defaultSuggestion: true,
+      keywords: ["reload", "rescan"]
     )
   )
   items.append(
@@ -278,7 +318,8 @@ private func globalCommandItems(showsNewWorktreeAction: Bool) -> [CommandPalette
       subtitle: nil,
       kind: .jumpToLatestUnread,
       category: .navigation,
-      defaultSuggestion: false
+      defaultSuggestion: true,
+      keywords: ["unread", "bell", "notification"]
     )
   )
   items.append(
@@ -288,7 +329,8 @@ private func globalCommandItems(showsNewWorktreeAction: Bool) -> [CommandPalette
       subtitle: nil,
       kind: .viewArchivedWorktrees,
       category: .worktree,
-      defaultSuggestion: false
+      defaultSuggestion: true,
+      keywords: ["archive", "history"]
     )
   )
   items.append(
@@ -298,7 +340,8 @@ private func globalCommandItems(showsNewWorktreeAction: Bool) -> [CommandPalette
       subtitle: nil,
       kind: .installCLI,
       category: .app,
-      defaultSuggestion: false
+      defaultSuggestion: true,
+      keywords: ["cli", "command line", "terminal", "prowl"]
     )
   )
   return items
@@ -643,26 +686,6 @@ private enum CommandPaletteItemID {
   }
 }
 
-private func prioritizeItems(
-  items: [CommandPaletteItem],
-  recencyByID: [CommandPaletteItem.ID: TimeInterval],
-  now: Date
-) -> [CommandPaletteItem] {
-  let scored = items.enumerated().map { index, item in
-    (item: item, index: index, recency: commandPaletteRecencyScore(item, recencyByID: recencyByID, now: now))
-  }
-  let sorted = scored.sorted { left, right in
-    if left.item.priorityTier != right.item.priorityTier {
-      return left.item.priorityTier < right.item.priorityTier
-    }
-    if left.item.priorityTier < CommandPaletteItem.defaultPriorityTier, left.recency != right.recency {
-      return left.recency > right.recency
-    }
-    return left.index < right.index
-  }
-  return sorted.map(\.item)
-}
-
 private func commandPaletteRecencyScore(
   _ item: CommandPaletteItem,
   recencyByID: [CommandPaletteItem.ID: TimeInterval],
@@ -899,19 +922,27 @@ private struct CommandPaletteFuzzyScorer {
       return ItemScore(score: 0, labelMatch: nil, descriptionMatch: nil)
     }
 
-    let label = item.title
-    let description = item.subtitle
-
     if let values = query.values, !values.isEmpty {
-      return scoreItemMultiple(label: label, description: description, query: values)
+      return scoreItemMultiple(
+        label: item.title,
+        description: item.subtitle,
+        keywords: item.keywords,
+        query: values
+      )
     }
 
-    return scoreItemSingle(label: label, description: description, query: query.piece)
+    return scoreItemForPiece(
+      label: item.title,
+      description: item.subtitle,
+      keywords: item.keywords,
+      query: query.piece
+    )
   }
 
   private func scoreItemMultiple(
     label: String,
     description: String?,
+    keywords: [String],
     query: [PreparedQueryPiece]
   ) -> ItemScore {
     var totalScore = 0
@@ -919,7 +950,7 @@ private struct CommandPaletteFuzzyScorer {
     var totalDescriptionMatches: [Match] = []
 
     for piece in query {
-      let score = scoreItemSingle(label: label, description: description, query: piece)
+      let score = scoreItemForPiece(label: label, description: description, keywords: keywords, query: piece)
       if score.score == 0 {
         return ItemScore(score: 0, labelMatch: nil, descriptionMatch: nil)
       }
@@ -937,6 +968,30 @@ private struct CommandPaletteFuzzyScorer {
       labelMatch: normalizeMatches(totalLabelMatches),
       descriptionMatch: normalizeMatches(totalDescriptionMatches)
     )
+  }
+
+  /// Score one query piece against the item's title (with description fallback)
+  /// and each keyword. Keywords act as alternative labels — when one outscores
+  /// the title path, we keep title-derived highlight positions so the UI never
+  /// paints offsets that don't exist in the visible string.
+  private func scoreItemForPiece(
+    label: String,
+    description: String?,
+    keywords: [String],
+    query: PreparedQueryPiece
+  ) -> ItemScore {
+    var best = scoreItemSingle(label: label, description: description, query: query)
+    for keyword in keywords {
+      let keywordScore = scoreItemSingle(label: keyword, description: nil, query: query)
+      if keywordScore.score > best.score {
+        best = ItemScore(
+          score: keywordScore.score,
+          labelMatch: best.labelMatch,
+          descriptionMatch: best.descriptionMatch
+        )
+      }
+    }
+    return best
   }
 
   private func scoreItemSingle(

--- a/supacode/Features/CommandPalette/Views/CommandPaletteOverlayView.swift
+++ b/supacode/Features/CommandPalette/Views/CommandPaletteOverlayView.swift
@@ -11,6 +11,7 @@ struct CommandPaletteOverlayView: View {
   @State private var queryFocusTask: Task<Void, Never>?
   @State private var hoveredID: CommandPaletteItem.ID?
   @State private var filteredItems: [CommandPaletteItem] = []
+  @State private var sectionedSuggestions: CommandPaletteSuggestions?
 
   var body: some View {
     ZStack {
@@ -36,6 +37,7 @@ struct CommandPaletteOverlayView: View {
                 query: $store.query,
                 selectedIndex: $store.selectedIndex,
                 items: filteredItems,
+                sections: sectionedSuggestions,
                 resolvedKeybindings: resolvedKeybindings,
                 hoveredID: $hoveredID,
                 isQueryFocused: isQueryFocused,
@@ -142,14 +144,25 @@ struct CommandPaletteOverlayView: View {
 
   private func refreshFilteredItems(items: [CommandPaletteItem]) -> [CommandPaletteItem] {
     let now = Date.now
-    let updatedItems = CommandPaletteFeature.filterItems(
-      items: items,
-      query: store.query,
-      recencyByID: store.recencyByItemID,
-      now: now
-    )
-    filteredItems = updatedItems
-    return updatedItems
+    let trimmed = store.query.trimmingCharacters(in: .whitespacesAndNewlines)
+    if trimmed.isEmpty {
+      let suggestions = CommandPaletteFeature.suggestions(
+        items: items,
+        recencyByID: store.recencyByItemID,
+        now: now
+      )
+      sectionedSuggestions = suggestions
+      filteredItems = suggestions.allItems
+    } else {
+      sectionedSuggestions = nil
+      filteredItems = CommandPaletteFeature.filterItems(
+        items: items,
+        query: trimmed,
+        recencyByID: store.recencyByItemID,
+        now: now
+      )
+    }
+    return filteredItems
   }
 
   private func focusQueryField() {
@@ -179,6 +192,7 @@ private struct CommandPaletteCard: View {
   @Binding var query: String
   @Binding var selectedIndex: Int?
   let items: [CommandPaletteItem]
+  let sections: CommandPaletteSuggestions?
   let resolvedKeybindings: ResolvedKeybindingMap
   @Binding var hoveredID: CommandPaletteItem.ID?
   let isQueryFocused: Bool
@@ -207,6 +221,7 @@ private struct CommandPaletteCard: View {
 
       CommandPaletteList(
         rows: items,
+        sections: sections,
         resolvedKeybindings: resolvedKeybindings,
         selectedIndex: $selectedIndex,
         hoveredID: $hoveredID
@@ -416,6 +431,7 @@ private struct CommandPaletteList: View {
   static let listHeight: CGFloat = 200
 
   let rows: [CommandPaletteItem]
+  let sections: CommandPaletteSuggestions?
   let resolvedKeybindings: ResolvedKeybindingMap
   @Binding var selectedIndex: Int?
   @Binding var hoveredID: CommandPaletteItem.ID?
@@ -428,17 +444,10 @@ private struct CommandPaletteList: View {
       ScrollViewReader { proxy in
         ScrollView {
           VStack(alignment: .leading, spacing: 4) {
-            ForEach(Array(rows.enumerated()), id: \.1.id) { index, row in
-              CommandPaletteRowView(
-                row: row,
-                resolvedKeybindings: resolvedKeybindings,
-                shortcutIndex: index < 5 ? index : nil,
-                isSelected: isRowSelected(index: index),
-                hoveredID: $hoveredID
-              ) {
-                activate(row.id)
-              }
-              .id(row.id)
+            if let sections {
+              renderSectioned(sections)
+            } else {
+              renderFlat()
             }
           }
           .padding(10)
@@ -452,12 +461,65 @@ private struct CommandPaletteList: View {
     }
   }
 
+  @ViewBuilder
+  private func renderFlat() -> some View {
+    ForEach(Array(rows.enumerated()), id: \.1.id) { index, row in
+      rowView(for: row, index: index)
+    }
+  }
+
+  @ViewBuilder
+  private func renderSectioned(_ sections: CommandPaletteSuggestions) -> some View {
+    if !sections.recent.isEmpty {
+      CommandPaletteSectionHeader(title: "Recent")
+      ForEach(sections.recent) { row in
+        if let index = rows.firstIndex(where: { $0.id == row.id }) {
+          rowView(for: row, index: index)
+        }
+      }
+    }
+    if !sections.suggested.isEmpty {
+      CommandPaletteSectionHeader(title: "Suggested")
+        .padding(.top, sections.recent.isEmpty ? 0 : 6)
+      ForEach(sections.suggested) { row in
+        if let index = rows.firstIndex(where: { $0.id == row.id }) {
+          rowView(for: row, index: index)
+        }
+      }
+    }
+  }
+
+  private func rowView(for row: CommandPaletteItem, index: Int) -> some View {
+    CommandPaletteRowView(
+      row: row,
+      resolvedKeybindings: resolvedKeybindings,
+      shortcutIndex: index < 5 ? index : nil,
+      isSelected: isRowSelected(index: index),
+      hoveredID: $hoveredID
+    ) {
+      activate(row.id)
+    }
+    .id(row.id)
+  }
+
   private func isRowSelected(index: Int) -> Bool {
     guard let selectedIndex else { return false }
     if selectedIndex < rows.count {
       return selectedIndex == index
     }
     return index == rows.count - 1
+  }
+}
+
+private struct CommandPaletteSectionHeader: View {
+  let title: String
+
+  var body: some View {
+    Text(title.uppercased())
+      .font(.caption2.weight(.semibold))
+      .foregroundStyle(.secondary)
+      .padding(.horizontal, 6)
+      .padding(.bottom, 2)
   }
 }
 

--- a/supacodeTests/CommandPaletteFeatureTests.swift
+++ b/supacodeTests/CommandPaletteFeatureTests.swift
@@ -247,6 +247,222 @@ struct CommandPaletteFeatureTests {
     #expect(searchedItems.contains(where: { $0.id == changeIconItem?.id }))
   }
 
+  @Test func keywordOnlyMatchSurfacesItem() {
+    // "preferences" cannot fuzzy-match "Open Settings" (no p/r/f) so a match
+    // only succeeds if keywords participate.
+    let openSettings = makeItem(
+      id: "global.open-settings",
+      title: "Open Settings",
+      subtitle: nil,
+      kind: .openSettings,
+      keywords: ["preferences"]
+    )
+
+    let result = CommandPaletteFeature.filterItems(items: [openSettings], query: "preferences")
+    expectNoDifference(result.map(\.id), [openSettings.id])
+  }
+
+  @Test func keywordMatchRanksBelowDirectTitleMatch() {
+    let openSettings = makeItem(
+      id: "global.open-settings",
+      title: "Open Settings",
+      subtitle: nil,
+      kind: .openSettings,
+      keywords: ["preferences"]
+    )
+    let prefBranch = makeItem(
+      id: "worktree.preferences.select",
+      title: "preferences",
+      subtitle: nil,
+      kind: .worktreeSelect("wt-pref")
+    )
+
+    let result = CommandPaletteFeature.filterItems(items: [openSettings, prefBranch], query: "preferences")
+    #expect(result.first?.id == prefBranch.id)
+  }
+
+  @Test func keywordMatchSurvivesMultiPieceQuery() {
+    // "preferences" has to match via the keyword; "settings" matches the title.
+    let openSettings = makeItem(
+      id: "global.open-settings",
+      title: "Open Settings",
+      subtitle: nil,
+      kind: .openSettings,
+      keywords: ["preferences"]
+    )
+
+    let result = CommandPaletteFeature.filterItems(items: [openSettings], query: "preferences settings")
+    expectNoDifference(result.map(\.id), [openSettings.id])
+  }
+
+  @Test func keywordMatchDoesNotIntroduceLabelHighlightsOutsideTitle() {
+    let openSettings = makeItem(
+      id: "global.open-settings",
+      title: "Open Settings",
+      subtitle: nil,
+      kind: .openSettings,
+      keywords: ["preferences"]
+    )
+
+    let result = CommandPaletteFeature.filterItems(items: [openSettings], query: "preferences")
+    #expect(result.count == 1)
+    // Sanity: the returned item is unchanged — no synthetic match positions leaked into the item.
+    #expect(result.first?.title == openSettings.title)
+  }
+
+  // MARK: - suggestions()
+
+  @Test func suggestionsEmptyInputReturnsEmptySections() {
+    let result = CommandPaletteFeature.suggestions(items: [], recencyByID: [:], now: .now)
+    #expect(result.recent.isEmpty)
+    #expect(result.suggested.isEmpty)
+  }
+
+  @Test func suggestionsOnlyDefaultSuggestionItemsAppearWhenNoRecency() {
+    let suggested = makeItem(
+      id: "s",
+      title: "Suggested",
+      subtitle: nil,
+      kind: .openSettings
+    )
+    let hidden = makeItem(
+      id: "h",
+      title: "Hidden",
+      subtitle: nil,
+      kind: .ghosttyCommand("focus_split")
+    )
+    let suggestedWithFlag = CommandPaletteItem(
+      id: suggested.id,
+      title: suggested.title,
+      subtitle: suggested.subtitle,
+      kind: suggested.kind,
+      category: suggested.category,
+      defaultSuggestion: true
+    )
+
+    let result = CommandPaletteFeature.suggestions(
+      items: [suggestedWithFlag, hidden],
+      recencyByID: [:],
+      now: .now
+    )
+    #expect(result.recent.isEmpty)
+    expectNoDifference(result.suggested.map(\.id), [suggestedWithFlag.id])
+  }
+
+  @Test func suggestionsRecentIncludesNonSuggestionItemsWithRecency() {
+    let now = Date(timeIntervalSince1970: 1_000_000)
+    let worktree = makeItem(
+      id: "worktree.fox.select",
+      title: "Repo / fox",
+      subtitle: nil,
+      kind: .worktreeSelect("wt-fox")
+    )
+
+    let result = CommandPaletteFeature.suggestions(
+      items: [worktree],
+      recencyByID: [worktree.id: now.timeIntervalSince1970 - 86_400],
+      now: now
+    )
+    expectNoDifference(result.recent.map(\.id), [worktree.id])
+    #expect(result.suggested.isEmpty)
+  }
+
+  @Test func suggestionsRecentSortedByRecencyDesc() {
+    let now = Date(timeIntervalSince1970: 1_000_000)
+    let recent = makeItem(id: "recent", title: "Recent", subtitle: nil, kind: .openSettings)
+    let older = makeItem(id: "older", title: "Older", subtitle: nil, kind: .openRepository)
+
+    let result = CommandPaletteFeature.suggestions(
+      items: [older, recent],
+      recencyByID: [
+        recent.id: now.timeIntervalSince1970 - 86_400,
+        older.id: now.timeIntervalSince1970 - 10 * 86_400,
+      ],
+      now: now
+    )
+    expectNoDifference(result.recent.map(\.id), [recent.id, older.id])
+  }
+
+  @Test func suggestionsDedupesRecentFromSuggested() {
+    let now = Date(timeIntervalSince1970: 1_000_000)
+    let appLevel = CommandPaletteItem(
+      id: "global.open-settings",
+      title: "Open Settings",
+      subtitle: nil,
+      kind: .openSettings,
+      category: .app,
+      defaultSuggestion: true
+    )
+
+    let result = CommandPaletteFeature.suggestions(
+      items: [appLevel],
+      recencyByID: [appLevel.id: now.timeIntervalSince1970 - 86_400],
+      now: now
+    )
+    expectNoDifference(result.recent.map(\.id), [appLevel.id])
+    #expect(result.suggested.isEmpty)
+  }
+
+  @Test func suggestionsCapsTotalAt8() {
+    let now = Date(timeIntervalSince1970: 1_000_000)
+    let items = (0..<12).map { index in
+      makeItem(
+        id: "item-\(index)",
+        title: "Item \(index)",
+        subtitle: nil,
+        kind: .worktreeSelect("wt-\(index)")
+      )
+    }
+    let recency = Dictionary(
+      uniqueKeysWithValues: items.enumerated().map { idx, item in
+        (item.id, now.timeIntervalSince1970 - TimeInterval(idx + 1) * 3600)
+      }
+    )
+
+    let result = CommandPaletteFeature.suggestions(items: items, recencyByID: recency, now: now)
+    #expect(result.recent.count + result.suggested.count == CommandPaletteSuggestions.maxItems)
+  }
+
+  @Test func suggestionsSuggestedSortsByPriorityTierThenDeclarationOrder() {
+    let lowPriority = CommandPaletteItem(
+      id: "low",
+      title: "Low",
+      subtitle: nil,
+      kind: .openSettings,
+      category: .app,
+      defaultSuggestion: true,
+      priorityTier: 0
+    )
+    let defaultPriorityFirst = CommandPaletteItem(
+      id: "default-first",
+      title: "Default First",
+      subtitle: nil,
+      kind: .openSettings,
+      category: .app,
+      defaultSuggestion: true,
+      priorityTier: CommandPaletteItem.defaultPriorityTier
+    )
+    let defaultPrioritySecond = CommandPaletteItem(
+      id: "default-second",
+      title: "Default Second",
+      subtitle: nil,
+      kind: .openSettings,
+      category: .app,
+      defaultSuggestion: true,
+      priorityTier: CommandPaletteItem.defaultPriorityTier
+    )
+
+    let result = CommandPaletteFeature.suggestions(
+      items: [defaultPriorityFirst, defaultPrioritySecond, lowPriority],
+      recencyByID: [:],
+      now: .now
+    )
+    expectNoDifference(
+      result.suggested.map(\.id),
+      [lowPriority.id, defaultPriorityFirst.id, defaultPrioritySecond.id]
+    )
+  }
+
   @Test func filterItemsEmptyQueryHonorsDefaultSuggestionFlagOnly() {
     let suggested = CommandPaletteItem(
       id: "suggested",
@@ -519,13 +735,11 @@ struct CommandPaletteFeatureTests {
       kind: .removeWorktree("wt-fox", "repo-fox")
     )
 
-    expectNoDifference(
-      CommandPaletteFeature.filterItems(
-        items: [openSettings, newWorktree, selectFox, archiveFox, removeFox],
-        query: ""
-      ),
-      []
+    let result = CommandPaletteFeature.filterItems(
+      items: [openSettings, newWorktree, selectFox, archiveFox, removeFox],
+      query: ""
     )
+    expectNoDifference(result.map(\.id), [openSettings.id, newWorktree.id])
   }
 
   @Test func queryKeepsSelectionWhenEmpty() async {
@@ -1026,7 +1240,7 @@ struct CommandPaletteFeatureTests {
     #expect(result.first?.id == worktreeItem.id)
   }
 
-  @Test func emptyQueryStillHidesRootActionsAndWorktrees() {
+  @Test func emptyQueryShowsSuggestionItemsAndHidesContextualOnes() {
     let checkForUpdates = makeItem(
       id: "global.check-for-updates",
       title: "Check for Updates",
@@ -1052,7 +1266,7 @@ struct CommandPaletteFeatureTests {
       query: ""
     )
 
-    #expect(!result.contains { $0.id == checkForUpdates.id })
+    #expect(result.contains { $0.id == checkForUpdates.id })
     #expect(!result.contains { $0.id == worktreeFox.id })
     #expect(result.contains { $0.id == prAction.id })
   }
@@ -1197,6 +1411,7 @@ private func makeItem(
   title: String,
   subtitle: String?,
   kind: CommandPaletteItem.Kind,
+  keywords: [String] = [],
   priorityTier: Int = CommandPaletteItem.defaultPriorityTier
 ) -> CommandPaletteItem {
   CommandPaletteItem(
@@ -1206,6 +1421,7 @@ private func makeItem(
     kind: kind,
     category: testCategory(for: kind),
     defaultSuggestion: testDefaultSuggestion(for: kind),
+    keywords: keywords,
     priorityTier: priorityTier
   )
 }
@@ -1234,12 +1450,12 @@ private func testCategory(for kind: CommandPaletteItem.Kind) -> CommandPaletteIt
 
 private func testDefaultSuggestion(for kind: CommandPaletteItem.Kind) -> Bool {
   switch kind {
-  case .openPullRequest, .markPullRequestReady, .mergePullRequest, .closePullRequest,
-    .copyFailingJobURL, .copyCiFailureLogs, .rerunFailedJobs, .openFailingCheckDetails:
-    return true
   case .checkForUpdates, .openSettings, .openRepository, .installCLI,
     .newWorktree, .refreshWorktrees, .viewArchivedWorktrees, .jumpToLatestUnread,
-    .worktreeSelect, .removeWorktree, .archiveWorktree, .changeFocusedTabIcon,
+    .openPullRequest, .markPullRequestReady, .mergePullRequest, .closePullRequest,
+    .copyFailingJobURL, .copyCiFailureLogs, .rerunFailedJobs, .openFailingCheckDetails:
+    return true
+  case .worktreeSelect, .removeWorktree, .archiveWorktree, .changeFocusedTabIcon,
     .ghosttyCommand, .openRepositoryOnCodeHost:
     return false
   #if DEBUG


### PR DESCRIPTION
## Summary

PR2 of the four-PR command palette plan (`doc-onevcat/plans/2026-05-16-command-palette-architecture-plan.md`). Builds on PR1's model refactor to actually deliver visible-to-the-user improvements.

### What changes for the user

- **Empty Cmd+P is no longer blank.** Opening the palette with no query shows up to 8 items split into two sections:
  - **Recent** — anything used in the past month, ordered by 7-day half-life recency.
  - **Suggested** — `defaultSuggestion: true` items not already in Recent, sorted by `priorityTier` then declaration order.
  - Section headers render only on empty query. Typing collapses back to the flat fuzzy-ranked list.
- **App-level commands now appear on open.** The 8 app-level commands (Check for Updates, Open Settings, Open Repository, New Worktree, Refresh Worktrees, Jump to Latest Unread, View Archived Worktrees, Install CLI) flip to `defaultSuggestion: true`.
- **Keyword aliases.** Each app-level command gets short aliases:
  - `preferences` / `config` → Open Settings
  - `update` / `version` → Check for Updates
  - `cli` / `command line` / `terminal` / `prowl` → Install CLI
  - `unread` / `bell` / `notification` → Jump to Latest Unread
  - `repo` / `add repo` → Open Repository
  - `worktree` / `branch` → New Worktree
  - `reload` / `rescan` → Refresh Worktrees
  - `archive` / `history` → View Archived Worktrees
  Keywords participate in fuzzy scoring but never display. If a keyword outscores the title, the row still uses title-derived highlight positions so no synthetic offsets leak into the visible string.

### What changes for the code

- New value type `CommandPaletteSuggestions(recent: [Item], suggested: [Item])` with `maxItems = 8` and `allItems` flattener.
- New static method `CommandPaletteFeature.suggestions(items:, recencyByID:, now:) -> CommandPaletteSuggestions`.
- `filterItems(query: "")` now delegates to `suggestions(...).allItems` (preserves flat-array contract — existing callers and tests untouched).
- Scorer's `scoreItemSingle` is now wrapped by `scoreItemForPiece(label:description:keywords:query:)` that scores title and each keyword as alternative labels, taking the max.
- `CommandPaletteOverlayView` tracks `sectionedSuggestions: CommandPaletteSuggestions?` alongside the flat `filteredItems`. `CommandPaletteList` accepts a `sections:` parameter and renders headers via a new `CommandPaletteSectionHeader` subview.
- Keyboard navigation stays index-based on the flat list; section rendering looks up each row's global index by id.

## Test plan

- [x] `make build-app` — green
- [x] `make check` (swift-format + swiftlint strict) — green
- [x] Full palette suite: `CommandPaletteFeatureTests`, `AppFeatureCommandPaletteTests`, `AppShortcutsTests` — all pass
- [x] New tests added:
  - 4 keyword behaviors (only match, ranking, multi-piece, no synthetic highlights)
  - 7 suggestions() behaviors (empty input, default-suggestion filter, recency-promotes-non-suggested, recent sort, dedup, 8-cap, priority sort)
- [x] **Manual UI verification** — please confirm before merging:
  - Open Cmd+P with no PR context → see "SUGGESTED" header + 8 app-level commands
  - Type `pref` → flat list with Open Settings ranked at top (no section headers)
  - Activate Open Settings → re-open Cmd+P → Open Settings now under "RECENT" header
  - Open Cmd+P on a worktree with an open PR → PR commands rank above app-level in Suggested
