### PR TITLE
Add configurable line changes polling intervals

### DIFF
--- a/supacode/Clients/WorktreeInfoWatcher/WorktreeInfoWatcherClient.swift
+++ b/supacode/Clients/WorktreeInfoWatcher/WorktreeInfoWatcherClient.swift
@@ -5,8 +5,14 @@ struct WorktreeInfoWatcherClient {
   var send: @MainActor @Sendable (Command) -> Void
   var events: @MainActor @Sendable () -> AsyncStream<Event>
 
+  struct LineChangesRefreshInterval: Equatable, Sendable {
+    var focusedSeconds: Int
+    var unfocusedSeconds: Int
+  }
+
   enum Command: Equatable {
     case setWorktrees([Worktree])
+    case setLineChangesRefreshIntervals([String: LineChangesRefreshInterval])
     case setSelectedWorktreeID(Worktree.ID?)
     case setPullRequestTrackingEnabled(Bool)
     case stop

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -34,6 +34,20 @@ private func makeTerminalRestorableWorktrees(from repositories: [Repository]) ->
   return worktrees
 }
 
+private func makeLineChangesRefreshIntervals(
+  from repositories: some Sequence<Repository>
+) -> [String: WorktreeInfoWatcherClient.LineChangesRefreshInterval] {
+  var intervals: [String: WorktreeInfoWatcherClient.LineChangesRefreshInterval] = [:]
+  for repository in repositories where repository.capabilities.supportsWorktrees {
+    @Shared(.repositorySettings(repository.rootURL)) var repositorySettings
+    intervals[repository.id] = WorktreeInfoWatcherClient.LineChangesRefreshInterval(
+      focusedSeconds: repositorySettings.focusedLineChangesRefreshIntervalSeconds,
+      unfocusedSeconds: repositorySettings.unfocusedLineChangesRefreshIntervalSeconds
+    )
+  }
+  return intervals
+}
+
 @Reducer
 struct AppFeature {
   @ObservableState
@@ -381,6 +395,7 @@ struct AppFeature {
           customCommands: state.selectedCustomCommands
         )
         let worktrees = state.repositories.worktreesForInfoWatcher()
+        let lineChangesRefreshIntervals = makeLineChangesRefreshIntervals(from: repositories)
         let shouldRestoreLayout =
           state.launchRestoreMode == .restoreLayout
           && state.repositories.snapshotPersistencePhase == .active
@@ -409,6 +424,9 @@ struct AppFeature {
             .run { _ in
               await worktreeInfoWatcher.send(.setWorktrees(worktrees))
             },
+            .run { _ in
+              await worktreeInfoWatcher.send(.setLineChangesRefreshIntervals(lineChangesRefreshIntervals))
+            },
           ]
           if shouldRestoreLayout {
             effects.append(
@@ -427,6 +445,9 @@ struct AppFeature {
           },
           .run { _ in
             await worktreeInfoWatcher.send(.setWorktrees(worktrees))
+          },
+          .run { _ in
+            await worktreeInfoWatcher.send(.setLineChangesRefreshIntervals(lineChangesRefreshIntervals))
           },
         ]
         if shouldRestoreLayout {
@@ -893,16 +914,21 @@ struct AppFeature {
         // `RepositoriesFeature.State.repositoryCustomTitles` rather
         // than subscribing to the per-repo settings file directly.
         let refreshCustomTitle = Effect<Action>.send(.repositories(.refreshCustomTitle(rootURL)))
+        let lineChangesRefreshIntervals = makeLineChangesRefreshIntervals(from: state.repositories.repositories)
+        let syncLineChangesRefreshIntervals = Effect<Action>.run { _ in
+          await worktreeInfoWatcher.send(.setLineChangesRefreshIntervals(lineChangesRefreshIntervals))
+        }
         guard let selectedWorktree = state.repositories.selectedTerminalWorktree,
           selectedWorktree.repositoryRootURL == rootURL
         else {
-          return refreshCustomTitle
+          return .merge(refreshCustomTitle, syncLineChangesRefreshIntervals)
         }
         let worktreeID = selectedWorktree.id
         @Shared(.repositorySettings(rootURL)) var repositorySettings
         @Shared(.userRepositorySettings(rootURL)) var userRepositorySettings
         return .concatenate(
           refreshCustomTitle,
+          syncLineChangesRefreshIntervals,
           .send(.worktreeSettingsLoaded(repositorySettings, worktreeID: worktreeID)),
           .send(.worktreeUserSettingsLoaded(userRepositorySettings, worktreeID: worktreeID))
         )

--- a/supacode/Features/Repositories/BusinessLogic/WorktreeInfoWatcherManager.swift
+++ b/supacode/Features/Repositories/BusinessLogic/WorktreeInfoWatcherManager.swift
@@ -39,6 +39,9 @@ final class WorktreeInfoWatcherManager {
   private let filesChangedDebounceInterval: Duration
   private let pullRequestSelectionRefreshCooldown: Duration
   private let refreshTiming: RefreshTiming
+  private let defaultLineChangesRefreshTiming: RefreshTiming
+  private var lineChangesRefreshIntervalByRepositoryID: [String: WorktreeInfoWatcherClient.LineChangesRefreshInterval] =
+    [:]
   private let lineChangePhaseOffset: WorktreePhaseOffset
   private let pullRequestPhaseOffset: RepositoryPhaseOffset
   private let sleep: @Sendable (Duration) async throws -> Void
@@ -59,6 +62,12 @@ final class WorktreeInfoWatcherManager {
   init<C: Clock<Duration>>(
     focusedInterval: Duration = .seconds(30),
     unfocusedInterval: Duration = .seconds(60),
+    focusedLineChangesRefreshInterval: Duration = .seconds(
+      RepositorySettings.defaultFocusedLineChangesRefreshIntervalSeconds
+    ),
+    unfocusedLineChangesRefreshInterval: Duration = .seconds(
+      RepositorySettings.defaultUnfocusedLineChangesRefreshIntervalSeconds
+    ),
     filesChangedDebounceInterval: Duration = .seconds(5),
     pullRequestSelectionRefreshCooldown: Duration = .seconds(5),
     lineChangePhaseOffset: @escaping WorktreePhaseOffset = WorktreeInfoWatcherManager.defaultLineChangePhaseOffset,
@@ -66,6 +75,10 @@ final class WorktreeInfoWatcherManager {
     clock: C = ContinuousClock()
   ) {
     refreshTiming = RefreshTiming(focused: focusedInterval, unfocused: unfocusedInterval)
+    defaultLineChangesRefreshTiming = RefreshTiming(
+      focused: focusedLineChangesRefreshInterval,
+      unfocused: unfocusedLineChangesRefreshInterval
+    )
     self.filesChangedDebounceInterval = filesChangedDebounceInterval
     self.pullRequestSelectionRefreshCooldown = pullRequestSelectionRefreshCooldown
     self.lineChangePhaseOffset = lineChangePhaseOffset
@@ -79,6 +92,8 @@ final class WorktreeInfoWatcherManager {
     switch command {
     case .setWorktrees(let worktrees):
       setWorktrees(worktrees)
+    case .setLineChangesRefreshIntervals(let intervals):
+      setLineChangesRefreshIntervals(intervals)
     case .setSelectedWorktreeID(let worktreeID):
       setSelectedWorktreeID(worktreeID)
     case .setPullRequestTrackingEnabled(let isEnabled):
@@ -135,6 +150,28 @@ final class WorktreeInfoWatcherManager {
     }
     for repositoryRootURL in obsoleteCooldownRepositories {
       cancelPullRequestSelectionCooldown(for: repositoryRootURL)
+    }
+  }
+
+  private func setLineChangesRefreshIntervals(
+    _ intervals: [String: WorktreeInfoWatcherClient.LineChangesRefreshInterval]
+  ) {
+    let normalized = intervals.mapValues { interval in
+      WorktreeInfoWatcherClient.LineChangesRefreshInterval(
+        focusedSeconds: RepositorySettings.normalizedLineChangesRefreshIntervalSeconds(
+          interval.focusedSeconds
+        ),
+        unfocusedSeconds: RepositorySettings.normalizedLineChangesRefreshIntervalSeconds(
+          interval.unfocusedSeconds
+        )
+      )
+    }
+    guard normalized != lineChangesRefreshIntervalByRepositoryID else {
+      return
+    }
+    lineChangesRefreshIntervalByRepositoryID = normalized
+    for worktreeID in worktrees.keys {
+      updateLineChangeSchedule(worktreeID: worktreeID, immediate: false, forceReschedule: true)
     }
   }
 
@@ -415,10 +452,10 @@ final class WorktreeInfoWatcherManager {
     immediate: Bool,
     forceReschedule: Bool = false
   ) {
-    guard worktrees[worktreeID] != nil else {
+    guard let worktree = worktrees[worktreeID] else {
       return
     }
-    let interval = worktreeID == selectedWorktreeID ? refreshTiming.focused : refreshTiming.unfocused
+    let interval = lineChangesRefreshInterval(for: worktree)
     let shouldEmit = immediate && !deferredLineChangeIDs.contains(worktreeID)
     let request = RepeatingTaskRequest(
       worktreeID: worktreeID,
@@ -432,6 +469,16 @@ final class WorktreeInfoWatcherManager {
       }
     )
     updateRepeatingTask(request, tasks: &lineChangeTasks)
+  }
+
+  private func lineChangesRefreshInterval(for worktree: Worktree) -> Duration {
+    let repositoryID = worktree.repositoryRootURL.standardizedFileURL.path(percentEncoded: false)
+    let isFocused = worktree.id == selectedWorktreeID
+    guard let interval = lineChangesRefreshIntervalByRepositoryID[repositoryID] else {
+      return isFocused ? defaultLineChangesRefreshTiming.focused : defaultLineChangesRefreshTiming.unfocused
+    }
+    let seconds = isFocused ? interval.focusedSeconds : interval.unfocusedSeconds
+    return .seconds(RepositorySettings.normalizedLineChangesRefreshIntervalSeconds(seconds))
   }
 
   private func updateRepeatingTask(

--- a/supacode/Features/Settings/Models/RepositorySettings.swift
+++ b/supacode/Features/Settings/Models/RepositorySettings.swift
@@ -5,6 +5,9 @@ nonisolated struct RepositorySettings: Codable, Equatable, Sendable {
   private static let legacyCopyIgnoredDefault = false
   private static let legacyCopyUntrackedDefault = false
   private static let legacyMergeStrategyDefault: PullRequestMergeStrategy = .merge
+  static let defaultFocusedLineChangesRefreshIntervalSeconds = 30
+  static let defaultUnfocusedLineChangesRefreshIntervalSeconds = 60
+  static let minimumLineChangesRefreshIntervalSeconds = 5
 
   var setupScript: String
   var archiveScript: String
@@ -16,6 +19,8 @@ nonisolated struct RepositorySettings: Codable, Equatable, Sendable {
   var copyUntrackedOnWorktreeCreate: Bool?
   var pullRequestMergeStrategy: PullRequestMergeStrategy?
   var customTitle: String?
+  var focusedLineChangesRefreshIntervalSeconds: Int
+  var unfocusedLineChangesRefreshIntervalSeconds: Int
   private var schemaVersion: Int
 
   private enum CodingKeys: String, CodingKey {
@@ -30,6 +35,8 @@ nonisolated struct RepositorySettings: Codable, Equatable, Sendable {
     case copyUntrackedOnWorktreeCreate
     case pullRequestMergeStrategy
     case customTitle
+    case focusedLineChangesRefreshIntervalSeconds
+    case unfocusedLineChangesRefreshIntervalSeconds
   }
 
   static let `default` = RepositorySettings(
@@ -42,7 +49,9 @@ nonisolated struct RepositorySettings: Codable, Equatable, Sendable {
     copyIgnoredOnWorktreeCreate: nil,
     copyUntrackedOnWorktreeCreate: nil,
     pullRequestMergeStrategy: nil,
-    customTitle: nil
+    customTitle: nil,
+    focusedLineChangesRefreshIntervalSeconds: defaultFocusedLineChangesRefreshIntervalSeconds,
+    unfocusedLineChangesRefreshIntervalSeconds: defaultUnfocusedLineChangesRefreshIntervalSeconds
   )
 
   init(
@@ -55,7 +64,9 @@ nonisolated struct RepositorySettings: Codable, Equatable, Sendable {
     copyIgnoredOnWorktreeCreate: Bool? = nil,
     copyUntrackedOnWorktreeCreate: Bool? = nil,
     pullRequestMergeStrategy: PullRequestMergeStrategy? = nil,
-    customTitle: String? = nil
+    customTitle: String? = nil,
+    focusedLineChangesRefreshIntervalSeconds: Int = defaultFocusedLineChangesRefreshIntervalSeconds,
+    unfocusedLineChangesRefreshIntervalSeconds: Int = defaultUnfocusedLineChangesRefreshIntervalSeconds
   ) {
     self.setupScript = setupScript
     self.archiveScript = archiveScript
@@ -67,6 +78,12 @@ nonisolated struct RepositorySettings: Codable, Equatable, Sendable {
     self.copyUntrackedOnWorktreeCreate = copyUntrackedOnWorktreeCreate
     self.pullRequestMergeStrategy = pullRequestMergeStrategy
     self.customTitle = customTitle
+    self.focusedLineChangesRefreshIntervalSeconds = Self.normalizedLineChangesRefreshIntervalSeconds(
+      focusedLineChangesRefreshIntervalSeconds
+    )
+    self.unfocusedLineChangesRefreshIntervalSeconds = Self.normalizedLineChangesRefreshIntervalSeconds(
+      unfocusedLineChangesRefreshIntervalSeconds
+    )
     schemaVersion = Self.currentSchemaVersion
   }
 
@@ -93,6 +110,14 @@ nonisolated struct RepositorySettings: Codable, Equatable, Sendable {
       try container.decodeIfPresent(String.self, forKey: .worktreeBaseDirectoryPath)
     customTitle =
       try container.decodeIfPresent(String.self, forKey: .customTitle)
+    focusedLineChangesRefreshIntervalSeconds = Self.normalizedLineChangesRefreshIntervalSeconds(
+      try container.decodeIfPresent(Int.self, forKey: .focusedLineChangesRefreshIntervalSeconds)
+        ?? Self.default.focusedLineChangesRefreshIntervalSeconds
+    )
+    unfocusedLineChangesRefreshIntervalSeconds = Self.normalizedLineChangesRefreshIntervalSeconds(
+      try container.decodeIfPresent(Int.self, forKey: .unfocusedLineChangesRefreshIntervalSeconds)
+        ?? Self.default.unfocusedLineChangesRefreshIntervalSeconds
+    )
     if decodedSchemaVersion >= Self.currentSchemaVersion {
       copyIgnoredOnWorktreeCreate =
         try container.decodeIfPresent(
@@ -134,9 +159,36 @@ nonisolated struct RepositorySettings: Codable, Equatable, Sendable {
     }
     schemaVersion = Self.currentSchemaVersion
   }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(schemaVersion, forKey: .schemaVersion)
+    try container.encode(setupScript, forKey: .setupScript)
+    try container.encode(archiveScript, forKey: .archiveScript)
+    try container.encode(runScript, forKey: .runScript)
+    try container.encode(openActionID, forKey: .openActionID)
+    try container.encodeIfPresent(worktreeBaseRef, forKey: .worktreeBaseRef)
+    try container.encodeIfPresent(worktreeBaseDirectoryPath, forKey: .worktreeBaseDirectoryPath)
+    try container.encodeIfPresent(copyIgnoredOnWorktreeCreate, forKey: .copyIgnoredOnWorktreeCreate)
+    try container.encodeIfPresent(copyUntrackedOnWorktreeCreate, forKey: .copyUntrackedOnWorktreeCreate)
+    try container.encodeIfPresent(pullRequestMergeStrategy, forKey: .pullRequestMergeStrategy)
+    try container.encodeIfPresent(customTitle, forKey: .customTitle)
+    try container.encode(
+      focusedLineChangesRefreshIntervalSeconds,
+      forKey: .focusedLineChangesRefreshIntervalSeconds
+    )
+    try container.encode(
+      unfocusedLineChangesRefreshIntervalSeconds,
+      forKey: .unfocusedLineChangesRefreshIntervalSeconds
+    )
+  }
 }
 
 extension RepositorySettings {
+  nonisolated static func normalizedLineChangesRefreshIntervalSeconds(_ value: Int) -> Int {
+    max(minimumLineChangesRefreshIntervalSeconds, value)
+  }
+
   nonisolated private static func normalizeLegacyOverride<Value: Equatable>(
     _ value: Value?,
     legacyDefault: Value

--- a/supacode/Features/Settings/Views/RepositorySettingsView.swift
+++ b/supacode/Features/Settings/Views/RepositorySettingsView.swift
@@ -185,6 +185,27 @@ struct RepositorySettingsView: View {
         }
       }
 
+      if store.showsWorktreeSettings {
+        Section {
+          lineChangesIntervalRow(
+            title: "Focused interval",
+            value: settings.focusedLineChangesRefreshIntervalSeconds
+          )
+          lineChangesIntervalRow(
+            title: "Unfocused interval",
+            value: settings.unfocusedLineChangesRefreshIntervalSeconds
+          )
+          Text("Increase this for very large repositories to reduce background Git diff work.")
+            .foregroundStyle(.secondary)
+        } header: {
+          VStack(alignment: .leading, spacing: 4) {
+            Text("Performance")
+            Text("Controls repository background checks")
+              .foregroundStyle(.secondary)
+          }
+        }
+      }
+
       if store.showsPullRequestSettings {
         Section {
           Picker(selection: settings.pullRequestMergeStrategy) {
@@ -955,6 +976,28 @@ struct RepositorySettingsView: View {
         }
       }
     )
+  }
+
+  private func lineChangesIntervalRow(title: String, value: Binding<Int>) -> some View {
+    LabeledContent {
+      HStack(spacing: 8) {
+        TextField("", value: value, format: .number)
+          .textFieldStyle(.roundedBorder)
+          .multilineTextAlignment(.trailing)
+          .frame(width: 72)
+        Text("seconds")
+          .foregroundStyle(.secondary)
+        Stepper(
+          title,
+          value: value,
+          in: RepositorySettings.minimumLineChangesRefreshIntervalSeconds...3_600,
+          step: 5
+        )
+        .labelsHidden()
+      }
+    } label: {
+      Text(title)
+    }
   }
 
   private func syncSelectedCommandID(with commands: [UserCustomCommand]) {

--- a/supacodeTests/RepositorySettingsFeatureTests.swift
+++ b/supacodeTests/RepositorySettingsFeatureTests.swift
@@ -221,6 +221,73 @@ struct RepositorySettingsFeatureTests {
     #expect(decoded.customTitle == nil)
   }
 
+  @Test(.dependencies) func lineChangesRefreshIntervalsPersistToRepositoryFile() async throws {
+    let rootURL = URL(fileURLWithPath: "/tmp/repo-\(UUID().uuidString)")
+    let settingsStorage = SettingsTestStorage()
+    let localStorage = RepositoryLocalSettingsTestStorage()
+    let settingsFileURL = URL(fileURLWithPath: "/tmp/supacode-settings-\(UUID().uuidString).json")
+    let repositorySettingsURL = SupacodePaths.repositorySettingsURL(for: rootURL)
+
+    let seedData = try #require(try? JSONEncoder().encode(RepositorySettings.default))
+    try #require(try? localStorage.save(seedData, at: repositorySettingsURL))
+
+    let store = TestStore(
+      initialState: RepositorySettingsFeature.State(
+        rootURL: rootURL,
+        repositoryKind: .git,
+        settings: .default,
+        userSettings: .default
+      )
+    ) {
+      RepositorySettingsFeature()
+    } withDependencies: {
+      $0.settingsFileStorage = settingsStorage.storage
+      $0.settingsFileURL = settingsFileURL
+      $0.repositoryLocalSettingsStorage = localStorage.storage
+    }
+
+    await store.send(.binding(.set(\.settings.focusedLineChangesRefreshIntervalSeconds, 120))) {
+      $0.settings.focusedLineChangesRefreshIntervalSeconds = 120
+    }
+    await store.receive(\.delegate.settingsChanged)
+
+    await store.send(.binding(.set(\.settings.unfocusedLineChangesRefreshIntervalSeconds, 300))) {
+      $0.settings.unfocusedLineChangesRefreshIntervalSeconds = 300
+    }
+    await store.receive(\.delegate.settingsChanged)
+
+    let savedData = try #require(localStorage.data(at: repositorySettingsURL))
+    let decoded = try JSONDecoder().decode(RepositorySettings.self, from: savedData)
+    #expect(decoded.focusedLineChangesRefreshIntervalSeconds == 120)
+    #expect(decoded.unfocusedLineChangesRefreshIntervalSeconds == 300)
+  }
+
+  @Test func lineChangesRefreshIntervalsDecodeWithDefaultAndMinimum() throws {
+    let missingData = Data("{}".utf8)
+    let missing = try JSONDecoder().decode(RepositorySettings.self, from: missingData)
+    #expect(
+      missing.focusedLineChangesRefreshIntervalSeconds
+        == RepositorySettings.defaultFocusedLineChangesRefreshIntervalSeconds
+    )
+    #expect(
+      missing.unfocusedLineChangesRefreshIntervalSeconds
+        == RepositorySettings.defaultUnfocusedLineChangesRefreshIntervalSeconds
+    )
+
+    let lowData = Data(
+      """
+      {
+        "focusedLineChangesRefreshIntervalSeconds": 1,
+        "unfocusedLineChangesRefreshIntervalSeconds": 2
+      }
+      """.utf8
+    )
+    let low = try JSONDecoder().decode(RepositorySettings.self, from: lowData)
+    #expect(low.focusedLineChangesRefreshIntervalSeconds == RepositorySettings.minimumLineChangesRefreshIntervalSeconds)
+    #expect(
+      low.unfocusedLineChangesRefreshIntervalSeconds == RepositorySettings.minimumLineChangesRefreshIntervalSeconds)
+  }
+
   @Test(.dependencies) func taskLoadsLatestUserSettingsAfterAsyncGitProbe() async throws {
     let rootURL = URL(fileURLWithPath: "/tmp/repo-\(UUID().uuidString)")
     let settingsStorage = SettingsTestStorage()

--- a/supacodeTests/WorktreeInfoWatcherManagerTests.swift
+++ b/supacodeTests/WorktreeInfoWatcherManagerTests.swift
@@ -33,6 +33,8 @@ struct WorktreeInfoWatcherManagerTests {
     let manager = WorktreeInfoWatcherManager(
       focusedInterval: .milliseconds(80),
       unfocusedInterval: .milliseconds(80),
+      focusedLineChangesRefreshInterval: .milliseconds(80),
+      unfocusedLineChangesRefreshInterval: .milliseconds(80),
       lineChangePhaseOffset: { _, _ in .zero },
       pullRequestPhaseOffset: { _, _ in .zero },
       clock: clock
@@ -70,6 +72,8 @@ struct WorktreeInfoWatcherManagerTests {
     let manager = WorktreeInfoWatcherManager(
       focusedInterval: .milliseconds(80),
       unfocusedInterval: .milliseconds(80),
+      focusedLineChangesRefreshInterval: .milliseconds(80),
+      unfocusedLineChangesRefreshInterval: .milliseconds(80),
       lineChangePhaseOffset: { worktreeID, _ in
         switch worktreeID {
         case secondWorktree.id:
@@ -169,6 +173,70 @@ struct WorktreeInfoWatcherManagerTests {
     await task.value
     try FileManager.default.removeItem(at: firstRepository.tempRoot)
     try FileManager.default.removeItem(at: secondRepository.tempRoot)
+  }
+
+  @Test func usesFocusedAndUnfocusedRepositoryLineChangesRefreshIntervals() async throws {
+    let clock = TestClock()
+    let tempRepository = try makeTempRepository(worktreeNames: ["sparrow", "swift"])
+    let focusedWorktree = try #require(tempRepository.worktrees.first)
+    let unfocusedWorktree = try #require(tempRepository.worktrees.dropFirst().first)
+    let manager = WorktreeInfoWatcherManager(
+      focusedInterval: .seconds(3_600),
+      unfocusedInterval: .seconds(3_600),
+      focusedLineChangesRefreshInterval: .milliseconds(80),
+      unfocusedLineChangesRefreshInterval: .milliseconds(160),
+      lineChangePhaseOffset: { _, _ in .zero },
+      pullRequestPhaseOffset: { _, _ in .zero },
+      clock: clock
+    )
+    let (collector, task) = startCollecting(manager.eventStream())
+
+    manager.handleCommand(.setPullRequestTrackingEnabled(false))
+    manager.handleCommand(.setWorktrees([focusedWorktree, unfocusedWorktree]))
+    manager.handleCommand(.setSelectedWorktreeID(focusedWorktree.id))
+    await drainAsyncEvents(120)
+    #expect(await collector.filesChangedCount(worktreeID: focusedWorktree.id) == 2)
+    #expect(await collector.filesChangedCount(worktreeID: unfocusedWorktree.id) == 1)
+
+    await clock.advance(by: .milliseconds(79))
+    await drainAsyncEvents(120)
+    #expect(await collector.filesChangedCount(worktreeID: focusedWorktree.id) == 2)
+    #expect(await collector.filesChangedCount(worktreeID: unfocusedWorktree.id) == 1)
+
+    await clock.advance(by: .milliseconds(1))
+    await drainAsyncEvents(120)
+    #expect(await collector.filesChangedCount(worktreeID: focusedWorktree.id) == 3)
+    #expect(await collector.filesChangedCount(worktreeID: unfocusedWorktree.id) == 1)
+
+    await clock.advance(by: .milliseconds(80))
+    await drainAsyncEvents(120)
+    #expect(await collector.filesChangedCount(worktreeID: unfocusedWorktree.id) == 2)
+
+    manager.handleCommand(
+      .setLineChangesRefreshIntervals([
+        tempRepository.tempRoot.path(percentEncoded: false): WorktreeInfoWatcherClient.LineChangesRefreshInterval(
+          focusedSeconds: 5,
+          unfocusedSeconds: 10
+        )
+      ])
+    )
+    await clock.advance(by: .seconds(4))
+    await drainAsyncEvents(120)
+    #expect(await collector.filesChangedCount(worktreeID: focusedWorktree.id) == 3)
+    #expect(await collector.filesChangedCount(worktreeID: unfocusedWorktree.id) == 2)
+
+    await clock.advance(by: .seconds(1))
+    await drainAsyncEvents(120)
+    #expect(await collector.filesChangedCount(worktreeID: focusedWorktree.id) == 4)
+    #expect(await collector.filesChangedCount(worktreeID: unfocusedWorktree.id) == 2)
+
+    await clock.advance(by: .seconds(5))
+    await drainAsyncEvents(120)
+    #expect(await collector.filesChangedCount(worktreeID: unfocusedWorktree.id) == 3)
+
+    manager.handleCommand(.stop)
+    await task.value
+    try FileManager.default.removeItem(at: tempRepository.tempRoot)
   }
 
   @Test func selectionRefreshUsesCooldownWithinRepository() async throws {


### PR DESCRIPTION
## Summary
- Add per-repository configuration for line-changes polling intervals.
- Split polling into focused and unfocused intervals so inactive worktrees can be checked less often.
- Update repository settings UI to support both stepper controls and direct numeric entry for these intervals.

## Motivation
Large repositories can make repeated `git diff HEAD --shortstat` checks expensive. Previously, line-change polling used a fixed cadence for every repository and worktree, which could create unnecessary background CPU usage when a large repository had inactive worktrees.

This change lets users tune polling per repository. Focused worktrees keep a responsive default interval, while unfocused worktrees default to a slower cadence to reduce background Git work.

## Testing
- `xcrun swift-format -p --in-place --configuration ./.swift-format.json ...`
- `git diff --check`
- `make build-app`

## Screenshot
<img width="1061" height="424" alt="Screenshot 2026-05-28 at 17-18-00" src="https://github.com/user-attachments/assets/94aee00a-0df8-4143-8b9b-987b5f0e87d9" />
