### PR TITLE
Propagate Task cancellation into ShellClient processes

### DIFF
--- a/supacode/Clients/Shell/ShellClient.swift
+++ b/supacode/Clients/Shell/ShellClient.swift
@@ -168,7 +168,12 @@ nonisolated private func runProcessStream(
   currentDirectoryURL: URL?
 ) -> AsyncThrowingStream<ShellStreamEvent, Error> {
   AsyncThrowingStream { continuation in
-    Task.detached {
+    // Stored so onTermination can SIGTERM the process when the consumer of the
+    // stream goes away (Task cancellation, for-await throw, explicit finish).
+    // Without this hook structured-concurrency timeouts that wrap a ShellClient
+    // call would have to wait for the process to exit on its own.
+    let processBox = LockIsolated<Process?>(nil)
+    let workerTask = Task {
       let outputAccumulator = ShellOutputAccumulator()
       let process = Process()
       process.executableURL = executableURL
@@ -184,33 +189,24 @@ nonisolated private func runProcessStream(
       let command = ([executableURL.path(percentEncoded: false)] + arguments).joined(separator: " ")
       do {
         try process.run()
-        let stdoutTask = Task.detached {
+        processBox.withValue { $0 = process }
+        let stdoutTask = Task {
           for await line in lineStream(from: outputHandle) {
             await outputAccumulator.append(line, source: .stdout)
-            continuation.yield(
-              .line(
-                ShellStreamLine(
-                  source: .stdout,
-                  text: line
-                )
-              )
-            )
+            continuation.yield(.line(ShellStreamLine(source: .stdout, text: line)))
           }
         }
-        let stderrTask = Task.detached {
+        let stderrTask = Task {
           for await line in lineStream(from: errorHandle) {
             await outputAccumulator.append(line, source: .stderr)
-            continuation.yield(
-              .line(
-                ShellStreamLine(
-                  source: .stderr,
-                  text: line
-                )
-              )
-            )
+            continuation.yield(.line(ShellStreamLine(source: .stderr, text: line)))
           }
         }
-        process.waitUntilExit()
+        await withTaskCancellationHandler {
+          await waitForExit(of: process)
+        } onCancel: {
+          process.terminate()
+        }
         await stdoutTask.value
         await stderrTask.value
         let output = await outputAccumulator.output(exitCode: process.terminationStatus)
@@ -230,6 +226,35 @@ nonisolated private func runProcessStream(
       } catch {
         continuation.finish(throwing: error)
       }
+    }
+    continuation.onTermination = { _ in
+      processBox.withValue { $0?.terminate() }
+      workerTask.cancel()
+    }
+  }
+}
+
+/// Waits asynchronously for `process` to exit using `terminationHandler`
+/// instead of `process.waitUntilExit()` so the caller's Task cancellation
+/// can be honoured. The handler is paired with a synchronous `isRunning`
+/// check to cover the race where the process exits before the handler is
+/// installed.
+nonisolated private func waitForExit(of process: Process) async {
+  await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+    let resumed = LockIsolated(false)
+    let resumeOnce: @Sendable () -> Void = {
+      let shouldResume = resumed.withValue { (value: inout Bool) -> Bool in
+        guard !value else { return false }
+        value = true
+        return true
+      }
+      if shouldResume {
+        continuation.resume()
+      }
+    }
+    process.terminationHandler = { _ in resumeOnce() }
+    if !process.isRunning {
+      resumeOnce()
     }
   }
 }

--- a/supacodeTests/ShellClientStreamingTests.swift
+++ b/supacodeTests/ShellClientStreamingTests.swift
@@ -127,6 +127,75 @@ struct ShellClientStreamingTests {
     #expect(streamedLines.contains(where: { $0.source == .stderr && $0.text == "err" }))
   }
 
+  @Test func cancellingRunStreamConsumerTerminatesProcessQuickly() async throws {
+    let shell = ShellClient.liveValue
+    let commandURL = URL(fileURLWithPath: "/bin/sleep")
+    let stream = shell.runStream(commandURL, ["30"], nil)
+
+    let consumer = Task {
+      var lines: [ShellStreamLine] = []
+      do {
+        for try await event in stream {
+          if case .line(let line) = event {
+            lines.append(line)
+          }
+        }
+      } catch {
+        // CancellationError or ShellClientError after SIGTERM both indicate
+        // the cancellation pathway is connected.
+      }
+      return lines
+    }
+
+    try await Task.sleep(for: .milliseconds(120))
+
+    let start = ContinuousClock.now
+    consumer.cancel()
+    _ = await consumer.value
+    let elapsed = ContinuousClock.now - start
+
+    #expect(
+      elapsed < .seconds(2),
+      "consumer cancel should propagate to the shell process; took \(elapsed)"
+    )
+  }
+
+  @Test func runReturnsQuicklyWhenCallingTaskIsCancelled() async {
+    let shell = ShellClient.liveValue
+    let commandURL = URL(fileURLWithPath: "/bin/sleep")
+
+    let runTask = Task {
+      try await shell.run(commandURL, ["30"], nil)
+    }
+
+    try? await Task.sleep(for: .milliseconds(120))
+
+    let start = ContinuousClock.now
+    runTask.cancel()
+    _ = await runTask.result
+    let elapsed = ContinuousClock.now - start
+
+    #expect(
+      elapsed < .seconds(2),
+      "run() should propagate cancellation to the process; took \(elapsed)"
+    )
+  }
+
+  @Test func runStreamSucceedsForShortLivedProcessAfterCancellationFixes() async throws {
+    // Regression guard: terminationHandler / isRunning race in waitForExit
+    // must not deadlock or double-resume on fast-exiting processes.
+    let shell = ShellClient.liveValue
+    let commandURL = URL(fileURLWithPath: "/bin/sh")
+    let stream = shell.runStream(commandURL, ["-c", "true"], nil)
+    var finished: ShellOutput?
+    for try await event in stream {
+      if case .finished(let output) = event {
+        finished = output
+      }
+    }
+    #expect(finished?.exitCode == 0)
+  }
+
   @Test func runLoginStreamForwardsParameters() async throws {
     let recorder = LoginStreamCallRecorder()
     let shell = ShellClient(


### PR DESCRIPTION
## Summary

`ShellClient.runProcessStream` ran its worker on `Task.detached` and blocked on `Process.waitUntilExit()`, so a structured-concurrency timeout wrapping any `ShellClient` call (notably `PullRequestRefreshCoordinator.runBatchWithTimeout` introduced in #366) could not interrupt the running command — the catch path only fired after `gh` (or whatever shell program) terminated on its own.

This PR wires cancellation through end-to-end:

1. **Cancellation-aware wait.** `process.waitUntilExit()` is replaced with `waitForExit(of:)`, an async wait built on `process.terminationHandler` + `CheckedContinuation`. A `LockIsolated<Bool>` guards against double-resume in the race where the process exits between handler assignment and the `isRunning` sanity check.
2. **SIGTERM on Task cancel.** The wait is wrapped in `withTaskCancellationHandler { … } onCancel: { process.terminate() }`, so a cancelled worker Task immediately sends SIGTERM rather than waiting for natural exit.
3. **Consumer-side termination hook.** The running `Process` is held in a `LockIsolated` box; `continuation.onTermination` calls `process.terminate()` and `workerTask.cancel()`, so when the stream consumer goes away (Task cancel, `for await` throw, explicit `finish`) the underlying process is torn down too.

`Task.detached` switched to inheriting `Task { … }` while in the area — the worker and pipe-reader tasks were already isolated by virtue of being created inside the stream closure, but the explicit form removes a small footgun.

Once this lands the `softTimeout` parameter introduced in #366 regains its protective effect without any further changes there.

Closes #368.

## Test plan

- [x] `make check` — clean
- [x] `make build-app` — only the unrelated pre-existing `FSEventStreamScheduleWithRunLoop` deprecation warning
- [x] New `ShellClientStreamingTests`:
      - `cancellingRunStreamConsumerTerminatesProcessQuickly` — runs `/bin/sleep 30`, cancels consumer, expects exit in under 2 s (observed ~10 ms)
      - `runReturnsQuicklyWhenCallingTaskIsCancelled` — same against the one-shot `run` path
      - `runStreamSucceedsForShortLivedProcessAfterCancellationFixes` — regression guard for the `terminationHandler` / `isRunning` race against `/bin/sh -c true`
- [x] Existing `ShellClientStreamingTests` — pass unchanged
- [x] Reviewer: spot-check the LockIsolated capture in `onTermination` and the `resumed` flag in `waitForExit` for re-entrancy / double-fire scenarios

## Related

#366 introduces the soft-timeout pathway that exposed this gap; once this PR is merged that timeout starts working in production without further code changes.
