### PR TITLE
[codex] Fix duplicate PR refresh repo requests

### DIFF
--- a/supacode/Features/Repositories/BusinessLogic/PullRequestRefreshCoordinator.swift
+++ b/supacode/Features/Repositories/BusinessLogic/PullRequestRefreshCoordinator.swift
@@ -157,28 +157,34 @@ final class PullRequestRefreshCoordinator {
   }
 
   private func processBatch(host: String, requests: [Request]) async {
-    let crossRepoRequests = requests.map {
-      CrossRepoPullRequestRequest(owner: $0.owner, repo: $0.repo, branches: $0.branches)
+    let groupsByKey = groupRequestsByRepo(requests)
+    let crossRepoRequests = groupsByKey.values.map { group in
+      CrossRepoPullRequestRequest(
+        owner: group.key.owner,
+        repo: group.key.repo,
+        branches: group.branches
+      )
     }
     do {
       let result = try await runBatchWithTimeout(host: host, requests: crossRepoRequests)
-      let requestsByKey = Dictionary(
-        uniqueKeysWithValues: requests.map { (RepoKey(owner: $0.owner, repo: $0.repo), $0) }
-      )
       for (key, prsByBranch) in result.successByRepo {
-        guard let request = requestsByKey[key] else {
+        guard let group = groupsByKey[key] else {
           continue
         }
-        resultHandler(
-          .refreshed(
-            repositoryID: request.repositoryID,
-            repositoryRootURL: request.repositoryRootURL,
-            worktreeIDs: request.worktreeIDs,
-            prsByBranch: prsByBranch
+        for request in group.requests {
+          resultHandler(
+            .refreshed(
+              repositoryID: request.repositoryID,
+              repositoryRootURL: request.repositoryRootURL,
+              worktreeIDs: request.worktreeIDs,
+              prsByBranch: prsByBranch.filter { request.branches.contains($0.key) }
+            )
           )
-        )
+        }
       }
-      let failedRequests = result.failedRepos.keys.compactMap { requestsByKey[$0] }
+      let failedRequests = result.failedRepos.keys.flatMap { key in
+        groupsByKey[key]?.requests ?? []
+      }
       if !failedRequests.isEmpty {
         await fanOutFallback(failedRequests)
       }
@@ -188,12 +194,13 @@ final class PullRequestRefreshCoordinator {
   }
 
   private func fanOutFallback(_ requests: [Request]) async {
+    let groups = Array(groupRequestsByRepo(requests).values)
     // Run per-repo fallback requests concurrently; serial awaits here would multiply
     // a slow recovery path by the number of repos in the batch.
     await withTaskGroup(of: Void.self) { group in
-      for request in requests {
+      for requestGroup in groups {
         group.addTask { [weak self] in
-          await self?.fallbackPerRepo(request)
+          await self?.fallbackPerRepo(requestGroup)
         }
       }
     }
@@ -228,30 +235,61 @@ final class PullRequestRefreshCoordinator {
     }
   }
 
-  private func fallbackPerRepo(_ request: Request) async {
+  private func fallbackPerRepo(_ group: RepoRequestGroup) async {
     do {
       let prs = try await githubCLI.batchPullRequests(
-        request.host,
-        request.owner,
-        request.repo,
-        request.branches
+        group.requests[0].host,
+        group.key.owner,
+        group.key.repo,
+        group.branches
       )
-      resultHandler(
-        .refreshed(
-          repositoryID: request.repositoryID,
-          repositoryRootURL: request.repositoryRootURL,
-          worktreeIDs: request.worktreeIDs,
-          prsByBranch: prs
+      for request in group.requests {
+        resultHandler(
+          .refreshed(
+            repositoryID: request.repositoryID,
+            repositoryRootURL: request.repositoryRootURL,
+            worktreeIDs: request.worktreeIDs,
+            prsByBranch: prs.filter { request.branches.contains($0.key) }
+          )
         )
-      )
+      }
     } catch {
-      resultHandler(
-        .failed(
-          repositoryID: request.repositoryID,
-          worktreeIDs: request.worktreeIDs,
-          message: String(describing: error)
+      for request in group.requests {
+        resultHandler(
+          .failed(
+            repositoryID: request.repositoryID,
+            worktreeIDs: request.worktreeIDs,
+            message: String(describing: error)
+          )
         )
-      )
+      }
+    }
+  }
+
+  private func groupRequestsByRepo(_ requests: [Request]) -> [RepoKey: RepoRequestGroup] {
+    var groupsByKey: [RepoKey: RepoRequestGroup] = [:]
+    for request in requests {
+      let key = RepoKey(owner: request.owner, repo: request.repo)
+      groupsByKey[key, default: RepoRequestGroup(key: key)].append(request)
+    }
+    return groupsByKey
+  }
+
+  private struct RepoRequestGroup: Sendable {
+    let key: RepoKey
+    private(set) var requests: [Request] = []
+    private(set) var branches: [String] = []
+    private var seenBranches: Set<String> = []
+
+    init(key: RepoKey) {
+      self.key = key
+    }
+
+    mutating func append(_ request: Request) {
+      requests.append(request)
+      for branch in request.branches where seenBranches.insert(branch).inserted {
+        branches.append(branch)
+      }
     }
   }
 

--- a/supacodeTests/PullRequestRefreshCoordinatorTests.swift
+++ b/supacodeTests/PullRequestRefreshCoordinatorTests.swift
@@ -227,6 +227,94 @@ struct PullRequestRefreshCoordinatorTests {
     #expect(Set(alphaRequest.branches) == ["feat-1", "feat-2"])
   }
 
+  @Test func duplicateRepoKeysBatchOnceAndFanOutToEachRepository() async throws {
+    let clock = TestClock()
+    let probe = CoordinatorProbe()
+    let outcomes = OutcomeCollector()
+    let coordinator = makeCoordinator(
+      probe: probe,
+      clock: clock,
+      outcomes: outcomes,
+      batched: { _, requests in
+        var dict: [RepoKey: [String: GithubPullRequest]] = [:]
+        for request in requests {
+          dict[request.key] = [
+            "feat-1": makeFixturePullRequest(repo: request.repo),
+            "feat-2": makeFixturePullRequest(repo: request.repo),
+          ]
+        }
+        return CrossRepoPullRequestResult(successByRepo: dict)
+      }
+    )
+
+    coordinator.enqueue(
+      request(repo: "alpha", repositoryID: "alpha-a", branches: ["feat-1"])
+    )
+    coordinator.enqueue(
+      request(repo: "alpha", repositoryID: "alpha-b", branches: ["feat-2"])
+    )
+    await clock.advance(by: .milliseconds(250))
+    await Task.yield()
+    await Task.yield()
+
+    let calls = await probe.batchedCalls()
+    #expect(calls.count == 1)
+    let batchedRequest = try #require(calls.first?.requests.first)
+    #expect(calls.first?.requests.count == 1)
+    #expect(batchedRequest.owner == "khoi")
+    #expect(batchedRequest.repo == "alpha")
+    #expect(Set(batchedRequest.branches) == ["feat-1", "feat-2"])
+
+    let snapshots = await outcomes.snapshot()
+    let refreshed = snapshots.compactMap { outcome -> (Repository.ID, [String])? in
+      if case .refreshed(let id, _, _, let prs) = outcome {
+        return (id, Array(prs.keys))
+      }
+      return nil
+    }
+    #expect(Set(refreshed.map(\.0)) == ["alpha-a", "alpha-b"])
+    #expect(refreshed.first { $0.0 == "alpha-a" }?.1 == ["feat-1"])
+    #expect(refreshed.first { $0.0 == "alpha-b" }?.1 == ["feat-2"])
+  }
+
+  @Test func duplicateRepoKeysFallbackOnceAndFanOutToEachRepository() async throws {
+    let clock = TestClock()
+    let probe = CoordinatorProbe()
+    let outcomes = OutcomeCollector()
+    let coordinator = makeCoordinator(
+      probe: probe,
+      clock: clock,
+      outcomes: outcomes,
+      batched: { _, _ in
+        throw GithubCLIError.commandFailed("batch unavailable")
+      },
+      legacy: { _, _, repo, branches in
+        Dictionary(
+          uniqueKeysWithValues: branches.map { branch in
+            (branch, makeFixturePullRequest(repo: repo))
+          }
+        )
+      }
+    )
+
+    coordinator.enqueue(
+      request(repo: "alpha", repositoryID: "alpha-a", branches: ["feat-1"])
+    )
+    coordinator.enqueue(
+      request(repo: "alpha", repositoryID: "alpha-b", branches: ["feat-2"])
+    )
+    await clock.advance(by: .milliseconds(250))
+    await Task.yield()
+    await Task.yield()
+
+    let legacyCalls = await probe.legacyCalls()
+    #expect(legacyCalls.count == 1)
+    #expect(legacyCalls.first?.repo == "alpha")
+    #expect(Set(legacyCalls.first?.branches ?? []) == ["feat-1", "feat-2"])
+    let refreshed = await outcomes.refreshedRepositories()
+    #expect(Set(refreshed) == ["alpha-a", "alpha-b"])
+  }
+
   @Test func softTimeoutFallsBackToLegacy() async throws {
     let clock = TestClock()
     let probe = CoordinatorProbe()
@@ -439,17 +527,21 @@ private func waitUntil(
 
 nonisolated private func request(
   repo: String,
+  repositoryID: Repository.ID? = nil,
+  rootPath: String? = nil,
   host: String = "github.com",
-  branches: [String] = ["feat-1"]
+  branches: [String] = ["feat-1"],
+  worktreeIDs: [Worktree.ID]? = nil
 ) -> PullRequestRefreshCoordinator.Request {
-  PullRequestRefreshCoordinator.Request(
-    repositoryID: repo,
-    repositoryRootURL: URL(fileURLWithPath: "/tmp/\(repo)"),
+  let resolvedRepositoryID = repositoryID ?? repo
+  return PullRequestRefreshCoordinator.Request(
+    repositoryID: resolvedRepositoryID,
+    repositoryRootURL: URL(fileURLWithPath: rootPath ?? "/tmp/\(resolvedRepositoryID)"),
     host: host,
     owner: "khoi",
     repo: repo,
     branches: branches,
-    worktreeIDs: ["\(repo)-wt"]
+    worktreeIDs: worktreeIDs ?? ["\(resolvedRepositoryID)-wt"]
   )
 }
 


### PR DESCRIPTION
## Summary

- Group pull request refresh work by GitHub repo key before issuing cross-repo batch requests.
- Fan out each repo-level result back to all local repositories that requested the same GitHub repo.
- Apply the same grouping to the legacy fallback path so a failed batch only falls back once per repo.
- Add regression tests for duplicate repo keys on both successful batch refresh and fallback refresh.

## Root Cause

`PullRequestRefreshCoordinator.processBatch` built a dictionary with `Dictionary(uniqueKeysWithValues:)` from requests keyed by `RepoKey(owner, repo)`. When multiple local repositories resolved to the same GitHub repo, Swift trapped on the duplicate key.

## Validation

- `xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -only-testing:supacodeTests/PullRequestRefreshCoordinatorTests ...`
- `swift-format lint --strict --configuration ./.swift-format.json supacode/Features/Repositories/BusinessLogic/PullRequestRefreshCoordinator.swift supacodeTests/PullRequestRefreshCoordinatorTests.swift`
- `git diff --check`