### PR TITLE
Fix non-Sendable closure conversion warning in delete worktree toggle

### DIFF
--- a/supacode/Features/Repositories/Views/DeleteWorktreeConfirmationView.swift
+++ b/supacode/Features/Repositories/Views/DeleteWorktreeConfirmationView.swift
@@ -20,7 +20,7 @@ struct DeleteWorktreeConfirmationView: View {
         "Also delete local branch",
         isOn: Binding(
           get: { confirmation.deleteBranch },
-          set: onDeleteBranchChanged
+          set: { onDeleteBranchChanged($0) }
         )
       )
       .help("Try to delete the local branch with git branch -d after removing the worktree.")


### PR DESCRIPTION
## Summary

The Release build emitted a data-race warning at `DeleteWorktreeConfirmationView.swift:23`:

> converting non-Sendable function value to '@isolated(any) @Sendable (Bool) -> Void' may introduce data races

The view passed its stored `onDeleteBranchChanged: (Bool) -> Void` property directly as the `set:` argument of `Binding(get:set:)`. SwiftUI's binding setter is now typed `@isolated(any) @Sendable`, so handing it a plain stored function value is a non-Sendable conversion.

## Fix

Wrap the call in a closure literal — `set: { onDeleteBranchChanged($0) }`. Because `body` is `@MainActor`, the closure literal is inferred as `@MainActor`-isolated, which satisfies `@isolated(any)` without any behavior change.

## Test plan

- [x] `make build-app` — 0 errors, 0 warnings (warning gone)
- [x] `make check` — clean (swift-format + swiftlint)
