### PR TITLE
Recognize OMX as Codex agent

### DIFF
--- a/supacode/Infrastructure/AgentDetection/AgentClassifier.swift
+++ b/supacode/Infrastructure/AgentDetection/AgentClassifier.swift
@@ -6,7 +6,7 @@ func identifyAgent(processName: String) -> DetectedAgent? {
     return .pi
   case "claude", "claude-code":
     return .claude
-  case "codex":
+  case "codex", "omx", "oh-my-codex":
     return .codex
   case "gemini":
     return .gemini

--- a/supacodeTests/AgentClassifierTests.swift
+++ b/supacodeTests/AgentClassifierTests.swift
@@ -8,6 +8,8 @@ struct AgentClassifierTests {
     #expect(identifyAgent(processName: "claude") == .claude)
     #expect(identifyAgent(processName: "claude-code") == .claude)
     #expect(identifyAgent(processName: "codex") == .codex)
+    #expect(identifyAgent(processName: "omx") == .codex)
+    #expect(identifyAgent(processName: "oh-my-codex") == .codex)
     #expect(identifyAgent(processName: "gemini") == .gemini)
     #expect(identifyAgent(processName: "cursor") == .cursor)
     #expect(identifyAgent(processName: "cursor-agent") == .cursor)
@@ -102,6 +104,24 @@ struct AgentClassifierTests {
     let result = try #require(identifyAgentInJob(job))
     #expect(result.agent == .codex)
     #expect(result.name == "codex")
+  }
+
+  @Test func identifiesOmxAsCodexWrapper() throws {
+    let job = ForegroundJob(
+      processGroupID: 42,
+      processes: [
+        ForegroundProcess(
+          pid: 100,
+          name: "node",
+          argv0: "node",
+          cmdline: "node /opt/homebrew/bin/omx --madmax --high"
+        )
+      ]
+    )
+
+    let result = try #require(identifyAgentInJob(job))
+    #expect(result.agent == .codex)
+    #expect(result.name == "omx")
   }
 
   @Test func prefersDirectAgentProcessOverWrapper() throws {


### PR DESCRIPTION
## Summary

- Recognize `omx` and `oh-my-codex` process names as the existing Codex agent type.
- Add coverage for both direct process-name matching and a Node-wrapped `omx` command line.

## Investigation Evidence

I checked the official `Yeachan-Heo/oh-my-codex` repo at `0776355ac840a61b9fddeb62f96fee63cc808169`:

- `package.json` exposes the package as the `omx` binary: https://github.com/Yeachan-Heo/oh-my-codex/blob/0776355ac840a61b9fddeb62f96fee63cc808169/package.json#L7-L8
- The README describes OMX as a workflow layer for OpenAI Codex CLI: https://github.com/Yeachan-Heo/oh-my-codex/blob/0776355ac840a61b9fddeb62f96fee63cc808169/README.md#L26
- The README says OMX only needs a working authenticated `codex` command on PATH and does not require Codex to be installed through npm: https://github.com/Yeachan-Heo/oh-my-codex/blob/0776355ac840a61b9fddeb62f96fee63cc808169/README.md#L84
- The CLI launch path ultimately calls `spawnPlatformCommandSync("codex", launchArgs, ...)`: https://github.com/Yeachan-Heo/oh-my-codex/blob/0776355ac840a61b9fddeb62f96fee63cc808169/src/cli/index.ts#L1142-L1148
- `omx exec` injects its wrapper args and then calls the same Codex launch helper: https://github.com/Yeachan-Heo/oh-my-codex/blob/0776355ac840a61b9fddeb62f96fee63cc808169/src/cli/index.ts#L2233-L2252

That matches the issue hypothesis: for Prowl's active-agent panel, this is an alias/process-name classification problem, not a new agent type.

## Validation

- `xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -only-testing:supacodeTests/AgentClassifierTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation`
