### PR TITLE
Fix terminal surface leak on tab close

### DIFF
--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -659,6 +659,10 @@ final class WorktreeTerminalState {
     workingDirectoryOverride: URL? = nil,
     context: ghostty_surface_context_e = GHOSTTY_SURFACE_CONTEXT_TAB
   ) -> SplitTree<GhosttySurfaceView> {
+    guard tabManager.tabs.contains(where: { $0.id == tabId }) else {
+      terminalLifecycleLogger.info("skip splitTree for stale tabID=\(tabId)")
+      return SplitTree()
+    }
     if let existing = trees[tabId] {
       return existing
     }

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -6,7 +6,6 @@ import Observation
 import Sharing
 
 private let terminalStateLogger = SupaLogger("TerminalState")
-private let terminalLifecycleLogger = SupaLogger("TerminalLifecycle")
 private let activeAgentDetectionInterval: Duration = .milliseconds(300)
 private let idleAgentDetectionInterval: Duration = .seconds(2)
 
@@ -660,7 +659,6 @@ final class WorktreeTerminalState {
     context: ghostty_surface_context_e = GHOSTTY_SURFACE_CONTEXT_TAB
   ) -> SplitTree<GhosttySurfaceView> {
     guard tabManager.tabs.contains(where: { $0.id == tabId }) else {
-      terminalLifecycleLogger.info("skip splitTree for stale tabID=\(tabId)")
       return SplitTree()
     }
     if let existing = trees[tabId] {
@@ -673,11 +671,6 @@ final class WorktreeTerminalState {
       workingDirectoryOverride: workingDirectoryOverride,
       context: context
     )
-    terminalLifecycleLogger.info(
-      "created surfaceID=\(surface.id.uuidString) tabID=\(tabId) worktreeID=\(worktree.id) "
-        + "context=\(context.rawValue) inheritedFrom=\(inheritingFromSurfaceId?.uuidString ?? "nil") "
-        + "workingDirectory=\((workingDirectoryOverride ?? worktree.workingDirectory).path(percentEncoded: false)) "
-        + "hasInitialInput=\(initialInput != nil)")
     let tree = SplitTree(view: surface)
     trees[tabId] = tree
     focusedSurfaceIdByTab[tabId] = surface.id
@@ -2009,8 +2002,6 @@ final class WorktreeTerminalState {
 
   private func removeTree(for tabId: TerminalTabID) {
     guard let tree = trees.removeValue(forKey: tabId) else { return }
-    terminalLifecycleLogger.info(
-      "removeTree tabID=\(tabId) surfaceIDs=\(tree.leaves().map { $0.id.uuidString })")
     for surface in tree.leaves() {
       surface.closeSurface()
       forgetSurface(surface.id)
@@ -2164,9 +2155,6 @@ final class WorktreeTerminalState {
   }
 
   private func handleCloseRequest(for view: GhosttySurfaceView, processAlive: Bool) {
-    terminalLifecycleLogger.info(
-      "handleCloseRequest surfaceID=\(view.id.uuidString) processAlive=\(processAlive) "
-        + "tracked=\(surfaces[view.id] != nil)")
     guard surfaces[view.id] != nil else { return }
     if processAlive {
       guard confirmCloseIfNeeded(surfaceIDs: [view.id], mode: .prompt(.pane)) else { return }

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -6,6 +6,7 @@ import Observation
 import Sharing
 
 private let terminalStateLogger = SupaLogger("TerminalState")
+private let terminalLifecycleLogger = SupaLogger("TerminalLifecycle")
 private let activeAgentDetectionInterval: Duration = .milliseconds(300)
 private let idleAgentDetectionInterval: Duration = .seconds(2)
 
@@ -668,6 +669,11 @@ final class WorktreeTerminalState {
       workingDirectoryOverride: workingDirectoryOverride,
       context: context
     )
+    terminalLifecycleLogger.info(
+      "created surfaceID=\(surface.id.uuidString) tabID=\(tabId) worktreeID=\(worktree.id) "
+        + "context=\(context.rawValue) inheritedFrom=\(inheritingFromSurfaceId?.uuidString ?? "nil") "
+        + "workingDirectory=\((workingDirectoryOverride ?? worktree.workingDirectory).path(percentEncoded: false)) "
+        + "hasInitialInput=\(initialInput != nil)")
     let tree = SplitTree(view: surface)
     trees[tabId] = tree
     focusedSurfaceIdByTab[tabId] = surface.id
@@ -1999,6 +2005,8 @@ final class WorktreeTerminalState {
 
   private func removeTree(for tabId: TerminalTabID) {
     guard let tree = trees.removeValue(forKey: tabId) else { return }
+    terminalLifecycleLogger.info(
+      "removeTree tabID=\(tabId) surfaceIDs=\(tree.leaves().map { $0.id.uuidString })")
     for surface in tree.leaves() {
       surface.closeSurface()
       forgetSurface(surface.id)
@@ -2152,6 +2160,9 @@ final class WorktreeTerminalState {
   }
 
   private func handleCloseRequest(for view: GhosttySurfaceView, processAlive: Bool) {
+    terminalLifecycleLogger.info(
+      "handleCloseRequest surfaceID=\(view.id.uuidString) processAlive=\(processAlive) "
+        + "tracked=\(surfaces[view.id] != nil)")
     guard surfaces[view.id] != nil else { return }
     if processAlive {
       guard confirmCloseIfNeeded(surfaceIDs: [view.id], mode: .prompt(.pane)) else { return }

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -286,10 +286,7 @@ final class WorktreeTerminalState {
     inheritingFromSurfaceId: UUID? = nil,
     workingDirectoryOverride: URL? = nil
   ) -> TerminalTabID? {
-    let context: ghostty_surface_context_e =
-      tabManager.tabs.isEmpty
-      ? GHOSTTY_SURFACE_CONTEXT_WINDOW
-      : GHOSTTY_SURFACE_CONTEXT_TAB
+    let context = GHOSTTY_SURFACE_CONTEXT_TAB
     let resolvedInheritanceSurfaceId = inheritingFromSurfaceId ?? currentFocusedSurfaceId()
     let title = "\(worktree.name) \(nextTabIndex())"
     let setupInput = setupScriptInput(setupScript: setupScript)

--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
@@ -112,6 +112,9 @@ final class GhosttySurfaceView: NSView, Identifiable {
   private let envVarCount: Int
   private let fontSize: Float32
   private let context: ghostty_surface_context_e
+  var surfaceContextForTesting: ghostty_surface_context_e {
+    context
+  }
   private let skipsSurfaceCreationForTesting: Bool
   private var trackingArea: NSTrackingArea?
   private var lastBackingSize: CGSize = .zero

--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
@@ -1,13 +1,11 @@
 import AppKit
 import Carbon
 import CoreText
-import Darwin
 import GhosttyKit
 import QuartzCore
 import SwiftUI
 
 private let surfaceLogger = SupaLogger("Surface")
-private let surfaceLifecycleLogger = SupaLogger("SurfaceLifecycle")
 
 final class GhosttySurfaceView: NSView, Identifiable {
   struct OcclusionState {
@@ -334,11 +332,6 @@ final class GhosttySurfaceView: NSView, Identifiable {
   func closeSurface() {
     clearNotificationObservers()
     if let surface {
-      let childPID = ghostty_surface_pid(surface)
-      let foregroundProcessGroupID = ghostty_surface_foreground_process_group(surface)
-      let processExited = ghostty_surface_process_exited(surface)
-      logLifecycle(
-        "close begin childPID=\(childPID) foregroundPGID=\(foregroundProcessGroupID) processExited=\(processExited)")
       if let surfaceRef {
         runtime.unregisterSurface(surfaceRef)
         self.surfaceRef = nil
@@ -348,10 +341,6 @@ final class GhosttySurfaceView: NSView, Identifiable {
       bridge.surface = nil
       occlusionState.reset()
       lastSurfaceFocus = nil
-      logLifecycle("close returned childPID=\(childPID)")
-      scheduleChildExitProbe(childPID: childPID)
-    } else {
-      logLifecycle("close skipped surface=nil")
     }
   }
 
@@ -1069,14 +1058,6 @@ final class GhosttySurfaceView: NSView, Identifiable {
     }
     surface = ghostty_surface_new(app, &config)
     bridge.surface = surface
-    if let surface {
-      logLifecycle(
-        "created childPID=\(ghostty_surface_pid(surface)) "
-          + "foregroundPGID=\(ghostty_surface_foreground_process_group(surface)) "
-          + "processExited=\(ghostty_surface_process_exited(surface))")
-    } else {
-      logLifecycle("create failed")
-    }
     occlusionState.reset()
     lastSurfaceFocus = nil
     // A freshly created Ghostty surface defaults to focused (blinking cursor).
@@ -1101,38 +1082,6 @@ final class GhosttySurfaceView: NSView, Identifiable {
       return screen.backingScaleFactor
     }
     return 2.0
-  }
-
-  private func logLifecycle(_ message: String) {
-    surfaceLifecycleLogger.info(
-      "surfaceID=\(id.uuidString) context=\(context.rawValue) \(message)")
-  }
-
-  private func scheduleChildExitProbe(childPID: Int32) {
-    guard childPID > 0 else { return }
-    let surfaceID = id.uuidString
-    let context = context.rawValue
-    Task { @MainActor in
-      try? await ContinuousClock().sleep(for: .milliseconds(500))
-      Self.logChildExitProbe(surfaceID: surfaceID, context: context, childPID: childPID, delay: "0.5s")
-      try? await ContinuousClock().sleep(for: .milliseconds(1500))
-      Self.logChildExitProbe(surfaceID: surfaceID, context: context, childPID: childPID, delay: "2.0s")
-    }
-  }
-
-  private static func logChildExitProbe(
-    surfaceID: String,
-    context: UInt32,
-    childPID: Int32,
-    delay: String
-  ) {
-    surfaceLifecycleLogger.info(
-      "surfaceID=\(surfaceID) context=\(context) close probe delay=\(delay) childPID=\(childPID) "
-        + "alive=\(isProcessAlive(pid: pid_t(childPID)))")
-  }
-
-  private static func isProcessAlive(pid: pid_t) -> Bool {
-    kill(pid, 0) == 0 || errno == EPERM
   }
 
   func setOcclusion(_ visible: Bool) {

--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
@@ -1,11 +1,13 @@
 import AppKit
 import Carbon
 import CoreText
+import Darwin
 import GhosttyKit
 import QuartzCore
 import SwiftUI
 
 private let surfaceLogger = SupaLogger("Surface")
+private let surfaceLifecycleLogger = SupaLogger("SurfaceLifecycle")
 
 final class GhosttySurfaceView: NSView, Identifiable {
   struct OcclusionState {
@@ -332,6 +334,11 @@ final class GhosttySurfaceView: NSView, Identifiable {
   func closeSurface() {
     clearNotificationObservers()
     if let surface {
+      let childPID = ghostty_surface_pid(surface)
+      let foregroundProcessGroupID = ghostty_surface_foreground_process_group(surface)
+      let processExited = ghostty_surface_process_exited(surface)
+      logLifecycle(
+        "close begin childPID=\(childPID) foregroundPGID=\(foregroundProcessGroupID) processExited=\(processExited)")
       if let surfaceRef {
         runtime.unregisterSurface(surfaceRef)
         self.surfaceRef = nil
@@ -341,6 +348,10 @@ final class GhosttySurfaceView: NSView, Identifiable {
       bridge.surface = nil
       occlusionState.reset()
       lastSurfaceFocus = nil
+      logLifecycle("close returned childPID=\(childPID)")
+      scheduleChildExitProbe(childPID: childPID)
+    } else {
+      logLifecycle("close skipped surface=nil")
     }
   }
 
@@ -1058,6 +1069,14 @@ final class GhosttySurfaceView: NSView, Identifiable {
     }
     surface = ghostty_surface_new(app, &config)
     bridge.surface = surface
+    if let surface {
+      logLifecycle(
+        "created childPID=\(ghostty_surface_pid(surface)) "
+          + "foregroundPGID=\(ghostty_surface_foreground_process_group(surface)) "
+          + "processExited=\(ghostty_surface_process_exited(surface))")
+    } else {
+      logLifecycle("create failed")
+    }
     occlusionState.reset()
     lastSurfaceFocus = nil
     // A freshly created Ghostty surface defaults to focused (blinking cursor).
@@ -1082,6 +1101,38 @@ final class GhosttySurfaceView: NSView, Identifiable {
       return screen.backingScaleFactor
     }
     return 2.0
+  }
+
+  private func logLifecycle(_ message: String) {
+    surfaceLifecycleLogger.info(
+      "surfaceID=\(id.uuidString) context=\(context.rawValue) \(message)")
+  }
+
+  private func scheduleChildExitProbe(childPID: Int32) {
+    guard childPID > 0 else { return }
+    let surfaceID = id.uuidString
+    let context = context.rawValue
+    Task { @MainActor in
+      try? await ContinuousClock().sleep(for: .milliseconds(500))
+      Self.logChildExitProbe(surfaceID: surfaceID, context: context, childPID: childPID, delay: "0.5s")
+      try? await ContinuousClock().sleep(for: .milliseconds(1500))
+      Self.logChildExitProbe(surfaceID: surfaceID, context: context, childPID: childPID, delay: "2.0s")
+    }
+  }
+
+  private static func logChildExitProbe(
+    surfaceID: String,
+    context: UInt32,
+    childPID: Int32,
+    delay: String
+  ) {
+    surfaceLifecycleLogger.info(
+      "surfaceID=\(surfaceID) context=\(context) close probe delay=\(delay) childPID=\(childPID) "
+        + "alive=\(isProcessAlive(pid: pid_t(childPID)))")
+  }
+
+  private static func isProcessAlive(pid: pid_t) -> Bool {
+    kill(pid, 0) == 0 || errno == EPERM
   }
 
   func setOcclusion(_ visible: Bool) {

--- a/supacodeTests/WorktreeTerminalManagerTests.swift
+++ b/supacodeTests/WorktreeTerminalManagerTests.swift
@@ -117,6 +117,24 @@ struct WorktreeTerminalManagerTests {
     #expect(state.surfaceView(for: tabId) == nil)
   }
 
+  @Test func ghosttyCloseRequestDoesNotRecreateSurfaceForClosedTab() throws {
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    let worktree = makeWorktree()
+    let state = manager.state(for: worktree)
+
+    let tabId = try #require(state.createTab())
+    let surfaceId = try #require(state.focusedSurfaceId(in: tabId))
+    let surface = try #require(state.surfaceView(for: surfaceId))
+
+    surface.bridge.closeSurface(processAlive: false)
+    let staleTree = state.splitTree(for: tabId)
+
+    #expect(staleTree.isEmpty)
+    #expect(state.tabManager.tabs.isEmpty)
+    #expect(state.surfaceView(for: surfaceId) == nil)
+    #expect(state.surfaceView(for: tabId) == nil)
+  }
+
   @Test func notificationIndicatorUsesCurrentCountOnStreamStart() async {
     let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
     let worktree = makeWorktree()

--- a/supacodeTests/WorktreeTerminalManagerTests.swift
+++ b/supacodeTests/WorktreeTerminalManagerTests.swift
@@ -101,6 +101,22 @@ struct WorktreeTerminalManagerTests {
     #expect(surface.surfaceContextForTesting == GHOSTTY_SURFACE_CONTEXT_TAB)
   }
 
+  @Test func splitTreeDoesNotRecreateSurfaceForClosedTab() throws {
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    let worktree = makeWorktree()
+    let state = manager.state(for: worktree)
+
+    let tabId = try #require(state.createTab())
+    let surfaceId = try #require(state.focusedSurfaceId(in: tabId))
+
+    state.closeTab(tabId)
+    let staleTree = state.splitTree(for: tabId)
+
+    #expect(staleTree.isEmpty)
+    #expect(state.surfaceView(for: surfaceId) == nil)
+    #expect(state.surfaceView(for: tabId) == nil)
+  }
+
   @Test func notificationIndicatorUsesCurrentCountOnStreamStart() async {
     let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
     let worktree = makeWorktree()

--- a/supacodeTests/WorktreeTerminalManagerTests.swift
+++ b/supacodeTests/WorktreeTerminalManagerTests.swift
@@ -1,6 +1,7 @@
 import ConcurrencyExtras
 import DependenciesTestSupport
 import Foundation
+import GhosttyKit
 import Testing
 
 @testable import supacode
@@ -86,6 +87,18 @@ struct WorktreeTerminalManagerTests {
 
     #expect(state.canCloseFocusedTab == false)
     #expect(state.canCloseFocusedSurface == false)
+  }
+
+  @Test func firstTabUsesTabSurfaceContext() throws {
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    let worktree = makeWorktree()
+    let state = manager.state(for: worktree)
+
+    let tabId = try #require(state.createTab())
+    let surfaceId = try #require(state.focusedSurfaceId(in: tabId))
+    let surface = try #require(state.surfaceView(for: surfaceId))
+
+    #expect(surface.surfaceContextForTesting == GHOSTTY_SURFACE_CONTEXT_TAB)
   }
 
   @Test func notificationIndicatorUsesCurrentCountOnStreamStart() async {


### PR DESCRIPTION
Fixes #370 

## Summary
- use Ghostty tab context for Prowl terminal tabs instead of window context
- prevent stale SwiftUI renders from recreating a surface for a tab that has already closed
- add regression coverage for normal tab close and Ghostty close callback paths

## Root Cause
A terminal tab could be closed while SwiftUI still rendered a stale selected tab id. `splitTree(for:)` treated any missing tree as lazily creatable, so that stale render created a fresh Ghostty surface for an already-closed tab. That spawned another shell and left it outside the visible tab lifecycle.

The initial terminal surface also used Ghostty's window context even though Prowl embeds terminal tabs in its own window/tab UI. The first tab now uses tab context, matching subsequent Prowl terminal tabs.

## Validation
- `make check`
- `xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -only-testing:supacodeTests/WorktreeTerminalManagerTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation`
- `make build-app`
