### PR TITLE
Added option to hide toolbar item and added notification dot and jump app icon

### DIFF
--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -499,6 +499,7 @@ struct AppFeature {
           settings: state.settings,
           customCommands: state.selectedCustomCommands
         )
+        let showDot = settings.showNotificationDotOnDock && state.notificationIndicatorCount > 0
         return .merge(
           .send(.repositories(.githubIntegration(.setGithubIntegrationEnabled(settings.githubIntegrationEnabled)))),
           .send(
@@ -569,6 +570,11 @@ struct AppFeature {
               }
             case .denied:
               await send(.systemNotificationsPermissionFailed(errorMessage: "Authorization status is denied."))
+            }
+          },
+          .run { _ in
+            await MainActor.run {
+              NSApplication.shared.dockTile.badgeLabel = showDot ? "●" : nil
             }
           }
         )
@@ -1194,13 +1200,34 @@ struct AppFeature {
             }
           )
         }
+        switch state.settings.dockBounceMode {
+        case .off:
+          break
+        case .once:
+          effects.append(
+            .run { _ in
+              await MainActor.run {
+                _ = NSApp.requestUserAttention(.informationalRequest)
+              }
+            }
+          )
+        case .continuous:
+          effects.append(
+            .run { _ in
+              await MainActor.run {
+                _ = NSApp.requestUserAttention(.criticalRequest)
+              }
+            }
+          )
+        }
         return .merge(effects)
 
       case .terminalEvent(.notificationIndicatorChanged(let count)):
         state.notificationIndicatorCount = count
+        let showDot = state.settings.showNotificationDotOnDock && count > 0
         return .run { _ in
           await MainActor.run {
-            NSApplication.shared.dockTile.badgeLabel = nil
+            NSApplication.shared.dockTile.badgeLabel = showDot ? "●" : nil
           }
         }
 

--- a/supacode/Features/Repositories/Views/WorktreeDetailView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailView.swift
@@ -16,6 +16,8 @@ struct WorktreeDetailView: View {
     let customCommands: [UserCustomCommand]
     let isUpdateAvailable: Bool
     let availableUpdateVersion: String?
+    let showRunButtonInToolbar: Bool
+    let showDefaultEditorInToolbar: Bool
   }
 
   @Bindable var store: StoreOf<AppFeature>
@@ -89,7 +91,9 @@ struct WorktreeDetailView: View {
             runScriptIsRunning: runScriptIsRunning,
             customCommands: customCommands,
             isUpdateAvailable: state.updates.isUpdateAvailable,
-            availableUpdateVersion: state.updates.availableVersion
+            availableUpdateVersion: state.updates.availableVersion,
+            showRunButtonInToolbar: settingsFile.global.showRunButtonInToolbar,
+            showDefaultEditorInToolbar: settingsFile.global.showDefaultEditorInToolbar
           )
         )
       {
@@ -206,7 +210,9 @@ struct WorktreeDetailView: View {
       runScriptIsRunning: input.runScriptIsRunning,
       customCommands: input.customCommands,
       isUpdateAvailable: input.isUpdateAvailable,
-      availableUpdateVersion: input.availableUpdateVersion
+      availableUpdateVersion: input.availableUpdateVersion,
+      showRunButtonInToolbar: input.showRunButtonInToolbar,
+      showDefaultEditorInToolbar: input.showDefaultEditorInToolbar
     )
   }
 
@@ -572,6 +578,8 @@ struct WorktreeDetailView: View {
     let customCommands: [UserCustomCommand]
     let isUpdateAvailable: Bool
     let availableUpdateVersion: String?
+    let showRunButtonInToolbar: Bool
+    let showDefaultEditorInToolbar: Bool
   }
 
   fileprivate struct WorktreeToolbarContent: ToolbarContent {
@@ -624,15 +632,15 @@ struct WorktreeDetailView: View {
         }
       }
 
-      ToolbarSpacer(.fixed)
-
-      ToolbarItemGroup {
-        openMenu(
-          openActionSelection: toolbarState.openActionSelection,
-          showExtras: toolbarState.showExtras
-        )
+      if toolbarState.showDefaultEditorInToolbar {
+        ToolbarSpacer(.fixed)
+        ToolbarItemGroup {
+          openMenu(
+            openActionSelection: toolbarState.openActionSelection,
+            showExtras: toolbarState.showExtras
+          )
+        }
       }
-      ToolbarSpacer(.fixed)
       commandToolbarItems
 
     }
