### PR TITLE
fix: decouple agent status from terminal scroll

### DIFF
--- a/supacode/Domain/AgentDetection/PaneAgentState.swift
+++ b/supacode/Domain/AgentDetection/PaneAgentState.swift
@@ -67,31 +67,35 @@ struct AgentDetectionPresence: Equatable, Sendable {
   }
 }
 
-private let claudeWorkingHold: TimeInterval = 1.2
+private let agentWorkingHold: TimeInterval = 1.2
 
 func stabilizeAgentState(
   agent: DetectedAgent?,
+  previousAgent: DetectedAgent? = nil,
   previous: AgentRawState,
   raw: AgentRawState,
   now: Date,
-  lastClaudeWorkingAt: inout Date?
+  lastWorkingAt: inout Date?
 ) -> AgentRawState {
-  guard agent == .claude else {
-    lastClaudeWorkingAt = nil
+  guard let agent else {
+    lastWorkingAt = nil
     return raw
+  }
+  if let previousAgent, previousAgent != agent {
+    lastWorkingAt = nil
   }
 
   switch raw {
   case .working:
-    lastClaudeWorkingAt = now
+    lastWorkingAt = now
     return .working
   case .blocked:
     return .blocked
   case .idle where previous == .working:
-    guard let lastClaudeWorkingAt else {
+    guard let lastWorkingAt else {
       return .idle
     }
-    return now.timeIntervalSince(lastClaudeWorkingAt) < claudeWorkingHold ? .working : .idle
+    return now.timeIntervalSince(lastWorkingAt) < agentWorkingHold ? .working : .idle
   case .idle, .unknown:
     return raw
   }

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -72,7 +72,7 @@ final class WorktreeTerminalState {
   private(set) var surfaceAgentStates: [UUID: PaneAgentState] = [:]
   private var agentDetectionTasks: [UUID: Task<Void, Never>] = [:]
   private var agentDetectionPresenceBySurface: [UUID: AgentDetectionPresence] = [:]
-  private var lastClaudeWorkingAtBySurface: [UUID: Date] = [:]
+  private var lastAgentWorkingAtBySurface: [UUID: Date] = [:]
   private var lastAgentDetectionDiagnosticsBySurface: [UUID: String] = [:]
   private var agentDetectionEnabled = true
   var tabIsRunningById: [TerminalTabID: Bool] = [:]
@@ -1744,25 +1744,26 @@ final class WorktreeTerminalState {
 
     let now = Date()
     let previous = surfaceAgentStates[surfaceID] ?? PaneAgentState(lastChangedAt: now)
-    let activeText = view.bridge.readActiveText() ?? ""
-    // `detectState` is a `nonisolated` pure function that runs in well under a
-    // millisecond on a terminal-sized active screen, so the prior `Task.detached` hop
+    let detectionText = view.bridge.readAgentDetectionText() ?? ""
+    // `detectState` is a `nonisolated` pure function that first trims to the
+    // recent terminal tail, so the prior `Task.detached` hop
     // bought nothing but allocator churn. In long sessions, each detection
     // tick (300 ms or 2 s per surface) was leaving a task stack + closure
     // capture behind that never reached ARC; over a 24 h session this added
     // up to hundreds of MB of unreferenced allocations.
-    let raw = agent.detectState(in: activeText)
+    let raw = agent.detectState(in: detectionText)
     guard surfaces[surfaceID] != nil else { return }
 
-    var lastClaudeWorkingAt = lastClaudeWorkingAtBySurface[surfaceID]
+    var lastAgentWorkingAt = lastAgentWorkingAtBySurface[surfaceID]
     let stabilized = stabilizeAgentState(
       agent: agent,
+      previousAgent: previous.detectedAgent,
       previous: previous.state,
       raw: raw,
       now: now,
-      lastClaudeWorkingAt: &lastClaudeWorkingAt
+      lastWorkingAt: &lastAgentWorkingAt
     )
-    lastClaudeWorkingAtBySurface[surfaceID] = lastClaudeWorkingAt
+    lastAgentWorkingAtBySurface[surfaceID] = lastAgentWorkingAt
 
     let isForeground = isSelected() && isFocusedSurface(surfaceID)
     let becameIdleFromActive =
@@ -1819,7 +1820,7 @@ final class WorktreeTerminalState {
   private func removeAgentEntryIfNeeded(surfaceID: UUID) {
     guard surfaceAgentStates[surfaceID]?.detectedAgent != nil else { return }
     surfaceAgentStates[surfaceID] = PaneAgentState(lastChangedAt: Date())
-    lastClaudeWorkingAtBySurface.removeValue(forKey: surfaceID)
+    lastAgentWorkingAtBySurface.removeValue(forKey: surfaceID)
     onAgentEntryRemoved?(surfaceID)
   }
 
@@ -1864,7 +1865,7 @@ final class WorktreeTerminalState {
     agentDetectionTasks.removeValue(forKey: surfaceId)
     surfaceAgentStates.removeValue(forKey: surfaceId)
     agentDetectionPresenceBySurface.removeValue(forKey: surfaceId)
-    lastClaudeWorkingAtBySurface.removeValue(forKey: surfaceId)
+    lastAgentWorkingAtBySurface.removeValue(forKey: surfaceId)
     lastAgentDetectionDiagnosticsBySurface.removeValue(forKey: surfaceId)
     onAgentEntryRemoved?(surfaceId)
   }
@@ -1877,7 +1878,7 @@ final class WorktreeTerminalState {
     agentDetectionTasks.removeAll()
     surfaceAgentStates.removeAll()
     agentDetectionPresenceBySurface.removeAll()
-    lastClaudeWorkingAtBySurface.removeAll()
+    lastAgentWorkingAtBySurface.removeAll()
     lastAgentDetectionDiagnosticsBySurface.removeAll()
     for id in removedIDs {
       onAgentEntryRemoved?(id)

--- a/supacode/Infrastructure/AgentDetection/ScreenHeuristics.swift
+++ b/supacode/Infrastructure/AgentDetection/ScreenHeuristics.swift
@@ -1,10 +1,10 @@
 import Foundation
 
-nonisolated private let agentDetectionRecentLineLimit = 24
+nonisolated let agentDetectionRecentLineLimit = 24
 
 extension DetectedAgent {
   nonisolated func detectState(in screen: String) -> AgentRawState {
-    let screen = recentLines(screen, limit: agentDetectionRecentLineLimit)
+    let screen = agentDetectionRecentText(screen, limit: agentDetectionRecentLineLimit)
     switch self {
     case .pi:
       return detectPi(screen)
@@ -32,7 +32,7 @@ extension DetectedAgent {
   }
 }
 
-nonisolated private func recentLines(_ content: String, limit: Int) -> String {
+nonisolated func agentDetectionRecentText(_ content: String, limit: Int) -> String {
   let lines = content.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
   var remainingNonBlankLines = limit
   var startIndex = lines.startIndex

--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceBridge.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceBridge.swift
@@ -59,6 +59,11 @@ final class GhosttySurfaceBridge {
     surfaceView?.readActiveContentsForCLI()
   }
 
+  func readAgentDetectionText() -> String? {
+    // Screen text is anchored to the last written row, while active/viewport can vary with user scrolling.
+    surfaceView?.readScreenContentsForCLI() ?? surfaceView?.readActiveContentsForCLI()
+  }
+
   func childPID() -> pid_t? {
     guard let surface else { return nil }
     let pid = ghostty_surface_pid(surface)

--- a/supacodeTests/GhosttySurfaceBridgeTests.swift
+++ b/supacodeTests/GhosttySurfaceBridgeTests.swift
@@ -11,6 +11,12 @@ struct GhosttySurfaceBridgeTests {
     #expect(bridge.readActiveText() == nil)
   }
 
+  @Test func agentDetectionTextReturnsNilWithoutSurfaceView() {
+    let bridge = GhosttySurfaceBridge()
+
+    #expect(bridge.readAgentDetectionText() == nil)
+  }
+
   @Test func desktopNotificationEmitsCallback() {
     let bridge = GhosttySurfaceBridge()
     var received: (String, String)?

--- a/supacodeTests/PaneAgentStateTests.swift
+++ b/supacodeTests/PaneAgentStateTests.swift
@@ -27,7 +27,7 @@ struct PaneAgentStateTests {
       previous: .idle,
       raw: .working,
       now: now,
-      lastClaudeWorkingAt: &lastWorking
+      lastWorkingAt: &lastWorking
     )
     #expect(working == .working)
 
@@ -36,7 +36,7 @@ struct PaneAgentStateTests {
       previous: .working,
       raw: .idle,
       now: now.addingTimeInterval(0.4),
-      lastClaudeWorkingAt: &lastWorking
+      lastWorkingAt: &lastWorking
     )
     #expect(stillWorking == .working)
   }
@@ -50,13 +50,29 @@ struct PaneAgentStateTests {
       previous: .working,
       raw: .idle,
       now: now.addingTimeInterval(1.201),
-      lastClaudeWorkingAt: &lastWorking
+      lastWorkingAt: &lastWorking
     )
 
     #expect(idle == .idle)
   }
 
-  @Test func nonClaudeDoesNotUseStickyWindow() {
+  @Test func codexWorkingIsStickyForShortIdleGap() {
+    let now = Date(timeIntervalSince1970: 100)
+    var lastWorking: Date? = now
+
+    let working = stabilizeAgentState(
+      agent: .codex,
+      previous: .working,
+      raw: .idle,
+      now: now.addingTimeInterval(0.4),
+      lastWorkingAt: &lastWorking
+    )
+
+    #expect(working == .working)
+    #expect(lastWorking == now)
+  }
+
+  @Test func codexTransitionsToIdleAfterStickyWindow() {
     let now = Date(timeIntervalSince1970: 100)
     var lastWorking: Date? = now
 
@@ -64,8 +80,24 @@ struct PaneAgentStateTests {
       agent: .codex,
       previous: .working,
       raw: .idle,
-      now: now,
-      lastClaudeWorkingAt: &lastWorking
+      now: now.addingTimeInterval(1.201),
+      lastWorkingAt: &lastWorking
+    )
+
+    #expect(idle == .idle)
+  }
+
+  @Test func stickyWindowResetsWhenAgentChanges() {
+    let now = Date(timeIntervalSince1970: 100)
+    var lastWorking: Date? = now
+
+    let idle = stabilizeAgentState(
+      agent: .codex,
+      previousAgent: .claude,
+      previous: .working,
+      raw: .idle,
+      now: now.addingTimeInterval(0.4),
+      lastWorkingAt: &lastWorking
     )
 
     #expect(idle == .idle)

--- a/supacodeTests/ScreenHeuristicsTests.swift
+++ b/supacodeTests/ScreenHeuristicsTests.swift
@@ -183,6 +183,14 @@ struct ScreenHeuristicsTests {
     #expect(DetectedAgent.codex.detectState(in: "Ready for input") == .idle)
   }
 
+  @Test func codexDetectionUsesRecentScreenTailWhenScrollbackIsLong() {
+    let screen = ((1...80).map { "historical output \($0)" } + ["• Working (12s)", "esc to interrupt"])
+      .joined(separator: "\n")
+
+    #expect(agentDetectionRecentText(screen, limit: 2) == "• Working (12s)\nesc to interrupt")
+    #expect(DetectedAgent.codex.detectState(in: screen) == .working)
+  }
+
   @Test func geminiDetection() {
     #expect(DetectedAgent.gemini.detectState(in: "│ Apply this change") == .blocked)
     #expect(DetectedAgent.gemini.detectState(in: "esc to cancel") == .working)


### PR DESCRIPTION
## Summary
- Read Active Agents detection text from Ghostty screen contents instead of the scroll-sensitive active/viewport path, with active text as fallback.
- Keep agent state working briefly across transient idle reads for all agents, and reset that sticky window when the detected agent changes.
- Add coverage for long scrollback tail detection and non-Claude sticky transitions.

## Verification
- xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -only-testing:supacodeTests/ScreenHeuristicsTests -only-testing:supacodeTests/PaneAgentStateTests -only-testing:supacodeTests/GhosttySurfaceBridgeTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation
- make build-app
- PATH=""/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin:/Users/luoyangcan/.codex/tmp/arg0/codex-arg0wYkTPD:/opt/homebrew/lib/node_modules/@openai/codex/node_modules/@openai/codex-darwin-arm64/vendor/aarch64-apple-darwin/codex-path:/Users/luoyangcan/.local/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/opt/homebrew/bin:/Applications/Prowl.app/Contents/MacOS" make check
- make test