### PR TITLE
Fix Default View (Shelf/Canvas) launch race and restoration hang

### DIFF
--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -59,6 +59,7 @@ struct AppFeature {
     var notificationIndicatorCount: Int = 0
     var lastKnownSystemNotificationsEnabled: Bool
     var launchRestoreMode: LaunchRestoreMode
+    var hasAppliedInitialViewMode = false
     var suppressLayoutSaveUntilRelaunch = false
     var launchedAt: Date?
     var leftSidebarVisibility: NavigationSplitViewVisibility = .all
@@ -287,6 +288,30 @@ struct AppFeature {
     }
   }
 
+  private func applyDefaultViewMode(into state: inout State) -> Effect<Action> {
+    guard !state.hasAppliedInitialViewMode else { return .none }
+    state.hasAppliedInitialViewMode = true
+
+    @Shared(.settingsFile) var settingsFile
+    let shouldEnterShelf =
+      settingsFile.global.defaultViewMode == .shelf
+      && !state.repositories.isShelfActive
+    let shouldEnterCanvas =
+      settingsFile.global.defaultViewMode == .canvas
+      && !state.repositories.isShowingCanvas
+
+    var effects: [Effect<Action>] = []
+    if shouldEnterShelf {
+      effects.append(.send(.repositories(.toggleShelf)))
+    }
+    // Enter Canvas after the selection effects so `.selectCanvas`
+    // records the just-selected worktree as the pre-Canvas anchor.
+    if shouldEnterCanvas {
+      effects.append(.send(.repositories(.toggleCanvas)))
+    }
+    return effects.isEmpty ? .none : .merge(effects)
+  }
+
   var body: some Reducer<State, Action> {
     let core = Reduce<State, Action> { state, action in
       switch action {
@@ -458,6 +483,7 @@ struct AppFeature {
         let shouldRestoreLayout =
           state.launchRestoreMode == .restoreLayout
           && state.repositories.snapshotPersistencePhase == .active
+        let shouldDeferDefaultView = state.launchRestoreMode == .restoreLayout
         appLogger.info(
           "[LayoutRestore] repositoriesChanged: mode=\(String(describing: state.launchRestoreMode))"
             + " phase=\(String(describing: state.repositories.snapshotPersistencePhase))"
@@ -470,6 +496,10 @@ struct AppFeature {
         state.runScriptStatusByWorktreeID = state.runScriptStatusByWorktreeID.filter { ids.contains($0.key) }
         let restorableWorktrees = makeTerminalRestorableWorktrees(from: Array(repositories))
         appLogger.info("[LayoutRestore] restorableWorktrees count=\(restorableWorktrees.count)")
+        var allEffects: [Effect<Action>] = []
+        if !shouldDeferDefaultView {
+          allEffects.append(applyDefaultViewMode(into: &state))
+        }
         if case .repository(let repositoryID)? = state.settings.selection,
           !repositories.contains(where: { $0.id == repositoryID })
         {
@@ -494,7 +524,8 @@ struct AppFeature {
               }
             )
           }
-          return .merge(effects)
+          allEffects.append(.merge(effects))
+          return .merge(allEffects)
         }
         var effects: [Effect<Action>] = [
           .send(.commandPalette(.pruneRecency(recencyIDs))),
@@ -516,7 +547,8 @@ struct AppFeature {
             }
           )
         }
-        return .merge(effects)
+        allEffects.append(.merge(effects))
+        return .merge(allEffects)
 
       case .repositories(.delegate(.openRepositorySettings(let repositoryID))):
         guard state.repositories.repositories.contains(where: { $0.id == repositoryID }) else {
@@ -1345,19 +1377,10 @@ struct AppFeature {
 
       case .terminalEvent(.layoutRestored(let selectedWorktreeID)):
         appLogger.info("[LayoutRestore] layoutRestored: selectedWorktreeID=\(selectedWorktreeID ?? "nil")")
-        // Once layout is restored the saved tabs have all been re-created
-        // (each emits `tabCreated` → `markWorktreeOpened`) and a valid
-        // active worktree is in hand — the right moment to honor the
-        // "Default View = Shelf" preference for Layout-Restore launches,
-        // which the `repositorySnapshotLoaded` hook intentionally
-        // deferred to avoid a selection flash.
-        @Shared(.settingsFile) var settingsFile
-        let shouldEnterShelf =
-          settingsFile.global.defaultViewMode == .shelf
-          && !state.repositories.isShelfActive
-        let shouldEnterCanvas =
-          settingsFile.global.defaultViewMode == .canvas
-          && !state.repositories.isShowingCanvas
+        // Layout restore has settled: tabs are re-created, selection is set.
+        // Now apply the default view preference, which was deferred in
+        // `repositoriesChanged` (via `shouldDeferDefaultView`) to avoid
+        // stray spines and a selection flash.
         var effects: [Effect<Action>] = []
         if let selectedWorktreeID {
           // Plain folders use .repository selection, not .worktree
@@ -1369,19 +1392,14 @@ struct AppFeature {
             effects.append(.send(.repositories(.selectWorktree(selectedWorktreeID))))
           }
         }
-        if shouldEnterShelf {
-          effects.append(.send(.repositories(.toggleShelf)))
-        }
-        // Enter Canvas after the selection effects so `.selectCanvas`
-        // records the just-selected worktree as the pre-Canvas anchor.
-        if shouldEnterCanvas {
-          effects.append(.send(.repositories(.toggleCanvas)))
-        }
-        return effects.isEmpty ? .none : .merge(effects)
+        return .merge([.merge(effects), applyDefaultViewMode(into: &state)])
 
       case .terminalEvent(.layoutRestoreFailed(let message)):
         appLogger.warning("[LayoutRestore] layoutRestoreFailed: \(message)")
-        return .send(.repositories(.showToast(.warning(message))))
+        return .merge(
+          .send(.repositories(.showToast(.warning(message)))),
+          applyDefaultViewMode(into: &state)
+        )
 
       case .terminalEvent(.tabCreated(let worktreeID)):
         // Every tab creation (user +, CLI open, layout restore, …)

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -307,9 +307,36 @@ struct AppFeature {
     // Enter Canvas after the selection effects so `.selectCanvas`
     // records the just-selected worktree as the pre-Canvas anchor.
     if shouldEnterCanvas {
+      if state.repositories.selectedTerminalWorktree == nil,
+        let targetID = defaultViewFallbackSelectionID(in: state.repositories)
+      {
+        effects.append(defaultViewSelectionEffect(for: targetID, repositories: state.repositories))
+      }
       effects.append(.send(.repositories(.toggleCanvas)))
     }
-    return effects.isEmpty ? .none : .merge(effects)
+    return effects.isEmpty ? .none : .concatenate(effects)
+  }
+
+  private func defaultViewFallbackSelectionID(in repositories: RepositoriesFeature.State) -> Worktree.ID? {
+    let candidateIDs =
+      [repositories.lastFocusedWorktreeID].compactMap(\.self)
+      + repositories.orderedWorktreeRows().map(\.id)
+    return candidateIDs.first { id in
+      repositories.worktree(for: id) != nil
+        || repositories.repositories[id: id]?.kind == .plain
+    }
+  }
+
+  private func defaultViewSelectionEffect(
+    for targetID: Worktree.ID,
+    repositories: RepositoriesFeature.State
+  ) -> Effect<Action> {
+    if repositories.worktree(for: targetID) == nil,
+      repositories.repositories[id: targetID]?.kind == .plain
+    {
+      return .send(.repositories(.selectRepository(targetID)))
+    }
+    return .send(.repositories(.selectWorktree(targetID)))
   }
 
   var body: some Reducer<State, Action> {
@@ -1392,7 +1419,7 @@ struct AppFeature {
             effects.append(.send(.repositories(.selectWorktree(selectedWorktreeID))))
           }
         }
-        return .merge([.merge(effects), applyDefaultViewMode(into: &state)])
+        return .concatenate([.merge(effects), applyDefaultViewMode(into: &state)])
 
       case .terminalEvent(.layoutRestoreFailed(let message)):
         appLogger.warning("[LayoutRestore] layoutRestoreFailed: \(message)")

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -520,30 +520,6 @@ struct RepositoriesFeature {
           if selectionChanged {
             allEffects.append(.send(.delegate(.selectedWorktreeChanged(selectedWorktree))))
           }
-          // Apply "Default View = Shelf" preference once the initial
-          // repository snapshot has landed — reuses `.toggleShelf`'s
-          // guards (needs ≥1 book, falls back to `lastFocusedWorktreeID`
-          // when no selection is set yet). `repositorySnapshotLoaded`
-          // is only sent from `.task` at launch, so this won't re-enter
-          // Shelf if the user has already exited to Normal in the same
-          // session. When Layout Restore is about to run, defer to the
-          // `.layoutRestored` event in AppFeature — otherwise Layout
-          // Restore clears the selection we just set, and any books not
-          // in the saved layout would linger as stray spines.
-          @Shared(.settingsFile) var settingsFile
-          if state.launchRestoreMode != .restoreLayout {
-            switch settingsFile.global.defaultViewMode {
-            case .shelf where !state.isShelfActive:
-              allEffects.append(.send(.toggleShelf))
-            case .canvas where !state.isShowingCanvas:
-              // `.toggleCanvas` shares Shelf's guards: it only enters
-              // when at least one worktree row exists, otherwise it
-              // falls back to Normal.
-              allEffects.append(.send(.toggleCanvas))
-            case .normal, .shelf, .canvas:
-              break
-            }
-          }
           return .merge(allEffects)
 
         case .pinnedWorktreeIDsLoaded(let pinnedWorktreeIDs):

--- a/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
+++ b/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
@@ -575,6 +575,7 @@ final class WorktreeTerminalManager {
     terminalLogger.info("[LayoutRestore] restore: loading snapshot from disk")
     guard let payload = await layoutPersistence.loadSnapshot() else {
       terminalLogger.info("[LayoutRestore] restore: no snapshot found on disk, skipping")
+      emit(.layoutRestored(selectedWorktreeID: nil))
       return
     }
     terminalLogger.info(

--- a/supacodeTests/AppFeatureTerminalLayoutRestoreTests.swift
+++ b/supacodeTests/AppFeatureTerminalLayoutRestoreTests.swift
@@ -228,6 +228,150 @@ struct AppFeatureTerminalLayoutRestoreTests {
     }
   }
 
+  @Test(.dependencies) func repositoriesChangedAppliesDefaultShelfWhenNotRestoringLayout() async {
+    let worktree = makeWorktree()
+    let repository = makeRepository(worktrees: [worktree])
+    var repositoriesState = RepositoriesFeature.State(repositories: [repository])
+    repositoriesState.selection = .worktree(worktree.id)
+    setDefaultViewMode(.shelf)
+    defer { setDefaultViewMode(.normal) }
+
+    let store = TestStore(
+      initialState: AppFeature.State(repositories: repositoriesState)
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { _ in }
+      $0.worktreeInfoWatcher.send = { _ in }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.repositories(.delegate(.repositoriesChanged([repository])))) {
+      $0.hasAppliedInitialViewMode = true
+    }
+    await store.receive(\.repositories.toggleShelf) {
+      $0.repositories.isShelfActive = true
+      $0.repositories.openedWorktreeIDs = [worktree.id]
+      $0.repositories.pendingTerminalFocusWorktreeIDs = [worktree.id]
+    }
+    await store.finish()
+  }
+
+  @Test(.dependencies) func repositoriesChangedAppliesDefaultCanvasWhenNotRestoringLayout() async {
+    let worktree = makeWorktree()
+    let repository = makeRepository(worktrees: [worktree])
+    var repositoriesState = RepositoriesFeature.State(repositories: [repository])
+    repositoriesState.selection = .worktree(worktree.id)
+    setDefaultViewMode(.canvas)
+    defer { setDefaultViewMode(.normal) }
+    let sentCommands = LockIsolated<[TerminalClient.Command]>([])
+
+    let store = TestStore(
+      initialState: AppFeature.State(repositories: repositoriesState)
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in
+        sentCommands.withValue { $0.append(command) }
+      }
+      $0.worktreeInfoWatcher.send = { _ in }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.repositories(.delegate(.repositoriesChanged([repository])))) {
+      $0.hasAppliedInitialViewMode = true
+    }
+    await store.receive(\.repositories.toggleCanvas)
+    await store.receive(\.repositories.selectCanvas) {
+      $0.repositories.preCanvasWorktreeID = worktree.id
+      $0.repositories.preCanvasTerminalTargetID = worktree.id
+      $0.repositories.selection = .canvas
+    }
+    await store.finish()
+
+    #expect(
+      sentCommands.value.contains(
+        .ensureInitialTab(worktree, runSetupScriptIfNew: false, focusing: false)
+      )
+    )
+  }
+
+  @Test(.dependencies) func layoutRestoredNilAppliesDefaultCanvasWithLastFocusedAnchor() async {
+    let worktree = makeWorktree()
+    let repository = makeRepository(worktrees: [worktree])
+    var repositoriesState = RepositoriesFeature.State(repositories: [repository])
+    repositoriesState.lastFocusedWorktreeID = worktree.id
+    repositoriesState.selection = nil
+    setDefaultViewMode(.canvas)
+    defer { setDefaultViewMode(.normal) }
+    let sentCommands = LockIsolated<[TerminalClient.Command]>([])
+
+    let store = TestStore(
+      initialState: AppFeature.State(repositories: repositoriesState)
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in
+        sentCommands.withValue { $0.append(command) }
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.terminalEvent(.layoutRestored(selectedWorktreeID: nil))) {
+      $0.hasAppliedInitialViewMode = true
+    }
+    await store.receive(\.repositories.selectWorktree) {
+      $0.repositories.selection = .worktree(worktree.id)
+      $0.repositories.openedWorktreeIDs = [worktree.id]
+    }
+    await store.receive(\.repositories.toggleCanvas)
+    await store.receive(\.repositories.selectCanvas) {
+      $0.repositories.preCanvasWorktreeID = worktree.id
+      $0.repositories.preCanvasTerminalTargetID = worktree.id
+      $0.repositories.selection = .canvas
+    }
+    await store.finish()
+
+    #expect(
+      sentCommands.value.contains(
+        .ensureInitialTab(worktree, runSetupScriptIfNew: false, focusing: false)
+      )
+    )
+  }
+
+  @Test(.dependencies) func layoutRestoreFailedAppliesDefaultShelf() async {
+    let worktree = makeWorktree()
+    let repository = makeRepository(worktrees: [worktree])
+    var repositoriesState = RepositoriesFeature.State(repositories: [repository])
+    repositoriesState.lastFocusedWorktreeID = worktree.id
+    repositoriesState.selection = nil
+    setDefaultViewMode(.shelf)
+    defer { setDefaultViewMode(.normal) }
+
+    let store = TestStore(
+      initialState: AppFeature.State(repositories: repositoriesState)
+    ) {
+      AppFeature()
+    }
+    store.exhaustivity = .off
+
+    await store.send(.terminalEvent(.layoutRestoreFailed(message: "Invalid layout"))) {
+      $0.hasAppliedInitialViewMode = true
+    }
+    await store.receive(\.repositories.showToast) {
+      $0.repositories.statusToast = .warning("Invalid layout")
+    }
+    await store.receive(\.repositories.toggleShelf) {
+      $0.repositories.isShelfActive = true
+    }
+    await store.receive(\.repositories.selectWorktree) {
+      $0.repositories.selection = .worktree(worktree.id)
+      $0.repositories.openedWorktreeIDs = [worktree.id]
+      $0.repositories.pendingTerminalFocusWorktreeIDs = [worktree.id]
+    }
+    await store.finish()
+  }
+
   @Test(.dependencies) func scenePhaseInactiveSavesLayoutSnapshot() async {
     let sentCommands = LockIsolated<[TerminalClient.Command]>([])
     var settings = SettingsFeature.State()
@@ -350,4 +494,13 @@ private func makePlainRepository() -> Repository {
     kind: .plain,
     worktrees: IdentifiedArray()
   )
+}
+
+private func setDefaultViewMode(_ mode: DefaultViewMode) {
+  @Shared(.settingsFile) var settingsFile
+  $settingsFile.withLock {
+    var updated = $0.global
+    updated.defaultViewMode = mode
+    $0.global = updated
+  }
 }

--- a/supacodeTests/ShelfFeatureTests.swift
+++ b/supacodeTests/ShelfFeatureTests.swift
@@ -809,68 +809,6 @@ struct ShelfFeatureTests {
     await store.finish()
   }
 
-  @Test(.dependencies) func defaultViewShelfPreferenceDispatchesToggleAfterSnapshot() async {
-    let repoRoot = "/tmp/default-shelf-repo"
-    let rootURL = URL(fileURLWithPath: repoRoot)
-    let worktree = Worktree(
-      id: "\(repoRoot)/main",
-      name: "main",
-      detail: "",
-      workingDirectory: URL(fileURLWithPath: "\(repoRoot)/main"),
-      repositoryRootURL: rootURL
-    )
-    let repository = Repository(
-      id: repoRoot,
-      rootURL: rootURL,
-      name: "repo",
-      worktrees: IdentifiedArray(uniqueElements: [worktree])
-    )
-
-    @Shared(.settingsFile) var settingsFile
-    $settingsFile.withLock {
-      var updated = $0.global
-      updated.defaultViewMode = .shelf
-      $0.global = updated
-    }
-    // Restore settings after the test so `@Shared` state doesn't leak
-    // across parallel test runs in the same process.
-    defer {
-      $settingsFile.withLock {
-        var updated = $0.global
-        updated.defaultViewMode = .normal
-        $0.global = updated
-      }
-    }
-
-    // Drive only the reducer action under test, not the full `.task`
-    // flow — the launch pipeline is covered elsewhere. This isolates
-    // the new "default view shelf" hook from unrelated effects and
-    // keeps the assertion surface minimal.
-    var initialState = RepositoriesFeature.State()
-    initialState.lastFocusedWorktreeID = worktree.id
-    initialState.shouldRestoreLastFocusedWorktree = true
-    initialState.snapshotPersistencePhase = .restoring
-    let store = TestStore(initialState: initialState) {
-      RepositoriesFeature()
-    }
-
-    await store.send(.repositorySnapshotLoaded([repository])) {
-      $0.repositories = [repository]
-      $0.repositoryRoots = [rootURL]
-      $0.selection = .worktree(worktree.id)
-      $0.shouldRestoreLastFocusedWorktree = false
-      $0.isInitialLoadComplete = true
-    }
-    await store.receive(\.delegate.repositoriesChanged)
-    await store.receive(\.delegate.selectedWorktreeChanged)
-    await store.receive(\.toggleShelf) {
-      $0.isShelfActive = true
-      $0.openedWorktreeIDs = [worktree.id]
-      $0.pendingTerminalFocusWorktreeIDs = [worktree.id]
-    }
-    await store.finish()
-  }
-
   @Test(.dependencies) func defaultViewShelfDefersDuringLayoutRestore() async {
     // When Layout Restore is active the snapshot-load hook must stay
     // quiet: Layout Restore clears selection and replays tabs, so
@@ -927,67 +865,6 @@ struct ShelfFeatureTests {
     await store.receive(\.delegate.repositoriesChanged)
     await store.receive(\.delegate.selectedWorktreeChanged)
     // No `.toggleShelf` here — the Layout Restore path is responsible.
-    await store.finish()
-  }
-
-  @Test(.dependencies) func defaultViewCanvasPreferenceDispatchesToggleAfterSnapshot() async {
-    let repoRoot = "/tmp/default-canvas-repo"
-    let rootURL = URL(fileURLWithPath: repoRoot)
-    let worktree = Worktree(
-      id: "\(repoRoot)/main",
-      name: "main",
-      detail: "",
-      workingDirectory: URL(fileURLWithPath: "\(repoRoot)/main"),
-      repositoryRootURL: rootURL
-    )
-    let repository = Repository(
-      id: repoRoot,
-      rootURL: rootURL,
-      name: "repo",
-      worktrees: IdentifiedArray(uniqueElements: [worktree])
-    )
-
-    @Shared(.settingsFile) var settingsFile
-    $settingsFile.withLock {
-      var updated = $0.global
-      updated.defaultViewMode = .canvas
-      $0.global = updated
-    }
-    // Restore settings after the test so `@Shared` state doesn't leak
-    // across parallel test runs in the same process.
-    defer {
-      $settingsFile.withLock {
-        var updated = $0.global
-        updated.defaultViewMode = .normal
-        $0.global = updated
-      }
-    }
-
-    var initialState = RepositoriesFeature.State()
-    initialState.lastFocusedWorktreeID = worktree.id
-    initialState.shouldRestoreLastFocusedWorktree = true
-    initialState.snapshotPersistencePhase = .restoring
-    let store = TestStore(initialState: initialState) {
-      RepositoriesFeature()
-    }
-
-    await store.send(.repositorySnapshotLoaded([repository])) {
-      $0.repositories = [repository]
-      $0.repositoryRoots = [rootURL]
-      $0.selection = .worktree(worktree.id)
-      $0.shouldRestoreLastFocusedWorktree = false
-      $0.isInitialLoadComplete = true
-    }
-    await store.receive(\.delegate.repositoriesChanged)
-    await store.receive(\.delegate.selectedWorktreeChanged)
-    // `.toggleCanvas` enters Canvas via `.selectCanvas`, which records the
-    // current worktree as the pre-Canvas anchor before flipping selection.
-    await store.receive(\.toggleCanvas)
-    await store.receive(\.selectCanvas) {
-      $0.preCanvasWorktreeID = worktree.id
-      $0.preCanvasTerminalTargetID = worktree.id
-      $0.selection = .canvas
-    }
     await store.finish()
   }
 

--- a/supacodeTests/WorktreeTerminalManagerTests.swift
+++ b/supacodeTests/WorktreeTerminalManagerTests.swift
@@ -473,6 +473,26 @@ struct WorktreeTerminalManagerTests {
     #expect(event == .layoutRestoreFailed(message: "Saved terminal layout was invalid and has been reset"))
   }
 
+  @Test func restoreLayoutSnapshotEmitsRestoredNilWhenSnapshotMissing() async {
+    let manager = WorktreeTerminalManager(
+      runtime: GhosttyRuntime(),
+      layoutPersistence: TerminalLayoutPersistenceClient(
+        loadSnapshot: { nil },
+        saveSnapshot: { _ in true },
+        clearSnapshot: { true }
+      )
+    )
+    let stream = manager.eventStream()
+
+    await manager.restoreLayoutSnapshot(from: [makeWorktree()])
+
+    let event = await nextEvent(stream) { event in
+      event == .layoutRestored(selectedWorktreeID: nil)
+    }
+
+    #expect(event == .layoutRestored(selectedWorktreeID: nil))
+  }
+
   @Test func persistLayoutSnapshotWithoutTabsClearsSnapshot() async {
     let clearCount = LockIsolated(0)
     let saveCount = LockIsolated(0)


### PR DESCRIPTION
- **WorktreeTerminalManager:** emit `.layoutRestored(nil)` when no snapshot is found on disk, so the restoration phase doesn't stall indefinitely.
- **AppFeature:** centralize default view application into `applyDefaultViewMode`. Apply it from `repositoriesChanged` (after settings and snapshot are reliably loaded) instead of early in `RepositoriesFeature`. Also apply on `layoutRestoreFailed`.
- **RepositoriesFeature:** remove the redundant launch-view logic.