### PR TITLE
Fix Active Agents selection for plain folders

### DIFF
--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -418,14 +418,23 @@ struct RepositoriesFeature {
 
         case .activeAgents(.entryTapped(let id)):
           guard let entry = state.activeAgents.entries[id: id] else { return .none }
+          let isPlainFolder =
+            state.repositories[id: entry.worktreeID]?.kind == .plain
+          if isPlainFolder {
+            state.pendingTerminalFocusWorktreeIDs.insert(entry.worktreeID)
+          }
           return .run { send in
             // Focus the target surface (which selects its tab) before making the
-            // worktree visible, so it shows the right tab immediately instead of
-            // flashing its previously-focused tab. Then select the worktree with
-            // `focusTerminal` so the terminal view focuses the now-correct selected
-            // tab once it appears, regardless of where first responder currently is.
+            // terminal target visible, so it shows the right tab immediately instead
+            // of flashing its previously-focused tab. Plain folders are represented
+            // by their repository id, not a real worktree row, so they must select the
+            // repository rather than attempting a worktree selection.
             _ = await terminalClient.focusSurface(entry.worktreeID, entry.surfaceID)
-            await send(.selectWorktree(entry.worktreeID, focusTerminal: true))
+            if isPlainFolder {
+              await send(.selectRepository(entry.worktreeID))
+            } else {
+              await send(.selectWorktree(entry.worktreeID, focusTerminal: true))
+            }
           }
 
         case .activeAgents:

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -977,6 +977,55 @@ struct RepositoriesFeatureTests {
     #expect(focusedSurface.value?.1 == surfaceID)
   }
 
+  @Test func activeAgentEntryTappedSelectsPlainRepository() async {
+    let repository = makeRepository(
+      id: "/tmp/folder",
+      name: "folder",
+      kind: .plain,
+      worktrees: []
+    )
+    var state = makeState(repositories: [repository])
+    let surfaceID = UUID()
+    let entry = ActiveAgentEntry(
+      id: surfaceID,
+      worktreeID: repository.id,
+      worktreeName: repository.name,
+      tabID: TerminalTabID(rawValue: UUID()),
+      tabTitle: "agent",
+      surfaceID: surfaceID,
+      paneIndex: 0,
+      agent: .codex,
+      rawState: .working,
+      displayState: .working,
+      lastChangedAt: Date(timeIntervalSince1970: 0)
+    )
+    state.activeAgents.entries = [entry]
+
+    let focusedSurface = LockIsolated<(Worktree.ID, UUID)?>(nil)
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.terminalClient.focusSurface = { worktreeID, surface in
+        focusedSurface.setValue((worktreeID, surface))
+        return true
+      }
+    }
+
+    await store.send(.activeAgents(.entryTapped(entry.id))) {
+      $0.pendingTerminalFocusWorktreeIDs = [repository.id]
+      $0.activeAgents.focusedSurfaceID = surfaceID
+    }
+    await store.receive(\.selectRepository) {
+      $0.selection = .repository(repository.id)
+      $0.sidebarSelectedWorktreeIDs = []
+      $0.openedWorktreeIDs = [repository.id]
+    }
+    await store.receive(\.delegate.selectedWorktreeChanged)
+
+    #expect(focusedSurface.value?.0 == repository.id)
+    #expect(focusedSurface.value?.1 == surfaceID)
+  }
+
   @Test func selectWorktreeCollapsesSidebarSelectedWorktreeIDs() async {
     let wt1 = makeWorktree(id: "/tmp/repo/wt1", name: "wt1", repoRoot: "/tmp/repo")
     let wt2 = makeWorktree(id: "/tmp/repo/wt2", name: "wt2", repoRoot: "/tmp/repo")


### PR DESCRIPTION
## Summary
- Fix Active Agents row activation for plain folders by selecting the plain repository instead of treating its id as a git worktree.
- Preserve the existing surface-first focus behavior so the target tab is focused before the terminal target becomes visible.
- Add a regression test for tapping an Active Agents entry backed by a plain folder.

Fixes #342

## Tests
- `xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -only-testing:supacodeTests/RepositoriesFeatureTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation`
