### PR TITLE
Harden failed worktree cleanup

### DIFF
--- a/supacode/Clients/Git/GitClient.swift
+++ b/supacode/Clients/Git/GitClient.swift
@@ -587,7 +587,14 @@ struct GitClient {
     let rootPath = worktree.repositoryRootURL.path(percentEncoded: false)
     let worktreeURL = worktree.workingDirectory.standardizedFileURL
     let worktreePath = worktreeURL.path(percentEncoded: false)
-    let relocatedURL = Self.relocateWorktreeDirectory(worktreeURL)
+    let registeredWorktreePaths = try await registeredWorktreePaths(rootPath: rootPath)
+    guard registeredWorktreePaths.contains(worktreePath) else {
+      return worktree.workingDirectory
+    }
+    let relocatedURL =
+      Self.worktreeDirectoryHasGitMetadata(worktreeURL)
+      ? Self.relocateWorktreeDirectory(worktreeURL)
+      : nil
     if let relocatedURL {
       do {
         _ = try await runGit(
@@ -618,6 +625,14 @@ struct GitClient {
       )
     }
     return worktree.workingDirectory
+  }
+
+  nonisolated private func registeredWorktreePaths(rootPath: String) async throws -> Set<String> {
+    let output = try await runGit(
+      operation: .worktreeList,
+      arguments: ["-C", rootPath, "worktree", "list", "--porcelain"]
+    )
+    return Self.parseGitWorktreePorcelainPaths(output)
   }
 
   nonisolated func deleteLocalBranch(
@@ -912,6 +927,27 @@ struct GitClient {
       }
     }
     return nil
+  }
+
+  nonisolated private static func worktreeDirectoryHasGitMetadata(_ worktreeURL: URL) -> Bool {
+    let gitMetadataURL = worktreeURL.appending(path: ".git")
+    return FileManager.default.fileExists(atPath: gitMetadataURL.path(percentEncoded: false))
+  }
+
+  nonisolated static func parseGitWorktreePorcelainPaths(_ output: String) -> Set<String> {
+    Set(
+      output
+        .split(whereSeparator: \.isNewline)
+        .compactMap { line -> String? in
+          let prefix = "worktree "
+          guard line.hasPrefix(prefix) else {
+            return nil
+          }
+          return String(line.dropFirst(prefix.count))
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        .filter { !$0.isEmpty }
+    )
   }
 
   nonisolated static func parseRepositoryWebInfo(_ remoteURL: String) -> GitRemoteWebInfo? {

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+WorktreeCreation.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+WorktreeCreation.swift
@@ -626,7 +626,7 @@ extension RepositoriesFeature {
         let repositoryRootURL = cleanupWorktree.repositoryRootURL
         effects.append(
           .run { send in
-            _ = try? await gitClient.removeWorktree(cleanupWorktree, true)
+            _ = try? await gitClient.removeWorktree(cleanupWorktree, false)
             _ = try? await gitClient.pruneWorktrees(repositoryRootURL)
             await send(.reloadRepositories(animated: true))
           }

--- a/supacodeTests/GitClientRemoveWorktreeTests.swift
+++ b/supacodeTests/GitClientRemoveWorktreeTests.swift
@@ -43,7 +43,9 @@ struct GitClientRemoveWorktreeTests {
 
   @Test func removeWorktreeDeletesNonProtectedLocalBranchWhenRequested() async throws {
     let store = ShellCallStore()
-    let worktreePath = "/tmp/repo-feature"
+    let worktreePath = FileManager.default.temporaryDirectory
+      .appending(path: "prowl-repo-feature-\(UUID().uuidString)", directoryHint: .isDirectory)
+      .path(percentEncoded: false)
     let shell = ShellClient(
       run: { _, arguments, _ in
         await store.record(arguments)

--- a/supacodeTests/GitClientRemoveWorktreeTests.swift
+++ b/supacodeTests/GitClientRemoveWorktreeTests.swift
@@ -6,9 +6,14 @@ import Testing
 struct GitClientRemoveWorktreeTests {
   @Test func removeWorktreeDoesNotDeleteMainBranch() async throws {
     let store = ShellCallStore()
+    let worktreePath = "/tmp/repo-main-copy"
     let shell = ShellClient(
       run: { _, arguments, _ in
         await store.record(arguments)
+        if arguments.contains("--porcelain") {
+          return ShellOutput(
+            stdout: "worktree \(worktreePath)\nHEAD abc\nbranch refs/heads/main\n", stderr: "", exitCode: 0)
+        }
         if arguments.contains("for-each-ref") {
           return ShellOutput(stdout: "main\nfeature\n", stderr: "", exitCode: 0)
         }
@@ -18,10 +23,10 @@ struct GitClientRemoveWorktreeTests {
     )
     let client = GitClient(shell: shell)
     let worktree = Worktree(
-      id: "/tmp/repo-main-copy",
+      id: worktreePath,
       name: "main",
       detail: "../repo-main-copy",
-      workingDirectory: URL(fileURLWithPath: "/tmp/repo-main-copy"),
+      workingDirectory: URL(fileURLWithPath: worktreePath),
       repositoryRootURL: URL(fileURLWithPath: "/tmp/repo")
     )
 
@@ -36,9 +41,17 @@ struct GitClientRemoveWorktreeTests {
 
   @Test func removeWorktreeDeletesNonProtectedLocalBranchWhenRequested() async throws {
     let store = ShellCallStore()
+    let worktreePath = "/tmp/repo-feature"
     let shell = ShellClient(
       run: { _, arguments, _ in
         await store.record(arguments)
+        if arguments.contains("--porcelain") {
+          return ShellOutput(
+            stdout: "worktree \(worktreePath)\nHEAD abc\nbranch refs/heads/feature\n",
+            stderr: "",
+            exitCode: 0
+          )
+        }
         if arguments.contains("for-each-ref") {
           return ShellOutput(stdout: "main\nfeature\n", stderr: "", exitCode: 0)
         }
@@ -48,10 +61,10 @@ struct GitClientRemoveWorktreeTests {
     )
     let client = GitClient(shell: shell)
     let worktree = Worktree(
-      id: "/tmp/repo-feature",
+      id: worktreePath,
       name: "feature",
       detail: "../repo-feature",
-      workingDirectory: URL(fileURLWithPath: "/tmp/repo-feature"),
+      workingDirectory: URL(fileURLWithPath: worktreePath),
       repositoryRootURL: URL(fileURLWithPath: "/tmp/repo")
     )
 
@@ -59,6 +72,59 @@ struct GitClientRemoveWorktreeTests {
 
     let calls = await store.calls
     #expect(calls.contains { $0.suffix(3) == ["branch", "-d", "feature"] })
+  }
+
+  @Test func removeWorktreeDoesNotMoveDirectoryWhenPathIsNotRegisteredExactly() async throws {
+    let fileManager = FileManager.default
+    let rootURL = fileManager.temporaryDirectory.appending(
+      path: "prowl-remove-worktree-\(UUID().uuidString)",
+      directoryHint: .isDirectory
+    )
+    let parentURL = rootURL.appending(path: ".worktrees/feat", directoryHint: .isDirectory)
+    let childURL = parentURL.appending(path: "foo", directoryHint: .isDirectory)
+    try fileManager.createDirectory(at: childURL, withIntermediateDirectories: true)
+    try Data("gitdir: ../../.git/worktrees/foo\n".utf8).write(to: childURL.appending(path: ".git"))
+    defer {
+      try? fileManager.removeItem(at: rootURL)
+    }
+
+    let store = ShellCallStore()
+    let shell = ShellClient(
+      run: { _, arguments, _ in
+        await store.record(arguments)
+        if arguments.contains("--porcelain") {
+          return ShellOutput(
+            stdout: "worktree \(childURL.path(percentEncoded: false))\nHEAD abc\nbranch refs/heads/feat/foo\n",
+            stderr: "",
+            exitCode: 0
+          )
+        }
+        if arguments.contains("for-each-ref") {
+          return ShellOutput(stdout: "feat\nfeat/foo\n", stderr: "", exitCode: 0)
+        }
+        return ShellOutput(stdout: "", stderr: "", exitCode: 0)
+      },
+      runLoginImpl: { _, _, _, _ in ShellOutput(stdout: "", stderr: "", exitCode: 0) }
+    )
+    let client = GitClient(shell: shell)
+    let worktree = Worktree(
+      id: parentURL.path(percentEncoded: false),
+      name: "feat",
+      detail: ".worktrees/feat",
+      workingDirectory: parentURL,
+      repositoryRootURL: rootURL
+    )
+
+    _ = try await client.removeWorktree(worktree, deleteBranch: true)
+
+    let parentExists = fileManager.fileExists(atPath: parentURL.path(percentEncoded: false))
+    let childExists = fileManager.fileExists(atPath: childURL.path(percentEncoded: false))
+    #expect(parentExists)
+    #expect(childExists)
+    let calls = await store.calls
+    #expect(!calls.contains { $0.contains("prune") })
+    #expect(!calls.contains { $0.contains("remove") })
+    #expect(!calls.contains { $0.suffix(3) == ["branch", "-d", "feat"] })
   }
 
   @Test func forceDeleteLocalBranchUsesForceFlag() async throws {

--- a/supacodeTests/GitClientRemoveWorktreeTests.swift
+++ b/supacodeTests/GitClientRemoveWorktreeTests.swift
@@ -6,7 +6,9 @@ import Testing
 struct GitClientRemoveWorktreeTests {
   @Test func removeWorktreeDoesNotDeleteMainBranch() async throws {
     let store = ShellCallStore()
-    let worktreePath = "/tmp/repo-main-copy"
+    let worktreePath = FileManager.default.temporaryDirectory
+      .appending(path: "prowl-repo-main-copy-\(UUID().uuidString)", directoryHint: .isDirectory)
+      .path(percentEncoded: false)
     let shell = ShellClient(
       run: { _, arguments, _ in
         await store.record(arguments)

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -2130,7 +2130,7 @@ struct RepositoriesFeatureTests {
       globalDefaultPath: "/tmp/worktrees-changed",
       repositoryOverridePath: nil
     )
-    let removedWorktreePath = LockIsolated<String?>(nil)
+    let removedWorktree = LockIsolated<(path: String, deleteBranch: Bool)?>(nil)
     @Shared(.settingsFile) var settingsFile
     $settingsFile.withLock {
       $0.global.defaultWorktreeBaseDirectoryPath = "/tmp/worktrees-changed"
@@ -2138,9 +2138,11 @@ struct RepositoriesFeatureTests {
     let store = TestStore(initialState: makeState(repositories: [repository])) {
       RepositoriesFeature()
     } withDependencies: {
-      $0.gitClient.removeWorktree = { worktree, _ in
+      $0.gitClient.removeWorktree = { worktree, deleteBranch in
         let workingDirectory = await MainActor.run { worktree.workingDirectory }
-        removedWorktreePath.withValue { $0 = workingDirectory.path(percentEncoded: false) }
+        removedWorktree.withValue {
+          $0 = (workingDirectory.path(percentEncoded: false), deleteBranch)
+        }
         return workingDirectory
       }
       $0.gitClient.pruneWorktrees = { _ in }
@@ -2174,15 +2176,16 @@ struct RepositoriesFeatureTests {
     await store.finish()
 
     #expect(changedBaseDirectory != createTimeBaseDirectory)
-    #expect(removedWorktreePath.value != nil)
+    #expect(removedWorktree.value != nil)
+    #expect(removedWorktree.value?.deleteBranch == false)
     #expect(
-      removedWorktreePath.value
+      removedWorktree.value?.path
         == createTimeBaseDirectory
         .appending(path: "new-branch", directoryHint: .isDirectory)
         .path(percentEncoded: false)
     )
     #expect(
-      removedWorktreePath.value
+      removedWorktree.value?.path
         != changedBaseDirectory
         .appending(path: "new-branch", directoryHint: .isDirectory)
         .path(percentEncoded: false)


### PR DESCRIPTION
## Summary
- require an exact `git worktree list --porcelain` path match before removing or relocating a worktree directory
- only relocate existing worktree directories when they contain `.git` metadata
- stop failed worktree creation cleanup from requesting branch deletion

## Tests
- `make check`
- `xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -only-testing:supacodeTests/GitClientRemoveWorktreeTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation 2>&1 | xcsift -f toon`
- `xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -only-testing:supacodeTests/RepositoriesFeatureTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation 2>&1 | xcsift -f toon`
- `make build-app 2>&1 | xcsift -f toon`
