### PR TITLE
feat(command palette): add View toggles (Sidebar, Active Agents, Canvas, Shelf, Show Diff)

### DIFF
--- a/supacode/App/ContentView.swift
+++ b/supacode/App/ContentView.swift
@@ -15,7 +15,6 @@ struct ContentView: View {
   let terminalManager: WorktreeTerminalManager
   @Environment(\.scenePhase) private var scenePhase
   @Environment(GhosttyShortcutManager.self) private var ghosttyShortcuts
-  @State private var leftSidebarVisibility: NavigationSplitViewVisibility = .all
 
   init(store: StoreOf<AppFeature>, terminalManager: WorktreeTerminalManager) {
     self.store = store
@@ -34,13 +33,7 @@ struct ContentView: View {
     )
     Group {
       if store.repositories.isInitialLoadComplete {
-        NavigationSplitView(columnVisibility: $leftSidebarVisibility) {
-          SidebarView(store: repositoriesStore, terminalManager: terminalManager)
-            .navigationSplitViewColumnWidth(min: 220, ideal: 260, max: 320)
-        } detail: {
-          WorktreeDetailView(store: store, terminalManager: terminalManager)
-        }
-        .navigationSplitViewStyle(.automatic)
+        mainSplitView
       } else {
         AppLoadingView()
           .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -102,18 +95,29 @@ struct ContentView: View {
     .background(WindowTabbingDisabler())
   }
 
-  private func toggleLeftSidebar() {
-    withAnimation(.easeOut(duration: 0.2)) {
-      leftSidebarVisibility = leftSidebarVisibility == .detailOnly ? .all : .detailOnly
+  private var mainSplitView: some View {
+    let visibility = Binding<NavigationSplitViewVisibility>(
+      get: { store.leftSidebarVisibility },
+      set: { store.send(.setLeftSidebarVisibility($0)) }
+    )
+    return NavigationSplitView(columnVisibility: visibility) {
+      SidebarView(store: repositoriesStore, terminalManager: terminalManager)
+        .navigationSplitViewColumnWidth(min: 220, ideal: 260, max: 320)
+    } detail: {
+      WorktreeDetailView(store: store, terminalManager: terminalManager)
     }
+    .navigationSplitViewStyle(.automatic)
+    .animation(.easeOut(duration: 0.2), value: store.leftSidebarVisibility)
+  }
+
+  private func toggleLeftSidebar() {
+    store.send(.toggleLeftSidebar)
   }
 
   private var revealInSidebarAction: (() -> Void)? {
     guard store.repositories.selectedWorktreeID != nil else { return nil }
     return {
-      withAnimation(.easeOut(duration: 0.2)) {
-        leftSidebarVisibility = .all
-      }
+      store.send(.showLeftSidebar)
       store.send(.repositories(.revealSelectedWorktreeInSidebar))
     }
   }

--- a/supacode/Commands/SidebarCommands.swift
+++ b/supacode/Commands/SidebarCommands.swift
@@ -55,7 +55,7 @@ struct SidebarCommands: Commands {
       )
       .help(helpText(title: "Select Previous Book", commandID: AppShortcuts.CommandID.selectPreviousShelfBook))
       shelfBookMenuButtons
-      Button("Show Diff") {
+      Button("Show Diff", systemImage: "plusminus.circle") {
         let repos = store.repositories
         guard let worktreeID = repos.selectedWorktreeID,
           let worktree = repos.worktree(for: worktreeID)

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -54,6 +54,7 @@ struct AppFeature {
     var launchRestoreMode: LaunchRestoreMode
     var suppressLayoutSaveUntilRelaunch = false
     var launchedAt: Date?
+    var leftSidebarVisibility: NavigationSplitViewVisibility = .all
     @Presents var alert: AlertState<Alert>?
 
     init(
@@ -83,6 +84,9 @@ struct AppFeature {
     case requestQuit
     case newTerminal
     case jumpToLatestUnread
+    case toggleLeftSidebar
+    case showLeftSidebar
+    case setLeftSidebarVisibility(NavigationSplitViewVisibility)
     case runScript
     case runCustomCommand(Int)
     case runScriptDraftChanged(String)
@@ -679,6 +683,18 @@ struct AppFeature {
           }
         )
 
+      case .toggleLeftSidebar:
+        state.leftSidebarVisibility = state.leftSidebarVisibility == .detailOnly ? .all : .detailOnly
+        return .none
+
+      case .showLeftSidebar:
+        state.leftSidebarVisibility = .all
+        return .none
+
+      case .setLeftSidebarVisibility(let visibility):
+        state.leftSidebarVisibility = visibility
+        return .none
+
       case .runScript:
         guard let worktree = state.repositories.selectedTerminalWorktree else {
           return .none
@@ -1017,6 +1033,35 @@ struct AppFeature {
 
       case .commandPalette(.delegate(.installCLI)):
         return .send(.settings(.installCLIButtonTapped(showAlert: false)))
+
+      case .commandPalette(.delegate(.toggleLeftSidebar)):
+        return .send(.toggleLeftSidebar)
+
+      case .commandPalette(.delegate(.toggleActiveAgentsPanel)):
+        return .send(.repositories(.activeAgents(.togglePanelVisibility)))
+
+      case .commandPalette(.delegate(.toggleCanvas)):
+        return .send(.repositories(.toggleCanvas))
+
+      case .commandPalette(.delegate(.toggleShelf)):
+        return .send(.repositories(.toggleShelf))
+
+      case .commandPalette(.delegate(.showDiff)):
+        guard let worktreeID = state.repositories.selectedWorktreeID,
+          let worktree = state.repositories.worktree(for: worktreeID)
+        else {
+          return .none
+        }
+        let keybindings = state.resolvedKeybindings
+        return .run { _ in
+          await MainActor.run {
+            DiffWindowManager.shared.show(
+              worktreeURL: worktree.workingDirectory,
+              branchName: worktree.name,
+              resolvedKeybindings: keybindings
+            )
+          }
+        }
 
       case .commandPalette(.delegate(.ghosttyCommand(let action))):
         guard let worktree = state.repositories.selectedTerminalWorktree else {

--- a/supacode/Features/CommandPalette/CommandPaletteItem.swift
+++ b/supacode/Features/CommandPalette/CommandPaletteItem.swift
@@ -63,6 +63,11 @@ struct CommandPaletteItem: Identifiable, Equatable {
     case openFailingCheckDetails(Worktree.ID)
     case installCLI
     case changeFocusedTabIcon(Worktree.ID)
+    case toggleLeftSidebar
+    case toggleActiveAgentsPanel
+    case toggleCanvas
+    case toggleShelf
+    case showDiff
     #if DEBUG
       case debugTestToast(RepositoriesFeature.StatusToast)
       case debugSimulateUpdateFound
@@ -100,6 +105,16 @@ struct CommandPaletteItem: Identifiable, Equatable {
     case .openPullRequest,
       .openRepositoryOnCodeHost:
       return AppShortcuts.CommandID.openPullRequest
+    case .toggleLeftSidebar:
+      return AppShortcuts.CommandID.toggleLeftSidebar
+    case .toggleActiveAgentsPanel:
+      return AppShortcuts.CommandID.toggleActiveAgentsPanel
+    case .toggleCanvas:
+      return AppShortcuts.CommandID.toggleCanvas
+    case .toggleShelf:
+      return AppShortcuts.CommandID.toggleShelf
+    case .showDiff:
+      return AppShortcuts.CommandID.showDiff
     case .ghosttyCommand,
       .markPullRequestReady,
       .mergePullRequest,

--- a/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
+++ b/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
@@ -52,6 +52,11 @@ struct CommandPaletteFeature {
     case openFailingCheckDetails(Worktree.ID)
     case installCLI
     case changeFocusedTabIcon(Worktree.ID)
+    case toggleLeftSidebar
+    case toggleActiveAgentsPanel
+    case toggleCanvas
+    case toggleShelf
+    case showDiff
     #if DEBUG
       case debugTestToast(RepositoriesFeature.StatusToast)
       case debugSimulateUpdateFound
@@ -207,6 +212,17 @@ struct CommandPaletteFeature {
       repositories.repositories.isEmpty
       || repositories.repositories.contains { $0.capabilities.supportsWorktrees }
     var items = globalCommandItems(showsNewWorktreeAction: showsNewWorktreeAction)
+    if repositories.selectedWorktreeID != nil {
+      items.append(
+        .appShortcut(
+          id: CommandPaletteItemID.globalShowDiff,
+          title: "Show Diff",
+          category: .view,
+          kind: .showDiff,
+          keywords: ["diff", "changes", "git"]
+        )
+      )
+    }
     if let terminalWorktree = repositories.selectedTerminalWorktree {
       items.append(
         CommandPaletteItem(
@@ -328,7 +344,41 @@ private func globalCommandItems(showsNewWorktreeAction: Bool) -> [CommandPalette
       keywords: ["cli", "command line", "terminal", "prowl"]
     )
   )
+  items.append(contentsOf: viewToggleCommandItems())
   return items
+}
+
+private func viewToggleCommandItems() -> [CommandPaletteItem] {
+  [
+    .appShortcut(
+      id: CommandPaletteItemID.globalToggleLeftSidebar,
+      title: "Toggle Sidebar",
+      category: .view,
+      kind: .toggleLeftSidebar,
+      keywords: ["sidebar", "hide", "left panel"]
+    ),
+    .appShortcut(
+      id: CommandPaletteItemID.globalToggleActiveAgentsPanel,
+      title: "Toggle Active Agents Panel",
+      category: .view,
+      kind: .toggleActiveAgentsPanel,
+      keywords: ["agents", "panel"]
+    ),
+    .appShortcut(
+      id: CommandPaletteItemID.globalToggleCanvas,
+      title: "Toggle Canvas",
+      category: .view,
+      kind: .toggleCanvas,
+      keywords: ["canvas", "overview", "grid"]
+    ),
+    .appShortcut(
+      id: CommandPaletteItemID.globalToggleShelf,
+      title: "Toggle Shelf",
+      category: .view,
+      kind: .toggleShelf,
+      keywords: ["shelf", "books"]
+    ),
+  ]
 }
 
 private func selectedCodeHostItems(
@@ -598,6 +648,11 @@ private enum CommandPaletteItemID {
   static let globalJumpToLatestUnread = "global.jump-to-latest-unread"
   static let globalViewArchivedWorktrees = "global.view-archived-worktrees"
   static let globalInstallCLI = "global.install-cli"
+  static let globalToggleLeftSidebar = "global.toggle-left-sidebar"
+  static let globalToggleActiveAgentsPanel = "global.toggle-active-agents-panel"
+  static let globalToggleCanvas = "global.toggle-canvas"
+  static let globalToggleShelf = "global.toggle-shelf"
+  static let globalShowDiff = "global.show-diff"
 
   static var globalIDs: [CommandPaletteItem.ID] {
     [
@@ -609,6 +664,11 @@ private enum CommandPaletteItemID {
       globalJumpToLatestUnread,
       globalViewArchivedWorktrees,
       globalInstallCLI,
+      globalToggleLeftSidebar,
+      globalToggleActiveAgentsPanel,
+      globalToggleCanvas,
+      globalToggleShelf,
+      globalShowDiff,
     ]
   }
 
@@ -720,7 +780,12 @@ private func delegateAction(for kind: CommandPaletteItem.Kind) -> CommandPalette
     .viewArchivedWorktrees,
     .refreshWorktrees,
     .jumpToLatestUnread,
-    .installCLI:
+    .installCLI,
+    .toggleLeftSidebar,
+    .toggleActiveAgentsPanel,
+    .toggleCanvas,
+    .toggleShelf,
+    .showDiff:
     fatalError("appDelegateAction should handle app-level command palette actions")
   }
 }
@@ -743,6 +808,16 @@ private func appDelegateAction(for kind: CommandPaletteItem.Kind) -> CommandPale
     return .jumpToLatestUnread
   case .installCLI:
     return .installCLI
+  case .toggleLeftSidebar:
+    return .toggleLeftSidebar
+  case .toggleActiveAgentsPanel:
+    return .toggleActiveAgentsPanel
+  case .toggleCanvas:
+    return .toggleCanvas
+  case .toggleShelf:
+    return .toggleShelf
+  case .showDiff:
+    return .showDiff
   default:
     return nil
   }
@@ -781,7 +856,12 @@ private func pullRequestDelegateAction(
     .jumpToLatestUnread,
     .installCLI,
     .ghosttyCommand,
-    .changeFocusedTabIcon:
+    .changeFocusedTabIcon,
+    .toggleLeftSidebar,
+    .toggleActiveAgentsPanel,
+    .toggleCanvas,
+    .toggleShelf,
+    .showDiff:
     return nil
   #if DEBUG
     case .debugTestToast, .debugSimulateUpdateFound:

--- a/supacode/Features/CommandPalette/Views/CommandPaletteOverlayView.swift
+++ b/supacode/Features/CommandPalette/Views/CommandPaletteOverlayView.swift
@@ -538,7 +538,8 @@ private struct CommandPaletteRowView: View {
       .openPullRequest, .openRepositoryOnCodeHost, .markPullRequestReady, .mergePullRequest, .closePullRequest,
       .copyFailingJobURL,
       .copyCiFailureLogs,
-      .rerunFailedJobs, .openFailingCheckDetails, .worktreeSelect, .changeFocusedTabIcon:
+      .rerunFailedJobs, .openFailingCheckDetails, .worktreeSelect, .changeFocusedTabIcon,
+      .toggleLeftSidebar, .toggleActiveAgentsPanel, .toggleCanvas, .toggleShelf, .showDiff:
       return nil
     case .removeWorktree:
       return "Remove"
@@ -595,6 +596,16 @@ private struct CommandPaletteRowView: View {
       return "trash"
     case .archiveWorktree:
       return "archivebox"
+    case .toggleLeftSidebar:
+      return "sidebar.left"
+    case .toggleActiveAgentsPanel:
+      return "person.2"
+    case .toggleCanvas:
+      return "square.grid.2x2"
+    case .toggleShelf:
+      return "books.vertical"
+    case .showDiff:
+      return "doc.text.magnifyingglass"
     #if DEBUG
       case .debugTestToast:
         return "ladybug"
@@ -611,7 +622,8 @@ private struct CommandPaletteRowView: View {
       .openPullRequest, .openRepositoryOnCodeHost, .markPullRequestReady, .mergePullRequest, .closePullRequest,
       .copyFailingJobURL,
       .copyCiFailureLogs,
-      .rerunFailedJobs, .openFailingCheckDetails, .changeFocusedTabIcon:
+      .rerunFailedJobs, .openFailingCheckDetails, .changeFocusedTabIcon,
+      .toggleLeftSidebar, .toggleActiveAgentsPanel, .toggleCanvas, .toggleShelf, .showDiff:
       return true
     case .worktreeSelect, .removeWorktree, .archiveWorktree:
       return false
@@ -731,6 +743,16 @@ private struct CommandPaletteRowView: View {
       base = "Install Command Line Tool"
     case .changeFocusedTabIcon:
       base = "Change Tab Icon"
+    case .toggleLeftSidebar:
+      base = "Toggle Sidebar"
+    case .toggleActiveAgentsPanel:
+      base = "Toggle Active Agents Panel"
+    case .toggleCanvas:
+      base = "Toggle Canvas"
+    case .toggleShelf:
+      base = "Toggle Shelf"
+    case .showDiff:
+      base = "Show Diff"
     #if DEBUG
       case .debugTestToast, .debugSimulateUpdateFound:
         base = row.title

--- a/supacode/Features/CommandPalette/Views/CommandPaletteOverlayView.swift
+++ b/supacode/Features/CommandPalette/Views/CommandPaletteOverlayView.swift
@@ -599,13 +599,13 @@ private struct CommandPaletteRowView: View {
     case .toggleLeftSidebar:
       return "sidebar.left"
     case .toggleActiveAgentsPanel:
-      return "person.2"
+      return "person.crop.rectangle.stack"
     case .toggleCanvas:
       return "square.grid.2x2"
     case .toggleShelf:
       return "books.vertical"
     case .showDiff:
-      return "doc.text.magnifyingglass"
+      return "plusminus.circle"
     #if DEBUG
       case .debugTestToast:
         return "ladybug"

--- a/supacodeTests/CommandPaletteFeatureTests.swift
+++ b/supacodeTests/CommandPaletteFeatureTests.swift
@@ -19,6 +19,10 @@ struct CommandPaletteFeatureTests {
       "global.jump-to-latest-unread",
       "global.view-archived-worktrees",
       "global.install-cli",
+      "global.toggle-left-sidebar",
+      "global.toggle-active-agents-panel",
+      "global.toggle-canvas",
+      "global.toggle-shelf",
     ]
     #if DEBUG
       expectedIDs.append(contentsOf: [
@@ -28,6 +32,22 @@ struct CommandPaletteFeatureTests {
       ])
     #endif
     expectNoDifference(items.map(\.id), expectedIDs)
+  }
+
+  @Test func commandPaletteItems_includesShowDiffWhenWorktreeSelected() {
+    let rootPath = "/tmp/repo-diff"
+    let worktree = makeWorktree(id: "\(rootPath)/wt-1", name: "wt-1", repoRoot: rootPath)
+    let repository = makeRepository(rootPath: rootPath, name: "Repo", worktrees: [worktree])
+    var state = RepositoriesFeature.State(repositories: [repository])
+    state.selection = .worktree(worktree.id)
+
+    let items = CommandPaletteFeature.commandPaletteItems(from: state)
+    #expect(items.contains { $0.id == "global.show-diff" })
+  }
+
+  @Test func commandPaletteItems_omitsShowDiffWithoutSelectedWorktree() {
+    let items = CommandPaletteFeature.commandPaletteItems(from: RepositoriesFeature.State())
+    #expect(!items.contains { $0.id == "global.show-diff" })
   }
 
   @Test func commandPaletteItems_includeJumpToLatestUnreadAction() {
@@ -1441,6 +1461,8 @@ private func testCategory(for kind: CommandPaletteItem.Kind) -> CommandPaletteIt
     return .pullRequest
   case .ghosttyCommand:
     return .terminal
+  case .toggleLeftSidebar, .toggleActiveAgentsPanel, .toggleCanvas, .toggleShelf, .showDiff:
+    return .view
   #if DEBUG
     case .debugTestToast, .debugSimulateUpdateFound:
       return .debug
@@ -1453,7 +1475,8 @@ private func testDefaultSuggestion(for kind: CommandPaletteItem.Kind) -> Bool {
   case .checkForUpdates, .openSettings, .openRepository, .installCLI,
     .newWorktree, .refreshWorktrees, .viewArchivedWorktrees, .jumpToLatestUnread,
     .openPullRequest, .markPullRequestReady, .mergePullRequest, .closePullRequest,
-    .copyFailingJobURL, .copyCiFailureLogs, .rerunFailedJobs, .openFailingCheckDetails:
+    .copyFailingJobURL, .copyCiFailureLogs, .rerunFailedJobs, .openFailingCheckDetails,
+    .toggleLeftSidebar, .toggleActiveAgentsPanel, .toggleCanvas, .toggleShelf, .showDiff:
     return true
   case .worktreeSelect, .removeWorktree, .archiveWorktree, .changeFocusedTabIcon,
     .ghosttyCommand, .openRepositoryOnCodeHost:


### PR DESCRIPTION
## Summary

PR4 of the four-PR command palette plan (`doc-onevcat/plans/2026-05-16-command-palette-architecture-plan.md`). Surfaces the 5 view toggles that were previously hotkey-only.

| Command | Hotkey | Category | Suggested? | Gating |
|---------|--------|----------|------------|--------|
| Toggle Sidebar | ⌘⌃S | `.view` | yes | always |
| Toggle Active Agents Panel | ⌘⌥P | `.view` | yes | always |
| Toggle Canvas | ⌘⌥↩ | `.view` | yes | always |
| Toggle Shelf | ⌘⇧↩ | `.view` | yes | always |
| Show Diff | ⌘⇧Y | `.view` | yes | hidden unless a worktree is selected |

Each is a one-liner through PR3's `.appShortcut` factory, with keyword aliases for fuzzy search (`sidebar`, `agents`, `canvas`, `shelf`, `diff`, etc.).

## Architectural change: lift `leftSidebarVisibility` into AppFeature.State

Previously the main window's sidebar visibility lived as `@State` in `ContentView`, mutated via a `FocusedValue` closure invoked from the menu's "Toggle Left Sidebar" button. The palette can't reach scene-scoped `FocusedValue` closures from a reducer, so I lifted the state up:

- `AppFeature.State.leftSidebarVisibility: NavigationSplitViewVisibility`
- New actions: `.toggleLeftSidebar`, `.showLeftSidebar`, `.setLeftSidebarVisibility(_)` (last one backs the NavigationSplitView's `columnVisibility` binding)
- `ContentView` constructs a `Binding(get:set:)` against the store
- Animation moves from `withAnimation { ... }` (in the imperative closure) to `.animation(.easeOut(duration: 0.2), value: store.leftSidebarVisibility)` (on the view)
- The diff window keeps its own per-scene `columnVisibility` — they're independent NavigationSplitViews, so this doesn't affect the diff sidebar's behavior

The `FocusedValue` closures (`toggleLeftSidebarAction`, `revealInSidebarAction`) still exist and now dispatch TCA actions instead of mutating local state — menu behavior unchanged.

## Test plan

- [x] `make build-app` — green
- [x] `make check` (swift-format + swiftlint strict) — green
- [x] `CommandPaletteFeatureTests` + `AppFeatureCommandPaletteTests` + `AppShortcutsTests` — all pass
- [x] New tests:
  - `commandPaletteItems_onlyGlobalWhenEmpty` updated to include the 4 new always-on view commands
  - `commandPaletteItems_includesShowDiffWhenWorktreeSelected`
  - `commandPaletteItems_omitsShowDiffWithoutSelectedWorktree`
- [x] **Manual UI verification** — please confirm before merging:
  - Open Cmd+P → see 4 "Toggle X" commands and (when on a worktree) "Show Diff" in Suggested
  - Activate each — sidebar collapses/expands, canvas/shelf/agents panels toggle, diff window opens
  - Trigger ⌘⌃S directly (no palette) — sidebar still toggles via menu/FocusedValue path
  - Open the diff window, hit ⌘⌃S there — diff window's own sidebar toggles independently
