### PR TITLE
Command palette: worktree actions + custom commands

### DIFF
--- a/supacode/App/ContentView.swift
+++ b/supacode/App/ContentView.swift
@@ -87,6 +87,8 @@ struct ContentView: View {
         store: store.scope(state: \.commandPalette, action: \.commandPalette),
         items: CommandPaletteFeature.commandPaletteItems(
           from: store.repositories,
+          customCommands: store.selectedCustomCommands,
+          runScriptStatusByWorktreeID: store.runScriptStatusByWorktreeID,
           ghosttyCommands: ghosttyShortcuts.commandPaletteEntries
         ),
         resolvedKeybindings: store.resolvedKeybindings

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -143,7 +143,7 @@ struct AppFeature {
   ) -> Bool {
     switch delegate {
     case .selectWorktree, .jumpToLatestUnread, .viewArchivedWorktrees,
-      .newWorktree, .toggleCanvas:
+      .newWorktree, .toggleCanvas, .renameBranch:
       return true
     default:
       return false
@@ -1102,6 +1102,10 @@ struct AppFeature {
 
       case .commandPalette(.delegate(.stopRunScript)):
         return .send(.stopRunScript)
+
+      case .commandPalette(.delegate(.renameBranch)):
+        guard let worktreeID = state.repositories.selectedWorktreeID else { return .none }
+        return .send(.repositories(.requestRenameBranchPrompt(worktreeID)))
 
       case .commandPalette(.delegate(.togglePinWorktree(let worktreeID, let isCurrentlyPinned))):
         if isCurrentlyPinned {

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -376,7 +376,10 @@ struct AppFeature {
       case .repositories(.delegate(.repositoriesChanged(let repositories))):
         let archivedIDs = state.repositories.archivedWorktreeIDSet
         let ids = state.repositories.terminalStateIDs.subtracting(archivedIDs)
-        let recencyIDs = CommandPaletteFeature.recencyRetentionIDs(from: repositories)
+        let recencyIDs = CommandPaletteFeature.recencyRetentionIDs(
+          from: repositories,
+          customCommands: state.selectedCustomCommands
+        )
         let worktrees = state.repositories.worktreesForInfoWatcher()
         let shouldRestoreLayout =
           state.launchRestoreMode == .restoreLayout
@@ -1093,6 +1096,21 @@ struct AppFeature {
           .send(.showLeftSidebar),
           .send(.repositories(.revealSelectedWorktreeInSidebar))
         )
+
+      case .commandPalette(.delegate(.runScript)):
+        return .send(.runScript)
+
+      case .commandPalette(.delegate(.stopRunScript)):
+        return .send(.stopRunScript)
+
+      case .commandPalette(.delegate(.togglePinWorktree(let worktreeID, let isCurrentlyPinned))):
+        if isCurrentlyPinned {
+          return .send(.repositories(.worktreeOrdering(.unpinWorktree(worktreeID))))
+        }
+        return .send(.repositories(.worktreeOrdering(.pinWorktree(worktreeID))))
+
+      case .commandPalette(.delegate(.runCustomCommand(let index))):
+        return .send(.runCustomCommand(index))
 
       case .commandPalette(.delegate(.ghosttyCommand(let action))):
         guard let worktree = state.repositories.selectedTerminalWorktree else {

--- a/supacode/Features/CommandPalette/CommandPaletteItem.swift
+++ b/supacode/Features/CommandPalette/CommandPaletteItem.swift
@@ -75,6 +75,7 @@ struct CommandPaletteItem: Identifiable, Equatable {
     case stopRunScript
     case togglePinWorktree(Worktree.ID, isCurrentlyPinned: Bool)
     case deleteWorktree(Worktree.ID, Repository.ID)
+    case renameBranch
     case runCustomCommand(index: Int, commandID: String, systemImage: String)
     #if DEBUG
       case debugTestToast(RepositoriesFeature.StatusToast)
@@ -129,6 +130,8 @@ struct CommandPaletteItem: Identifiable, Equatable {
       return AppShortcuts.CommandID.runScript
     case .stopRunScript:
       return AppShortcuts.CommandID.stopScript
+    case .renameBranch:
+      return AppShortcuts.CommandID.renameBranch
     case .ghosttyCommand,
       .markPullRequestReady,
       .mergePullRequest,

--- a/supacode/Features/CommandPalette/CommandPaletteItem.swift
+++ b/supacode/Features/CommandPalette/CommandPaletteItem.swift
@@ -71,6 +71,11 @@ struct CommandPaletteItem: Identifiable, Equatable {
     case revealInFinder
     case copyPath
     case revealInSidebar
+    case runScript
+    case stopRunScript
+    case togglePinWorktree(Worktree.ID, isCurrentlyPinned: Bool)
+    case deleteWorktree(Worktree.ID, Repository.ID)
+    case runCustomCommand(index: Int, commandID: String, systemImage: String)
     #if DEBUG
       case debugTestToast(RepositoriesFeature.StatusToast)
       case debugSimulateUpdateFound
@@ -120,6 +125,10 @@ struct CommandPaletteItem: Identifiable, Equatable {
       return AppShortcuts.CommandID.showDiff
     case .revealInSidebar:
       return AppShortcuts.CommandID.revealInSidebar
+    case .runScript:
+      return AppShortcuts.CommandID.runScript
+    case .stopRunScript:
+      return AppShortcuts.CommandID.stopScript
     case .ghosttyCommand,
       .markPullRequestReady,
       .mergePullRequest,
@@ -134,7 +143,10 @@ struct CommandPaletteItem: Identifiable, Equatable {
       .archiveWorktree,
       .changeFocusedTabIcon,
       .revealInFinder,
-      .copyPath:
+      .copyPath,
+      .togglePinWorktree,
+      .deleteWorktree,
+      .runCustomCommand:
       return nil
     #if DEBUG
       case .debugTestToast, .debugSimulateUpdateFound:

--- a/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
+++ b/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
@@ -63,6 +63,7 @@ struct CommandPaletteFeature {
     case runScript
     case stopRunScript
     case togglePinWorktree(Worktree.ID, isCurrentlyPinned: Bool)
+    case renameBranch
     case runCustomCommand(Int)
     #if DEBUG
       case debugTestToast(RepositoriesFeature.StatusToast)
@@ -406,6 +407,15 @@ private func worktreeActionCommandItems(
         category: .worktree,
         kind: .togglePinWorktree(worktreeID, isCurrentlyPinned: row.isPinned),
         keywords: pinKeywords
+      )
+    )
+    items.append(
+      .appShortcut(
+        id: CommandPaletteItemID.globalRenameBranch,
+        title: "Rename Branch",
+        category: .worktree,
+        kind: .renameBranch,
+        keywords: ["rename", "branch", "name"]
       )
     )
     if let repositoryID = repositories.repositoryID(containing: worktreeID) {
@@ -796,6 +806,7 @@ private enum CommandPaletteItemID {
   static let globalRunScript = "global.run-script"
   static let globalStopRunScript = "global.stop-run-script"
   static let globalTogglePinWorktree = "global.toggle-pin-worktree"
+  static let globalRenameBranch = "global.rename-branch"
   static let globalDeleteWorktree = "global.delete-worktree"
 
   static func customCommand(_ commandID: String) -> CommandPaletteItem.ID {
@@ -823,6 +834,7 @@ private enum CommandPaletteItemID {
       globalRunScript,
       globalStopRunScript,
       globalTogglePinWorktree,
+      globalRenameBranch,
       globalDeleteWorktree,
     ]
   }
@@ -950,7 +962,8 @@ private func delegateAction(for kind: CommandPaletteItem.Kind) -> CommandPalette
     .copyPath,
     .revealInSidebar,
     .runScript,
-    .stopRunScript:
+    .stopRunScript,
+    .renameBranch:
     fatalError("appDelegateAction should handle app-level command palette actions")
   }
 }
@@ -983,6 +996,8 @@ private func appDelegateAction(for kind: CommandPaletteItem.Kind) -> CommandPale
     return .runScript
   case .stopRunScript:
     return .stopRunScript
+  case .renameBranch:
+    return .renameBranch
   default:
     return nil
   }
@@ -1063,6 +1078,7 @@ private func pullRequestDelegateAction(
     .runScript,
     .stopRunScript,
     .togglePinWorktree,
+    .renameBranch,
     .deleteWorktree,
     .runCustomCommand:
     return nil

--- a/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
+++ b/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
@@ -396,41 +396,43 @@ private func worktreeActionCommandItems(
       )
     )
   }
-  if let row = repositories.selectedRow(for: worktreeID), !row.isMainWorktree {
-    let pinTitle = row.isPinned ? "Unpin Worktree" : "Pin Worktree"
-    let pinKeywords =
-      row.isPinned ? ["unpin", "favorite"] : ["pin", "favorite", "top"]
+  guard let row = repositories.selectedRow(for: worktreeID) else { return items }
+  // Rename Branch works on any worktree (main included).
+  items.append(
+    .appShortcut(
+      id: CommandPaletteItemID.globalRenameBranch,
+      title: "Rename Branch",
+      category: .worktree,
+      kind: .renameBranch,
+      keywords: ["rename", "branch", "name"]
+    )
+  )
+  // Pin / Unpin / Delete only apply to non-main worktrees.
+  guard !row.isMainWorktree else { return items }
+  let pinTitle = row.isPinned ? "Unpin Worktree" : "Pin Worktree"
+  let pinKeywords =
+    row.isPinned ? ["unpin", "favorite"] : ["pin", "favorite", "top"]
+  items.append(
+    .appShortcut(
+      id: CommandPaletteItemID.globalTogglePinWorktree,
+      title: pinTitle,
+      category: .worktree,
+      kind: .togglePinWorktree(worktreeID, isCurrentlyPinned: row.isPinned),
+      keywords: pinKeywords
+    )
+  )
+  if let repositoryID = repositories.repositoryID(containing: worktreeID) {
     items.append(
-      .appShortcut(
-        id: CommandPaletteItemID.globalTogglePinWorktree,
-        title: pinTitle,
+      CommandPaletteItem(
+        id: CommandPaletteItemID.globalDeleteWorktree,
+        title: "Delete Worktree",
+        subtitle: row.name,
+        kind: .deleteWorktree(worktreeID, repositoryID),
         category: .worktree,
-        kind: .togglePinWorktree(worktreeID, isCurrentlyPinned: row.isPinned),
-        keywords: pinKeywords
+        defaultSuggestion: false,
+        keywords: ["delete", "remove", "destroy"]
       )
     )
-    items.append(
-      .appShortcut(
-        id: CommandPaletteItemID.globalRenameBranch,
-        title: "Rename Branch",
-        category: .worktree,
-        kind: .renameBranch,
-        keywords: ["rename", "branch", "name"]
-      )
-    )
-    if let repositoryID = repositories.repositoryID(containing: worktreeID) {
-      items.append(
-        CommandPaletteItem(
-          id: CommandPaletteItemID.globalDeleteWorktree,
-          title: "Delete Worktree",
-          subtitle: row.name,
-          kind: .deleteWorktree(worktreeID, repositoryID),
-          category: .worktree,
-          defaultSuggestion: false,
-          keywords: ["delete", "remove", "destroy"]
-        )
-      )
-    }
   }
   return items
 }

--- a/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
+++ b/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
@@ -431,7 +431,7 @@ private func customCommandItems(_ commands: [UserCustomCommand]) -> [CommandPale
     return CommandPaletteItem(
       id: CommandPaletteItemID.customCommand(command.id),
       title: command.resolvedTitle,
-      subtitle: command.execution.title,
+      subtitle: customCommandSubtitle(for: command),
       kind: .runCustomCommand(
         index: index,
         commandID: command.id,
@@ -441,6 +441,21 @@ private func customCommandItems(_ commands: [UserCustomCommand]) -> [CommandPale
       defaultSuggestion: false,
       keywords: ["custom", "command", "script"]
     )
+  }
+}
+
+private func customCommandSubtitle(for command: UserCustomCommand) -> String {
+  "Custom command in this repo · \(customCommandExecutionDescription(for: command))"
+}
+
+private func customCommandExecutionDescription(for command: UserCustomCommand) -> String {
+  switch command.execution {
+  case .shellScript:
+    return "Opens in a new tab"
+  case .terminalInput:
+    return "Runs in the focused terminal"
+  case .split:
+    return "Opens in a new split (\(command.splitDirection.title.lowercased()))"
   }
 }
 

--- a/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
+++ b/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
@@ -60,6 +60,10 @@ struct CommandPaletteFeature {
     case revealInFinder
     case copyPath
     case revealInSidebar
+    case runScript
+    case stopRunScript
+    case togglePinWorktree(Worktree.ID, isCurrentlyPinned: Bool)
+    case runCustomCommand(Int)
     #if DEBUG
       case debugTestToast(RepositoriesFeature.StatusToast)
       case debugSimulateUpdateFound
@@ -209,6 +213,8 @@ struct CommandPaletteFeature {
 
   static func commandPaletteItems(
     from repositories: RepositoriesFeature.State,
+    customCommands: [UserCustomCommand] = [],
+    runScriptStatusByWorktreeID: [Worktree.ID: Bool] = [:],
     ghosttyCommands: [GhosttyCommand] = []
   ) -> [CommandPaletteItem] {
     let showsNewWorktreeAction =
@@ -226,7 +232,14 @@ struct CommandPaletteFeature {
         )
       )
       items.append(contentsOf: worktreeNavigationCommandItems())
+      items.append(
+        contentsOf: worktreeActionCommandItems(
+          repositories: repositories,
+          runScriptStatusByWorktreeID: runScriptStatusByWorktreeID
+        )
+      )
     }
+    items.append(contentsOf: customCommandItems(customCommands))
     if let terminalWorktree = repositories.selectedTerminalWorktree {
       items.append(
         CommandPaletteItem(
@@ -263,9 +276,11 @@ struct CommandPaletteFeature {
   }
 
   static func recencyRetentionIDs(
-    from repositories: IdentifiedArrayOf<Repository>
+    from repositories: IdentifiedArrayOf<Repository>,
+    customCommands: [UserCustomCommand] = []
   ) -> [CommandPaletteItem.ID] {
     var ids = CommandPaletteItemID.globalIDs
+    ids.append(contentsOf: customCommands.map { CommandPaletteItemID.customCommand($0.id) })
     for repository in repositories {
       ids.append(contentsOf: CommandPaletteItemID.pullRequestIDs(repositoryID: repository.id))
       for worktree in repository.worktrees {
@@ -350,6 +365,83 @@ private func globalCommandItems(showsNewWorktreeAction: Bool) -> [CommandPalette
   )
   items.append(contentsOf: viewToggleCommandItems())
   return items
+}
+
+private func worktreeActionCommandItems(
+  repositories: RepositoriesFeature.State,
+  runScriptStatusByWorktreeID: [Worktree.ID: Bool]
+) -> [CommandPaletteItem] {
+  guard let worktreeID = repositories.selectedWorktreeID else { return [] }
+  var items: [CommandPaletteItem] = []
+  let isRunScriptRunning = runScriptStatusByWorktreeID[worktreeID] ?? false
+  if isRunScriptRunning {
+    items.append(
+      .appShortcut(
+        id: CommandPaletteItemID.globalStopRunScript,
+        title: "Stop Script",
+        category: .worktree,
+        kind: .stopRunScript,
+        keywords: ["stop", "kill", "cancel", "script"]
+      )
+    )
+  } else {
+    items.append(
+      .appShortcut(
+        id: CommandPaletteItemID.globalRunScript,
+        title: "Run Script",
+        category: .worktree,
+        kind: .runScript,
+        keywords: ["run", "script", "execute"]
+      )
+    )
+  }
+  if let row = repositories.selectedRow(for: worktreeID), !row.isMainWorktree {
+    let pinTitle = row.isPinned ? "Unpin Worktree" : "Pin Worktree"
+    let pinKeywords =
+      row.isPinned ? ["unpin", "favorite"] : ["pin", "favorite", "top"]
+    items.append(
+      .appShortcut(
+        id: CommandPaletteItemID.globalTogglePinWorktree,
+        title: pinTitle,
+        category: .worktree,
+        kind: .togglePinWorktree(worktreeID, isCurrentlyPinned: row.isPinned),
+        keywords: pinKeywords
+      )
+    )
+    if let repositoryID = repositories.repositoryID(containing: worktreeID) {
+      items.append(
+        CommandPaletteItem(
+          id: CommandPaletteItemID.globalDeleteWorktree,
+          title: "Delete Worktree",
+          subtitle: row.name,
+          kind: .deleteWorktree(worktreeID, repositoryID),
+          category: .worktree,
+          defaultSuggestion: false,
+          keywords: ["delete", "remove", "destroy"]
+        )
+      )
+    }
+  }
+  return items
+}
+
+private func customCommandItems(_ commands: [UserCustomCommand]) -> [CommandPaletteItem] {
+  commands.enumerated().compactMap { index, command in
+    guard command.hasRunnableCommand else { return nil }
+    return CommandPaletteItem(
+      id: CommandPaletteItemID.customCommand(command.id),
+      title: command.resolvedTitle,
+      subtitle: command.execution.title,
+      kind: .runCustomCommand(
+        index: index,
+        commandID: command.id,
+        systemImage: command.resolvedSystemImage
+      ),
+      category: .worktree,
+      defaultSuggestion: false,
+      keywords: ["custom", "command", "script"]
+    )
+  }
 }
 
 private func worktreeNavigationCommandItems() -> [CommandPaletteItem] {
@@ -686,6 +778,14 @@ private enum CommandPaletteItemID {
   static let globalRevealInFinder = "global.reveal-in-finder"
   static let globalCopyPath = "global.copy-path"
   static let globalRevealInSidebar = "global.reveal-in-sidebar"
+  static let globalRunScript = "global.run-script"
+  static let globalStopRunScript = "global.stop-run-script"
+  static let globalTogglePinWorktree = "global.toggle-pin-worktree"
+  static let globalDeleteWorktree = "global.delete-worktree"
+
+  static func customCommand(_ commandID: String) -> CommandPaletteItem.ID {
+    "custom-command.\(commandID)"
+  }
 
   static var globalIDs: [CommandPaletteItem.ID] {
     [
@@ -705,6 +805,10 @@ private enum CommandPaletteItemID {
       globalRevealInFinder,
       globalCopyPath,
       globalRevealInSidebar,
+      globalRunScript,
+      globalStopRunScript,
+      globalTogglePinWorktree,
+      globalDeleteWorktree,
     ]
   }
 
@@ -785,7 +889,8 @@ private func delegateAction(for kind: CommandPaletteItem.Kind) -> CommandPalette
   switch kind {
   case .worktreeSelect(let id):
     return .selectWorktree(id)
-  case .removeWorktree(let worktreeID, let repositoryID):
+  case .removeWorktree(let worktreeID, let repositoryID),
+    .deleteWorktree(let worktreeID, let repositoryID):
     return .removeWorktree(worktreeID, repositoryID)
   case .archiveWorktree(let worktreeID, let repositoryID):
     return .archiveWorktree(worktreeID, repositoryID)
@@ -793,6 +898,10 @@ private func delegateAction(for kind: CommandPaletteItem.Kind) -> CommandPalette
     return .ghosttyCommand(action)
   case .changeFocusedTabIcon(let worktreeID):
     return .changeFocusedTabIcon(worktreeID)
+  case .togglePinWorktree(let worktreeID, let isCurrentlyPinned):
+    return .togglePinWorktree(worktreeID, isCurrentlyPinned: isCurrentlyPinned)
+  case .runCustomCommand(let index, _, _):
+    return .runCustomCommand(index)
   case .openPullRequest,
     .openRepositoryOnCodeHost,
     .markPullRequestReady,
@@ -824,13 +933,18 @@ private func delegateAction(for kind: CommandPaletteItem.Kind) -> CommandPalette
     .showDiff,
     .revealInFinder,
     .copyPath,
-    .revealInSidebar:
+    .revealInSidebar,
+    .runScript,
+    .stopRunScript:
     fatalError("appDelegateAction should handle app-level command palette actions")
   }
 }
 
 private func appDelegateAction(for kind: CommandPaletteItem.Kind) -> CommandPaletteFeature.Delegate? {
   if let delegate = navigationDelegateAction(for: kind) {
+    return delegate
+  }
+  if let delegate = viewDelegateAction(for: kind) {
     return delegate
   }
   switch kind {
@@ -850,16 +964,10 @@ private func appDelegateAction(for kind: CommandPaletteItem.Kind) -> CommandPale
     return .jumpToLatestUnread
   case .installCLI:
     return .installCLI
-  case .toggleLeftSidebar:
-    return .toggleLeftSidebar
-  case .toggleActiveAgentsPanel:
-    return .toggleActiveAgentsPanel
-  case .toggleCanvas:
-    return .toggleCanvas
-  case .toggleShelf:
-    return .toggleShelf
-  case .showDiff:
-    return .showDiff
+  case .runScript:
+    return .runScript
+  case .stopRunScript:
+    return .stopRunScript
   default:
     return nil
   }
@@ -873,6 +981,23 @@ private func navigationDelegateAction(for kind: CommandPaletteItem.Kind) -> Comm
     return .copyPath
   case .revealInSidebar:
     return .revealInSidebar
+  default:
+    return nil
+  }
+}
+
+private func viewDelegateAction(for kind: CommandPaletteItem.Kind) -> CommandPaletteFeature.Delegate? {
+  switch kind {
+  case .toggleLeftSidebar:
+    return .toggleLeftSidebar
+  case .toggleActiveAgentsPanel:
+    return .toggleActiveAgentsPanel
+  case .toggleCanvas:
+    return .toggleCanvas
+  case .toggleShelf:
+    return .toggleShelf
+  case .showDiff:
+    return .showDiff
   default:
     return nil
   }
@@ -919,7 +1044,12 @@ private func pullRequestDelegateAction(
     .showDiff,
     .revealInFinder,
     .copyPath,
-    .revealInSidebar:
+    .revealInSidebar,
+    .runScript,
+    .stopRunScript,
+    .togglePinWorktree,
+    .deleteWorktree,
+    .runCustomCommand:
     return nil
   #if DEBUG
     case .debugTestToast, .debugSimulateUpdateFound:

--- a/supacode/Features/CommandPalette/Views/CommandPaletteOverlayView.swift
+++ b/supacode/Features/CommandPalette/Views/CommandPaletteOverlayView.swift
@@ -541,7 +541,7 @@ private struct CommandPaletteRowView: View {
       .rerunFailedJobs, .openFailingCheckDetails, .worktreeSelect, .changeFocusedTabIcon,
       .toggleLeftSidebar, .toggleActiveAgentsPanel, .toggleCanvas, .toggleShelf, .showDiff,
       .revealInFinder, .copyPath, .revealInSidebar,
-      .runScript, .stopRunScript, .togglePinWorktree, .runCustomCommand:
+      .runScript, .stopRunScript, .togglePinWorktree, .renameBranch, .runCustomCommand:
       return nil
     case .removeWorktree:
       return "Remove"
@@ -622,6 +622,8 @@ private struct CommandPaletteRowView: View {
       return "stop.circle"
     case .togglePinWorktree(_, let isCurrentlyPinned):
       return isCurrentlyPinned ? "pin.slash" : "pin"
+    case .renameBranch:
+      return "pencil"
     case .deleteWorktree:
       return "trash"
     case .runCustomCommand(_, _, let systemImage):
@@ -645,7 +647,8 @@ private struct CommandPaletteRowView: View {
       .rerunFailedJobs, .openFailingCheckDetails, .changeFocusedTabIcon,
       .toggleLeftSidebar, .toggleActiveAgentsPanel, .toggleCanvas, .toggleShelf, .showDiff,
       .revealInFinder, .copyPath, .revealInSidebar,
-      .runScript, .stopRunScript, .togglePinWorktree, .deleteWorktree, .runCustomCommand:
+      .runScript, .stopRunScript, .togglePinWorktree, .renameBranch,
+      .deleteWorktree, .runCustomCommand:
       return true
     case .worktreeSelect, .removeWorktree, .archiveWorktree:
       return false
@@ -787,6 +790,8 @@ private struct CommandPaletteRowView: View {
       base = "Stop Script"
     case .togglePinWorktree(_, let isCurrentlyPinned):
       base = isCurrentlyPinned ? "Unpin Worktree" : "Pin Worktree"
+    case .renameBranch:
+      base = "Rename Branch"
     case .deleteWorktree:
       base = "Delete \(row.title)"
     case .runCustomCommand:

--- a/supacode/Features/CommandPalette/Views/CommandPaletteOverlayView.swift
+++ b/supacode/Features/CommandPalette/Views/CommandPaletteOverlayView.swift
@@ -540,12 +540,15 @@ private struct CommandPaletteRowView: View {
       .copyCiFailureLogs,
       .rerunFailedJobs, .openFailingCheckDetails, .worktreeSelect, .changeFocusedTabIcon,
       .toggleLeftSidebar, .toggleActiveAgentsPanel, .toggleCanvas, .toggleShelf, .showDiff,
-      .revealInFinder, .copyPath, .revealInSidebar:
+      .revealInFinder, .copyPath, .revealInSidebar,
+      .runScript, .stopRunScript, .togglePinWorktree, .runCustomCommand:
       return nil
     case .removeWorktree:
       return "Remove"
     case .archiveWorktree:
       return "Archive"
+    case .deleteWorktree:
+      return "Delete"
     #if DEBUG
       case .debugTestToast, .debugSimulateUpdateFound:
         return "Debug"
@@ -613,6 +616,16 @@ private struct CommandPaletteRowView: View {
       return "doc.on.clipboard"
     case .revealInSidebar:
       return "sidebar.left.badge.dot"
+    case .runScript:
+      return "play.circle"
+    case .stopRunScript:
+      return "stop.circle"
+    case .togglePinWorktree(_, let isCurrentlyPinned):
+      return isCurrentlyPinned ? "pin.slash" : "pin"
+    case .deleteWorktree:
+      return "trash"
+    case .runCustomCommand(_, _, let systemImage):
+      return systemImage
     #if DEBUG
       case .debugTestToast:
         return "ladybug"
@@ -631,7 +644,8 @@ private struct CommandPaletteRowView: View {
       .copyCiFailureLogs,
       .rerunFailedJobs, .openFailingCheckDetails, .changeFocusedTabIcon,
       .toggleLeftSidebar, .toggleActiveAgentsPanel, .toggleCanvas, .toggleShelf, .showDiff,
-      .revealInFinder, .copyPath, .revealInSidebar:
+      .revealInFinder, .copyPath, .revealInSidebar,
+      .runScript, .stopRunScript, .togglePinWorktree, .deleteWorktree, .runCustomCommand:
       return true
     case .worktreeSelect, .removeWorktree, .archiveWorktree:
       return false
@@ -767,6 +781,16 @@ private struct CommandPaletteRowView: View {
       base = "Copy Path"
     case .revealInSidebar:
       base = "Reveal in Sidebar"
+    case .runScript:
+      base = "Run Script"
+    case .stopRunScript:
+      base = "Stop Script"
+    case .togglePinWorktree(_, let isCurrentlyPinned):
+      base = isCurrentlyPinned ? "Unpin Worktree" : "Pin Worktree"
+    case .deleteWorktree:
+      base = "Delete \(row.title)"
+    case .runCustomCommand:
+      base = "Run Custom Command: \(row.title)"
     #if DEBUG
       case .debugTestToast, .debugSimulateUpdateFound:
         base = row.title

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -50,6 +50,11 @@ struct PendingSidebarReveal: Equatable, Sendable {
   let worktreeID: Worktree.ID
 }
 
+struct PendingRenameBranchRequest: Equatable, Sendable {
+  let id: Int
+  let worktreeID: Worktree.ID
+}
+
 @Reducer
 struct RepositoriesFeature {
   enum CancelID {
@@ -238,6 +243,8 @@ struct RepositoriesFeature {
     var sidebarSelectedWorktreeIDs: Set<Worktree.ID> = []
     var nextPendingSidebarRevealID = 0
     var pendingSidebarReveal: PendingSidebarReveal?
+    var nextPendingRenameBranchRequestID = 0
+    var pendingRenameBranchRequest: PendingRenameBranchRequest?
     var isSidebarDragActive = false
     var pendingSidebarNotifyReorderIDs: [Worktree.ID] = []
     var activeAgents = ActiveAgentsFeature.State()
@@ -313,6 +320,8 @@ struct RepositoriesFeature {
     case worktreeHistoryForward
     case revealSelectedWorktreeInSidebar
     case consumePendingSidebarReveal(Int)
+    case requestRenameBranchPrompt(Worktree.ID)
+    case consumePendingRenameBranchRequest(Int)
     case requestRenameBranch(Worktree.ID, String)
     case presentAlert(title: String, message: String)
     case worktreeInfoEvent(WorktreeInfoWatcherClient.Event)
@@ -943,6 +952,20 @@ struct RepositoriesFeature {
         case .consumePendingSidebarReveal(let revealID):
           guard state.pendingSidebarReveal?.id == revealID else { return .none }
           state.pendingSidebarReveal = nil
+          return .none
+
+        case .requestRenameBranchPrompt(let worktreeID):
+          guard state.worktree(for: worktreeID) != nil else { return .none }
+          state.nextPendingRenameBranchRequestID += 1
+          state.pendingRenameBranchRequest = .init(
+            id: state.nextPendingRenameBranchRequestID,
+            worktreeID: worktreeID
+          )
+          return .none
+
+        case .consumePendingRenameBranchRequest(let requestID):
+          guard state.pendingRenameBranchRequest?.id == requestID else { return .none }
+          state.pendingRenameBranchRequest = nil
           return .none
 
         case .requestRenameBranch(let worktreeID, let branchName):

--- a/supacode/Features/Repositories/Views/WorktreeDetailTitleView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailTitleView.swift
@@ -3,6 +3,8 @@ import SwiftUI
 struct WorktreeDetailTitleView: View {
   let title: DetailToolbarTitle
   let onSubmit: ((String) -> Void)?
+  let externalRenamePrompt: PendingRenameBranchRequest?
+  let onConsumeExternalRenamePrompt: (Int) -> Void
   @Environment(\.resolvedKeybindings) private var resolvedKeybindings
 
   @State private var isPresented = false
@@ -13,8 +15,7 @@ struct WorktreeDetailTitleView: View {
     Group {
       if title.supportsRename {
         Button {
-          draftName = title.text
-          isPresented = true
+          openRenamePopover()
         } label: {
           labelContent
         }
@@ -48,6 +49,16 @@ struct WorktreeDetailTitleView: View {
         }
       )
     }
+    .task(id: externalRenamePrompt?.id) {
+      guard let prompt = externalRenamePrompt, title.supportsRename else { return }
+      openRenamePopover()
+      onConsumeExternalRenamePrompt(prompt.id)
+    }
+  }
+
+  private func openRenamePopover() {
+    draftName = title.text
+    isPresented = true
   }
 
   private var labelContent: some View {

--- a/supacode/Features/Repositories/Views/WorktreeDetailView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailView.swift
@@ -89,31 +89,12 @@ struct WorktreeDetailView: View {
           )
         )
       {
-        WorktreeToolbarContent(
+        worktreeToolbarContent(
           toolbarState: toolbarState,
-          onRenameBranch: { newBranch in
-            guard let selectedWorktree else { return }
-            store.send(.repositories(.requestRenameBranch(selectedWorktree.id, newBranch)))
-          },
-          onOpenWorktree: { action in
-            store.send(.openWorktree(action))
-          },
-          onOpenActionSelectionChanged: { action in
-            store.send(.openActionSelectionChanged(action))
-          },
-          onCopyPath: {
-            guard let selectedTerminalWorktree else { return }
-            NSPasteboard.general.clearContents()
-            NSPasteboard.general.setString(selectedTerminalWorktree.workingDirectory.path, forType: .string)
-          },
-          onSelectNotification: selectToolbarNotification,
-          onDismissAllNotifications: { dismissAllToolbarNotifications(in: notificationGroups) },
-          onRunScript: { store.send(.runScript) },
-          onStopRunScript: { store.send(.stopRunScript) },
-          onRunCustomCommand: { index in
-            store.send(.runCustomCommand(index))
-          },
-          onCheckForUpdates: { store.send(.updates(.checkForUpdates)) }
+          repositories: repositories,
+          selectedWorktree: selectedWorktree,
+          selectedTerminalWorktree: selectedTerminalWorktree,
+          notificationGroups: notificationGroups
         )
       }
     }
@@ -124,6 +105,49 @@ struct WorktreeDetailView: View {
       runScriptIsRunning: runScriptIsRunning
     )
     return applyFocusedActions(content: content, actions: actions)
+  }
+
+  @ToolbarContentBuilder
+  private func worktreeToolbarContent(
+    toolbarState: WorktreeToolbarState,
+    repositories: RepositoriesFeature.State,
+    selectedWorktree: Worktree?,
+    selectedTerminalWorktree: Worktree?,
+    notificationGroups: [ToolbarNotificationRepositoryGroup]
+  ) -> some ToolbarContent {
+    WorktreeToolbarContent(
+      toolbarState: toolbarState,
+      onRenameBranch: { newBranch in
+        guard let selectedWorktree else { return }
+        store.send(.repositories(.requestRenameBranch(selectedWorktree.id, newBranch)))
+      },
+      externalRenamePrompt: repositories.pendingRenameBranchRequest
+        .flatMap { request in
+          request.worktreeID == selectedWorktree?.id ? request : nil
+        },
+      onConsumeExternalRenamePrompt: { requestID in
+        store.send(.repositories(.consumePendingRenameBranchRequest(requestID)))
+      },
+      onOpenWorktree: { action in
+        store.send(.openWorktree(action))
+      },
+      onOpenActionSelectionChanged: { action in
+        store.send(.openActionSelectionChanged(action))
+      },
+      onCopyPath: {
+        guard let selectedTerminalWorktree else { return }
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(selectedTerminalWorktree.workingDirectory.path, forType: .string)
+      },
+      onSelectNotification: selectToolbarNotification,
+      onDismissAllNotifications: { dismissAllToolbarNotifications(in: notificationGroups) },
+      onRunScript: { store.send(.runScript) },
+      onStopRunScript: { store.send(.stopRunScript) },
+      onRunCustomCommand: { index in
+        store.send(.runCustomCommand(index))
+      },
+      onCheckForUpdates: { store.send(.updates(.checkForUpdates)) }
+    )
   }
 
   @ToolbarContentBuilder
@@ -477,6 +501,8 @@ struct WorktreeDetailView: View {
   fileprivate struct WorktreeToolbarContent: ToolbarContent {
     let toolbarState: WorktreeToolbarState
     let onRenameBranch: (String) -> Void
+    let externalRenamePrompt: PendingRenameBranchRequest?
+    let onConsumeExternalRenamePrompt: (Int) -> Void
     let onOpenWorktree: (OpenWorktreeAction) -> Void
     let onOpenActionSelectionChanged: (OpenWorktreeAction) -> Void
     let onCopyPath: () -> Void
@@ -492,7 +518,9 @@ struct WorktreeDetailView: View {
       ToolbarItem {
         WorktreeDetailTitleView(
           title: toolbarState.title,
-          onSubmit: toolbarState.title.supportsRename ? onRenameBranch : nil
+          onSubmit: toolbarState.title.supportsRename ? onRenameBranch : nil,
+          externalRenamePrompt: externalRenamePrompt,
+          onConsumeExternalRenamePrompt: onConsumeExternalRenamePrompt
         )
       }
 
@@ -975,6 +1003,8 @@ private struct WorktreeToolbarPreview: View {
       WorktreeDetailView.WorktreeToolbarContent(
         toolbarState: toolbarState,
         onRenameBranch: { _ in },
+        externalRenamePrompt: nil,
+        onConsumeExternalRenamePrompt: { _ in },
         onOpenWorktree: { _ in },
         onOpenActionSelectionChanged: { _ in },
         onCopyPath: {},

--- a/supacodeTests/AppFeatureCommandPaletteTests.swift
+++ b/supacodeTests/AppFeatureCommandPaletteTests.swift
@@ -537,6 +537,45 @@ struct AppFeatureCommandPaletteTests {
     await store.receive(\.repositories.worktreeOrdering.unpinWorktree)
   }
 
+  @Test(.dependencies) func renameBranchDelegateDispatchesRequestPrompt() async {
+    let worktree = makeWorktree(
+      id: "/tmp/repo-rename/wt-1",
+      name: "wt-1",
+      repoRoot: "/tmp/repo-rename"
+    )
+    let repository = makeRepository(id: "/tmp/repo-rename", worktrees: [worktree])
+    var repositoriesState = RepositoriesFeature.State()
+    repositoriesState.repositories = [repository]
+    repositoriesState.selection = .worktree(worktree.id)
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: repositoriesState,
+        settings: SettingsFeature.State()
+      )
+    ) {
+      AppFeature()
+    }
+    store.exhaustivity = .off
+
+    await store.send(.commandPalette(.delegate(.renameBranch)))
+    await store.receive(\.repositories.requestRenameBranchPrompt) {
+      $0.repositories.nextPendingRenameBranchRequestID = 1
+      $0.repositories.pendingRenameBranchRequest = PendingRenameBranchRequest(
+        id: 1,
+        worktreeID: worktree.id
+      )
+    }
+  }
+
+  @Test(.dependencies) func renameBranchDelegateNoopsWithoutSelectedWorktree() async {
+    let store = TestStore(initialState: AppFeature.State()) {
+      AppFeature()
+    }
+
+    await store.send(.commandPalette(.delegate(.renameBranch)))
+    await store.finish()
+  }
+
   @Test(.dependencies) func runCustomCommandDelegateDispatchesAppAction() async {
     let store = TestStore(initialState: AppFeature.State()) {
       AppFeature()

--- a/supacodeTests/AppFeatureCommandPaletteTests.swift
+++ b/supacodeTests/AppFeatureCommandPaletteTests.swift
@@ -493,6 +493,60 @@ struct AppFeatureCommandPaletteTests {
     await store.finish()
   }
 
+  @Test(.dependencies) func runScriptDelegateDispatchesAppAction() async {
+    let store = TestStore(initialState: AppFeature.State()) {
+      AppFeature()
+    }
+    store.exhaustivity = .off
+
+    await store.send(.commandPalette(.delegate(.runScript)))
+    await store.receive(\.runScript)
+  }
+
+  @Test(.dependencies) func stopRunScriptDelegateDispatchesAppAction() async {
+    let store = TestStore(initialState: AppFeature.State()) {
+      AppFeature()
+    }
+    store.exhaustivity = .off
+
+    await store.send(.commandPalette(.delegate(.stopRunScript)))
+    await store.receive(\.stopRunScript)
+  }
+
+  @Test(.dependencies) func togglePinWorktreeWhenNotPinnedDispatchesPin() async {
+    let store = TestStore(initialState: AppFeature.State()) {
+      AppFeature()
+    }
+    store.exhaustivity = .off
+
+    await store.send(
+      .commandPalette(.delegate(.togglePinWorktree("/tmp/repo/wt-1", isCurrentlyPinned: false)))
+    )
+    await store.receive(\.repositories.worktreeOrdering.pinWorktree)
+  }
+
+  @Test(.dependencies) func togglePinWorktreeWhenPinnedDispatchesUnpin() async {
+    let store = TestStore(initialState: AppFeature.State()) {
+      AppFeature()
+    }
+    store.exhaustivity = .off
+
+    await store.send(
+      .commandPalette(.delegate(.togglePinWorktree("/tmp/repo/wt-1", isCurrentlyPinned: true)))
+    )
+    await store.receive(\.repositories.worktreeOrdering.unpinWorktree)
+  }
+
+  @Test(.dependencies) func runCustomCommandDelegateDispatchesAppAction() async {
+    let store = TestStore(initialState: AppFeature.State()) {
+      AppFeature()
+    }
+    store.exhaustivity = .off
+
+    await store.send(.commandPalette(.delegate(.runCustomCommand(3))))
+    await store.receive(\.runCustomCommand)
+  }
+
   @Test(.dependencies) func closePullRequestDispatchesAction() async {
     let store = TestStore(initialState: AppFeature.State()) {
       AppFeature()

--- a/supacodeTests/CommandPaletteFeatureTests.swift
+++ b/supacodeTests/CommandPaletteFeatureTests.swift
@@ -128,6 +128,20 @@ struct CommandPaletteFeatureTests {
     #expect(pinItem?.kind == .togglePinWorktree(worktree.id, isCurrentlyPinned: true))
   }
 
+  @Test func commandPaletteItems_includesRenameBranchForNonMainWorktree() {
+    let rootPath = "/tmp/repo-rename"
+    let worktree = makeWorktree(id: "\(rootPath)/wt-1", name: "wt-1", repoRoot: rootPath)
+    let repository = makeRepository(rootPath: rootPath, name: "Repo", worktrees: [worktree])
+    var state = RepositoriesFeature.State(repositories: [repository])
+    state.selection = .worktree(worktree.id)
+
+    let items = CommandPaletteFeature.commandPaletteItems(from: state)
+    let renameItem = items.first { $0.id == "global.rename-branch" }
+    #expect(renameItem?.title == "Rename Branch")
+    #expect(renameItem?.kind == .renameBranch)
+    #expect(renameItem?.appShortcutCommandID == AppShortcuts.CommandID.renameBranch)
+  }
+
   @Test func commandPaletteItems_omitsPinAndDeleteForMainWorktree() {
     let rootPath = "/tmp/repo-main"
     // Main worktree: workingDirectory == repositoryRootURL → Worktree.isMain == true
@@ -145,6 +159,7 @@ struct CommandPaletteFeatureTests {
     let ids = Set(items.map(\.id))
     #expect(!ids.contains("global.toggle-pin-worktree"))
     #expect(!ids.contains("global.delete-worktree"))
+    #expect(!ids.contains("global.rename-branch"))
   }
 
   @Test func commandPaletteItems_includesDeleteWorktreeForNonMain() {
@@ -1647,7 +1662,7 @@ private func testCategory(for kind: CommandPaletteItem.Kind) -> CommandPaletteIt
   case .newWorktree, .refreshWorktrees, .viewArchivedWorktrees,
     .removeWorktree, .archiveWorktree, .changeFocusedTabIcon,
     .runScript, .stopRunScript, .togglePinWorktree,
-    .deleteWorktree, .runCustomCommand:
+    .renameBranch, .deleteWorktree, .runCustomCommand:
     return .worktree
   case .jumpToLatestUnread, .worktreeSelect, .revealInFinder, .copyPath, .revealInSidebar:
     return .navigation
@@ -1674,7 +1689,7 @@ private func testDefaultSuggestion(for kind: CommandPaletteItem.Kind) -> Bool {
     .copyFailingJobURL, .copyCiFailureLogs, .rerunFailedJobs, .openFailingCheckDetails,
     .toggleLeftSidebar, .toggleActiveAgentsPanel, .toggleCanvas, .toggleShelf, .showDiff,
     .revealInFinder, .copyPath, .revealInSidebar,
-    .runScript, .stopRunScript, .togglePinWorktree:
+    .runScript, .stopRunScript, .togglePinWorktree, .renameBranch:
     return true
   case .worktreeSelect, .removeWorktree, .archiveWorktree, .changeFocusedTabIcon,
     .ghosttyCommand, .openRepositoryOnCodeHost,

--- a/supacodeTests/CommandPaletteFeatureTests.swift
+++ b/supacodeTests/CommandPaletteFeatureTests.swift
@@ -159,7 +159,9 @@ struct CommandPaletteFeatureTests {
     let ids = Set(items.map(\.id))
     #expect(!ids.contains("global.toggle-pin-worktree"))
     #expect(!ids.contains("global.delete-worktree"))
-    #expect(!ids.contains("global.rename-branch"))
+    // Rename Branch is still available on the main worktree — `git branch -m`
+    // works on the main branch the same as any other.
+    #expect(ids.contains("global.rename-branch"))
   }
 
   @Test func commandPaletteItems_includesDeleteWorktreeForNonMain() {

--- a/supacodeTests/CommandPaletteFeatureTests.swift
+++ b/supacodeTests/CommandPaletteFeatureTests.swift
@@ -189,11 +189,58 @@ struct CommandPaletteFeatureTests {
 
     let buildItem = items.first { $0.id == "custom-command.cmd-build" }
     #expect(buildItem?.title == "Build")
-    #expect(buildItem?.subtitle == "New Tab")
+    #expect(buildItem?.subtitle == "Custom command in this repo · Opens in a new tab")
     #expect(buildItem?.defaultSuggestion == false)
     #expect(
       buildItem?.kind
         == .runCustomCommand(index: 0, commandID: "cmd-build", systemImage: "hammer")
+    )
+  }
+
+  @Test func commandPaletteItems_customCommandSubtitleVariants() {
+    let shellCmd = UserCustomCommand(
+      id: "cmd-shell",
+      title: "Shell",
+      systemImage: "terminal",
+      command: "make",
+      execution: .shellScript,
+      shortcut: nil
+    )
+    let inlineCmd = UserCustomCommand(
+      id: "cmd-inline",
+      title: "Inline",
+      systemImage: "terminal",
+      command: "ls",
+      execution: .terminalInput,
+      shortcut: nil
+    )
+    let splitCmd = UserCustomCommand(
+      id: "cmd-split",
+      title: "Split",
+      systemImage: "terminal",
+      command: "watch",
+      execution: .split,
+      splitDirection: .down,
+      closeOnSuccess: false,
+      shortcut: nil
+    )
+
+    let items = CommandPaletteFeature.commandPaletteItems(
+      from: RepositoriesFeature.State(),
+      customCommands: [shellCmd, inlineCmd, splitCmd]
+    )
+
+    #expect(
+      items.first { $0.id == "custom-command.cmd-shell" }?.subtitle
+        == "Custom command in this repo · Opens in a new tab"
+    )
+    #expect(
+      items.first { $0.id == "custom-command.cmd-inline" }?.subtitle
+        == "Custom command in this repo · Runs in the focused terminal"
+    )
+    #expect(
+      items.first { $0.id == "custom-command.cmd-split" }?.subtitle
+        == "Custom command in this repo · Opens in a new split (down)"
     )
   }
 

--- a/supacodeTests/CommandPaletteFeatureTests.swift
+++ b/supacodeTests/CommandPaletteFeatureTests.swift
@@ -72,6 +72,131 @@ struct CommandPaletteFeatureTests {
     #expect(!ids.contains("global.reveal-in-sidebar"))
   }
 
+  @Test func commandPaletteItems_includesRunScriptWhenIdle() {
+    let rootPath = "/tmp/repo-run"
+    let worktree = makeWorktree(id: "\(rootPath)/wt-1", name: "wt-1", repoRoot: rootPath)
+    let repository = makeRepository(rootPath: rootPath, name: "Repo", worktrees: [worktree])
+    var state = RepositoriesFeature.State(repositories: [repository])
+    state.selection = .worktree(worktree.id)
+
+    let items = CommandPaletteFeature.commandPaletteItems(from: state)
+    let ids = Set(items.map(\.id))
+    #expect(ids.contains("global.run-script"))
+    #expect(!ids.contains("global.stop-run-script"))
+  }
+
+  @Test func commandPaletteItems_includesStopScriptWhenRunning() {
+    let rootPath = "/tmp/repo-run"
+    let worktree = makeWorktree(id: "\(rootPath)/wt-1", name: "wt-1", repoRoot: rootPath)
+    let repository = makeRepository(rootPath: rootPath, name: "Repo", worktrees: [worktree])
+    var state = RepositoriesFeature.State(repositories: [repository])
+    state.selection = .worktree(worktree.id)
+
+    let items = CommandPaletteFeature.commandPaletteItems(
+      from: state,
+      runScriptStatusByWorktreeID: [worktree.id: true]
+    )
+    let ids = Set(items.map(\.id))
+    #expect(ids.contains("global.stop-run-script"))
+    #expect(!ids.contains("global.run-script"))
+  }
+
+  @Test func commandPaletteItems_includesPinForNonPinnedWorktree() {
+    let rootPath = "/tmp/repo-pin"
+    let worktree = makeWorktree(id: "\(rootPath)/wt-1", name: "wt-1", repoRoot: rootPath)
+    let repository = makeRepository(rootPath: rootPath, name: "Repo", worktrees: [worktree])
+    var state = RepositoriesFeature.State(repositories: [repository])
+    state.selection = .worktree(worktree.id)
+
+    let items = CommandPaletteFeature.commandPaletteItems(from: state)
+    let pinItem = items.first { $0.id == "global.toggle-pin-worktree" }
+    #expect(pinItem?.title == "Pin Worktree")
+    #expect(pinItem?.kind == .togglePinWorktree(worktree.id, isCurrentlyPinned: false))
+  }
+
+  @Test func commandPaletteItems_includesUnpinForPinnedWorktree() {
+    let rootPath = "/tmp/repo-pin"
+    let worktree = makeWorktree(id: "\(rootPath)/wt-1", name: "wt-1", repoRoot: rootPath)
+    let repository = makeRepository(rootPath: rootPath, name: "Repo", worktrees: [worktree])
+    var state = RepositoriesFeature.State(repositories: [repository])
+    state.selection = .worktree(worktree.id)
+    state.pinnedWorktreeIDs = [worktree.id]
+
+    let items = CommandPaletteFeature.commandPaletteItems(from: state)
+    let pinItem = items.first { $0.id == "global.toggle-pin-worktree" }
+    #expect(pinItem?.title == "Unpin Worktree")
+    #expect(pinItem?.kind == .togglePinWorktree(worktree.id, isCurrentlyPinned: true))
+  }
+
+  @Test func commandPaletteItems_omitsPinAndDeleteForMainWorktree() {
+    let rootPath = "/tmp/repo-main"
+    // Main worktree: workingDirectory == repositoryRootURL → Worktree.isMain == true
+    let main = makeWorktree(
+      id: rootPath,
+      name: "main",
+      repoRoot: rootPath,
+      workingDirectory: rootPath
+    )
+    let repository = makeRepository(rootPath: rootPath, name: "Repo", worktrees: [main])
+    var state = RepositoriesFeature.State(repositories: [repository])
+    state.selection = .worktree(main.id)
+
+    let items = CommandPaletteFeature.commandPaletteItems(from: state)
+    let ids = Set(items.map(\.id))
+    #expect(!ids.contains("global.toggle-pin-worktree"))
+    #expect(!ids.contains("global.delete-worktree"))
+  }
+
+  @Test func commandPaletteItems_includesDeleteWorktreeForNonMain() {
+    let rootPath = "/tmp/repo-delete"
+    let worktree = makeWorktree(id: "\(rootPath)/wt-1", name: "wt-1", repoRoot: rootPath)
+    let repository = makeRepository(rootPath: rootPath, name: "Repo", worktrees: [worktree])
+    var state = RepositoriesFeature.State(repositories: [repository])
+    state.selection = .worktree(worktree.id)
+
+    let items = CommandPaletteFeature.commandPaletteItems(from: state)
+    let deleteItem = items.first { $0.id == "global.delete-worktree" }
+    #expect(deleteItem?.title == "Delete Worktree")
+    #expect(deleteItem?.defaultSuggestion == false)
+  }
+
+  @Test func commandPaletteItems_includesCustomCommands() {
+    let buildCmd = UserCustomCommand(
+      id: "cmd-build",
+      title: "Build",
+      systemImage: "hammer",
+      command: "make build",
+      execution: .shellScript,
+      shortcut: nil
+    )
+    let emptyCmd = UserCustomCommand(
+      id: "cmd-empty",
+      title: "Empty",
+      systemImage: "terminal",
+      command: "   ",
+      execution: .shellScript,
+      shortcut: nil
+    )
+
+    let items = CommandPaletteFeature.commandPaletteItems(
+      from: RepositoriesFeature.State(),
+      customCommands: [buildCmd, emptyCmd]
+    )
+    let ids = Set(items.map(\.id))
+    #expect(ids.contains("custom-command.cmd-build"))
+    // Commands with empty body are filtered out.
+    #expect(!ids.contains("custom-command.cmd-empty"))
+
+    let buildItem = items.first { $0.id == "custom-command.cmd-build" }
+    #expect(buildItem?.title == "Build")
+    #expect(buildItem?.subtitle == "New Tab")
+    #expect(buildItem?.defaultSuggestion == false)
+    #expect(
+      buildItem?.kind
+        == .runCustomCommand(index: 0, commandID: "cmd-build", systemImage: "hammer")
+    )
+  }
+
   @Test func commandPaletteItems_includeJumpToLatestUnreadAction() {
     let items = CommandPaletteFeature.commandPaletteItems(from: RepositoriesFeature.State())
     let item = items.first { $0.id == "global.jump-to-latest-unread" }
@@ -1473,7 +1598,9 @@ private func testCategory(for kind: CommandPaletteItem.Kind) -> CommandPaletteIt
   case .checkForUpdates, .openSettings, .openRepository, .installCLI:
     return .app
   case .newWorktree, .refreshWorktrees, .viewArchivedWorktrees,
-    .removeWorktree, .archiveWorktree, .changeFocusedTabIcon:
+    .removeWorktree, .archiveWorktree, .changeFocusedTabIcon,
+    .runScript, .stopRunScript, .togglePinWorktree,
+    .deleteWorktree, .runCustomCommand:
     return .worktree
   case .jumpToLatestUnread, .worktreeSelect, .revealInFinder, .copyPath, .revealInSidebar:
     return .navigation
@@ -1499,10 +1626,12 @@ private func testDefaultSuggestion(for kind: CommandPaletteItem.Kind) -> Bool {
     .openPullRequest, .markPullRequestReady, .mergePullRequest, .closePullRequest,
     .copyFailingJobURL, .copyCiFailureLogs, .rerunFailedJobs, .openFailingCheckDetails,
     .toggleLeftSidebar, .toggleActiveAgentsPanel, .toggleCanvas, .toggleShelf, .showDiff,
-    .revealInFinder, .copyPath, .revealInSidebar:
+    .revealInFinder, .copyPath, .revealInSidebar,
+    .runScript, .stopRunScript, .togglePinWorktree:
     return true
   case .worktreeSelect, .removeWorktree, .archiveWorktree, .changeFocusedTabIcon,
-    .ghosttyCommand, .openRepositoryOnCodeHost:
+    .ghosttyCommand, .openRepositoryOnCodeHost,
+    .deleteWorktree, .runCustomCommand:
     return false
   #if DEBUG
     case .debugTestToast, .debugSimulateUpdateFound:


### PR DESCRIPTION
## Summary

PR6 + PR6.5 of the command-palette buildout. Surfaces six worktree-scoped actions plus the repo's user-defined custom commands, and adds a small TCA channel for Rename Branch so the palette can drive a previously view-local popover.

## Commands added

### Run / Stop Script
- **Run Script** (⌘R) — appears when no script is running for the selected worktree; dispatches `AppFeature.runScript`.
- **Stop Script** (⌘.) — replaces Run Script while one is running (consults the new `runScriptStatusByWorktreeID` builder parameter).

### Pin / Delete (non-main worktrees only)
- **Pin / Unpin Worktree** — single command whose title and icon flip on the selected worktree's pin state.
- **Delete Worktree** — non-default-suggestion; routes through the existing `removeWorktree` delegate so the existing alert flow is reused.

### Rename Branch (any worktree, including main)
- **Rename Branch** (⌘⇧M) — opens the existing popover in `WorktreeDetailTitleView`.
- Implementation needs a small TCA channel because the popover's visibility is view-local `@State`. Pattern mirrors `pendingSidebarReveal`:
  - `RepositoriesFeature.State` gains `pendingRenameBranchRequest: PendingRenameBranchRequest?` plus a monotonic id.
  - New actions `requestRenameBranchPrompt(worktreeID)` / `consumePendingRenameBranchRequest(id)`.
  - `WorktreeDetailTitleView` receives the request via a `.task(id:)` that opens its popover and consumes the request, so the view stays the single owner of `isPresented`.
- Added to `commandPaletteDelegateChangesActiveSelection` so the post-delegate focus restore doesn't steal focus from the popover's `TextField`.

### Custom commands (dynamic, per-repo)
- Builder accepts `customCommands: [UserCustomCommand]` and emits one palette item per command. Empty bodies are filtered out.
- Items use the user-defined title and icon. Subtitle is descriptive and includes execution mode + split direction:
  - `Custom command in this repo · Opens in a new tab`
  - `Custom command in this repo · Runs in the focused terminal`
  - `Custom command in this repo · Opens in a new split (right)`
- **Not** default-suggested — they only appear when the user types, to avoid flooding the empty-query view.
- `recencyRetentionIDs` gained a `customCommands` parameter so per-command recency survives across sessions.
- Item IDs are stable (UUID-based via `CommandPaletteItemID.customCommand`).

## Refactor

- Split `appDelegateAction` into `navigationDelegateAction` (PR5) + `viewDelegateAction` (new) + remaining flat switch, keeping cyclomatic complexity under the SwiftLint threshold while adding `runScript` / `stopRunScript` / `renameBranch`.
- Extracted `worktreeToolbarContent` helper from `WorktreeDetailView.detailBody` to stay under the 100-line function-body lint threshold after wiring the new rename plumbing through `WorktreeToolbarContent`.
- `ContentView` passes `selectedCustomCommands` + `runScriptStatusByWorktreeID` into the builder.

## Focus restore

All new delegates fall through to the default-on restore added in PR5, **except** `.renameBranch`, which joins the deny list so it doesn't fight the rename popover's `TextField` focus.

## Commits

1. `94b5b52d` — Run/Stop/Pin/Unpin/Delete + custom commands
2. `9d46815b` — Custom command subtitle made more descriptive (`"Custom command in this repo · …"`)
3. `9eafddb6` — Rename Branch (PR6.5) via `pendingRenameBranchRequest` channel
4. `a167be10` — Show Rename Branch on the main worktree too (initial commit incorrectly gated on `!isMainWorktree`)

## Test plan

- [x] `make check` clean
- [x] `make test` (1119 passed, +14 over main)
- [x] `make build-app` succeeds
- [x] Manual: open worktree → ⌘P → "run" / "stop" / "pin" / "delete" / "rename" search-match and execute
- [x] Manual: while script is running, palette shows "Stop Script" not "Run Script"; switches back once stopped
- [x] Manual: on main worktree, Pin and Delete absent but Rename Branch present
- [x] Manual: custom commands appear when typed (e.g. command title or "custom"); empty-query view doesn't show them; subtitle reads "Custom command in this repo · Opens in a new tab" (etc.)
- [x] Manual: after any of these commands, terminal regains keyboard focus — except Rename, where the popover's `TextField` keeps focus
