### PR TITLE
Fix stale PR chip on main worktree

### DIFF
--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+GithubIntegration.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+GithubIntegration.swift
@@ -197,7 +197,8 @@ extension RepositoriesFeature {
         guard let worktree = repository.worktrees[id: worktreeID] else {
           continue
         }
-        let pullRequest = pullRequestsByWorktreeID[worktreeID] ?? nil
+        let loadedPullRequest = pullRequestsByWorktreeID[worktreeID] ?? nil
+        let pullRequest = Self.displayPullRequest(loadedPullRequest, for: worktree)
         let previousPullRequest = state.worktreeInfoByID[worktreeID]?.pullRequest
         guard previousPullRequest != pullRequest else {
           continue
@@ -624,6 +625,16 @@ extension RepositoriesFeature {
       state.mergedWorktreeAction = action
       return .none
     }
+  }
+
+  nonisolated private static func displayPullRequest(
+    _ pullRequest: GithubPullRequest?,
+    for worktree: Worktree
+  ) -> GithubPullRequest? {
+    if worktree.isMain, pullRequest?.state.uppercased() == "MERGED" {
+      return nil
+    }
+    return pullRequest
   }
 
   nonisolated private static func validWebURL(_ raw: String) -> URL? {

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -3212,13 +3212,7 @@ struct RepositoriesFeatureTests {
           repositoryID: repository.id,
           pullRequestsByWorktreeID: [mainWorktree.id: mergedPullRequest]
         ))
-    ) {
-      $0.worktreeInfoByID[mainWorktree.id] = WorktreeInfoEntry(
-        addedLines: nil,
-        removedLines: nil,
-        pullRequest: mergedPullRequest
-      )
-    }
+    )
     await store.finish()
   }
 
@@ -3276,13 +3270,7 @@ struct RepositoriesFeatureTests {
           repositoryID: repository.id,
           pullRequestsByWorktreeID: [mainWorktree.id: mergedPullRequest]
         ))
-    ) {
-      $0.worktreeInfoByID[mainWorktree.id] = WorktreeInfoEntry(
-        addedLines: nil,
-        removedLines: nil,
-        pullRequest: mergedPullRequest
-      )
-    }
+    )
     await store.finish()
   }
 
@@ -4039,6 +4027,32 @@ struct RepositoriesFeatureTests {
         ))
     ) {
       $0.worktreeInfoByID.removeValue(forKey: featureWorktree.id)
+    }
+  }
+
+  @Test func repositoryPullRequestsLoadedClearsMergedPullRequestForMainWorktree() async {
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree])
+    let mergedPullRequest = makePullRequest(state: "MERGED", headRefName: mainWorktree.name)
+    var state = makeState(repositories: [repository])
+    state.worktreeInfoByID[mainWorktree.id] = WorktreeInfoEntry(
+      addedLines: nil,
+      removedLines: nil,
+      pullRequest: mergedPullRequest
+    )
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    }
+
+    await store.send(
+      .githubIntegration(
+        .repositoryPullRequestsLoaded(
+          repositoryID: repository.id,
+          pullRequestsByWorktreeID: [mainWorktree.id: mergedPullRequest]
+        ))
+    ) {
+      $0.worktreeInfoByID.removeValue(forKey: mainWorktree.id)
     }
   }
 


### PR DESCRIPTION
## Summary
- Ignore merged pull requests when applying PR metadata to the main worktree.
- Keep merged pull request display behavior for non-main worktrees.
- Update reducer tests for main worktree merged PR handling.

## Tests
- `xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -only-testing:supacodeTests/RepositoriesFeatureTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation 2>&1 | mise exec -- xcsift -f toon`
- `make format-changed`
- `make build-app`
