### PR TITLE
Differentiate terminal tab states with an adaptive brightness ladder

### DIFF
--- a/supacode/Features/Terminal/TabBar/TerminalTabBarColors.swift
+++ b/supacode/Features/Terminal/TabBar/TerminalTabBarColors.swift
@@ -6,16 +6,39 @@ enum TerminalTabBarColors {
     Color(nsColor: .windowBackgroundColor)
   }
 
+  // Selection is conveyed by a brightness ladder layered over `barBackground`,
+  // but only in dark mode. There, `controlBackgroundColor` is actually *darker*
+  // than `windowBackgroundColor`, so the old selection sank into the bar; a
+  // `labelColor` (≈ `Color.primary`) tint brightens reliably instead, keeping
+  // bar < inactive < hovered < active distinct. In light mode that same tint
+  // would *darken* the tab and read unnaturally, so we keep the original system
+  // appearance: a white tab floating on the gray bar.
   static var activeTabBackground: Color {
-    Color(nsColor: .controlBackgroundColor)
+    adaptiveFill(dark: { .labelColor.withAlphaComponent(0.14) }, light: { .controlBackgroundColor })
   }
 
   static var hoveredTabBackground: Color {
-    Color(nsColor: .controlBackgroundColor).opacity(0.5)
+    adaptiveFill(
+      dark: { .labelColor.withAlphaComponent(0.08) },
+      light: { .controlBackgroundColor.withAlphaComponent(0.5) }
+    )
   }
 
   static var inactiveTabBackground: Color {
-    .clear
+    adaptiveFill(dark: { .labelColor.withAlphaComponent(0.035) }, light: { .clear })
+  }
+
+  /// Resolves to `dark` under Dark Aqua and `light` otherwise, wrapped in a
+  /// dynamic `NSColor` so callers stay appearance-agnostic.
+  private static func adaptiveFill(
+    dark: @escaping () -> NSColor,
+    light: @escaping () -> NSColor
+  ) -> Color {
+    Color(
+      nsColor: NSColor(name: nil) { appearance in
+        appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua ? dark() : light()
+      }
+    )
   }
 
   static var activeText: Color {


### PR DESCRIPTION
## Problem

The selected terminal tab was hard to distinguish from inactive tabs and the bar background — particularly in **dark mode**, where `controlBackgroundColor` (used for the selected tab) is actually *darker* than `windowBackgroundColor` (the bar), so the selection sank into the bar. This got worse when the surface background was opaque, because the selection no longer had any wallpaper/terminal contrast to ride on.

## Change

Convey selection with a brightness ladder layered over the bar, made appearance-aware via a dynamic `NSColor` (so call sites stay unchanged):

| Layer | Dark Mode | Light Mode |
|---|---|---|
| Selected tab | `labelColor @ 0.14` | `controlBackgroundColor` (white tab on gray bar) |
| Hovered | `labelColor @ 0.08` | `controlBackgroundColor @ 0.5` |
| Inactive tab | `labelColor @ 0.035` | `.clear` |
| Bar background | `windowBackgroundColor` | `windowBackgroundColor` |

- **Dark mode**: a `labelColor`-based ladder keeps `bar < inactive < hovered < active` distinct regardless of background opacity. (`labelColor` is opaque in dark, so `withAlphaComponent(0.14)` matches the previous `Color.primary.opacity(0.14)` exactly.)
- **Light mode**: keeps the original native look, since the same tint would *darken* the tab and read unnaturally.

Only `TerminalTabBarColors` changed; tab bar structure, layout, and all interactions are untouched.

## Testing

- `make build-app` ✅
- `make check` ✅
- Verified by hand in both Dark and Light Mode.

Closes #311
