### PR TITLE
Major UI Enhancements

### DIFF
--- a/supacode/Features/ActiveAgents/Views/ActiveAgentRow.swift
+++ b/supacode/Features/ActiveAgents/Views/ActiveAgentRow.swift
@@ -78,32 +78,55 @@ struct ActiveAgentRow: View {
 }
 
 struct BaguaWorkingIndicator: View {
-  static let frames = ["☰", "☱", "☲", "☳", "☴", "☵", "☶", "☷"]
-  static let frameDuration = 0.12
+  static let cycleDuration: Double = 1.0
+
+  static let perimeter: [(row: Int, col: Int)] = [
+    (0, 0), (0, 1), (0, 2),
+    (1, 2),
+    (2, 2), (2, 1), (2, 0),
+    (1, 0),
+  ]
 
   var body: some View {
-    TimelineView(.periodic(from: .now, by: Self.frameDuration)) { context in
-      frameText(Self.frame(at: context.date))
+    TimelineView(.animation) { context in
+      let elapsed = context.date.timeIntervalSinceReferenceDate
+      let phase =
+        (elapsed / Self.cycleDuration).truncatingRemainder(dividingBy: 1)
+        * Double(Self.perimeter.count)
+
+      VStack(spacing: 2) {
+        ForEach(0..<3, id: \.self) { row in
+          HStack(spacing: 2) {
+            ForEach(0..<3, id: \.self) { col in
+              dot(opacity: opacity(row: row, col: col, phase: phase))
+            }
+          }
+        }
+      }
+      .frame(width: 20, height: 18)
+      .accessibilityHidden(true)
     }
   }
 
-  static func frame(at date: Date) -> String {
-    frames[frameIndex(at: date)]
+  private func opacity(row: Int, col: Int, phase: Double) -> Double {
+    if row == 1 && col == 1 { return 0.18 }
+    guard
+      let index = Self.perimeter.firstIndex(where: { $0.row == row && $0.col == col })
+    else {
+      return 0.18
+    }
+    let count = Double(Self.perimeter.count)
+    let raw = abs(Double(index) - phase)
+    let distance = min(raw, count - raw)
+    let intensity = max(0, 1 - distance / 3)
+    return 0.18 + intensity * 0.82
   }
 
-  static func frameIndex(at date: Date) -> Int {
-    let tick = Int(date.timeIntervalSinceReferenceDate / frameDuration)
-    let cycleLength = (frames.count * 2) - 2
-    let cycleIndex = ((tick % cycleLength) + cycleLength) % cycleLength
-    return cycleIndex < frames.count ? cycleIndex : cycleLength - cycleIndex
-  }
-
-  private func frameText(_ frame: String) -> some View {
-    Text(frame)
-      .font(.system(size: 17, weight: .bold, design: .monospaced))
-      .lineLimit(1)
-      .frame(width: 20, height: 18)
-      .accessibilityHidden(true)
+  private func dot(opacity: Double) -> some View {
+    Circle()
+      .fill(.foreground)
+      .frame(width: 4, height: 4)
+      .opacity(opacity)
   }
 }
 
@@ -133,4 +156,10 @@ extension AgentDisplayState {
       return .secondary
     }
   }
+}
+
+#Preview {
+  BaguaWorkingIndicator()
+    .foregroundStyle(.orange)
+    .frame(width: 100, height: 100)
 }

