### PR TITLE
Fix CI parallel test step masking build/test failures

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,12 +37,12 @@ jobs:
             shift
             local log="build/ci-logs/${name}.log"
             echo "::group::${name}"
-            if "$@" >"$log" 2>&1; then
-              cat "$log"
-              echo "::endgroup::"
-              return 0
-            fi
-            local status=$?
+            # Capture the command's own exit code. Reading $? after an
+            # `if cmd; then ...; fi` block yields the `if` status (0 when the
+            # condition is false and there is no else), which silently masked
+            # failures and let the step pass on a failing build.
+            local status=0
+            "$@" >"$log" 2>&1 || status=$?
             cat "$log"
             echo "::endgroup::"
             return "$status"


### PR DESCRIPTION
## Problem

The `Run tests in parallel` step reported **success even when the build/tests failed**. For example, [run 26277410954](https://github.com/onevcat/Prowl/actions/runs/26277410954/job/77344988514) merged a PR whose test target failed to compile (`type 'SidebarListView' has no member 'showsRepositoryListHeader'`, 9 errors) — the job still went green.

## Root cause

`run_task` captured the failure code like this:

```bash
if "$@" >"$log" 2>&1; then
  ...
  return 0
fi
local status=$?   # <- $? here is the `if` statement's exit code
```

When the command **fails**, the `if` condition is false and there is no `else` branch, so the `if` compound command itself exits `0`. `$?` immediately after `fi` is therefore `0`, not the command's real exit code. `run_task` always returned `0`, every `wait "$pid" || failed=1` saw success, and the step exited `0`.

Verified locally:

```console
$ bash -c 'if false; then :; fi; echo $?'
0
```

## Fix

Capture the command's own exit status directly with `|| status=$?`:

```bash
local status=0
"$@" >"$log" 2>&1 || status=$?
...
return "$status"
```

Verified the fixed `run_task` + `wait` flow now exits `1` when a task fails.

## Notes

- Only the parallel test step was affected. The `make build-app` step pipes through `bash -o pipefail`, so its exit code was always correct.
- `actionlint` and `bash -n` both pass on the updated workflow.
