### PR TITLE
Fix Active Agents tab and highlight flicker when selecting agents

### DIFF
--- a/supacode/Features/ActiveAgents/Reducer/ActiveAgentsFeature.swift
+++ b/supacode/Features/ActiveAgents/Reducer/ActiveAgentsFeature.swift
@@ -50,7 +50,13 @@ struct ActiveAgentsFeature {
         state.entries.remove(id: id)
         return .none
 
-      case .entryTapped:
+      case .entryTapped(let id):
+        // Mirror the tapped surface into the focus anchor so the panel highlight and
+        // keyboard navigation step from the just-selected agent immediately. The async
+        // `focusChanged` event can't be relied on here: it is deduplicated per worktree
+        // (`emitFocusChangedIfNeeded`), so re-focusing a worktree's previously focused
+        // surface emits nothing and would leave the anchor stale.
+        state.focusedSurfaceID = state.entries[id: id]?.surfaceID
         return .none
 
       case .focusedSurfaceChanged(let surfaceID):

--- a/supacode/Features/ActiveAgents/Views/ActiveAgentsPanel.swift
+++ b/supacode/Features/ActiveAgents/Views/ActiveAgentsPanel.swift
@@ -133,14 +133,13 @@ struct ActiveAgentsPanel: View {
   }
 
   private func isDimmed(_ entry: ActiveAgentEntry) -> Bool {
-    // Prefer the reducer-tracked focused surface so keyboard navigation highlights
-    // the target immediately. `selectedSurfaceID` is derived from the selected
-    // worktree's active surface and only catches up once the async `focusSurface`
-    // completes, which would otherwise flash that worktree's previous agent for a
-    // frame when navigation wraps across worktrees. Falls back to it before the
-    // first focus is recorded.
-    if let activeSurfaceID = store.focusedSurfaceID ?? selectedSurfaceID {
-      return entry.surfaceID != activeSurfaceID
+    // Highlight the selected worktree's active surface. `entryTapped` now focuses
+    // the target surface before selecting its worktree, so `selectedSurfaceID` is
+    // already correct by the time the selection lands — no cross-worktree flash and
+    // no dependence on the reducer's focus anchor, which can go stale when the
+    // per-worktree `focusChanged` dedup suppresses an event.
+    if let selectedSurfaceID {
+      return entry.surfaceID != selectedSurfaceID
     }
     return false
   }

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -418,12 +418,15 @@ struct RepositoriesFeature {
 
         case .activeAgents(.entryTapped(let id)):
           guard let entry = state.activeAgents.entries[id: id] else { return .none }
-          return .merge(
-            .send(.selectWorktree(entry.worktreeID, focusTerminal: false)),
-            .run { _ in
-              _ = await terminalClient.focusSurface(entry.worktreeID, entry.surfaceID)
-            }
-          )
+          return .run { send in
+            // Focus the target surface (which selects its tab) before making the
+            // worktree visible, so it shows the right tab immediately instead of
+            // flashing its previously-focused tab. Then select the worktree with
+            // `focusTerminal` so the terminal view focuses the now-correct selected
+            // tab once it appears, regardless of where first responder currently is.
+            _ = await terminalClient.focusSurface(entry.worktreeID, entry.surfaceID)
+            await send(.selectWorktree(entry.worktreeID, focusTerminal: true))
+          }
 
         case .activeAgents:
           return .none

--- a/supacodeTests/ActiveAgentsFeatureTests.swift
+++ b/supacodeTests/ActiveAgentsFeatureTests.swift
@@ -129,6 +129,21 @@ struct ActiveAgentsFeatureTests {
     await store.send(.selectPreviousEntry)
   }
 
+  @Test func entryTappedUpdatesFocusAnchor() async {
+    var state = ActiveAgentsFeature.State()
+    state.entries = sampleEntries()
+    let store = TestStore(initialState: state) {
+      ActiveAgentsFeature()
+    }
+
+    // Tapping mirrors the entry's surface into the focus anchor so keyboard
+    // navigation continues from the just-selected agent, without relying on the
+    // (per-worktree deduplicated) async `focusChanged` event.
+    await store.send(.entryTapped(UUID(2))) {
+      $0.focusedSurfaceID = UUID(2)
+    }
+  }
+
   @Test func focusedSurfaceChangedUpdatesAnchor() async {
     let store = TestStore(initialState: ActiveAgentsFeature.State()) {
       ActiveAgentsFeature()

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -928,6 +928,55 @@ struct RepositoriesFeatureTests {
     await store.receive(\.delegate.selectedWorktreeChanged)
   }
 
+  @Test func activeAgentEntryTappedFocusesSurfaceBeforeSelectingWorktree() async {
+    let worktree = makeWorktree(id: "/tmp/repo/wt", name: "wt")
+    let repository = makeRepository(id: "/tmp/repo", worktrees: [worktree])
+    var state = makeState(repositories: [repository])
+    let surfaceID = UUID()
+    let entry = ActiveAgentEntry(
+      id: surfaceID,
+      worktreeID: worktree.id,
+      worktreeName: worktree.name,
+      tabID: TerminalTabID(rawValue: UUID()),
+      tabTitle: "agent",
+      surfaceID: surfaceID,
+      paneIndex: 0,
+      agent: .codex,
+      rawState: .working,
+      displayState: .working,
+      lastChangedAt: Date(timeIntervalSince1970: 0)
+    )
+    state.activeAgents.entries = [entry]
+
+    let focusedSurface = LockIsolated<(Worktree.ID, UUID)?>(nil)
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.terminalClient.focusSurface = { worktreeID, surface in
+        focusedSurface.setValue((worktreeID, surface))
+        return true
+      }
+    }
+
+    // Tapping mirrors the surface into the keyboard-nav anchor synchronously...
+    await store.send(.activeAgents(.entryTapped(entry.id))) {
+      $0.activeAgents.focusedSurfaceID = surfaceID
+    }
+    // ...then the worktree is selected with `focusTerminal` (proved by the pending
+    // focus set) only after the target surface has already been focused, so the
+    // worktree shows the right tab the instant it becomes visible.
+    await store.receive(\.selectWorktree) {
+      $0.selection = .worktree(worktree.id)
+      $0.sidebarSelectedWorktreeIDs = [worktree.id]
+      $0.openedWorktreeIDs = [worktree.id]
+      $0.pendingTerminalFocusWorktreeIDs = [worktree.id]
+    }
+    await store.receive(\.delegate.selectedWorktreeChanged)
+
+    #expect(focusedSurface.value?.0 == worktree.id)
+    #expect(focusedSurface.value?.1 == surfaceID)
+  }
+
   @Test func selectWorktreeCollapsesSidebarSelectedWorktreeIDs() async {
     let wt1 = makeWorktree(id: "/tmp/repo/wt1", name: "wt1", repoRoot: "/tmp/repo")
     let wt2 = makeWorktree(id: "/tmp/repo/wt2", name: "wt2", repoRoot: "/tmp/repo")


### PR DESCRIPTION
## Problem

Selecting an agent in the Active Agents panel (by click or keyboard) wrapped two effects in a `merge`: `selectWorktree` and `focusSurface`. The selection landed first, so the worktree became visible showing its **previously-focused tab** before `focusSurface` switched to the target tab — a visible tab flip, and the panel highlight (derived from the selected worktree's active surface) flashed the wrong agent for a frame.

A prior attempt (#335) masked the highlight flash by reading the reducer's focus anchor (`focusedSurfaceID`) first. But that anchor only updates via keyboard navigation and via `focusChanged` events, which are **deduplicated per worktree** (`emitFocusChangedIfNeeded`). Re-focusing a worktree's already-focused surface emits nothing, so clicking an agent left the anchor stale and the highlight stuck on the last keyboard-selected agent — i.e. only keyboard-selected agents could be highlighted.

## Fix

Fix the ordering at the source in `RepositoriesFeature.entryTapped`:

```
await focusSurface(worktree, surface)            // pre-selects the target tab while the worktree is not visible yet
await send(selectWorktree(focusTerminal: true))  // shows the now-correct tab; forceAutoFocus lands keyboard focus
```

The worktree shows the right tab immediately and `selectedSurfaceID` is already correct when the selection lands, so:

- `ActiveAgentsPanel.isDimmed` reverts to plain `selectedSurfaceID` — no flicker, no dependence on the dedup-prone focus anchor.
- `ActiveAgentsFeature.entryTapped` still mirrors the tapped surface into `focusedSurfaceID`, used only as the keyboard-navigation anchor so navigation continues from the just-selected agent regardless of the dedup.

## Verification

- `make build-app`: 0 errors / 0 warnings
- `make check`: swift-format + swiftlint clean
- Tests: 12 passed, including new `ActiveAgentsFeatureTests.entryTappedUpdatesFocusAnchor` and `RepositoriesFeatureTests.activeAgentEntryTappedFocusesSurfaceBeforeSelectingWorktree` (asserts focus-before-select ordering with `focusTerminal: true`)
- Manual GUI verification: cross-worktree keyboard wrap, mouse-click selection (incl. cross-worktree), keyboard focus landing on the terminal after navigation, same-worktree navigation, and sidebar worktree selection all behave correctly.

Follow-up fix to #335.
