### PR TITLE
Command palette: post-buildout cleanup

### DIFF
--- a/supacode/App/AppShortcuts.swift
+++ b/supacode/App/AppShortcuts.swift
@@ -89,7 +89,6 @@ enum AppShortcuts {
     static let quitApplication = "quit_application"
     static let openSettings = "open_settings"
     static let openWorktree = "open_worktree"
-    static let copyPath = "copy_path"
     static let openRepository = "open_repository"
     static let openPullRequest = "open_pull_request"
     static let toggleLeftSidebar = "toggle_left_sidebar"
@@ -179,7 +178,6 @@ enum AppShortcuts {
   static let quitApplication = AppShortcut(key: "q", modifiers: .command)
   static let openSettings = AppShortcut(key: ",", modifiers: .command)
   static let openFinder = AppShortcut(key: "o", modifiers: .command)
-  static let copyPath = AppShortcut(key: "c", modifiers: [.command, .shift])
   static let openRepository = AppShortcut(key: "o", modifiers: [.command, .shift])
   static let openPullRequest = AppShortcut(key: "g", modifiers: [.command, .control])
   static let toggleLeftSidebar = AppShortcut(key: "s", modifiers: [.command, .control])
@@ -376,12 +374,6 @@ enum AppShortcuts {
       title: "Open Worktree",
       scope: .configurableAppAction,
       shortcut: openFinder
-    ),
-    .init(
-      id: CommandID.copyPath,
-      title: "Copy Path",
-      scope: .configurableAppAction,
-      shortcut: copyPath
     ),
     .init(
       id: CommandID.openRepository,
@@ -868,7 +860,6 @@ enum AppShortcuts {
     newWorktree,
     openSettings,
     openFinder,
-    copyPath,
     openRepository,
     openPullRequest,
     toggleLeftSidebar,

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -1028,11 +1028,8 @@ struct AppFeature {
       case .commandPalette(.delegate(.openRepository)):
         return .send(.repositories(.setOpenPanelPresented(true)))
 
-      case .commandPalette(.delegate(.removeWorktree(let worktreeID, let repositoryID))):
+      case .commandPalette(.delegate(.deleteWorktree(let worktreeID, let repositoryID))):
         return .send(.repositories(.worktreeLifecycle(.requestDeleteWorktree(worktreeID, repositoryID))))
-
-      case .commandPalette(.delegate(.archiveWorktree(let worktreeID, let repositoryID))):
-        return .send(.repositories(.worktreeLifecycle(.requestArchiveWorktree(worktreeID, repositoryID))))
 
       case .commandPalette(.delegate(.viewArchivedWorktrees)):
         return .send(.repositories(.selectArchivedWorktrees))
@@ -1108,12 +1105,10 @@ struct AppFeature {
         return .send(.repositories(.requestRenameBranchPrompt(worktreeID)))
 
       case .commandPalette(.delegate(.openRepositorySettings(let repositoryID))):
-        return .merge(
-          .send(.settings(.setSelection(.repository(repositoryID)))),
-          .run { _ in
-            await settingsWindowClient.show()
-          }
-        )
+        // Reuse the existing repo-side flow so the repo-existence guard and
+        // settingsWindowClient.show() live in one place
+        // (.repositories(.delegate(.openRepositorySettings(_))) at line ~441).
+        return .send(.repositories(.repositoryManagement(.openRepositorySettings(repositoryID))))
 
       case .commandPalette(.delegate(.togglePinWorktree(let worktreeID, let isCurrentlyPinned))):
         if isCurrentlyPinned {

--- a/supacode/Features/CommandPalette/CommandPaletteItem.swift
+++ b/supacode/Features/CommandPalette/CommandPaletteItem.swift
@@ -46,8 +46,6 @@ struct CommandPaletteItem: Identifiable, Equatable {
     case worktreeSelect(Worktree.ID)
     case openSettings
     case newWorktree
-    case removeWorktree(Worktree.ID, Repository.ID)
-    case archiveWorktree(Worktree.ID, Repository.ID)
     case viewArchivedWorktrees
     case refreshWorktrees
     case jumpToLatestUnread
@@ -143,8 +141,6 @@ struct CommandPaletteItem: Identifiable, Equatable {
       .openFailingCheckDetails,
       .installCLI,
       .worktreeSelect,
-      .removeWorktree,
-      .archiveWorktree,
       .changeFocusedTabIcon,
       .revealInFinder,
       .copyPath,

--- a/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
+++ b/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
@@ -36,8 +36,7 @@ struct CommandPaletteFeature {
     case openSettings
     case newWorktree
     case openRepository
-    case removeWorktree(Worktree.ID, Repository.ID)
-    case archiveWorktree(Worktree.ID, Repository.ID)
+    case deleteWorktree(Worktree.ID, Repository.ID)
     case viewArchivedWorktrees
     case refreshWorktrees
     case jumpToLatestUnread
@@ -955,11 +954,8 @@ private func delegateAction(for kind: CommandPaletteItem.Kind) -> CommandPalette
   switch kind {
   case .worktreeSelect(let id):
     return .selectWorktree(id)
-  case .removeWorktree(let worktreeID, let repositoryID),
-    .deleteWorktree(let worktreeID, let repositoryID):
-    return .removeWorktree(worktreeID, repositoryID)
-  case .archiveWorktree(let worktreeID, let repositoryID):
-    return .archiveWorktree(worktreeID, repositoryID)
+  case .deleteWorktree(let worktreeID, let repositoryID):
+    return .deleteWorktree(worktreeID, repositoryID)
   case .ghosttyCommand(let action):
     return .ghosttyCommand(action)
   case .changeFocusedTabIcon(let worktreeID):
@@ -1100,8 +1096,6 @@ private func pullRequestDelegateAction(
     .openSettings,
     .newWorktree,
     .openRepository,
-    .removeWorktree,
-    .archiveWorktree,
     .viewArchivedWorktrees,
     .refreshWorktrees,
     .jumpToLatestUnread,

--- a/supacode/Features/CommandPalette/Views/CommandPaletteOverlayView.swift
+++ b/supacode/Features/CommandPalette/Views/CommandPaletteOverlayView.swift
@@ -544,10 +544,6 @@ private struct CommandPaletteRowView: View {
       .runScript, .stopRunScript, .togglePinWorktree, .renameBranch,
       .openRepositorySettings, .runCustomCommand:
       return nil
-    case .removeWorktree:
-      return "Remove"
-    case .archiveWorktree:
-      return "Archive"
     case .deleteWorktree:
       return "Delete"
     #if DEBUG
@@ -597,10 +593,6 @@ private struct CommandPaletteRowView: View {
       return nil
     case .changeFocusedTabIcon:
       return "rectangle.on.rectangle"
-    case .removeWorktree:
-      return "trash"
-    case .archiveWorktree:
-      return "archivebox"
     case .toggleLeftSidebar:
       return "sidebar.left"
     case .toggleActiveAgentsPanel:
@@ -654,7 +646,7 @@ private struct CommandPaletteRowView: View {
       .openRepositorySettings,
       .deleteWorktree, .runCustomCommand:
       return true
-    case .worktreeSelect, .removeWorktree, .archiveWorktree:
+    case .worktreeSelect:
       return false
     #if DEBUG
       case .debugTestToast, .debugSimulateUpdateFound:
@@ -748,10 +740,6 @@ private struct CommandPaletteRowView: View {
       base = "Jump to Latest Unread"
     case .ghosttyCommand:
       base = row.title
-    case .removeWorktree:
-      base = "Remove \(row.title)"
-    case .archiveWorktree:
-      base = "Archive \(row.title)"
     case .openPullRequest, .openRepositoryOnCodeHost:
       base = row.title
     case .markPullRequestReady:

--- a/supacodeTests/AppFeatureCommandPaletteTests.swift
+++ b/supacodeTests/AppFeatureCommandPaletteTests.swift
@@ -577,8 +577,19 @@ struct AppFeatureCommandPaletteTests {
   }
 
   @Test(.dependencies) func openRepositorySettingsDelegateNavigatesAndShowsWindow() async {
+    // Palette handler funnels through the existing
+    // repositories.repositoryManagement.openRepositorySettings flow, which
+    // guards on the repo actually existing.
+    let repository = makeRepository(id: "/tmp/repo-x", worktrees: [])
+    var repositoriesState = RepositoriesFeature.State()
+    repositoriesState.repositories = [repository]
     let shown = LockIsolated(false)
-    let store = TestStore(initialState: AppFeature.State()) {
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: repositoriesState,
+        settings: SettingsFeature.State()
+      )
+    ) {
       AppFeature()
     } withDependencies: {
       $0.settingsWindowClient.show = { shown.withValue { $0 = true } }
@@ -613,7 +624,7 @@ struct AppFeatureCommandPaletteTests {
     await store.receive(\.repositories.githubIntegration.pullRequestAction)
   }
 
-  @Test(.dependencies) func removeWorktreeDispatchesRequest() async {
+  @Test(.dependencies) func deleteWorktreeDispatchesRequest() async {
     let worktree = makeWorktree(
       id: "/tmp/repo-run/wt-1",
       name: "wt-1",
@@ -644,46 +655,8 @@ struct AppFeatureCommandPaletteTests {
       TextState("Delete \(worktree.name)? This deletes the worktree directory and its local branch.")
     }
 
-    await store.send(.commandPalette(.delegate(.removeWorktree(worktree.id, repository.id))))
+    await store.send(.commandPalette(.delegate(.deleteWorktree(worktree.id, repository.id))))
     await store.receive(\.repositories.worktreeLifecycle.requestDeleteWorktree) {
-      $0.repositories.alert = expectedAlert
-    }
-  }
-
-  @Test(.dependencies) func archiveWorktreeDispatchesRequest() async {
-    let worktree = makeWorktree(
-      id: "/tmp/repo-archive/wt-1",
-      name: "wt-1",
-      repoRoot: "/tmp/repo-archive"
-    )
-    let repository = makeRepository(id: "/tmp/repo-archive", worktrees: [worktree])
-    var repositoriesState = RepositoriesFeature.State()
-    repositoriesState.repositories = [repository]
-    let store = TestStore(
-      initialState: AppFeature.State(
-        repositories: repositoriesState,
-        settings: SettingsFeature.State()
-      )
-    ) {
-      AppFeature()
-    }
-
-    let archivedDisplay = AppShortcuts.archivedWorktrees.display
-    let expectedAlert = AlertState<RepositoriesFeature.Alert> {
-      TextState("Archive worktree?")
-    } actions: {
-      ButtonState(role: .destructive, action: .confirmArchiveWorktree(worktree.id, repository.id)) {
-        TextState("Archive (⌘↩)")
-      }
-      ButtonState(role: .cancel) {
-        TextState("Cancel")
-      }
-    } message: {
-      TextState("Find \(worktree.name) later in Menu Bar > Worktrees > Archived Worktrees (\(archivedDisplay)).")
-    }
-
-    await store.send(.commandPalette(.delegate(.archiveWorktree(worktree.id, repository.id))))
-    await store.receive(\.repositories.worktreeLifecycle.requestArchiveWorktree) {
       $0.repositories.alert = expectedAlert
     }
   }

--- a/supacodeTests/AppShortcutsTests.swift
+++ b/supacodeTests/AppShortcutsTests.swift
@@ -10,7 +10,7 @@ struct AppShortcutsTests {
     let shortcuts: [AppShortcut] = [
       AppShortcuts.openSettings,
       AppShortcuts.newWorktree,
-      AppShortcuts.copyPath,
+      AppShortcuts.openRepository,
     ]
 
     for shortcut in shortcuts {

--- a/supacodeTests/CommandPaletteFeatureTests.swift
+++ b/supacodeTests/CommandPaletteFeatureTests.swift
@@ -786,66 +786,12 @@ struct CommandPaletteFeatureTests {
     )
 
     #expect(
-      items.contains {
-        if case .removeWorktree = $0.kind {
-          return true
-        }
-        return false
-      } == false
-    )
-    #expect(
-      items.contains {
-        if case .archiveWorktree = $0.kind {
-          return true
-        }
-        return false
-      } == false
-    )
-    #expect(
       items.filter {
         if case .worktreeSelect = $0.kind {
           return true
         }
         return false
       }.count == 1
-    )
-  }
-
-  @Test func commandPaletteItems_omitsSubActionsForNonMainWorktree() {
-    let rootPath = "/tmp/repo"
-    let main = makeWorktree(
-      id: rootPath,
-      name: "repo",
-      detail: "main",
-      repoRoot: rootPath,
-      workingDirectory: rootPath
-    )
-    let feature = makeWorktree(
-      id: "\(rootPath)/wt-feature",
-      name: "feature",
-      detail: "feature",
-      repoRoot: rootPath
-    )
-    let repository = makeRepository(rootPath: rootPath, name: "Repo", worktrees: [main, feature])
-    let items = CommandPaletteFeature.commandPaletteItems(
-      from: RepositoriesFeature.State(repositories: [repository])
-    )
-
-    #expect(
-      items.contains {
-        if case .removeWorktree = $0.kind {
-          return true
-        }
-        return false
-      } == false
-    )
-    #expect(
-      items.contains {
-        if case .archiveWorktree = $0.kind {
-          return true
-        }
-        return false
-      } == false
     )
   }
 
@@ -984,21 +930,21 @@ struct CommandPaletteFeatureTests {
       subtitle: "main",
       kind: .worktreeSelect("wt-fox")
     )
-    let archiveFox = makeItem(
-      id: "worktree.fox.archive",
-      title: "Repo / fox",
-      subtitle: "Archive Worktree - main",
-      kind: .archiveWorktree("wt-fox", "repo-fox")
+    let deleteFox = makeItem(
+      id: "worktree.fox.delete",
+      title: "Delete Worktree",
+      subtitle: "fox",
+      kind: .deleteWorktree("wt-fox", "repo-fox")
     )
-    let removeFox = makeItem(
-      id: "worktree.fox.remove",
-      title: "Repo / fox",
-      subtitle: "Remove Worktree - main",
-      kind: .removeWorktree("wt-fox", "repo-fox")
+    let changeFoxIcon = makeItem(
+      id: "worktree.fox.change-icon",
+      title: "Change Tab Icon...",
+      subtitle: "fox",
+      kind: .changeFocusedTabIcon("wt-fox")
     )
 
     let result = CommandPaletteFeature.filterItems(
-      items: [openSettings, newWorktree, selectFox, archiveFox, removeFox],
+      items: [openSettings, newWorktree, selectFox, deleteFox, changeFoxIcon],
       query: ""
     )
     expectNoDifference(result.map(\.id), [openSettings.id, newWorktree.id])
@@ -1694,7 +1640,7 @@ private func testCategory(for kind: CommandPaletteItem.Kind) -> CommandPaletteIt
     .openRepositorySettings:
     return .app
   case .newWorktree, .refreshWorktrees, .viewArchivedWorktrees,
-    .removeWorktree, .archiveWorktree, .changeFocusedTabIcon,
+    .changeFocusedTabIcon,
     .runScript, .stopRunScript, .togglePinWorktree,
     .renameBranch, .deleteWorktree, .runCustomCommand:
     return .worktree
@@ -1726,7 +1672,7 @@ private func testDefaultSuggestion(for kind: CommandPaletteItem.Kind) -> Bool {
     .runScript, .stopRunScript, .togglePinWorktree, .renameBranch,
     .openRepositorySettings:
     return true
-  case .worktreeSelect, .removeWorktree, .archiveWorktree, .changeFocusedTabIcon,
+  case .worktreeSelect, .changeFocusedTabIcon,
     .ghosttyCommand, .openRepositoryOnCodeHost,
     .deleteWorktree, .runCustomCommand:
     return false


### PR DESCRIPTION
## Summary

Three loose ends from the command-palette buildout, swept together. Pure cleanup — no user-facing behavior change.

### 1. Simplify Repo Settings palette handler

`AppFeature` had two near-identical handlers landing on the settings window — the existing repo right-click path (`.repositories(.delegate(.openRepositorySettings(_)))`) and PR7's palette path (`.commandPalette(.delegate(.openRepositorySettings(_)))`).

Funnels the palette path through the existing repositories pipeline so the repo-existence guard and `settingsWindowClient.show()` call live in one place.

### 2. Delete the dead `copyPath` ⌘⇧C shortcut (closes #295)

The binding was never wired to any `Button` + `KeyboardShortcutModifier`, so pressing ⌘⇧C did nothing. The two real Copy Path entry points (right-click context menu, "Open in..." dropdown) carry no shortcut, and the palette item already hides the (dead) hint.

Removes:
- `AppShortcuts.CommandID.copyPath`
- `AppShortcuts.copyPath`
- The `configurableAppAction` entry binding the two
- `copyPath` in `AppShortcuts.all`

### 3. Remove dead `.removeWorktree` / `.archiveWorktree` Kind cases

Both Kinds were declared in `CommandPaletteItem.Kind` but **never constructed** anywhere — leftovers from an earlier design that anticipated right-click-on-row palette items. PR6 introduced `.deleteWorktree` as the actual constructed Kind for the "Delete Worktree" palette command (routed through the `.removeWorktree` Delegate for historical reasons).

- Deletes both unused Kinds.
- Renames `CommandPaletteFeature.Delegate.removeWorktree` → `.deleteWorktree` so the delegate name matches the user-facing command.
- Deletes `CommandPaletteFeature.Delegate.archiveWorktree` (no sender after the Kind goes).
- Cascades through `AppFeature` handlers, overlay view branches (`badge` / `leadingIcon` / `emphasis` / accessibility title), and the `pullRequestDelegateAction` exhaustiveness list.

## Tests

- `removeWorktreeDispatchesRequest` → renamed `deleteWorktreeDispatchesRequest`, updated to dispatch the new delegate name
- `archiveWorktreeDispatchesRequest` — deleted (Delegate is gone)
- `commandPaletteItems_omitsSubActionsForMainWorktree` / `…ForNonMainWorktree` — the `.removeWorktree` / `.archiveWorktree` `contains` assertions became tautological (Kinds no longer exist); the non-main test went empty and was deleted, the main one keeps its `worktreeSelect` count check
- `showsGlobalItemsWhenQueryEmpty` — replaced `archiveFox` / `removeFox` fixture items with `.deleteWorktree` + `.changeFocusedTabIcon` (also non-default-suggestion, so the empty-query filtering invariant is unchanged)
- `AppShortcutsTests.displaySymbolsMatchDisplay` — `AppShortcuts.copyPath` → `AppShortcuts.openRepository` for the round-trip sample
- `openRepositorySettingsDelegateNavigatesAndShowsWindow` — set up a real repo in state since the simplified handler now flows through the `repositories.contains` guard

## Net

8 files changed, 37 insertions(+), 154 deletions(-) — **-117 lines**.

## Test plan

- [x] `make check` clean
- [x] `make test` (1124 passed)
- [x] `make build-app` succeeds
- [x] Manual: ⌘⇧C does nothing (was never doing anything anyway)
- [x] Manual: "Delete Worktree" via palette still pops the existing confirmation alert
- [x] Manual: "Repo Settings" via palette still opens Settings window navigated to the right repo

Closes #295
