### PR TITLE
Relax shell cancellation timing tests

### DIFF
--- a/supacodeTests/ShellClientStreamingTests.swift
+++ b/supacodeTests/ShellClientStreamingTests.swift
@@ -155,7 +155,7 @@ struct ShellClientStreamingTests {
     let elapsed = ContinuousClock.now - start
 
     #expect(
-      elapsed < .seconds(2),
+      elapsed < .seconds(5),
       "consumer cancel should propagate to the shell process; took \(elapsed)"
     )
   }
@@ -176,7 +176,7 @@ struct ShellClientStreamingTests {
     let elapsed = ContinuousClock.now - start
 
     #expect(
-      elapsed < .seconds(2),
+      elapsed < .seconds(5),
       "run() should propagate cancellation to the process; took \(elapsed)"
     )
   }


### PR DESCRIPTION
## Summary
- Relax ShellClient live process cancellation timing assertions from 2 seconds to 5 seconds.
- Keep the tests focused on bounded cancellation while avoiding CI runner scheduling flakes.

## Tests
- `xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -only-testing:supacodeTests/ShellClientStreamingTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation 2>&1 | xcsift -f toon`
- `make check`
- `make build-app 2>&1 | xcsift -f toon`