--- a/supacode/Features/ActiveAgents/Views/ActiveAgentsPanel.swift
+++ b/supacode/Features/ActiveAgents/Views/ActiveAgentsPanel.swift
@@ -13,6 +13,7 @@ struct ActiveAgentsPanel: View {
   let onHeightChanged: (Double) -> Void
   let onHeightChangeEnded: (Double) -> Void
   @State private var dragStartHeight: Double?
+  @State private var dragIndicatorPillOpacity: CGFloat = 0.4
 
   var body: some View {
     VStack(spacing: 0) {
@@ -61,10 +62,6 @@ struct ActiveAgentsPanel: View {
         .fill(.thinMaterial)
     }
     .clipShape(panelBackgroundShape)
-    .overlay {
-      panelBackgroundShape
-        .stroke(.separator.opacity(0.7), lineWidth: 1)
-    }
   }
 
   private var resizeHandle: some View {
@@ -73,10 +70,10 @@ struct ActiveAgentsPanel: View {
       .frame(height: 1)
       .frame(maxWidth: .infinity)
       .overlay(alignment: .top) {
-        Rectangle()
-          .fill(.separator.opacity(0.7))
-          .frame(height: 1)
-          .padding(.horizontal, 8)
+        Capsule()
+          .fill(.separator.opacity(dragIndicatorPillOpacity))
+          .frame(width: 32, height: 4)
+          .padding(.vertical, 4)
       }
       .overlay {
         Rectangle()
@@ -90,12 +87,14 @@ struct ActiveAgentsPanel: View {
             let start = dragStartHeight ?? height
             dragStartHeight = start
             onHeightChanged(clampedHeight(start - value.translation.height))
+            dragIndicatorPillOpacity = 0.8
           }
           .onEnded { value in
             let start = dragStartHeight ?? height
             let height = clampedHeight(start - value.translation.height)
             dragStartHeight = nil
             onHeightChangeEnded(height)
+            dragIndicatorPillOpacity = 0.4
           }
       )
       .onHover { hovering in
@@ -135,15 +134,7 @@ struct ActiveAgentsPanel: View {
     return trimmed.isEmpty ? "Untitled tab" : trimmed
   }
 
-  private var panelBackgroundShape: UnevenRoundedRectangle {
-    UnevenRoundedRectangle(
-      cornerRadii: .init(
-        topLeading: 8,
-        bottomLeading: 0,
-        bottomTrailing: 0,
-        topTrailing: 8
-      ),
-      style: .continuous
-    )
+  private var panelBackgroundShape: RoundedRectangle {
+    RoundedRectangle(cornerRadius: 14)
   }
 }

--- a/supacode/Features/CommandPalette/Views/CommandPaletteOverlayView.swift
+++ b/supacode/Features/CommandPalette/Views/CommandPaletteOverlayView.swift
@@ -230,20 +230,7 @@ private struct CommandPaletteCard: View {
       }
     }
     .frame(maxWidth: 500)
-    .background(
-      ZStack {
-        Rectangle().fill(.ultraThinMaterial)
-        Rectangle()
-          .fill(backgroundColor)
-          .blendMode(.color)
-      }
-      .compositingGroup()
-    )
-    .clipShape(RoundedRectangle(cornerRadius: 10))
-    .overlay(
-      RoundedRectangle(cornerRadius: 10)
-        .stroke(Color(nsColor: .tertiaryLabelColor).opacity(0.75))
-    )
+    .glassEffect(.regular, in: RoundedRectangle(cornerRadius: 14))
     .shadow(radius: 32, x: 0, y: 12)
     .padding(Self.padding)
     .environment(\.colorScheme, colorScheme)
@@ -696,9 +683,8 @@ private struct CommandPaletteRowView: View {
         }
       }
       .padding(8)
-      .contentShape(Rectangle())
       .background(rowBackground)
-      .clipShape(.rect(cornerRadius: 5))
+      .clipShape(.rect(cornerRadius: 14))
     }
     .buttonStyle(.plain)
     .help(helpText)
@@ -712,7 +698,7 @@ private struct CommandPaletteRowView: View {
       if isSelected {
         Color(nsColor: .selectedContentBackgroundColor)
       } else if hoveredID == row.id {
-        Color(nsColor: .unemphasizedSelectedContentBackgroundColor)
+        Color(nsColor: .unemphasizedSelectedContentBackgroundColor).opacity(0.7)
       } else {
         Color.clear
       }

--- a/supacode/Features/Repositories/Models/TopSegment.swift
+++ b/supacode/Features/Repositories/Models/TopSegment.swift
@@ -1,0 +1,5 @@
+enum TopSegment: Hashable {
+  case tabbed
+  case canvas
+  case shelf
+}

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -304,6 +304,9 @@ struct RepositoriesFeature {
     case codeHostsDetected([Repository.ID: CodeHost])
     case selectArchivedWorktrees
     case selectCanvas
+    case selectShelf
+    case selectTabbed
+    case setTopSegment(TopSegment)
     case toggleCanvas
     case toggleShelf
     case selectNextShelfBook
@@ -744,6 +747,29 @@ struct RepositoriesFeature {
           state.sidebarSelectedWorktreeIDs = []
           return .run { _ in
             await terminalClient.send(.setCanvasMode(true))
+          }
+
+        case .selectShelf:
+          guard !state.isShelfActive else { return .none }
+          return .send(.toggleShelf)
+
+        case .selectTabbed:
+          if state.isShowingCanvas {
+            return .send(.toggleCanvas)
+          }
+          if state.isShowingShelf {
+            return .send(.toggleShelf)
+          }
+          return .none
+
+        case .setTopSegment(let segment):
+          switch segment {
+          case .tabbed:
+            return .send(.selectTabbed)
+          case .canvas:
+            return .send(.selectCanvas)
+          case .shelf:
+            return .send(.selectShelf)
           }
 
         case .toggleCanvas:
@@ -1681,6 +1707,12 @@ extension RepositoriesFeature.State {
 
   var isShowingShelf: Bool {
     isShelfActive
+  }
+
+  var topSegment: TopSegment {
+    if isShowingCanvas { return .canvas }
+    if isShowingShelf { return .shelf }
+    return .tabbed
   }
 
   private var canUseWorktreeHistory: Bool {

--- a/supacode/Features/Repositories/Views/RepositorySectionView.swift
+++ b/supacode/Features/Repositories/Views/RepositorySectionView.swift
@@ -86,13 +86,6 @@ struct RepositorySectionView: View {
             }
           }
       }
-      if let color = appearance.color {
-        Circle()
-          .fill(color.color)
-          .frame(width: 8, height: 8)
-          .help(color.displayName)
-          .accessibilityLabel(Text("Repo color: \(color.displayName)"))
-      }
       if isHovering {
         Menu {
           Button("Repo Settings") {
@@ -178,6 +171,13 @@ struct RepositorySectionView: View {
           .foregroundStyle(.secondary)
           .help(isExpanded ? "Collapse" : "Expand")
         }
+      }
+      if let color = appearance.color {
+        Circle()
+          .glassEffect(.regular.tint(color.color))
+          .frame(width: 8, height: 8)
+          .help(color.displayName)
+          .accessibilityLabel(Text("Repo color: \(color.displayName)"))
       }
     }
     .frame(maxWidth: .infinity, minHeight: headerCellHeight, maxHeight: .infinity, alignment: .center)

--- a/supacode/Features/Repositories/Views/SidebarFooterView.swift
+++ b/supacode/Features/Repositories/Views/SidebarFooterView.swift
@@ -94,16 +94,6 @@ struct SidebarFooterView: View {
     .padding(.horizontal, 12)
     .padding(.vertical, 8)
     .frame(maxWidth: .infinity, alignment: .leading)
-    .background {
-      if surfaceBottomChromeBackgroundOpacity < 1 {
-        Rectangle().fill(.regularMaterial)
-      } else {
-        Color(nsColor: .windowBackgroundColor)
-      }
-    }
-    .overlay(alignment: .top) {
-      Divider()
-    }
   }
 
   static func activeAgentsPanelIconName(isPanelHidden: Bool) -> String {

--- a/supacode/Features/Repositories/Views/SidebarListView.swift
+++ b/supacode/Features/Repositories/Views/SidebarListView.swift
@@ -5,33 +5,6 @@ import SwiftUI
 // Uses LazyVStack rather than List for repository drag precision; keyboard
 // worktree navigation goes through Cmd+Ctrl+↑/↓ (`selectNextWorktree`).
 struct SidebarListView: View {
-  enum RepositoryListHeaderAction: Equatable {
-    case expandAll
-    case collapseAll
-
-    var title: String {
-      switch self {
-      case .expandAll:
-        return "Expand All"
-      case .collapseAll:
-        return "Collapse All"
-      }
-    }
-
-    var systemImageName: String {
-      "chevron.right"
-    }
-
-    var rotation: Angle {
-      switch self {
-      case .expandAll:
-        return .zero
-      case .collapseAll:
-        return .degrees(90)
-      }
-    }
-  }
-
   @Bindable var store: StoreOf<RepositoriesFeature>
   @Binding var expandedRepoIDs: Set<Repository.ID>
   @Binding var sidebarSelections: Set<SidebarSelection>
@@ -48,18 +21,7 @@ struct SidebarListView: View {
     let state = store.state
     let hotkeyRows = state.orderedWorktreeRows(includingRepositoryIDs: expandedRepoIDs)
     let presentation = state.sidebarPresentation(expandedRepositoryIDs: expandedRepoIDs)
-    let expandableRepositoryIDs = Self.expandableRepositoryIDs(in: state.repositories)
-    let repositoryListHeaderAction = Self.repositoryListHeaderAction(
-      expandedRepoIDs: expandedRepoIDs,
-      expandableRepositoryIDs: expandableRepositoryIDs
-    )
     let repositoryItems = presentation.items.filter(\.isRepositoryOrderItem)
-    let showsRepositoryListHeader = presentation.items.contains { item in
-      if case .listHeader = item {
-        return true
-      }
-      return false
-    }
     let selectedWorktreeIDs = Self.selectedWorktreeIDs(in: state)
     let selectedSurfaceID = state.selectedWorktreeID.flatMap { worktreeID in
       terminalManager.stateIfExists(for: worktreeID)?.activeSurfaceID
@@ -82,26 +44,31 @@ struct SidebarListView: View {
 
     ScrollViewReader { scrollProxy in
       ScrollView {
-        LazyVStack(spacing: 0) {
-          if showsRepositoryListHeader {
-            repositoryListHeader(
-              action: repositoryListHeaderAction,
-              expandableRepositoryIDs: expandableRepositoryIDs
-            )
-          }
-
-          if repositoryItems.isEmpty {
-            emptyRepositoryHint()
-          }
-
-          ForEach(Array(repositoryItems.enumerated()), id: \.element.id) { index, item in
-            repositoryItemView(
-              item,
-              index: index,
-              repositoryOrderIDs: presentation.repositoryOrderIDs,
-              hotkeyRows: hotkeyRows,
-              selectedWorktreeIDs: selectedWorktreeIDs
-            )
+        LazyVStack(spacing: 0, pinnedViews: .sectionHeaders) {
+          Section {
+            if repositoryItems.isEmpty {
+              emptyRepositoryHint()
+            }
+            ForEach(Array(repositoryItems.enumerated()), id: \.element.id) { index, item in
+              repositoryItemView(
+                item,
+                index: index,
+                repositoryOrderIDs: presentation.repositoryOrderIDs,
+                hotkeyRows: hotkeyRows,
+                selectedWorktreeIDs: selectedWorktreeIDs
+              )
+            }
+          } header: {
+            Picker("", selection: $store.topSegment.sending(\.setTopSegment)) {
+              Text("Tabbed").tag(TopSegment.tabbed)
+              Text("Canvas").tag(TopSegment.canvas)
+              Text("Shelf").tag(TopSegment.shelf)
+            }
+            .pickerStyle(.segmented)
+            .controlSize(.large)
+            .labelsHidden()
+            .padding(.horizontal)
+            .padding(.vertical, 4)
           }
         }
         .padding(.vertical, 2)
@@ -109,7 +76,6 @@ struct SidebarListView: View {
       }
       .scrollIndicators(.never)
       .frame(minWidth: 220)
-      .background(.bar)
       .clipped()
       .onGeometryChange(for: Double.self) { proxy in
         Double(proxy.size.height)
@@ -125,24 +91,6 @@ struct SidebarListView: View {
           endSidebarDrag()
         }
       }
-      .safeAreaInset(edge: .top, spacing: 0) {
-        HStack(spacing: 4) {
-          CanvasSidebarButton(
-            store: store,
-            isSelected: state.isShowingCanvas
-          )
-          ShelfSidebarButton(
-            store: store,
-            isSelected: state.isShowingShelf
-          )
-        }
-        .padding(.top, 4)
-        .padding(.horizontal, 4)
-        .background(.bar)
-        .overlay(alignment: .bottom) {
-          Divider()
-        }
-      }
       .safeAreaInset(edge: .bottom, spacing: 0) {
         SidebarFooterView(store: store)
           .onGeometryChange(for: Double.self) { proxy in
@@ -150,29 +98,28 @@ struct SidebarListView: View {
           } action: { newHeight in
             sidebarFooterHeight = newHeight
           }
+          .padding(.vertical, 4)
       }
       .overlay(alignment: .bottom) {
-        ZStack(alignment: .bottom) {
-          ActiveAgentsPanel(
-            store: store.scope(state: \.activeAgents, action: \.activeAgents),
-            repositoryNamesByWorktreeID: agentWorktreeMetadata.repositoryNamesByWorktreeID,
-            branchNamesByWorktreeID: agentWorktreeMetadata.branchNamesByWorktreeID,
-            repositoryColorsByWorktreeID: agentWorktreeMetadata.repositoryColorsByWorktreeID,
-            selectedSurfaceID: selectedSurfaceID,
-            height: panelHeight,
-            maximumHeight: maximumPanelHeight,
-            onHeightChanged: { height in
-              resizingPanelHeight = height
-            },
-            onHeightChangeEnded: { height in
-              resizingPanelHeight = nil
-              store.send(.activeAgents(.panelHeightChanged(height)))
-            }
-          )
-          .frame(height: panelHeight)
-          .offset(y: panelOffset)
-        }
+        ActiveAgentsPanel(
+          store: store.scope(state: \.activeAgents, action: \.activeAgents),
+          repositoryNamesByWorktreeID: agentWorktreeMetadata.repositoryNamesByWorktreeID,
+          branchNamesByWorktreeID: agentWorktreeMetadata.branchNamesByWorktreeID,
+          repositoryColorsByWorktreeID: agentWorktreeMetadata.repositoryColorsByWorktreeID,
+          selectedSurfaceID: selectedSurfaceID,
+          height: panelHeight,
+          maximumHeight: maximumPanelHeight,
+          onHeightChanged: { height in
+            resizingPanelHeight = height
+          },
+          onHeightChangeEnded: { height in
+            resizingPanelHeight = nil
+            store.send(.activeAgents(.panelHeightChanged(height)))
+          }
+        )
+        .padding(8)
         .frame(height: panelHeight)
+        .offset(y: panelOffset)
         .clipped()
         .padding(.bottom, sidebarFooterHeight)
         .allowsHitTesting(!state.activeAgents.isPanelHidden)
@@ -190,6 +137,16 @@ struct SidebarListView: View {
       .task(id: pendingSidebarReveal?.id) {
         await revealPendingSidebarWorktree(pendingSidebarReveal, with: scrollProxy)
       }
+      .toolbar {
+        ToolbarItem(placement: .automatic) {
+          Button {
+            store.send(.setOpenPanelPresented(true))
+          } label: {
+            Label("Add Repository", systemImage: "folder.badge.plus")
+          }
+          .help("Add Repository")
+        }
+      }
     }  // ScrollViewReader
   }
 
@@ -204,55 +161,6 @@ struct SidebarListView: View {
         }
       }
     }
-  }
-
-  private func repositoryListHeader(
-    action: RepositoryListHeaderAction,
-    expandableRepositoryIDs: Set<Repository.ID>
-  ) -> some View {
-    HStack(spacing: 4) {
-      Text("Repositories")
-        .font(.caption)
-        .foregroundStyle(.tertiary)
-        .frame(maxWidth: .infinity, alignment: .leading)
-      Button {
-        store.send(.setOpenPanelPresented(true))
-      } label: {
-        Label("Add Repository", systemImage: "plus")
-          .labelStyle(.iconOnly)
-          .frame(width: 20, height: 20)
-          .contentShape(.rect)
-      }
-      .buttonStyle(.plain)
-      .foregroundStyle(.secondary)
-      .help("Add Repository")
-      if !expandableRepositoryIDs.isEmpty {
-        Button {
-          withAnimation(.easeOut(duration: 0.2)) {
-            switch action {
-            case .expandAll:
-              expandedRepoIDs.formUnion(expandableRepositoryIDs)
-            case .collapseAll:
-              expandedRepoIDs.subtract(expandableRepositoryIDs)
-            }
-          }
-        } label: {
-          Label(action.title, systemImage: action.systemImageName)
-            .labelStyle(.iconOnly)
-            .frame(width: 20, height: 20)
-            .rotationEffect(action.rotation)
-            .contentShape(.rect)
-        }
-        .buttonStyle(.plain)
-        .foregroundStyle(.secondary)
-        .help(action.title)
-      }
-    }
-    .frame(maxWidth: .infinity, minHeight: 26, alignment: .center)
-    .padding(.leading, 12)
-    .padding(.trailing, 7)
-    .padding(.top, 2)
-    .padding(.bottom, 4)
   }
 
   private func emptyRepositoryHint() -> some View {
@@ -409,29 +317,6 @@ struct SidebarListView: View {
       scrollProxy.scrollTo(SidebarScrollID.worktree(pendingSidebarReveal.worktreeID), anchor: .center)
     }
     store.send(.consumePendingSidebarReveal(pendingSidebarReveal.id))
-  }
-
-  static func expandableRepositoryIDs<Repositories: Sequence>(
-    in repositories: Repositories
-  ) -> Set<Repository.ID> where Repositories.Element == Repository {
-    Set(
-      repositories
-        .filter(\.capabilities.supportsWorktrees)
-        .map(\.id)
-    )
-  }
-
-  static func repositoryListHeaderAction(
-    expandedRepoIDs: Set<Repository.ID>,
-    expandableRepositoryIDs: Set<Repository.ID>
-  ) -> RepositoryListHeaderAction {
-    !expandedRepoIDs.isDisjoint(with: expandableRepositoryIDs)
-      ? .collapseAll
-      : .expandAll
-  }
-
-  static func showsRepositoryListHeader(repositoryCount: Int) -> Bool {
-    SidebarPresentation.showsListHeader(repositoryCount: repositoryCount)
   }
 
   static func selectedWorktreeIDs(in state: RepositoriesFeature.State) -> Set<Worktree.ID> {

--- a/supacode/Features/Repositories/Views/WorktreeDetailView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailView.swift
@@ -64,6 +64,7 @@ struct WorktreeDetailView: View {
     )
     .navigationTitle(WindowTitle.compute(repositories: repositories, terminalManager: terminalManager))
     .toolbar(removing: repositories.isShowingCanvas ? nil : .title)
+    .toolbarBackgroundVisibility(.hidden, for: .windowToolbar)
     .toolbar {
       if repositories.isShowingCanvas {
         canvasToolbarContent(

--- a/supacode/Features/Repositories/Views/WorktreeRow.swift
+++ b/supacode/Features/Repositories/Views/WorktreeRow.swift
@@ -338,7 +338,7 @@ private struct WorktreeRowChangeCountView: View {
     .padding(.vertical, 0)
     .fixedSize(horizontal: true, vertical: false)
     .overlay {
-      RoundedRectangle(cornerRadius: 4, style: .continuous)
+      Capsule()
         .stroke(isSelected ? AnyShapeStyle(.secondary.opacity(0.3)) : AnyShapeStyle(.tertiary), lineWidth: 1)
     }
     .monospacedDigit()

--- a/supacode/Features/Repositories/Views/WorktreeRowsView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeRowsView.swift
@@ -367,18 +367,19 @@ struct WorktreeRowsView: View {
     .padding(.trailing, 8)
     .background {
       if isSelected {
-        RoundedRectangle(cornerRadius: 5)
+        RoundedRectangle(cornerRadius: 8)
           .fill(Color.accentColor.opacity(0.18))
           .padding(.horizontal, 6)
       }
     }
     .overlay {
       if showsContextMenuHighlight {
-        RoundedRectangle(cornerRadius: 5)
-          .stroke(Color.accentColor, lineWidth: 2)
+        RoundedRectangle(cornerRadius: 8)
+          .stroke(Color.accentColor, lineWidth: 1)
           .padding(.horizontal, 6)
       }
     }
+    .padding(.vertical, 2)
     .transition(.opacity)
     .moveDisabled(config.moveDisabled)
   }

--- a/supacode/Features/Shelf/Views/ShelfSpineView.swift
+++ b/supacode/Features/Shelf/Views/ShelfSpineView.swift
@@ -68,6 +68,7 @@ struct ShelfSpineView: View {
       // if/else did). Fill is derived from a stepped accent-alpha ladder
       // so the open book glows strongest and neighbors fade outward.
       Rectangle().fill(spineBackgroundColor)
+        .ignoresSafeArea(edges: .all)
     )
     // Whole-spine tap target. Inner Buttons (header, tab slots, controls)
     // absorb their own clicks; clicks that fall on empty areas (scroll

--- a/supacode/Features/Terminal/TabBar/TerminalTabBarMetrics.swift
+++ b/supacode/Features/Terminal/TabBar/TerminalTabBarMetrics.swift
@@ -1,13 +1,13 @@
 import CoreGraphics
 
 enum TerminalTabBarMetrics {
-  static let barHeight: CGFloat = 33
+  static let barHeight: CGFloat = 34
   static let barPadding: CGFloat = 0
   static let tabHeight: CGFloat = 32
   static let tabMinWidth: CGFloat = 140
   static let tabMaxWidth: CGFloat = 220
-  static let tabCornerRadius: CGFloat = 0
-  static let tabSpacing: CGFloat = 0
+  static let tabCornerRadius: CGFloat = 4
+  static let tabSpacing: CGFloat = 2
   static let tabHorizontalPadding: CGFloat = 12
   static let contentSpacing: CGFloat = 6
   static let contentTrailingSpacing: CGFloat = 4

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabBarTrailingAccessories.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabBarTrailingAccessories.swift
@@ -35,8 +35,10 @@ struct TerminalTabBarTrailingAccessories: View {
       )
       .disabled(!canSplit)
     }
-    .frame(height: TerminalTabBarMetrics.barHeight)
-    .padding(.trailing, 8)
+    .frame(height: TerminalTabBarMetrics.barHeight - 4)
+    .padding(.horizontal, 8)
+    .glassEffect(.regular, in: Capsule())
+    .padding(.vertical, 2)
   }
 
   private var newTabButton: some View {

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabBarView.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabBarView.swift
@@ -37,8 +37,8 @@ struct TerminalTabBarView: View {
       )
     }
     .frame(height: TerminalTabBarMetrics.barHeight)
-    .background(TerminalTabBarBackground())
     .saturation(activeState == .inactive ? 0 : 1)
+    .padding(.horizontal, 4)
     .clipped()
   }
 }

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabLabelView.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabLabelView.swift
@@ -13,6 +13,7 @@ struct TerminalTabLabelView: View {
       if tab.isDirty || tab.icon != nil {
         TerminalTabIconBadge(tab: tab, isActive: isActive)
       }
+      Spacer(minLength: TerminalTabBarMetrics.contentTrailingSpacing)
       Text(tab.displayTitle)
         .font(.caption)
         .lineLimit(1)

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabView.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabView.swift
@@ -119,8 +119,9 @@ struct TerminalTabView: View {
     }
     .padding(.bottom, isActive ? TerminalTabBarMetrics.activeTabBottomPadding : 0)
     .offset(y: isActive ? TerminalTabBarMetrics.activeTabOffset : 0)
-    .clipShape(.rect(cornerRadius: TerminalTabBarMetrics.tabCornerRadius))
-    .contentShape(.rect)
+    .clipShape(.capsule)
+    .contentShape(.capsule)
+    .glassEffect()
     .onHover { hovering in
       isHovering = hovering
     }

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabsRowView.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabsRowView.swift
@@ -76,10 +76,6 @@ struct TerminalTabsRowView: View {
               )
             )
             .id(id)
-
-            if index < openedTabs.count - 1 {
-              TerminalTabDivider()
-            }
           }
         }
       }

--- a/supacode/Features/Terminal/Views/GhosttySurfaceSearchOverlay.swift
+++ b/supacode/Features/Terminal/Views/GhosttySurfaceSearchOverlay.swift
@@ -41,7 +41,7 @@ struct GhosttySurfaceSearchOverlay: View {
           .padding(.trailing, 50)
           .padding(.vertical, 6)
           .background(Color.primary.opacity(0.1))
-          .clipShape(.rect(cornerRadius: 6))
+          .clipShape(.capsule)
           .overlay(alignment: .trailing) {
             matchLabel
           }
@@ -81,7 +81,7 @@ struct GhosttySurfaceSearchOverlay: View {
         }
         .padding(8)
         .background(.background)
-        .clipShape(GhosttySearchOverlayShape())
+        .clipShape(.capsule)
         .shadow(radius: 4)
         .background(
           GeometryReader { barGeo in
@@ -249,10 +249,7 @@ private enum GhosttySearchCorner {
 
 private struct GhosttySearchOverlayShape: Shape {
   func path(in rect: CGRect) -> Path {
-    if #available(macOS 26.0, *) {
-      return ConcentricRectangle(corners: .concentric(minimum: 8), isUniform: true).path(in: rect)
-    }
-    return RoundedRectangle(cornerRadius: 8).path(in: rect)
+    ConcentricRectangle(corners: .concentric(minimum: 8), isUniform: true).path(in: rect)
   }
 }
 
@@ -262,16 +259,8 @@ private struct SearchButtonLabel: View {
   let systemImage: String
 
   var body: some View {
-    Label {
-      if let shortcut {
-        Text("\(title) \(Text("(\(shortcut))").foregroundColor(.secondary.opacity(0.7)))")
-      } else {
-        Text(title)
-      }
-    } icon: {
-      Image(systemName: systemImage)
-        .accessibilityHidden(true)
-    }
+    Image(systemName: systemImage)
+      .accessibilityHidden(true)
   }
 }
 
@@ -352,10 +341,10 @@ private struct GhosttySearchButtonStyle: ButtonStyle {
   func makeBody(configuration: Configuration) -> some View {
     configuration.label
       .foregroundStyle(isHovered || configuration.isPressed ? .primary : .secondary)
-      .padding(.horizontal, 2)
+      .padding(.horizontal, 6)
       .frame(height: 26)
       .background(
-        RoundedRectangle(cornerRadius: 6)
+        Capsule()
           .fill(backgroundColor(isPressed: configuration.isPressed))
       )
       .onHover { hovering in

--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
@@ -493,9 +493,9 @@ final class GhosttySurfaceView: NSView, Identifiable {
   private func applyWindowBackgroundAppearance() {
     guard let window, window.isVisible else { return }
     let opacity = runtime.backgroundOpacity()
+    window.titlebarAppearsTransparent = true
     if !isBackgroundOpaqueOverride, !window.styleMask.contains(.fullScreen), opacity < 1 {
       window.isOpaque = false
-      window.titlebarAppearsTransparent = true
       let isDark = window.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
       window.backgroundColor = GhosttyRuntime.chromeBackgroundColor(for: isDark ? .black : .white)
       if let app = runtime.app {
@@ -507,7 +507,6 @@ final class GhosttySurfaceView: NSView, Identifiable {
       return
     }
     window.isOpaque = true
-    window.titlebarAppearsTransparent = false
     window.backgroundColor = runtime.backgroundColor().withAlphaComponent(1)
   }
 


### PR DESCRIPTION
Updated many components
Tabbed | Canvas | Shelf
-|-|-
<img width="1528" height="1086" alt="Screenshot 2026-05-22 at 1 55 30 PM" src="https://github.com/user-attachments/assets/80b51d54-e32c-4d47-bada-4a5fcc76e871" /> | <img width="1528" height="1086" alt="Screenshot 2026-05-22 at 2 43 56 PM" src="https://github.com/user-attachments/assets/796bc03c-ef90-4c29-9ea3-e56dcbec1f06" /> | <img width="1528" height="1086" alt="Screenshot 2026-05-22 at 2 45 48 PM" src="https://github.com/user-attachments/assets/548cbd7d-9578-4c16-87f7-09f81665eb4b" />


Fixed: 
- #311 
- #315 
- #317
- Cmd ⌘ + F ( find menu redesign) <br> <img width="437" height="262" alt="image" src="https://github.com/user-attachments/assets/7cfc8c04-2a4b-49fa-afe8-ee3ddfc16016" />
- Tab bar trailing button UI enhancement (check above screenshot)
- Agent Viewer and claude loading indicator improvments <br>  <img width="317" height="306" alt="image" src="https://github.com/user-attachments/assets/d833a771-2c97-40ac-a90b-22c5eb5e4356" /> <img width="319" height="297" alt="ezgif-7436dba278ce2543" src="https://github.com/user-attachments/assets/f1e52ae8-83b2-4447-bd49-8426bce3da9f" />
- Moved Add repository to sidebar toolbar <br> <img width="393" height="189" alt="image" src="https://github.com/user-attachments/assets/2d57343c-6625-48fa-ae49-f3edd852e5ab" />
- Command Palette UI enhanced <br> <img width="615" height="354" alt="image" src="https://github.com/user-attachments/assets/c1759d0e-e264-4b50-ba6c-fd3a59c2d1f5" />

