### PR TITLE
[codex] Run CI test steps in parallel

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,9 +26,40 @@ jobs:
       - uses: ./.github/actions/setup-macos
       - run: make lint
       - run: make build-app
-      - run: make test
-      - run: make test-cli-smoke
-      - run: make test-cli-integration
+      - name: Run tests in parallel
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p build/ci-logs
+
+          run_task() {
+            local name="$1"
+            shift
+            local log="build/ci-logs/${name}.log"
+            echo "::group::${name}"
+            if "$@" >"$log" 2>&1; then
+              cat "$log"
+              echo "::endgroup::"
+              return 0
+            fi
+            local status=$?
+            cat "$log"
+            echo "::endgroup::"
+            return "$status"
+          }
+
+          run_task app-tests make test-app &
+          pid_app=$!
+          run_task cli-smoke make test-cli-smoke &
+          pid_smoke=$!
+          run_task cli-integration make test-cli-integration &
+          pid_cli=$!
+
+          failed=0
+          wait "$pid_app" || failed=1
+          wait "$pid_smoke" || failed=1
+          wait "$pid_cli" || failed=1
+          exit "$failed"
       - name: Upload xcresult bundle (on failure)
         if: failure()
         uses: actions/upload-artifact@v4

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ PROWL_POSTHOG_API_KEY ?=
 PROWL_POSTHOG_HOST ?=
 
 .DEFAULT_GOAL := help
-.PHONY: build-ghostty-xcframework ensure-ghostty sync-ghostty _check-ghostty-hash _record-ghostty-hash build-app build-cli build-cli-release embed-cli-debug embed-cli run-app install-dev-build install-release archive export-archive format format-changed format-lint lint check test test-cli-smoke test-cli-integration bump-version bump-and-release log-stream
+.PHONY: build-ghostty-xcframework ensure-ghostty sync-ghostty _check-ghostty-hash _record-ghostty-hash build-app build-cli build-cli-release embed-cli-debug embed-cli run-app install-dev-build install-release archive export-archive format format-changed format-lint lint check test test-app test-cli-smoke test-cli-integration bump-version bump-and-release log-stream
 
 help:  # Display this help.
 	@-+echo "Run make with one of the following targets:"
@@ -71,7 +71,7 @@ _check-ghostty-hash:
 	done; \
 	if [ "$$current_sha" != "$$last_sha" ] || [ "$$artifacts_ok" -ne 1 ]; then \
 		echo "Syncing GhosttyKit for submodule $$current_sha"; \
-		$(MAKE) -B build-ghostty-xcframework; \
+		$(MAKE) -B build-ghostty-xcframework || exit $$?; \
 		if [ "$$current_sha" != "$$last_sha" ]; then \
 			rm -rf ~/Library/Developer/Xcode/DerivedData/supacode-*; \
 			echo "Cleared Xcode DerivedData for ghostty header/module changes"; \
@@ -276,7 +276,9 @@ archive: build-ghostty-xcframework embed-cli # Archive Release build for distrib
 export-archive: # Export xarchive
 	bash -o pipefail -c 'xcodebuild -exportArchive -archivePath build/supacode.xcarchive -exportPath build/export -exportOptionsPlist build/ExportOptions.plist 2>&1 | mise exec -- xcsift -qw --format toon'
 
-test: ensure-ghostty
+test: ensure-ghostty embed-cli-debug test-app
+
+test-app: ensure-ghostty # Run app/unit tests via xcodebuild
 	@set -euo pipefail; \
 	result_bundle="$(CURRENT_MAKEFILE_DIR)/build/test-results/supacode-tests.xcresult"; \
 	mkdir -p "$$(dirname "$$result_bundle")"; \


### PR DESCRIPTION
## Summary

- keep the explicit CI app build step
- add a test-app make target for app/unit tests only
- run app tests, CLI smoke, and CLI integration concurrently after build-app
- keep make test self-contained for local usage by embedding the debug CLI before test-app
- make ensure-ghostty fail immediately if the GhosttyKit rebuild fails

## Why

A previous attempt to remove the standalone build-app step passed but did not speed up CI because make test absorbed the full build cost. This branch keeps build-app and only parallelizes the independent test commands that currently run after it.

Expected impact is modest but lower-risk: roughly the serial tail of CLI smoke + CLI integration, around 40-50 seconds on recent runs.

## Validation

Local validation before pushing:

- make build-app
- parallel make test-app / make test-cli-smoke / make test-cli-integration using the same shell pattern as this workflow
- git diff --check
