### PR TITLE
Batch PR refresh into a single GraphQL query per host

### DIFF
--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -14,6 +14,11 @@ import Sentry
 import Sharing
 import SwiftUI
 
+@MainActor
+private final class SupacodeAppStoreBox {
+  weak var store: StoreOf<AppFeature>?
+}
+
 private enum GhosttyCLI {
   static func argv(resolvedKeybindings: ResolvedKeybindingMap) -> [UnsafeMutablePointer<CChar>?] {
     var args: [UnsafeMutablePointer<CChar>?] = []
@@ -95,6 +100,7 @@ struct SupacodeApp: App {
   @State private var ghosttyShortcuts: GhosttyShortcutManager
   @State private var terminalManager: WorktreeTerminalManager
   @State private var worktreeInfoWatcher: WorktreeInfoWatcherManager
+  @State private var pullRequestRefreshCoordinator: PullRequestRefreshCoordinator
   @State private var commandKeyObserver: CommandKeyObserver
   @State private var cliSocketServer: CLISocketServer
   @State private var store: StoreOf<AppFeature>
@@ -186,6 +192,9 @@ struct SupacodeApp: App {
     _terminalManager = State(initialValue: terminalManager)
     let worktreeInfoWatcher = WorktreeInfoWatcherManager()
     _worktreeInfoWatcher = State(initialValue: worktreeInfoWatcher)
+    let storeBox = SupacodeAppStoreBox()
+    let coordinator = Self.makePullRequestRefreshCoordinator(storeBox: storeBox)
+    _pullRequestRefreshCoordinator = State(initialValue: coordinator)
     let keyObserver = CommandKeyObserver()
     _commandKeyObserver = State(initialValue: keyObserver)
     var initialAppState = AppFeature.State(settings: SettingsFeature.State(settings: initialSettings))
@@ -207,8 +216,12 @@ struct SupacodeApp: App {
           worktreeInfoWatcher.eventStream()
         }
       )
+      values.pullRequestRefreshCoordinator = Self.makePullRequestRefreshCoordinatorClient(
+        coordinator: coordinator
+      )
     }
     _store = State(initialValue: appStore)
+    storeBox.store = appStore
 
     let cliServer = Self.makeCLISocketServer(appStore: appStore, terminalManager: terminalManager)
     _cliSocketServer = State(initialValue: cliServer)
@@ -233,6 +246,42 @@ struct SupacodeApp: App {
     #if DEBUG
       DebugWindowManager.shared.configure(store: appStore)
     #endif
+  }
+
+  @MainActor
+  private static func makePullRequestRefreshCoordinator(
+    storeBox: SupacodeAppStoreBox
+  ) -> PullRequestRefreshCoordinator {
+    PullRequestRefreshCoordinator(
+      githubCLI: .liveValue,
+      clock: ContinuousClock()
+    ) { outcome in
+      storeBox.store?.send(
+        .repositories(.githubIntegration(.pullRequestRefreshBatchOutcome(outcome)))
+      )
+    }
+  }
+
+  private static func makePullRequestRefreshCoordinatorClient(
+    coordinator: PullRequestRefreshCoordinator
+  ) -> PullRequestRefreshCoordinatorClient {
+    PullRequestRefreshCoordinatorClient(
+      enqueue: { request in
+        Task { @MainActor in
+          coordinator.enqueue(request)
+        }
+      },
+      cancelHost: { host in
+        Task { @MainActor in
+          coordinator.cancelHost(host)
+        }
+      },
+      reset: {
+        Task { @MainActor in
+          coordinator.reset()
+        }
+      }
+    )
   }
 
   private static func makeMemoryWatchdog(

--- a/supacode/Clients/Github/CrossRepoPullRequestResponse.swift
+++ b/supacode/Clients/Github/CrossRepoPullRequestResponse.swift
@@ -1,0 +1,110 @@
+import Foundation
+
+nonisolated struct CrossRepoPullRequestResponse: Decodable {
+  let repositories: [String: CrossRepoPullRequestPayload]
+  let errors: [CrossRepoPullRequestResponseError]
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: TopLevelKey.self)
+    self.errors =
+      (try? container.decode([CrossRepoPullRequestResponseError].self, forKey: .errors)) ?? []
+    if container.contains(.data),
+      let dataContainer = try? container.nestedContainer(
+        keyedBy: CrossRepoDynamicKey.self,
+        forKey: .data
+      )
+    {
+      var dict: [String: CrossRepoPullRequestPayload] = [:]
+      for key in dataContainer.allKeys {
+        if (try? dataContainer.decodeNil(forKey: key)) == true {
+          continue
+        }
+        if let payload = try? dataContainer.decode(
+          CrossRepoPullRequestPayload.self, forKey: key
+        ) {
+          dict[key.stringValue] = payload
+        }
+      }
+      self.repositories = dict
+    } else {
+      self.repositories = [:]
+    }
+  }
+
+  func failedAliases() -> Set<String> {
+    var aliases: Set<String> = []
+    for error in errors {
+      guard let first = error.path.first else {
+        continue
+      }
+      aliases.insert(first)
+    }
+    return aliases
+  }
+
+  private enum TopLevelKey: String, CodingKey {
+    case data
+    case errors
+  }
+}
+
+nonisolated struct CrossRepoPullRequestPayload: Decodable {
+  let pullRequestsByAlias: [String: GithubGraphQLPullRequestResponse.PullRequestConnection]
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CrossRepoDynamicKey.self)
+    var dict: [String: GithubGraphQLPullRequestResponse.PullRequestConnection] = [:]
+    for key in container.allKeys {
+      dict[key.stringValue] = try container.decode(
+        GithubGraphQLPullRequestResponse.PullRequestConnection.self,
+        forKey: key
+      )
+    }
+    self.pullRequestsByAlias = dict
+  }
+}
+
+nonisolated struct CrossRepoPullRequestResponseError: Decodable {
+  let message: String?
+  let path: [String]
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: Keys.self)
+    self.message = try container.decodeIfPresent(String.self, forKey: .message)
+    var components: [String] = []
+    if container.contains(.path),
+      var unkeyed = try? container.nestedUnkeyedContainer(forKey: .path)
+    {
+      while !unkeyed.isAtEnd {
+        if let value = try? unkeyed.decode(String.self) {
+          components.append(value)
+        } else if let value = try? unkeyed.decode(Int.self) {
+          components.append("\(value)")
+        } else {
+          _ = try? unkeyed.decodeNil()
+        }
+      }
+    }
+    self.path = components
+  }
+
+  private enum Keys: String, CodingKey {
+    case message
+    case path
+  }
+}
+
+nonisolated struct CrossRepoDynamicKey: CodingKey {
+  let stringValue: String
+  let intValue: Int?
+
+  init?(stringValue: String) {
+    self.stringValue = stringValue
+    self.intValue = nil
+  }
+
+  init?(intValue: Int) {
+    self.stringValue = "\(intValue)"
+    self.intValue = intValue
+  }
+}

--- a/supacode/Clients/Github/CrossRepoPullRequestResponse.swift
+++ b/supacode/Clients/Github/CrossRepoPullRequestResponse.swift
@@ -31,15 +31,29 @@ nonisolated struct CrossRepoPullRequestResponse: Decodable {
     }
   }
 
