### PR TITLE
Command palette: navigation actions + focus restore by default

### DIFF
--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -135,6 +135,21 @@ struct AppFeature {
     }
   }
 
+  /// Delegate actions that intentionally shift focus elsewhere (selection
+  /// changes, view changes that swap the focused terminal). These skip the
+  /// post-delegate focus restore so we don't fight the natural new focus.
+  private static func commandPaletteDelegateChangesActiveSelection(
+    _ delegate: CommandPaletteFeature.Delegate
+  ) -> Bool {
+    switch delegate {
+    case .selectWorktree, .jumpToLatestUnread, .viewArchivedWorktrees,
+      .newWorktree, .toggleCanvas:
+      return true
+    default:
+      return false
+    }
+  }
+
   private func commandPaletteTerminalFocusTarget(repositories: RepositoriesFeature.State) -> Worktree? {
     if let worktree = repositories.selectedTerminalWorktree {
       return worktree
@@ -994,10 +1009,7 @@ struct AppFeature {
         return .send(.repositories(.selectWorktree(worktreeID)))
 
       case .commandPalette(.delegate(.checkForUpdates)):
-        return .merge(
-          .send(.updates(.checkForUpdates)),
-          restoreCommandPaletteTerminalFocusEffect(repositories: state.repositories)
-        )
+        return .send(.updates(.checkForUpdates))
 
       case .commandPalette(.delegate(.openSettings)):
         return .merge(
@@ -1023,10 +1035,7 @@ struct AppFeature {
         return .send(.repositories(.selectArchivedWorktrees))
 
       case .commandPalette(.delegate(.refreshWorktrees)):
-        return .merge(
-          .send(.repositories(.refreshWorktrees)),
-          restoreCommandPaletteTerminalFocusEffect(repositories: state.repositories)
-        )
+        return .send(.repositories(.refreshWorktrees))
 
       case .commandPalette(.delegate(.jumpToLatestUnread)):
         return .send(.jumpToLatestUnread)
@@ -1062,6 +1071,28 @@ struct AppFeature {
             )
           }
         }
+
+      case .commandPalette(.delegate(.revealInFinder)):
+        return .send(.openWorktree(.finder))
+
+      case .commandPalette(.delegate(.copyPath)):
+        guard let worktree = state.repositories.selectedTerminalWorktree else {
+          return .none
+        }
+        let path = worktree.workingDirectory.path
+        return .run { _ in
+          await MainActor.run {
+            NSPasteboard.general.clearContents()
+            NSPasteboard.general.setString(path, forType: .string)
+          }
+        }
+
+      case .commandPalette(.delegate(.revealInSidebar)):
+        guard state.repositories.selectedWorktreeID != nil else { return .none }
+        return .merge(
+          .send(.showLeftSidebar),
+          .send(.repositories(.revealSelectedWorktreeInSidebar))
+        )
 
       case .commandPalette(.delegate(.ghosttyCommand(let action))):
         guard let worktree = state.repositories.selectedTerminalWorktree else {
@@ -1107,10 +1138,7 @@ struct AppFeature {
 
       #if DEBUG
         case .commandPalette(.delegate(.debugTestToast(let toast))):
-          return .merge(
-            .send(.repositories(.showToast(toast))),
-            restoreCommandPaletteTerminalFocusEffect(repositories: state.repositories)
-          )
+          return .send(.repositories(.showToast(toast)))
 
         case .commandPalette(.delegate(.debugSimulateUpdateFound)):
           return .send(.updates(.debugSimulateUpdateFound))
@@ -1244,6 +1272,18 @@ struct AppFeature {
       }
     }
     core
+    Reduce<State, Action> { state, action in
+      // Default-on focus restore: every command-palette delegate action that
+      // doesn't intentionally shift selection sends focus back to the active
+      // terminal once its effect has dispatched. Runs after `core` so it
+      // sees the same action and adds a parallel effect.
+      guard case .commandPalette(.delegate(let delegate)) = action,
+        !Self.commandPaletteDelegateChangesActiveSelection(delegate)
+      else {
+        return .none
+      }
+      return restoreCommandPaletteTerminalFocusEffect(repositories: state.repositories)
+    }
     Scope(state: \.repositories, action: \.repositories) {
       RepositoriesFeature()
     }

--- a/supacode/Features/CommandPalette/CommandPaletteItem.swift
+++ b/supacode/Features/CommandPalette/CommandPaletteItem.swift
@@ -68,6 +68,9 @@ struct CommandPaletteItem: Identifiable, Equatable {
     case toggleCanvas
     case toggleShelf
     case showDiff
+    case revealInFinder
+    case copyPath
+    case revealInSidebar
     #if DEBUG
       case debugTestToast(RepositoriesFeature.StatusToast)
       case debugSimulateUpdateFound
@@ -115,6 +118,8 @@ struct CommandPaletteItem: Identifiable, Equatable {
       return AppShortcuts.CommandID.toggleShelf
     case .showDiff:
       return AppShortcuts.CommandID.showDiff
+    case .revealInSidebar:
+      return AppShortcuts.CommandID.revealInSidebar
     case .ghosttyCommand,
       .markPullRequestReady,
       .mergePullRequest,
@@ -127,7 +132,9 @@ struct CommandPaletteItem: Identifiable, Equatable {
       .worktreeSelect,
       .removeWorktree,
       .archiveWorktree,
-      .changeFocusedTabIcon:
+      .changeFocusedTabIcon,
+      .revealInFinder,
+      .copyPath:
       return nil
     #if DEBUG
       case .debugTestToast, .debugSimulateUpdateFound:

--- a/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
+++ b/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
@@ -57,6 +57,9 @@ struct CommandPaletteFeature {
     case toggleCanvas
     case toggleShelf
     case showDiff
+    case revealInFinder
+    case copyPath
+    case revealInSidebar
     #if DEBUG
       case debugTestToast(RepositoriesFeature.StatusToast)
       case debugSimulateUpdateFound
@@ -222,6 +225,7 @@ struct CommandPaletteFeature {
           keywords: ["diff", "changes", "git"]
         )
       )
+      items.append(contentsOf: worktreeNavigationCommandItems())
     }
     if let terminalWorktree = repositories.selectedTerminalWorktree {
       items.append(
@@ -346,6 +350,32 @@ private func globalCommandItems(showsNewWorktreeAction: Bool) -> [CommandPalette
   )
   items.append(contentsOf: viewToggleCommandItems())
   return items
+}
+
+private func worktreeNavigationCommandItems() -> [CommandPaletteItem] {
+  [
+    .appShortcut(
+      id: CommandPaletteItemID.globalRevealInFinder,
+      title: "Reveal in Finder",
+      category: .navigation,
+      kind: .revealInFinder,
+      keywords: ["finder", "open", "show"]
+    ),
+    .appShortcut(
+      id: CommandPaletteItemID.globalCopyPath,
+      title: "Copy Path",
+      category: .navigation,
+      kind: .copyPath,
+      keywords: ["copy", "path", "clipboard"]
+    ),
+    .appShortcut(
+      id: CommandPaletteItemID.globalRevealInSidebar,
+      title: "Reveal in Sidebar",
+      category: .navigation,
+      kind: .revealInSidebar,
+      keywords: ["reveal", "locate", "find worktree"]
+    ),
+  ]
 }
 
 private func viewToggleCommandItems() -> [CommandPaletteItem] {
@@ -653,6 +683,9 @@ private enum CommandPaletteItemID {
   static let globalToggleCanvas = "global.toggle-canvas"
   static let globalToggleShelf = "global.toggle-shelf"
   static let globalShowDiff = "global.show-diff"
+  static let globalRevealInFinder = "global.reveal-in-finder"
+  static let globalCopyPath = "global.copy-path"
+  static let globalRevealInSidebar = "global.reveal-in-sidebar"
 
   static var globalIDs: [CommandPaletteItem.ID] {
     [
@@ -669,6 +702,9 @@ private enum CommandPaletteItemID {
       globalToggleCanvas,
       globalToggleShelf,
       globalShowDiff,
+      globalRevealInFinder,
+      globalCopyPath,
+      globalRevealInSidebar,
     ]
   }
 
@@ -785,12 +821,18 @@ private func delegateAction(for kind: CommandPaletteItem.Kind) -> CommandPalette
     .toggleActiveAgentsPanel,
     .toggleCanvas,
     .toggleShelf,
-    .showDiff:
+    .showDiff,
+    .revealInFinder,
+    .copyPath,
+    .revealInSidebar:
     fatalError("appDelegateAction should handle app-level command palette actions")
   }
 }
 
 private func appDelegateAction(for kind: CommandPaletteItem.Kind) -> CommandPaletteFeature.Delegate? {
+  if let delegate = navigationDelegateAction(for: kind) {
+    return delegate
+  }
   switch kind {
   case .checkForUpdates:
     return .checkForUpdates
@@ -818,6 +860,19 @@ private func appDelegateAction(for kind: CommandPaletteItem.Kind) -> CommandPale
     return .toggleShelf
   case .showDiff:
     return .showDiff
+  default:
+    return nil
+  }
+}
+
+private func navigationDelegateAction(for kind: CommandPaletteItem.Kind) -> CommandPaletteFeature.Delegate? {
+  switch kind {
+  case .revealInFinder:
+    return .revealInFinder
+  case .copyPath:
+    return .copyPath
+  case .revealInSidebar:
+    return .revealInSidebar
   default:
     return nil
   }
@@ -861,7 +916,10 @@ private func pullRequestDelegateAction(
     .toggleActiveAgentsPanel,
     .toggleCanvas,
     .toggleShelf,
-    .showDiff:
+    .showDiff,
+    .revealInFinder,
+    .copyPath,
+    .revealInSidebar:
     return nil
   #if DEBUG
     case .debugTestToast, .debugSimulateUpdateFound:

--- a/supacode/Features/CommandPalette/Views/CommandPaletteOverlayView.swift
+++ b/supacode/Features/CommandPalette/Views/CommandPaletteOverlayView.swift
@@ -539,7 +539,8 @@ private struct CommandPaletteRowView: View {
       .copyFailingJobURL,
       .copyCiFailureLogs,
       .rerunFailedJobs, .openFailingCheckDetails, .worktreeSelect, .changeFocusedTabIcon,
-      .toggleLeftSidebar, .toggleActiveAgentsPanel, .toggleCanvas, .toggleShelf, .showDiff:
+      .toggleLeftSidebar, .toggleActiveAgentsPanel, .toggleCanvas, .toggleShelf, .showDiff,
+      .revealInFinder, .copyPath, .revealInSidebar:
       return nil
     case .removeWorktree:
       return "Remove"
@@ -606,6 +607,12 @@ private struct CommandPaletteRowView: View {
       return "books.vertical"
     case .showDiff:
       return "plusminus.circle"
+    case .revealInFinder:
+      return "folder"
+    case .copyPath:
+      return "doc.on.clipboard"
+    case .revealInSidebar:
+      return "sidebar.left.badge.dot"
     #if DEBUG
       case .debugTestToast:
         return "ladybug"
@@ -623,7 +630,8 @@ private struct CommandPaletteRowView: View {
       .copyFailingJobURL,
       .copyCiFailureLogs,
       .rerunFailedJobs, .openFailingCheckDetails, .changeFocusedTabIcon,
-      .toggleLeftSidebar, .toggleActiveAgentsPanel, .toggleCanvas, .toggleShelf, .showDiff:
+      .toggleLeftSidebar, .toggleActiveAgentsPanel, .toggleCanvas, .toggleShelf, .showDiff,
+      .revealInFinder, .copyPath, .revealInSidebar:
       return true
     case .worktreeSelect, .removeWorktree, .archiveWorktree:
       return false
@@ -753,6 +761,12 @@ private struct CommandPaletteRowView: View {
       base = "Toggle Shelf"
     case .showDiff:
       base = "Show Diff"
+    case .revealInFinder:
+      base = "Reveal in Finder"
+    case .copyPath:
+      base = "Copy Path"
+    case .revealInSidebar:
+      base = "Reveal in Sidebar"
     #if DEBUG
       case .debugTestToast, .debugSimulateUpdateFound:
         base = row.title

--- a/supacodeTests/AppFeatureCommandPaletteTests.swift
+++ b/supacodeTests/AppFeatureCommandPaletteTests.swift
@@ -1,7 +1,9 @@
+import AppKit
 import ComposableArchitecture
 import DependenciesTestSupport
 import Foundation
 import IdentifiedCollections
+import SwiftUI
 import Testing
 
 @testable import supacode
@@ -325,11 +327,170 @@ struct AppFeatureCommandPaletteTests {
     await store.send(.commandPalette(.delegate(.ghosttyCommand("goto_split:right"))))
     await store.finish()
 
-    #expect(
-      sent.value == [
-        .performBindingAction(worktree, action: "goto_split:right")
-      ]
+    // Two effects run in parallel (.merge) — assert both fire without
+    // depending on dispatch order.
+    #expect(sent.value.count == 2)
+    #expect(sent.value.contains(.performBindingAction(worktree, action: "goto_split:right")))
+    #expect(sent.value.contains(.focusSelectedTab(worktree)))
+  }
+
+  @Test(.dependencies) func viewToggleDelegateRestoresTerminalFocusByDefault() async {
+    let worktree = makeWorktree(
+      id: "/tmp/repo-view-toggle/wt-1",
+      name: "wt-1",
+      repoRoot: "/tmp/repo-view-toggle"
     )
+    let repository = makeRepository(id: "/tmp/repo-view-toggle", worktrees: [worktree])
+    var repositoriesState = RepositoriesFeature.State()
+    repositoriesState.repositories = [repository]
+    repositoriesState.selection = .worktree(worktree.id)
+    let sent = LockIsolated<[TerminalClient.Command]>([])
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: repositoriesState,
+        settings: SettingsFeature.State()
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in
+        sent.withValue { $0.append(command) }
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.commandPalette(.delegate(.toggleLeftSidebar)))
+    await store.finish()
+
+    #expect(sent.value.contains(.focusSelectedTab(worktree)))
+  }
+
+  @Test(.dependencies) func toggleCanvasDelegateDoesNotRestoreTerminalFocus() async {
+    let worktree = makeWorktree(
+      id: "/tmp/repo-canvas-toggle/wt-1",
+      name: "wt-1",
+      repoRoot: "/tmp/repo-canvas-toggle"
+    )
+    let repository = makeRepository(id: "/tmp/repo-canvas-toggle", worktrees: [worktree])
+    var repositoriesState = RepositoriesFeature.State()
+    repositoriesState.repositories = [repository]
+    repositoriesState.selection = .worktree(worktree.id)
+    let sent = LockIsolated<[TerminalClient.Command]>([])
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: repositoriesState,
+        settings: SettingsFeature.State()
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in
+        sent.withValue { $0.append(command) }
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.commandPalette(.delegate(.toggleCanvas)))
+    await store.finish()
+
+    #expect(!sent.value.contains(.focusSelectedTab(worktree)))
+  }
+
+  @Test(.dependencies) func revealInFinderDispatchesOpenWorktreeFinder() async {
+    let worktree = makeWorktree(
+      id: "/tmp/repo-finder/wt-1",
+      name: "wt-1",
+      repoRoot: "/tmp/repo-finder"
+    )
+    let repository = makeRepository(id: "/tmp/repo-finder", worktrees: [worktree])
+    var repositoriesState = RepositoriesFeature.State()
+    repositoriesState.repositories = [repository]
+    repositoriesState.selection = .worktree(worktree.id)
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: repositoriesState,
+        settings: SettingsFeature.State()
+      )
+    ) {
+      AppFeature()
+    }
+    store.exhaustivity = .off
+
+    await store.send(.commandPalette(.delegate(.revealInFinder)))
+    await store.receive(\.openWorktree)
+  }
+
+  @Test(.dependencies) func copyPathWritesWorktreePathToPasteboard() async {
+    let worktree = makeWorktree(
+      id: "/tmp/repo-copy/wt-1",
+      name: "wt-1",
+      repoRoot: "/tmp/repo-copy"
+    )
+    let repository = makeRepository(id: "/tmp/repo-copy", worktrees: [worktree])
+    var repositoriesState = RepositoriesFeature.State()
+    repositoriesState.repositories = [repository]
+    repositoriesState.selection = .worktree(worktree.id)
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: repositoriesState,
+        settings: SettingsFeature.State()
+      )
+    ) {
+      AppFeature()
+    }
+
+    NSPasteboard.general.clearContents()
+    NSPasteboard.general.setString("__sentinel__", forType: .string)
+
+    await store.send(.commandPalette(.delegate(.copyPath)))
+    await store.finish()
+
+    #expect(NSPasteboard.general.string(forType: .string) == worktree.workingDirectory.path)
+  }
+
+  @Test(.dependencies) func copyPathWithoutSelectedWorktreeIsNoop() async {
+    let store = TestStore(initialState: AppFeature.State()) {
+      AppFeature()
+    }
+
+    await store.send(.commandPalette(.delegate(.copyPath)))
+    await store.finish()
+  }
+
+  @Test(.dependencies) func revealInSidebarShowsSidebarAndReveals() async {
+    let worktree = makeWorktree(
+      id: "/tmp/repo-reveal/wt-1",
+      name: "wt-1",
+      repoRoot: "/tmp/repo-reveal"
+    )
+    let repository = makeRepository(id: "/tmp/repo-reveal", worktrees: [worktree])
+    var repositoriesState = RepositoriesFeature.State()
+    repositoriesState.repositories = [repository]
+    repositoriesState.selection = .worktree(worktree.id)
+    var appState = AppFeature.State(
+      repositories: repositoriesState,
+      settings: SettingsFeature.State()
+    )
+    appState.leftSidebarVisibility = .detailOnly
+    let store = TestStore(initialState: appState) {
+      AppFeature()
+    }
+    store.exhaustivity = .off
+
+    await store.send(.commandPalette(.delegate(.revealInSidebar)))
+    await store.receive(\.showLeftSidebar) {
+      $0.leftSidebarVisibility = .all
+    }
+    await store.receive(\.repositories.revealSelectedWorktreeInSidebar)
+  }
+
+  @Test(.dependencies) func revealInSidebarWithoutSelectedWorktreeIsNoop() async {
+    let store = TestStore(initialState: AppFeature.State()) {
+      AppFeature()
+    }
+
+    await store.send(.commandPalette(.delegate(.revealInSidebar)))
+    await store.finish()
   }
 
   @Test(.dependencies) func closePullRequestDispatchesAction() async {

--- a/supacodeTests/CommandPaletteFeatureTests.swift
+++ b/supacodeTests/CommandPaletteFeatureTests.swift
@@ -50,6 +50,28 @@ struct CommandPaletteFeatureTests {
     #expect(!items.contains { $0.id == "global.show-diff" })
   }
 
+  @Test func commandPaletteItems_includesWorktreeNavigationWhenWorktreeSelected() {
+    let rootPath = "/tmp/repo-nav"
+    let worktree = makeWorktree(id: "\(rootPath)/wt-1", name: "wt-1", repoRoot: rootPath)
+    let repository = makeRepository(rootPath: rootPath, name: "Repo", worktrees: [worktree])
+    var state = RepositoriesFeature.State(repositories: [repository])
+    state.selection = .worktree(worktree.id)
+
+    let items = CommandPaletteFeature.commandPaletteItems(from: state)
+    let ids = Set(items.map(\.id))
+    #expect(ids.contains("global.reveal-in-finder"))
+    #expect(ids.contains("global.copy-path"))
+    #expect(ids.contains("global.reveal-in-sidebar"))
+  }
+
+  @Test func commandPaletteItems_omitsWorktreeNavigationWithoutSelectedWorktree() {
+    let items = CommandPaletteFeature.commandPaletteItems(from: RepositoriesFeature.State())
+    let ids = Set(items.map(\.id))
+    #expect(!ids.contains("global.reveal-in-finder"))
+    #expect(!ids.contains("global.copy-path"))
+    #expect(!ids.contains("global.reveal-in-sidebar"))
+  }
+
   @Test func commandPaletteItems_includeJumpToLatestUnreadAction() {
     let items = CommandPaletteFeature.commandPaletteItems(from: RepositoriesFeature.State())
     let item = items.first { $0.id == "global.jump-to-latest-unread" }
@@ -1453,7 +1475,7 @@ private func testCategory(for kind: CommandPaletteItem.Kind) -> CommandPaletteIt
   case .newWorktree, .refreshWorktrees, .viewArchivedWorktrees,
     .removeWorktree, .archiveWorktree, .changeFocusedTabIcon:
     return .worktree
-  case .jumpToLatestUnread, .worktreeSelect:
+  case .jumpToLatestUnread, .worktreeSelect, .revealInFinder, .copyPath, .revealInSidebar:
     return .navigation
   case .openPullRequest, .openRepositoryOnCodeHost, .markPullRequestReady,
     .mergePullRequest, .closePullRequest, .copyFailingJobURL, .copyCiFailureLogs,
@@ -1476,7 +1498,8 @@ private func testDefaultSuggestion(for kind: CommandPaletteItem.Kind) -> Bool {
     .newWorktree, .refreshWorktrees, .viewArchivedWorktrees, .jumpToLatestUnread,
     .openPullRequest, .markPullRequestReady, .mergePullRequest, .closePullRequest,
     .copyFailingJobURL, .copyCiFailureLogs, .rerunFailedJobs, .openFailingCheckDetails,
-    .toggleLeftSidebar, .toggleActiveAgentsPanel, .toggleCanvas, .toggleShelf, .showDiff:
+    .toggleLeftSidebar, .toggleActiveAgentsPanel, .toggleCanvas, .toggleShelf, .showDiff,
+    .revealInFinder, .copyPath, .revealInSidebar:
     return true
   case .worktreeSelect, .removeWorktree, .archiveWorktree, .changeFocusedTabIcon,
     .ghosttyCommand, .openRepositoryOnCodeHost:


### PR DESCRIPTION
## Summary

PR5 of the command-palette buildout. Adds three worktree navigation commands and fixes a structural bug where new delegate handlers silently lost terminal-focus restoration.

### Navigation actions

Gated on `selectedWorktreeID != nil`, category `.navigation`, default-suggested:

- **Reveal in Finder** — dispatches `openWorktree(.finder)`, always opens Finder regardless of the user's configured default editor. No hotkey hint (⌘O binds the configurable `openWorktree` action, not Finder specifically).
- **Copy Path** — writes `selectedTerminalWorktree.workingDirectory.path` to `NSPasteboard`. No hotkey hint: the underlying ⌘⇧C binding is dead (#295 tracks removing it).
- **Reveal in Sidebar** — sends `.showLeftSidebar` then `.repositories(.revealSelectedWorktreeInSidebar)`.

### Focus restore refactor

#287 patched five sites to merge `restoreCommandPaletteTerminalFocusEffect` into their effects. Every delegate handler added since (PR4 view toggles, Show Diff, the three navigation actions in this PR) silently dropped the behavior.

This PR moves the restore to a dedicated `Reduce` after `core` that fires for every `CommandPalette.delegate` action **except** those in `commandPaletteDelegateChangesActiveSelection`:

- `selectWorktree`
- `jumpToLatestUnread`
- `viewArchivedWorktrees`
- `newWorktree`
- `toggleCanvas`

The three explicit `.merge(restore...)` calls in `checkForUpdates` / `refreshWorktrees` / `debugTestToast` are removed since they're now redundant. Future commands get focus restoration by default; opting out means adding to the deny list.

### Notes

- `navigationDelegateAction` helper in `CommandPaletteFeature` mirrors the existing `pullRequestDelegateAction` pattern, keeping `appDelegateAction` under the cyclomatic-complexity threshold.
- `ghosttyCommand` test updated to assert both `performBindingAction` and the new `focusSelectedTab` effect (order-independent).
- New tests cover the whitelist default (`toggleLeftSidebar` → restore fires) and the deny list (`toggleCanvas` → no restore), plus delegate routing for the three new navigation actions.

## Test plan

- [x] `make check` clean
- [x] `make test` (1104 passed)
- [x] `make build-app` succeeds
- [x] Manual smoke: open a worktree → ⌘P → "find" / "copy" / "reveal" each search-match and execute correctly
- [x] Manual smoke: after any non-selection-changing palette command, terminal regains keyboard focus
- [x] Manual smoke: after `Toggle Canvas` or `Jump to Latest Unread`, focus does NOT bounce back to the previous terminal
