### PR TITLE
Upgrade Sparkle to 2.9.2 and harden update driver isolation

### DIFF
--- a/doc-onevcat/scripts/release.sh
+++ b/doc-onevcat/scripts/release.sh
@@ -223,6 +223,19 @@ if [[ "$SENTRY_ENABLED" -eq 1 ]]; then
     log "WARNING: $DSYM_DIR not found, skipping dSYM upload"
   fi
 
+  # Sparkle ships as a prebuilt binaryTarget (Sparkle.xcframework), so Xcode never emits a
+  # dSYM for it into the archive — the archive-dSYM upload above therefore never covers
+  # Sparkle. Upload the dSYMs bundled inside the xcframework directly so each new Sparkle
+  # version is symbolicated automatically, instead of relying on a one-off manual bulk upload.
+  SPARKLE_XCFRAMEWORK="$HOME/Library/Caches/supacode-spm-cache/SourcePackages/artifacts/sparkle/Sparkle/Sparkle.xcframework"
+  if [[ -d "$SPARKLE_XCFRAMEWORK" ]]; then
+    log "uploading Sparkle xcframework dSYMs to Sentry..."
+    sentry-cli debug-files upload --wait "$SPARKLE_XCFRAMEWORK" \
+      || log "WARNING: Sparkle dSYM upload failed (release will continue)"
+  else
+    log "WARNING: $SPARKLE_XCFRAMEWORK not found, skipping Sparkle dSYM upload"
+  fi
+
   log "associating commits with Sentry release..."
   sentry-cli releases set-commits "$SENTRY_RELEASE_NAME" --auto \
     || log "WARNING: failed to associate commits (continuing)"