@@ -691,7 +699,10 @@ struct WorktreeDetailView: View {
 
     @ToolbarContentBuilder
     private var commandToolbarItems: some ToolbarContent {
-      if toolbarState.runScriptIsRunning || toolbarState.runScriptEnabled {
+      if toolbarState.showRunButtonInToolbar,
+        toolbarState.runScriptIsRunning || toolbarState.runScriptEnabled
+      {
+        ToolbarSpacer(.fixed)
         ToolbarItem {
           RunScriptToolbarButton(
             isRunning: toolbarState.runScriptIsRunning,
@@ -1060,7 +1071,9 @@ private struct WorktreeToolbarPreview: View {
         )
       ],
       isUpdateAvailable: true,
-      availableUpdateVersion: "2026.5.1"
+      availableUpdateVersion: "2026.5.1",
+      showRunButtonInToolbar: true,
+      showDefaultEditorInToolbar: true
     )
     let observer = CommandKeyObserver()
     observer.isPressed = false

--- a/supacode/Features/Settings/Models/DockBounceMode.swift
+++ b/supacode/Features/Settings/Models/DockBounceMode.swift
@@ -1,0 +1,27 @@
+/// Controls whether and how the Prowl dock icon bounces when an in-app
+/// notification is received.
+///
+/// Persistence: encoded as the raw `String` (case name). Cases must never
+/// be renamed once shipped because user JSON references them by name.
+enum DockBounceMode: String, CaseIterable, Identifiable, Codable, Sendable {
+  /// Do not bounce the dock icon.
+  case off
+  /// Bounce the dock icon once (`NSRequestUserAttentionType.informationalRequest`).
+  case once
+  /// Bounce the dock icon repeatedly until Prowl is brought to the front
+  /// (`NSRequestUserAttentionType.criticalRequest`).
+  case continuous
+
+  var id: String { rawValue }
+
+  var title: String {
+    switch self {
+    case .off:
+      return "Off"
+    case .once:
+      return "Once"
+    case .continuous:
+      return "Continuously"
+    }
+  }
+}

--- a/supacode/Features/Settings/Models/GlobalSettings.swift
+++ b/supacode/Features/Settings/Models/GlobalSettings.swift
@@ -31,6 +31,8 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
   var autoShowActiveAgentsPanel: Bool
   var windowTintMode: WindowTintMode
   var windowTintCustomColor: TintColor
+  var showRunButtonInToolbar: Bool
+  var showDefaultEditorInToolbar: Bool
 
   static let `default` = GlobalSettings(
     appearanceMode: .dark,
@@ -64,7 +66,9 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     dimUnfocusedSplits: true,
     autoShowActiveAgentsPanel: false,
     windowTintMode: .repositoryColor,
-    windowTintCustomColor: .default
+    windowTintCustomColor: .default,
+    showRunButtonInToolbar: true,
+    showDefaultEditorInToolbar: true
   )
 
   init(
@@ -99,7 +103,9 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     dimUnfocusedSplits: Bool = true,
     autoShowActiveAgentsPanel: Bool = false,
     windowTintMode: WindowTintMode = .repositoryColor,
-    windowTintCustomColor: TintColor = .default
+    windowTintCustomColor: TintColor = .default,
+    showRunButtonInToolbar: Bool = true,
+    showDefaultEditorInToolbar: Bool = true
   ) {
     self.appearanceMode = appearanceMode
     self.defaultEditorID = defaultEditorID
@@ -133,6 +139,8 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     self.autoShowActiveAgentsPanel = autoShowActiveAgentsPanel
     self.windowTintMode = windowTintMode
     self.windowTintCustomColor = windowTintCustomColor
+    self.showRunButtonInToolbar = showRunButtonInToolbar
+    self.showDefaultEditorInToolbar = showDefaultEditorInToolbar
   }
 
   func encode(to encoder: any Encoder) throws {
@@ -169,6 +177,8 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     try container.encode(autoShowActiveAgentsPanel, forKey: .autoShowActiveAgentsPanel)
     try container.encode(windowTintMode, forKey: .windowTintMode)
     try container.encode(windowTintCustomColor, forKey: .windowTintCustomColor)
+    try container.encode(showRunButtonInToolbar, forKey: .showRunButtonInToolbar)
+    try container.encode(showDefaultEditorInToolbar, forKey: .showDefaultEditorInToolbar)
   }
 
   private enum CodingKeys: String, CodingKey {
@@ -204,6 +214,8 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     case autoShowActiveAgentsPanel
     case windowTintMode
     case windowTintCustomColor
+    case showRunButtonInToolbar
+    case showDefaultEditorInToolbar
     // Legacy key for migration
     case automaticallyArchiveMergedWorktrees
   }
@@ -308,5 +320,11 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     windowTintCustomColor =
       try container.decodeIfPresent(TintColor.self, forKey: .windowTintCustomColor)
       ?? Self.default.windowTintCustomColor
+    showRunButtonInToolbar =
+      try container.decodeIfPresent(Bool.self, forKey: .showRunButtonInToolbar)
+      ?? Self.default.showRunButtonInToolbar
+    showDefaultEditorInToolbar =
+      try container.decodeIfPresent(Bool.self, forKey: .showDefaultEditorInToolbar)
+      ?? Self.default.showDefaultEditorInToolbar
   }
 }

--- a/supacode/Features/Settings/Models/GlobalSettings.swift
+++ b/supacode/Features/Settings/Models/GlobalSettings.swift
@@ -33,6 +33,8 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
   var windowTintCustomColor: TintColor
   var showRunButtonInToolbar: Bool
   var showDefaultEditorInToolbar: Bool
+  var dockBounceMode: DockBounceMode
+  var showNotificationDotOnDock: Bool
 
   static let `default` = GlobalSettings(
     appearanceMode: .dark,
@@ -68,7 +70,9 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     windowTintMode: .repositoryColor,
     windowTintCustomColor: .default,
     showRunButtonInToolbar: true,
-    showDefaultEditorInToolbar: true
+    showDefaultEditorInToolbar: true,
+    dockBounceMode: .off,
+    showNotificationDotOnDock: false
   )
 
   init(
@@ -105,7 +109,9 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     windowTintMode: WindowTintMode = .repositoryColor,
     windowTintCustomColor: TintColor = .default,
     showRunButtonInToolbar: Bool = true,
-    showDefaultEditorInToolbar: Bool = true
+    showDefaultEditorInToolbar: Bool = true,
+    dockBounceMode: DockBounceMode = .off,
+    showNotificationDotOnDock: Bool = false
   ) {
     self.appearanceMode = appearanceMode
     self.defaultEditorID = defaultEditorID
@@ -141,6 +147,8 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     self.windowTintCustomColor = windowTintCustomColor
     self.showRunButtonInToolbar = showRunButtonInToolbar
     self.showDefaultEditorInToolbar = showDefaultEditorInToolbar
+    self.dockBounceMode = dockBounceMode
+    self.showNotificationDotOnDock = showNotificationDotOnDock
   }
 
   func encode(to encoder: any Encoder) throws {
@@ -179,6 +187,8 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     try container.encode(windowTintCustomColor, forKey: .windowTintCustomColor)
     try container.encode(showRunButtonInToolbar, forKey: .showRunButtonInToolbar)
     try container.encode(showDefaultEditorInToolbar, forKey: .showDefaultEditorInToolbar)
+    try container.encode(dockBounceMode, forKey: .dockBounceMode)
+    try container.encode(showNotificationDotOnDock, forKey: .showNotificationDotOnDock)
   }
 
   private enum CodingKeys: String, CodingKey {
@@ -216,6 +226,8 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     case windowTintCustomColor
     case showRunButtonInToolbar
     case showDefaultEditorInToolbar
+    case dockBounceMode
+    case showNotificationDotOnDock
     // Legacy key for migration
     case automaticallyArchiveMergedWorktrees
   }
@@ -326,5 +338,11 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     showDefaultEditorInToolbar =
       try container.decodeIfPresent(Bool.self, forKey: .showDefaultEditorInToolbar)
       ?? Self.default.showDefaultEditorInToolbar
+    dockBounceMode =
+      try container.decodeIfPresent(DockBounceMode.self, forKey: .dockBounceMode)
+      ?? Self.default.dockBounceMode
+    showNotificationDotOnDock =
+      try container.decodeIfPresent(Bool.self, forKey: .showNotificationDotOnDock)
+      ?? Self.default.showNotificationDotOnDock
   }
 }

