### PR TITLE
Fix toolbar title hover layout shift

### DIFF
--- a/supacode/Features/Repositories/Views/WorktreeDetailTitleView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailTitleView.swift
@@ -68,10 +68,12 @@ struct WorktreeDetailTitleView: View {
         .accessibilityHidden(true)
         .frame(width: iconWidth, alignment: .center)
       Text(title.text)
-      if title.supportsRename && isHovered {
+      if title.supportsRename {
         Image(systemName: "pencil")
           .foregroundStyle(.secondary)
+          .opacity(isHovered ? 1 : 0)
           .accessibilityHidden(true)
+          .frame(width: iconWidth, alignment: .center)
       }
     }
     .font(.headline)


### PR DESCRIPTION
## Summary
- Keep the branch rename pencil affordance in the toolbar title layout at all times
- Toggle only the pencil opacity on hover so the title item keeps a stable intrinsic width

## Verification
- PATH="/Applications/Xcode-26.4.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin:$PATH" make check
- make build-app

Fixes #313
