### PR TITLE
Add Canvas option to Default View setting

### DIFF
--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -1259,6 +1259,9 @@ struct AppFeature {
         let shouldEnterShelf =
           settingsFile.global.defaultViewMode == .shelf
           && !state.repositories.isShelfActive
+        let shouldEnterCanvas =
+          settingsFile.global.defaultViewMode == .canvas
+          && !state.repositories.isShowingCanvas
         var effects: [Effect<Action>] = []
         if let selectedWorktreeID {
           // Plain folders use .repository selection, not .worktree
@@ -1272,6 +1275,11 @@ struct AppFeature {
         }
         if shouldEnterShelf {
           effects.append(.send(.repositories(.toggleShelf)))
+        }
+        // Enter Canvas after the selection effects so `.selectCanvas`
+        // records the just-selected worktree as the pre-Canvas anchor.
+        if shouldEnterCanvas {
+          effects.append(.send(.repositories(.toggleCanvas)))
         }
         return effects.isEmpty ? .none : .merge(effects)
 

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -750,12 +750,26 @@ struct RepositoriesFeature {
 
         case .selectCanvas:
           // Remember the current worktree so toggleCanvas can restore it.
+          let canvasSeedWorktree = state.selectedTerminalWorktree
           state.preCanvasWorktreeID = state.selectedWorktreeID
-          state.preCanvasTerminalTargetID = state.selectedTerminalWorktree?.id
+          state.preCanvasTerminalTargetID = canvasSeedWorktree?.id
           state.isShelfActive = false
           state.selection = .canvas
           state.sidebarSelectedWorktreeIDs = []
+          // Canvas only renders cards for worktrees that already have a live
+          // terminal surface. Normal/Shelf get the previously-focused worktree
+          // opened lazily when its view mounts and calls `ensureInitialTab`;
+          // Canvas mounts no such per-worktree view, so launching straight into
+          // Canvas would show an empty board. Seed the surface for the worktree
+          // we're entering from so at least that card appears — matching the
+          // single-tab restore Normal and Shelf perform. `ensureInitialTab` is
+          // idempotent, so this no-ops once the worktree already has tabs.
           return .run { _ in
+            if let canvasSeedWorktree {
+              await terminalClient.send(
+                .ensureInitialTab(canvasSeedWorktree, runSetupScriptIfNew: false, focusing: false)
+              )
+            }
             await terminalClient.send(.setCanvasMode(true))
           }
 

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -495,11 +495,18 @@ struct RepositoriesFeature {
           // Restore clears the selection we just set, and any books not
           // in the saved layout would linger as stray spines.
           @Shared(.settingsFile) var settingsFile
-          if settingsFile.global.defaultViewMode == .shelf,
-            state.launchRestoreMode != .restoreLayout,
-            !state.isShelfActive
-          {
-            allEffects.append(.send(.toggleShelf))
+          if state.launchRestoreMode != .restoreLayout {
+            switch settingsFile.global.defaultViewMode {
+            case .shelf where !state.isShelfActive:
+              allEffects.append(.send(.toggleShelf))
+            case .canvas where !state.isShowingCanvas:
+              // `.toggleCanvas` shares Shelf's guards: it only enters
+              // when at least one worktree row exists, otherwise it
+              // falls back to Normal.
+              allEffects.append(.send(.toggleCanvas))
+            case .normal, .shelf, .canvas:
+              break
+            }
           }
           return .merge(allEffects)
 

--- a/supacode/Features/Settings/Models/DefaultViewMode.swift
+++ b/supacode/Features/Settings/Models/DefaultViewMode.swift
@@ -1,10 +1,12 @@
 /// Which presentation the app enters on launch. `normal` keeps the
 /// historical behavior (sidebar + terminal detail); `shelf` boots
-/// straight into Shelf so power users who live in Shelf don't have to
-/// toggle it every time they open Prowl.
+/// straight into Shelf and `canvas` boots straight into Canvas, so
+/// power users who live in those views don't have to toggle them
+/// every time they open Prowl.
 enum DefaultViewMode: String, CaseIterable, Identifiable, Codable, Sendable {
   case normal
   case shelf
+  case canvas
 
   var id: String { rawValue }
 
@@ -14,6 +16,8 @@ enum DefaultViewMode: String, CaseIterable, Identifiable, Codable, Sendable {
       return "Normal View"
     case .shelf:
       return "Shelf View"
+    case .canvas:
+      return "Canvas View"
     }
   }
 }

--- a/supacode/Features/Settings/Views/AppearanceSettingsView.swift
+++ b/supacode/Features/Settings/Views/AppearanceSettingsView.swift
@@ -90,7 +90,7 @@ struct AppearanceSettingsView: View {
               Text(mode.title).tag(mode)
             }
           }
-          .help("View Prowl starts in on launch. Shelf requires at least one worktree or folder.")
+          .help("View Prowl starts in on launch. Shelf and Canvas require at least one worktree or folder.")
         }
         Section("Default Editor") {
           Picker(

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -1098,6 +1098,60 @@ struct RepositoriesFeatureTests {
     await store.receive(\.delegate.selectedWorktreeChanged)
   }
 
+  @Test func selectCanvasSeedsInitialTabForSelectedWorktree() async {
+    // Canvas only renders cards for worktrees with a live terminal surface.
+    // Entering Canvas must seed the selected worktree's tab so launching
+    // straight into Canvas shows that worktree's card — Normal/Shelf open one
+    // tab on launch, but Canvas mounts no per-worktree view to do it lazily.
+    let worktree = makeWorktree(id: "/tmp/repo/main", name: "main", repoRoot: "/tmp/repo")
+    let repository = makeRepository(id: "/tmp/repo", worktrees: [worktree])
+    var initialState = makeState(repositories: [repository])
+    initialState.selection = .worktree(worktree.id)
+
+    let sentCommands = LockIsolated<[TerminalClient.Command]>([])
+    let store = TestStore(initialState: initialState) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in
+        sentCommands.withValue { $0.append(command) }
+      }
+    }
+
+    await store.send(.selectCanvas) {
+      $0.preCanvasWorktreeID = worktree.id
+      $0.preCanvasTerminalTargetID = worktree.id
+      $0.selection = .canvas
+    }
+    await store.finish()
+
+    #expect(
+      sentCommands.value == [
+        .ensureInitialTab(worktree, runSetupScriptIfNew: false, focusing: false),
+        .setCanvasMode(true),
+      ]
+    )
+  }
+
+  @Test func selectCanvasWithoutSelectionOnlyEntersCanvasMode() async {
+    // With nothing selected there is no surface to seed — Canvas just flips
+    // into canvas mode and renders an empty board.
+    let sentCommands = LockIsolated<[TerminalClient.Command]>([])
+    let store = TestStore(initialState: RepositoriesFeature.State()) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in
+        sentCommands.withValue { $0.append(command) }
+      }
+    }
+
+    await store.send(.selectCanvas) {
+      $0.selection = .canvas
+    }
+    await store.finish()
+
+    #expect(sentCommands.value == [.setCanvasMode(true)])
+  }
+
   @Test func selectRepositoryIgnoresUnknownRepository() async {
     let store = TestStore(initialState: RepositoriesFeature.State()) {
       RepositoriesFeature()

--- a/supacodeTests/ShelfFeatureTests.swift
+++ b/supacodeTests/ShelfFeatureTests.swift
@@ -930,6 +930,122 @@ struct ShelfFeatureTests {
     await store.finish()
   }
 
+  @Test(.dependencies) func defaultViewCanvasPreferenceDispatchesToggleAfterSnapshot() async {
+    let repoRoot = "/tmp/default-canvas-repo"
+    let rootURL = URL(fileURLWithPath: repoRoot)
+    let worktree = Worktree(
+      id: "\(repoRoot)/main",
+      name: "main",
+      detail: "",
+      workingDirectory: URL(fileURLWithPath: "\(repoRoot)/main"),
+      repositoryRootURL: rootURL
+    )
+    let repository = Repository(
+      id: repoRoot,
+      rootURL: rootURL,
+      name: "repo",
+      worktrees: IdentifiedArray(uniqueElements: [worktree])
+    )
+
+    @Shared(.settingsFile) var settingsFile
+    $settingsFile.withLock {
+      var updated = $0.global
+      updated.defaultViewMode = .canvas
+      $0.global = updated
+    }
+    // Restore settings after the test so `@Shared` state doesn't leak
+    // across parallel test runs in the same process.
+    defer {
+      $settingsFile.withLock {
+        var updated = $0.global
+        updated.defaultViewMode = .normal
+        $0.global = updated
+      }
+    }
+
+    var initialState = RepositoriesFeature.State()
+    initialState.lastFocusedWorktreeID = worktree.id
+    initialState.shouldRestoreLastFocusedWorktree = true
+    initialState.snapshotPersistencePhase = .restoring
+    let store = TestStore(initialState: initialState) {
+      RepositoriesFeature()
+    }
+
+    await store.send(.repositorySnapshotLoaded([repository])) {
+      $0.repositories = [repository]
+      $0.repositoryRoots = [rootURL]
+      $0.selection = .worktree(worktree.id)
+      $0.shouldRestoreLastFocusedWorktree = false
+      $0.isInitialLoadComplete = true
+    }
+    await store.receive(\.delegate.repositoriesChanged)
+    await store.receive(\.delegate.selectedWorktreeChanged)
+    // `.toggleCanvas` enters Canvas via `.selectCanvas`, which records the
+    // current worktree as the pre-Canvas anchor before flipping selection.
+    await store.receive(\.toggleCanvas)
+    await store.receive(\.selectCanvas) {
+      $0.preCanvasWorktreeID = worktree.id
+      $0.preCanvasTerminalTargetID = worktree.id
+      $0.selection = .canvas
+    }
+    await store.finish()
+  }
+
+  @Test(.dependencies) func defaultViewCanvasDefersDuringLayoutRestore() async {
+    // Mirrors the Shelf deferral: during Layout Restore the snapshot-load
+    // hook stays quiet and the AppFeature `.layoutRestored` path takes over.
+    let repoRoot = "/tmp/default-canvas-restore-repo"
+    let rootURL = URL(fileURLWithPath: repoRoot)
+    let worktree = Worktree(
+      id: "\(repoRoot)/main",
+      name: "main",
+      detail: "",
+      workingDirectory: URL(fileURLWithPath: "\(repoRoot)/main"),
+      repositoryRootURL: rootURL
+    )
+    let repository = Repository(
+      id: repoRoot,
+      rootURL: rootURL,
+      name: "repo",
+      worktrees: IdentifiedArray(uniqueElements: [worktree])
+    )
+
+    @Shared(.settingsFile) var settingsFile
+    $settingsFile.withLock {
+      var updated = $0.global
+      updated.defaultViewMode = .canvas
+      $0.global = updated
+    }
+    defer {
+      $settingsFile.withLock {
+        var updated = $0.global
+        updated.defaultViewMode = .normal
+        $0.global = updated
+      }
+    }
+
+    var initialState = RepositoriesFeature.State()
+    initialState.lastFocusedWorktreeID = worktree.id
+    initialState.shouldRestoreLastFocusedWorktree = true
+    initialState.snapshotPersistencePhase = .restoring
+    initialState.launchRestoreMode = .restoreLayout
+    let store = TestStore(initialState: initialState) {
+      RepositoriesFeature()
+    }
+
+    await store.send(.repositorySnapshotLoaded([repository])) {
+      $0.repositories = [repository]
+      $0.repositoryRoots = [rootURL]
+      $0.selection = .worktree(worktree.id)
+      $0.shouldRestoreLastFocusedWorktree = false
+      $0.isInitialLoadComplete = true
+    }
+    await store.receive(\.delegate.repositoriesChanged)
+    await store.receive(\.delegate.selectedWorktreeChanged)
+    // No `.toggleCanvas` here — the Layout Restore path is responsible.
+    await store.finish()
+  }
+
   @Test func isShowingShelfRequiresAtLeastOneRepository() {
     let rootURL = URL(fileURLWithPath: "/tmp/repo")
     let repository = Repository(


### PR DESCRIPTION
## What

Adds a **Canvas View** choice to Settings → Appearance → Default View, alongside the existing Normal and Shelf options. When set, Prowl boots straight into Canvas on launch (as long as at least one worktree row exists; otherwise it falls back to Normal, mirroring Shelf's guard).

## Changes

- **`DefaultViewMode`**: add `.canvas` case and `"Canvas View"` title. The picker (`CaseIterable`) and persistence (`Codable`) pick this up automatically.
- **`RepositoriesFeature`**: on the initial repository snapshot load for non Layout-Restore launches, dispatch `.toggleCanvas`. `toggleCanvas` already guards on having at least one worktree row and routes through `.selectCanvas` (which flips terminal canvas mode on).
- **`AppFeature`**: honor `.canvas` on `.layoutRestored` for Layout-Restore launches, entering Canvas *after* the selection effects so `.selectCanvas` records the just-selected worktree as the pre-Canvas anchor.
- **`AppearanceSettingsView`**: update the picker help text to mention Canvas.

## Tests

Mirrored the existing Shelf default-view tests for the Canvas branch in `ShelfFeatureTests`:
- `defaultViewCanvasPreferenceDispatchesToggleAfterSnapshot` — non Layout-Restore launch enters Canvas.
- `defaultViewCanvasDefersDuringLayoutRestore` — Layout-Restore defers to the AppFeature path.

## Verification

- `make build-app` ✅
- `ShelfFeatureTests` ✅ (29 passed, incl. the two new Canvas tests)
- `make check` ✅ (format + swift-format lint + swiftlint)
