### PR TITLE
Command palette: Repo Settings

### DIFF
--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -1107,6 +1107,17 @@ struct AppFeature {
         guard let worktreeID = state.repositories.selectedWorktreeID else { return .none }
         return .send(.repositories(.requestRenameBranchPrompt(worktreeID)))
 
+      case .commandPalette(.delegate(.newTab)):
+        return .send(.newTerminal)
+
+      case .commandPalette(.delegate(.openRepositorySettings(let repositoryID))):
+        return .merge(
+          .send(.settings(.setSelection(.repository(repositoryID)))),
+          .run { _ in
+            await settingsWindowClient.show()
+          }
+        )
+
       case .commandPalette(.delegate(.togglePinWorktree(let worktreeID, let isCurrentlyPinned))):
         if isCurrentlyPinned {
           return .send(.repositories(.worktreeOrdering(.unpinWorktree(worktreeID))))

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -1107,9 +1107,6 @@ struct AppFeature {
         guard let worktreeID = state.repositories.selectedWorktreeID else { return .none }
         return .send(.repositories(.requestRenameBranchPrompt(worktreeID)))
 
-      case .commandPalette(.delegate(.newTab)):
-        return .send(.newTerminal)
-
       case .commandPalette(.delegate(.openRepositorySettings(let repositoryID))):
         return .merge(
           .send(.settings(.setSelection(.repository(repositoryID)))),

--- a/supacode/Features/CommandPalette/CommandPaletteItem.swift
+++ b/supacode/Features/CommandPalette/CommandPaletteItem.swift
@@ -76,7 +76,6 @@ struct CommandPaletteItem: Identifiable, Equatable {
     case togglePinWorktree(Worktree.ID, isCurrentlyPinned: Bool)
     case deleteWorktree(Worktree.ID, Repository.ID)
     case renameBranch
-    case newTab
     case openRepositorySettings(Repository.ID)
     case runCustomCommand(index: Int, commandID: String, systemImage: String)
     #if DEBUG
@@ -151,7 +150,6 @@ struct CommandPaletteItem: Identifiable, Equatable {
       .copyPath,
       .togglePinWorktree,
       .deleteWorktree,
-      .newTab,
       .openRepositorySettings,
       .runCustomCommand:
       return nil

--- a/supacode/Features/CommandPalette/CommandPaletteItem.swift
+++ b/supacode/Features/CommandPalette/CommandPaletteItem.swift
@@ -76,6 +76,8 @@ struct CommandPaletteItem: Identifiable, Equatable {
     case togglePinWorktree(Worktree.ID, isCurrentlyPinned: Bool)
     case deleteWorktree(Worktree.ID, Repository.ID)
     case renameBranch
+    case newTab
+    case openRepositorySettings(Repository.ID)
     case runCustomCommand(index: Int, commandID: String, systemImage: String)
     #if DEBUG
       case debugTestToast(RepositoriesFeature.StatusToast)
@@ -149,6 +151,8 @@ struct CommandPaletteItem: Identifiable, Equatable {
       .copyPath,
       .togglePinWorktree,
       .deleteWorktree,
+      .newTab,
+      .openRepositorySettings,
       .runCustomCommand:
       return nil
     #if DEBUG

--- a/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
+++ b/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
@@ -64,7 +64,6 @@ struct CommandPaletteFeature {
     case stopRunScript
     case togglePinWorktree(Worktree.ID, isCurrentlyPinned: Bool)
     case renameBranch
-    case newTab
     case openRepositorySettings(Repository.ID)
     case runCustomCommand(Int)
     #if DEBUG
@@ -244,15 +243,6 @@ struct CommandPaletteFeature {
     }
     items.append(contentsOf: customCommandItems(customCommands))
     if let terminalWorktree = repositories.selectedTerminalWorktree {
-      items.append(
-        .appShortcut(
-          id: CommandPaletteItemID.globalNewTab,
-          title: "New Tab",
-          category: .worktree,
-          kind: .newTab,
-          keywords: ["new", "tab", "terminal"]
-        )
-      )
       items.append(
         CommandPaletteItem(
           id: CommandPaletteItemID.changeFocusedTabIcon(terminalWorktree.id),
@@ -853,7 +843,6 @@ private enum CommandPaletteItemID {
   static let globalTogglePinWorktree = "global.toggle-pin-worktree"
   static let globalRenameBranch = "global.rename-branch"
   static let globalDeleteWorktree = "global.delete-worktree"
-  static let globalNewTab = "global.new-tab"
 
   static func openRepositorySettings(_ repositoryID: Repository.ID) -> CommandPaletteItem.ID {
     "repo.\(repositoryID).open-settings"
@@ -886,7 +875,6 @@ private enum CommandPaletteItemID {
       globalTogglePinWorktree,
       globalRenameBranch,
       globalDeleteWorktree,
-      globalNewTab,
     ]
   }
 
@@ -1016,8 +1004,7 @@ private func delegateAction(for kind: CommandPaletteItem.Kind) -> CommandPalette
     .revealInSidebar,
     .runScript,
     .stopRunScript,
-    .renameBranch,
-    .newTab:
+    .renameBranch:
     fatalError("appDelegateAction should handle app-level command palette actions")
   }
 }
@@ -1052,8 +1039,6 @@ private func appDelegateAction(for kind: CommandPaletteItem.Kind) -> CommandPale
     return .stopRunScript
   case .renameBranch:
     return .renameBranch
-  case .newTab:
-    return .newTab
   default:
     return nil
   }
@@ -1136,7 +1121,6 @@ private func pullRequestDelegateAction(
     .togglePinWorktree,
     .renameBranch,
     .deleteWorktree,
-    .newTab,
     .openRepositorySettings,
     .runCustomCommand:
     return nil

--- a/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
+++ b/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
@@ -64,6 +64,8 @@ struct CommandPaletteFeature {
     case stopRunScript
     case togglePinWorktree(Worktree.ID, isCurrentlyPinned: Bool)
     case renameBranch
+    case newTab
+    case openRepositorySettings(Repository.ID)
     case runCustomCommand(Int)
     #if DEBUG
       case debugTestToast(RepositoriesFeature.StatusToast)
@@ -243,6 +245,15 @@ struct CommandPaletteFeature {
     items.append(contentsOf: customCommandItems(customCommands))
     if let terminalWorktree = repositories.selectedTerminalWorktree {
       items.append(
+        .appShortcut(
+          id: CommandPaletteItemID.globalNewTab,
+          title: "New Tab",
+          category: .worktree,
+          kind: .newTab,
+          keywords: ["new", "tab", "terminal"]
+        )
+      )
+      items.append(
         CommandPaletteItem(
           id: CommandPaletteItemID.changeFocusedTabIcon(terminalWorktree.id),
           title: "Change Tab Icon...",
@@ -253,6 +264,19 @@ struct CommandPaletteFeature {
         )
       )
       items.append(contentsOf: ghosttyCommandItems(ghosttyCommands))
+    }
+    if let repository = activeRepository(in: repositories) {
+      items.append(
+        CommandPaletteItem(
+          id: CommandPaletteItemID.openRepositorySettings(repository.id),
+          title: "Repo Settings",
+          subtitle: repository.name,
+          kind: .openRepositorySettings(repository.id),
+          category: .app,
+          defaultSuggestion: true,
+          keywords: ["repo", "settings", "configure", "preferences"]
+        )
+      )
     }
     items.append(contentsOf: selectedCodeHostItems(from: repositories))
     #if DEBUG
@@ -284,6 +308,7 @@ struct CommandPaletteFeature {
     ids.append(contentsOf: customCommands.map { CommandPaletteItemID.customCommand($0.id) })
     for repository in repositories {
       ids.append(contentsOf: CommandPaletteItemID.pullRequestIDs(repositoryID: repository.id))
+      ids.append(CommandPaletteItemID.openRepositorySettings(repository.id))
       for worktree in repository.worktrees {
         ids.append(CommandPaletteItemID.worktreeSelect(worktree.id))
         ids.append(CommandPaletteItemID.changeFocusedTabIcon(worktree.id))
@@ -435,6 +460,24 @@ private func worktreeActionCommandItems(
     )
   }
   return items
+}
+
+/// Resolves the "active" repository for repo-scoped palette commands:
+/// prefers an explicitly selected repo, then falls back to the repo that
+/// owns the currently-selected worktree. Returns nil when nothing relevant
+/// is selected (e.g., archived view, empty palette).
+private func activeRepository(
+  in repositories: RepositoriesFeature.State
+) -> Repository? {
+  if let repository = repositories.selectedRepository {
+    return repository
+  }
+  guard let worktreeID = repositories.selectedWorktreeID,
+    let repositoryID = repositories.repositoryID(containing: worktreeID)
+  else {
+    return nil
+  }
+  return repositories.repositories[id: repositoryID]
 }
 
 private func customCommandItems(_ commands: [UserCustomCommand]) -> [CommandPaletteItem] {
@@ -810,6 +853,11 @@ private enum CommandPaletteItemID {
   static let globalTogglePinWorktree = "global.toggle-pin-worktree"
   static let globalRenameBranch = "global.rename-branch"
   static let globalDeleteWorktree = "global.delete-worktree"
+  static let globalNewTab = "global.new-tab"
+
+  static func openRepositorySettings(_ repositoryID: Repository.ID) -> CommandPaletteItem.ID {
+    "repo.\(repositoryID).open-settings"
+  }
 
   static func customCommand(_ commandID: String) -> CommandPaletteItem.ID {
     "custom-command.\(commandID)"
@@ -838,6 +886,7 @@ private enum CommandPaletteItemID {
       globalTogglePinWorktree,
       globalRenameBranch,
       globalDeleteWorktree,
+      globalNewTab,
     ]
   }
 
@@ -929,6 +978,8 @@ private func delegateAction(for kind: CommandPaletteItem.Kind) -> CommandPalette
     return .changeFocusedTabIcon(worktreeID)
   case .togglePinWorktree(let worktreeID, let isCurrentlyPinned):
     return .togglePinWorktree(worktreeID, isCurrentlyPinned: isCurrentlyPinned)
+  case .openRepositorySettings(let repositoryID):
+    return .openRepositorySettings(repositoryID)
   case .runCustomCommand(let index, _, _):
     return .runCustomCommand(index)
   case .openPullRequest,
@@ -965,7 +1016,8 @@ private func delegateAction(for kind: CommandPaletteItem.Kind) -> CommandPalette
     .revealInSidebar,
     .runScript,
     .stopRunScript,
-    .renameBranch:
+    .renameBranch,
+    .newTab:
     fatalError("appDelegateAction should handle app-level command palette actions")
   }
 }
@@ -1000,6 +1052,8 @@ private func appDelegateAction(for kind: CommandPaletteItem.Kind) -> CommandPale
     return .stopRunScript
   case .renameBranch:
     return .renameBranch
+  case .newTab:
+    return .newTab
   default:
     return nil
   }
@@ -1082,6 +1136,8 @@ private func pullRequestDelegateAction(
     .togglePinWorktree,
     .renameBranch,
     .deleteWorktree,
+    .newTab,
+    .openRepositorySettings,
     .runCustomCommand:
     return nil
   #if DEBUG

--- a/supacode/Features/CommandPalette/Views/CommandPaletteOverlayView.swift
+++ b/supacode/Features/CommandPalette/Views/CommandPaletteOverlayView.swift
@@ -542,7 +542,7 @@ private struct CommandPaletteRowView: View {
       .toggleLeftSidebar, .toggleActiveAgentsPanel, .toggleCanvas, .toggleShelf, .showDiff,
       .revealInFinder, .copyPath, .revealInSidebar,
       .runScript, .stopRunScript, .togglePinWorktree, .renameBranch,
-      .newTab, .openRepositorySettings, .runCustomCommand:
+      .openRepositorySettings, .runCustomCommand:
       return nil
     case .removeWorktree:
       return "Remove"
@@ -625,8 +625,6 @@ private struct CommandPaletteRowView: View {
       return isCurrentlyPinned ? "pin.slash" : "pin"
     case .renameBranch:
       return "pencil"
-    case .newTab:
-      return "plus.rectangle.on.rectangle"
     case .openRepositorySettings:
       return "gearshape"
     case .deleteWorktree:
@@ -653,7 +651,7 @@ private struct CommandPaletteRowView: View {
       .toggleLeftSidebar, .toggleActiveAgentsPanel, .toggleCanvas, .toggleShelf, .showDiff,
       .revealInFinder, .copyPath, .revealInSidebar,
       .runScript, .stopRunScript, .togglePinWorktree, .renameBranch,
-      .newTab, .openRepositorySettings,
+      .openRepositorySettings,
       .deleteWorktree, .runCustomCommand:
       return true
     case .worktreeSelect, .removeWorktree, .archiveWorktree:
@@ -798,8 +796,6 @@ private struct CommandPaletteRowView: View {
       base = isCurrentlyPinned ? "Unpin Worktree" : "Pin Worktree"
     case .renameBranch:
       base = "Rename Branch"
-    case .newTab:
-      base = "New Tab"
     case .openRepositorySettings:
       base = "Open Repo Settings"
     case .deleteWorktree:

--- a/supacode/Features/CommandPalette/Views/CommandPaletteOverlayView.swift
+++ b/supacode/Features/CommandPalette/Views/CommandPaletteOverlayView.swift
@@ -541,7 +541,8 @@ private struct CommandPaletteRowView: View {
       .rerunFailedJobs, .openFailingCheckDetails, .worktreeSelect, .changeFocusedTabIcon,
       .toggleLeftSidebar, .toggleActiveAgentsPanel, .toggleCanvas, .toggleShelf, .showDiff,
       .revealInFinder, .copyPath, .revealInSidebar,
-      .runScript, .stopRunScript, .togglePinWorktree, .renameBranch, .runCustomCommand:
+      .runScript, .stopRunScript, .togglePinWorktree, .renameBranch,
+      .newTab, .openRepositorySettings, .runCustomCommand:
       return nil
     case .removeWorktree:
       return "Remove"
@@ -624,6 +625,10 @@ private struct CommandPaletteRowView: View {
       return isCurrentlyPinned ? "pin.slash" : "pin"
     case .renameBranch:
       return "pencil"
+    case .newTab:
+      return "plus.rectangle.on.rectangle"
+    case .openRepositorySettings:
+      return "gearshape"
     case .deleteWorktree:
       return "trash"
     case .runCustomCommand(_, _, let systemImage):
@@ -648,6 +653,7 @@ private struct CommandPaletteRowView: View {
       .toggleLeftSidebar, .toggleActiveAgentsPanel, .toggleCanvas, .toggleShelf, .showDiff,
       .revealInFinder, .copyPath, .revealInSidebar,
       .runScript, .stopRunScript, .togglePinWorktree, .renameBranch,
+      .newTab, .openRepositorySettings,
       .deleteWorktree, .runCustomCommand:
       return true
     case .worktreeSelect, .removeWorktree, .archiveWorktree:
@@ -792,6 +798,10 @@ private struct CommandPaletteRowView: View {
       base = isCurrentlyPinned ? "Unpin Worktree" : "Pin Worktree"
     case .renameBranch:
       base = "Rename Branch"
+    case .newTab:
+      base = "New Tab"
+    case .openRepositorySettings:
+      base = "Open Repo Settings"
     case .deleteWorktree:
       base = "Delete \(row.title)"
     case .runCustomCommand:

--- a/supacodeTests/AppFeatureCommandPaletteTests.swift
+++ b/supacodeTests/AppFeatureCommandPaletteTests.swift
@@ -576,6 +576,33 @@ struct AppFeatureCommandPaletteTests {
     await store.finish()
   }
 
+  @Test(.dependencies) func newTabDelegateDispatchesAppAction() async {
+    let store = TestStore(initialState: AppFeature.State()) {
+      AppFeature()
+    }
+    store.exhaustivity = .off
+
+    await store.send(.commandPalette(.delegate(.newTab)))
+    await store.receive(\.newTerminal)
+  }
+
+  @Test(.dependencies) func openRepositorySettingsDelegateNavigatesAndShowsWindow() async {
+    let shown = LockIsolated(false)
+    let store = TestStore(initialState: AppFeature.State()) {
+      AppFeature()
+    } withDependencies: {
+      $0.settingsWindowClient.show = { shown.withValue { $0 = true } }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.commandPalette(.delegate(.openRepositorySettings("/tmp/repo-x"))))
+    await store.receive(\.settings.setSelection) {
+      $0.settings.selection = .repository("/tmp/repo-x")
+    }
+    await store.finish()
+    #expect(shown.value)
+  }
+
   @Test(.dependencies) func runCustomCommandDelegateDispatchesAppAction() async {
     let store = TestStore(initialState: AppFeature.State()) {
       AppFeature()

--- a/supacodeTests/AppFeatureCommandPaletteTests.swift
+++ b/supacodeTests/AppFeatureCommandPaletteTests.swift
@@ -576,16 +576,6 @@ struct AppFeatureCommandPaletteTests {
     await store.finish()
   }
 
-  @Test(.dependencies) func newTabDelegateDispatchesAppAction() async {
-    let store = TestStore(initialState: AppFeature.State()) {
-      AppFeature()
-    }
-    store.exhaustivity = .off
-
-    await store.send(.commandPalette(.delegate(.newTab)))
-    await store.receive(\.newTerminal)
-  }
-
   @Test(.dependencies) func openRepositorySettingsDelegateNavigatesAndShowsWindow() async {
     let shown = LockIsolated(false)
     let store = TestStore(initialState: AppFeature.State()) {

--- a/supacodeTests/CommandPaletteFeatureTests.swift
+++ b/supacodeTests/CommandPaletteFeatureTests.swift
@@ -214,25 +214,6 @@ struct CommandPaletteFeatureTests {
     )
   }
 
-  @Test func commandPaletteItems_includesNewTabWhenWorktreeSelected() {
-    let rootPath = "/tmp/repo-newtab"
-    let worktree = makeWorktree(id: "\(rootPath)/wt-1", name: "wt-1", repoRoot: rootPath)
-    let repository = makeRepository(rootPath: rootPath, name: "Repo", worktrees: [worktree])
-    var state = RepositoriesFeature.State(repositories: [repository])
-    state.selection = .worktree(worktree.id)
-
-    let items = CommandPaletteFeature.commandPaletteItems(from: state)
-    let item = items.first { $0.id == "global.new-tab" }
-    #expect(item?.title == "New Tab")
-    #expect(item?.kind == .newTab)
-    #expect(item?.defaultSuggestion == true)
-  }
-
-  @Test func commandPaletteItems_omitsNewTabWithoutSelectedWorktree() {
-    let items = CommandPaletteFeature.commandPaletteItems(from: RepositoriesFeature.State())
-    #expect(!items.contains { $0.id == "global.new-tab" })
-  }
-
   @Test func commandPaletteItems_includesRepoSettingsForSelectedWorktree() {
     let rootPath = "/tmp/repo-settings"
     let worktree = makeWorktree(id: "\(rootPath)/wt-1", name: "wt-1", repoRoot: rootPath)
@@ -1715,7 +1696,7 @@ private func testCategory(for kind: CommandPaletteItem.Kind) -> CommandPaletteIt
   case .newWorktree, .refreshWorktrees, .viewArchivedWorktrees,
     .removeWorktree, .archiveWorktree, .changeFocusedTabIcon,
     .runScript, .stopRunScript, .togglePinWorktree,
-    .renameBranch, .deleteWorktree, .newTab, .runCustomCommand:
+    .renameBranch, .deleteWorktree, .runCustomCommand:
     return .worktree
   case .jumpToLatestUnread, .worktreeSelect, .revealInFinder, .copyPath, .revealInSidebar:
     return .navigation
@@ -1743,7 +1724,7 @@ private func testDefaultSuggestion(for kind: CommandPaletteItem.Kind) -> Bool {
     .toggleLeftSidebar, .toggleActiveAgentsPanel, .toggleCanvas, .toggleShelf, .showDiff,
     .revealInFinder, .copyPath, .revealInSidebar,
     .runScript, .stopRunScript, .togglePinWorktree, .renameBranch,
-    .newTab, .openRepositorySettings:
+    .openRepositorySettings:
     return true
   case .worktreeSelect, .removeWorktree, .archiveWorktree, .changeFocusedTabIcon,
     .ghosttyCommand, .openRepositoryOnCodeHost,

--- a/supacodeTests/CommandPaletteFeatureTests.swift
+++ b/supacodeTests/CommandPaletteFeatureTests.swift
@@ -214,6 +214,56 @@ struct CommandPaletteFeatureTests {
     )
   }
 
+  @Test func commandPaletteItems_includesNewTabWhenWorktreeSelected() {
+    let rootPath = "/tmp/repo-newtab"
+    let worktree = makeWorktree(id: "\(rootPath)/wt-1", name: "wt-1", repoRoot: rootPath)
+    let repository = makeRepository(rootPath: rootPath, name: "Repo", worktrees: [worktree])
+    var state = RepositoriesFeature.State(repositories: [repository])
+    state.selection = .worktree(worktree.id)
+
+    let items = CommandPaletteFeature.commandPaletteItems(from: state)
+    let item = items.first { $0.id == "global.new-tab" }
+    #expect(item?.title == "New Tab")
+    #expect(item?.kind == .newTab)
+    #expect(item?.defaultSuggestion == true)
+  }
+
+  @Test func commandPaletteItems_omitsNewTabWithoutSelectedWorktree() {
+    let items = CommandPaletteFeature.commandPaletteItems(from: RepositoriesFeature.State())
+    #expect(!items.contains { $0.id == "global.new-tab" })
+  }
+
+  @Test func commandPaletteItems_includesRepoSettingsForSelectedWorktree() {
+    let rootPath = "/tmp/repo-settings"
+    let worktree = makeWorktree(id: "\(rootPath)/wt-1", name: "wt-1", repoRoot: rootPath)
+    let repository = makeRepository(rootPath: rootPath, name: "Repo", worktrees: [worktree])
+    var state = RepositoriesFeature.State(repositories: [repository])
+    state.selection = .worktree(worktree.id)
+
+    let items = CommandPaletteFeature.commandPaletteItems(from: state)
+    let item = items.first { $0.id == "repo.\(repository.id).open-settings" }
+    #expect(item?.title == "Repo Settings")
+    #expect(item?.subtitle == "Repo")
+    #expect(item?.kind == .openRepositorySettings(repository.id))
+    #expect(item?.category == .app)
+  }
+
+  @Test func commandPaletteItems_includesRepoSettingsForSelectedRepository() {
+    let rootPath = "/tmp/repo-settings-direct"
+    let worktree = makeWorktree(id: "\(rootPath)/wt-1", name: "wt-1", repoRoot: rootPath)
+    let repository = makeRepository(rootPath: rootPath, name: "RepoDirect", worktrees: [worktree])
+    var state = RepositoriesFeature.State(repositories: [repository])
+    state.selection = .repository(repository.id)
+
+    let items = CommandPaletteFeature.commandPaletteItems(from: state)
+    #expect(items.contains { $0.id == "repo.\(repository.id).open-settings" })
+  }
+
+  @Test func commandPaletteItems_omitsRepoSettingsWithoutSelection() {
+    let items = CommandPaletteFeature.commandPaletteItems(from: RepositoriesFeature.State())
+    #expect(!items.contains { $0.id.hasPrefix("repo.") })
+  }
+
   @Test func commandPaletteItems_customCommandSubtitleVariants() {
     let shellCmd = UserCustomCommand(
       id: "cmd-shell",
@@ -1659,12 +1709,13 @@ private func makeItem(
 
 private func testCategory(for kind: CommandPaletteItem.Kind) -> CommandPaletteItem.Category {
   switch kind {
-  case .checkForUpdates, .openSettings, .openRepository, .installCLI:
+  case .checkForUpdates, .openSettings, .openRepository, .installCLI,
+    .openRepositorySettings:
     return .app
   case .newWorktree, .refreshWorktrees, .viewArchivedWorktrees,
     .removeWorktree, .archiveWorktree, .changeFocusedTabIcon,
     .runScript, .stopRunScript, .togglePinWorktree,
-    .renameBranch, .deleteWorktree, .runCustomCommand:
+    .renameBranch, .deleteWorktree, .newTab, .runCustomCommand:
     return .worktree
   case .jumpToLatestUnread, .worktreeSelect, .revealInFinder, .copyPath, .revealInSidebar:
     return .navigation
@@ -1691,7 +1742,8 @@ private func testDefaultSuggestion(for kind: CommandPaletteItem.Kind) -> Bool {
     .copyFailingJobURL, .copyCiFailureLogs, .rerunFailedJobs, .openFailingCheckDetails,
     .toggleLeftSidebar, .toggleActiveAgentsPanel, .toggleCanvas, .toggleShelf, .showDiff,
     .revealInFinder, .copyPath, .revealInSidebar,
-    .runScript, .stopRunScript, .togglePinWorktree, .renameBranch:
+    .runScript, .stopRunScript, .togglePinWorktree, .renameBranch,
+    .newTab, .openRepositorySettings:
     return true
   case .worktreeSelect, .removeWorktree, .archiveWorktree, .changeFocusedTabIcon,
     .ghosttyCommand, .openRepositoryOnCodeHost,


### PR DESCRIPTION
## Summary

PR7 of the command-palette buildout, scoped down to **one** command after the audit.

Originally added two commands; New Tab was dropped because Ghostty already auto-exposes a `new_tab` entry via `command-palette-entry`, and both code paths converge on the same backend (`WorktreeTerminalState.createTab`). Keeping only the Ghostty bridge stays consistent with every other Prowl terminal lifecycle command in the palette (Close Tab / Close Surface / font size / find — all auto-bridged).

### Repo Settings

- New per-repo command that opens the Settings window and navigates to `SettingsSection.repository(repoID)`.
- Resolution: prefer an explicitly selected repository; otherwise fall back to the repo that owns the currently-selected worktree (via the new private `activeRepository(in:)` helper).
- Subtitle shows the repo name so multi-repo users can tell which one the command targets.
- Per-repo stable ID (`CommandPaletteItemID.openRepositorySettings(_:)`) so recency carries across sessions; added to `recencyRetentionIDs`.

## Audit notes (for reference)

The plan's original PR7 list is mostly resolved:

| Item | Status |
|---|---|
| Tab switching (Select Tab 1-9, Prev/Next Tab) | dropped (not needed) |
| Pane switching | dropped (not needed) |
| Font size +/-/reset | already covered (Ghostty bridge + TerminalCommands menu) |
| Find / Find Next / Hide Find | dropped (⌘F is intuitive) |
| Close Terminal / Close Tab | already covered (Ghostty bridge + TerminalCommands menu) |
| New Terminal → New Tab | already covered (Ghostty bridge) |
| Shelf navigation | dropped |
| Repo Settings | **this PR** |
| Repo Remove / Bulk selection / Confirm Worktree Action | dropped |

## Focus restore

`.openRepositorySettings` falls through to the default-on restore added in PR5 — the Settings window handles its own focus once it appears.

## Test plan

- [x] `make check` clean
- [x] `make test` (1123 passed, +4)
- [x] `make build-app` succeeds
- [x] Manual: ⌘P → "settings" / "repo" / the repo name → Settings window opens with that repo selected
- [x] Manual: works with either a worktree selected (resolves to its container repo) or a repo node selected directly
- [x] Manual: with nothing selected → Repo Settings absent from palette
- [x] Manual: only one "New Tab" entry in palette (Ghostty's), no duplicate

## What's next

After this lands, the architecture plan is essentially complete for the chosen scope. Remaining loose ends (low priority):

- Issue #295 — delete the dead `copyPath` ⌘⇧C binding
- PR3's deferred `contextual` factory — no current pain point
