### PR TITLE
Use dispatch queue for FSEvents

### DIFF
--- a/supacode/Features/Repositories/BusinessLogic/WorktreeInfoWatcherManager.swift
+++ b/supacode/Features/Repositories/BusinessLogic/WorktreeInfoWatcherManager.swift
@@ -744,11 +744,7 @@ private final class FSEventsWorktreeFileEventMonitor: WorktreeFileEventMonitorin
     guard let stream else {
       return nil
     }
-    FSEventStreamScheduleWithRunLoop(
-      stream,
-      CFRunLoopGetMain(),
-      CFRunLoopMode.defaultMode.rawValue
-    )
+    FSEventStreamSetDispatchQueue(stream, DispatchQueue.main)
     guard FSEventStreamStart(stream) else {
       FSEventStreamInvalidate(stream)
       FSEventStreamRelease(stream)


### PR DESCRIPTION
## Summary
- Replace deprecated `FSEventStreamScheduleWithRunLoop` with `FSEventStreamSetDispatchQueue`.
- Keep the stream on the main dispatch queue, matching the previous main run loop scheduling intent.

## Testing
- `make check`
- `xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -only-testing:supacodeTests/WorktreeInfoWatcherManagerTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation 2>&1 | xcsift -f toon`
- `make build-app`
