### PR TITLE
Avoid reading text from modifier key events

### DIFF
--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
@@ -7,6 +7,26 @@ import SwiftUI
 
 private let surfaceLogger = SupaLogger("Surface")
 
+enum GhosttyEventText {
+  static func characters(for event: NSEvent) -> String? {
+    guard event.type == .keyDown || event.type == .keyUp else {
+      return nil
+    }
+    guard let characters = event.characters else { return nil }
+    if characters.count == 1,
+      let scalar = characters.unicodeScalars.first
+    {
+      if scalar.value < 0x20 {
+        return event.characters(byApplyingModifiers: event.modifierFlags.subtracting(.control))
+      }
+      if scalar.value >= 0xF700 && scalar.value <= 0xF8FF {
+        return nil
+      }
+    }
+    return characters
+  }
+}
+
 final class GhosttySurfaceView: NSView, Identifiable {
   struct OcclusionState {
     private(set) var desired: Bool?
@@ -1694,18 +1714,7 @@ final class GhosttySurfaceView: NSView, Identifiable {
   }
 
   private func ghosttyCharacters(_ event: NSEvent) -> String? {
-    guard let characters = event.characters else { return nil }
-    if characters.count == 1,
-      let scalar = characters.unicodeScalars.first
-    {
-      if scalar.value < 0x20 {
-        return event.characters(byApplyingModifiers: event.modifierFlags.subtracting(.control))
-      }
-      if scalar.value >= 0xF700 && scalar.value <= 0xF8FF {
-        return nil
-      }
-    }
-    return characters
+    GhosttyEventText.characters(for: event)
   }
 
   private func syncPreedit(clearIfNeeded: Bool = true) {

--- a/supacodeTests/MirroredTerminalKeyTests.swift
+++ b/supacodeTests/MirroredTerminalKeyTests.swift
@@ -118,4 +118,38 @@ struct MirroredTerminalKeyTests {
 
     #expect(MirroredTerminalKey(event: try #require(event)) == nil)
   }
+
+  @Test func ghosttyTextIgnoresFlagsChangedEvents() throws {
+    let event = NSEvent.keyEvent(
+      with: .flagsChanged,
+      location: .zero,
+      modifierFlags: [.command],
+      timestamp: 0,
+      windowNumber: 0,
+      context: nil,
+      characters: "",
+      charactersIgnoringModifiers: "",
+      isARepeat: false,
+      keyCode: 55
+    )
+
+    #expect(GhosttyEventText.characters(for: try #require(event)) == nil)
+  }
+
+  @Test func ghosttyTextReadsKeyEvents() throws {
+    let event = NSEvent.keyEvent(
+      with: .keyDown,
+      location: .zero,
+      modifierFlags: [],
+      timestamp: 0,
+      windowNumber: 0,
+      context: nil,
+      characters: "a",
+      charactersIgnoringModifiers: "a",
+      isARepeat: false,
+      keyCode: 0
+    )
+
+    #expect(GhosttyEventText.characters(for: try #require(event)) == "a")
+  }
 }


### PR DESCRIPTION
## Summary
- Prevent Ghostty key text extraction from reading `NSEvent.characters` on non-key text events.
- Keep modifier-only `.flagsChanged` events textless while preserving existing keyDown/keyUp character handling.
- Add regression coverage for `.flagsChanged` and regular keyDown text extraction.

## Testing
- xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -only-testing:supacodeTests/MirroredTerminalKeyTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation
- make check
- make build-app
