### PR TITLE
Show split shortcut hints when bindings are chained

### DIFF
--- a/supacode/Infrastructure/Ghostty/GhosttyShortcutManager.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttyShortcutManager.swift
@@ -39,7 +39,37 @@ final class GhosttyShortcutManager {
   }
 
   func display(for action: String) -> String? {
-    guard let shortcut = keyboardShortcut(for: action) else { return nil }
-    return shortcut.display
+    // Live lookup wins: `ghostty_config_trigger` returns the real key whenever
+    // the action is bound by a plain (non-chained) keybind, so a user's custom
+    // rebind is reflected automatically.
+    if let shortcut = keyboardShortcut(for: action) {
+      return shortcut.display
+    }
+    // Ghostty deliberately excludes chained / sequenced / performable triggers
+    // from its reverse map (they can't be expressed as a single accelerator),
+    // so `ghostty_config_trigger` returns nothing for them — e.g. a config that
+    // chains `equalize_splits` onto `super+d=new_split:right`. For such known
+    // actions, fall back to Ghostty's built-in default binding so the hint
+    // still shows. The reverse map can't distinguish "chained on the default
+    // key" from "chained on a custom key", so this is best-effort and matches
+    // the common case (chaining onto the default key). Preview/test instances
+    // have no runtime and keep returning nil so views render without Ghostty.
+    guard runtime != nil else { return nil }
+    return Self.builtInDefaultShortcuts[action]?.display
+  }
+
+  /// Ghostty's built-in default bindings for actions whose live reverse lookup
+  /// can come back empty because the user chained/sequenced them (chained
+  /// triggers are omitted from Ghostty's reverse map). Display-only; used purely
+  /// to surface the key that triggers the action inside the focused surface.
+  private static let builtInDefaultShortcuts: [String: KeyboardShortcut] = [
+    "new_split:right": KeyboardShortcut("d", modifiers: .command),
+    "new_split:down": KeyboardShortcut("d", modifiers: [.command, .shift]),
+  ]
+
+  /// Display string for Ghostty's built-in default binding of `action`, if one
+  /// is known. Exposed for testing the fallback mapping.
+  static func builtInDefaultDisplay(for action: String) -> String? {
+    builtInDefaultShortcuts[action]?.display
   }
 }

--- a/supacodeTests/GhosttyShortcutManagerTests.swift
+++ b/supacodeTests/GhosttyShortcutManagerTests.swift
@@ -1,0 +1,23 @@
+import Testing
+
+@testable import supacode
+
+@MainActor
+struct GhosttyShortcutManagerTests {
+  @Test func verticalSplitFallsBackToCommandD() {
+    #expect(GhosttyShortcutManager.builtInDefaultDisplay(for: "new_split:right") == "⌘D")
+  }
+
+  @Test func horizontalSplitFallsBackToCommandShiftD() {
+    #expect(GhosttyShortcutManager.builtInDefaultDisplay(for: "new_split:down") == "⌘⇧D")
+  }
+
+  @Test func unknownActionHasNoBuiltInFallback() {
+    #expect(GhosttyShortcutManager.builtInDefaultDisplay(for: "new_tab") == nil)
+  }
+
+  @Test func previewInstanceReturnsNilForSplitActions() {
+    let manager = GhosttyShortcutManager(preview: ())
+    #expect(manager.display(for: "new_split:right") == nil)
+  }
+}


### PR DESCRIPTION
## What

The tab bar "+" hover menu (and the toolbar split-button tooltips / shelf spine buttons) now show keyboard shortcut hints for **Split Vertically** (`⌘D`) and **Split Horizontally** (`⌘⇧D`), matching the existing `⌘T` hint on **New Tab**.

## Real root cause (verified)

This is **not** a parameterized-action problem and **not** a stale framework. Verified by running Ghostty's own Zig source under a temporary probe:

- In a **default** config, the reverse lookup of `new_split:right` / `new_split:down` **does resolve** (`present=true`).
- Once the binding is **chained** (the user's `~/.config/ghostty/config` does `super+d=new_split:right` then `chain=equalize_splits`), the reverse lookup returns **nothing** (`present=false`), while unchained `new_tab` still resolves.

Ghostty **deliberately excludes chained / sequenced / performable triggers from its reverse map** — they can't be expressed as a single menu accelerator (see `appendChain` in `input/Binding.zig`). `ghostty_config_trigger` queries that reverse map, which is why the split hints were blank while New Tab showed `⌘T`.

Split bindings are **Ghostty-native** (they live in Ghostty's own config, not Prowl's settings), and the only C API to read them back is `ghostty_config_trigger` (reverse-only). So Prowl cannot read a chained trigger without a new forward-search C API.

## How

Centralized in `GhosttyShortcutManager.display(for:)`:

- **Live reverse lookup stays primary.** It already returns the real key for any plain (non-chained) binding, including a user's custom rebind — so ordinary customization is reflected automatically with no hardcoding.
- **Fallback only when the live lookup is empty** (chained / sequenced / performable / unbound): show Ghostty's built-in default (`⌘D` / `⌘⇧D`). The reverse map can't distinguish "chained on the default key" from "chained on a custom key", so this is best-effort and matches the common case (chaining onto the default key).
- Preview/test instances (no runtime) keep returning `nil`, preserving the "render without a live Ghostty app" contract.

Because the fix lives in the shared manager, the tab bar popover rows, the toolbar button tooltips, and the shelf spine buttons all pick up the hints with no view changes.

### Known limitation

A user who chains onto a **non-default** split key would see the default `⌘D` rather than their actual key. Fully correct behavior (always show the real binding, hide when truly unbound) requires a forward-search C API in Ghostty (`getTriggerAny` over the forward binding map, incl. chained leaves) plus a framework rebuild — intentionally out of scope here.

## Tests

`GhosttyShortcutManagerTests`:
- `new_split:right` → `⌘D`, `new_split:down` → `⌘⇧D`
- unknown action (`new_tab`) has no built-in fallback (relies on live lookup)
- preview instance returns `nil` for split actions

`make build-app`, the new tests, and `make check` all pass.
