### PR TITLE
Revert auto-scroll for Settings repository selection

### DIFF
--- a/supacode/Features/Settings/Views/SettingsView.swift
+++ b/supacode/Features/Settings/Views/SettingsView.swift
@@ -29,53 +29,36 @@ struct SettingsView: View {
 
     NavigationSplitView(columnVisibility: .constant(.all)) {
       VStack(spacing: 0) {
-        ScrollViewReader { scrollProxy in
-          List(selection: $settingsStore.selection.sending(\.setSelection)) {
-            Label("General", systemImage: "gearshape")
-              .tag(SettingsSection.general)
-              .id(SettingsSection.general)
-            Label("Notifications", systemImage: "bell")
-              .tag(SettingsSection.notifications)
-              .id(SettingsSection.notifications)
-            Label("Shortcuts", systemImage: "keyboard")
-              .tag(SettingsSection.shortcuts)
-              .id(SettingsSection.shortcuts)
-            Label("Worktree", systemImage: "archivebox")
-              .tag(SettingsSection.worktree)
-              .id(SettingsSection.worktree)
-            Label("Updates", systemImage: "arrow.down.circle")
-              .tag(SettingsSection.updates)
-              .id(SettingsSection.updates)
-            Label("Advanced", systemImage: "gearshape.2")
-              .tag(SettingsSection.advanced)
-              .id(SettingsSection.advanced)
-            Label("GitHub", systemImage: "arrow.triangle.branch")
-              .tag(SettingsSection.github)
-              .id(SettingsSection.github)
+        List(selection: $settingsStore.selection.sending(\.setSelection)) {
+          Label("General", systemImage: "gearshape")
+            .tag(SettingsSection.general)
+          Label("Notifications", systemImage: "bell")
+            .tag(SettingsSection.notifications)
+          Label("Shortcuts", systemImage: "keyboard")
+            .tag(SettingsSection.shortcuts)
+          Label("Worktree", systemImage: "archivebox")
+            .tag(SettingsSection.worktree)
+          Label("Updates", systemImage: "arrow.down.circle")
+            .tag(SettingsSection.updates)
+          Label("Advanced", systemImage: "gearshape.2")
+            .tag(SettingsSection.advanced)
+          Label("GitHub", systemImage: "arrow.triangle.branch")
+            .tag(SettingsSection.github)
 
-            Section("Repositories") {
-              ForEach(repositories) { repository in
-                let repositorySection = SettingsSection.repository(repository.id)
-                RepoDisplayName(
-                  fallbackName: repository.name,
-                  customTitle: customTitles[repository.id]
-                )
-                .tag(repositorySection)
-                .id(repositorySection)
-              }
+          Section("Repositories") {
+            ForEach(repositories) { repository in
+              RepoDisplayName(
+                fallbackName: repository.name,
+                customTitle: customTitles[repository.id]
+              )
+              .tag(SettingsSection.repository(repository.id))
             }
           }
-          .listStyle(.sidebar)
-          .frame(minWidth: 220, maxHeight: .infinity)
-          .navigationSplitViewColumnWidth(220)
-          .removingSidebarToggle()
-          .onAppear {
-            scrollToRepositorySelection(settingsStore.selection, proxy: scrollProxy)
-          }
-          .onChange(of: settingsStore.selection) { _, selection in
-            scrollToRepositorySelection(selection, proxy: scrollProxy)
-          }
         }
+        .listStyle(.sidebar)
+        .frame(minWidth: 220, maxHeight: .infinity)
+        .navigationSplitViewColumnWidth(220)
+        .removingSidebarToggle()
       }
     } detail: {
       switch selection {
@@ -151,12 +134,5 @@ struct SettingsView: View {
       WindowLevelSetter(level: .normal)
     }
     .ignoresSafeArea(.container, edges: .top)
-  }
-
-  private func scrollToRepositorySelection(_ selection: SettingsSection?, proxy: ScrollViewProxy) {
-    guard case .repository(let repositoryID) = selection else { return }
-    withAnimation {
-      proxy.scrollTo(SettingsSection.repository(repositoryID), anchor: .center)
-    }
   }
 }


### PR DESCRIPTION
## Summary
- Revert the `ScrollViewReader` + `.id(...)` wiring added in #301 — the auto-scroll behavior in the Settings sidebar didn't feel right.
- Keep the Cmd-W close shortcut and its tests from the same PR intact.

## Test plan
- [x] `make build-app`
- [x] `make check`
- [x] Manually open Settings, switch between sections and repositories, confirm the sidebar no longer auto-scrolls on selection and Cmd-W still closes the window.
