### PR TITLE
Add ⌃⌥↑/↓ shortcuts to navigate Active Agents list

### DIFF
--- a/supacode/App/AppShortcuts.swift
+++ b/supacode/App/AppShortcuts.swift
@@ -93,6 +93,8 @@ enum AppShortcuts {
     static let openPullRequest = "open_pull_request"
     static let toggleLeftSidebar = "toggle_left_sidebar"
     static let toggleActiveAgentsPanel = "toggle_active_agents_panel"
+    static let selectNextActiveAgent = "select_next_active_agent"
+    static let selectPreviousActiveAgent = "select_previous_active_agent"
     static let refreshWorktrees = "refresh_worktrees"
     static let jumpToLatestUnread = "jump_to_latest_unread"
     static let runScript = "run_script"
@@ -182,6 +184,12 @@ enum AppShortcuts {
   static let openPullRequest = AppShortcut(key: "g", modifiers: [.command, .control])
   static let toggleLeftSidebar = AppShortcut(key: "s", modifiers: [.command, .control])
   static let toggleActiveAgentsPanel = AppShortcut(key: "p", modifiers: [.command, .option])
+  static let selectNextActiveAgent = AppShortcut(
+    keyEquivalent: .downArrow, ghosttyKeyName: "arrow_down", modifiers: [.control, .option]
+  )
+  static let selectPreviousActiveAgent = AppShortcut(
+    keyEquivalent: .upArrow, ghosttyKeyName: "arrow_up", modifiers: [.control, .option]
+  )
   static let refreshWorktrees = AppShortcut(key: "r", modifiers: [.command, .shift])
   static let jumpToLatestUnread = AppShortcut(key: "u", modifiers: [.command, .option])
   static let runScript = AppShortcut(key: "r", modifiers: .command)
@@ -330,6 +338,8 @@ enum AppShortcuts {
     .init(actionTitle: "Open Settings", shortcut: openSettings),
     .init(actionTitle: "Toggle Left Sidebar", shortcut: toggleLeftSidebar),
     .init(actionTitle: "Toggle Active Agents Panel", shortcut: toggleActiveAgentsPanel),
+    .init(actionTitle: "Select Next Agent", shortcut: selectNextActiveAgent),
+    .init(actionTitle: "Select Previous Agent", shortcut: selectPreviousActiveAgent),
     .init(actionTitle: "Jump to Latest Unread", shortcut: jumpToLatestUnread),
     .init(actionTitle: "Run Script", shortcut: runScript),
     .init(actionTitle: "Stop Script", shortcut: stopRunScript),
@@ -398,6 +408,18 @@ enum AppShortcuts {
       title: "Toggle Active Agents Panel",
       scope: .configurableAppAction,
       shortcut: toggleActiveAgentsPanel
+    ),
+    .init(
+      id: CommandID.selectNextActiveAgent,
+      title: "Select Next Agent",
+      scope: .configurableAppAction,
+      shortcut: selectNextActiveAgent
+    ),
+    .init(
+      id: CommandID.selectPreviousActiveAgent,
+      title: "Select Previous Agent",
+      scope: .configurableAppAction,
+      shortcut: selectPreviousActiveAgent
     ),
     .init(
       id: CommandID.refreshWorktrees,
@@ -864,6 +886,8 @@ enum AppShortcuts {
     openPullRequest,
     toggleLeftSidebar,
     toggleActiveAgentsPanel,
+    selectNextActiveAgent,
+    selectPreviousActiveAgent,
     revealInSidebar,
     refreshWorktrees,
     jumpToLatestUnread,

--- a/supacode/App/AppShortcuts.swift
+++ b/supacode/App/AppShortcuts.swift
@@ -819,6 +819,24 @@ enum AppShortcuts {
     return display(for: worktreeSelectionCommandIDs[index], in: resolvedKeybindings)
   }
 
+  /// Combined up/down display for the Active Agents list navigation (e.g. "⌥⌃↑↓").
+  ///
+  /// Returns `nil` once either binding has been customized, so callers can hide a
+  /// hint that the merged glyph form could otherwise render inaccurately.
+  static func activeAgentsNavigationDisplay(in resolvedKeybindings: ResolvedKeybindingMap) -> String? {
+    guard
+      let previous = resolvedKeybindings.binding(for: CommandID.selectPreviousActiveAgent),
+      let next = resolvedKeybindings.binding(for: CommandID.selectNextActiveAgent),
+      previous.source == .appDefault,
+      next.source == .appDefault,
+      let upDisplay = resolvedKeybindings.display(for: CommandID.selectPreviousActiveAgent),
+      let downGlyph = resolvedKeybindings.display(for: CommandID.selectNextActiveAgent)?.last
+    else {
+      return nil
+    }
+    return upDisplay + String(downGlyph)
+  }
+
   static func terminalTabSelectionDisplay(at index: Int, in resolvedKeybindings: ResolvedKeybindingMap) -> String? {
     guard terminalTabSelectionCommandIDs.indices.contains(index) else { return nil }
     return display(for: terminalTabSelectionCommandIDs[index], in: resolvedKeybindings)

--- a/supacode/Commands/SidebarCommands.swift
+++ b/supacode/Commands/SidebarCommands.swift
@@ -28,6 +28,22 @@ struct SidebarCommands: Commands {
         KeyboardShortcutModifier(shortcut: keyboardShortcut(for: AppShortcuts.CommandID.toggleActiveAgentsPanel))
       )
       .help(helpText(title: "Active Agents", commandID: AppShortcuts.CommandID.toggleActiveAgentsPanel))
+      Button("Select Next Agent") {
+        store.send(.repositories(.activeAgents(.selectNextEntry)))
+      }
+      .modifier(
+        KeyboardShortcutModifier(shortcut: keyboardShortcut(for: AppShortcuts.CommandID.selectNextActiveAgent))
+      )
+      .help(helpText(title: "Select Next Agent", commandID: AppShortcuts.CommandID.selectNextActiveAgent))
+      Button("Select Previous Agent") {
+        store.send(.repositories(.activeAgents(.selectPreviousEntry)))
+      }
+      .modifier(
+        KeyboardShortcutModifier(
+          shortcut: keyboardShortcut(for: AppShortcuts.CommandID.selectPreviousActiveAgent)
+        )
+      )
+      .help(helpText(title: "Select Previous Agent", commandID: AppShortcuts.CommandID.selectPreviousActiveAgent))
       Button("Canvas") {
         store.send(.repositories(.toggleCanvas))
       }

--- a/supacode/Features/ActiveAgents/Reducer/ActiveAgentsFeature.swift
+++ b/supacode/Features/ActiveAgents/Reducer/ActiveAgentsFeature.swift
@@ -9,9 +9,18 @@ struct ActiveAgentsFeature {
   static let maximumPanelHeight = 560.0
   static let reservedSidebarListHeight = 200.0
 
+  /// Direction for keyboard navigation across the agent list.
+  enum NavigationDirection {
+    case next
+    case previous
+  }
+
   @ObservableState
   struct State: Equatable {
     var entries: IdentifiedArrayOf<ActiveAgentEntry> = []
+    /// Surface that currently has terminal focus, mirrored from `focusChanged` events.
+    /// Used as the anchor for keyboard list navigation; not persisted.
+    var focusedSurfaceID: UUID?
     @Shared(.appStorage("activeAgentsPanelHidden")) var isPanelHidden: Bool = false
     @Shared(.appStorage("activeAgentsPanelHeight")) var panelHeight: Double = 200
   }
@@ -20,6 +29,9 @@ struct ActiveAgentsFeature {
     case agentEntryChanged(ActiveAgentEntry, autoShowPanel: Bool)
     case agentEntryRemoved(ActiveAgentEntry.ID)
     case entryTapped(ActiveAgentEntry.ID)
+    case focusedSurfaceChanged(UUID?)
+    case selectNextEntry
+    case selectPreviousEntry
     case togglePanelVisibility
     case panelHeightChanged(Double)
   }
@@ -41,6 +53,16 @@ struct ActiveAgentsFeature {
       case .entryTapped:
         return .none
 
+      case .focusedSurfaceChanged(let surfaceID):
+        state.focusedSurfaceID = surfaceID
+        return .none
+
+      case .selectNextEntry:
+        return navigate(&state, direction: .next)
+
+      case .selectPreviousEntry:
+        return navigate(&state, direction: .previous)
+
       case .togglePanelVisibility:
         state.$isPanelHidden.withLock { $0.toggle() }
         return .none
@@ -49,6 +71,46 @@ struct ActiveAgentsFeature {
         state.$panelHeight.withLock { $0 = Self.clampedPanelHeight(height) }
         return .none
       }
+    }
+  }
+
+  /// Moves the keyboard anchor to the neighbouring entry and reuses `entryTapped`
+  /// so the parent reducer performs the actual worktree selection + surface focus.
+  private func navigate(_ state: inout State, direction: NavigationDirection) -> Effect<Action> {
+    guard
+      let targetID = Self.entryID(
+        navigatingFrom: state.focusedSurfaceID,
+        direction: direction,
+        in: state.entries
+      )
+    else {
+      return .none
+    }
+    state.focusedSurfaceID = state.entries[id: targetID]?.surfaceID
+    return .send(.entryTapped(targetID))
+  }
+
+  /// Resolves the entry to navigate to, anchored on the focused surface.
+  ///
+  /// When no entry matches the focused surface the list wraps from an edge:
+  /// `.next` starts at the first entry and `.previous` at the last. With a known
+  /// anchor it steps one position and wraps around the ends.
+  static func entryID(
+    navigatingFrom focusedSurfaceID: UUID?,
+    direction: NavigationDirection,
+    in entries: IdentifiedArrayOf<ActiveAgentEntry>
+  ) -> ActiveAgentEntry.ID? {
+    guard !entries.isEmpty else { return nil }
+    let anchorIndex = focusedSurfaceID.flatMap { surfaceID in
+      entries.firstIndex { $0.surfaceID == surfaceID }
+    }
+    switch direction {
+    case .next:
+      guard let anchorIndex else { return entries.first?.id }
+      return entries[(anchorIndex + 1) % entries.count].id
+    case .previous:
+      guard let anchorIndex else { return entries.last?.id }
+      return entries[(anchorIndex - 1 + entries.count) % entries.count].id
     }
   }
 

--- a/supacode/Features/ActiveAgents/Views/ActiveAgentsPanel.swift
+++ b/supacode/Features/ActiveAgents/Views/ActiveAgentsPanel.swift
@@ -133,8 +133,14 @@ struct ActiveAgentsPanel: View {
   }
 
   private func isDimmed(_ entry: ActiveAgentEntry) -> Bool {
-    if let selectedSurfaceID {
-      return entry.surfaceID != selectedSurfaceID
+    // Prefer the reducer-tracked focused surface so keyboard navigation highlights
+    // the target immediately. `selectedSurfaceID` is derived from the selected
+    // worktree's active surface and only catches up once the async `focusSurface`
+    // completes, which would otherwise flash that worktree's previous agent for a
+    // frame when navigation wraps across worktrees. Falls back to it before the
+    // first focus is recorded.
+    if let activeSurfaceID = store.focusedSurfaceID ?? selectedSurfaceID {
+      return entry.surfaceID != activeSurfaceID
     }
     return false
   }

--- a/supacode/Features/ActiveAgents/Views/ActiveAgentsPanel.swift
+++ b/supacode/Features/ActiveAgents/Views/ActiveAgentsPanel.swift
@@ -8,6 +8,9 @@ struct ActiveAgentsPanel: View {
   let branchNamesByWorktreeID: [Worktree.ID: String]
   let repositoryColorsByWorktreeID: [Worktree.ID: RepositoryColorChoice]
   let selectedSurfaceID: UUID?
+  /// Merged "⌥⌃↑↓" hint shown while Cmd is held; `nil` hides it (bindings customized
+  /// or Cmd not held). Resolved by the parent so the panel stays presentational.
+  let navigationShortcutHint: String?
   let height: Double
   let maximumHeight: Double
   let onHeightChanged: (Double) -> Void
@@ -23,10 +26,15 @@ struct ActiveAgentsPanel: View {
           .font(.caption)
           .foregroundStyle(.secondary)
         Spacer()
+        if let navigationShortcutHint, !store.entries.isEmpty {
+          ShortcutHintView(text: navigationShortcutHint, color: .secondary)
+            .transition(.opacity)
+        }
       }
       .padding(.horizontal, 12)
       .padding(.top, 8)
       .padding(.bottom, 4)
+      .animation(.easeInOut(duration: 0.15), value: navigationShortcutHint)
 
       if store.entries.isEmpty {
         Spacer(minLength: 0)

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -1292,6 +1292,11 @@ struct AppFeature {
         guard remainingTabs == 0 else { return .none }
         return .send(.repositories(.markWorktreeClosed(worktreeID)))
 
+      case .terminalEvent(.focusChanged(_, let surfaceID)):
+        // Keep the Active Agents panel's keyboard-navigation anchor in sync with
+        // the surface that actually has focus, so ⌃⌥↑/↓ steps from the right place.
+        return .send(.repositories(.activeAgents(.focusedSurfaceChanged(surfaceID))))
+
       case .terminalEvent:
         return .none
       }

--- a/supacode/Features/Repositories/Views/SidebarListView.swift
+++ b/supacode/Features/Repositories/Views/SidebarListView.swift
@@ -44,6 +44,7 @@ struct SidebarListView: View {
   @State private var resizingPanelHeight: Double?
   @Namespace private var topSegmentNamespace
   @Environment(\.resolvedKeybindings) private var resolvedKeybindings
+  @Environment(CommandKeyObserver.self) private var commandKeyObserver
   @Shared(.repositoryAppearances) private var repositoryAppearances
 
   var body: some View {
@@ -60,6 +61,12 @@ struct SidebarListView: View {
     let selectedSurfaceID = state.selectedWorktreeID.flatMap { worktreeID in
       terminalManager.stateIfExists(for: worktreeID)?.activeSurfaceID
     }
+    // Only surface the hint while Cmd is held and the bindings are still at their
+    // defaults; a customized binding makes the merged "⌥⌃↑↓" glyph inaccurate.
+    let activeAgentsShortcutHint =
+      commandKeyObserver.isPressed
+      ? AppShortcuts.activeAgentsNavigationDisplay(in: resolvedKeybindings)
+      : nil
     let pendingSidebarReveal = state.pendingSidebarReveal
 
     let maximumPanelHeight =
@@ -149,6 +156,7 @@ struct SidebarListView: View {
           branchNamesByWorktreeID: agentWorktreeMetadata.branchNamesByWorktreeID,
           repositoryColorsByWorktreeID: agentWorktreeMetadata.repositoryColorsByWorktreeID,
           selectedSurfaceID: selectedSurfaceID,
+          navigationShortcutHint: activeAgentsShortcutHint,
           height: panelHeight,
           maximumHeight: maximumPanelHeight,
           onHeightChanged: { height in

--- a/supacodeTests/ActiveAgentsFeatureTests.swift
+++ b/supacodeTests/ActiveAgentsFeatureTests.swift
@@ -69,6 +69,88 @@ struct ActiveAgentsFeatureTests {
     #expect(ActiveAgentsFeature.maximumPanelHeight(forContainerHeight: 250) == 120)
   }
 
+  @Test func navigationReturnsNilForEmptyList() {
+    let entries: IdentifiedArrayOf<ActiveAgentEntry> = []
+    #expect(ActiveAgentsFeature.entryID(navigatingFrom: nil, direction: .next, in: entries) == nil)
+    #expect(ActiveAgentsFeature.entryID(navigatingFrom: nil, direction: .previous, in: entries) == nil)
+  }
+
+  @Test func navigationWithoutAnchorStartsFromEdges() {
+    let entries = sampleEntries()
+    // No focus, or focus on a surface that is not in the list, anchors on an edge.
+    #expect(ActiveAgentsFeature.entryID(navigatingFrom: nil, direction: .next, in: entries) == UUID(0))
+    #expect(ActiveAgentsFeature.entryID(navigatingFrom: nil, direction: .previous, in: entries) == UUID(2))
+    #expect(ActiveAgentsFeature.entryID(navigatingFrom: UUID(99), direction: .next, in: entries) == UUID(0))
+    #expect(ActiveAgentsFeature.entryID(navigatingFrom: UUID(99), direction: .previous, in: entries) == UUID(2))
+  }
+
+  @Test func navigationStepsAndWrapsAroundAnchor() {
+    let entries = sampleEntries()
+    #expect(ActiveAgentsFeature.entryID(navigatingFrom: UUID(0), direction: .next, in: entries) == UUID(1))
+    #expect(ActiveAgentsFeature.entryID(navigatingFrom: UUID(2), direction: .next, in: entries) == UUID(0))
+    #expect(ActiveAgentsFeature.entryID(navigatingFrom: UUID(1), direction: .previous, in: entries) == UUID(0))
+    #expect(ActiveAgentsFeature.entryID(navigatingFrom: UUID(0), direction: .previous, in: entries) == UUID(2))
+  }
+
+  @Test func selectNextEntryAdvancesAnchorAndTapsNeighbour() async {
+    var state = ActiveAgentsFeature.State()
+    state.entries = sampleEntries()
+    state.focusedSurfaceID = UUID(0)
+    let store = TestStore(initialState: state) {
+      ActiveAgentsFeature()
+    }
+
+    await store.send(.selectNextEntry) {
+      $0.focusedSurfaceID = UUID(1)
+    }
+    await store.receive(.entryTapped(UUID(1)))
+  }
+
+  @Test func selectPreviousEntryWrapsToLastWhenAtFirst() async {
+    var state = ActiveAgentsFeature.State()
+    state.entries = sampleEntries()
+    state.focusedSurfaceID = UUID(0)
+    let store = TestStore(initialState: state) {
+      ActiveAgentsFeature()
+    }
+
+    await store.send(.selectPreviousEntry) {
+      $0.focusedSurfaceID = UUID(2)
+    }
+    await store.receive(.entryTapped(UUID(2)))
+  }
+
+  @Test func navigationWithoutEntriesIsNoOp() async {
+    let store = TestStore(initialState: ActiveAgentsFeature.State()) {
+      ActiveAgentsFeature()
+    }
+
+    await store.send(.selectNextEntry)
+    await store.send(.selectPreviousEntry)
+  }
+
+  @Test func focusedSurfaceChangedUpdatesAnchor() async {
+    let store = TestStore(initialState: ActiveAgentsFeature.State()) {
+      ActiveAgentsFeature()
+    }
+
+    await store.send(.focusedSurfaceChanged(UUID(7))) {
+      $0.focusedSurfaceID = UUID(7)
+    }
+    await store.send(.focusedSurfaceChanged(nil)) {
+      $0.focusedSurfaceID = nil
+    }
+  }
+
+  private func sampleEntries() -> IdentifiedArrayOf<ActiveAgentEntry> {
+    let now = Date(timeIntervalSince1970: 10)
+    return [
+      entry(id: UUID(0), state: .working, changedAt: now),
+      entry(id: UUID(1), state: .idle, changedAt: now),
+      entry(id: UUID(2), state: .blocked, changedAt: now),
+    ]
+  }
+
   private func entry(id: UUID, state: AgentDisplayState, changedAt: Date) -> ActiveAgentEntry {
     ActiveAgentEntry(
       id: id,

--- a/supacodeTests/AppShortcutsTests.swift
+++ b/supacodeTests/AppShortcutsTests.swift
@@ -309,6 +309,36 @@ struct AppShortcutsTests {
     #expect(arguments.contains("--keybind=ctrl+m=goto_tab:1") == false)
   }
 
+  @Test func activeAgentsNavigationDisplayMergesDefaultBindings() {
+    #expect(AppShortcuts.activeAgentsNavigationDisplay(in: .appDefaults) == "⌥⌃↑↓")
+  }
+
+  @Test func activeAgentsNavigationDisplayHiddenWhenEitherBindingCustomized() {
+    let nextOverridden = KeybindingResolver.resolve(
+      schema: .appResolverSchema(),
+      userOverrides: KeybindingUserOverrideStore(
+        overrides: [
+          AppShortcuts.CommandID.selectNextActiveAgent: KeybindingUserOverride(
+            binding: Keybinding(key: "j", modifiers: .init(command: true))
+          )
+        ]
+      )
+    )
+    #expect(AppShortcuts.activeAgentsNavigationDisplay(in: nextOverridden) == nil)
+
+    let previousOverridden = KeybindingResolver.resolve(
+      schema: .appResolverSchema(),
+      userOverrides: KeybindingUserOverrideStore(
+        overrides: [
+          AppShortcuts.CommandID.selectPreviousActiveAgent: KeybindingUserOverride(
+            binding: Keybinding(key: "k", modifiers: .init(command: true))
+          )
+        ]
+      )
+    )
+    #expect(AppShortcuts.activeAgentsNavigationDisplay(in: previousOverridden) == nil)
+  }
+
   @Test func disabledManagedGhosttyActionKeepsDefaultUnboundWithoutBindingAction() {
     let overrides = KeybindingUserOverrideStore(
       overrides: [


### PR DESCRIPTION
## What

Adds two keyboard shortcuts to move focus up/down the **Active Agents** panel list:

| Shortcut | Command | Action |
|---|---|---|
| **⌃⌥↓** | Select Next Agent | Jump to the next agent and focus its surface |
| **⌃⌥↑** | Select Previous Agent | Jump to the previous agent and focus its surface |

Navigation is anchored on the currently focused surface and wraps at the list ends. When no list entry matches the focused surface, **↓** starts at the first entry and **↑** at the last.

## Why

`⌘⌥↑↓` (split pane) and `⌃⌘↑↓` (worktree) were already taken; `⌃⌥↑↓` was free and stays clear of Shift-based terminal text selection. Both commands are user-customizable in **Settings → Shortcuts**.

## How

- `ActiveAgentsFeature`: new `focusedSurfaceID` anchor state, `selectNextEntry` / `selectPreviousEntry` / `focusedSurfaceChanged` actions, and a pure `entryID(navigatingFrom:direction:in:)` helper for the step/wrap logic. Navigation reuses the existing `entryTapped` flow (select worktree + focus surface) by re-dispatching it, so no jump logic is duplicated.
- `AppFeature`: consumes the terminal `focusChanged` event and forwards it to keep the anchor in sync with the surface that actually has focus.
- `AppShortcuts`: registers the two commands across all five binding tables (CommandID, default `AppShortcut`, `bindings`, `reservedCustomCommandBindings`, `all`).
- `SidebarCommands`: adds the two menu items with shortcut + tooltip under the Active Agents entry.

## Tests

Added to `ActiveAgentsFeatureTests`: pure-function coverage for empty list / edge-anchoring / step + wrap-around, plus reducer tests for `selectNextEntry`, `selectPreviousEntry` (wrap), the empty-list no-op, and `focusedSurfaceChanged`.

`make build-app`, `make check`, and the relevant test suites all pass.
