### PR TITLE
[codex] Persist Canvas card layout order

### DIFF
--- a/supacode/Features/Canvas/Models/CanvasCardLayout.swift
+++ b/supacode/Features/Canvas/Models/CanvasCardLayout.swift
@@ -236,23 +236,103 @@ final class CanvasLayoutStore {
   /// Whether auto-arrange has run in this app session. Resets on app launch.
   static var hasAutoArrangedInSession = false
 
+  private let defaults: UserDefaults
+  private let initiallyLoadedCardKeys: Set<String>
+
   var cardLayouts: [String: CanvasCardLayout] {
     didSet { save() }
   }
 
-  init() {
-    if let data = UserDefaults.standard.data(forKey: Self.storageKey),
-      let layouts = try? JSONDecoder().decode([String: CanvasCardLayout].self, from: data)
-    {
-      self.cardLayouts = layouts
-    } else {
-      self.cardLayouts = [:]
+  var zOrder: [String] {
+    didSet { save() }
+  }
+
+  init(defaults: UserDefaults = .standard) {
+    self.defaults = defaults
+    let stored = Self.load(from: defaults)
+    cardLayouts = stored.cardLayouts
+    zOrder = stored.zOrder
+    initiallyLoadedCardKeys = Set(stored.cardLayouts.keys)
+  }
+
+  func shouldAutoArrangeOnInitialEntry(for cardKeys: [String]) -> Bool {
+    guard !cardKeys.isEmpty else { return false }
+    return !cardKeys.contains { initiallyLoadedCardKeys.contains($0) }
+  }
+
+  func setCardLayouts(_ layouts: [String: CanvasCardLayout], zOrder newZOrder: [String]? = nil) {
+    cardLayouts = layouts
+    zOrder = normalizedZOrder(newZOrder ?? zOrder, visibleKeys: Array(layouts.keys))
+  }
+
+  func ensureZOrder(for visibleKeys: [String]) {
+    zOrder = normalizedZOrder(zOrder, visibleKeys: visibleKeys)
+  }
+
+  func prune(to visibleKeys: Set<String>) {
+    cardLayouts = cardLayouts.filter { visibleKeys.contains($0.key) }
+    zOrder = zOrder.filter { visibleKeys.contains($0) }
+  }
+
+  func moveToFront(_ cardKey: String) {
+    guard cardLayouts[cardKey] != nil else { return }
+    zOrder.removeAll { $0 == cardKey }
+    zOrder.append(cardKey)
+  }
+
+  func zIndex(for cardKey: String) -> Double {
+    guard let index = zOrder.firstIndex(of: cardKey) else { return 0 }
+    return Double(index)
+  }
+
+  private static func load(from defaults: UserDefaults) -> CanvasLayoutStoragePayload {
+    guard let data = defaults.data(forKey: storageKey) else {
+      return CanvasLayoutStoragePayload(cardLayouts: [:], zOrder: [])
     }
+
+    if let payload = try? JSONDecoder().decode(CanvasLayoutStoragePayload.self, from: data) {
+      return CanvasLayoutStoragePayload(
+        cardLayouts: payload.cardLayouts,
+        zOrder: normalizedZOrder(payload.zOrder, visibleKeys: Array(payload.cardLayouts.keys))
+      )
+    }
+
+    if let layouts = try? JSONDecoder().decode([String: CanvasCardLayout].self, from: data) {
+      return CanvasLayoutStoragePayload(cardLayouts: layouts, zOrder: Array(layouts.keys).sorted())
+    }
+
+    return CanvasLayoutStoragePayload(cardLayouts: [:], zOrder: [])
   }
 
   private func save() {
-    if let data = try? JSONEncoder().encode(cardLayouts) {
-      UserDefaults.standard.set(data, forKey: Self.storageKey)
+    let payload = CanvasLayoutStoragePayload(
+      cardLayouts: cardLayouts,
+      zOrder: Self.normalizedZOrder(zOrder, visibleKeys: Array(cardLayouts.keys))
+    )
+    if let data = try? JSONEncoder().encode(payload) {
+      defaults.set(data, forKey: Self.storageKey)
     }
   }
+
+  private func normalizedZOrder(_ order: [String], visibleKeys: [String]) -> [String] {
+    Self.normalizedZOrder(order, visibleKeys: visibleKeys)
+  }
+
+  private static func normalizedZOrder(_ order: [String], visibleKeys: [String]) -> [String] {
+    let visibleKeySet = Set(visibleKeys)
+    var seen: Set<String> = []
+    var normalized: [String] = []
+    for key in order where visibleKeySet.contains(key) && seen.insert(key).inserted {
+      normalized.append(key)
+    }
+    for key in visibleKeys.sorted() where seen.insert(key).inserted {
+      normalized.append(key)
+    }
+    return normalized
+  }
+}
+
+private struct CanvasLayoutStoragePayload: Codable, Equatable {
+  var cardLayouts: [String: CanvasCardLayout]
+  var zOrder: [String]
 }

--- a/supacode/Features/Canvas/Views/CanvasView.swift
+++ b/supacode/Features/Canvas/Views/CanvasView.swift
@@ -24,6 +24,7 @@ struct CanvasView: View {
   @State private var lastTitleBarTapDate: Date = .distantPast
   @State private var activeResize: [TerminalTabID: ActiveResize] = [:]
   @State private var hasPerformedInitialFit = false
+  @State private var hasSeenCanvasCards = false
   @State private var viewportSize: CGSize = .zero
   @State private var showsCanvasHelp = false
   @State private var configReloadCounter = 0
@@ -59,15 +60,29 @@ struct CanvasView: View {
         // Background layer: handles canvas pan and tap-to-clear.
         Color.clear
           .onAppear {
+            if !allCardKeys.isEmpty {
+              hasSeenCanvasCards = true
+            }
             ensureLayouts(for: allCardKeys)
+            if !allCardKeys.isEmpty {
+              layoutStore.ensureZOrder(for: allCardKeys)
+            }
             pruneSelection(previousOrder: [], currentOrder: allTabIDs, states: activeStates)
             syncBroadcastCallbacks(states: activeStates)
           }
           .onChange(of: allCardKeys) { _, newKeys in
             if newKeys.isEmpty {
               CanvasLayoutStore.hasAutoArrangedInSession = false
+              if hasSeenCanvasCards {
+                layoutStore.prune(to: [])
+              }
+            } else {
+              hasSeenCanvasCards = true
             }
             ensureLayouts(for: newKeys)
+            if !newKeys.isEmpty {
+              layoutStore.ensureZOrder(for: newKeys)
+            }
             syncBroadcastCallbacks(states: activeStates)
           }
           .onChange(of: allTabIDs) { oldTabIDs, newTabIDs in
@@ -86,11 +101,14 @@ struct CanvasView: View {
         proxy.size
       } action: { newSize in
         viewportSize = newSize
-        if !hasPerformedInitialFit {
+        let currentCardKeys = collectCardKeys(from: terminalManager.activeWorktreeStates)
+        if !hasPerformedInitialFit, !currentCardKeys.isEmpty {
           hasPerformedInitialFit = true
           if !CanvasLayoutStore.hasAutoArrangedInSession {
             CanvasLayoutStore.hasAutoArrangedInSession = true
-            arrangeCards()
+            if layoutStore.shouldAutoArrangeOnInitialEntry(for: currentCardKeys) {
+              arrangeCards()
+            }
           }
           fitToView(canvasSize: newSize)
         }
@@ -233,7 +251,7 @@ struct CanvasView: View {
       x: screenCenter.x - resized.size.width / 2,
       y: screenCenter.y - cardTotalHeight / 2
     )
-    .zIndex(zIndex(for: tab.id))
+    .zIndex(zIndex(for: tab.id, cardKey: cardKey))
   }
 
   // MARK: - Canvas Gestures
@@ -301,7 +319,7 @@ struct CanvasView: View {
         position: gridPosition(index: positionedCount + offset, columns: columns)
       )
     }
-    layoutStore.cardLayouts = layouts
+    layoutStore.setCardLayouts(layouts)
   }
 
   /// Balanced grid: columns ≈ sqrt(N). No viewport constraint — the canvas
@@ -392,7 +410,7 @@ struct CanvasView: View {
         position: gridPosition(index: index, columns: columns)
       )
     }
-    layoutStore.cardLayouts = layouts
+    layoutStore.setCardLayouts(layouts, zOrder: keys)
   }
 
   /// Arrange cards using MaxRects-BSSF bin packing. Preserves each card's
@@ -412,7 +430,7 @@ struct CanvasView: View {
     let result = packer.pack(cards: cards, targetRatio: targetRatio)
 
     guard !result.layouts.isEmpty else { return }
-    layoutStore.cardLayouts = result.layouts
+    layoutStore.setCardLayouts(result.layouts, zOrder: keys)
   }
 
   /// Adjust scale and offset so all cards fit within the viewport.
@@ -460,13 +478,8 @@ struct CanvasView: View {
   /// Remove stored layouts for tabs that no longer exist.
   private func cleanStaleLayouts() {
     let visibleKeys = Set(collectCardKeys(from: terminalManager.activeWorktreeStates))
-    let staleKeys = layoutStore.cardLayouts.keys.filter { !visibleKeys.contains($0) }
-    guard !staleKeys.isEmpty else { return }
-    var layouts = layoutStore.cardLayouts
-    for key in staleKeys {
-      layouts.removeValue(forKey: key)
-    }
-    layoutStore.cardLayouts = layouts
+    guard !visibleKeys.isEmpty || hasSeenCanvasCards else { return }
+    layoutStore.prune(to: visibleKeys)
   }
 
   private var canvasHelpButton: some View {
@@ -580,14 +593,15 @@ struct CanvasView: View {
     .padding()
   }
 
-  private func zIndex(for tabID: TerminalTabID) -> Double {
+  private func zIndex(for tabID: TerminalTabID, cardKey: String) -> Double {
+    let base = layoutStore.zIndex(for: cardKey)
     if selectionState.primaryTabID == tabID {
-      return 2
+      return 10_000 + base
     }
     if selectionState.selectedTabIDs.contains(tabID) {
-      return 1
+      return 9_000 + base
     }
-    return 0
+    return base
   }
 
   // MARK: - Drag
@@ -633,6 +647,7 @@ struct CanvasView: View {
     surfaceState _: WorktreeTerminalState,
     states: [WorktreeTerminalState]
   ) {
+    layoutStore.moveToFront(tabID.rawValue.uuidString)
     mutateSelection(states: states) { state in
       state.focusSingle(tabID)
     }
@@ -700,6 +715,7 @@ struct CanvasView: View {
       return
     }
 
+    layoutStore.moveToFront(newTabID.rawValue.uuidString)
     ownerState.tabManager.selectTab(newTabID)
     terminalManager.canvasFocusedWorktreeID = ownerState.worktreeID
     surfaceView.focusDidChange(true)

--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
@@ -1041,6 +1041,11 @@ final class GhosttySurfaceView: NSView, Identifiable {
     bridge.surface = surface
     occlusionState.reset()
     lastSurfaceFocus = nil
+    // A freshly created Ghostty surface defaults to focused (blinking cursor).
+    // Sync it to our Swift-side `focused` flag so background/restored surfaces
+    // that were never explicitly focused don't blink. `focusDidChange(false)`
+    // would no-op here (self.focused already false), so push the state directly.
+    setSurfaceFocus(focused)
     updateSurfaceSize()
   }
 

--- a/supacodeTests/CanvasLayoutStoreTests.swift
+++ b/supacodeTests/CanvasLayoutStoreTests.swift
@@ -1,0 +1,88 @@
+import CoreGraphics
+import Foundation
+import Testing
+
+@testable import supacode
+
+@MainActor
+struct CanvasLayoutStoreTests {
+  @Test func loadsLegacyCardLayoutDictionary() throws {
+    let defaults = makeDefaults()
+    defer { defaults.removePersistentDomain(forName: defaultsSuiteName(defaults)) }
+    let legacyLayouts = [
+      "tab-a": CanvasCardLayout(position: CGPoint(x: 10, y: 20), size: CGSize(width: 300, height: 200)),
+      "tab-b": CanvasCardLayout(position: CGPoint(x: 30, y: 40), size: CGSize(width: 500, height: 400)),
+    ]
+    let data = try JSONEncoder().encode(legacyLayouts)
+    defaults.set(data, forKey: "canvasCardLayouts")
+
+    let store = CanvasLayoutStore(defaults: defaults)
+
+    #expect(store.cardLayouts == legacyLayouts)
+    #expect(Set(store.zOrder) == Set(legacyLayouts.keys))
+    #expect(store.shouldAutoArrangeOnInitialEntry(for: ["tab-a", "tab-b"]) == false)
+  }
+
+  @Test func skipsInitialAutoArrangeWhenCurrentCardsWereLoadedFromStorage() throws {
+    let defaults = makeDefaults()
+    defer { defaults.removePersistentDomain(forName: defaultsSuiteName(defaults)) }
+    let store = CanvasLayoutStore(defaults: defaults)
+    store.setCardLayouts([
+      "tab-a": CanvasCardLayout(position: CGPoint(x: 10, y: 20)),
+      "tab-b": CanvasCardLayout(position: CGPoint(x: 30, y: 40)),
+    ])
+
+    let restoredStore = CanvasLayoutStore(defaults: defaults)
+
+    #expect(restoredStore.shouldAutoArrangeOnInitialEntry(for: ["tab-a", "tab-b"]) == false)
+    #expect(restoredStore.shouldAutoArrangeOnInitialEntry(for: ["tab-c", "tab-d"]))
+  }
+
+  @Test func moveToFrontPersistsZOrder() {
+    let defaults = makeDefaults()
+    defer { defaults.removePersistentDomain(forName: defaultsSuiteName(defaults)) }
+    let store = CanvasLayoutStore(defaults: defaults)
+    store.setCardLayouts(
+      [
+        "tab-a": CanvasCardLayout(position: .zero),
+        "tab-b": CanvasCardLayout(position: .zero),
+      ],
+      zOrder: ["tab-a", "tab-b"]
+    )
+
+    store.moveToFront("tab-a")
+    let restoredStore = CanvasLayoutStore(defaults: defaults)
+
+    #expect(restoredStore.zOrder == ["tab-b", "tab-a"])
+    #expect(restoredStore.zIndex(for: "tab-a") > restoredStore.zIndex(for: "tab-b"))
+  }
+
+  @Test func pruneRemovesStaleLayoutsAndZOrder() {
+    let defaults = makeDefaults()
+    defer { defaults.removePersistentDomain(forName: defaultsSuiteName(defaults)) }
+    let store = CanvasLayoutStore(defaults: defaults)
+    store.setCardLayouts(
+      [
+        "tab-a": CanvasCardLayout(position: .zero),
+        "tab-b": CanvasCardLayout(position: .zero),
+      ],
+      zOrder: ["tab-a", "tab-b"]
+    )
+
+    store.prune(to: ["tab-b"])
+
+    #expect(Array(store.cardLayouts.keys) == ["tab-b"])
+    #expect(store.zOrder == ["tab-b"])
+  }
+}
+
+private func makeDefaults() -> UserDefaults {
+  let suiteName = "CanvasLayoutStoreTests-\(UUID().uuidString)"
+  let defaults = UserDefaults(suiteName: suiteName)!
+  defaults.set(suiteName, forKey: "__suiteName")
+  return defaults
+}
+
+private func defaultsSuiteName(_ defaults: UserDefaults) -> String {
+  defaults.string(forKey: "__suiteName")!
+}


### PR DESCRIPTION
## Summary

- preserve saved Canvas card positions on first Canvas entry after launch instead of auto-arranging over restored layouts
- persist Canvas card z-order and bring focused cards to the front
- migrate the previous `UserDefaults` layout dictionary format and add focused `CanvasLayoutStore` coverage

Fixes #328

## Validation

- `make check`
- `xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -only-testing:supacodeTests/CanvasLayoutStoreTests -only-testing:supacodeTests/CanvasCardPackerTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation`
- `make build-app`
