### PR TITLE
Toolbar visibility + Dock notification options (refines #340)

### DIFF
--- a/supacode/Clients/Dock/DockClient.swift
+++ b/supacode/Clients/Dock/DockClient.swift
@@ -15,7 +15,11 @@ struct DockClient {
 extension DockClient: DependencyKey {
   static let liveValue = DockClient(
     setNotificationBadge: { count in
-      NSApplication.shared.dockTile.badgeLabel = count > 0 ? String(count) : nil
+      let dockTile = NSApplication.shared.dockTile
+      dockTile.badgeLabel = count > 0 ? String(count) : nil
+      // Setting `badgeLabel` alone doesn't always repaint the tile; force a
+      // redraw so the badge actually appears/clears.
+      dockTile.display()
     },
     bounce: { mode in
       switch mode {

--- a/supacode/Clients/Dock/DockClient.swift
+++ b/supacode/Clients/Dock/DockClient.swift
@@ -1,0 +1,44 @@
+import AppKit
+import ComposableArchitecture
+
+/// Side effects targeting the app's Dock tile: the pending-notification badge
+/// and the attention bounce. Wrapping these in a dependency keeps the reducer
+/// testable and matches how the other AppKit side effects are injected.
+struct DockClient {
+  /// Show (`true`) or clear (`false`) the notification badge on the Dock tile.
+  var setNotificationBadge: @MainActor @Sendable (_ isVisible: Bool) -> Void
+  /// Bounce the Dock icon according to the configured mode. `.off` is a no-op.
+  var bounce: @MainActor @Sendable (_ mode: DockBounceMode) -> Void
+}
+
+extension DockClient: DependencyKey {
+  static let liveValue = DockClient(
+    setNotificationBadge: { isVisible in
+      // An empty (but non-nil) label renders the bare red badge dot; `nil`
+      // hides it. A glyph inside the pill would just look redundant.
+      NSApplication.shared.dockTile.badgeLabel = isVisible ? "" : nil
+    },
+    bounce: { mode in
+      switch mode {
+      case .off:
+        break
+      case .once:
+        _ = NSApp.requestUserAttention(.informationalRequest)
+      case .continuous:
+        _ = NSApp.requestUserAttention(.criticalRequest)
+      }
+    }
+  )
+
+  static let testValue = DockClient(
+    setNotificationBadge: { _ in },
+    bounce: { _ in }
+  )
+}
+
+extension DependencyValues {
+  var dockClient: DockClient {
+    get { self[DockClient.self] }
+    set { self[DockClient.self] = newValue }
+  }
+}

--- a/supacode/Clients/Dock/DockClient.swift
+++ b/supacode/Clients/Dock/DockClient.swift
@@ -5,18 +5,17 @@ import ComposableArchitecture
 /// and the attention bounce. Wrapping these in a dependency keeps the reducer
 /// testable and matches how the other AppKit side effects are injected.
 struct DockClient {
-  /// Show (`true`) or clear (`false`) the notification badge on the Dock tile.
-  var setNotificationBadge: @MainActor @Sendable (_ isVisible: Bool) -> Void
+  /// Set the Dock tile's notification badge to `count` unread items, or clear
+  /// it when `count` is zero.
+  var setNotificationBadge: @MainActor @Sendable (_ count: Int) -> Void
   /// Bounce the Dock icon according to the configured mode. `.off` is a no-op.
   var bounce: @MainActor @Sendable (_ mode: DockBounceMode) -> Void
 }
 
 extension DockClient: DependencyKey {
   static let liveValue = DockClient(
-    setNotificationBadge: { isVisible in
-      // An empty (but non-nil) label renders the bare red badge dot; `nil`
-      // hides it. A glyph inside the pill would just look redundant.
-      NSApplication.shared.dockTile.badgeLabel = isVisible ? "" : nil
+    setNotificationBadge: { count in
+      NSApplication.shared.dockTile.badgeLabel = count > 0 ? String(count) : nil
     },
     bounce: { mode in
       switch mode {

--- a/supacode/Clients/Notifications/SystemNotificationClient.swift
+++ b/supacode/Clients/Notifications/SystemNotificationClient.swift
@@ -64,7 +64,20 @@ struct SystemNotificationClient {
     case notDetermined
   }
 
+  /// Whether macOS will actually render the app's Dock badge. The Dock badge
+  /// is gated by the system notification permission plus the per-app "Badge
+  /// app icon" switch — it does not depend on Prowl's own banner toggle.
+  enum DockBadgeAuthorization: Equatable {
+    /// Notifications are allowed and "Badge app icon" is on.
+    case available
+    /// macOS is not allowing notifications for Prowl (denied or not yet asked).
+    case notificationsDenied
+    /// Notifications are allowed, but "Badge app icon" is turned off.
+    case badgeDisabled
+  }
+
   var authorizationStatus: @MainActor @Sendable () async -> AuthorizationStatus
+  var dockBadgeAuthorization: @MainActor @Sendable () async -> DockBadgeAuthorization
   var requestAuthorization: @MainActor @Sendable () async -> AuthorizationRequestResult
   var send:
     @MainActor @Sendable (_ title: String, _ body: String, _ worktreeID: Worktree.ID?, _ surfaceID: UUID?) async -> Void
@@ -85,6 +98,16 @@ extension SystemNotificationClient: DependencyKey {
         return .notDetermined
       @unknown default:
         return .denied
+      }
+    },
+    dockBadgeAuthorization: {
+      let center = configuredNotificationCenter()
+      let settings = await center.notificationSettings()
+      switch settings.authorizationStatus {
+      case .authorized, .provisional:
+        return settings.badgeSetting == .enabled ? .available : .badgeDisabled
+      default:
+        return .notificationsDenied
       }
     },
     requestAuthorization: {
@@ -130,6 +153,7 @@ extension SystemNotificationClient: DependencyKey {
 
   static let testValue = SystemNotificationClient(
     authorizationStatus: { .notDetermined },
+    dockBadgeAuthorization: { .available },
     requestAuthorization: { AuthorizationRequestResult(granted: false, errorMessage: nil) },
     send: { _, _, _, _ in },
     openSettings: {}

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -119,6 +119,7 @@ struct AppFeature {
   @Dependency(AppLifecycleClient.self) private var appLifecycleClient
   @Dependency(NotificationSoundClient.self) private var notificationSoundClient
   @Dependency(SystemNotificationClient.self) private var systemNotificationClient
+  @Dependency(DockClient.self) private var dockClient
   @Dependency(TerminalClient.self) private var terminalClient
   @Dependency(WorktreeInfoWatcherClient.self) private var worktreeInfoWatcher
   @Dependency(CustomShortcutRegistryClient.self) private var customShortcutRegistryClient
@@ -236,9 +237,7 @@ struct AppFeature {
             await terminalClient.send(.setAgentDetectionEnabled(agentDetectionEnabled))
           },
           .run { _ in
-            await MainActor.run {
-              NSApplication.shared.dockTile.badgeLabel = nil
-            }
+            await dockClient.setNotificationBadge(false)
           },
           .run { send in
             for await event in await terminalClient.events() {
@@ -573,9 +572,7 @@ struct AppFeature {
             }
           },
           .run { _ in
-            await MainActor.run {
-              NSApplication.shared.dockTile.badgeLabel = showDot ? "●" : nil
-            }
+            await dockClient.setNotificationBadge(showDot)
           }
         )
 
@@ -1173,6 +1170,9 @@ struct AppFeature {
 
         case .commandPalette(.delegate(.debugSimulateUpdateFound)):
           return .send(.updates(.debugSimulateUpdateFound))
+
+        case .commandPalette(.delegate(.debugLightDockNotificationDot)):
+          return .run { _ in await dockClient.setNotificationBadge(true) }
       #endif
 
       case .commandPalette:
@@ -1200,23 +1200,11 @@ struct AppFeature {
             }
           )
         }
-        switch state.settings.dockBounceMode {
-        case .off:
-          break
-        case .once:
+        let bounceMode = state.settings.dockBounceMode
+        if bounceMode != .off {
           effects.append(
             .run { _ in
-              await MainActor.run {
-                _ = NSApp.requestUserAttention(.informationalRequest)
-              }
-            }
-          )
-        case .continuous:
-          effects.append(
-            .run { _ in
-              await MainActor.run {
-                _ = NSApp.requestUserAttention(.criticalRequest)
-              }
+              await dockClient.bounce(bounceMode)
             }
           )
         }
@@ -1226,9 +1214,7 @@ struct AppFeature {
         state.notificationIndicatorCount = count
         let showDot = state.settings.showNotificationDotOnDock && count > 0
         return .run { _ in
-          await MainActor.run {
-            NSApplication.shared.dockTile.badgeLabel = showDot ? "●" : nil
-          }
+          await dockClient.setNotificationBadge(showDot)
         }
 
       case .terminalEvent(.runScriptStatusChanged(let worktreeID, let isRunning)):

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -499,6 +499,7 @@ struct AppFeature {
           settings: state.settings,
           customCommands: state.selectedCustomCommands
         )
+        let showDot = settings.showNotificationDotOnDock && state.notificationIndicatorCount > 0
         return .merge(
           .send(.repositories(.githubIntegration(.setGithubIntegrationEnabled(settings.githubIntegrationEnabled)))),
           .send(
@@ -569,6 +570,11 @@ struct AppFeature {
               }
             case .denied:
               await send(.systemNotificationsPermissionFailed(errorMessage: "Authorization status is denied."))
+            }
+          },
+          .run { _ in
+            await MainActor.run {
+              NSApplication.shared.dockTile.badgeLabel = showDot ? "●" : nil
             }
           }
         )
@@ -1194,13 +1200,34 @@ struct AppFeature {
             }
           )
         }
+        switch state.settings.dockBounceMode {
+        case .off:
+          break
+        case .once:
+          effects.append(
+            .run { _ in
+              await MainActor.run {
+                _ = NSApp.requestUserAttention(.informationalRequest)
+              }
+            }
+          )
+        case .continuous:
+          effects.append(
+            .run { _ in
+              await MainActor.run {
+                _ = NSApp.requestUserAttention(.criticalRequest)
+              }
+            }
+          )
+        }
         return .merge(effects)
 
       case .terminalEvent(.notificationIndicatorChanged(let count)):
         state.notificationIndicatorCount = count
+        let showDot = state.settings.showNotificationDotOnDock && count > 0
         return .run { _ in
           await MainActor.run {
-            NSApplication.shared.dockTile.badgeLabel = nil
+            NSApplication.shared.dockTile.badgeLabel = showDot ? "●" : nil
           }
         }
 

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -237,7 +237,7 @@ struct AppFeature {
             await terminalClient.send(.setAgentDetectionEnabled(agentDetectionEnabled))
           },
           .run { _ in
-            await dockClient.setNotificationBadge(false)
+            await dockClient.setNotificationBadge(0)
           },
           .run { send in
             for await event in await terminalClient.events() {
@@ -498,7 +498,7 @@ struct AppFeature {
           settings: state.settings,
           customCommands: state.selectedCustomCommands
         )
-        let showDot = settings.showNotificationDotOnDock && state.notificationIndicatorCount > 0
+        let badgeCount = settings.showNotificationDotOnDock ? state.notificationIndicatorCount : 0
         return .merge(
           .send(.repositories(.githubIntegration(.setGithubIntegrationEnabled(settings.githubIntegrationEnabled)))),
           .send(
@@ -572,7 +572,7 @@ struct AppFeature {
             }
           },
           .run { _ in
-            await dockClient.setNotificationBadge(showDot)
+            await dockClient.setNotificationBadge(badgeCount)
           }
         )
 
@@ -1172,7 +1172,7 @@ struct AppFeature {
           return .send(.updates(.debugSimulateUpdateFound))
 
         case .commandPalette(.delegate(.debugLightDockNotificationDot)):
-          return .run { _ in await dockClient.setNotificationBadge(true) }
+          return .run { _ in await dockClient.setNotificationBadge(1) }
       #endif
 
       case .commandPalette:
@@ -1212,9 +1212,9 @@ struct AppFeature {
 
       case .terminalEvent(.notificationIndicatorChanged(let count)):
         state.notificationIndicatorCount = count
-        let showDot = state.settings.showNotificationDotOnDock && count > 0
+        let badgeCount = state.settings.showNotificationDotOnDock ? count : 0
         return .run { _ in
-          await dockClient.setNotificationBadge(showDot)
+          await dockClient.setNotificationBadge(badgeCount)
         }
 
       case .terminalEvent(.runScriptStatusChanged(let worktreeID, let isRunning)):

--- a/supacode/Features/CommandPalette/CommandPaletteItem.swift
+++ b/supacode/Features/CommandPalette/CommandPaletteItem.swift
@@ -79,6 +79,7 @@ struct CommandPaletteItem: Identifiable, Equatable {
     #if DEBUG
       case debugTestToast(RepositoriesFeature.StatusToast)
       case debugSimulateUpdateFound
+      case debugLightDockNotificationDot
     #endif
   }
 
@@ -150,7 +151,7 @@ struct CommandPaletteItem: Identifiable, Equatable {
       .runCustomCommand:
       return nil
     #if DEBUG
-      case .debugTestToast, .debugSimulateUpdateFound:
+      case .debugTestToast, .debugSimulateUpdateFound, .debugLightDockNotificationDot:
         return nil
     #endif
     }

--- a/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
+++ b/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
@@ -68,6 +68,7 @@ struct CommandPaletteFeature {
     #if DEBUG
       case debugTestToast(RepositoriesFeature.StatusToast)
       case debugSimulateUpdateFound
+      case debugLightDockNotificationDot
     #endif
   }
 
@@ -815,6 +816,14 @@ private func makeClosePullRequestItem(
         category: .debug,
         defaultSuggestion: true
       ),
+      CommandPaletteItem(
+        id: "debug.dock.notification-dot",
+        title: "[Debug] Light Dock Notification Dot",
+        subtitle: "Forces the Dock notification badge on for visual testing",
+        kind: .debugLightDockNotificationDot,
+        category: .debug,
+        defaultSuggestion: true
+      ),
     ]
   }
 #endif
@@ -981,6 +990,8 @@ private func delegateAction(for kind: CommandPaletteItem.Kind) -> CommandPalette
       return .debugTestToast(toast)
     case .debugSimulateUpdateFound:
       return .debugSimulateUpdateFound
+    case .debugLightDockNotificationDot:
+      return .debugLightDockNotificationDot
   #endif
   case .checkForUpdates,
     .openSettings,
@@ -1119,7 +1130,7 @@ private func pullRequestDelegateAction(
     .runCustomCommand:
     return nil
   #if DEBUG
-    case .debugTestToast, .debugSimulateUpdateFound:
+    case .debugTestToast, .debugSimulateUpdateFound, .debugLightDockNotificationDot:
       return nil
   #endif
   }

--- a/supacode/Features/CommandPalette/Views/CommandPaletteOverlayView.swift
+++ b/supacode/Features/CommandPalette/Views/CommandPaletteOverlayView.swift
@@ -534,7 +534,7 @@ private struct CommandPaletteRowView: View {
     case .deleteWorktree:
       return "Delete"
     #if DEBUG
-      case .debugTestToast, .debugSimulateUpdateFound:
+      case .debugTestToast, .debugSimulateUpdateFound, .debugLightDockNotificationDot:
         return "Debug"
     #endif
     }
@@ -615,6 +615,8 @@ private struct CommandPaletteRowView: View {
         return "ladybug"
       case .debugSimulateUpdateFound:
         return "ladybug"
+      case .debugLightDockNotificationDot:
+        return "ladybug"
     #endif
     }
   }
@@ -636,7 +638,7 @@ private struct CommandPaletteRowView: View {
     case .worktreeSelect:
       return false
     #if DEBUG
-      case .debugTestToast, .debugSimulateUpdateFound:
+      case .debugTestToast, .debugSimulateUpdateFound, .debugLightDockNotificationDot:
         return true
     #endif
     }
@@ -777,7 +779,7 @@ private struct CommandPaletteRowView: View {
     case .runCustomCommand:
       base = "Run Custom Command: \(row.title)"
     #if DEBUG
-      case .debugTestToast, .debugSimulateUpdateFound:
+      case .debugTestToast, .debugSimulateUpdateFound, .debugLightDockNotificationDot:
         base = row.title
     #endif
     }

--- a/supacode/Features/Repositories/Views/WorktreeDetailView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailView.swift
@@ -699,10 +699,22 @@ struct WorktreeDetailView: View {
 
     @ToolbarContentBuilder
     private var commandToolbarItems: some ToolbarContent {
-      if toolbarState.showRunButtonInToolbar,
-        toolbarState.runScriptIsRunning || toolbarState.runScriptEnabled
-      {
+      let showRunButton =
+        toolbarState.showRunButtonInToolbar
+        && (toolbarState.runScriptIsRunning || toolbarState.runScriptEnabled)
+      let entries = customCommandEntries
+      let inlineEntries = Array(entries.prefix(3))
+      let overflowEntries = Array(entries.dropFirst(3))
+
+      // One fixed separator in front of the whole Run + Custom Command cluster
+      // keeps it distinct from the Open Editor / notification groups no matter
+      // which items are hidden. Run and the custom commands share one group (no
+      // spacer between them), matching the grouping before the toolbar toggles.
+      if showRunButton || !inlineEntries.isEmpty || !overflowEntries.isEmpty {
         ToolbarSpacer(.fixed)
+      }
+
+      if showRunButton {
         ToolbarItem {
           RunScriptToolbarButton(
             isRunning: toolbarState.runScriptIsRunning,
@@ -724,10 +736,6 @@ struct WorktreeDetailView: View {
           )
         }
       }
-
-      let entries = customCommandEntries
-      let inlineEntries = Array(entries.prefix(3))
-      let overflowEntries = Array(entries.dropFirst(3))
 
       if !inlineEntries.isEmpty {
         ToolbarItemGroup {

--- a/supacode/Features/Repositories/Views/WorktreeDetailView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailView.swift
@@ -16,6 +16,8 @@ struct WorktreeDetailView: View {
     let customCommands: [UserCustomCommand]
     let isUpdateAvailable: Bool
     let availableUpdateVersion: String?
+    let showRunButtonInToolbar: Bool
+    let showDefaultEditorInToolbar: Bool
   }
 
   @Bindable var store: StoreOf<AppFeature>
@@ -89,7 +91,9 @@ struct WorktreeDetailView: View {
             runScriptIsRunning: runScriptIsRunning,
             customCommands: customCommands,
             isUpdateAvailable: state.updates.isUpdateAvailable,
-            availableUpdateVersion: state.updates.availableVersion
+            availableUpdateVersion: state.updates.availableVersion,
+            showRunButtonInToolbar: settingsFile.global.showRunButtonInToolbar,
+            showDefaultEditorInToolbar: settingsFile.global.showDefaultEditorInToolbar
           )
         )
       {
@@ -206,7 +210,9 @@ struct WorktreeDetailView: View {
       runScriptIsRunning: input.runScriptIsRunning,
       customCommands: input.customCommands,
       isUpdateAvailable: input.isUpdateAvailable,
-      availableUpdateVersion: input.availableUpdateVersion
+      availableUpdateVersion: input.availableUpdateVersion,
+      showRunButtonInToolbar: input.showRunButtonInToolbar,
+      showDefaultEditorInToolbar: input.showDefaultEditorInToolbar
     )
   }
 
@@ -572,6 +578,8 @@ struct WorktreeDetailView: View {
     let customCommands: [UserCustomCommand]
     let isUpdateAvailable: Bool
     let availableUpdateVersion: String?
+    let showRunButtonInToolbar: Bool
+    let showDefaultEditorInToolbar: Bool
   }
 
   fileprivate struct WorktreeToolbarContent: ToolbarContent {
@@ -624,15 +632,15 @@ struct WorktreeDetailView: View {
         }
       }
 
-      ToolbarSpacer(.fixed)
-
-      ToolbarItemGroup {
-        openMenu(
-          openActionSelection: toolbarState.openActionSelection,
-          showExtras: toolbarState.showExtras
-        )
+      if toolbarState.showDefaultEditorInToolbar {
+        ToolbarSpacer(.fixed)
+        ToolbarItemGroup {
+          openMenu(
+            openActionSelection: toolbarState.openActionSelection,
+            showExtras: toolbarState.showExtras
+          )
+        }
       }
-      ToolbarSpacer(.fixed)
       commandToolbarItems
 
     }
@@ -691,7 +699,10 @@ struct WorktreeDetailView: View {
 
     @ToolbarContentBuilder
     private var commandToolbarItems: some ToolbarContent {
-      if toolbarState.runScriptIsRunning || toolbarState.runScriptEnabled {
+      if toolbarState.showRunButtonInToolbar,
+        toolbarState.runScriptIsRunning || toolbarState.runScriptEnabled
+      {
+        ToolbarSpacer(.fixed)
         ToolbarItem {
           RunScriptToolbarButton(
             isRunning: toolbarState.runScriptIsRunning,
@@ -1060,7 +1071,9 @@ private struct WorktreeToolbarPreview: View {
         )
       ],
       isUpdateAvailable: true,
-      availableUpdateVersion: "2026.5.1"
+      availableUpdateVersion: "2026.5.1",
+      showRunButtonInToolbar: true,
+      showDefaultEditorInToolbar: true
     )
     let observer = CommandKeyObserver()
     observer.isPressed = false

--- a/supacode/Features/Settings/Models/DockBounceMode.swift
+++ b/supacode/Features/Settings/Models/DockBounceMode.swift
@@ -1,0 +1,27 @@
+/// Controls whether and how the Prowl dock icon bounces when an in-app
+/// notification is received.
+///
+/// Persistence: encoded as the raw `String` (case name). Cases must never
+/// be renamed once shipped because user JSON references them by name.
+enum DockBounceMode: String, CaseIterable, Identifiable, Codable, Sendable {
+  /// Do not bounce the dock icon.
+  case off
+  /// Bounce the dock icon once (`NSRequestUserAttentionType.informationalRequest`).
+  case once
+  /// Bounce the dock icon repeatedly until Prowl is brought to the front
+  /// (`NSRequestUserAttentionType.criticalRequest`).
+  case continuous
+
+  var id: String { rawValue }
+
+  var title: String {
+    switch self {
+    case .off:
+      return "Off"
+    case .once:
+      return "Once"
+    case .continuous:
+      return "Continuously"
+    }
+  }
+}

--- a/supacode/Features/Settings/Models/GlobalSettings.swift
+++ b/supacode/Features/Settings/Models/GlobalSettings.swift
@@ -31,6 +31,8 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
   var autoShowActiveAgentsPanel: Bool
   var windowTintMode: WindowTintMode
   var windowTintCustomColor: TintColor
+  var showRunButtonInToolbar: Bool
+  var showDefaultEditorInToolbar: Bool
 
   static let `default` = GlobalSettings(
     appearanceMode: .dark,
@@ -64,7 +66,9 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     dimUnfocusedSplits: true,
     autoShowActiveAgentsPanel: false,
     windowTintMode: .repositoryColor,
-    windowTintCustomColor: .default
+    windowTintCustomColor: .default,
+    showRunButtonInToolbar: true,
+    showDefaultEditorInToolbar: true
   )
 
   init(
@@ -99,7 +103,9 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     dimUnfocusedSplits: Bool = true,
     autoShowActiveAgentsPanel: Bool = false,
     windowTintMode: WindowTintMode = .repositoryColor,
-    windowTintCustomColor: TintColor = .default
+    windowTintCustomColor: TintColor = .default,
+    showRunButtonInToolbar: Bool = true,
+    showDefaultEditorInToolbar: Bool = true
   ) {
     self.appearanceMode = appearanceMode
     self.defaultEditorID = defaultEditorID
@@ -133,6 +139,8 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     self.autoShowActiveAgentsPanel = autoShowActiveAgentsPanel
     self.windowTintMode = windowTintMode
     self.windowTintCustomColor = windowTintCustomColor
+    self.showRunButtonInToolbar = showRunButtonInToolbar
+    self.showDefaultEditorInToolbar = showDefaultEditorInToolbar
   }
 
   func encode(to encoder: any Encoder) throws {
@@ -169,6 +177,8 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     try container.encode(autoShowActiveAgentsPanel, forKey: .autoShowActiveAgentsPanel)
     try container.encode(windowTintMode, forKey: .windowTintMode)
     try container.encode(windowTintCustomColor, forKey: .windowTintCustomColor)
+    try container.encode(showRunButtonInToolbar, forKey: .showRunButtonInToolbar)
+    try container.encode(showDefaultEditorInToolbar, forKey: .showDefaultEditorInToolbar)
   }
 
   private enum CodingKeys: String, CodingKey {
@@ -204,6 +214,8 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     case autoShowActiveAgentsPanel
     case windowTintMode
     case windowTintCustomColor
+    case showRunButtonInToolbar
+    case showDefaultEditorInToolbar
     // Legacy key for migration
     case automaticallyArchiveMergedWorktrees
   }
@@ -308,5 +320,11 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     windowTintCustomColor =
       try container.decodeIfPresent(TintColor.self, forKey: .windowTintCustomColor)
       ?? Self.default.windowTintCustomColor
+    showRunButtonInToolbar =
+      try container.decodeIfPresent(Bool.self, forKey: .showRunButtonInToolbar)
+      ?? Self.default.showRunButtonInToolbar
+    showDefaultEditorInToolbar =
+      try container.decodeIfPresent(Bool.self, forKey: .showDefaultEditorInToolbar)
+      ?? Self.default.showDefaultEditorInToolbar
   }
 }

--- a/supacode/Features/Settings/Models/GlobalSettings.swift
+++ b/supacode/Features/Settings/Models/GlobalSettings.swift
@@ -33,6 +33,8 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
   var windowTintCustomColor: TintColor
   var showRunButtonInToolbar: Bool
   var showDefaultEditorInToolbar: Bool
+  var dockBounceMode: DockBounceMode
+  var showNotificationDotOnDock: Bool
 
   static let `default` = GlobalSettings(
     appearanceMode: .dark,
@@ -68,7 +70,9 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     windowTintMode: .repositoryColor,
     windowTintCustomColor: .default,
     showRunButtonInToolbar: true,
-    showDefaultEditorInToolbar: true
+    showDefaultEditorInToolbar: true,
+    dockBounceMode: .off,
+    showNotificationDotOnDock: false
   )
 
   init(
@@ -105,7 +109,9 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     windowTintMode: WindowTintMode = .repositoryColor,
     windowTintCustomColor: TintColor = .default,
     showRunButtonInToolbar: Bool = true,
-    showDefaultEditorInToolbar: Bool = true
+    showDefaultEditorInToolbar: Bool = true,
+    dockBounceMode: DockBounceMode = .off,
+    showNotificationDotOnDock: Bool = false
   ) {
     self.appearanceMode = appearanceMode
     self.defaultEditorID = defaultEditorID
@@ -141,6 +147,8 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     self.windowTintCustomColor = windowTintCustomColor
     self.showRunButtonInToolbar = showRunButtonInToolbar
     self.showDefaultEditorInToolbar = showDefaultEditorInToolbar
+    self.dockBounceMode = dockBounceMode
+    self.showNotificationDotOnDock = showNotificationDotOnDock
   }
 
   func encode(to encoder: any Encoder) throws {
@@ -179,6 +187,8 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     try container.encode(windowTintCustomColor, forKey: .windowTintCustomColor)
     try container.encode(showRunButtonInToolbar, forKey: .showRunButtonInToolbar)
     try container.encode(showDefaultEditorInToolbar, forKey: .showDefaultEditorInToolbar)
+    try container.encode(dockBounceMode, forKey: .dockBounceMode)
+    try container.encode(showNotificationDotOnDock, forKey: .showNotificationDotOnDock)
   }
 
   private enum CodingKeys: String, CodingKey {
@@ -216,6 +226,8 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     case windowTintCustomColor
     case showRunButtonInToolbar
     case showDefaultEditorInToolbar
+    case dockBounceMode
+    case showNotificationDotOnDock
     // Legacy key for migration
     case automaticallyArchiveMergedWorktrees
   }
@@ -326,5 +338,11 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     showDefaultEditorInToolbar =
       try container.decodeIfPresent(Bool.self, forKey: .showDefaultEditorInToolbar)
       ?? Self.default.showDefaultEditorInToolbar
+    dockBounceMode =
+      try container.decodeIfPresent(DockBounceMode.self, forKey: .dockBounceMode)
+      ?? Self.default.dockBounceMode
+    showNotificationDotOnDock =
+      try container.decodeIfPresent(Bool.self, forKey: .showNotificationDotOnDock)
+      ?? Self.default.showNotificationDotOnDock
   }
 }

--- a/supacode/Features/Settings/Models/GlobalSettings.swift
+++ b/supacode/Features/Settings/Models/GlobalSettings.swift
@@ -232,7 +232,6 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     case automaticallyArchiveMergedWorktrees
   }
 
-  // swiftlint:disable:next function_body_length
   init(from decoder: any Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     appearanceMode = try container.decode(AppearanceMode.self, forKey: .appearanceMode)
@@ -277,15 +276,7 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     deleteBranchOnDeleteWorktree =
       try container.decodeIfPresent(Bool.self, forKey: .deleteBranchOnDeleteWorktree)
       ?? Self.default.deleteBranchOnDeleteWorktree
-    if let decoded = try container.decodeIfPresent(MergedWorktreeAction.self, forKey: .mergedWorktreeAction) {
-      mergedWorktreeAction = decoded
-    } else if let legacyBool = try container.decodeIfPresent(
-      Bool.self, forKey: .automaticallyArchiveMergedWorktrees
-    ) {
-      mergedWorktreeAction = legacyBool ? .archive : nil
-    } else {
-      mergedWorktreeAction = Self.default.mergedWorktreeAction
-    }
+    mergedWorktreeAction = try Self.decodeMergedWorktreeAction(from: container)
     promptForWorktreeCreation =
       try container.decodeIfPresent(Bool.self, forKey: .promptForWorktreeCreation)
       ?? Self.default.promptForWorktreeCreation
@@ -327,23 +318,59 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     autoShowActiveAgentsPanel =
       try container.decodeIfPresent(Bool.self, forKey: .autoShowActiveAgentsPanel)
       ?? Self.default.autoShowActiveAgentsPanel
-    windowTintMode =
+    (windowTintMode, windowTintCustomColor) = try Self.decodeWindowTint(from: container)
+    let toolbarAndDock = try Self.decodeToolbarAndDockSettings(from: container)
+    showRunButtonInToolbar = toolbarAndDock.showRunButtonInToolbar
+    showDefaultEditorInToolbar = toolbarAndDock.showDefaultEditorInToolbar
+    dockBounceMode = toolbarAndDock.dockBounceMode
+    showNotificationDotOnDock = toolbarAndDock.showNotificationDotOnDock
+  }
+
+  private static func decodeWindowTint(
+    from container: KeyedDecodingContainer<CodingKeys>
+  ) throws -> (WindowTintMode, TintColor) {
+    let mode =
       try container.decodeIfPresent(WindowTintMode.self, forKey: .windowTintMode)
       ?? Self.default.windowTintMode
-    windowTintCustomColor =
+    let customColor =
       try container.decodeIfPresent(TintColor.self, forKey: .windowTintCustomColor)
       ?? Self.default.windowTintCustomColor
-    showRunButtonInToolbar =
-      try container.decodeIfPresent(Bool.self, forKey: .showRunButtonInToolbar)
-      ?? Self.default.showRunButtonInToolbar
-    showDefaultEditorInToolbar =
-      try container.decodeIfPresent(Bool.self, forKey: .showDefaultEditorInToolbar)
-      ?? Self.default.showDefaultEditorInToolbar
-    dockBounceMode =
-      try container.decodeIfPresent(DockBounceMode.self, forKey: .dockBounceMode)
-      ?? Self.default.dockBounceMode
-    showNotificationDotOnDock =
-      try container.decodeIfPresent(Bool.self, forKey: .showNotificationDotOnDock)
-      ?? Self.default.showNotificationDotOnDock
+    return (mode, customColor)
+  }
+
+  private static func decodeMergedWorktreeAction(
+    from container: KeyedDecodingContainer<CodingKeys>
+  ) throws -> MergedWorktreeAction? {
+    if let decoded = try container.decodeIfPresent(MergedWorktreeAction.self, forKey: .mergedWorktreeAction) {
+      return decoded
+    }
+    if let legacyBool = try container.decodeIfPresent(Bool.self, forKey: .automaticallyArchiveMergedWorktrees) {
+      return legacyBool ? .archive : nil
+    }
+    return Self.default.mergedWorktreeAction
+  }
+
+  /// The toolbar-visibility and Dock-notification preferences, decoded as a
+  /// unit so `init(from:)` stays within the body-length limit.
+  private struct ToolbarAndDockSettings {
+    let showRunButtonInToolbar: Bool
+    let showDefaultEditorInToolbar: Bool
+    let dockBounceMode: DockBounceMode
+    let showNotificationDotOnDock: Bool
+  }
+
+  private static func decodeToolbarAndDockSettings(
+    from container: KeyedDecodingContainer<CodingKeys>
+  ) throws -> ToolbarAndDockSettings {
+    try ToolbarAndDockSettings(
+      showRunButtonInToolbar: container.decodeIfPresent(Bool.self, forKey: .showRunButtonInToolbar)
+        ?? Self.default.showRunButtonInToolbar,
+      showDefaultEditorInToolbar: container.decodeIfPresent(Bool.self, forKey: .showDefaultEditorInToolbar)
+        ?? Self.default.showDefaultEditorInToolbar,
+      dockBounceMode: container.decodeIfPresent(DockBounceMode.self, forKey: .dockBounceMode)
+        ?? Self.default.dockBounceMode,
+      showNotificationDotOnDock: container.decodeIfPresent(Bool.self, forKey: .showNotificationDotOnDock)
+        ?? Self.default.showNotificationDotOnDock
+    )
   }
 }

--- a/supacode/Features/Settings/Models/GlobalSettings.swift
+++ b/supacode/Features/Settings/Models/GlobalSettings.swift
@@ -232,6 +232,7 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     case automaticallyArchiveMergedWorktrees
   }
 
+  // swiftlint:disable:next function_body_length
   init(from decoder: any Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     appearanceMode = try container.decode(AppearanceMode.self, forKey: .appearanceMode)

--- a/supacode/Features/Settings/Reducer/SettingsFeature.swift
+++ b/supacode/Features/Settings/Reducer/SettingsFeature.swift
@@ -43,6 +43,8 @@ struct SettingsFeature {
     var windowTintCustomColor: Color
     var showRunButtonInToolbar: Bool
     var showDefaultEditorInToolbar: Bool
+    var dockBounceMode: DockBounceMode
+    var showNotificationDotOnDock: Bool
     var cliInstallStatus: CLIInstallStatus = .notInstalled
     var cliInstallShowAlert: Bool = true
     var selection: SettingsSection? = .general
@@ -86,6 +88,8 @@ struct SettingsFeature {
       windowTintCustomColor = settings.windowTintCustomColor.color
       showRunButtonInToolbar = settings.showRunButtonInToolbar
       showDefaultEditorInToolbar = settings.showDefaultEditorInToolbar
+      dockBounceMode = settings.dockBounceMode
+      showNotificationDotOnDock = settings.showNotificationDotOnDock
     }
 
     var globalSettings: GlobalSettings {
@@ -125,7 +129,9 @@ struct SettingsFeature {
         windowTintMode: windowTintMode,
         windowTintCustomColor: TintColor(windowTintCustomColor),
         showRunButtonInToolbar: showRunButtonInToolbar,
-        showDefaultEditorInToolbar: showDefaultEditorInToolbar
+        showDefaultEditorInToolbar: showDefaultEditorInToolbar,
+        dockBounceMode: dockBounceMode,
+        showNotificationDotOnDock: showNotificationDotOnDock
       )
     }
   }
@@ -232,6 +238,8 @@ struct SettingsFeature {
         state.windowTintCustomColor = normalizedSettings.windowTintCustomColor.color
         state.showRunButtonInToolbar = normalizedSettings.showRunButtonInToolbar
         state.showDefaultEditorInToolbar = normalizedSettings.showDefaultEditorInToolbar
+        state.dockBounceMode = normalizedSettings.dockBounceMode
+        state.showNotificationDotOnDock = normalizedSettings.showNotificationDotOnDock
         state.syncGlobalDefaults(from: normalizedSettings)
         return .send(.delegate(.settingsChanged(normalizedSettings)))
 

--- a/supacode/Features/Settings/Reducer/SettingsFeature.swift
+++ b/supacode/Features/Settings/Reducer/SettingsFeature.swift
@@ -41,6 +41,8 @@ struct SettingsFeature {
     /// the `ColorPicker` can bind to it directly; converted back to the
     /// persistable `TintColor` at the `globalSettings` boundary.
     var windowTintCustomColor: Color
+    var showRunButtonInToolbar: Bool
+    var showDefaultEditorInToolbar: Bool
     var cliInstallStatus: CLIInstallStatus = .notInstalled
     var cliInstallShowAlert: Bool = true
     var selection: SettingsSection? = .general
@@ -82,6 +84,8 @@ struct SettingsFeature {
       autoShowActiveAgentsPanel = settings.autoShowActiveAgentsPanel
       windowTintMode = settings.windowTintMode
       windowTintCustomColor = settings.windowTintCustomColor.color
+      showRunButtonInToolbar = settings.showRunButtonInToolbar
+      showDefaultEditorInToolbar = settings.showDefaultEditorInToolbar
     }
 
     var globalSettings: GlobalSettings {
@@ -119,7 +123,9 @@ struct SettingsFeature {
         dimUnfocusedSplits: dimUnfocusedSplits,
         autoShowActiveAgentsPanel: autoShowActiveAgentsPanel,
         windowTintMode: windowTintMode,
-        windowTintCustomColor: TintColor(windowTintCustomColor)
+        windowTintCustomColor: TintColor(windowTintCustomColor),
+        showRunButtonInToolbar: showRunButtonInToolbar,
+        showDefaultEditorInToolbar: showDefaultEditorInToolbar
       )
     }
   }
@@ -224,6 +230,8 @@ struct SettingsFeature {
         state.autoShowActiveAgentsPanel = normalizedSettings.autoShowActiveAgentsPanel
         state.windowTintMode = normalizedSettings.windowTintMode
         state.windowTintCustomColor = normalizedSettings.windowTintCustomColor.color
+        state.showRunButtonInToolbar = normalizedSettings.showRunButtonInToolbar
+        state.showDefaultEditorInToolbar = normalizedSettings.showDefaultEditorInToolbar
         state.syncGlobalDefaults(from: normalizedSettings)
         return .send(.delegate(.settingsChanged(normalizedSettings)))
 

--- a/supacode/Features/Settings/Reducer/SettingsFeature.swift
+++ b/supacode/Features/Settings/Reducer/SettingsFeature.swift
@@ -359,17 +359,9 @@ struct SettingsFeature {
         state.dockBadgeAuthorization = authorization
         return .none
 
-      case .showNotificationPermissionAlert(let errorMessage):
-        let message: String
-        if let errorMessage, !errorMessage.isEmpty {
-          message =
-            "Prowl cannot send system notifications.\n\n"
-            + "Error: \(errorMessage)"
-        } else {
-          message = "Prowl cannot send system notifications while permission is denied."
-        }
+      case .showNotificationPermissionAlert:
         state.alert = AlertState {
-          TextState("Enable Notifications in System Settings")
+          TextState("Prowl cannot send system notifications")
         } actions: {
           ButtonState(action: .openSystemNotificationSettings) {
             TextState("Open System Settings")
@@ -378,7 +370,9 @@ struct SettingsFeature {
             TextState("Cancel")
           }
         } message: {
-          TextState(message)
+          TextState(
+            "Notification permission is turned off. Open System Settings to allow Prowl to send notifications."
+          )
         }
         return .none
 

--- a/supacode/Features/Settings/Reducer/SettingsFeature.swift
+++ b/supacode/Features/Settings/Reducer/SettingsFeature.swift
@@ -47,6 +47,10 @@ struct SettingsFeature {
     var showNotificationDotOnDock: Bool
     var cliInstallStatus: CLIInstallStatus = .notInstalled
     var cliInstallShowAlert: Bool = true
+    /// Whether macOS will render the Dock notification badge (notification
+    /// permission + the per-app "Badge app icon" switch). Refreshed when the
+    /// Notifications settings pane appears.
+    var dockBadgeAuthorization: SystemNotificationClient.DockBadgeAuthorization = .available
     var selection: SettingsSection? = .general
     var repositorySettings: RepositorySettingsFeature.State?
     @Presents var alert: AlertState<Alert>?
@@ -148,6 +152,8 @@ struct SettingsFeature {
     case uninstallCLIButtonTapped
     case cliInstallCompleted(Result<String, CLIInstallError>)
     case refreshCLIInstallStatus
+    case refreshDockBadgeAuthorization
+    case dockBadgeAuthorizationResponse(SystemNotificationClient.DockBadgeAuthorization)
     case showNotificationPermissionAlert(errorMessage: String?)
     case repositorySettings(RepositorySettingsFeature.Action)
     case alert(PresentationAction<Alert>)
@@ -342,6 +348,15 @@ struct SettingsFeature {
 
       case .refreshCLIInstallStatus:
         state.cliInstallStatus = cliInstallClient.installationStatus(cliDefaultInstallPath)
+        return .none
+
+      case .refreshDockBadgeAuthorization:
+        return .run { send in
+          await send(.dockBadgeAuthorizationResponse(systemNotificationClient.dockBadgeAuthorization()))
+        }
+
+      case .dockBadgeAuthorizationResponse(let authorization):
+        state.dockBadgeAuthorization = authorization
         return .none
 
       case .showNotificationPermissionAlert(let errorMessage):

--- a/supacode/Features/Settings/Views/AppearanceSettingsView.swift
+++ b/supacode/Features/Settings/Views/AppearanceSettingsView.swift
@@ -93,6 +93,11 @@ struct AppearanceSettingsView: View {
           .help("View Prowl starts in on launch. Shelf and Canvas require at least one worktree or folder.")
         }
         Section("Default Editor") {
+          Toggle(
+            "Show in toolbar",
+            isOn: $store.showDefaultEditorInToolbar
+          )
+          .help("Show the Open in Editor button in the worktree toolbar.")
           Picker(
             "Default editor",
             selection: $store.defaultEditorID
@@ -105,6 +110,13 @@ struct AppearanceSettingsView: View {
             }
           }
           .help("Applies to worktrees without repository overrides.")
+        }
+        Section("Run") {
+          Toggle(
+            "Show in toolbar",
+            isOn: $store.showRunButtonInToolbar
+          )
+          .help("Show the Run button in the worktree toolbar.")
         }
         Section("Quit") {
           Toggle(

--- a/supacode/Features/Settings/Views/NotificationsSettingsView.swift
+++ b/supacode/Features/Settings/Views/NotificationsSettingsView.swift
@@ -29,6 +29,20 @@ struct NotificationsSettingsView: View {
             isOn: $store.moveNotifiedWorktreeToTop
           )
           .help("Bring the worktree to the top when the terminal receives a notification")
+          Picker(
+            "Bounce dock icon",
+            selection: $store.dockBounceMode
+          ) {
+            ForEach(DockBounceMode.allCases) { mode in
+              Text(mode.title).tag(mode)
+            }
+          }
+          .help("Bounce the Prowl app icon in the Dock when a notification is received.")
+          Toggle(
+            "Show notification dot on dock icon",
+            isOn: $store.showNotificationDotOnDock
+          )
+          .help("Show a badge on the Prowl dock icon while notifications are pending.")
         }
         Section("Command Finished") {
           Toggle(

--- a/supacode/Features/Settings/Views/NotificationsSettingsView.swift
+++ b/supacode/Features/Settings/Views/NotificationsSettingsView.swift
@@ -1,3 +1,5 @@
+import AppKit
+import Combine
 import ComposableArchitecture
 import SwiftUI
 
@@ -85,6 +87,12 @@ struct NotificationsSettingsView: View {
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     .task {
+      store.send(.refreshDockBadgeAuthorization)
+    }
+    // Changing the notification permission or "Badge app icon" switch happens
+    // in System Settings, so the moment Prowl regains focus is when to re-read
+    // the macOS state and update the toggle live (no restart needed).
+    .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
       store.send(.refreshDockBadgeAuthorization)
     }
   }

--- a/supacode/Features/Settings/Views/NotificationsSettingsView.swift
+++ b/supacode/Features/Settings/Views/NotificationsSettingsView.swift
@@ -20,11 +20,6 @@ struct NotificationsSettingsView: View {
           )
           .help("Play a sound when a notification is received")
           Toggle(
-            "System notifications",
-            isOn: $store.systemNotificationsEnabled
-          )
-          .help("Show macOS system notifications")
-          Toggle(
             "Move notified worktree to top",
             isOn: $store.moveNotifiedWorktreeToTop
           )
@@ -38,11 +33,24 @@ struct NotificationsSettingsView: View {
             }
           }
           .help("Bounce the Prowl app icon in the Dock when a notification is received.")
+        }
+        Section("System") {
           Toggle(
-            "Show notification dot on dock icon",
+            "System notifications",
+            isOn: $store.systemNotificationsEnabled
+          )
+          .help("Show macOS system notification banners")
+          Toggle(
+            "Show notification badge on dock icon",
             isOn: $store.showNotificationDotOnDock
           )
-          .help("Show a badge on the Prowl dock icon while notifications are pending.")
+          .help("Show the unread worktree count on the Prowl dock icon.")
+          .disabled(!dockBadgeAvailable)
+          if let dockBadgeCaption {
+            Text(dockBadgeCaption)
+              .font(.callout)
+              .foregroundStyle(.secondary)
+          }
         }
         Section("Command Finished") {
           Toggle(
@@ -76,5 +84,23 @@ struct NotificationsSettingsView: View {
       .formStyle(.grouped)
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    .task {
+      store.send(.refreshDockBadgeAuthorization)
+    }
+  }
+
+  private var dockBadgeAvailable: Bool {
+    store.dockBadgeAuthorization == .available
+  }
+
+  private var dockBadgeCaption: String? {
+    switch store.dockBadgeAuthorization {
+    case .available:
+      return nil
+    case .notificationsDenied:
+      return "Allow notifications for Prowl in System Settings to show the Dock badge."
+    case .badgeDisabled:
+      return "Turn on “Badge app icon” for Prowl in System Settings > Notifications."
+    }
   }
 }

--- a/supacodeTests/AppFeatureDockTests.swift
+++ b/supacodeTests/AppFeatureDockTests.swift
@@ -1,0 +1,138 @@
+import ComposableArchitecture
+import DependenciesTestSupport
+import Foundation
+import Testing
+
+@testable import supacode
+
+@MainActor
+struct AppFeatureDockTests {
+  private func notificationReceived() -> AppFeature.Action {
+    .terminalEvent(
+      .notificationReceived(
+        worktreeID: "/tmp/repo/wt-1",
+        surfaceID: UUID(),
+        title: "Done",
+        body: "Build succeeded"
+      )
+    )
+  }
+
+  @Test(.dependencies) func notificationReceivedBouncesOnceWhenModeIsOnce() async {
+    var globalSettings = GlobalSettings.default
+    globalSettings.dockBounceMode = .once
+    let bounces = LockIsolated<[DockBounceMode]>([])
+    let store = TestStore(
+      initialState: AppFeature.State(settings: SettingsFeature.State(settings: globalSettings))
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.dockClient.bounce = { mode in bounces.withValue { $0.append(mode) } }
+    }
+    store.exhaustivity = .off
+
+    await store.send(notificationReceived())
+    await store.finish()
+
+    #expect(bounces.value == [.once])
+  }
+
+  @Test(.dependencies) func notificationReceivedBouncesContinuouslyWhenModeIsContinuous() async {
+    var globalSettings = GlobalSettings.default
+    globalSettings.dockBounceMode = .continuous
+    let bounces = LockIsolated<[DockBounceMode]>([])
+    let store = TestStore(
+      initialState: AppFeature.State(settings: SettingsFeature.State(settings: globalSettings))
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.dockClient.bounce = { mode in bounces.withValue { $0.append(mode) } }
+    }
+    store.exhaustivity = .off
+
+    await store.send(notificationReceived())
+    await store.finish()
+
+    #expect(bounces.value == [.continuous])
+  }
+
+  @Test(.dependencies) func notificationReceivedDoesNotBounceWhenModeIsOff() async {
+    // `.off` is the default; no bounce effect should be scheduled at all.
+    let globalSettings = GlobalSettings.default
+    let bounces = LockIsolated<[DockBounceMode]>([])
+    let store = TestStore(
+      initialState: AppFeature.State(settings: SettingsFeature.State(settings: globalSettings))
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.dockClient.bounce = { mode in bounces.withValue { $0.append(mode) } }
+    }
+    store.exhaustivity = .off
+
+    await store.send(notificationReceived())
+    await store.finish()
+
+    #expect(bounces.value.isEmpty)
+  }
+
+  @Test(.dependencies) func indicatorChangeShowsBadgeWhenEnabledAndCountPositive() async {
+    var globalSettings = GlobalSettings.default
+    globalSettings.showNotificationDotOnDock = true
+    let badges = LockIsolated<[Bool]>([])
+    let store = TestStore(
+      initialState: AppFeature.State(settings: SettingsFeature.State(settings: globalSettings))
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.dockClient.setNotificationBadge = { isVisible in badges.withValue { $0.append(isVisible) } }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.terminalEvent(.notificationIndicatorChanged(count: 2))) {
+      $0.notificationIndicatorCount = 2
+    }
+    await store.finish()
+
+    #expect(badges.value == [true])
+  }
+
+  @Test(.dependencies) func indicatorChangeClearsBadgeWhenDisabled() async {
+    var globalSettings = GlobalSettings.default
+    globalSettings.showNotificationDotOnDock = false
+    let badges = LockIsolated<[Bool]>([])
+    let store = TestStore(
+      initialState: AppFeature.State(settings: SettingsFeature.State(settings: globalSettings))
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.dockClient.setNotificationBadge = { isVisible in badges.withValue { $0.append(isVisible) } }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.terminalEvent(.notificationIndicatorChanged(count: 3))) {
+      $0.notificationIndicatorCount = 3
+    }
+    await store.finish()
+
+    #expect(badges.value == [false])
+  }
+
+  @Test(.dependencies) func indicatorChangeClearsBadgeWhenCountZero() async {
+    var globalSettings = GlobalSettings.default
+    globalSettings.showNotificationDotOnDock = true
+    let badges = LockIsolated<[Bool]>([])
+    let store = TestStore(
+      initialState: AppFeature.State(settings: SettingsFeature.State(settings: globalSettings))
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.dockClient.setNotificationBadge = { isVisible in badges.withValue { $0.append(isVisible) } }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.terminalEvent(.notificationIndicatorChanged(count: 0)))
+    await store.finish()
+
+    #expect(badges.value == [false])
+  }
+}

--- a/supacodeTests/AppFeatureDockTests.swift
+++ b/supacodeTests/AppFeatureDockTests.swift
@@ -78,13 +78,13 @@ struct AppFeatureDockTests {
   @Test(.dependencies) func indicatorChangeShowsBadgeWhenEnabledAndCountPositive() async {
     var globalSettings = GlobalSettings.default
     globalSettings.showNotificationDotOnDock = true
-    let badges = LockIsolated<[Bool]>([])
+    let badges = LockIsolated<[Int]>([])
     let store = TestStore(
       initialState: AppFeature.State(settings: SettingsFeature.State(settings: globalSettings))
     ) {
       AppFeature()
     } withDependencies: {
-      $0.dockClient.setNotificationBadge = { isVisible in badges.withValue { $0.append(isVisible) } }
+      $0.dockClient.setNotificationBadge = { count in badges.withValue { $0.append(count) } }
     }
     store.exhaustivity = .off
 
@@ -93,19 +93,19 @@ struct AppFeatureDockTests {
     }
     await store.finish()
 
-    #expect(badges.value == [true])
+    #expect(badges.value == [2])
   }
 
   @Test(.dependencies) func indicatorChangeClearsBadgeWhenDisabled() async {
     var globalSettings = GlobalSettings.default
     globalSettings.showNotificationDotOnDock = false
-    let badges = LockIsolated<[Bool]>([])
+    let badges = LockIsolated<[Int]>([])
     let store = TestStore(
       initialState: AppFeature.State(settings: SettingsFeature.State(settings: globalSettings))
     ) {
       AppFeature()
     } withDependencies: {
-      $0.dockClient.setNotificationBadge = { isVisible in badges.withValue { $0.append(isVisible) } }
+      $0.dockClient.setNotificationBadge = { count in badges.withValue { $0.append(count) } }
     }
     store.exhaustivity = .off
 
@@ -114,25 +114,25 @@ struct AppFeatureDockTests {
     }
     await store.finish()
 
-    #expect(badges.value == [false])
+    #expect(badges.value == [0])
   }
 
   @Test(.dependencies) func indicatorChangeClearsBadgeWhenCountZero() async {
     var globalSettings = GlobalSettings.default
     globalSettings.showNotificationDotOnDock = true
-    let badges = LockIsolated<[Bool]>([])
+    let badges = LockIsolated<[Int]>([])
     let store = TestStore(
       initialState: AppFeature.State(settings: SettingsFeature.State(settings: globalSettings))
     ) {
       AppFeature()
     } withDependencies: {
-      $0.dockClient.setNotificationBadge = { isVisible in badges.withValue { $0.append(isVisible) } }
+      $0.dockClient.setNotificationBadge = { count in badges.withValue { $0.append(count) } }
     }
     store.exhaustivity = .off
 
     await store.send(.terminalEvent(.notificationIndicatorChanged(count: 0)))
     await store.finish()
 
-    #expect(badges.value == [false])
+    #expect(badges.value == [0])
   }
 }

--- a/supacodeTests/AppFeatureSystemNotificationTests.swift
+++ b/supacodeTests/AppFeatureSystemNotificationTests.swift
@@ -43,7 +43,7 @@ struct AppFeatureSystemNotificationTests {
       $0.settings.systemNotificationsEnabled = false
     }
     let expectedAlert = AlertState<SettingsFeature.Alert> {
-      TextState("Enable Notifications in System Settings")
+      TextState("Prowl cannot send system notifications")
     } actions: {
       ButtonState(action: .openSystemNotificationSettings) {
         TextState("Open System Settings")
@@ -52,7 +52,7 @@ struct AppFeatureSystemNotificationTests {
         TextState("Cancel")
       }
     } message: {
-      TextState("Prowl cannot send system notifications.\n\nError: Mock request error")
+      TextState("Notification permission is turned off. Open System Settings to allow Prowl to send notifications.")
     }
     await store.receive(\.settings.showNotificationPermissionAlert) {
       $0.settings.alert = expectedAlert
@@ -96,7 +96,7 @@ struct AppFeatureSystemNotificationTests {
       $0.settings.systemNotificationsEnabled = false
     }
     let expectedAlert = AlertState<SettingsFeature.Alert> {
-      TextState("Enable Notifications in System Settings")
+      TextState("Prowl cannot send system notifications")
     } actions: {
       ButtonState(action: .openSystemNotificationSettings) {
         TextState("Open System Settings")
@@ -105,7 +105,7 @@ struct AppFeatureSystemNotificationTests {
         TextState("Cancel")
       }
     } message: {
-      TextState("Prowl cannot send system notifications.\n\nError: Authorization status is denied.")
+      TextState("Notification permission is turned off. Open System Settings to allow Prowl to send notifications.")
     }
     await store.receive(\.settings.showNotificationPermissionAlert) {
       $0.settings.alert = expectedAlert

--- a/supacodeTests/CommandPaletteFeatureTests.swift
+++ b/supacodeTests/CommandPaletteFeatureTests.swift
@@ -29,6 +29,7 @@ struct CommandPaletteFeatureTests {
         "debug.toast.inProgress",
         "debug.toast.success",
         "debug.update.simulate-found",
+        "debug.dock.notification-dot",
       ])
     #endif
     expectNoDifference(items.map(\.id), expectedIDs)
@@ -1655,7 +1656,7 @@ private func testCategory(for kind: CommandPaletteItem.Kind) -> CommandPaletteIt
   case .toggleLeftSidebar, .toggleActiveAgentsPanel, .toggleCanvas, .toggleShelf, .showDiff:
     return .view
   #if DEBUG
-    case .debugTestToast, .debugSimulateUpdateFound:
+    case .debugTestToast, .debugSimulateUpdateFound, .debugLightDockNotificationDot:
       return .debug
   #endif
   }
@@ -1677,7 +1678,7 @@ private func testDefaultSuggestion(for kind: CommandPaletteItem.Kind) -> Bool {
     .deleteWorktree, .runCustomCommand:
     return false
   #if DEBUG
-    case .debugTestToast, .debugSimulateUpdateFound:
+    case .debugTestToast, .debugSimulateUpdateFound, .debugLightDockNotificationDot:
       return true
   #endif
   }

--- a/supacodeTests/SettingsFeatureTests.swift
+++ b/supacodeTests/SettingsFeatureTests.swift
@@ -126,6 +126,19 @@ struct SettingsFeatureTests {
     #expect(settingsFile.global.systemNotificationsEnabled == true)
   }
 
+  @Test(.dependencies) func refreshDockBadgeAuthorizationStoresSystemState() async {
+    let store = TestStore(initialState: SettingsFeature.State()) {
+      SettingsFeature()
+    } withDependencies: {
+      $0.systemNotificationClient.dockBadgeAuthorization = { .badgeDisabled }
+    }
+
+    await store.send(.refreshDockBadgeAuthorization)
+    await store.receive(\.dockBadgeAuthorizationResponse) {
+      $0.dockBadgeAuthorization = .badgeDisabled
+    }
+  }
+
   @Test(.dependencies) func selectionDoesNotMutateRepositorySettings() async {
     let selection = SettingsSection.repository("repo-id")
     let store = TestStore(initialState: SettingsFeature.State()) {

--- a/supacodeTests/SettingsFilePersistenceTests.swift
+++ b/supacodeTests/SettingsFilePersistenceTests.swift
@@ -55,6 +55,34 @@ struct SettingsFilePersistenceTests {
     #expect(reloaded.pinnedWorktreeIDs == ["/tmp/repo-a/wt-1"])
   }
 
+  @Test(.dependencies) func saveAndReloadToolbarAndDockSettings() throws {
+    let storage = SettingsTestStorage()
+
+    withDependencies {
+      $0.settingsFileStorage = storage.storage
+    } operation: {
+      @Shared(.settingsFile) var settings: SettingsFile
+      $settings.withLock {
+        $0.global.showRunButtonInToolbar = false
+        $0.global.showDefaultEditorInToolbar = false
+        $0.global.dockBounceMode = .continuous
+        $0.global.showNotificationDotOnDock = true
+      }
+    }
+
+    let reloaded: SettingsFile = withDependencies {
+      $0.settingsFileStorage = storage.storage
+    } operation: {
+      @Shared(.settingsFile) var settings: SettingsFile
+      return settings
+    }
+
+    #expect(reloaded.global.showRunButtonInToolbar == false)
+    #expect(reloaded.global.showDefaultEditorInToolbar == false)
+    #expect(reloaded.global.dockBounceMode == .continuous)
+    #expect(reloaded.global.showNotificationDotOnDock == true)
+  }
+
   @Test(.dependencies) func invalidJSONResetsToDefaults() throws {
     let storage = MutableTestStorage(initialData: Data("{".utf8))
 
@@ -113,6 +141,10 @@ struct SettingsFilePersistenceTests {
     #expect(settings.global.defaultWorktreeBaseDirectoryPath == nil)
     #expect(settings.global.restoreTerminalLayoutOnLaunch == false)
     #expect(settings.global.defaultEditorID == OpenWorktreeAction.automaticSettingsID)
+    #expect(settings.global.showRunButtonInToolbar == true)
+    #expect(settings.global.showDefaultEditorInToolbar == true)
+    #expect(settings.global.dockBounceMode == .off)
+    #expect(settings.global.showNotificationDotOnDock == false)
     #expect(settings.repositoryRoots.isEmpty)
     #expect(settings.pinnedWorktreeIDs.isEmpty)
   }


### PR DESCRIPTION
Builds on @abhi21git's work in #340 (hide toolbar items, Dock notification badge, Dock bounce) and adds correctness, architecture, and UX refinements on top.

## From #340 (original)
- Hide the Open-in-Editor toolbar item and the Run button (option-gated, shown by default).
- Dock notification badge + Dock bounce (off / once / continuous) when a notification arrives.

## Refinements added
- **Toolbar grouping fix**: the fixed separator was coupled to the Run button, so hiding Run (or any state without it) merged Custom Commands into the neighboring group. Moved it to the front of the whole Run + Custom Command cluster.
- **Injected `DockClient`**: Dock badge/bounce side effects now route through a `swift-dependencies` client instead of calling `NSApp` directly in the reducer (testable, matches the existing pattern).
- **Dock badge actually renders**: an empty `badgeLabel` shows nothing on macOS; now shows the unread worktree count and forces `dockTile.display()` so it repaints.
- **Notifications settings split** into an app-controlled section (bell, sound, move-to-top, bounce) and a System section (banners, badge). The badge toggle is disabled + grayed with an explanatory caption when macOS notifications are denied or "Badge app icon" is off, and re-reads that state when Prowl regains focus.
- **Friendlier permission alert**: replaced the raw `Error: Authorization status is denied.` text with a clear, actionable message.
- **Lint/cleanup**: removed a `function_body_length` SwiftLint disable in `GlobalSettings.init(from:)` by extracting decode helpers + a `ToolbarAndDockSettings` struct.
- **Tests**: `DockClient` reducer coverage, `GlobalSettings` persistence/migration, Dock-badge authorization refresh, and a DEBUG command-palette item to light the badge.

## Verification
- `make check`, `make build-app`
- Targeted tests green (AppFeatureDockTests, SettingsFeatureTests, SettingsFilePersistenceTests, CommandPaletteFeatureTests, AppFeatureSystemNotificationTests)
