### PR TITLE
Canvas custom actions (#358) + toolbar refinements & card-switch jump fix

### DIFF
--- a/supacode/App/ContentView.swift
+++ b/supacode/App/ContentView.swift
@@ -89,6 +89,9 @@ struct ContentView: View {
           from: store.repositories,
           customCommands: store.selectedCustomCommands,
           runScriptStatusByWorktreeID: store.runScriptStatusByWorktreeID,
+          actionTargetWorktreeID: store.repositories.isShowingCanvas
+            ? terminalManager.canvasFocusedWorktreeID
+            : nil,
           ghosttyCommands: ghosttyShortcuts.commandPaletteEntries
         ),
         resolvedKeybindings: store.resolvedKeybindings

--- a/supacode/Commands/WorktreeCommands.swift
+++ b/supacode/Commands/WorktreeCommands.swift
@@ -18,7 +18,9 @@ struct WorktreeCommands: Commands {
 
   var body: some Commands {
     let repositories = store.repositories
-    let hasActiveWorktree = repositories.worktree(for: repositories.selectedWorktreeID) != nil
+    let hasActiveWorktree =
+      repositories.selectedTerminalWorktree != nil
+      || (repositories.isShowingCanvas && !store.selectedCustomCommands.isEmpty)
     let orderedRows = visibleHotkeyWorktreeRows ?? repositories.orderedWorktreeRows()
     let codeHostWorktreeID = selectedCodeHostWorktreeID
     let codeHostLabel = "Open on \(repositories.codeHost(forWorktreeID: codeHostWorktreeID).displayName)"

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -89,6 +89,7 @@ struct AppFeature {
     case setLeftSidebarVisibility(NavigationSplitViewVisibility)
     case runScript
     case runCustomCommand(Int)
+    case canvasFocusedWorktreeChanged(Worktree.ID?)
     case runScriptDraftChanged(String)
     case runScriptPromptPresented(Bool)
     case saveRunScriptAndRun
@@ -154,11 +155,29 @@ struct AppFeature {
     if let worktree = repositories.selectedTerminalWorktree {
       return worktree
     }
+    return canvasFocusedTerminalWorktree(repositories: repositories)
+  }
+
+  private func actionTargetWorktree(repositories: RepositoriesFeature.State) -> Worktree? {
+    if let worktree = repositories.selectedTerminalWorktree {
+      return worktree
+    }
+    return canvasFocusedTerminalWorktree(repositories: repositories)
+  }
+
+  private func canvasFocusedTerminalWorktree(repositories: RepositoriesFeature.State) -> Worktree? {
     guard repositories.isShowingCanvas,
       let worktreeID = terminalClient.canvasFocusedWorktreeID()
     else {
       return nil
     }
+    return terminalWorktree(for: worktreeID, repositories: repositories)
+  }
+
+  private func terminalWorktree(
+    for worktreeID: Worktree.ID,
+    repositories: RepositoriesFeature.State
+  ) -> Worktree? {
     if let worktree = repositories.worktree(for: worktreeID) {
       return worktree
     }
@@ -714,7 +733,7 @@ struct AppFeature {
         return .none
 
       case .runScript:
-        guard let worktree = state.repositories.selectedTerminalWorktree else {
+        guard let worktree = actionTargetWorktree(repositories: state.repositories) else {
           return .none
         }
         let trimmed = state.selectedRunScript.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -733,7 +752,7 @@ struct AppFeature {
         }
 
       case .runCustomCommand(let index):
-        guard let worktree = state.repositories.selectedTerminalWorktree else {
+        guard let worktree = actionTargetWorktree(repositories: state.repositories) else {
           return .none
         }
         guard state.selectedCustomCommands.indices.contains(index) else {
@@ -789,6 +808,32 @@ struct AppFeature {
           }
         }
 
+      case .canvasFocusedWorktreeChanged(let worktreeID):
+        guard state.repositories.isShowingCanvas,
+          let worktreeID,
+          let worktree = terminalWorktree(for: worktreeID, repositories: state.repositories)
+        else {
+          state.openActionSelection = .finder
+          state.selectedRunScript = ""
+          state.selectedCustomCommands = []
+          state.resolvedKeybindings = resolvedKeybindings(
+            settings: state.settings,
+            customCommands: state.selectedCustomCommands
+          )
+          state.runScriptDraft = ""
+          state.isRunScriptPromptPresented = false
+          return .run { _ in
+            await customShortcutRegistryClient.setShortcuts([])
+          }
+        }
+        let rootURL = worktree.repositoryRootURL
+        @Shared(.repositorySettings(rootURL)) var repositorySettings
+        @Shared(.userRepositorySettings(rootURL)) var userRepositorySettings
+        return .concatenate(
+          .send(.worktreeSettingsLoaded(repositorySettings, worktreeID: worktreeID)),
+          .send(.worktreeUserSettingsLoaded(userRepositorySettings, worktreeID: worktreeID))
+        )
+
       case .runScriptDraftChanged(let script):
         state.runScriptDraft = script
         return .none
@@ -801,7 +846,7 @@ struct AppFeature {
         return .none
 
       case .saveRunScriptAndRun:
-        guard let worktree = state.repositories.selectedTerminalWorktree else {
+        guard let worktree = actionTargetWorktree(repositories: state.repositories) else {
           state.isRunScriptPromptPresented = false
           state.runScriptDraft = ""
           return .none
@@ -823,7 +868,7 @@ struct AppFeature {
         return .send(.runScript)
 
       case .stopRunScript:
-        guard let worktree = state.repositories.selectedTerminalWorktree else {
+        guard let worktree = actionTargetWorktree(repositories: state.repositories) else {
           return .none
         }
         return .run { _ in
@@ -908,7 +953,7 @@ struct AppFeature {
         )
 
       case .worktreeSettingsLoaded(let settings, let worktreeID):
-        guard state.repositories.selectedTerminalWorktree?.id == worktreeID else {
+        guard actionTargetWorktree(repositories: state.repositories)?.id == worktreeID else {
           return .none
         }
         @Shared(.settingsFile) var settingsFile
@@ -923,7 +968,7 @@ struct AppFeature {
         return .none
 
       case .worktreeUserSettingsLoaded(let settings, let worktreeID):
-        guard state.repositories.selectedTerminalWorktree?.id == worktreeID else {
+        guard actionTargetWorktree(repositories: state.repositories)?.id == worktreeID else {
           return .none
         }
         state.selectedCustomCommands = UserRepositorySettings.normalizedCommands(settings.customCommands)

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -235,6 +235,51 @@ struct AppFeature {
     return resolved
   }
 
+  /// Applies a worktree's repository settings (open action, run script) into
+  /// state. Shared by the normal `worktreeSettingsLoaded` action and the Canvas
+  /// focus path so both stay in sync.
+  private func applyWorktreeSettings(_ settings: RepositorySettings, into state: inout State) {
+    @Shared(.settingsFile) var settingsFile
+    let normalizedDefaultEditorID = OpenWorktreeAction.normalizedDefaultEditorID(
+      settingsFile.global.defaultEditorID
+    )
+    state.openActionSelection = OpenWorktreeAction.fromSettingsID(
+      settings.openActionID,
+      defaultEditorID: normalizedDefaultEditorID
+    )
+    state.selectedRunScript = settings.runScript
+  }
+
+  /// Applies a worktree's user settings (custom commands, keybindings) into
+  /// state and returns the effect that re-registers custom shortcuts. Shared by
+  /// the normal `worktreeUserSettingsLoaded` action and the Canvas focus path.
+  private func applyWorktreeUserSettings(
+    _ settings: UserRepositorySettings,
+    into state: inout State
+  ) -> Effect<Action> {
+    state.selectedCustomCommands = UserRepositorySettings.normalizedCommands(settings.customCommands)
+    state.resolvedKeybindings = resolvedKeybindings(
+      settings: state.settings,
+      customCommands: state.selectedCustomCommands
+    )
+    let userOverrideConflicts = AppShortcuts.userOverrideConflicts(in: state.selectedCustomCommands)
+    let shortcuts: [UserCustomShortcut] = state.selectedCustomCommands.compactMap { command in
+      let commandID = LegacyCustomCommandShortcutMigration.customCommandBindingID(for: command.id)
+      return state.resolvedKeybindings.keybinding(for: commandID)?.userCustomShortcut
+    }
+    return .run { _ in
+      let logger = SupaLogger("Shortcuts")
+      for conflict in userOverrideConflicts {
+        logger.warning(
+          "shortcut_conflict reason=userOverride app_action=\"\(conflict.appActionTitle)\" "
+            + "app_shortcut=\(conflict.appShortcutDisplay) custom_command=\"\(conflict.commandTitle)\" "
+            + "custom_shortcut=\(conflict.commandShortcutDisplay) result=customOverride"
+        )
+      }
+      await customShortcutRegistryClient.setShortcuts(shortcuts)
+    }
+  }
+
   var body: some Reducer<State, Action> {
     let core = Reduce<State, Action> { state, action in
       switch action {
@@ -832,10 +877,14 @@ struct AppFeature {
         let rootURL = worktree.repositoryRootURL
         @Shared(.repositorySettings(rootURL)) var repositorySettings
         @Shared(.userRepositorySettings(rootURL)) var userRepositorySettings
-        return .concatenate(
-          .send(.worktreeSettingsLoaded(repositorySettings, worktreeID: worktreeID)),
-          .send(.worktreeUserSettingsLoaded(userRepositorySettings, worktreeID: worktreeID))
-        )
+        // Apply both settings in this single reduce pass instead of dispatching
+        // follow-up `.send`s. The Canvas focus ID (an `@Observable` on the
+        // terminal manager) updates synchronously on card tap, so the toolbar's
+        // Run + Custom Command items must update in the same transaction —
+        // otherwise the command list lands a frame later and the toolbar
+        // visibly reflows when switching between cards with different commands.
+        applyWorktreeSettings(repositorySettings, into: &state)
+        return applyWorktreeUserSettings(userRepositorySettings, into: &state)
 
       case .runScriptDraftChanged(let script):
         state.runScriptDraft = script
@@ -959,42 +1008,14 @@ struct AppFeature {
         guard actionTargetWorktree(repositories: state.repositories)?.id == worktreeID else {
           return .none
         }
-        @Shared(.settingsFile) var settingsFile
-        let normalizedDefaultEditorID = OpenWorktreeAction.normalizedDefaultEditorID(
-          settingsFile.global.defaultEditorID
-        )
-        state.openActionSelection = OpenWorktreeAction.fromSettingsID(
-          settings.openActionID,
-          defaultEditorID: normalizedDefaultEditorID
-        )
-        state.selectedRunScript = settings.runScript
+        applyWorktreeSettings(settings, into: &state)
         return .none
 
       case .worktreeUserSettingsLoaded(let settings, let worktreeID):
         guard actionTargetWorktree(repositories: state.repositories)?.id == worktreeID else {
           return .none
         }
-        state.selectedCustomCommands = UserRepositorySettings.normalizedCommands(settings.customCommands)
-        state.resolvedKeybindings = resolvedKeybindings(
-          settings: state.settings,
-          customCommands: state.selectedCustomCommands
-        )
-        let userOverrideConflicts = AppShortcuts.userOverrideConflicts(in: state.selectedCustomCommands)
-        let shortcuts: [UserCustomShortcut] = state.selectedCustomCommands.compactMap { command in
-          let commandID = LegacyCustomCommandShortcutMigration.customCommandBindingID(for: command.id)
-          return state.resolvedKeybindings.keybinding(for: commandID)?.userCustomShortcut
-        }
-        return .run { _ in
-          let logger = SupaLogger("Shortcuts")
-          for conflict in userOverrideConflicts {
-            logger.warning(
-              "shortcut_conflict reason=userOverride app_action=\"\(conflict.appActionTitle)\" "
-                + "app_shortcut=\(conflict.appShortcutDisplay) custom_command=\"\(conflict.commandTitle)\" "
-                + "custom_shortcut=\(conflict.commandShortcutDisplay) result=customOverride"
-            )
-          }
-          await customShortcutRegistryClient.setShortcuts(shortcuts)
-        }
+        return applyWorktreeUserSettings(settings, into: &state)
 
       case .systemNotificationsPermissionFailed(let errorMessage):
         return .concatenate(

--- a/supacode/Features/Canvas/Views/CanvasView.swift
+++ b/supacode/Features/Canvas/Views/CanvasView.swift
@@ -13,6 +13,7 @@ struct CanvasView: View {
   /// per-frame canvas hot path.
   var repositoryCustomTitles: [Repository.ID: String] = [:]
   var onExitToTab: () -> Void = {}
+  var onFocusedWorktreeChanged: (Worktree.ID?) -> Void = { _ in }
   @State private var layoutStore = CanvasLayoutStore()
   @Shared(.repositoryAppearances) private var repositoryAppearances
 
@@ -712,12 +713,14 @@ struct CanvasView: View {
       let surfaceView = ownerState.surfaceView(for: newTabID)
     else {
       terminalManager.canvasFocusedWorktreeID = nil
+      onFocusedWorktreeChanged(nil)
       return
     }
 
     layoutStore.moveToFront(newTabID.rawValue.uuidString)
     ownerState.tabManager.selectTab(newTabID)
     terminalManager.canvasFocusedWorktreeID = ownerState.worktreeID
+    onFocusedWorktreeChanged(ownerState.worktreeID)
     surfaceView.focusDidChange(true)
     surfaceView.requestFocus()
   }

--- a/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
+++ b/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
@@ -216,12 +216,14 @@ struct CommandPaletteFeature {
     from repositories: RepositoriesFeature.State,
     customCommands: [UserCustomCommand] = [],
     runScriptStatusByWorktreeID: [Worktree.ID: Bool] = [:],
+    actionTargetWorktreeID: Worktree.ID? = nil,
     ghosttyCommands: [GhosttyCommand] = []
   ) -> [CommandPaletteItem] {
     let showsNewWorktreeAction =
       repositories.repositories.isEmpty
       || repositories.repositories.contains { $0.capabilities.supportsWorktrees }
     var items = globalCommandItems(showsNewWorktreeAction: showsNewWorktreeAction)
+    let worktreeActionTargetID = actionTargetWorktreeID ?? repositories.selectedWorktreeID
     if repositories.selectedWorktreeID != nil {
       items.append(
         .appShortcut(
@@ -236,7 +238,17 @@ struct CommandPaletteFeature {
       items.append(
         contentsOf: worktreeActionCommandItems(
           repositories: repositories,
+          worktreeID: worktreeActionTargetID,
           runScriptStatusByWorktreeID: runScriptStatusByWorktreeID
+        )
+      )
+    } else if worktreeActionTargetID != nil {
+      items.append(
+        contentsOf: worktreeActionCommandItems(
+          repositories: repositories,
+          worktreeID: worktreeActionTargetID,
+          runScriptStatusByWorktreeID: runScriptStatusByWorktreeID,
+          includeSelectionScopedItems: false
         )
       )
     }
@@ -384,9 +396,11 @@ private func globalCommandItems(showsNewWorktreeAction: Bool) -> [CommandPalette
 
 private func worktreeActionCommandItems(
   repositories: RepositoriesFeature.State,
-  runScriptStatusByWorktreeID: [Worktree.ID: Bool]
+  worktreeID: Worktree.ID?,
+  runScriptStatusByWorktreeID: [Worktree.ID: Bool],
+  includeSelectionScopedItems: Bool = true
 ) -> [CommandPaletteItem] {
-  guard let worktreeID = repositories.selectedWorktreeID else { return [] }
+  guard let worktreeID else { return [] }
   var items: [CommandPaletteItem] = []
   let isRunScriptRunning = runScriptStatusByWorktreeID[worktreeID] ?? false
   if isRunScriptRunning {
@@ -410,6 +424,7 @@ private func worktreeActionCommandItems(
       )
     )
   }
+  guard includeSelectionScopedItems else { return items }
   guard let row = repositories.selectedRow(for: worktreeID) else { return items }
   // Rename Branch works on any worktree (main included).
   items.append(

--- a/supacode/Features/Repositories/Views/WorktreeDetailView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailView.swift
@@ -18,6 +18,16 @@ struct WorktreeDetailView: View {
     let availableUpdateVersion: String?
   }
 
+  private struct CanvasToolbarState {
+    let notificationGroups: [ToolbarNotificationRepositoryGroup]
+    let unseenNotificationWorktreeCount: Int
+    let runScriptEnabled: Bool
+    let runScriptIsRunning: Bool
+    let customCommands: [UserCustomCommand]
+    let isUpdateAvailable: Bool
+    let availableUpdateVersion: String?
+  }
+
   @Bindable var store: StoreOf<AppFeature>
   let terminalManager: WorktreeTerminalManager
   @Environment(CommandKeyObserver.self) private var commandKeyObserver
@@ -34,6 +44,8 @@ struct WorktreeDetailView: View {
     let selectedRow = repositories.selectedRow(for: repositories.selectedWorktreeID)
     let selectedWorktree = repositories.worktree(for: repositories.selectedWorktreeID)
     let selectedTerminalWorktree = repositories.selectedTerminalWorktree
+    let canvasFocusedTerminalWorktree = canvasFocusedTerminalWorktree(repositories: repositories)
+    let actionTargetWorktree = selectedTerminalWorktree ?? canvasFocusedTerminalWorktree
     let selectedWorktreeSummaries = selectedWorktreeSummaries(from: repositories)
     let showsMultiSelectionSummary = shouldShowMultiSelectionSummary(
       repositories: repositories,
@@ -45,12 +57,12 @@ struct WorktreeDetailView: View {
       repositories: repositories
     )
     let hasActiveTerminalTarget =
-      selectedTerminalWorktree != nil
+      actionTargetWorktree != nil
       && loadingInfo == nil
       && !showsMultiSelectionSummary
     let openActionSelection = state.openActionSelection
     let runScriptEnabled = hasActiveTerminalTarget
-    let runScriptIsRunning = selectedTerminalWorktree.flatMap { state.runScriptStatusByWorktreeID[$0.id] } == true
+    let runScriptIsRunning = actionTargetWorktree.flatMap { state.runScriptStatusByWorktreeID[$0.id] } == true
     let customCommands = state.selectedCustomCommands
     let notificationGroups = repositories.toolbarNotificationGroups(
       terminalManager: terminalManager,
@@ -71,10 +83,15 @@ struct WorktreeDetailView: View {
     .toolbar {
       if repositories.isShowingCanvas {
         canvasToolbarContent(
-          notificationGroups: notificationGroups,
-          unseenNotificationWorktreeCount: unseenNotificationWorktreeCount,
-          isUpdateAvailable: state.updates.isUpdateAvailable,
-          availableUpdateVersion: state.updates.availableVersion
+          state: CanvasToolbarState(
+            notificationGroups: notificationGroups,
+            unseenNotificationWorktreeCount: unseenNotificationWorktreeCount,
+            runScriptEnabled: runScriptEnabled,
+            runScriptIsRunning: runScriptIsRunning,
+            customCommands: customCommands,
+            isUpdateAvailable: state.updates.isUpdateAvailable,
+            availableUpdateVersion: state.updates.availableVersion
+          )
         )
       } else if hasActiveTerminalTarget,
         let toolbarState = toolbarState(
@@ -97,7 +114,7 @@ struct WorktreeDetailView: View {
           toolbarState: toolbarState,
           repositories: repositories,
           selectedWorktree: selectedWorktree,
-          selectedTerminalWorktree: selectedTerminalWorktree,
+          actionTargetWorktree: actionTargetWorktree,
           notificationGroups: notificationGroups
         )
       }
@@ -117,7 +134,7 @@ struct WorktreeDetailView: View {
     toolbarState: WorktreeToolbarState,
     repositories: RepositoriesFeature.State,
     selectedWorktree: Worktree?,
-    selectedTerminalWorktree: Worktree?,
+    actionTargetWorktree: Worktree?,
     notificationGroups: [ToolbarNotificationRepositoryGroup]
   ) -> some ToolbarContent {
     WorktreeToolbarContent(
@@ -140,9 +157,9 @@ struct WorktreeDetailView: View {
         store.send(.openActionSelectionChanged(action))
       },
       onCopyPath: {
-        guard let selectedTerminalWorktree else { return }
+        guard let actionTargetWorktree else { return }
         NSPasteboard.general.clearContents()
-        NSPasteboard.general.setString(selectedTerminalWorktree.workingDirectory.path, forType: .string)
+        NSPasteboard.general.setString(actionTargetWorktree.workingDirectory.path, forType: .string)
       },
       onSelectNotification: selectToolbarNotification,
       onDismissAllNotifications: { dismissAllToolbarNotifications(in: notificationGroups) },
@@ -157,22 +174,67 @@ struct WorktreeDetailView: View {
 
   @ToolbarContentBuilder
   private func canvasToolbarContent(
-    notificationGroups: [ToolbarNotificationRepositoryGroup],
-    unseenNotificationWorktreeCount: Int,
-    isUpdateAvailable: Bool,
-    availableUpdateVersion: String?
+    state: CanvasToolbarState
   ) -> some ToolbarContent {
     ToolbarItemGroup(placement: .primaryAction) {
       ToolbarNotificationsPopoverButton(
-        groups: notificationGroups,
-        unseenWorktreeCount: unseenNotificationWorktreeCount,
+        groups: state.notificationGroups,
+        unseenWorktreeCount: state.unseenNotificationWorktreeCount,
         onSelectNotification: selectToolbarNotification,
-        onDismissAll: { dismissAllToolbarNotifications(in: notificationGroups) }
+        onDismissAll: { dismissAllToolbarNotifications(in: state.notificationGroups) }
       )
-      if isUpdateAvailable {
-        ToolbarUpdateButton(availableVersion: availableUpdateVersion) {
+      if state.isUpdateAvailable {
+        ToolbarUpdateButton(availableVersion: state.availableUpdateVersion) {
           store.send(.updates(.checkForUpdates))
         }
+      }
+      if state.runScriptIsRunning || state.runScriptEnabled {
+        RunScriptToolbarButton(
+          isRunning: state.runScriptIsRunning,
+          isEnabled: state.runScriptEnabled,
+          runHelpText: AppShortcuts.helpText(
+            title: "Run Script",
+            commandID: AppShortcuts.CommandID.runScript,
+            in: store.resolvedKeybindings
+          ),
+          stopHelpText: AppShortcuts.helpText(
+            title: "Stop Script",
+            commandID: AppShortcuts.CommandID.stopScript,
+            in: store.resolvedKeybindings
+          ),
+          runShortcut: store.resolvedKeybindings.display(for: AppShortcuts.CommandID.runScript),
+          stopShortcut: store.resolvedKeybindings.display(for: AppShortcuts.CommandID.stopScript),
+          runAction: { store.send(.runScript) },
+          stopAction: { store.send(.stopRunScript) }
+        )
+      }
+      ForEach(Array(state.customCommands.enumerated()).prefix(3), id: \.element.id) { index, command in
+        UserCustomCommandToolbarButton(
+          title: command.resolvedTitle,
+          systemImage: command.resolvedSystemImage,
+          shortcut: store.resolvedKeybindings.display(
+            for: LegacyCustomCommandShortcutMigration.customCommandBindingID(for: command.id)
+          ),
+          isEnabled: command.hasRunnableCommand,
+          action: {
+            store.send(.runCustomCommand(index))
+          }
+        )
+      }
+      if state.customCommands.count > 3 {
+        CustomCommandOverflowButton(
+          entries: Array(state.customCommands.enumerated().dropFirst(3)).map {
+            (index: $0.offset, command: $0.element)
+          },
+          shortcutDisplay: { command in
+            store.resolvedKeybindings.display(
+              for: LegacyCustomCommandShortcutMigration.customCommandBindingID(for: command.id)
+            )
+          },
+          onRunCustomCommand: { index in
+            store.send(.runCustomCommand(index))
+          }
+        )
       }
     }
   }
@@ -242,6 +304,30 @@ struct WorktreeDetailView: View {
       && selectedWorktreeSummaries.count > 1
   }
 
+  private func canvasFocusedTerminalWorktree(repositories: RepositoriesFeature.State) -> Worktree? {
+    guard repositories.isShowingCanvas,
+      let worktreeID = terminalManager.canvasFocusedWorktreeID
+    else {
+      return nil
+    }
+    if let worktree = repositories.worktree(for: worktreeID) {
+      return worktree
+    }
+    guard let repository = repositories.repositories[id: worktreeID],
+      repository.capabilities.supportsRunnableFolderActions,
+      !repository.capabilities.supportsWorktrees
+    else {
+      return nil
+    }
+    return Worktree(
+      id: repository.id,
+      name: repository.name,
+      detail: repository.rootURL.path(percentEncoded: false),
+      workingDirectory: repository.rootURL,
+      repositoryRootURL: repository.rootURL
+    )
+  }
+
   @ViewBuilder
   private func detailContent(
     repositories: RepositoriesFeature.State,
@@ -256,6 +342,9 @@ struct WorktreeDetailView: View {
         repositoryCustomTitles: repositories.repositoryCustomTitles,
         onExitToTab: {
           store.send(.repositories(.toggleCanvas))
+        },
+        onFocusedWorktreeChanged: { worktreeID in
+          store.send(.canvasFocusedWorktreeChanged(worktreeID))
         }
       )
       // Canvas tints the nav (leading) only; the toolbar is left untinted so

--- a/supacode/Features/Repositories/Views/WorktreeDetailView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailView.swift
@@ -28,6 +28,7 @@ struct WorktreeDetailView: View {
     let customCommands: [UserCustomCommand]
     let isUpdateAvailable: Bool
     let availableUpdateVersion: String?
+    let showRunButtonInToolbar: Bool
   }
 
   @Bindable var store: StoreOf<AppFeature>
@@ -92,7 +93,8 @@ struct WorktreeDetailView: View {
             runScriptIsRunning: runScriptIsRunning,
             customCommands: customCommands,
             isUpdateAvailable: state.updates.isUpdateAvailable,
-            availableUpdateVersion: state.updates.availableVersion
+            availableUpdateVersion: state.updates.availableVersion,
+            showRunButtonInToolbar: settingsFile.global.showRunButtonInToolbar
           )
         )
       } else if hasActiveTerminalTarget,
@@ -192,53 +194,89 @@ struct WorktreeDetailView: View {
           store.send(.updates(.checkForUpdates))
         }
       }
-      if state.runScriptIsRunning || state.runScriptEnabled {
-        RunScriptToolbarButton(
-          isRunning: state.runScriptIsRunning,
-          isEnabled: state.runScriptEnabled,
-          runHelpText: AppShortcuts.helpText(
-            title: "Run Script",
-            commandID: AppShortcuts.CommandID.runScript,
-            in: store.resolvedKeybindings
-          ),
-          stopHelpText: AppShortcuts.helpText(
-            title: "Stop Script",
-            commandID: AppShortcuts.CommandID.stopScript,
-            in: store.resolvedKeybindings
-          ),
-          runShortcut: store.resolvedKeybindings.display(for: AppShortcuts.CommandID.runScript),
-          stopShortcut: store.resolvedKeybindings.display(for: AppShortcuts.CommandID.stopScript),
-          runAction: { store.send(.runScript) },
-          stopAction: { store.send(.stopRunScript) }
-        )
-      }
-      ForEach(Array(state.customCommands.enumerated()).prefix(3), id: \.element.id) { index, command in
-        UserCustomCommandToolbarButton(
-          title: command.resolvedTitle,
-          systemImage: command.resolvedSystemImage,
-          shortcut: store.resolvedKeybindings.display(
-            for: LegacyCustomCommandShortcutMigration.customCommandBindingID(for: command.id)
-          ),
-          isEnabled: command.hasRunnableCommand,
-          action: {
-            store.send(.runCustomCommand(index))
-          }
-        )
-      }
-      if state.customCommands.count > 3 {
-        CustomCommandOverflowButton(
-          entries: Array(state.customCommands.enumerated().dropFirst(3)).map {
-            (index: $0.offset, command: $0.element)
-          },
-          shortcutDisplay: { command in
-            store.resolvedKeybindings.display(
-              for: LegacyCustomCommandShortcutMigration.customCommandBindingID(for: command.id)
+    }
+
+    let showRunButton =
+      state.showRunButtonInToolbar
+      && (state.runScriptIsRunning || state.runScriptEnabled)
+    let inlineCommands = Array(state.customCommands.enumerated().prefix(3))
+    let overflowCommands = Array(state.customCommands.enumerated().dropFirst(3))
+    // A fixed separator splits the Run + Custom Command cluster from the
+    // notification group, mirroring the Normal toolbar.
+    //
+    // INTENTIONAL DIVERGENCE FROM THE NORMAL TOOLBAR: the whole cluster is a
+    // single `ToolbarItem` (an HStack) here, whereas `commandToolbarItems`
+    // (Normal mode) lays the buttons out as separate items / a
+    // `ToolbarItemGroup`. The reason is how each mode updates NSToolbar (which
+    // SwiftUI's `.toolbar` bridges to):
+    //   - Normal: switching worktree swaps the whole detail view, so NSToolbar
+    //     is rebuilt wholesale — no per-item diff, no animation.
+    //   - Canvas: `CanvasView` stays mounted across card switches; only the
+    //     toolbar items change. With a multi-item structure NSToolbar performs
+    //     an incremental insert/remove with its own animation (which SwiftUI
+    //     transactions can't suppress), briefly overflowing the toolbar — the
+    //     visible "jump" when switching between cards with different command
+    //     counts.
+    // Collapsing the cluster into one item keeps NSToolbar's item set stable,
+    // so a command-count change is just an internal HStack relayout. Do NOT
+    // "unify" this back into a `ToolbarItemGroup` to match Normal — that
+    // reintroduces the jump.
+    if showRunButton || !state.customCommands.isEmpty {
+      ToolbarSpacer(.fixed)
+      ToolbarItem(placement: .primaryAction) {
+        // `spacing: 0` keeps the cluster as tight as the Normal toolbar's
+        // ToolbarItemGroup (whose buttons sit nearly flush on macOS 26); the
+        // buttons' own internal padding provides the visible gap.
+        HStack(spacing: 0) {
+          if showRunButton {
+            RunScriptToolbarButton(
+              isRunning: state.runScriptIsRunning,
+              isEnabled: state.runScriptEnabled,
+              runHelpText: AppShortcuts.helpText(
+                title: "Run Script",
+                commandID: AppShortcuts.CommandID.runScript,
+                in: store.resolvedKeybindings
+              ),
+              stopHelpText: AppShortcuts.helpText(
+                title: "Stop Script",
+                commandID: AppShortcuts.CommandID.stopScript,
+                in: store.resolvedKeybindings
+              ),
+              runShortcut: store.resolvedKeybindings.display(for: AppShortcuts.CommandID.runScript),
+              stopShortcut: store.resolvedKeybindings.display(for: AppShortcuts.CommandID.stopScript),
+              runAction: { store.send(.runScript) },
+              stopAction: { store.send(.stopRunScript) }
             )
-          },
-          onRunCustomCommand: { index in
-            store.send(.runCustomCommand(index))
           }
-        )
+          ForEach(inlineCommands, id: \.element.id) { index, command in
+            UserCustomCommandToolbarButton(
+              title: command.resolvedTitle,
+              systemImage: command.resolvedSystemImage,
+              shortcut: store.resolvedKeybindings.display(
+                for: LegacyCustomCommandShortcutMigration.customCommandBindingID(for: command.id)
+              ),
+              isEnabled: command.hasRunnableCommand,
+              action: {
+                store.send(.runCustomCommand(index))
+              }
+            )
+          }
+          if !overflowCommands.isEmpty {
+            CustomCommandOverflowButton(
+              entries: overflowCommands.map {
+                (index: $0.offset, command: $0.element)
+              },
+              shortcutDisplay: { command in
+                store.resolvedKeybindings.display(
+                  for: LegacyCustomCommandShortcutMigration.customCommandBindingID(for: command.id)
+                )
+              },
+              onRunCustomCommand: { index in
+                store.send(.runCustomCommand(index))
+              }
+            )
+          }
+        }
       }
     }
   }

--- a/supacodeTests/AppFeatureCustomCommandTests.swift
+++ b/supacodeTests/AppFeatureCustomCommandTests.swift
@@ -1,6 +1,7 @@
 import ComposableArchitecture
 import DependenciesTestSupport
 import Foundation
+import Sharing
 import Testing
 
 @testable import supacode
@@ -415,6 +416,97 @@ struct AppFeatureCustomCommandTests {
     }
 
     await store.send(.worktreeUserSettingsLoaded(settings, worktreeID: worktree.id)) {
+      $0.selectedCustomCommands = settings.customCommands
+      $0.resolvedKeybindings = KeybindingResolver.resolve(
+        schema: .appResolverSchema(customCommands: settings.customCommands),
+        migratedOverrides:
+          LegacyCustomCommandShortcutMigration
+          .migrate(commands: settings.customCommands)
+          .overrides
+      )
+    }
+  }
+
+  @Test(.dependencies) func customCommandUsesCanvasFocusedWorktree() async {
+    let worktree = makeWorktree()
+    let sent = LockIsolated<[TerminalClient.Command]>([])
+    var repositories = makeRepositoriesState(worktree: worktree)
+    repositories.selection = .canvas
+    var state = AppFeature.State(
+      repositories: repositories,
+      settings: SettingsFeature.State()
+    )
+    state.selectedCustomCommands = [
+      UserCustomCommand(
+        title: "Canvas Build",
+        systemImage: "hammer",
+        command: "make build",
+        execution: .shellScript,
+        shortcut: nil
+      )
+    ]
+
+    let store = TestStore(initialState: state) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.canvasFocusedWorktreeID = { worktree.id }
+      $0.terminalClient.send = { command in
+        sent.withValue { $0.append(command) }
+      }
+    }
+
+    await store.send(.runCustomCommand(0))
+    await store.finish()
+
+    #expect(
+      sent.value == [
+        .createTabWithInput(
+          worktree,
+          input: "make build",
+          runSetupScriptIfNew: false,
+          autoCloseOnSuccess: false,
+          customCommandName: "Canvas Build",
+          customCommandIcon: "hammer"
+        )
+      ]
+    )
+  }
+
+  @Test(.dependencies) func canvasFocusLoadsFocusedWorktreeCustomCommands() async {
+    let worktree = makeWorktree()
+    var repositories = makeRepositoriesState(worktree: worktree)
+    repositories.selection = .canvas
+    let settings = UserRepositorySettings(
+      customCommands: [
+        UserCustomCommand(
+          title: "Canvas Test",
+          systemImage: "checkmark.circle",
+          command: "swift test",
+          execution: .terminalInput,
+          shortcut: nil
+        )
+      ]
+    )
+    let store = withDependencies {
+      $0.defaultFileStorage = .inMemory
+    } operation: {
+      @Shared(.userRepositorySettings(worktree.repositoryRootURL)) var userRepositorySettings
+      $userRepositorySettings.withLock { $0 = settings }
+      return TestStore(
+        initialState: AppFeature.State(
+          repositories: repositories,
+          settings: SettingsFeature.State()
+        )
+      ) {
+        AppFeature()
+      } withDependencies: {
+        $0.terminalClient.canvasFocusedWorktreeID = { worktree.id }
+      }
+    }
+
+    await store.send(.canvasFocusedWorktreeChanged(worktree.id))
+    await store.receive(\.worktreeSettingsLoaded)
+    await store.receive(\.worktreeUserSettingsLoaded) {
       $0.selectedCustomCommands = settings.customCommands
       $0.resolvedKeybindings = KeybindingResolver.resolve(
         schema: .appResolverSchema(customCommands: settings.customCommands),

--- a/supacodeTests/AppFeatureCustomCommandTests.swift
+++ b/supacodeTests/AppFeatureCustomCommandTests.swift
@@ -506,7 +506,9 @@ struct AppFeatureCustomCommandTests {
     }
 
     await store.send(.canvasFocusedWorktreeChanged(worktree.id))
-    await store.receive(\.worktreeSettingsLoaded)
+    await store.receive(\.worktreeSettingsLoaded) {
+      $0.openActionSelection = expectedDefaultOpenAction()
+    }
     await store.receive(\.worktreeUserSettingsLoaded) {
       $0.selectedCustomCommands = settings.customCommands
       $0.resolvedKeybindings = KeybindingResolver.resolve(
@@ -570,6 +572,7 @@ struct AppFeatureCustomCommandTests {
 
     await store.send(.canvasFocusedWorktreeChanged(worktreeB.id))
     await store.receive(\.worktreeSettingsLoaded) {
+      $0.openActionSelection = expectedDefaultOpenAction()
       $0.selectedRunScript = "npm run repo-b"
     }
     await store.receive(\.worktreeUserSettingsLoaded) {
@@ -641,5 +644,14 @@ struct AppFeatureCustomCommandTests {
     repositoriesState.repositories = IdentifiedArray(uniqueElements: repositories)
     repositoriesState.selection = worktrees.first.map { .worktree($0.id) }
     return repositoriesState
+  }
+
+  private func expectedDefaultOpenAction() -> OpenWorktreeAction {
+    OpenWorktreeAction.fromSettingsID(
+      RepositorySettings.default.openActionID,
+      defaultEditorID: OpenWorktreeAction.normalizedDefaultEditorID(
+        SettingsFile.default.global.defaultEditorID
+      )
+    )
   }
 }

--- a/supacodeTests/AppFeatureCustomCommandTests.swift
+++ b/supacodeTests/AppFeatureCustomCommandTests.swift
@@ -1,6 +1,7 @@
 import ComposableArchitecture
 import DependenciesTestSupport
 import Foundation
+import IdentifiedCollections
 import Sharing
 import Testing
 
@@ -518,26 +519,127 @@ struct AppFeatureCustomCommandTests {
     }
   }
 
+  @Test(.dependencies) func canvasFocusWithMultipleReposUsesPrimaryFocusedWorktree() async {
+    let worktreeA = makeWorktree(id: "/tmp/repo-a/wt-a", name: "wt-a", repoRoot: "/tmp/repo-a")
+    let worktreeB = makeWorktree(id: "/tmp/repo-b/wt-b", name: "wt-b", repoRoot: "/tmp/repo-b")
+    let commandA = UserCustomCommand(
+      title: "Repo A Build",
+      systemImage: "a.circle",
+      command: "make repo-a",
+      execution: .shellScript,
+      shortcut: nil
+    )
+    let commandB = UserCustomCommand(
+      title: "Repo B Build",
+      systemImage: "b.circle",
+      command: "make repo-b",
+      execution: .shellScript,
+      shortcut: nil
+    )
+    let sent = LockIsolated<[TerminalClient.Command]>([])
+    let store = withDependencies {
+      $0.defaultFileStorage = .inMemory
+    } operation: {
+      @Shared(.repositorySettings(worktreeA.repositoryRootURL)) var repositorySettingsA
+      @Shared(.repositorySettings(worktreeB.repositoryRootURL)) var repositorySettingsB
+      @Shared(.userRepositorySettings(worktreeA.repositoryRootURL)) var userRepositorySettingsA
+      @Shared(.userRepositorySettings(worktreeB.repositoryRootURL)) var userRepositorySettingsB
+      $repositorySettingsA.withLock { $0.runScript = "npm run repo-a" }
+      $repositorySettingsB.withLock { $0.runScript = "npm run repo-b" }
+      $userRepositorySettingsA.withLock { $0.customCommands = [commandA] }
+      $userRepositorySettingsB.withLock { $0.customCommands = [commandB] }
+
+      var repositories = makeRepositoriesState(worktrees: [worktreeA, worktreeB])
+      repositories.selection = .canvas
+      var state = AppFeature.State(
+        repositories: repositories,
+        settings: SettingsFeature.State()
+      )
+      state.selectedRunScript = "npm run repo-a"
+      state.selectedCustomCommands = [commandA]
+
+      return TestStore(initialState: state) {
+        AppFeature()
+      } withDependencies: {
+        $0.terminalClient.canvasFocusedWorktreeID = { worktreeB.id }
+        $0.terminalClient.send = { command in
+          sent.withValue { $0.append(command) }
+        }
+      }
+    }
+
+    await store.send(.canvasFocusedWorktreeChanged(worktreeB.id))
+    await store.receive(\.worktreeSettingsLoaded) {
+      $0.selectedRunScript = "npm run repo-b"
+    }
+    await store.receive(\.worktreeUserSettingsLoaded) {
+      $0.selectedCustomCommands = [commandB]
+      $0.resolvedKeybindings = KeybindingResolver.resolve(
+        schema: .appResolverSchema(customCommands: [commandB]),
+        migratedOverrides:
+          LegacyCustomCommandShortcutMigration
+          .migrate(commands: [commandB])
+          .overrides
+      )
+    }
+
+    await store.send(.runScript)
+    await store.send(.runCustomCommand(0))
+    await store.finish()
+
+    #expect(
+      sent.value == [
+        .runScript(worktreeB, script: "npm run repo-b"),
+        .createTabWithInput(
+          worktreeB,
+          input: "make repo-b",
+          runSetupScriptIfNew: false,
+          autoCloseOnSuccess: false,
+          customCommandName: "Repo B Build",
+          customCommandIcon: "b.circle"
+        ),
+      ]
+    )
+  }
+
   private func makeWorktree() -> Worktree {
+    makeWorktree(id: "/tmp/repo/wt-1", name: "wt-1", repoRoot: "/tmp/repo")
+  }
+
+  private func makeWorktree(id: String, name: String, repoRoot: String) -> Worktree {
     Worktree(
-      id: "/tmp/repo/wt-1",
-      name: "wt-1",
+      id: id,
+      name: name,
       detail: "detail",
-      workingDirectory: URL(fileURLWithPath: "/tmp/repo/wt-1"),
-      repositoryRootURL: URL(fileURLWithPath: "/tmp/repo")
+      workingDirectory: URL(fileURLWithPath: id),
+      repositoryRootURL: URL(fileURLWithPath: repoRoot)
     )
   }
 
   private func makeRepositoriesState(worktree: Worktree) -> RepositoriesFeature.State {
-    let repository = Repository(
-      id: "/tmp/repo",
-      rootURL: URL(fileURLWithPath: "/tmp/repo"),
-      name: "repo",
-      worktrees: [worktree]
+    makeRepositoriesState(worktrees: [worktree])
+  }
+
+  private func makeRepositoriesState(worktrees: [Worktree]) -> RepositoriesFeature.State {
+    let worktreesByRepository = Dictionary(
+      grouping: worktrees,
+      by: { $0.repositoryRootURL.path(percentEncoded: false) }
     )
+    let repositories =
+      worktreesByRepository.keys.sorted().compactMap { rootPath in
+        worktreesByRepository[rootPath].map { worktrees in
+          let rootURL = URL(fileURLWithPath: rootPath)
+          return Repository(
+            id: rootPath,
+            rootURL: rootURL,
+            name: rootURL.lastPathComponent,
+            worktrees: IdentifiedArray(uniqueElements: worktrees)
+          )
+        }
+      }
     var repositoriesState = RepositoriesFeature.State()
-    repositoriesState.repositories = [repository]
-    repositoriesState.selection = .worktree(worktree.id)
+    repositoriesState.repositories = IdentifiedArray(uniqueElements: repositories)
+    repositoriesState.selection = worktrees.first.map { .worktree($0.id) }
     return repositoriesState
   }
 }

--- a/supacodeTests/AppFeatureCustomCommandTests.swift
+++ b/supacodeTests/AppFeatureCustomCommandTests.swift
@@ -505,11 +505,10 @@ struct AppFeatureCustomCommandTests {
       }
     }
 
-    await store.send(.canvasFocusedWorktreeChanged(worktree.id))
-    await store.receive(\.worktreeSettingsLoaded) {
+    // Canvas focus applies both repository and user settings in a single reduce
+    // pass so the toolbar updates atomically with the focus change.
+    await store.send(.canvasFocusedWorktreeChanged(worktree.id)) {
       $0.openActionSelection = expectedDefaultOpenAction()
-    }
-    await store.receive(\.worktreeUserSettingsLoaded) {
       $0.selectedCustomCommands = settings.customCommands
       $0.resolvedKeybindings = KeybindingResolver.resolve(
         schema: .appResolverSchema(customCommands: settings.customCommands),
@@ -519,6 +518,7 @@ struct AppFeatureCustomCommandTests {
           .overrides
       )
     }
+    await store.finish()
   }
 
   @Test(.dependencies) func canvasFocusWithMultipleReposUsesPrimaryFocusedWorktree() async {
@@ -570,12 +570,9 @@ struct AppFeatureCustomCommandTests {
       }
     }
 
-    await store.send(.canvasFocusedWorktreeChanged(worktreeB.id))
-    await store.receive(\.worktreeSettingsLoaded) {
+    await store.send(.canvasFocusedWorktreeChanged(worktreeB.id)) {
       $0.openActionSelection = expectedDefaultOpenAction()
       $0.selectedRunScript = "npm run repo-b"
-    }
-    await store.receive(\.worktreeUserSettingsLoaded) {
       $0.selectedCustomCommands = [commandB]
       $0.resolvedKeybindings = KeybindingResolver.resolve(
         schema: .appResolverSchema(customCommands: [commandB]),

--- a/supacodeTests/AppFeatureRunScriptTests.swift
+++ b/supacodeTests/AppFeatureRunScriptTests.swift
@@ -98,6 +98,31 @@ struct AppFeatureRunScriptTests {
     #expect(store.state.isRunScriptPromptPresented)
   }
 
+  @Test(.dependencies) func runScriptUsesCanvasFocusedWorktree() async {
+    let worktree = makeWorktree()
+    var repositories = makeRepositoriesState(worktree: worktree)
+    repositories.selection = .canvas
+    let sent = LockIsolated<[TerminalClient.Command]>([])
+    var state = AppFeature.State(
+      repositories: repositories,
+      settings: SettingsFeature.State()
+    )
+    state.selectedRunScript = "npm test"
+    let store = TestStore(initialState: state) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.canvasFocusedWorktreeID = { worktree.id }
+      $0.terminalClient.send = { command in
+        sent.withValue { $0.append(command) }
+      }
+    }
+
+    await store.send(.runScript)
+    await store.finish()
+
+    #expect(sent.value == [.runScript(worktree, script: "npm test")])
+  }
+
   private func makeWorktree() -> Worktree {
     Worktree(
       id: "/tmp/repo/wt-1",

--- a/supacodeTests/CommandPaletteFeatureTests.swift
+++ b/supacodeTests/CommandPaletteFeatureTests.swift
@@ -85,6 +85,23 @@ struct CommandPaletteFeatureTests {
     #expect(!ids.contains("global.stop-run-script"))
   }
 
+  @Test func commandPaletteItems_includesRunScriptForCanvasActionTarget() {
+    let rootPath = "/tmp/repo-canvas-run"
+    let worktree = makeWorktree(id: "\(rootPath)/wt-1", name: "wt-1", repoRoot: rootPath)
+    let repository = makeRepository(rootPath: rootPath, name: "Repo", worktrees: [worktree])
+    var state = RepositoriesFeature.State(repositories: [repository])
+    state.selection = .canvas
+
+    let items = CommandPaletteFeature.commandPaletteItems(
+      from: state,
+      actionTargetWorktreeID: worktree.id
+    )
+    let ids = Set(items.map(\.id))
+    #expect(ids.contains("global.run-script"))
+    #expect(!ids.contains("global.rename-branch"))
+    #expect(!ids.contains("global.toggle-pin-worktree"))
+  }
+
   @Test func commandPaletteItems_includesStopScriptWhenRunning() {
     let rootPath = "/tmp/repo-run"
     let worktree = makeWorktree(id: "\(rootPath)/wt-1", name: "wt-1", repoRoot: rootPath)


### PR DESCRIPTION
## Summary

Builds on #358 by @vince-hz (*Support Custom Actions in Canvas mode*, fixes #357). This branch carries the original #358 commits **plus** the refinements below, opened from the fork so it can land independently.

### From #358 (by @vince-hz)
- Route Run Script / Stop Script / Custom Commands through the focused Canvas card.
- Sync per-repo Run Script and Custom Actions settings as Canvas focus moves between cards.
- Surface the Canvas-focused actions in the toolbar / menu / Command Palette.

### Refinements added in this branch
- **Hide-Run-button setting**: the Canvas toolbar now honors `showRunButtonInToolbar` (merged from `main`).
- **Cluster separation**: a fixed `ToolbarSpacer` splits the notification group from the Run + Custom Command cluster, matching the Normal toolbar.
- **Atomic settings load**: `canvasFocusedWorktreeChanged` applies repository + user settings in a single reduce pass via shared `applyWorktreeSettings` / `applyWorktreeUserSettings` helpers (also reused by the normal selection path), so the toolbar updates in one transaction instead of across follow-up effects.
- **Card-switch jump fix**: the Run + Custom Command cluster is rendered as a single `ToolbarItem { HStack }`. On Canvas the host view stays mounted, so a multi-item structure made NSToolbar animate per-item insert/remove and briefly overflow the toolbar when switching between cards with different command counts. A single item keeps NSToolbar's item set stable. This is an intentional divergence from the Normal toolbar and is documented in code.

## Test plan
- `make build-app` — clean (0 errors / 0 warnings)
- `make check` — clean (swift-format + swiftlint)
- Reducer tests pass: `AppFeatureCustomCommandTests`, `AppFeatureRunScriptTests`, `CommandPaletteFeatureTests`, plus normal-path selection tests (`AppFeatureDefaultEditorTests`, `AppFeaturePlainFolderTerminalTests`, etc.)
- Manual (Canvas): switching between cards with different command counts no longer jumps; run-button hiding works; cluster spacing matches the Normal toolbar.

If merged, this can supersede #358.