--- a/supacode/Features/Settings/Models/GlobalSettings.swift
+++ b/supacode/Features/Settings/Models/GlobalSettings.swift
@@ -232,6 +232,7 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     case automaticallyArchiveMergedWorktrees
   }
 
+  // swiftlint:disable:next function_body_length
   init(from decoder: any Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     appearanceMode = try container.decode(AppearanceMode.self, forKey: .appearanceMode)

--- a/supacode/Features/Settings/Reducer/SettingsFeature.swift
+++ b/supacode/Features/Settings/Reducer/SettingsFeature.swift
@@ -43,6 +43,8 @@ struct SettingsFeature {
     var windowTintCustomColor: Color
     var showRunButtonInToolbar: Bool
     var showDefaultEditorInToolbar: Bool
+    var dockBounceMode: DockBounceMode
+    var showNotificationDotOnDock: Bool
     var cliInstallStatus: CLIInstallStatus = .notInstalled
     var cliInstallShowAlert: Bool = true
     var selection: SettingsSection? = .general
@@ -86,6 +88,8 @@ struct SettingsFeature {
       windowTintCustomColor = settings.windowTintCustomColor.color
       showRunButtonInToolbar = settings.showRunButtonInToolbar
       showDefaultEditorInToolbar = settings.showDefaultEditorInToolbar
+      dockBounceMode = settings.dockBounceMode
+      showNotificationDotOnDock = settings.showNotificationDotOnDock
     }
 
     var globalSettings: GlobalSettings {
@@ -125,7 +129,9 @@ struct SettingsFeature {
         windowTintMode: windowTintMode,
         windowTintCustomColor: TintColor(windowTintCustomColor),
         showRunButtonInToolbar: showRunButtonInToolbar,
-        showDefaultEditorInToolbar: showDefaultEditorInToolbar
+        showDefaultEditorInToolbar: showDefaultEditorInToolbar,
+        dockBounceMode: dockBounceMode,
+        showNotificationDotOnDock: showNotificationDotOnDock
       )
     }
   }
@@ -232,6 +238,8 @@ struct SettingsFeature {
         state.windowTintCustomColor = normalizedSettings.windowTintCustomColor.color
         state.showRunButtonInToolbar = normalizedSettings.showRunButtonInToolbar
         state.showDefaultEditorInToolbar = normalizedSettings.showDefaultEditorInToolbar
+        state.dockBounceMode = normalizedSettings.dockBounceMode
+        state.showNotificationDotOnDock = normalizedSettings.showNotificationDotOnDock
         state.syncGlobalDefaults(from: normalizedSettings)
         return .send(.delegate(.settingsChanged(normalizedSettings)))
 

--- a/supacode/Features/Settings/Reducer/SettingsFeature.swift
+++ b/supacode/Features/Settings/Reducer/SettingsFeature.swift
@@ -41,6 +41,8 @@ struct SettingsFeature {
     /// the `ColorPicker` can bind to it directly; converted back to the
     /// persistable `TintColor` at the `globalSettings` boundary.
     var windowTintCustomColor: Color
+    var showRunButtonInToolbar: Bool
+    var showDefaultEditorInToolbar: Bool
     var cliInstallStatus: CLIInstallStatus = .notInstalled
     var cliInstallShowAlert: Bool = true
     var selection: SettingsSection? = .general
@@ -82,6 +84,8 @@ struct SettingsFeature {
       autoShowActiveAgentsPanel = settings.autoShowActiveAgentsPanel
       windowTintMode = settings.windowTintMode
       windowTintCustomColor = settings.windowTintCustomColor.color
+      showRunButtonInToolbar = settings.showRunButtonInToolbar
+      showDefaultEditorInToolbar = settings.showDefaultEditorInToolbar
     }
 
     var globalSettings: GlobalSettings {
@@ -119,7 +123,9 @@ struct SettingsFeature {
         dimUnfocusedSplits: dimUnfocusedSplits,
         autoShowActiveAgentsPanel: autoShowActiveAgentsPanel,
         windowTintMode: windowTintMode,
-        windowTintCustomColor: TintColor(windowTintCustomColor)
+        windowTintCustomColor: TintColor(windowTintCustomColor),
+        showRunButtonInToolbar: showRunButtonInToolbar,
+        showDefaultEditorInToolbar: showDefaultEditorInToolbar
       )
     }
   }
@@ -224,6 +230,8 @@ struct SettingsFeature {
         state.autoShowActiveAgentsPanel = normalizedSettings.autoShowActiveAgentsPanel
         state.windowTintMode = normalizedSettings.windowTintMode
         state.windowTintCustomColor = normalizedSettings.windowTintCustomColor.color
+        state.showRunButtonInToolbar = normalizedSettings.showRunButtonInToolbar
+        state.showDefaultEditorInToolbar = normalizedSettings.showDefaultEditorInToolbar
         state.syncGlobalDefaults(from: normalizedSettings)
         return .send(.delegate(.settingsChanged(normalizedSettings)))
 

--- a/supacode/Features/Settings/Views/AppearanceSettingsView.swift
+++ b/supacode/Features/Settings/Views/AppearanceSettingsView.swift
@@ -93,6 +93,11 @@ struct AppearanceSettingsView: View {
           .help("View Prowl starts in on launch. Shelf and Canvas require at least one worktree or folder.")
         }
         Section("Default Editor") {
+          Toggle(
+            "Show in toolbar",
+            isOn: $store.showDefaultEditorInToolbar
+          )
+          .help("Show the Open in Editor button in the worktree toolbar.")
           Picker(
             "Default editor",
             selection: $store.defaultEditorID
@@ -105,6 +110,13 @@ struct AppearanceSettingsView: View {
             }
           }
           .help("Applies to worktrees without repository overrides.")
+        }
+        Section("Run") {
+          Toggle(
+            "Show in toolbar",
+            isOn: $store.showRunButtonInToolbar
+          )
+          .help("Show the Run button in the worktree toolbar.")
         }
         Section("Quit") {
           Toggle(

--- a/supacode/Features/Settings/Views/NotificationsSettingsView.swift
+++ b/supacode/Features/Settings/Views/NotificationsSettingsView.swift
@@ -29,6 +29,20 @@ struct NotificationsSettingsView: View {
             isOn: $store.moveNotifiedWorktreeToTop
           )
           .help("Bring the worktree to the top when the terminal receives a notification")
+          Picker(
+            "Bounce dock icon",
+            selection: $store.dockBounceMode
+          ) {
+            ForEach(DockBounceMode.allCases) { mode in
+              Text(mode.title).tag(mode)
+            }
+          }
+          .help("Bounce the Prowl app icon in the Dock when a notification is received.")
+          Toggle(
+            "Show notification dot on dock icon",
+            isOn: $store.showNotificationDotOnDock
+          )
+          .help("Show a badge on the Prowl dock icon while notifications are pending.")
         }
         Section("Command Finished") {
           Toggle(


### PR DESCRIPTION
Added the following features
- Hide the open editor option (by default its shown)
- Added an option to hide the run button  (shown by default) (#321) <br> 
<img width="912" height="712" alt="Screenshot 2026-05-25 at 2 44 52 PM" src="https://github.com/user-attachments/assets/f7edf8c6-ef6e-4ea1-9b7f-dda4dde5c85b" />
-  Added an option to show a dot on app icon when there is a notification <br> <img width="376" height="81" alt="image" src="https://github.com/user-attachments/assets/ead4b8f2-e8f5-49f6-9297-744c22acc74b" />
- Added an option where the user can select what will happen when there is a notification (bounce app icon or do nothing) <br> <img width="912" height="712" alt="image" src="https://github.com/user-attachments/assets/46775e5e-c991-46f4-81da-f12fd8062133" />

