### PR TITLE
Fix active agent detection while scrolled

### DIFF
--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -1744,14 +1744,14 @@ final class WorktreeTerminalState {
 
     let now = Date()
     let previous = surfaceAgentStates[surfaceID] ?? PaneAgentState(lastChangedAt: now)
-    let viewportText = view.bridge.readViewportText() ?? ""
+    let activeText = view.bridge.readActiveText() ?? ""
     // `detectState` is a `nonisolated` pure function that runs in well under a
-    // millisecond on a 24-line viewport, so the prior `Task.detached` hop
+    // millisecond on a terminal-sized active screen, so the prior `Task.detached` hop
     // bought nothing but allocator churn. In long sessions, each detection
     // tick (300 ms or 2 s per surface) was leaving a task stack + closure
     // capture behind that never reached ARC; over a 24 h session this added
     // up to hundreds of MB of unreferenced allocations.
-    let raw = agent.detectState(in: viewportText)
+    let raw = agent.detectState(in: activeText)
     guard surfaces[surfaceID] != nil else { return }
 
     var lastClaudeWorkingAt = lastClaudeWorkingAtBySurface[surfaceID]

--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceBridge.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceBridge.swift
@@ -55,6 +55,10 @@ final class GhosttySurfaceBridge {
     surfaceView?.readViewportContentsForCLI()
   }
 
+  func readActiveText() -> String? {
+    surfaceView?.readActiveContentsForCLI()
+  }
+
   func childPID() -> pid_t? {
     guard let surface else { return nil }
     let pid = ghostty_surface_pid(surface)

--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
@@ -689,6 +689,13 @@ final class GhosttySurfaceView: NSView, Identifiable {
     )
   }
 
+  func readActiveContentsForCLI() -> String? {
+    readText(
+      topLeftTag: GHOSTTY_POINT_ACTIVE,
+      bottomRightTag: GHOSTTY_POINT_ACTIVE
+    )
+  }
+
   func readScreenContentsForCLI() -> String? {
     readText(
       topLeftTag: GHOSTTY_POINT_SCREEN,

--- a/supacodeTests/GhosttySurfaceBridgeTests.swift
+++ b/supacodeTests/GhosttySurfaceBridgeTests.swift
@@ -5,6 +5,12 @@ import Testing
 
 @MainActor
 struct GhosttySurfaceBridgeTests {
+  @Test func activeTextReturnsNilWithoutSurfaceView() {
+    let bridge = GhosttySurfaceBridge()
+
+    #expect(bridge.readActiveText() == nil)
+  }
+
   @Test func desktopNotificationEmitsCallback() {
     let bridge = GhosttySurfaceBridge()
     var received: (String, String)?


### PR DESCRIPTION
## Summary
- Read active terminal screen content for Active Agent state detection instead of the user-scrolled viewport.
- Add a bridge entry point for active screen reads backed by Ghostty's `GHOSTTY_POINT_ACTIVE` range.
- Cover the new bridge API fallback behavior when no surface view is attached.

## Verification
- `xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -only-testing:supacodeTests/GhosttySurfaceBridgeTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation 2>&1 | xcsift -f toon`
- `make check 2>&1 | xcsift -f toon`
- `make build-app 2>&1 | xcsift -f toon`