-  func failedAliases() -> Set<String> {
-    var aliases: Set<String> = []
+  func errorMessagesByAlias() -> [String: String] {
+    var messages: [String: String] = [:]
     for error in errors {
-      guard let first = error.path.first else {
+      guard let alias = error.path.first else {
         continue
       }
-      aliases.insert(first)
+      let description = describeError(error)
+      if let existing = messages[alias], !existing.isEmpty {
+        messages[alias] = "\(existing); \(description)"
+      } else {
+        messages[alias] = description
+      }
     }
-    return aliases
+    return messages
+  }
+
+  private func describeError(_ error: CrossRepoPullRequestResponseError) -> String {
+    let message = error.message ?? "GraphQL error"
+    if error.path.count > 1 {
+      let field = error.path.dropFirst().joined(separator: ".")
+      return "\(message) (at \(field))"
+    }
+    return message
   }
 
   private enum TopLevelKey: String, CodingKey {

--- a/supacode/Clients/Github/GithubCLIClient.swift
+++ b/supacode/Clients/Github/GithubCLIClient.swift
@@ -40,11 +40,41 @@ extension GithubAuthStatusResponse.GithubAuthAccount: Decodable {
   }
 }
 
+nonisolated struct RepoKey: Hashable, Sendable {
+  let owner: String
+  let repo: String
+}
+
+nonisolated struct CrossRepoPullRequestRequest: Sendable, Hashable {
+  let owner: String
+  let repo: String
+  let branches: [String]
+
+  var key: RepoKey {
+    RepoKey(owner: owner, repo: repo)
+  }
+}
+
+nonisolated struct CrossRepoPullRequestResult: Sendable {
+  let successByRepo: [RepoKey: [String: GithubPullRequest]]
+  let failedRepos: [RepoKey: GithubCLIError]
+
+  init(
+    successByRepo: [RepoKey: [String: GithubPullRequest]] = [:],
+    failedRepos: [RepoKey: GithubCLIError] = [:]
+  ) {
+    self.successByRepo = successByRepo
+    self.failedRepos = failedRepos
+  }
+}
+
 struct GithubCLIClient: Sendable {
   var defaultBranch: @Sendable (URL) async throws -> String
   var resolveRemoteInfo: @Sendable (URL) async -> GithubRemoteInfo?
   var latestRun: @Sendable (URL, String) async throws -> GithubWorkflowRun?
   var batchPullRequests: @Sendable (String, String, String, [String]) async throws -> [String: GithubPullRequest]
+  var batchPullRequestsAcrossRepositories:
+    @Sendable (String, [CrossRepoPullRequestRequest]) async throws -> CrossRepoPullRequestResult
   var mergePullRequest: @Sendable (URL, GithubRemoteInfo, Int, PullRequestMergeStrategy) async throws -> Void
   var closePullRequest: @Sendable (URL, GithubRemoteInfo, Int) async throws -> Void
   var markPullRequestReady: @Sendable (URL, GithubRemoteInfo, Int) async throws -> Void
@@ -65,6 +95,7 @@ extension GithubCLIClient: DependencyKey {
       resolveRemoteInfo: resolveRemoteInfoFetcher(shell: shell, resolver: resolver),
       latestRun: latestRunFetcher(shell: shell, resolver: resolver),
       batchPullRequests: batchPullRequestsFetcher(shell: shell, resolver: resolver),
+      batchPullRequestsAcrossRepositories: batchPullRequestsAcrossRepositoriesFetcher(shell: shell, resolver: resolver),
       mergePullRequest: mergePullRequestFetcher(shell: shell, resolver: resolver),
       closePullRequest: closePullRequestFetcher(shell: shell, resolver: resolver),
       markPullRequestReady: markPullRequestReadyFetcher(shell: shell, resolver: resolver),
@@ -81,6 +112,7 @@ extension GithubCLIClient: DependencyKey {
     resolveRemoteInfo: { _ in nil },
     latestRun: { _, _ in nil },
     batchPullRequests: { _, _, _, _ in [:] },
+    batchPullRequestsAcrossRepositories: { _, _ in CrossRepoPullRequestResult() },
     mergePullRequest: { _, _, _, _ in },
     closePullRequest: { _, _, _ in },
     markPullRequestReady: { _, _, _ in },
@@ -294,6 +326,354 @@ nonisolated private func batchPullRequestsFetcher(
       chunkCount: chunks.count
     )
   }
+}
+
+nonisolated private let crossRepoBatchAliasLimit = 15
+nonisolated private let crossRepoBatchMaxConcurrentRequests = 3
+nonisolated private let crossRepoBatchLogger = SupaLogger("BPR")
+
+nonisolated private struct CrossRepoChunkOutcome: Sendable {
+  let successByRepo: [RepoKey: [String: GithubPullRequest]]
+  let failedRepos: [RepoKey: GithubCLIError]
+}
+
+nonisolated private func batchPullRequestsAcrossRepositoriesFetcher(
+  shell: ShellClient,
+  resolver: GithubCLIExecutableResolver
+) -> @Sendable (String, [CrossRepoPullRequestRequest]) async throws -> CrossRepoPullRequestResult {
+  { host, requests in
+    let cleaned = sanitizeCrossRepoRequests(requests)
+    guard !cleaned.isEmpty else {
+      return CrossRepoPullRequestResult()
+    }
+    let chunks = makeCrossRepoChunks(cleaned, chunkSize: crossRepoBatchAliasLimit)
+    // [BPR] remove after manual verification
+    crossRepoBatchLogger.debug(
+      "batch start host=\(host) repos=\(cleaned.count) chunks=\(chunks.count)"
+    )
+    let outcomes = try await loadCrossRepoChunks(
+      shell: shell,
+      resolver: resolver,
+      host: host,
+      chunks: chunks
+    )
+    return mergeCrossRepoChunkResults(outcomes)
+  }
+}
+
+nonisolated private func sanitizeCrossRepoRequests(
+  _ requests: [CrossRepoPullRequestRequest]
+) -> [CrossRepoPullRequestRequest] {
+  var sanitized: [CrossRepoPullRequestRequest] = []
+  for request in requests {
+    var seen = Set<String>()
+    let branches = request.branches.filter { value in
+      let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+      return !trimmed.isEmpty && seen.insert(value).inserted
+    }
+    guard !branches.isEmpty else {
+      continue
+    }
+    sanitized.append(
+      CrossRepoPullRequestRequest(owner: request.owner, repo: request.repo, branches: branches)
+    )
+  }
+  return sanitized
+}
+
+nonisolated private func makeCrossRepoChunks(
+  _ requests: [CrossRepoPullRequestRequest],
+  chunkSize: Int
+) -> [[CrossRepoPullRequestRequest]] {
+  guard !requests.isEmpty else {
+    return []
+  }
+  var chunks: [[CrossRepoPullRequestRequest]] = []
+  var index = 0
+  while index < requests.count {
+    let end = min(index + chunkSize, requests.count)
+    chunks.append(Array(requests[index..<end]))
+    index = end
+  }
+  return chunks
+}
+
+nonisolated private func loadCrossRepoChunks(
+  shell: ShellClient,
+  resolver: GithubCLIExecutableResolver,
+  host: String,
+  chunks: [[CrossRepoPullRequestRequest]]
+) async throws -> [CrossRepoChunkOutcome] {
+  try await withThrowingTaskGroup(of: (Int, CrossRepoChunkOutcome).self) { group in
+    var nextChunkIndex = 0
+    let initialCount = min(crossRepoBatchMaxConcurrentRequests, chunks.count)
+    while nextChunkIndex < initialCount {
+      let chunkIndex = nextChunkIndex
+      let chunk = chunks[chunkIndex]
+      group.addTask {
+        let outcome = try await fetchCrossRepoChunk(
+          shell: shell,
+          resolver: resolver,
+          host: host,
+          chunk: chunk,
+          chunkIndex: chunkIndex
+        )
+        return (chunkIndex, outcome)
+      }
+      nextChunkIndex += 1
+    }
+    var resultsByIndex: [Int: CrossRepoChunkOutcome] = [:]
+    while let (chunkIndex, outcome) = try await group.next() {
+      resultsByIndex[chunkIndex] = outcome
+      if nextChunkIndex < chunks.count {
+        let candidateIndex = nextChunkIndex
+        let candidateChunk = chunks[candidateIndex]
+        group.addTask {
+          let outcome = try await fetchCrossRepoChunk(
+            shell: shell,
+            resolver: resolver,
+            host: host,
+            chunk: candidateChunk,
+            chunkIndex: candidateIndex
+          )
+          return (candidateIndex, outcome)
+        }
+        nextChunkIndex += 1
+      }
+    }
+    return (0..<chunks.count).compactMap { resultsByIndex[$0] }
+  }
+}
+
+nonisolated private func mergeCrossRepoChunkResults(
+  _ outcomes: [CrossRepoChunkOutcome]
+) -> CrossRepoPullRequestResult {
+  var success: [RepoKey: [String: GithubPullRequest]] = [:]
+  var failed: [RepoKey: GithubCLIError] = [:]
+  for outcome in outcomes {
+    for (key, prs) in outcome.successByRepo {
+      success[key] = prs
+    }
+    for (key, error) in outcome.failedRepos {
+      failed[key] = error
+    }
+  }
+  return CrossRepoPullRequestResult(successByRepo: success, failedRepos: failed)
+}
+
+nonisolated private func fetchCrossRepoChunk(
+  shell: ShellClient,
+  resolver: GithubCLIExecutableResolver,
+  host: String,
+  chunk: [CrossRepoPullRequestRequest],
+  chunkIndex: Int
+) async throws -> CrossRepoChunkOutcome {
+  let plan = makeCrossRepoBatchQuery(requests: chunk)
+  // [BPR] remove after manual verification
+  crossRepoBatchLogger.debug(
+    "chunk[\(chunkIndex)] dispatch repos=\(plan.repoAliases.count) host=\(host)"
+  )
+  let output = try await runGh(
+    shell: shell,
+    resolver: resolver,
+    arguments: [
+      "api",
+      "graphql",
+      "--hostname",
+      host,
+      "-f",
+      "query=\(plan.query)",
+    ],
+    repoRoot: nil
+  )
+  guard !output.isEmpty else {
+    var failed: [RepoKey: GithubCLIError] = [:]
+    for key in plan.repoAliases.values {
+      failed[key] = .commandFailed("Empty response from gh api graphql")
+    }
+    return CrossRepoChunkOutcome(successByRepo: [:], failedRepos: failed)
+  }
+  let data = Data(output.utf8)
+  let decoder = JSONDecoder()
+  decoder.dateDecodingStrategy = .iso8601
+  let response = try decoder.decode(CrossRepoPullRequestResponse.self, from: data)
+
+  let failedAliases = response.failedAliases()
+  var success: [RepoKey: [String: GithubPullRequest]] = [:]
+  var failed: [RepoKey: GithubCLIError] = [:]
+  for (alias, key) in plan.repoAliases {
+    if failedAliases.contains(alias) {
+      // [BPR] remove after manual verification
+      crossRepoBatchLogger.debug("chunk[\(chunkIndex)] partial-error alias=\(alias) repo=\(key.owner)/\(key.repo)")
+      failed[key] = .commandFailed("Partial GraphQL error for \(key.owner)/\(key.repo)")
+      continue
+    }
+    guard let payload = response.repositories[alias] else {
+      failed[key] = .commandFailed("Missing response payload for \(key.owner)/\(key.repo)")
+      continue
+    }
+    let branchAliasMap = plan.branchAliasesByRepo[alias] ?? [:]
+    let prs = rankCrossRepoPullRequests(
+      pullRequestsByAlias: payload.pullRequestsByAlias,
+      aliasMap: branchAliasMap,
+      owner: key.owner,
+      repo: key.repo
+    )
+    success[key] = prs
+  }
+  // [BPR] remove after manual verification
+  crossRepoBatchLogger.debug(
+    "chunk[\(chunkIndex)] done success=\(success.count) failed=\(failed.count)"
+  )
+  return CrossRepoChunkOutcome(successByRepo: success, failedRepos: failed)
+}
+
+nonisolated private struct CrossRepoBatchQueryPlan: Sendable {
+  let query: String
+  let repoAliases: [String: RepoKey]
+  let branchAliasesByRepo: [String: [String: String]]
+}
+
+nonisolated private func makeCrossRepoBatchQuery(
+  requests: [CrossRepoPullRequestRequest]
+) -> CrossRepoBatchQueryPlan {
+  var repoAliases: [String: RepoKey] = [:]
+  var branchAliasesByRepo: [String: [String: String]] = [:]
+  var repoBlocks: [String] = []
+  let orderBy = "orderBy: {field: UPDATED_AT, direction: DESC}"
+  for (repoIndex, request) in requests.enumerated() {
+    let repoAlias = "r\(repoIndex)"
+    repoAliases[repoAlias] = RepoKey(owner: request.owner, repo: request.repo)
+    var branchAliasMap: [String: String] = [:]
+    var selections: [String] = []
+    for (branchIndex, branch) in request.branches.enumerated() {
+      let branchAlias = "\(repoAlias)_b\(branchIndex)"
+      branchAliasMap[branchAlias] = branch
+      let escapedBranch = escapeGraphQLString(branch)
+      let pullRequestsArgs =
+        "first: 5, states: [OPEN, MERGED], headRefName: \"\(escapedBranch)\", \(orderBy)"
+      let selection = """
+          \(branchAlias): pullRequests(\(pullRequestsArgs)) {
+            nodes {
+              number
+              title
+              state
+              additions
+              deletions
+              isDraft
+              reviewDecision
+              mergeable
+              mergeStateStatus
+              url
+              updatedAt
+              headRefName
+              baseRefName
+              commits {
+                totalCount
+              }
+              author {
+                login
+              }
+              headRepository {
+                name
+                owner { login }
+              }
+              statusCheckRollup {
+                contexts(first: 100) {
+                  nodes {
+                    ... on CheckRun {
+                      name
+                      status
+                      conclusion
+                      startedAt
+                      completedAt
+                      detailsUrl
+                    }
+                    ... on StatusContext {
+                      context
+                      state
+                      targetUrl
+                      createdAt
+                    }
+                  }
+                }
+              }
+            }
+          }
+        """
+      selections.append(selection)
+    }
+    branchAliasesByRepo[repoAlias] = branchAliasMap
+    let escapedOwner = escapeGraphQLString(request.owner)
+    let escapedRepo = escapeGraphQLString(request.repo)
+    let block = """
+        \(repoAlias): repository(owner: \"\(escapedOwner)\", name: \"\(escapedRepo)\") {
+      \(selections.joined(separator: "\n"))
+        }
+      """
+    repoBlocks.append(block)
+  }
+  let query = """
+    query {
+    \(repoBlocks.joined(separator: "\n"))
+    }
+    """
+  return CrossRepoBatchQueryPlan(
+    query: query,
+    repoAliases: repoAliases,
+    branchAliasesByRepo: branchAliasesByRepo
+  )
+}
+
+nonisolated private func rankCrossRepoPullRequests(
+  pullRequestsByAlias: [String: GithubGraphQLPullRequestResponse.PullRequestConnection],
+  aliasMap: [String: String],
+  owner: String,
+  repo: String
+) -> [String: GithubPullRequest] {
+  let normalizedOwner = owner.lowercased()
+  let normalizedRepo = repo.lowercased()
+  var results: [String: GithubPullRequest] = [:]
+  for (alias, connection) in pullRequestsByAlias {
+    guard let branch = aliasMap[alias] else {
+      continue
+    }
+    let upstreamCandidates = connection.nodes.filter {
+      $0.matches(owner: normalizedOwner, repo: normalizedRepo)
+    }
+    let candidates: [GithubGraphQLPullRequestResponse.PullRequestNode]
+    if !upstreamCandidates.isEmpty {
+      candidates = upstreamCandidates
+    } else {
+      let forkCandidates = connection.nodes.filter {
+        $0.headRepository != nil && $0.doesNotTargetSameBranch(branch)
+      }
+      candidates =
+        if !forkCandidates.isEmpty {
+          forkCandidates
+        } else {
+          connection.nodes.filter {
+            $0.headRepository == nil && $0.doesNotTargetSameBranch(branch)
+          }
+        }
+    }
+    if let node = candidates.max(by: { left, right in
+      let leftRank = left.stateRank
+      let rightRank = right.stateRank
+      if leftRank != rightRank {
+        return leftRank < rightRank
+      }
+      let leftDate = left.updatedAt ?? .distantPast
+      let rightDate = right.updatedAt ?? .distantPast
+      if leftDate != rightDate {
+        return leftDate < rightDate
+      }
+      return left.number < right.number
+    }) {
+      results[branch] = node.pullRequest
+    }
+  }
+  return results
 }
 
 nonisolated private func mergePullRequestFetcher(

--- a/supacode/Clients/Github/GithubCLIClient.swift
+++ b/supacode/Clients/Github/GithubCLIClient.swift
@@ -330,7 +330,6 @@ nonisolated private func batchPullRequestsFetcher(
 
 nonisolated private let crossRepoBatchAliasLimit = 15
 nonisolated private let crossRepoBatchMaxConcurrentRequests = 3
-nonisolated private let crossRepoBatchLogger = SupaLogger("BPR")
 
 nonisolated private struct CrossRepoChunkOutcome: Sendable {
   let successByRepo: [RepoKey: [String: GithubPullRequest]]
@@ -347,10 +346,6 @@ nonisolated private func batchPullRequestsAcrossRepositoriesFetcher(
       return CrossRepoPullRequestResult()
     }
     let chunks = makeCrossRepoChunks(cleaned, chunkSize: crossRepoBatchAliasLimit)
-    // [BPR] remove after manual verification
-    crossRepoBatchLogger.debug(
-      "batch start host=\(host) repos=\(cleaned.count) chunks=\(chunks.count)"
-    )
     let outcomes = try await loadCrossRepoChunks(
       shell: shell,
       resolver: resolver,
@@ -415,8 +410,7 @@ nonisolated private func loadCrossRepoChunks(
           shell: shell,
           resolver: resolver,
           host: host,
-          chunk: chunk,
-          chunkIndex: chunkIndex
+          chunk: chunk
         )
         return (chunkIndex, outcome)
       }
@@ -433,8 +427,7 @@ nonisolated private func loadCrossRepoChunks(
             shell: shell,
             resolver: resolver,
             host: host,
-            chunk: candidateChunk,
-            chunkIndex: candidateIndex
+            chunk: candidateChunk
           )
           return (candidateIndex, outcome)
         }
@@ -465,14 +458,9 @@ nonisolated private func fetchCrossRepoChunk(
   shell: ShellClient,
   resolver: GithubCLIExecutableResolver,
   host: String,
-  chunk: [CrossRepoPullRequestRequest],
-  chunkIndex: Int
+  chunk: [CrossRepoPullRequestRequest]
 ) async throws -> CrossRepoChunkOutcome {
   let plan = makeCrossRepoBatchQuery(requests: chunk)
-  // [BPR] remove after manual verification
-  crossRepoBatchLogger.debug(
-    "chunk[\(chunkIndex)] dispatch repos=\(plan.repoAliases.count) host=\(host)"
-  )
   let output = try await runGh(
     shell: shell,
     resolver: resolver,
@@ -503,8 +491,6 @@ nonisolated private func fetchCrossRepoChunk(
   var failed: [RepoKey: GithubCLIError] = [:]
   for (alias, key) in plan.repoAliases {
     if failedAliases.contains(alias) {
-      // [BPR] remove after manual verification
-      crossRepoBatchLogger.debug("chunk[\(chunkIndex)] partial-error alias=\(alias) repo=\(key.owner)/\(key.repo)")
       failed[key] = .commandFailed("Partial GraphQL error for \(key.owner)/\(key.repo)")
       continue
     }
@@ -521,10 +507,6 @@ nonisolated private func fetchCrossRepoChunk(
     )
     success[key] = prs
   }
-  // [BPR] remove after manual verification
-  crossRepoBatchLogger.debug(
-    "chunk[\(chunkIndex)] done success=\(success.count) failed=\(failed.count)"
-  )
   return CrossRepoChunkOutcome(successByRepo: success, failedRepos: failed)
 }
 

--- a/supacode/Clients/Github/GithubCLIClient.swift
+++ b/supacode/Clients/Github/GithubCLIClient.swift
@@ -362,9 +362,12 @@ nonisolated private func sanitizeCrossRepoRequests(
   var sanitized: [CrossRepoPullRequestRequest] = []
   for request in requests {
     var seen = Set<String>()
-    let branches = request.branches.filter { value in
+    let branches = request.branches.compactMap { value -> String? in
       let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
-      return !trimmed.isEmpty && seen.insert(value).inserted
+      guard !trimmed.isEmpty, seen.insert(trimmed).inserted else {
+        return nil
+      }
+      return trimmed
     }
     guard !branches.isEmpty else {
       continue
@@ -486,12 +489,12 @@ nonisolated private func fetchCrossRepoChunk(
   decoder.dateDecodingStrategy = .iso8601
   let response = try decoder.decode(CrossRepoPullRequestResponse.self, from: data)
 
-  let failedAliases = response.failedAliases()
+  let errorMessagesByAlias = response.errorMessagesByAlias()
   var success: [RepoKey: [String: GithubPullRequest]] = [:]
   var failed: [RepoKey: GithubCLIError] = [:]
   for (alias, key) in plan.repoAliases {
-    if failedAliases.contains(alias) {
-      failed[key] = .commandFailed("Partial GraphQL error for \(key.owner)/\(key.repo)")
+    if let detail = errorMessagesByAlias[alias] {
+      failed[key] = .commandFailed("GraphQL error for \(key.owner)/\(key.repo): \(detail)")
       continue
     }
     guard let payload = response.repositories[alias] else {

--- a/supacode/Features/Repositories/BusinessLogic/PullRequestRefreshCoordinator.swift
+++ b/supacode/Features/Repositories/BusinessLogic/PullRequestRefreshCoordinator.swift
@@ -31,7 +31,6 @@ final class PullRequestRefreshCoordinator {
   private let clock: any Clock<Duration>
   private let debounceWindow: Duration
   private let softTimeout: Duration
-  private let aliasLimit: Int
   private let resultHandler: @MainActor (Outcome) -> Void
 
   private var pendingByHost: [String: [Repository.ID: Request]] = [:]
@@ -44,21 +43,21 @@ final class PullRequestRefreshCoordinator {
     clock: any Clock<Duration>,
     debounceWindow: Duration = .milliseconds(250),
     softTimeout: Duration = .seconds(12),
-    aliasLimit: Int = 15,
     resultHandler: @MainActor @escaping (Outcome) -> Void
   ) {
     self.githubCLI = githubCLI
     self.clock = clock
     self.debounceWindow = debounceWindow
     self.softTimeout = softTimeout
-    self.aliasLimit = aliasLimit
     self.resultHandler = resultHandler
   }
 
   func enqueue(_ request: Request) {
-    // Sanitize branches at the gate: silently drop a request that contributes nothing.
-    let cleanedBranches = request.branches.filter {
-      !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    // Trim and drop whitespace-only entries so "feat" and "feat " do not get treated as
+    // distinct branches downstream and don't leak padding into the GraphQL headRefName.
+    let cleanedBranches = request.branches.compactMap { branch -> String? in
+      let trimmed = branch.trimmingCharacters(in: .whitespacesAndNewlines)
+      return trimmed.isEmpty ? nil : trimmed
     }
     guard !cleanedBranches.isEmpty else {
       return

--- a/supacode/Features/Repositories/BusinessLogic/PullRequestRefreshCoordinator.swift
+++ b/supacode/Features/Repositories/BusinessLogic/PullRequestRefreshCoordinator.swift
@@ -45,7 +45,7 @@ final class PullRequestRefreshCoordinator {
     githubCLI: GithubCLIClient,
     clock: any Clock<Duration>,
     debounceWindow: Duration = .milliseconds(250),
-    softTimeout: Duration = .seconds(6),
+    softTimeout: Duration = .seconds(12),
     aliasLimit: Int = 15,
     resultHandler: @MainActor @escaping (Outcome) -> Void
   ) {
@@ -189,19 +189,27 @@ final class PullRequestRefreshCoordinator {
           )
         )
       }
-      for (key, _) in result.failedRepos {
-        guard let request = requestsByKey[key] else {
-          continue
-        }
+      let failedRequests = result.failedRepos.keys.compactMap { requestsByKey[$0] }
+      if !failedRequests.isEmpty {
         // [BPR] remove after manual verification
-        logger.debug("fallback partial repo=\(key.owner)/\(key.repo)")
-        await fallbackPerRepo(request)
+        logger.debug("fallback partial host=\(host) count=\(failedRequests.count)")
+        await fanOutFallback(failedRequests)
       }
     } catch {
       // [BPR] remove after manual verification
       logger.debug("fallback batch host=\(host) error=\(String(describing: error))")
+      await fanOutFallback(requests)
+    }
+  }
+
+  private func fanOutFallback(_ requests: [Request]) async {
+    // Run per-repo fallback requests concurrently; serial awaits here would multiply
+    // a slow recovery path by the number of repos in the batch.
+    await withTaskGroup(of: Void.self) { group in
       for request in requests {
-        await fallbackPerRepo(request)
+        group.addTask { [weak self] in
+          await self?.fallbackPerRepo(request)
+        }
       }
     }
   }

--- a/supacode/Features/Repositories/BusinessLogic/PullRequestRefreshCoordinator.swift
+++ b/supacode/Features/Repositories/BusinessLogic/PullRequestRefreshCoordinator.swift
@@ -39,8 +39,6 @@ final class PullRequestRefreshCoordinator {
   private var inflightHosts: Set<String> = []
   private var queuedByHost: [String: [Repository.ID: Request]] = [:]
 
-  private let logger = SupaLogger("BPR")
-
   init(
     githubCLI: GithubCLIClient,
     clock: any Clock<Duration>,
@@ -76,15 +74,11 @@ final class PullRequestRefreshCoordinator {
     )
 
     if inflightHosts.contains(normalized.host) {
-      // [BPR] remove after manual verification
-      logger.debug("queue host=\(normalized.host) repo=\(normalized.owner)/\(normalized.repo) (inflight)")
       mergeRequest(normalized, into: &queuedByHost)
       return
     }
 
     mergeRequest(normalized, into: &pendingByHost)
-    // [BPR] remove after manual verification
-    logger.debug("enqueue host=\(normalized.host) repo=\(normalized.owner)/\(normalized.repo)")
     rescheduleDebounce(forHost: normalized.host)
   }
 
@@ -155,14 +149,10 @@ final class PullRequestRefreshCoordinator {
     }
     inflightHosts.insert(host)
     let requests = Array(bucket.values)
-    // [BPR] remove after manual verification
-    logger.debug("flush host=\(host) repos=\(requests.count)")
     await processBatch(host: host, requests: requests)
     inflightHosts.remove(host)
     if let queued = queuedByHost.removeValue(forKey: host), !queued.isEmpty {
       pendingByHost[host, default: [:]].merge(queued) { _, new in new }
-      // [BPR] remove after manual verification
-      logger.debug("drain-queued host=\(host) repos=\(queued.count)")
       await flush(host: host)
     }
   }
@@ -191,13 +181,9 @@ final class PullRequestRefreshCoordinator {
       }
       let failedRequests = result.failedRepos.keys.compactMap { requestsByKey[$0] }
       if !failedRequests.isEmpty {
-        // [BPR] remove after manual verification
-        logger.debug("fallback partial host=\(host) count=\(failedRequests.count)")
         await fanOutFallback(failedRequests)
       }
     } catch {
-      // [BPR] remove after manual verification
-      logger.debug("fallback batch host=\(host) error=\(String(describing: error))")
       await fanOutFallback(requests)
     }
   }

--- a/supacode/Features/Repositories/BusinessLogic/PullRequestRefreshCoordinator.swift
+++ b/supacode/Features/Repositories/BusinessLogic/PullRequestRefreshCoordinator.swift
@@ -1,0 +1,297 @@
+import ComposableArchitecture
+import Foundation
+
+@MainActor
+final class PullRequestRefreshCoordinator {
+  nonisolated struct Request: Equatable, Sendable {
+    let repositoryID: Repository.ID
+    let repositoryRootURL: URL
+    let host: String
+    let owner: String
+    let repo: String
+    let branches: [String]
+    let worktreeIDs: [Worktree.ID]
+  }
+
+  nonisolated enum Outcome: Sendable, Equatable {
+    case refreshed(
+      repositoryID: Repository.ID,
+      repositoryRootURL: URL,
+      worktreeIDs: [Worktree.ID],
+      prsByBranch: [String: GithubPullRequest]
+    )
+    case failed(
+      repositoryID: Repository.ID,
+      worktreeIDs: [Worktree.ID],
+      message: String
+    )
+  }
+
+  private let githubCLI: GithubCLIClient
+  private let clock: any Clock<Duration>
+  private let debounceWindow: Duration
+  private let softTimeout: Duration
+  private let aliasLimit: Int
+  private let resultHandler: @MainActor (Outcome) -> Void
+
+  private var pendingByHost: [String: [Repository.ID: Request]] = [:]
+  private var flushTaskByHost: [String: Task<Void, Never>] = [:]
+  private var inflightHosts: Set<String> = []
+  private var queuedByHost: [String: [Repository.ID: Request]] = [:]
+
+  private let logger = SupaLogger("BPR")
+
+  init(
+    githubCLI: GithubCLIClient,
+    clock: any Clock<Duration>,
+    debounceWindow: Duration = .milliseconds(250),
+    softTimeout: Duration = .seconds(6),
+    aliasLimit: Int = 15,
+    resultHandler: @MainActor @escaping (Outcome) -> Void
+  ) {
+    self.githubCLI = githubCLI
+    self.clock = clock
+    self.debounceWindow = debounceWindow
+    self.softTimeout = softTimeout
+    self.aliasLimit = aliasLimit
+    self.resultHandler = resultHandler
+  }
+
+  func enqueue(_ request: Request) {
+    // Sanitize branches at the gate: silently drop a request that contributes nothing.
+    let cleanedBranches = request.branches.filter {
+      !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+    guard !cleanedBranches.isEmpty else {
+      return
+    }
+    let normalized = Request(
+      repositoryID: request.repositoryID,
+      repositoryRootURL: request.repositoryRootURL,
+      host: request.host,
+      owner: request.owner,
+      repo: request.repo,
+      branches: cleanedBranches,
+      worktreeIDs: request.worktreeIDs
+    )
+
+    if inflightHosts.contains(normalized.host) {
+      // [BPR] remove after manual verification
+      logger.debug("queue host=\(normalized.host) repo=\(normalized.owner)/\(normalized.repo) (inflight)")
+      mergeRequest(normalized, into: &queuedByHost)
+      return
+    }
+
+    mergeRequest(normalized, into: &pendingByHost)
+    // [BPR] remove after manual verification
+    logger.debug("enqueue host=\(normalized.host) repo=\(normalized.owner)/\(normalized.repo)")
+    rescheduleDebounce(forHost: normalized.host)
+  }
+
+  func cancelHost(_ host: String) {
+    flushTaskByHost.removeValue(forKey: host)?.cancel()
+    pendingByHost.removeValue(forKey: host)
+    queuedByHost.removeValue(forKey: host)
+  }
+
+  func reset() {
+    for (_, task) in flushTaskByHost {
+      task.cancel()
+    }
+    flushTaskByHost.removeAll()
+    pendingByHost.removeAll()
+    queuedByHost.removeAll()
+    inflightHosts.removeAll()
+  }
+
+  private func mergeRequest(
+    _ request: Request,
+    into bucket: inout [String: [Repository.ID: Request]]
+  ) {
+    var hostBucket = bucket[request.host] ?? [:]
+    if let existing = hostBucket[request.repositoryID] {
+      var seen = Set<String>(existing.branches)
+      var combined = existing.branches
+      for branch in request.branches where seen.insert(branch).inserted {
+        combined.append(branch)
+      }
+      var workseen = Set<Worktree.ID>(existing.worktreeIDs)
+      var workCombined = existing.worktreeIDs
+      for worktreeID in request.worktreeIDs where workseen.insert(worktreeID).inserted {
+        workCombined.append(worktreeID)
+      }
+      hostBucket[request.repositoryID] = Request(
+        repositoryID: request.repositoryID,
+        repositoryRootURL: request.repositoryRootURL,
+        host: request.host,
+        owner: request.owner,
+        repo: request.repo,
+        branches: combined,
+        worktreeIDs: workCombined
+      )
+    } else {
+      hostBucket[request.repositoryID] = request
+    }
+    bucket[request.host] = hostBucket
+  }
+
+  private func rescheduleDebounce(forHost host: String) {
+    flushTaskByHost.removeValue(forKey: host)?.cancel()
+    let task = Task { [weak self, debounceWindow, clock] in
+      do {
+        try await clock.sleep(for: debounceWindow)
+      } catch {
+        return
+      }
+      await self?.flush(host: host)
+    }
+    flushTaskByHost[host] = task
+  }
+
+  private func flush(host: String) async {
+    flushTaskByHost.removeValue(forKey: host)
+    guard let bucket = pendingByHost.removeValue(forKey: host), !bucket.isEmpty else {
+      return
+    }
+    inflightHosts.insert(host)
+    let requests = Array(bucket.values)
+    // [BPR] remove after manual verification
+    logger.debug("flush host=\(host) repos=\(requests.count)")
+    await processBatch(host: host, requests: requests)
+    inflightHosts.remove(host)
+    if let queued = queuedByHost.removeValue(forKey: host), !queued.isEmpty {
+      pendingByHost[host, default: [:]].merge(queued) { _, new in new }
+      // [BPR] remove after manual verification
+      logger.debug("drain-queued host=\(host) repos=\(queued.count)")
+      await flush(host: host)
+    }
+  }
+
+  private func processBatch(host: String, requests: [Request]) async {
+    let crossRepoRequests = requests.map {
+      CrossRepoPullRequestRequest(owner: $0.owner, repo: $0.repo, branches: $0.branches)
+    }
+    do {
+      let result = try await runBatchWithTimeout(host: host, requests: crossRepoRequests)
+      let requestsByKey = Dictionary(
+        uniqueKeysWithValues: requests.map { (RepoKey(owner: $0.owner, repo: $0.repo), $0) }
+      )
+      for (key, prsByBranch) in result.successByRepo {
+        guard let request = requestsByKey[key] else {
+          continue
+        }
+        resultHandler(
+          .refreshed(
+            repositoryID: request.repositoryID,
+            repositoryRootURL: request.repositoryRootURL,
+            worktreeIDs: request.worktreeIDs,
+            prsByBranch: prsByBranch
+          )
+        )
+      }
+      for (key, _) in result.failedRepos {
+        guard let request = requestsByKey[key] else {
+          continue
+        }
+        // [BPR] remove after manual verification
+        logger.debug("fallback partial repo=\(key.owner)/\(key.repo)")
+        await fallbackPerRepo(request)
+      }
+    } catch {
+      // [BPR] remove after manual verification
+      logger.debug("fallback batch host=\(host) error=\(String(describing: error))")
+      for request in requests {
+        await fallbackPerRepo(request)
+      }
+    }
+  }
+
+  private func runBatchWithTimeout(
+    host: String,
+    requests: [CrossRepoPullRequestRequest]
+  ) async throws -> CrossRepoPullRequestResult {
+    try await withThrowingTaskGroup(of: BatchTimeoutOutcome.self) { group in
+      let githubCLI = self.githubCLI
+      let softTimeout = self.softTimeout
+      let clock = self.clock
+      group.addTask {
+        let value = try await githubCLI.batchPullRequestsAcrossRepositories(host, requests)
+        return .completed(value)
+      }
+      group.addTask {
+        try await clock.sleep(for: softTimeout)
+        return .timedOut
+      }
+      defer { group.cancelAll() }
+      while let outcome = try await group.next() {
+        switch outcome {
+        case .completed(let value):
+          return value
+        case .timedOut:
+          throw PullRequestRefreshCoordinatorError.softTimeout
+        }
+      }
+      throw PullRequestRefreshCoordinatorError.softTimeout
+    }
+  }
+
+  private func fallbackPerRepo(_ request: Request) async {
+    do {
+      let prs = try await githubCLI.batchPullRequests(
+        request.host,
+        request.owner,
+        request.repo,
+        request.branches
+      )
+      resultHandler(
+        .refreshed(
+          repositoryID: request.repositoryID,
+          repositoryRootURL: request.repositoryRootURL,
+          worktreeIDs: request.worktreeIDs,
+          prsByBranch: prs
+        )
+      )
+    } catch {
+      resultHandler(
+        .failed(
+          repositoryID: request.repositoryID,
+          worktreeIDs: request.worktreeIDs,
+          message: String(describing: error)
+        )
+      )
+    }
+  }
+
+  private enum BatchTimeoutOutcome: Sendable {
+    case completed(CrossRepoPullRequestResult)
+    case timedOut
+  }
+}
+
+enum PullRequestRefreshCoordinatorError: Error, Equatable {
+  case softTimeout
+}
+
+nonisolated struct PullRequestRefreshCoordinatorClient: Sendable {
+  var enqueue: @Sendable (PullRequestRefreshCoordinator.Request) -> Void
+  var cancelHost: @Sendable (String) -> Void
+  var reset: @Sendable () -> Void
+
+  nonisolated static let unimplemented = PullRequestRefreshCoordinatorClient(
+    enqueue: { _ in },
+    cancelHost: { _ in },
+    reset: {}
+  )
+}
+
+extension PullRequestRefreshCoordinatorClient: DependencyKey {
+  nonisolated static let liveValue = unimplemented
+  nonisolated static let testValue = unimplemented
+}
+
+extension DependencyValues {
+  var pullRequestRefreshCoordinator: PullRequestRefreshCoordinatorClient {
+    get { self[PullRequestRefreshCoordinatorClient.self] }
+    set { self[PullRequestRefreshCoordinatorClient.self] = newValue }
+  }
+}

--- a/supacode/Features/Repositories/BusinessLogic/WorktreeInfoWatcherManager.swift
+++ b/supacode/Features/Repositories/BusinessLogic/WorktreeInfoWatcherManager.swift
@@ -615,7 +615,11 @@ final class WorktreeInfoWatcherManager {
     repositoryRootURL: URL,
     interval: Duration
   ) -> Duration {
-    stablePhaseOffset(seed: repositoryRootURL.path(percentEncoded: false), interval: interval)
+    // PR refresh is now coalesced by PullRequestRefreshCoordinator, so emitting
+    // every repo on the same tick maximises the chance of folding into a single
+    // batched GraphQL query. The injectable parameter is kept so tests can still
+    // stagger emits when they need to assert ordering.
+    .zero
   }
 
   private static func defaultWorktreeFileEventMonitorFactory(

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+GithubIntegration.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+GithubIntegration.swift
@@ -4,7 +4,6 @@ import Foundation
 
 private let unresolvedGithubRepositoryMessage =
   "Prowl could not determine which GitHub repository owns this pull request. Check the repository remote and try again."
-nonisolated private let githubIntegrationLogger = SupaLogger("BPR")
 
 extension RepositoriesFeature {
   static func resolveGithubRemoteInfo(
@@ -647,10 +646,6 @@ extension RepositoriesFeature {
   ) -> Effect<Action> {
     switch outcome {
     case .refreshed(let repositoryID, _, let worktreeIDs, let prsByBranch):
-      // [BPR] remove after manual verification
-      githubIntegrationLogger.debug(
-        "BPR outcome refreshed repo=\(repositoryID) worktrees=\(worktreeIDs.count) branches=\(prsByBranch.count)"
-      )
       guard let repository = state.repositories[id: repositoryID] else {
         state.inFlightPullRequestRefreshRepositoryIDs.remove(repositoryID)
         return .none
@@ -672,9 +667,7 @@ extension RepositoriesFeature {
         ),
         .send(.githubIntegration(.repositoryPullRequestRefreshCompleted(repositoryID)))
       )
-    case .failed(let repositoryID, _, let message):
-      // [BPR] remove after manual verification
-      githubIntegrationLogger.debug("BPR outcome failed repo=\(repositoryID) message=\(message)")
+    case .failed(let repositoryID, _, _):
       return .send(.githubIntegration(.repositoryPullRequestRefreshCompleted(repositoryID)))
     }
   }
@@ -690,10 +683,6 @@ extension RepositoriesFeature {
     let coordinatorClient = pullRequestRefreshCoordinator
     let githubCLI = self.githubCLI
     let gitClient = self.gitClient
-    // [BPR] remove after manual verification
-    githubIntegrationLogger.debug(
-      "BPR enqueue repo=\(repositoryID) branches=\(branches.count) cached=\(cachedRemoteInfo != nil)"
-    )
     return .run { send in
       let resolvedRemoteInfo: GithubRemoteInfo?
       if let cachedRemoteInfo {
@@ -712,10 +701,6 @@ extension RepositoriesFeature {
         resolvedRemoteInfo = info
       }
       guard let info = resolvedRemoteInfo else {
-        // [BPR] remove after manual verification
-        githubIntegrationLogger.debug(
-          "BPR enqueue abort repo=\(repositoryID) reason=remoteInfo-unresolved"
-        )
         await send(.githubIntegration(.repositoryPullRequestRefreshCompleted(repositoryID)))
         return
       }

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+GithubIntegration.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+GithubIntegration.swift
@@ -4,6 +4,7 @@ import Foundation
 
 private let unresolvedGithubRepositoryMessage =
   "Prowl could not determine which GitHub repository owns this pull request. Check the repository remote and try again."
+nonisolated private let githubIntegrationLogger = SupaLogger("BPR")
 
 extension RepositoriesFeature {
   static func resolveGithubRemoteInfo(
@@ -74,6 +75,15 @@ extension RepositoriesFeature {
           return .none
         }
         state.inFlightPullRequestRefreshRepositoryIDs.insert(repositoryID)
+        if state.batchedPullRequestRefreshEnabled {
+          return enqueueBatchedPullRequestRefresh(
+            repositoryID: repositoryID,
+            repositoryRootURL: repositoryRootURL,
+            worktrees: worktrees,
+            branches: branches,
+            cachedRemoteInfo: state.remoteInfoByRepositoryID[repositoryID]
+          )
+        }
         return refreshRepositoryPullRequests(
           repositoryID: repositoryID,
           repositoryRootURL: repositoryRootURL,
@@ -624,6 +634,105 @@ extension RepositoriesFeature {
     case .setMergedWorktreeAction(let action):
       state.mergedWorktreeAction = action
       return .none
+
+    case .cacheRemoteInfo(let repositoryID, let remoteInfo):
+      state.remoteInfoByRepositoryID[repositoryID] = remoteInfo
+      return .none
+
+    case .pullRequestRefreshBatchOutcome(let outcome):
+      return reduceBatchOutcome(state: &state, outcome: outcome)
+    }
+  }
+
+  private func reduceBatchOutcome(
+    state: inout State,
+    outcome: PullRequestRefreshCoordinator.Outcome
+  ) -> Effect<Action> {
+    switch outcome {
+    case .refreshed(let repositoryID, _, let worktreeIDs, let prsByBranch):
+      // [BPR] remove after manual verification
+      githubIntegrationLogger.debug(
+        "BPR outcome refreshed repo=\(repositoryID) worktrees=\(worktreeIDs.count) branches=\(prsByBranch.count)"
+      )
+      guard let repository = state.repositories[id: repositoryID] else {
+        state.inFlightPullRequestRefreshRepositoryIDs.remove(repositoryID)
+        return .none
+      }
+      var prsByWorktreeID: [Worktree.ID: GithubPullRequest?] = [:]
+      for worktreeID in worktreeIDs {
+        if let worktree = repository.worktrees[id: worktreeID] {
+          prsByWorktreeID[worktreeID] = prsByBranch[worktree.name]
+        }
+      }
+      return .merge(
+        .send(
+          .githubIntegration(
+            .repositoryPullRequestsLoaded(
+              repositoryID: repositoryID,
+              pullRequestsByWorktreeID: prsByWorktreeID
+            )
+          )
+        ),
+        .send(.githubIntegration(.repositoryPullRequestRefreshCompleted(repositoryID)))
+      )
+    case .failed(let repositoryID, _, let message):
+      // [BPR] remove after manual verification
+      githubIntegrationLogger.debug("BPR outcome failed repo=\(repositoryID) message=\(message)")
+      return .send(.githubIntegration(.repositoryPullRequestRefreshCompleted(repositoryID)))
+    }
+  }
+
+  func enqueueBatchedPullRequestRefresh(
+    repositoryID: Repository.ID,
+    repositoryRootURL: URL,
+    worktrees: [Worktree],
+    branches: [String],
+    cachedRemoteInfo: GithubRemoteInfo?
+  ) -> Effect<Action> {
+    let worktreeIDs = worktrees.map(\.id)
+    let coordinatorClient = pullRequestRefreshCoordinator
+    let githubCLI = self.githubCLI
+    let gitClient = self.gitClient
+    // [BPR] remove after manual verification
+    githubIntegrationLogger.debug(
+      "BPR enqueue repo=\(repositoryID) branches=\(branches.count) cached=\(cachedRemoteInfo != nil)"
+    )
+    return .run { send in
+      let resolvedRemoteInfo: GithubRemoteInfo?
+      if let cachedRemoteInfo {
+        resolvedRemoteInfo = cachedRemoteInfo
+      } else {
+        let info = await RepositoriesFeature.resolveGithubRemoteInfo(
+          repositoryRootURL: repositoryRootURL,
+          githubCLI: githubCLI,
+          gitClient: gitClient
+        )
+        if let info {
+          await send(
+            .githubIntegration(.cacheRemoteInfo(repositoryID: repositoryID, remoteInfo: info))
+          )
+        }
+        resolvedRemoteInfo = info
+      }
+      guard let info = resolvedRemoteInfo else {
+        // [BPR] remove after manual verification
+        githubIntegrationLogger.debug(
+          "BPR enqueue abort repo=\(repositoryID) reason=remoteInfo-unresolved"
+        )
+        await send(.githubIntegration(.repositoryPullRequestRefreshCompleted(repositoryID)))
+        return
+      }
+      coordinatorClient.enqueue(
+        PullRequestRefreshCoordinator.Request(
+          repositoryID: repositoryID,
+          repositoryRootURL: repositoryRootURL,
+          host: info.host,
+          owner: info.owner,
+          repo: info.repo,
+          branches: branches,
+          worktreeIDs: worktreeIDs
+        )
+      )
     }
   }
 

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+GithubIntegration.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+GithubIntegration.swift
@@ -12,10 +12,15 @@ extension RepositoriesFeature {
     githubCLI: GithubCLIClient,
     gitClient: GitClientDependency
   ) async -> GithubRemoteInfo? {
-    if let remoteInfo = await githubCLI.resolveRemoteInfo(repositoryRootURL) {
+    // Parsing the local git remote URL is ~20x faster than spawning `gh repo view`
+    // (no gh subprocess, no network round trip). The batched GraphQL query that
+    // follows is itself authoritative about whether the repo exists on GitHub, so
+    // gh is only useful as a fallback for non-standard remotes that the regex in
+    // GitClient cannot parse.
+    if let remoteInfo = await gitClient.remoteInfo(repositoryRootURL) {
       return remoteInfo
     }
-    return await gitClient.remoteInfo(repositoryRootURL)
+    return await githubCLI.resolveRemoteInfo(repositoryRootURL)
   }
 }
 
@@ -75,20 +80,12 @@ extension RepositoriesFeature {
           return .none
         }
         state.inFlightPullRequestRefreshRepositoryIDs.insert(repositoryID)
-        if state.batchedPullRequestRefreshEnabled {
-          return enqueueBatchedPullRequestRefresh(
-            repositoryID: repositoryID,
-            repositoryRootURL: repositoryRootURL,
-            worktrees: worktrees,
-            branches: branches,
-            cachedRemoteInfo: state.remoteInfoByRepositoryID[repositoryID]
-          )
-        }
-        return refreshRepositoryPullRequests(
+        return enqueueBatchedPullRequestRefresh(
           repositoryID: repositoryID,
           repositoryRootURL: repositoryRootURL,
           worktrees: worktrees,
-          branches: branches
+          branches: branches,
+          cachedRemoteInfo: state.remoteInfoByRepositoryID[repositoryID]
         )
       case .unknown:
         queuePullRequestRefresh(

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -242,7 +242,6 @@ struct RepositoriesFeature {
     var inFlightPullRequestRefreshRepositoryIDs: Set<Repository.ID> = []
     var queuedPullRequestRefreshByRepositoryID: [Repository.ID: PendingPullRequestRefresh] = [:]
     var remoteInfoByRepositoryID: [Repository.ID: GithubRemoteInfo] = [:]
-    @Shared(.appStorage("githubBatchedPullRequestRefreshEnabled")) var batchedPullRequestRefreshEnabled = false
     var codeHostByRepositoryID: [Repository.ID: CodeHost] = [:]
     var sidebarSelectedWorktreeIDs: Set<Worktree.ID> = []
     var nextPendingSidebarRevealID = 0
@@ -1256,52 +1255,6 @@ struct RepositoriesFeature {
       let meaningful = detected.filter { $0.value != .unknown }
       guard !meaningful.isEmpty else { return }
       await send(.codeHostsDetected(meaningful))
-    }
-  }
-
-  func refreshRepositoryPullRequests(
-    repositoryID: Repository.ID,
-    repositoryRootURL: URL,
-    worktrees: [Worktree],
-    branches: [String]
-  ) -> Effect<Action> {
-    let gitClient = gitClient
-    let githubCLI = githubCLI
-    return .run { send in
-      guard
-        let remoteInfo = await Self.resolveGithubRemoteInfo(
-          repositoryRootURL: repositoryRootURL,
-          githubCLI: githubCLI,
-          gitClient: gitClient
-        )
-      else {
-        await send(.githubIntegration(.repositoryPullRequestRefreshCompleted(repositoryID)))
-        return
-      }
-      do {
-        let prsByBranch = try await githubCLI.batchPullRequests(
-          remoteInfo.host,
-          remoteInfo.owner,
-          remoteInfo.repo,
-          branches
-        )
-        var pullRequestsByWorktreeID: [Worktree.ID: GithubPullRequest?] = [:]
-        for worktree in worktrees {
-          pullRequestsByWorktreeID[worktree.id] = prsByBranch[worktree.name]
-        }
-        await send(
-          .githubIntegration(
-            .repositoryPullRequestsLoaded(
-              repositoryID: repositoryID,
-              pullRequestsByWorktreeID: pullRequestsByWorktreeID
-            )
-          )
-        )
-      } catch {
-        await send(.githubIntegration(.repositoryPullRequestRefreshCompleted(repositoryID)))
-        return
-      }
-      await send(.githubIntegration(.repositoryPullRequestRefreshCompleted(repositoryID)))
     }
   }
 

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -169,6 +169,8 @@ struct RepositoriesFeature {
     case setGithubIntegrationEnabled(Bool)
     case setMergedWorktreeAction(MergedWorktreeAction?)
     case pullRequestAction(Worktree.ID, PullRequestAction)
+    case cacheRemoteInfo(repositoryID: Repository.ID, remoteInfo: GithubRemoteInfo)
+    case pullRequestRefreshBatchOutcome(PullRequestRefreshCoordinator.Outcome)
   }
 
   @CasePathable
@@ -239,6 +241,8 @@ struct RepositoriesFeature {
     var pendingPullRequestRefreshByRepositoryID: [Repository.ID: PendingPullRequestRefresh] = [:]
     var inFlightPullRequestRefreshRepositoryIDs: Set<Repository.ID> = []
     var queuedPullRequestRefreshByRepositoryID: [Repository.ID: PendingPullRequestRefresh] = [:]
+    var remoteInfoByRepositoryID: [Repository.ID: GithubRemoteInfo] = [:]
+    @Shared(.appStorage("githubBatchedPullRequestRefreshEnabled")) var batchedPullRequestRefreshEnabled = false
     var codeHostByRepositoryID: [Repository.ID: CodeHost] = [:]
     var sidebarSelectedWorktreeIDs: Set<Worktree.ID> = []
     var nextPendingSidebarRevealID = 0
@@ -402,6 +406,7 @@ struct RepositoriesFeature {
   @Dependency(AnalyticsClient.self) var analyticsClient
   @Dependency(GitClientDependency.self) var gitClient
   @Dependency(GithubCLIClient.self) var githubCLI
+  @Dependency(PullRequestRefreshCoordinatorClient.self) var pullRequestRefreshCoordinator
   @Dependency(GithubIntegrationClient.self) var githubIntegration
   @Dependency(OpenURLClient.self) var openURLClient
   @Dependency(RepositoryPersistenceClient.self) var repositoryPersistence

--- a/supacodeTests/BatchedPullRequestRefreshReducerTests.swift
+++ b/supacodeTests/BatchedPullRequestRefreshReducerTests.swift
@@ -2,49 +2,16 @@ import ComposableArchitecture
 import DependenciesTestSupport
 import Foundation
 import IdentifiedCollections
-import Sharing
 import Testing
 
 @testable import supacode
 
 @MainActor
 struct BatchedPullRequestRefreshReducerTests {
-  @Test func batchedFlagOffStillRunsLegacyBatchPullRequests() async {
-    let context = makeContext()
-    let store = TestStore(initialState: context.state) {
-      RepositoriesFeature()
-    } withDependencies: {
-      $0.gitClient.remoteInfo = { _ in context.remoteInfo }
-      $0.githubCLI.resolveRemoteInfo = { _ in context.remoteInfo }
-      $0.githubCLI.batchPullRequests = { _, _, _, _ in [:] }
-      $0.pullRequestRefreshCoordinator = .unimplemented
-    }
-    // Flag default false → exercises legacy code path; assert no coordinator call by relying on
-    // the unimplemented default coordinator which does nothing.
-
-    await store.send(
-      .worktreeInfoEvent(
-        .repositoryPullRequestRefresh(
-          repositoryRootURL: context.repoRootURL,
-          worktreeIDs: context.worktreeIDs
-        )
-      )
-    )
-    await store.receive(\.githubIntegration.repositoryPullRequestRefreshRequested) {
-      $0.inFlightPullRequestRefreshRepositoryIDs = [context.repository.id]
-    }
-    await store.receive(\.githubIntegration.repositoryPullRequestsLoaded)
-    await store.receive(\.githubIntegration.repositoryPullRequestRefreshCompleted) {
-      $0.inFlightPullRequestRefreshRepositoryIDs = []
-    }
-    await store.finish()
-  }
-
-  @Test func batchedFlagOnDispatchesViaCoordinatorWhenRemoteInfoCached() async {
+  @Test func refreshDispatchesViaCoordinatorWhenRemoteInfoCached() async {
     let context = makeContext()
     let enqueued = LockIsolated<[PullRequestRefreshCoordinator.Request]>([])
     var initialState = context.state
-    initialState.$batchedPullRequestRefreshEnabled.withLock { $0 = true }
     initialState.remoteInfoByRepositoryID[context.repository.id] = context.remoteInfo
 
     let store = TestStore(initialState: initialState) {
@@ -89,18 +56,17 @@ struct BatchedPullRequestRefreshReducerTests {
     #expect(request?.branches == ["main", "feature"])
   }
 
-  @Test func batchedFlagOnResolvesAndCachesRemoteInfoOnFirstRun() async {
+  @Test func refreshResolvesAndCachesRemoteInfoOnFirstRun() async {
     let context = makeContext()
     let enqueued = LockIsolated<[PullRequestRefreshCoordinator.Request]>([])
-    var initialState = context.state
-    initialState.$batchedPullRequestRefreshEnabled.withLock { $0 = true }
+    let initialState = context.state
 
     let store = TestStore(initialState: initialState) {
       RepositoriesFeature()
     } withDependencies: {
-      $0.githubCLI.resolveRemoteInfo = { _ in context.remoteInfo }
-      $0.gitClient.remoteInfo = { _ in
-        Issue.record("git remoteInfo should not be used when gh resolve succeeds")
+      $0.gitClient.remoteInfo = { _ in context.remoteInfo }
+      $0.githubCLI.resolveRemoteInfo = { _ in
+        Issue.record("gh resolveRemoteInfo should not run when git remote resolves")
         return nil
       }
       $0.pullRequestRefreshCoordinator = PullRequestRefreshCoordinatorClient(

--- a/supacodeTests/BatchedPullRequestRefreshReducerTests.swift
+++ b/supacodeTests/BatchedPullRequestRefreshReducerTests.swift
@@ -1,0 +1,279 @@
+import ComposableArchitecture
+import DependenciesTestSupport
+import Foundation
+import IdentifiedCollections
+import Sharing
+import Testing
+
+@testable import supacode
+
+@MainActor
+struct BatchedPullRequestRefreshReducerTests {
+  @Test func batchedFlagOffStillRunsLegacyBatchPullRequests() async {
+    let context = makeContext()
+    let store = TestStore(initialState: context.state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.gitClient.remoteInfo = { _ in context.remoteInfo }
+      $0.githubCLI.resolveRemoteInfo = { _ in context.remoteInfo }
+      $0.githubCLI.batchPullRequests = { _, _, _, _ in [:] }
+      $0.pullRequestRefreshCoordinator = .unimplemented
+    }
+    // Flag default false → exercises legacy code path; assert no coordinator call by relying on
+    // the unimplemented default coordinator which does nothing.
+
+    await store.send(
+      .worktreeInfoEvent(
+        .repositoryPullRequestRefresh(
+          repositoryRootURL: context.repoRootURL,
+          worktreeIDs: context.worktreeIDs
+        )
+      )
+    )
+    await store.receive(\.githubIntegration.repositoryPullRequestRefreshRequested) {
+      $0.inFlightPullRequestRefreshRepositoryIDs = [context.repository.id]
+    }
+    await store.receive(\.githubIntegration.repositoryPullRequestsLoaded)
+    await store.receive(\.githubIntegration.repositoryPullRequestRefreshCompleted) {
+      $0.inFlightPullRequestRefreshRepositoryIDs = []
+    }
+    await store.finish()
+  }
+
+  @Test func batchedFlagOnDispatchesViaCoordinatorWhenRemoteInfoCached() async {
+    let context = makeContext()
+    let enqueued = LockIsolated<[PullRequestRefreshCoordinator.Request]>([])
+    var initialState = context.state
+    initialState.$batchedPullRequestRefreshEnabled.withLock { $0 = true }
+    initialState.remoteInfoByRepositoryID[context.repository.id] = context.remoteInfo
+
+    let store = TestStore(initialState: initialState) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.githubCLI.resolveRemoteInfo = { _ in
+        Issue.record("Should not resolve when cache hit")
+        return nil
+      }
+      $0.githubCLI.batchPullRequests = { _, _, _, _ in
+        Issue.record("Legacy batchPullRequests should not run on coordinator path")
+        return [:]
+      }
+      $0.pullRequestRefreshCoordinator = PullRequestRefreshCoordinatorClient(
+        enqueue: { request in
+          enqueued.withValue { $0.append(request) }
+        },
+        cancelHost: { _ in },
+        reset: {}
+      )
+    }
+
+    await store.send(
+      .worktreeInfoEvent(
+        .repositoryPullRequestRefresh(
+          repositoryRootURL: context.repoRootURL,
+          worktreeIDs: context.worktreeIDs
+        )
+      )
+    )
+    await store.receive(\.githubIntegration.repositoryPullRequestRefreshRequested) {
+      $0.inFlightPullRequestRefreshRepositoryIDs = [context.repository.id]
+    }
+    await store.finish()
+
+    let snapshot = enqueued.value
+    #expect(snapshot.count == 1)
+    let request = try? #require(snapshot.first)
+    #expect(request?.host == "github.com")
+    #expect(request?.owner == "khoi")
+    #expect(request?.repo == "alpha")
+    #expect(request?.branches == ["main", "feature"])
+  }
+
+  @Test func batchedFlagOnResolvesAndCachesRemoteInfoOnFirstRun() async {
+    let context = makeContext()
+    let enqueued = LockIsolated<[PullRequestRefreshCoordinator.Request]>([])
+    var initialState = context.state
+    initialState.$batchedPullRequestRefreshEnabled.withLock { $0 = true }
+
+    let store = TestStore(initialState: initialState) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.githubCLI.resolveRemoteInfo = { _ in context.remoteInfo }
+      $0.gitClient.remoteInfo = { _ in
+        Issue.record("git remoteInfo should not be used when gh resolve succeeds")
+        return nil
+      }
+      $0.pullRequestRefreshCoordinator = PullRequestRefreshCoordinatorClient(
+        enqueue: { request in
+          enqueued.withValue { $0.append(request) }
+        },
+        cancelHost: { _ in },
+        reset: {}
+      )
+    }
+
+    await store.send(
+      .worktreeInfoEvent(
+        .repositoryPullRequestRefresh(
+          repositoryRootURL: context.repoRootURL,
+          worktreeIDs: context.worktreeIDs
+        )
+      )
+    )
+    await store.receive(\.githubIntegration.repositoryPullRequestRefreshRequested) {
+      $0.inFlightPullRequestRefreshRepositoryIDs = [context.repository.id]
+    }
+    await store.receive(\.githubIntegration.cacheRemoteInfo) {
+      $0.remoteInfoByRepositoryID[context.repository.id] = context.remoteInfo
+    }
+    await store.finish()
+
+    #expect(enqueued.value.count == 1)
+  }
+
+  @Test func coordinatorOutcomeRefreshedTranslatesToLoadedAndCompleted() async {
+    let context = makeContext()
+    var initialState = context.state
+    initialState.inFlightPullRequestRefreshRepositoryIDs = [context.repository.id]
+
+    let store = TestStore(initialState: initialState) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.pullRequestRefreshCoordinator = .unimplemented
+    }
+
+    let pullRequest = makePullRequestFixture()
+    let outcome = PullRequestRefreshCoordinator.Outcome.refreshed(
+      repositoryID: context.repository.id,
+      repositoryRootURL: context.repoRootURL,
+      worktreeIDs: context.worktreeIDs,
+      prsByBranch: ["feature": pullRequest]
+    )
+
+    await store.send(.githubIntegration(.pullRequestRefreshBatchOutcome(outcome)))
+    await store.receive(\.githubIntegration.repositoryPullRequestsLoaded) {
+      var entry = WorktreeInfoEntry()
+      entry.pullRequest = pullRequest
+      $0.worktreeInfoByID[context.featureWorktree.id] = entry
+    }
+    await store.receive(\.githubIntegration.repositoryPullRequestRefreshCompleted) {
+      $0.inFlightPullRequestRefreshRepositoryIDs = []
+    }
+    await store.finish()
+  }
+
+  @Test func coordinatorOutcomeFailedClearsInFlight() async {
+    let context = makeContext()
+    var initialState = context.state
+    initialState.inFlightPullRequestRefreshRepositoryIDs = [context.repository.id]
+
+    let store = TestStore(initialState: initialState) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.pullRequestRefreshCoordinator = .unimplemented
+    }
+
+    let outcome = PullRequestRefreshCoordinator.Outcome.failed(
+      repositoryID: context.repository.id,
+      worktreeIDs: context.worktreeIDs,
+      message: "boom"
+    )
+
+    await store.send(.githubIntegration(.pullRequestRefreshBatchOutcome(outcome)))
+    await store.receive(\.githubIntegration.repositoryPullRequestRefreshCompleted) {
+      $0.inFlightPullRequestRefreshRepositoryIDs = []
+    }
+    await store.finish()
+  }
+
+  @Test func cacheRemoteInfoStoresMappingInState() async {
+    let context = makeContext()
+    let store = TestStore(initialState: context.state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.pullRequestRefreshCoordinator = .unimplemented
+    }
+
+    await store.send(
+      .githubIntegration(
+        .cacheRemoteInfo(repositoryID: context.repository.id, remoteInfo: context.remoteInfo)
+      )
+    ) {
+      $0.remoteInfoByRepositoryID[context.repository.id] = context.remoteInfo
+    }
+    await store.finish()
+  }
+}
+
+// MARK: - Fixtures
+
+@MainActor
+private func makeContext() -> RefreshTestContext {
+  let repoRoot = "/tmp/coord-repo"
+  let mainWorktree = Worktree(
+    id: repoRoot,
+    name: "main",
+    detail: "detail",
+    workingDirectory: URL(fileURLWithPath: repoRoot),
+    repositoryRootURL: URL(fileURLWithPath: repoRoot)
+  )
+  let featureWorktree = Worktree(
+    id: "\(repoRoot)/feature",
+    name: "feature",
+    detail: "detail",
+    workingDirectory: URL(fileURLWithPath: "\(repoRoot)/feature"),
+    repositoryRootURL: URL(fileURLWithPath: repoRoot)
+  )
+  let repository = Repository(
+    id: repoRoot,
+    rootURL: URL(fileURLWithPath: repoRoot),
+    name: "alpha",
+    worktrees: IdentifiedArrayOf(uniqueElements: [mainWorktree, featureWorktree])
+  )
+  var state = RepositoriesFeature.State()
+  state.repositories = [repository]
+  state.repositoryRoots = [repository.rootURL]
+  state.githubIntegrationAvailability = .available
+  return RefreshTestContext(
+    repoRoot: repoRoot,
+    repository: repository,
+    mainWorktree: mainWorktree,
+    featureWorktree: featureWorktree,
+    remoteInfo: GithubRemoteInfo(host: "github.com", owner: "khoi", repo: "alpha"),
+    state: state
+  )
+}
+
+@MainActor
+private struct RefreshTestContext {
+  let repoRoot: String
+  let repository: Repository
+  let mainWorktree: Worktree
+  let featureWorktree: Worktree
+  let remoteInfo: GithubRemoteInfo
+  let state: RepositoriesFeature.State
+
+  var repoRootURL: URL { URL(fileURLWithPath: repoRoot) }
+  var worktreeIDs: [Worktree.ID] { [mainWorktree.id, featureWorktree.id] }
+}
+
+nonisolated private func makePullRequestFixture() -> GithubPullRequest {
+  GithubPullRequest(
+    number: 7,
+    title: "Coord PR",
+    state: "OPEN",
+    additions: 0,
+    deletions: 0,
+    isDraft: false,
+    reviewDecision: nil,
+    mergeable: nil,
+    mergeStateStatus: nil,
+    updatedAt: nil,
+    url: "https://example.com/coord-pr/7",
+    headRefName: "feature",
+    baseRefName: "main",
+    commitsCount: 1,
+    authorLogin: "khoi",
+    statusCheckRollup: nil
+  )
+}

--- a/supacodeTests/GithubCLIClientTests.swift
+++ b/supacodeTests/GithubCLIClientTests.swift
@@ -268,6 +268,327 @@ struct GithubCLIClientTests {
     #expect(snapshot.loginCallCount == 2)
   }
 
+  @Test func batchAcrossRepositoriesReturnsEmptyResultWhenNoRequests() async throws {
+    let probe = GithubBatchShellProbe()
+    let shell = makeBatchAcrossShellMock(probe: probe) { _ in
+      ShellOutput(stdout: #"{"data":{}}"#, stderr: "", exitCode: 0)
+    }
+    let client = GithubCLIClient.live(shell: shell)
+
+    let result = try await client.batchPullRequestsAcrossRepositories("github.com", [])
+
+    #expect(result.successByRepo.isEmpty)
+    #expect(result.failedRepos.isEmpty)
+    let snapshot = await probe.snapshot()
+    #expect(snapshot.ghCallCount == 0)
+    #expect(snapshot.whichCallCount == 0)
+  }
+
+  @Test func batchAcrossRepositoriesSkipsReposWithoutBranches() async throws {
+    let probe = GithubBatchShellProbe()
+    let shell = makeBatchAcrossShellMock(probe: probe) { arguments in
+      ShellOutput(stdout: crossRepoGraphQLResponse(for: arguments), stderr: "", exitCode: 0)
+    }
+    let client = GithubCLIClient.live(shell: shell)
+    let requests = [
+      CrossRepoPullRequestRequest(owner: "khoi", repo: "alpha", branches: []),
+      CrossRepoPullRequestRequest(owner: "khoi", repo: "beta", branches: ["", "  "]),
+    ]
+
+    let result = try await client.batchPullRequestsAcrossRepositories("github.com", requests)
+
+    #expect(result.successByRepo.isEmpty)
+    #expect(result.failedRepos.isEmpty)
+    let snapshot = await probe.snapshot()
+    #expect(snapshot.ghCallCount == 0)
+  }
+
+  @Test func batchAcrossRepositoriesSendsSingleGraphQLCallForMultipleRepos() async throws {
+    let probe = GithubBatchShellProbe()
+    let observedArguments = ObservedArguments()
+    let shell = makeBatchAcrossShellMock(probe: probe) { arguments in
+      await observedArguments.append(arguments)
+      return ShellOutput(stdout: crossRepoGraphQLResponse(for: arguments), stderr: "", exitCode: 0)
+    }
+    let client = GithubCLIClient.live(shell: shell)
+    let requests = [
+      CrossRepoPullRequestRequest(owner: "khoi", repo: "alpha", branches: ["feat-1", "feat-2"]),
+      CrossRepoPullRequestRequest(owner: "supabit", repo: "beta", branches: ["feat-3"]),
+    ]
+
+    let result = try await client.batchPullRequestsAcrossRepositories("github.com", requests)
+
+    #expect(result.successByRepo[RepoKey(owner: "khoi", repo: "alpha")] != nil)
+    #expect(result.successByRepo[RepoKey(owner: "supabit", repo: "beta")] != nil)
+    #expect(result.failedRepos.isEmpty)
+    let snapshot = await probe.snapshot()
+    #expect(snapshot.ghCallCount == 1)
+    let invocations = await observedArguments.snapshot()
+    #expect(invocations.count == 1)
+  }
+
+  @Test func batchAcrossRepositoriesUsesProvidedHostnameInGhArguments() async throws {
+    let probe = GithubBatchShellProbe()
+    let observedArguments = ObservedArguments()
+    let shell = makeBatchAcrossShellMock(probe: probe) { arguments in
+      await observedArguments.append(arguments)
+      return ShellOutput(stdout: crossRepoGraphQLResponse(for: arguments), stderr: "", exitCode: 0)
+    }
+    let client = GithubCLIClient.live(shell: shell)
+    let requests = [
+      CrossRepoPullRequestRequest(owner: "octo", repo: "ghe-repo", branches: ["main"])
+    ]
+
+    _ = try await client.batchPullRequestsAcrossRepositories("github.enterprise.test", requests)
+
+    let invocations = await observedArguments.snapshot()
+    #expect(invocations.count == 1)
+    let firstCall = try #require(invocations.first)
+    #expect(firstCall.contains("api"))
+    #expect(firstCall.contains("graphql"))
+    let hostnameIndex = try #require(firstCall.firstIndex(of: "--hostname"))
+    #expect(firstCall[firstCall.index(after: hostnameIndex)] == "github.enterprise.test")
+  }
+
+  @Test func batchAcrossRepositoriesEmbedsOwnerAndRepoLiteralsInQuery() async throws {
+    let probe = GithubBatchShellProbe()
+    let observedArguments = ObservedArguments()
+    let shell = makeBatchAcrossShellMock(probe: probe) { arguments in
+      await observedArguments.append(arguments)
+      return ShellOutput(stdout: crossRepoGraphQLResponse(for: arguments), stderr: "", exitCode: 0)
+    }
+    let client = GithubCLIClient.live(shell: shell)
+    let requests = [
+      CrossRepoPullRequestRequest(owner: "khoi", repo: "alpha", branches: ["feat-1"]),
+      CrossRepoPullRequestRequest(owner: "supabit", repo: "beta", branches: ["feat-2"]),
+    ]
+
+    _ = try await client.batchPullRequestsAcrossRepositories("github.com", requests)
+
+    let invocations = await observedArguments.snapshot()
+    let queryArgument = try #require(invocations.first?.first(where: { $0.hasPrefix("query=") }))
+    let query = String(queryArgument.dropFirst("query=".count))
+    #expect(query.contains(#"owner: "khoi""#))
+    #expect(query.contains(#"name: "alpha""#))
+    #expect(query.contains(#"owner: "supabit""#))
+    #expect(query.contains(#"name: "beta""#))
+    let structure = parseCrossRepoQuery(query)
+    #expect(structure.repos.count == 2)
+    #expect(structure.repos.allSatisfy { !$0.branchAliases.isEmpty })
+  }
+
+  @Test func batchAcrossRepositoriesDeduplicatesBranchesPerRepo() async throws {
+    let probe = GithubBatchShellProbe()
+    let observedArguments = ObservedArguments()
+    let shell = makeBatchAcrossShellMock(probe: probe) { arguments in
+      await observedArguments.append(arguments)
+      return ShellOutput(stdout: crossRepoGraphQLResponse(for: arguments), stderr: "", exitCode: 0)
+    }
+    let client = GithubCLIClient.live(shell: shell)
+    let requests = [
+      CrossRepoPullRequestRequest(
+        owner: "khoi",
+        repo: "alpha",
+        branches: ["feat-1", "feat-1", "feat-2", "", "feat-2"]
+      )
+    ]
+
+    _ = try await client.batchPullRequestsAcrossRepositories("github.com", requests)
+
+    let invocations = await observedArguments.snapshot()
+    let queryArgument = try #require(invocations.first?.first(where: { $0.hasPrefix("query=") }))
+    let structure = parseCrossRepoQuery(String(queryArgument.dropFirst("query=".count)))
+    let alpha = try #require(structure.repos.first { $0.repo == "alpha" })
+    #expect(alpha.branchAliases.count == 2)
+  }
+
+  @Test func batchAcrossRepositoriesSplitsAtAliasLimit() async throws {
+    let probe = GithubBatchShellProbe()
+    let observedArguments = ObservedArguments()
+    let shell = makeBatchAcrossShellMock(probe: probe) { arguments in
+      await observedArguments.append(arguments)
+      return ShellOutput(stdout: crossRepoGraphQLResponse(for: arguments), stderr: "", exitCode: 0)
+    }
+    let client = GithubCLIClient.live(shell: shell)
+    let requests = (0..<18).map { index in
+      CrossRepoPullRequestRequest(owner: "khoi", repo: "repo-\(index)", branches: ["main"])
+    }
+
+    let result = try await client.batchPullRequestsAcrossRepositories("github.com", requests)
+
+    let snapshot = await probe.snapshot()
+    #expect(snapshot.ghCallCount == 2)
+    let invocations = await observedArguments.snapshot()
+    #expect(invocations.count == 2)
+    let totalRepoBlocks = invocations.reduce(0) { partial, args in
+      guard let queryArg = args.first(where: { $0.hasPrefix("query=") }) else {
+        return partial
+      }
+      let query = String(queryArg.dropFirst("query=".count))
+      return partial + parseCrossRepoQuery(query).repos.count
+    }
+    #expect(totalRepoBlocks == 18)
+    #expect(result.successByRepo.count == 18)
+    #expect(result.failedRepos.isEmpty)
+  }
+
+  @Test func batchAcrossRepositoriesCapsConcurrencyAtThree() async throws {
+    let probe = GithubBatchShellProbe()
+    let shell = makeBatchAcrossShellMock(probe: probe) { arguments in
+      try await ContinuousClock().sleep(for: .milliseconds(80))
+      return ShellOutput(stdout: crossRepoGraphQLResponse(for: arguments), stderr: "", exitCode: 0)
+    }
+    let client = GithubCLIClient.live(shell: shell)
+    let requests = (0..<60).map { index in
+      CrossRepoPullRequestRequest(owner: "khoi", repo: "repo-\(index)", branches: ["main"])
+    }
+
+    _ = try await client.batchPullRequestsAcrossRepositories("github.com", requests)
+
+    let snapshot = await probe.snapshot()
+    #expect(snapshot.ghCallCount == 4)
+    #expect(snapshot.maxInFlight == 3)
+  }
+
+  @Test func batchAcrossRepositoriesRoutesPartialErrorsToFailedRepos() async throws {
+    let probe = GithubBatchShellProbe()
+    let shell = makeBatchAcrossShellMock(probe: probe) { arguments in
+      let stdout = crossRepoGraphQLResponse(for: arguments, failedRepoAliases: ["r1"])
+      return ShellOutput(stdout: stdout, stderr: "", exitCode: 0)
+    }
+    let client = GithubCLIClient.live(shell: shell)
+    let requests = [
+      CrossRepoPullRequestRequest(owner: "khoi", repo: "alpha", branches: ["feat-1"]),
+      CrossRepoPullRequestRequest(owner: "ghost", repo: "missing", branches: ["main"]),
+      CrossRepoPullRequestRequest(owner: "supabit", repo: "beta", branches: ["feat-2"]),
+    ]
+
+    let result = try await client.batchPullRequestsAcrossRepositories("github.com", requests)
+
+    #expect(result.successByRepo[RepoKey(owner: "khoi", repo: "alpha")] != nil)
+    #expect(result.successByRepo[RepoKey(owner: "supabit", repo: "beta")] != nil)
+    #expect(result.failedRepos[RepoKey(owner: "ghost", repo: "missing")] != nil)
+  }
+
+  @Test func batchAcrossRepositoriesRoutesFieldErrorPathToOwnRepo() async throws {
+    let probe = GithubBatchShellProbe()
+    let shell = makeBatchAcrossShellMock(probe: probe) { arguments in
+      let stdout = crossRepoGraphQLResponse(
+        for: arguments,
+        fieldErrorPaths: [["r0", "r0_b1"]]
+      )
+      return ShellOutput(stdout: stdout, stderr: "", exitCode: 0)
+    }
+    let client = GithubCLIClient.live(shell: shell)
+    let requests = [
+      CrossRepoPullRequestRequest(owner: "khoi", repo: "alpha", branches: ["feat-1", "feat-2"]),
+      CrossRepoPullRequestRequest(owner: "supabit", repo: "beta", branches: ["feat-3"]),
+    ]
+
+    let result = try await client.batchPullRequestsAcrossRepositories("github.com", requests)
+
+    #expect(result.failedRepos[RepoKey(owner: "khoi", repo: "alpha")] != nil)
+    #expect(result.successByRepo[RepoKey(owner: "supabit", repo: "beta")] != nil)
+  }
+
+  @Test func batchAcrossRepositoriesReturnsAllFailedWhenAllReposErrored() async throws {
+    let probe = GithubBatchShellProbe()
+    let shell = makeBatchAcrossShellMock(probe: probe) { arguments in
+      let stdout = crossRepoGraphQLResponse(
+        for: arguments,
+        failedRepoAliases: ["r0", "r1"]
+      )
+      return ShellOutput(stdout: stdout, stderr: "", exitCode: 0)
+    }
+    let client = GithubCLIClient.live(shell: shell)
+    let requests = [
+      CrossRepoPullRequestRequest(owner: "khoi", repo: "alpha", branches: ["feat-1"]),
+      CrossRepoPullRequestRequest(owner: "supabit", repo: "beta", branches: ["feat-2"]),
+    ]
+
+    let result = try await client.batchPullRequestsAcrossRepositories("github.com", requests)
+
+    #expect(result.successByRepo.isEmpty)
+    #expect(result.failedRepos.count == 2)
+  }
+
+  @Test func batchAcrossRepositoriesThrowsOnTotalShellFailure() async {
+    let probe = GithubBatchShellProbe()
+    let shell = makeBatchAcrossShellMock(probe: probe) { _ in
+      throw ShellClientError(
+        command: "gh api graphql",
+        stdout: "",
+        stderr: "boom",
+        exitCode: 1
+      )
+    }
+    let client = GithubCLIClient.live(shell: shell)
+    let requests = [
+      CrossRepoPullRequestRequest(owner: "khoi", repo: "alpha", branches: ["feat-1"])
+    ]
+
+    do {
+      _ = try await client.batchPullRequestsAcrossRepositories("github.com", requests)
+      Issue.record("Expected batchPullRequestsAcrossRepositories to throw")
+    } catch let error as GithubCLIError {
+      switch error {
+      case .commandFailed:
+        break
+      case .outdated, .unavailable:
+        Issue.record("Unexpected GithubCLIError: \(error.localizedDescription)")
+      }
+    } catch {
+      Issue.record("Unexpected error type: \(error.localizedDescription)")
+    }
+  }
+
+  @Test func batchAcrossRepositoriesEscapesBranchSpecialCharacters() async throws {
+    let probe = GithubBatchShellProbe()
+    let observedArguments = ObservedArguments()
+    let shell = makeBatchAcrossShellMock(probe: probe) { arguments in
+      await observedArguments.append(arguments)
+      return ShellOutput(stdout: crossRepoGraphQLResponse(for: arguments), stderr: "", exitCode: 0)
+    }
+    let client = GithubCLIClient.live(shell: shell)
+    let requests = [
+      CrossRepoPullRequestRequest(
+        owner: "khoi",
+        repo: "alpha",
+        branches: [#"weird"branch"#, "tab\there", "back\\slash"]
+      )
+    ]
+
+    _ = try await client.batchPullRequestsAcrossRepositories("github.com", requests)
+
+    let invocations = await observedArguments.snapshot()
+    let queryArgument = try #require(invocations.first?.first(where: { $0.hasPrefix("query=") }))
+    let query = String(queryArgument.dropFirst("query=".count))
+    #expect(query.contains(#"\""#))
+    #expect(query.contains(#"\t"#))
+    #expect(query.contains(#"\\"#))
+  }
+
+  @Test func batchAcrossRepositoriesSurfacesDecodedPullRequestData() async throws {
+    let probe = GithubBatchShellProbe()
+    let shell = makeBatchAcrossShellMock(probe: probe) { arguments in
+      let stdout = crossRepoGraphQLResponseWithSinglePR(
+        for: arguments,
+        prNumber: 42
+      )
+      return ShellOutput(stdout: stdout, stderr: "", exitCode: 0)
+    }
+    let client = GithubCLIClient.live(shell: shell)
+    let requests = [
+      CrossRepoPullRequestRequest(owner: "khoi", repo: "alpha", branches: ["feat-1"])
+    ]
+
+    let result = try await client.batchPullRequestsAcrossRepositories("github.com", requests)
+
+    let alphaPRs = try #require(result.successByRepo[RepoKey(owner: "khoi", repo: "alpha")])
+    let pullRequest = try #require(alphaPRs["feat-1"])
+    #expect(pullRequest.number == 42)
+  }
+
   @Test func executableResolutionIsSingleFlightAndReused() async {
     let probe = GithubBatchShellProbe()
     let shell = ShellClient(
@@ -329,4 +650,193 @@ nonisolated private func queryAliases(from query: String) -> [String] {
     }
   }
   return aliases
+}
+
+nonisolated struct CrossRepoQueryStructure {
+  let repos: [Entry]
+
+  struct Entry {
+    let alias: String
+    let owner: String
+    let repo: String
+    let branchAliases: [String]
+  }
+}
+
+nonisolated func parseCrossRepoQuery(_ query: String) -> CrossRepoQueryStructure {
+  guard
+    let repoRegex = try? NSRegularExpression(
+      pattern: #"(r\d+):\s*repository\(owner:\s*"([^"]+)",\s*name:\s*"([^"]+)"\)"#
+    )
+  else {
+    return CrossRepoQueryStructure(repos: [])
+  }
+  let nsQuery = query as NSString
+  let queryRange = NSRange(location: 0, length: nsQuery.length)
+  var entries: [CrossRepoQueryStructure.Entry] = []
+  let repoMatches = repoRegex.matches(in: query, range: queryRange)
+  for (matchIndex, match) in repoMatches.enumerated() {
+    let alias = nsQuery.substring(with: match.range(at: 1))
+    let owner = nsQuery.substring(with: match.range(at: 2))
+    let repo = nsQuery.substring(with: match.range(at: 3))
+    let blockStart = match.range.location + match.range.length
+    let blockEnd: Int
+    if matchIndex + 1 < repoMatches.count {
+      blockEnd = repoMatches[matchIndex + 1].range.location
+    } else {
+      blockEnd = nsQuery.length
+    }
+    guard blockEnd > blockStart else {
+      continue
+    }
+    let blockRange = NSRange(location: blockStart, length: blockEnd - blockStart)
+    let block = nsQuery.substring(with: blockRange)
+    let branchAliases = matchedAliases(in: block, pattern: "\(alias)_b\\d+")
+    entries.append(
+      CrossRepoQueryStructure.Entry(alias: alias, owner: owner, repo: repo, branchAliases: branchAliases)
+    )
+  }
+  return CrossRepoQueryStructure(repos: entries)
+}
+
+nonisolated private func matchedAliases(in text: String, pattern: String) -> [String] {
+  guard let regex = try? NSRegularExpression(pattern: pattern) else {
+    return []
+  }
+  let range = NSRange(text.startIndex..<text.endIndex, in: text)
+  var seen = Set<String>()
+  var aliases: [String] = []
+  for match in regex.matches(in: text, range: range) {
+    guard let matchRange = Range(match.range, in: text) else {
+      continue
+    }
+    let alias = String(text[matchRange])
+    if seen.insert(alias).inserted {
+      aliases.append(alias)
+    }
+  }
+  return aliases
+}
+
+nonisolated func crossRepoGraphQLResponse(
+  for arguments: [String],
+  failedRepoAliases: Set<String> = [],
+  fieldErrorPaths: [[String]] = []
+) -> String {
+  guard let queryArgument = arguments.first(where: { $0.hasPrefix("query=") }) else {
+    return #"{"data":null}"#
+  }
+  let query = String(queryArgument.dropFirst("query=".count))
+  let structure = parseCrossRepoQuery(query)
+  var dataEntries: [String] = []
+  for entry in structure.repos {
+    if failedRepoAliases.contains(entry.alias) {
+      dataEntries.append(#""\#(entry.alias)":null"#)
+      continue
+    }
+    let aliasEntries = entry.branchAliases.map { #""\#($0)":{"nodes":[]}"# }.joined(separator: ",")
+    dataEntries.append(#""\#(entry.alias)":{\#(aliasEntries)}"#)
+  }
+  let dataJSON = "{\(dataEntries.joined(separator: ","))}"
+  var errorEntries: [String] = []
+  for alias in failedRepoAliases {
+    errorEntries.append(
+      #"{"path":["\#(alias)"],"message":"Could not resolve to a Repository","type":"NOT_FOUND"}"#
+    )
+  }
+  for path in fieldErrorPaths {
+    let serializedPath = path.map { #""\#($0)""# }.joined(separator: ",")
+    errorEntries.append(#"{"path":[\#(serializedPath)],"message":"Field error"}"#)
+  }
+  if errorEntries.isEmpty {
+    return #"{"data":\#(dataJSON)}"#
+  }
+  let errorsJSON = "[\(errorEntries.joined(separator: ","))]"
+  return #"{"data":\#(dataJSON),"errors":\#(errorsJSON)}"#
+}
+
+actor ObservedArguments {
+  private var calls: [[String]] = []
+
+  func append(_ arguments: [String]) {
+    calls.append(arguments)
+  }
+
+  func snapshot() -> [[String]] {
+    calls
+  }
+}
+
+nonisolated func crossRepoGraphQLResponseWithSinglePR(
+  for arguments: [String],
+  prNumber: Int
+) -> String {
+  guard let queryArgument = arguments.first(where: { $0.hasPrefix("query=") }) else {
+    return #"{"data":{}}"#
+  }
+  let structure = parseCrossRepoQuery(String(queryArgument.dropFirst("query=".count)))
+  var repositoryPayload: [String: Any] = [:]
+  for (entryIndex, entry) in structure.repos.enumerated() {
+    var aliasPayload: [String: Any] = [:]
+    for (branchIndex, alias) in entry.branchAliases.enumerated() {
+      let node: [String: Any] = [
+        "number": prNumber + entryIndex * 100 + branchIndex,
+        "title": "PR",
+        "state": "OPEN",
+        "additions": 1,
+        "deletions": 1,
+        "isDraft": false,
+        "reviewDecision": NSNull(),
+        "mergeable": "MERGEABLE",
+        "mergeStateStatus": "CLEAN",
+        "url": "https://example.com/pr",
+        "updatedAt": NSNull(),
+        "headRefName": NSNull(),
+        "baseRefName": "main",
+        "commits": ["totalCount": 1],
+        "author": ["login": "khoi"],
+        "headRepository": NSNull(),
+        "statusCheckRollup": NSNull(),
+      ]
+      aliasPayload[alias] = ["nodes": [node]]
+    }
+    repositoryPayload[entry.alias] = aliasPayload
+  }
+  let body: [String: Any] = ["data": repositoryPayload]
+  guard let data = try? JSONSerialization.data(withJSONObject: body),
+    let json = String(bytes: data, encoding: .utf8)
+  else {
+    return #"{"data":{}}"#
+  }
+  return json
+}
+
+nonisolated func makeBatchAcrossShellMock(
+  probe: GithubBatchShellProbe,
+  responseBuilder: @escaping @Sendable (_ arguments: [String]) async throws -> ShellOutput
+) -> ShellClient {
+  ShellClient(
+    run: { executableURL, _, _ in
+      if executableURL.lastPathComponent == "which" {
+        await probe.recordWhichCall()
+        return ShellOutput(stdout: "/usr/bin/gh", stderr: "", exitCode: 0)
+      }
+      return ShellOutput(stdout: "", stderr: "", exitCode: 0)
+    },
+    runLoginImpl: { executableURL, arguments, _, _ in
+      guard executableURL.lastPathComponent == "gh" else {
+        return ShellOutput(stdout: "", stderr: "", exitCode: 0)
+      }
+      await probe.recordLoginCall()
+      _ = await probe.beginGhCall()
+      do {
+        let output = try await responseBuilder(arguments)
+        await probe.endGhCall()
+        return output
+      } catch {
+        await probe.endGhCall()
+        throw error
+      }
+    }
+  )
 }

--- a/supacodeTests/PullRequestRefreshCoordinatorTests.swift
+++ b/supacodeTests/PullRequestRefreshCoordinatorTests.swift
@@ -398,7 +398,6 @@ private func makeCoordinator(
   outcomes: OutcomeCollector,
   debounce: Duration = .milliseconds(250),
   softTimeout: Duration = .seconds(6),
-  aliasLimit: Int = 15,
   batched:
     @escaping @Sendable (String, [CrossRepoPullRequestRequest]) async throws ->
     CrossRepoPullRequestResult,
@@ -419,8 +418,7 @@ private func makeCoordinator(
     githubCLI: client,
     clock: clock,
     debounceWindow: debounce,
-    softTimeout: softTimeout,
-    aliasLimit: aliasLimit
+    softTimeout: softTimeout
   ) { outcome in
     Task { await outcomes.record(outcome) }
   }

--- a/supacodeTests/PullRequestRefreshCoordinatorTests.swift
+++ b/supacodeTests/PullRequestRefreshCoordinatorTests.swift
@@ -1,0 +1,579 @@
+import Clocks
+import Foundation
+import Testing
+
+@testable import supacode
+
+@MainActor
+struct PullRequestRefreshCoordinatorTests {
+  @Test func enqueueCoalescesMultipleReposIntoSingleBatchAfterDebounce() async throws {
+    let clock = TestClock()
+    let probe = CoordinatorProbe()
+    let outcomes = OutcomeCollector()
+    let coordinator = makeCoordinator(
+      probe: probe, clock: clock, outcomes: outcomes,
+      batched: { _, requests in successResult(for: requests) }
+    )
+
+    coordinator.enqueue(request(repo: "alpha"))
+    coordinator.enqueue(request(repo: "beta"))
+    coordinator.enqueue(request(repo: "gamma"))
+
+    await clock.advance(by: .milliseconds(250))
+    await Task.yield()
+    await Task.yield()
+
+    let batchedCalls = await probe.batchedCalls()
+    #expect(batchedCalls.count == 1)
+    #expect(batchedCalls.first?.requests.count == 3)
+    let refreshed = await outcomes.refreshedRepositories()
+    #expect(Set(refreshed) == Set(["alpha", "beta", "gamma"]))
+  }
+
+  @Test func enqueueDoesNotFlushBeforeDebounceWindow() async throws {
+    let clock = TestClock()
+    let probe = CoordinatorProbe()
+    let outcomes = OutcomeCollector()
+    let coordinator = makeCoordinator(
+      probe: probe, clock: clock, outcomes: outcomes,
+      batched: { _, requests in successResult(for: requests) }
+    )
+
+    coordinator.enqueue(request(repo: "alpha"))
+    await clock.advance(by: .milliseconds(100))
+    await Task.yield()
+
+    #expect(await probe.batchedCalls().isEmpty)
+  }
+
+  @Test func multipleHostsTriggerIndependentBatches() async throws {
+    let clock = TestClock()
+    let probe = CoordinatorProbe()
+    let outcomes = OutcomeCollector()
+    let coordinator = makeCoordinator(
+      probe: probe, clock: clock, outcomes: outcomes,
+      batched: { _, requests in successResult(for: requests) }
+    )
+
+    coordinator.enqueue(request(repo: "alpha", host: "github.com"))
+    coordinator.enqueue(request(repo: "beta", host: "github.com"))
+    coordinator.enqueue(request(repo: "gamma", host: "ghe.example"))
+
+    await clock.advance(by: .milliseconds(250))
+    await Task.yield()
+    await Task.yield()
+
+    let calls = await probe.batchedCalls()
+    #expect(calls.count == 2)
+    let hosts = Set(calls.map(\.host))
+    #expect(hosts == ["github.com", "ghe.example"])
+  }
+
+  @Test func partialErrorTriggersPerRepoFallback() async throws {
+    let clock = TestClock()
+    let probe = CoordinatorProbe()
+    let outcomes = OutcomeCollector()
+    let coordinator = makeCoordinator(
+      probe: probe,
+      clock: clock,
+      outcomes: outcomes,
+      batched: { _, requests in
+        var success: [RepoKey: [String: GithubPullRequest]] = [:]
+        var failed: [RepoKey: GithubCLIError] = [:]
+        for request in requests {
+          let key = RepoKey(owner: request.owner, repo: request.repo)
+          if request.repo == "beta" {
+            failed[key] = .commandFailed("not found")
+          } else {
+            success[key] = [:]
+          }
+        }
+        return CrossRepoPullRequestResult(successByRepo: success, failedRepos: failed)
+      },
+      legacy: { _, _, repo, _ in
+        ["legacy-branch": makeFixturePullRequest(repo: repo)]
+      }
+    )
+
+    coordinator.enqueue(request(repo: "alpha"))
+    coordinator.enqueue(request(repo: "beta"))
+
+    await clock.advance(by: .milliseconds(250))
+    await Task.yield()
+    await Task.yield()
+
+    let legacyCalls = await probe.legacyCalls()
+    #expect(legacyCalls.count == 1)
+    #expect(legacyCalls.first?.repo == "beta")
+    let refreshed = await outcomes.refreshedRepositories()
+    #expect(Set(refreshed) == ["alpha", "beta"])
+  }
+
+  @Test func batchedThrowFallsBackAllReposToLegacy() async throws {
+    let clock = TestClock()
+    let probe = CoordinatorProbe()
+    let outcomes = OutcomeCollector()
+    let coordinator = makeCoordinator(
+      probe: probe,
+      clock: clock,
+      outcomes: outcomes,
+      batched: { _, _ in
+        throw GithubCLIError.commandFailed("network down")
+      },
+      legacy: { _, _, _, _ in
+        [:]
+      }
+    )
+
+    coordinator.enqueue(request(repo: "alpha"))
+    coordinator.enqueue(request(repo: "beta"))
+
+    await clock.advance(by: .milliseconds(250))
+    await Task.yield()
+    await Task.yield()
+
+    let legacyCalls = await probe.legacyCalls()
+    #expect(Set(legacyCalls.map(\.repo)) == ["alpha", "beta"])
+  }
+
+  @Test func legacyFailureSurfacesAsFailedOutcome() async throws {
+    let clock = TestClock()
+    let probe = CoordinatorProbe()
+    let outcomes = OutcomeCollector()
+    let coordinator = makeCoordinator(
+      probe: probe,
+      clock: clock,
+      outcomes: outcomes,
+      batched: { _, _ in
+        throw GithubCLIError.commandFailed("offline")
+      },
+      legacy: { _, _, _, _ in
+        throw GithubCLIError.commandFailed("legacy down too")
+      }
+    )
+
+    coordinator.enqueue(request(repo: "alpha"))
+    await clock.advance(by: .milliseconds(250))
+    await Task.yield()
+    await Task.yield()
+
+    let failed = await outcomes.failedRepositories()
+    #expect(failed == ["alpha"])
+  }
+
+  @Test func inflightHostBuffersNewEnqueueAndFlushesAfterCompletion() async throws {
+    let clock = TestClock()
+    let probe = CoordinatorProbe()
+    let outcomes = OutcomeCollector()
+    let release = AsyncStreamFlag()
+    let coordinator = makeCoordinator(
+      probe: probe,
+      clock: clock,
+      outcomes: outcomes,
+      batched: { _, requests in
+        await release.wait()
+        return successResult(for: requests)
+      }
+    )
+
+    coordinator.enqueue(request(repo: "alpha"))
+    await clock.advance(by: .milliseconds(250))
+    await waitUntil { await probe.batchedCalls().count == 1 }
+
+    coordinator.enqueue(request(repo: "beta"))
+    await Task.yield()
+    #expect(await probe.batchedCalls().count == 1)
+
+    await release.signal()
+    await waitUntil { await probe.batchedCalls().count == 2 }
+    let calls = await probe.batchedCalls()
+    #expect(calls.last?.requests.map(\.repo) == ["beta"])
+  }
+
+  @Test func enqueueIgnoresEmptyBranches() async throws {
+    let clock = TestClock()
+    let probe = CoordinatorProbe()
+    let outcomes = OutcomeCollector()
+    let coordinator = makeCoordinator(
+      probe: probe, clock: clock, outcomes: outcomes,
+      batched: { _, requests in successResult(for: requests) }
+    )
+
+    coordinator.enqueue(request(repo: "alpha", branches: []))
+    coordinator.enqueue(request(repo: "beta", branches: ["", "   "]))
+    await clock.advance(by: .milliseconds(250))
+    await Task.yield()
+
+    #expect(await probe.batchedCalls().isEmpty)
+  }
+
+  @Test func enqueueMergesBranchListsForSameRepositoryWithinWindow() async throws {
+    let clock = TestClock()
+    let probe = CoordinatorProbe()
+    let outcomes = OutcomeCollector()
+    let coordinator = makeCoordinator(
+      probe: probe, clock: clock, outcomes: outcomes,
+      batched: { _, requests in successResult(for: requests) }
+    )
+
+    coordinator.enqueue(request(repo: "alpha", branches: ["feat-1"]))
+    coordinator.enqueue(request(repo: "alpha", branches: ["feat-2", "feat-1"]))
+    await clock.advance(by: .milliseconds(250))
+    await Task.yield()
+
+    let calls = await probe.batchedCalls()
+    #expect(calls.count == 1)
+    let alphaRequest = try #require(calls.first?.requests.first { $0.repo == "alpha" })
+    #expect(Set(alphaRequest.branches) == ["feat-1", "feat-2"])
+  }
+
+  @Test func softTimeoutFallsBackToLegacy() async throws {
+    let clock = TestClock()
+    let probe = CoordinatorProbe()
+    let outcomes = OutcomeCollector()
+    let neverFinish = AsyncStreamFlag()
+    let coordinator = makeCoordinator(
+      probe: probe,
+      clock: clock,
+      outcomes: outcomes,
+      debounce: .milliseconds(250),
+      softTimeout: .seconds(6),
+      batched: { _, _ in
+        await neverFinish.wait()
+        return CrossRepoPullRequestResult()
+      },
+      legacy: { _, _, _, _ in [:] }
+    )
+
+    coordinator.enqueue(request(repo: "alpha"))
+    await clock.advance(by: .milliseconds(250))
+    await waitUntil { await probe.batchedCalls().count >= 1 }
+    await clock.advance(by: .seconds(6))
+    await waitUntil { await probe.legacyCalls().count >= 1 }
+
+    let legacyCalls = await probe.legacyCalls()
+    #expect(legacyCalls.map(\.repo) == ["alpha"])
+    await neverFinish.signal()
+  }
+
+  @Test func resetCancelsPendingDebouncesAndInflight() async throws {
+    let clock = TestClock()
+    let probe = CoordinatorProbe()
+    let outcomes = OutcomeCollector()
+    let coordinator = makeCoordinator(
+      probe: probe, clock: clock, outcomes: outcomes,
+      batched: { _, requests in successResult(for: requests) }
+    )
+
+    coordinator.enqueue(request(repo: "alpha"))
+    coordinator.reset()
+    await clock.advance(by: .milliseconds(250))
+    await Task.yield()
+
+    #expect(await probe.batchedCalls().isEmpty)
+  }
+
+  @Test func cancelHostStopsPendingFlush() async throws {
+    let clock = TestClock()
+    let probe = CoordinatorProbe()
+    let outcomes = OutcomeCollector()
+    let coordinator = makeCoordinator(
+      probe: probe, clock: clock, outcomes: outcomes,
+      batched: { _, requests in successResult(for: requests) }
+    )
+
+    coordinator.enqueue(request(repo: "alpha", host: "host-a"))
+    coordinator.enqueue(request(repo: "beta", host: "host-b"))
+    coordinator.cancelHost("host-a")
+    await clock.advance(by: .milliseconds(250))
+    await Task.yield()
+    await Task.yield()
+
+    let calls = await probe.batchedCalls()
+    #expect(calls.map(\.host) == ["host-b"])
+  }
+
+  @Test func batchedSuccessEmitsRefreshedWithBranchPRs() async throws {
+    let clock = TestClock()
+    let probe = CoordinatorProbe()
+    let outcomes = OutcomeCollector()
+    let coordinator = makeCoordinator(
+      probe: probe,
+      clock: clock,
+      outcomes: outcomes,
+      batched: { _, requests in
+        var dict: [RepoKey: [String: GithubPullRequest]] = [:]
+        for request in requests {
+          let pullRequest = makeFixturePullRequest(repo: request.repo)
+          dict[RepoKey(owner: request.owner, repo: request.repo)] = ["feat-1": pullRequest]
+        }
+        return CrossRepoPullRequestResult(successByRepo: dict)
+      }
+    )
+
+    coordinator.enqueue(request(repo: "alpha", branches: ["feat-1"]))
+    await clock.advance(by: .milliseconds(250))
+    await Task.yield()
+    await Task.yield()
+
+    let snapshots = await outcomes.snapshot()
+    let refresh = try #require(
+      snapshots.compactMap { snapshot -> (String, [String: GithubPullRequest])? in
+        if case .refreshed(let id, _, _, let prs) = snapshot {
+          return (id, prs)
+        }
+        return nil
+      }
+      .first
+    )
+    #expect(refresh.0 == "alpha")
+    #expect(refresh.1["feat-1"]?.title == "PR-alpha")
+  }
+
+  @Test func enqueueAfterFlushStartsNewDebounceWindow() async throws {
+    let clock = TestClock()
+    let probe = CoordinatorProbe()
+    let outcomes = OutcomeCollector()
+    let coordinator = makeCoordinator(
+      probe: probe, clock: clock, outcomes: outcomes,
+      batched: { _, requests in successResult(for: requests) }
+    )
+
+    coordinator.enqueue(request(repo: "alpha"))
+    await clock.advance(by: .milliseconds(250))
+    await Task.yield()
+    await Task.yield()
+    #expect(await probe.batchedCalls().count == 1)
+
+    coordinator.enqueue(request(repo: "beta"))
+    await clock.advance(by: .milliseconds(100))
+    await Task.yield()
+    #expect(await probe.batchedCalls().count == 1)
+    await clock.advance(by: .milliseconds(150))
+    await Task.yield()
+    await Task.yield()
+    #expect(await probe.batchedCalls().count == 2)
+  }
+
+  @Test func legacyFallbackArgumentsMirrorOriginalRequest() async throws {
+    let clock = TestClock()
+    let probe = CoordinatorProbe()
+    let outcomes = OutcomeCollector()
+    let coordinator = makeCoordinator(
+      probe: probe,
+      clock: clock,
+      outcomes: outcomes,
+      batched: { _, requests in
+        var failed: [RepoKey: GithubCLIError] = [:]
+        for request in requests {
+          failed[RepoKey(owner: request.owner, repo: request.repo)] = .commandFailed("nope")
+        }
+        return CrossRepoPullRequestResult(failedRepos: failed)
+      },
+      legacy: { _, _, _, _ in [:] }
+    )
+
+    coordinator.enqueue(
+      request(repo: "alpha", host: "ghe.example", branches: ["feat-x", "feat-y"])
+    )
+    await clock.advance(by: .milliseconds(250))
+    await Task.yield()
+    await Task.yield()
+
+    let calls = await probe.legacyCalls()
+    let call = try #require(calls.first)
+    #expect(call.host == "ghe.example")
+    #expect(call.owner == "khoi")
+    #expect(call.repo == "alpha")
+    #expect(Set(call.branches) == ["feat-x", "feat-y"])
+  }
+}
+
+// MARK: - Helpers
+
+@MainActor
+private func makeCoordinator(
+  probe: CoordinatorProbe,
+  clock: TestClock<Duration>,
+  outcomes: OutcomeCollector,
+  debounce: Duration = .milliseconds(250),
+  softTimeout: Duration = .seconds(6),
+  aliasLimit: Int = 15,
+  batched:
+    @escaping @Sendable (String, [CrossRepoPullRequestRequest]) async throws ->
+    CrossRepoPullRequestResult,
+  legacy:
+    @escaping @Sendable (String, String, String, [String]) async throws ->
+    [String: GithubPullRequest] = { _, _, _, _ in [:] }
+) -> PullRequestRefreshCoordinator {
+  var client = GithubCLIClient.testValue
+  client.batchPullRequestsAcrossRepositories = { host, requests in
+    await probe.recordBatched(host: host, requests: requests)
+    return try await batched(host, requests)
+  }
+  client.batchPullRequests = { host, owner, repo, branches in
+    await probe.recordLegacy(host: host, owner: owner, repo: repo, branches: branches)
+    return try await legacy(host, owner, repo, branches)
+  }
+  return PullRequestRefreshCoordinator(
+    githubCLI: client,
+    clock: clock,
+    debounceWindow: debounce,
+    softTimeout: softTimeout,
+    aliasLimit: aliasLimit
+  ) { outcome in
+    Task { await outcomes.record(outcome) }
+  }
+}
+
+@MainActor
+private func waitUntil(
+  _ condition: @MainActor @escaping () async -> Bool,
+  maxIterations: Int = 500
+) async {
+  for _ in 0..<maxIterations {
+    if await condition() {
+      return
+    }
+    await Task.yield()
+  }
+}
+
+nonisolated private func request(
+  repo: String,
+  host: String = "github.com",
+  branches: [String] = ["feat-1"]
+) -> PullRequestRefreshCoordinator.Request {
+  PullRequestRefreshCoordinator.Request(
+    repositoryID: repo,
+    repositoryRootURL: URL(fileURLWithPath: "/tmp/\(repo)"),
+    host: host,
+    owner: "khoi",
+    repo: repo,
+    branches: branches,
+    worktreeIDs: ["\(repo)-wt"]
+  )
+}
+
+nonisolated private func successResult(
+  for requests: [CrossRepoPullRequestRequest]
+) -> CrossRepoPullRequestResult {
+  var dict: [RepoKey: [String: GithubPullRequest]] = [:]
+  for request in requests {
+    dict[RepoKey(owner: request.owner, repo: request.repo)] = [:]
+  }
+  return CrossRepoPullRequestResult(successByRepo: dict)
+}
+
+nonisolated func makeFixturePullRequest(repo: String) -> GithubPullRequest {
+  GithubPullRequest(
+    number: 1,
+    title: "PR-\(repo)",
+    state: "OPEN",
+    additions: 0,
+    deletions: 0,
+    isDraft: false,
+    reviewDecision: nil,
+    mergeable: nil,
+    mergeStateStatus: nil,
+    updatedAt: nil,
+    url: "https://example.com/\(repo)/pull/1",
+    headRefName: nil,
+    baseRefName: "main",
+    commitsCount: 1,
+    authorLogin: "khoi",
+    statusCheckRollup: nil
+  )
+}
+
+actor CoordinatorProbe {
+  struct BatchedCall: Sendable {
+    let host: String
+    let requests: [CrossRepoPullRequestRequest]
+  }
+
+  struct LegacyCall: Sendable {
+    let host: String
+    let owner: String
+    let repo: String
+    let branches: [String]
+  }
+
+  private var batched: [BatchedCall] = []
+  private var legacy: [LegacyCall] = []
+
+  func recordBatched(host: String, requests: [CrossRepoPullRequestRequest]) {
+    batched.append(BatchedCall(host: host, requests: requests))
+  }
+
+  func recordLegacy(host: String, owner: String, repo: String, branches: [String]) {
+    legacy.append(LegacyCall(host: host, owner: owner, repo: repo, branches: branches))
+  }
+
+  func batchedCalls() -> [BatchedCall] {
+    batched
+  }
+
+  func legacyCalls() -> [LegacyCall] {
+    legacy
+  }
+}
+
+actor OutcomeCollector {
+  private var outcomes: [PullRequestRefreshCoordinator.Outcome] = []
+
+  func record(_ outcome: PullRequestRefreshCoordinator.Outcome) {
+    outcomes.append(outcome)
+  }
+
+  func snapshot() -> [PullRequestRefreshCoordinator.Outcome] {
+    outcomes
+  }
+
+  func refreshedRepositories() -> [String] {
+    outcomes.compactMap {
+      if case .refreshed(let id, _, _, _) = $0 {
+        return id
+      }
+      return nil
+    }
+  }
+
+  func failedRepositories() -> [String] {
+    outcomes.compactMap {
+      if case .failed(let id, _, _) = $0 {
+        return id
+      }
+      return nil
+    }
+  }
+}
+
+actor AsyncStreamFlag {
+  private var resumed = false
+  private var continuation: CheckedContinuation<Void, Never>?
+
+  func wait() async {
+    if resumed {
+      return
+    }
+    await withTaskCancellationHandler {
+      await withCheckedContinuation { continuation in
+        self.continuation = continuation
+      }
+    } onCancel: {
+      Task { await self.cancel() }
+    }
+  }
+
+  func signal() {
+    resumed = true
+    continuation?.resume()
+    continuation = nil
+  }
+
+  private func cancel() {
+    continuation?.resume()
+    continuation = nil
+  }
+}

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -3546,12 +3546,12 @@ struct RepositoriesFeatureTests {
       RepositoriesFeature()
     } withDependencies: {
       $0.githubIntegration.isAvailable = { true }
-      $0.githubCLI.resolveRemoteInfo = { root in
+      $0.gitClient.remoteInfo = { root in
         #expect(root == URL(fileURLWithPath: repoRoot))
         return upstreamRemoteInfo
       }
-      $0.gitClient.remoteInfo = { _ in
-        Issue.record("git remoteInfo should not be used when gh repo view succeeds")
+      $0.githubCLI.resolveRemoteInfo = { _ in
+        Issue.record("gh resolveRemoteInfo should not run when git remote resolves")
         return nil
       }
       $0.githubCLI.mergePullRequest = { root, remoteInfo, number, _ in
@@ -3843,58 +3843,6 @@ struct RepositoriesFeatureTests {
     await store.receive(\.githubIntegration.repositoryPullRequestRefreshCompleted) {
       $0.inFlightPullRequestRefreshRepositoryIDs = []
     }
-    await store.finish()
-  }
-
-  @Test func worktreeInfoEventRepositoryPullRequestRefreshPrefersResolvedRemoteInfo() async {
-    let repoRoot = "/tmp/repo"
-    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
-    let featureWorktree = makeWorktree(
-      id: "\(repoRoot)/feature",
-      name: "feature",
-      repoRoot: repoRoot
-    )
-    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree, featureWorktree])
-    let upstreamRemoteInfo = GithubRemoteInfo(host: "github.com", owner: "supabitapp", repo: "supacode")
-    let requestedRemoteInfos = LockIsolated<[GithubRemoteInfo]>([])
-    var initialState = makeState(repositories: [repository])
-    initialState.githubIntegrationAvailability = .available
-    let store = TestStore(initialState: initialState) {
-      RepositoriesFeature()
-    } withDependencies: {
-      $0.githubCLI.resolveRemoteInfo = { root in
-        #expect(root == URL(fileURLWithPath: repoRoot))
-        return upstreamRemoteInfo
-      }
-      $0.gitClient.remoteInfo = { _ in
-        Issue.record("git remoteInfo should not be used when gh repo view succeeds")
-        return nil
-      }
-      $0.githubCLI.batchPullRequests = { host, owner, repo, branches in
-        #expect(branches == ["main", "feature"])
-        requestedRemoteInfos.withValue {
-          $0.append(GithubRemoteInfo(host: host, owner: owner, repo: repo))
-        }
-        return [:]
-      }
-    }
-
-    await store.send(
-      .worktreeInfoEvent(
-        .repositoryPullRequestRefresh(
-          repositoryRootURL: URL(fileURLWithPath: repoRoot),
-          worktreeIDs: [mainWorktree.id, featureWorktree.id]
-        )
-      )
-    )
-    await store.receive(\.githubIntegration.repositoryPullRequestRefreshRequested) {
-      $0.inFlightPullRequestRefreshRepositoryIDs = [repository.id]
-    }
-    await store.receive(\.githubIntegration.repositoryPullRequestsLoaded)
-    await store.receive(\.githubIntegration.repositoryPullRequestRefreshCompleted) {
-      $0.inFlightPullRequestRefreshRepositoryIDs = []
-    }
-    #expect(requestedRemoteInfos.value == [upstreamRemoteInfo])
     await store.finish()
   }
 


### PR DESCRIPTION
## Summary

PR status refresh used to spawn `2N` `gh` subprocesses per cycle for `N`
opened repositories — one `gh repo view` per repo to resolve the
GitHub remote, plus one `gh api graphql` per repo to fetch the actual
PRs. On 14 repos every 30s that ran near 60 subprocesses per minute
and burned proportional CPU/energy budget.

This PR collapses both halves to roughly one subprocess per refresh:

- A new `batchPullRequestsAcrossRepositories` on `GithubCLIClient`
  issues a single multi-repository GraphQL query, aliasing each repo
  and its branches so up to 15 repos fold into one call. Top-level
  `errors[]` entries are routed back to the owning repository so one
  bad permission cannot drop data for the rest.

- A new `@MainActor PullRequestRefreshCoordinator` sits between
  reducer effects and the client. It buckets requests by host,
  debounces 250ms to coalesce concurrent enqueues, serialises per-host
  work with an inflight lock so mid-flight enqueues queue and flush
  after the prior batch completes, falls back to per-repo `batchPullRequests`
  concurrently on partial errors, and triggers a 12s soft timeout that
  similarly falls back the entire host. Backed by 15 unit tests using
  `TestClock`.

- `RepositoriesFeature` caches resolved `GithubRemoteInfo` per
  repository, so after the first refresh the gh subprocess for
  remote resolution disappears entirely.

- `resolveGithubRemoteInfo` now tries `git remote get-url` (~10ms)
  before falling back to `gh repo view` (~200ms). The batched GraphQL
  query is itself authoritative about repo existence, so the gh call
  was redundant in steady state.

- `WorktreeInfoWatcherManager.defaultPullRequestPhaseOffset` returns
  zero so all repos co-fire into the same debounce window instead of
  fragmenting across batches.

The feature was rolled out behind `@Shared` app-storage flag during
development and removed in `Make coordinator the canonical PR refresh
path` after end-to-end verification against 14 live repositories
(including a non-GitHub `tang` remote that exercises the unresolved-remote
abort path).

## Test plan

- [x] `make check` (swift-format strict + swiftlint strict)
- [x] `make build-app`
- [x] `xcodebuild test` against:
      - `GithubCLIClientTests` (14 new + 6 pre-existing)
      - `PullRequestRefreshCoordinatorTests` (15 new)
      - `BatchedPullRequestRefreshReducerTests` (5 new)
      - `RepositoriesFeatureTests` (zero regression)
      - `WorktreeInfoWatcherManagerTests` (zero regression)
- [x] Manual: 14 repos + 1 non-GitHub repo, observed `flush host=github.com
      repos=14` -> single batched call -> 14 success outcomes both on cold
      start and after cache warm-up
- [x] Reviewer: spot-check `RepositoriesFeature+GithubIntegration` route
      and `PullRequestRefreshCoordinator` lifecycle in
      `supacodeApp.swift`



## Related

#364 tunes another background-polling axis (line-changes intervals, per-repo user-configurable). Together both PRs reduce the steady-state CPU/subprocess footprint of having many repositories open — that one on the user-controlled side, this one automatic.