--- a/supacode.xcodeproj/project.pbxproj
+++ b/supacode.xcodeproj/project.pbxproj
@@ -670,7 +670,7 @@
 			repositoryURL = "https://github.com/sparkle-project/Sparkle";
 			requirement = {
 				kind = exactVersion;
-				version = "2.9.0-beta.2";
+				version = "2.9.2";
 			};
 		};
 		911B4AAD84AF4B34BE232133 /* XCRemoteSwiftPackageReference "swift-case-paths" */ = {

--- a/supacode.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/supacode.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sparkle-project/Sparkle",
       "state" : {
-        "revision" : "afea2cda87819c960114f26e26f369a1a0945b17",
-        "version" : "2.9.0-beta.2"
+        "revision" : "6276ba2b404829d139c45ff98427cf90e2efc59b",
+        "version" : "2.9.2"
       }
     },
     {

--- a/supacode/Clients/Updates/UpdaterClient.swift
+++ b/supacode/Clients/Updates/UpdaterClient.swift
@@ -43,135 +43,105 @@ final class SilentUpdateDriver: NSObject, SPUUserDriver {
     self.continuation = continuation
   }
 
-  nonisolated func show(
+  // `SPUUserDriver` is declared `NS_SWIFT_UI_ACTOR` (main-actor isolated) as of Sparkle 2.9,
+  // so these callbacks are guaranteed to arrive on the main thread. Implement them as plain
+  // `@MainActor` methods and let the compiler enforce isolation, rather than reaching for
+  // `MainActor.assumeIsolated`, which would crash on any future off-main delivery.
+  func show(
     _ request: SPUUpdatePermissionRequest,
     reply: @escaping @Sendable (SUUpdatePermissionResponse) -> Void
   ) {
-    MainActor.assumeIsolated {
-      standard.show(request, reply: reply)
-    }
+    standard.show(request, reply: reply)
   }
 
-  nonisolated func showUserInitiatedUpdateCheck(cancellation: @escaping @Sendable () -> Void) {
-    MainActor.assumeIsolated {
-      standard.showUserInitiatedUpdateCheck(cancellation: cancellation)
-    }
+  func showUserInitiatedUpdateCheck(cancellation: @escaping @Sendable () -> Void) {
+    standard.showUserInitiatedUpdateCheck(cancellation: cancellation)
   }
 
-  nonisolated func showUpdateFound(
+  func showUpdateFound(
     with appcastItem: SUAppcastItem,
     state: SPUUserUpdateState,
     reply: @escaping @Sendable (SPUUserUpdateChoice) -> Void
   ) {
-    MainActor.assumeIsolated {
-      if state.userInitiated {
-        standard.showUpdateFound(with: appcastItem, state: state, reply: reply)
-        return
-      }
-      // Background check: surface the availability silently, then defer so Sparkle
-      // will re-offer the same update on the next (user-initiated) check.
-      continuation?.yield(.silentUpdateFound(version: appcastItem.displayVersionString))
-      reply(.dismiss)
+    if state.userInitiated {
+      standard.showUpdateFound(with: appcastItem, state: state, reply: reply)
+      return
     }
+    // Background check: surface the availability silently, then defer so Sparkle
+    // will re-offer the same update on the next (user-initiated) check.
+    continuation?.yield(.silentUpdateFound(version: appcastItem.displayVersionString))
+    reply(.dismiss)
   }
 
-  nonisolated func showUpdateReleaseNotes(with downloadData: SPUDownloadData) {
-    MainActor.assumeIsolated {
-      standard.showUpdateReleaseNotes(with: downloadData)
-    }
+  func showUpdateReleaseNotes(with downloadData: SPUDownloadData) {
+    standard.showUpdateReleaseNotes(with: downloadData)
   }
 
-  nonisolated func showUpdateReleaseNotesFailedToDownloadWithError(_ error: any Error) {
-    MainActor.assumeIsolated {
-      standard.showUpdateReleaseNotesFailedToDownloadWithError(error)
-    }
+  func showUpdateReleaseNotesFailedToDownloadWithError(_ error: any Error) {
+    standard.showUpdateReleaseNotesFailedToDownloadWithError(error)
   }
 
-  nonisolated func showUpdateNotFoundWithError(
+  func showUpdateNotFoundWithError(
     _ error: any Error,
     acknowledgement: @escaping @Sendable () -> Void
   ) {
-    MainActor.assumeIsolated {
-      standard.showUpdateNotFoundWithError(error, acknowledgement: acknowledgement)
-    }
+    standard.showUpdateNotFoundWithError(error, acknowledgement: acknowledgement)
   }
 
-  nonisolated func showUpdaterError(
+  func showUpdaterError(
     _ error: any Error,
     acknowledgement: @escaping @Sendable () -> Void
   ) {
-    MainActor.assumeIsolated {
-      standard.showUpdaterError(error, acknowledgement: acknowledgement)
-    }
+    standard.showUpdaterError(error, acknowledgement: acknowledgement)
   }
 
-  nonisolated func showDownloadInitiated(cancellation: @escaping @Sendable () -> Void) {
-    MainActor.assumeIsolated {
-      standard.showDownloadInitiated(cancellation: cancellation)
-    }
+  func showDownloadInitiated(cancellation: @escaping @Sendable () -> Void) {
+    standard.showDownloadInitiated(cancellation: cancellation)
   }
 
-  nonisolated func showDownloadDidReceiveExpectedContentLength(_ expectedContentLength: UInt64) {
-    MainActor.assumeIsolated {
-      standard.showDownloadDidReceiveExpectedContentLength(expectedContentLength)
-    }
+  func showDownloadDidReceiveExpectedContentLength(_ expectedContentLength: UInt64) {
+    standard.showDownloadDidReceiveExpectedContentLength(expectedContentLength)
   }
 
-  nonisolated func showDownloadDidReceiveData(ofLength length: UInt64) {
-    MainActor.assumeIsolated {
-      standard.showDownloadDidReceiveData(ofLength: length)
-    }
+  func showDownloadDidReceiveData(ofLength length: UInt64) {
+    standard.showDownloadDidReceiveData(ofLength: length)
   }
 
-  nonisolated func showDownloadDidStartExtractingUpdate() {
-    MainActor.assumeIsolated {
-      standard.showDownloadDidStartExtractingUpdate()
-    }
+  func showDownloadDidStartExtractingUpdate() {
+    standard.showDownloadDidStartExtractingUpdate()
   }
 
-  nonisolated func showExtractionReceivedProgress(_ progress: Double) {
-    MainActor.assumeIsolated {
-      standard.showExtractionReceivedProgress(progress)
-    }
+  func showExtractionReceivedProgress(_ progress: Double) {
+    standard.showExtractionReceivedProgress(progress)
   }
 
-  nonisolated func showReady(toInstallAndRelaunch reply: @escaping @Sendable (SPUUserUpdateChoice) -> Void) {
-    MainActor.assumeIsolated {
-      standard.showReady(toInstallAndRelaunch: reply)
-    }
+  func showReady(toInstallAndRelaunch reply: @escaping @Sendable (SPUUserUpdateChoice) -> Void) {
+    standard.showReady(toInstallAndRelaunch: reply)
   }
 
-  nonisolated func showInstallingUpdate(
+  func showInstallingUpdate(
     withApplicationTerminated applicationTerminated: Bool,
     retryTerminatingApplication: @escaping @Sendable () -> Void
   ) {
-    MainActor.assumeIsolated {
-      standard.showInstallingUpdate(
-        withApplicationTerminated: applicationTerminated,
-        retryTerminatingApplication: retryTerminatingApplication
-      )
-    }
+    standard.showInstallingUpdate(
+      withApplicationTerminated: applicationTerminated,
+      retryTerminatingApplication: retryTerminatingApplication
+    )
   }
 
-  nonisolated func showUpdateInstalledAndRelaunched(
+  func showUpdateInstalledAndRelaunched(
     _ relaunched: Bool,
     acknowledgement: @escaping @Sendable () -> Void
   ) {
-    MainActor.assumeIsolated {
-      standard.showUpdateInstalledAndRelaunched(relaunched, acknowledgement: acknowledgement)
-    }
+    standard.showUpdateInstalledAndRelaunched(relaunched, acknowledgement: acknowledgement)
   }
 
-  nonisolated func showUpdateInFocus() {
-    MainActor.assumeIsolated {
-      standard.showUpdateInFocus()
-    }
+  func showUpdateInFocus() {
+    standard.showUpdateInFocus()
   }
 
-  nonisolated func dismissUpdateInstallation() {
-    MainActor.assumeIsolated {
-      standard.dismissUpdateInstallation()
-    }
+  func dismissUpdateInstallation() {
+    standard.dismissUpdateInstallation()
   }
 }
 


### PR DESCRIPTION
## Background

Investigating Sentry issue `PROWL-MACOS-AC` — an `EXC_BAD_ACCESS` (`KERN_INVALID_ADDRESS`) on a background thread, entirely inside `Sparkle.framework`. From the registers, `x19` (callee-saved object pointer) held a non-canonical garbage value `0x8d47d4bb091215c` and the crash dereferenced `[x19 + 0x5c]` — a use-after-free / wild-pointer signature. Single event, single user, not reproduced, on `prowl@2026.5.20` (Sparkle `2.9.0-beta.2`).

The crash can't be cleanly root-caused from our side (whole stack in Sparkle internals, no app frames, one-off). This PR takes the low-risk, defensible actions instead.

## Changes

**1. Sparkle `2.9.0-beta.2` → `2.9.2`** (`project.pbxproj`, `Package.resolved`)
We were pinned to a January beta of the auto-updater in notarized builds. 2.9.2 is the latest stable and picks up three stable releases of fixes (crash fix in `clearDownloadedUpdate`, `CFRelease` NULL-guard, Swift-concurrency API annotations).

**2. Harden `SilentUpdateDriver` isolation** (`UpdaterClient.swift`)
`SPUUserDriver` is declared `NS_SWIFT_UI_ACTOR` (main-actor isolated) as of Sparkle 2.9, with the header guaranteeing callbacks arrive on the main thread. So the `nonisolated` + `MainActor.assumeIsolated { … }` boilerplate on every callback is no longer needed — implement them as plain `@MainActor` methods and let the compiler enforce isolation. This removes ~16 `assumeIsolated` trap points that would hard-crash on any future off-main delivery. Behavior (silent dismiss on background checks) is unchanged.

**3. Auto-upload Sparkle dSYMs on release** (`release.sh`)
Sparkle ships as a prebuilt `binaryTarget` (`Sparkle.xcframework`), so Xcode never emits a dSYM for it into the archive — the existing `xcarchive/dSYMs/` upload never covers Sparkle. Its symbols only reached Sentry via a one-off manual bulk upload (2026-04-18), so shipping a new Sparkle version would otherwise leave it unsymbolicated. Upload the dSYMs bundled inside the xcframework directly so each new version symbolicates automatically.

### dSYM note (scope correction)

This does **not** fix every unsymbolicated Sparkle frame. For `PROWL-MACOS-AC`'s event, the Sparkle image *was* present in `debug_meta.images`, the crash pc *was* covered, and the matching dSYM *was* already on Sentry — so `__isPlatformVersionAtLeast.cold.2` is most likely a real attribution, not a missing-dSYM artifact. Separately, some other events drop the Sparkle image from `debug_meta` entirely (sentry-cocoa side); no dSYM upload can recover those. This change only ensures new Sparkle versions' dSYMs are present when an event *does* carry the image.

## Verification
- `make build-app` — success, 0 errors / 0 warnings (existing code already compiled against 2.9.2; hardening also clean)
- `make check` — format + swift-format lint + swiftlint pass

No new tests: only dependency version + isolation annotations + a release-script step changed; no reducer/logic behavior changed.
