### PR TITLE
Add `prowl read --wait-stable` and harden the prowl-cli skill

### DIFF
--- a/.agents/skills/prowl-cli
+++ b/.agents/skills/prowl-cli
@@ -1,0 +1,1 @@
+../../skills/prowl-cli

--- a/.claude/skills/prowl-cli
+++ b/.claude/skills/prowl-cli
@@ -1,0 +1,1 @@
+../../skills/prowl-cli

--- a/ProwlCLI/Commands/ReadCommand.swift
+++ b/ProwlCLI/Commands/ReadCommand.swift
@@ -15,6 +15,27 @@ struct ReadCommand: ParsableCommand {
   @Option(name: .long, help: "Number of recent lines to read (omit for snapshot).")
   var last: Int?
 
+  @Flag(name: .long, help: "Re-read the pane until its output stops changing before returning (good for live TUIs).")
+  var waitStable = false
+
+  @Option(
+    name: .long,
+    help: "Sampling interval in milliseconds while waiting for stable output (50–5000, default: 200)."
+  )
+  var stableInterval: Int?
+
+  @Option(
+    name: .long,
+    help: "Output must stay unchanged for this many milliseconds to count as stable (100–60000, default: 800)."
+  )
+  var stablePeriod: Int?
+
+  @Option(
+    name: .long,
+    help: "Maximum seconds to keep waiting for stable output (1–300, default: 10)."
+  )
+  var waitTimeout: Int?
+
   @Argument(help: "Target pane/tab UUID or worktree id/name/path (auto-resolved).")
   var target: String?
 
@@ -29,11 +50,51 @@ struct ReadCommand: ParsableCommand {
         )
       }
 
+      try validateStabilityOptions()
+
       let envelope = CommandEnvelope(
         output: options.outputMode,
-        command: .read(ReadInput(selector: sel, last: last))
+        command: .read(ReadInput(
+          selector: sel,
+          last: last,
+          waitStable: waitStable,
+          stableIntervalMs: stableInterval,
+          stablePeriodMs: stablePeriod,
+          waitTimeoutSeconds: waitTimeout
+        ))
       )
       try CLIRunner.execute(envelope)
+    }
+  }
+
+  /// Stability tuning options only apply together with `--wait-stable`; validate ranges up front.
+  private func validateStabilityOptions() throws {
+    if !waitStable, stableInterval != nil || stablePeriod != nil || waitTimeout != nil {
+      throw ExitError(
+        code: CLIErrorCode.invalidArgument,
+        message: "--stable-interval/--stable-period/--wait-timeout require --wait-stable."
+      )
+    }
+
+    if let stableInterval, stableInterval < 50 || stableInterval > 5000 {
+      throw ExitError(
+        code: CLIErrorCode.invalidArgument,
+        message: "--stable-interval must be between 50 and 5000 milliseconds."
+      )
+    }
+
+    if let stablePeriod, stablePeriod < 100 || stablePeriod > 60000 {
+      throw ExitError(
+        code: CLIErrorCode.invalidArgument,
+        message: "--stable-period must be between 100 and 60000 milliseconds."
+      )
+    }
+
+    if let waitTimeout, waitTimeout < 1 || waitTimeout > 300 {
+      throw ExitError(
+        code: CLIErrorCode.invalidArgument,
+        message: "--wait-timeout must be between 1 and 300 seconds."
+      )
     }
   }
 }

--- a/ProwlCLI/Output/OutputRenderer.swift
+++ b/ProwlCLI/Output/OutputRenderer.swift
@@ -314,6 +314,15 @@ enum OutputRenderer {
       + "  \("lines:".dim) \(payload.lineCount)"
     )
 
+    if let stabilized = payload.stabilized {
+      let stableLabel = stabilized ? "yes".green : "timed out".yellow
+      lines.append(
+        "  \("stable:".dim) \(stableLabel)"
+        + "  \("waited:".dim) \(formatDurationMs(payload.waitedMs ?? 0))"
+        + "  \("samples:".dim) \(payload.samples ?? 0)"
+      )
+    }
+
     if let cwd = pane.cwd {
       lines.append("  \("cwd:".dim) \(cwd)")
     }

--- a/ProwlCLITests/ProwlCLIIntegrationTests.swift
+++ b/ProwlCLITests/ProwlCLIIntegrationTests.swift
@@ -1166,6 +1166,58 @@ final class ProwlCLIIntegrationTests: XCTestCase {
     XCTAssertTrue(result.stdout.contains("a\nb\nc"), "Missing text body: \(result.stdout)")
   }
 
+  func testReadWaitStablePassesOptionsToEnvelope() throws {
+    let socketPath = temporarySocketPath(suffix: "read-wait-stable")
+    let response = CommandResponse(
+      ok: true,
+      command: "read",
+      schemaVersion: "prowl.cli.read.v1"
+    )
+
+    let (requestData, result) = try runWithMockServer(
+      socketPath: socketPath,
+      response: response,
+      args: [
+        "read", "--wait-stable",
+        "--stable-interval", "150",
+        "--stable-period", "600",
+        "--wait-timeout", "5",
+        "--json",
+      ]
+    )
+
+    XCTAssertEqual(result.exitCode, 0)
+    let envelope = try JSONDecoder().decode(CommandEnvelope.self, from: requestData)
+    if case .read(let input) = envelope.command {
+      XCTAssertTrue(input.waitStable)
+      XCTAssertEqual(input.stableIntervalMs, 150)
+      XCTAssertEqual(input.stablePeriodMs, 600)
+      XCTAssertEqual(input.waitTimeoutSeconds, 5)
+    } else {
+      XCTFail("Expected read command envelope")
+    }
+  }
+
+  func testReadStabilityOptionsRequireWaitStable() throws {
+    let result = try runProwl(args: ["read", "--stable-interval", "150", "--json"])
+
+    XCTAssertNotEqual(result.exitCode, 0)
+    let payload = try jsonObject(from: result.stdout)
+    XCTAssertEqual(payload["ok"] as? Bool, false)
+    let error = try XCTUnwrap(payload["error"] as? [String: Any])
+    XCTAssertEqual(error["code"] as? String, CLIErrorCode.invalidArgument)
+  }
+
+  func testReadWaitStableRejectsOutOfRangeInterval() throws {
+    let result = try runProwl(args: ["read", "--wait-stable", "--stable-interval", "10", "--json"])
+
+    XCTAssertNotEqual(result.exitCode, 0)
+    let payload = try jsonObject(from: result.stdout)
+    XCTAssertEqual(payload["ok"] as? Bool, false)
+    let error = try XCTUnwrap(payload["error"] as? [String: Any])
+    XCTAssertEqual(error["code"] as? String, CLIErrorCode.invalidArgument)
+  }
+
   // MARK: - Helpers
 
   private func runWithMockServer(

--- a/skills/prowl-cli/SKILL.md
+++ b/skills/prowl-cli/SKILL.md
@@ -13,6 +13,8 @@ Do not use it just because the current shell happens to be inside a Prowl reposi
 
 If your own session was launched from a Prowl terminal, then **one of the panes `prowl list` returns is you.** `prowl list` does not exclude the caller. Acting on your own pane is self-harm: `prowl key --pane <self> esc` (or `ctrl-c`) interrupts or kills *your own* current request, and `send` injects into your own prompt.
 
+**Worse: omitting `--target`/`--pane` makes `send`/`key` default to the _focused_ pane — which is usually you.** A bare `prowl send 'x'` types into your own prompt; a bare `prowl key ctrl-c` aborts your own request. Always pass an explicit `--pane`.
+
 **Before any `send`, `key`, or `focus`, identify your own pane and never target it:**
 
 ```bash
@@ -71,11 +73,27 @@ Focus a pane:
 prowl focus --pane <pane-id> --json
 ```
 
-Open a path in Prowl:
+Open a path in Prowl. **Side effect:** this *always creates a new tab + pane* for the path — even a non-git path like `/tmp` (`created_tab: true`) — and brings the app to front. To re-focus an already-open worktree without spawning a tab, use `focus`, not `open`:
 
 ```bash
 prowl open /path/to/repo --json
 ```
+
+## `send` / `key` argument shapes
+
+Positional arguments are **position-sensitive** — the count changes their meaning:
+
+| command | 0 args | 1 arg | 2 args |
+|---|---|---|---|
+| `send` | text from **stdin** | text → **current** pane | `<target> <text>` |
+| `key`  | error (`INVALID_ARGUMENT`) | token → **current** pane | `<target> <token>` |
+
+"current pane" = the focused pane = **usually yourself**, so always prefer the explicit `--pane <id>` form over a positional target.
+
+- `key --repeat <1-100>` repeats the token, e.g. `prowl key --pane <id> down --repeat 10` (out-of-range → `INVALID_REPEAT`).
+- `send --no-enter` sends text without a trailing Enter (key Enter yourself later).
+- `send --capture` requires waiting *and* a trailing Enter; it diffs the screen before/after the command, so it **cannot** combine with `--no-wait` or `--no-enter` (either → `INVALID_ARGUMENT`).
+- Don't mix stdin piping and a positional text arg (→ `INVALID_ARGUMENT`).
 
 ## Finding Pane IDs
 
@@ -160,7 +178,9 @@ Two reliable ways to get the **final** output:
    ```
 
    The JSON gains `stabilized` (true = settled, false = hit the timeout),
-   `waited_ms`, and `samples`. Prefer this over manual `sleep`-then-`read`.
+   `waited_ms`, and `samples`. Prefer this over manual `sleep`-then-`read`. The
+   `--stable-*` options only work **with** `--wait-stable` — passing them alone
+   returns `INVALID_ARGUMENT`.
 
    Note this still only sees the rendered buffer, so content Claude Code has
    **folded** (`⎿ … +N lines (ctrl+o to expand)`) is never captured no matter
@@ -194,13 +214,21 @@ printf '%s\n' 'echo first' 'echo second' | prowl send --pane <pane-id> --no-wait
 
 ## Error Handling
 
+In `--json` mode, command-level errors come back as `{ "ok": false, "error": { "code", "message" } }`. Common codes:
+
 - `APP_NOT_RUNNING`: Prowl is not running, or its CLI service is unavailable. Ask the user before restarting Prowl.
-- `TARGET_NOT_FOUND` / `TARGET_NOT_UNIQUE`: run `prowl list --json` again and resolve an explicit pane UUID.
-- `WAIT_TIMEOUT`: retry with `--no-wait`, or use a pane with shell integration for `--capture`.
-- `UNSUPPORTED_KEY`: inspect `prowl key --help`; use canonical tokens such as `enter`, `esc`, `tab`, `up`, `down`, `ctrl-c`, `cmd-k`, or `f1`.
+- `TARGET_NOT_FOUND` / `TARGET_NOT_UNIQUE`: re-run `prowl list --json` and resolve an explicit pane UUID (the error does **not** enumerate the candidates).
+- `EMPTY_INPUT`: `send` got no text (no argument and no stdin).
+- `INVALID_ARGUMENT`: bad flag value or illegal combo (e.g. `--capture` with `--no-wait`, `--stable-*` without `--wait-stable`, `--last 0`).
+- `PATH_NOT_FOUND` / `PATH_NOT_DIRECTORY` / `PATH_NOT_ALLOWED`: `open` path problems.
+- `UNSUPPORTED_KEY` / `INVALID_REPEAT`: bad key token or out-of-range `--repeat`; see `prowl key --help`. Canonical tokens: `enter`, `esc`, `tab`, `up`, `down`, `ctrl-c`, `cmd-k`, `f1`, …
+- `WAIT_TIMEOUT`: `send` waited but the command never reported completion — retry with `--no-wait`, or use a shell-integrated pane for `--capture`.
+
+> ⚠️ **Not every failure is JSON.** Argument-*parsing* errors (unknown flag, wrong type such as `read --last abc`) are caught by the parser *before* `--json` takes effect: they print a plaintext usage error to **stderr** and exit non-zero. A `| jq …` pipeline will choke on these. Get flag names/types right, and always check the exit code rather than assuming stdout is JSON.
 
 ## Notes
 
-- JSON output is the automation surface; text output is for humans.
+- JSON output is the automation surface; text output is for humans. JSON keys are snake_case (`line_count`, `waited_ms`, `created_tab`, `trailing_enter_sent`, …) — match them exactly in `jq` or you'll silently get `null`.
+- `--no-color` is global (works on every command) and safe in automation.
 - `-t/--target` auto-resolves pane UUID, tab UUID, or worktree id/name/path, but explicit `--pane` is safer for automation.
-- Future Prowl versions may add commands such as `prowl action`, `prowl tab`, or `prowl pane`. Check `prowl --help` before using commands not listed here.
+- The current commands are `list`, `read`, `send`, `key`, `focus`, and `open` (the default). There is **no close/quit command** — you cannot close a tab/pane via the CLI (send `cmd-w` as a key if you must). Run `prowl --help` to confirm the command set before automating.

--- a/skills/prowl-cli/SKILL.md
+++ b/skills/prowl-cli/SKILL.md
@@ -132,6 +132,50 @@ prowl list --json | jq -r '
 '
 ```
 
+### `idle` does not mean the output finished rendering
+
+`task.status: idle` means the agent's model generation ended — **not** that the
+terminal has finished painting its reply. Claude Code's TUI repaints a long
+markdown answer line by line, and that rendering lags well behind `idle`. So
+reading a pane the instant it goes `idle` (or after a fixed `sleep`) routinely
+catches a half-drawn screen: the visible buffer stops mid-answer with the input
+prompt `❯` right under it. (Measured: at `idle` only the first ~2 of 6 sections
+had rendered; 10s later it still had not finished.) `--last` size does not fix
+this — the rest of the answer is not in the buffer yet.
+
+Two reliable ways to get the **final** output:
+
+1. **`prowl read --wait-stable`** — re-reads the pane on an interval until its
+   content stops changing, then returns the settled snapshot:
+
+   ```bash
+   # bare: 200ms sampling / settle after 800ms quiet / 10s cap
+   prowl read --pane <pane-id> --last 200 --wait-stable --json
+
+   # tuned
+   prowl read --pane <pane-id> --wait-stable \
+     --stable-interval 200 \   # sample every 200ms
+     --stable-period 800 \     # content must hold steady 800ms to count as stable
+     --wait-timeout 10 --json  # give up after 10s, return latest anyway
+   ```
+
+   The JSON gains `stabilized` (true = settled, false = hit the timeout),
+   `waited_ms`, and `samples`. Prefer this over manual `sleep`-then-`read`.
+
+   Note this still only sees the rendered buffer, so content Claude Code has
+   **folded** (`⎿ … +N lines (ctrl+o to expand)`) is never captured no matter
+   how stable it is.
+
+2. **Have the agent write its result to a file**, then read the file. This
+   bypasses both async rendering and folding, so it is the most robust when you
+   need the complete answer:
+
+   ```bash
+   prowl send --pane <pane-id> 'summarize … and write it to /tmp/out.md' --no-wait
+   # … wait for idle … then:
+   cat /tmp/out.md
+   ```
+
 ## Quoting
 
 Protect commands from the local shell when they should expand inside the target pane:

--- a/skills/prowl-cli/SKILL.md
+++ b/skills/prowl-cli/SKILL.md
@@ -9,27 +9,34 @@ Use `prowl` when the user explicitly wants to inspect or control Prowl: reading 
 
 Do not use it just because the current shell happens to be inside a Prowl repository. It is a remote-control interface for the running Prowl GUI app.
 
-## ⚠️ You are probably running *inside* one of these panes
+## ⚠️ Resolve the target by UUID — and know which pane is *you*
 
-If your own session was launched from a Prowl terminal, then **one of the panes `prowl list` returns is you.** `prowl list` does not exclude the caller. Acting on your own pane is self-harm: `prowl key --pane <self> esc` (or `ctrl-c`) interrupts or kills *your own* current request, and `send` injects into your own prompt.
+Targeting is the #1 source of mistakes. Two rules apply to **every** command:
 
-**Worse: omitting `--target`/`--pane` makes `send`/`key` default to the _focused_ pane — which is usually you.** A bare `prowl send 'x'` types into your own prompt; a bare `prowl key ctrl-c` aborts your own request. Always pass an explicit `--pane`.
+**1. Resolve the target from `prowl list --json` by UUID — never from the tab title.**
+A pane's tab *title* is free-form and will lie: a tab titled "UniWebView" can actually have `cwd` `/some/other/repo`. Decide the target from `pane.id` (UUID), `worktree.path`, `cwd`, and the `focused` flag — not the title — then pass the explicit `--pane <id>`.
 
-**Before any `send`, `key`, or `focus`, identify your own pane and never target it:**
+**2. Know which pane is yourself, because one of them usually is.**
+If your session was launched from a Prowl terminal, `prowl list` includes your own pane (it does not exclude the caller). Your own pane is the `focused` one, with `cwd` matching your `$PWD`:
 
 ```bash
-# Your own pane = the focused one (and its cwd matches your $PWD).
 echo "$PWD"
 prowl list --json | jq -r '.data.items[] | select(.pane.focused == true) | .pane.id'
 ```
 
-Danger signs that a pane you are reading **is yourself**: its content is your own conversation transcript, or it shows a prompt identical to the one you are currently executing. A pane's *tab title* can say anything (e.g. "UniWebView") while its real `cwd` is somewhere else — trust `cwd` and the focused flag, not the title.
+Operating on yourself is **not forbidden** — plenty of self-actions are legitimate: `read` (grab your own scrollback), `focus` (raise the window when a long job finishes), `key cmd-k` (clear), or `send --no-enter` (pre-fill a command for the user to review). What you must avoid is *accidentally* hitting yourself with an **interrupting** action:
 
-To run an agent "over in project X", do **not** reuse a same-looking existing pane. Open a fresh one and confirm its id differs from your own:
+- `key esc` / `ctrl-c` on yourself aborts your own current request.
+- `send` *with* a trailing Enter on yourself submits a prompt to yourself — this is how runaway self-recursion starts.
+- **Omitting `--target`/`--pane` defaults to the focused pane — usually you.** So a bare `prowl send 'x'` or `prowl key ctrl-c` lands on yourself. Always pass an explicit `--pane`.
+
+Danger signs that a pane you're reading **is yourself**: its content is your own transcript, or a prompt identical to the one you're currently running.
+
+To run an agent "over in project X", don't reuse a same-looking existing pane — open a fresh one and confirm its id differs from your own:
 
 ```bash
 prowl open /path/to/project-X --json   # returns a brand-new pane id
-# verify: the returned .data.target.pane.id != your own focused pane id
+# verify: .data.target.pane.id != your own focused pane id
 ```
 
 ## Core Workflow

--- a/skills/prowl-cli/SKILL.md
+++ b/skills/prowl-cli/SKILL.md
@@ -14,7 +14,7 @@ Do not use it just because the current shell happens to be inside a Prowl reposi
 Targeting is the #1 source of mistakes. Two rules apply to **every** command:
 
 **1. Resolve the target from `prowl list --json` by UUID — never from the tab title.**
-A pane's tab *title* is free-form and will lie: a tab titled "UniWebView" can actually have `cwd` `/some/other/repo`. Decide the target from `pane.id` (UUID), `worktree.path`, `cwd`, and the `focused` flag — not the title — then pass the explicit `--pane <id>`.
+A pane's tab *title* is free-form and will lie: a tab titled "MyGreateProject" can actually have `cwd` `/some/other/repo`. Decide the target from `pane.id` (UUID), `worktree.path`, `cwd`, and the `focused` flag — not only the title — then pass the explicit `--pane <id>`.
 
 **2. Know which pane is yourself, because one of them usually is.**
 If your session was launched from a Prowl terminal, `prowl list` includes your own pane (it does not exclude the caller). Your own pane is the `focused` one, with `cwd` matching your `$PWD`:

--- a/supacode/CLIService/ReadCommandHandler.swift
+++ b/supacode/CLIService/ReadCommandHandler.swift
@@ -54,16 +54,18 @@ final class ReadCommandHandler: CommandHandler {
 
   private let resolveProvider: ResolveProvider
   private let captureProvider: CaptureProvider
+  private let clock: any Clock<Duration>
 
   init(
     resolveProvider: @escaping ResolveProvider,
-    captureProvider: @escaping CaptureProvider
+    captureProvider: @escaping CaptureProvider,
+    clock: any Clock<Duration> = ContinuousClock()
   ) {
     self.resolveProvider = resolveProvider
     self.captureProvider = captureProvider
+    self.clock = clock
   }
 
-  // swiftlint:disable:next async_without_await
   func handle(envelope: CommandEnvelope) async -> CommandResponse {
     guard case .read(let input) = envelope.command else {
       return errorResponse(code: CLIErrorCode.readFailed, message: "Invalid command.")
@@ -77,23 +79,26 @@ final class ReadCommandHandler: CommandHandler {
       return mapResolverError(error)
     }
 
-    guard let captureInput = captureProvider(target) else {
-      return errorResponse(code: CLIErrorCode.readFailed, message: "Failed to read terminal text.")
-    }
-
     let capture: ReadCapture
-    if let last = input.last {
-      capture = captureLast(
-        requestedLineCount: last,
-        viewportText: captureInput.viewportText,
-        screenText: captureInput.screenText
-      )
+    let stabilized: Bool?
+    let waitedMs: Int?
+    let samples: Int?
+    if input.waitStable {
+      guard let result = await pollUntilStable(target: target, input: input) else {
+        return errorResponse(code: CLIErrorCode.readFailed, message: "Failed to read terminal text.")
+      }
+      capture = result.capture
+      stabilized = result.stabilized
+      waitedMs = result.waitedMs
+      samples = result.samples
     } else {
-      capture = ReadCapture(
-        text: captureInput.viewportText,
-        source: .screen,
-        truncated: false
-      )
+      guard let single = makeCapture(target: target, last: input.last) else {
+        return errorResponse(code: CLIErrorCode.readFailed, message: "Failed to read terminal text.")
+      }
+      capture = single
+      stabilized = nil
+      waitedMs = nil
+      samples = nil
     }
 
     let payload = ReadCommandPayload(
@@ -103,7 +108,10 @@ final class ReadCommandHandler: CommandHandler {
       source: capture.source,
       truncated: capture.truncated,
       lineCount: lineCount(in: capture.text),
-      text: capture.text
+      text: capture.text,
+      stabilized: stabilized,
+      waitedMs: waitedMs,
+      samples: samples
     )
 
     do {
@@ -116,6 +124,91 @@ final class ReadCommandHandler: CommandHandler {
     } catch {
       return errorResponse(code: CLIErrorCode.readFailed, message: "Failed to encode response.")
     }
+  }
+
+  private struct StableResult {
+    let capture: ReadCapture
+    let stabilized: Bool
+    let waitedMs: Int
+    let samples: Int
+  }
+
+  /// Default stability tuning, applied when the request omits the corresponding value.
+  private enum StabilityDefaults {
+    static let intervalMs = 200
+    static let periodMs = 800
+    static let timeoutSeconds = 10
+  }
+
+  /// Capture the pane's current content, applying `--last` line selection when requested.
+  private func makeCapture(target: ReadResolvedTarget, last: Int?) -> ReadCapture? {
+    guard let captureInput = captureProvider(target) else { return nil }
+    if let last {
+      return captureLast(
+        requestedLineCount: last,
+        viewportText: captureInput.viewportText,
+        screenText: captureInput.screenText
+      )
+    }
+    return ReadCapture(
+      text: captureInput.viewportText,
+      source: .screen,
+      truncated: false
+    )
+  }
+
+  /// Re-read the pane on a fixed interval until its content stops changing for a streak of
+  /// consecutive samples (≈ `period`), or until the timeout caps the total number of samples.
+  /// Returns the latest capture either way, flagging whether it actually stabilized.
+  private func pollUntilStable(target: ReadResolvedTarget, input: ReadInput) async -> StableResult? {
+    let intervalMs = input.stableIntervalMs ?? StabilityDefaults.intervalMs
+    let periodMs = input.stablePeriodMs ?? StabilityDefaults.periodMs
+    let timeoutMs = (input.waitTimeoutSeconds ?? StabilityDefaults.timeoutSeconds) * 1000
+    let interval = Duration.milliseconds(intervalMs)
+
+    // Consecutive unchanged samples that together cover `period`, and the hard cap from `timeout`.
+    let requiredStreak = max(1, Int((Double(periodMs) / Double(intervalMs)).rounded(.up)))
+    let maxSleeps = max(1, Int((Double(timeoutMs) / Double(intervalMs)).rounded(.up)))
+
+    guard var current = makeCapture(target: target, last: input.last) else { return nil }
+    var streak = 0
+    var samples = 1
+    var sleeps = 0
+    var stabilized = false
+
+    while true {
+      if streak >= requiredStreak {
+        stabilized = true
+        break
+      }
+      if sleeps >= maxSleeps {
+        stabilized = false
+        break
+      }
+      do {
+        try await clock.sleep(for: interval)
+      } catch {
+        break  // Cancelled: return the best capture so far.
+      }
+      sleeps += 1
+      guard let next = makeCapture(target: target, last: input.last) else {
+        break  // Capture became unavailable mid-poll (e.g. pane closed): stop with what we have.
+      }
+      samples += 1
+      if next.text == current.text {
+        streak += 1
+      } else {
+        current = next
+        streak = 0
+      }
+    }
+
+    return StableResult(
+      capture: current,
+      stabilized: stabilized,
+      waitedMs: sleeps * intervalMs,
+      samples: samples
+    )
   }
 
   private func captureLast(

--- a/supacode/CLIService/Shared/InputModels.swift
+++ b/supacode/CLIService/Shared/InputModels.swift
@@ -108,9 +108,28 @@ public struct KeyInput: Codable, Sendable {
 public struct ReadInput: Codable, Sendable {
   public let selector: TargetSelector
   public let last: Int?
+  /// When true, the app re-reads the pane until its output stops changing before responding.
+  public let waitStable: Bool
+  /// Sampling interval in milliseconds while waiting for stable output (nil → app default).
+  public let stableIntervalMs: Int?
+  /// Output must stay unchanged for this many milliseconds to count as stable (nil → app default).
+  public let stablePeriodMs: Int?
+  /// Maximum seconds to keep waiting for stable output before returning the latest snapshot (nil → app default).
+  public let waitTimeoutSeconds: Int?
 
-  public init(selector: TargetSelector = .none, last: Int? = nil) {
+  public init(
+    selector: TargetSelector = .none,
+    last: Int? = nil,
+    waitStable: Bool = false,
+    stableIntervalMs: Int? = nil,
+    stablePeriodMs: Int? = nil,
+    waitTimeoutSeconds: Int? = nil
+  ) {
     self.selector = selector
     self.last = last
+    self.waitStable = waitStable
+    self.stableIntervalMs = stableIntervalMs
+    self.stablePeriodMs = stablePeriodMs
+    self.waitTimeoutSeconds = waitTimeoutSeconds
   }
 }

--- a/supacode/CLIService/Shared/ReadCommandPayload.swift
+++ b/supacode/CLIService/Shared/ReadCommandPayload.swift
@@ -11,6 +11,12 @@ public struct ReadCommandPayload: Codable, Sendable, Equatable {
   public let truncated: Bool
   public let lineCount: Int
   public let text: String
+  /// Whether `--wait-stable` observed the output settle (true) or hit the timeout (false). Nil when not waiting.
+  public let stabilized: Bool?
+  /// Total milliseconds spent waiting for stable output. Nil when not waiting.
+  public let waitedMs: Int?
+  /// Number of samples taken while waiting for stable output. Nil when not waiting.
+  public let samples: Int?
 
   enum CodingKeys: String, CodingKey {
     case target
@@ -20,6 +26,9 @@ public struct ReadCommandPayload: Codable, Sendable, Equatable {
     case truncated
     case lineCount = "line_count"
     case text
+    case stabilized
+    case waitedMs = "waited_ms"
+    case samples
   }
 
   public init(
@@ -29,7 +38,10 @@ public struct ReadCommandPayload: Codable, Sendable, Equatable {
     source: ReadSource,
     truncated: Bool,
     lineCount: Int,
-    text: String
+    text: String,
+    stabilized: Bool? = nil,
+    waitedMs: Int? = nil,
+    samples: Int? = nil
   ) {
     self.target = target
     self.mode = mode
@@ -38,6 +50,9 @@ public struct ReadCommandPayload: Codable, Sendable, Equatable {
     self.truncated = truncated
     self.lineCount = lineCount
     self.text = text
+    self.stabilized = stabilized
+    self.waitedMs = waitedMs
+    self.samples = samples
   }
 }
 

--- a/supacodeTests/CLIReadCommandHandlerTests.swift
+++ b/supacodeTests/CLIReadCommandHandlerTests.swift
@@ -1,3 +1,4 @@
+import Clocks
 import Foundation
 import Testing
 
@@ -239,5 +240,142 @@ struct CLIReadCommandHandlerTests {
 
     #expect(response.ok == false)
     #expect(response.error?.code == CLIErrorCode.readFailed)
+  }
+
+  // MARK: - Wait-for-stable polling
+
+  @Test func waitStableReturnsWhenOutputSettles() async throws {
+    let clock = TestClock()
+    let capture = CaptureSequence(["ready"])
+    let handler = ReadCommandHandler(
+      resolveProvider: { _ in .success(Self.makeTarget()) },
+      captureProvider: { _ in capture.next() },
+      clock: clock
+    )
+
+    let task = Task {
+      await handler.handle(
+        envelope: Self.makeWaitStableEnvelope(intervalMs: 100, periodMs: 300, timeoutSeconds: 1)
+      )
+    }
+    await Self.drive(clock, steps: 15)
+    let response = await task.value
+
+    #expect(response.ok)
+    let payload = try #require(try response.data?.decode(as: ReadCommandPayload.self))
+    #expect(payload.text == "ready")
+    #expect(payload.stabilized == true)
+    // 1 initial sample + 3 consecutive unchanged samples to cover the 300ms / 100ms streak.
+    #expect(payload.samples == 4)
+    #expect(payload.waitedMs == 300)
+  }
+
+  @Test func waitStableReturnsLatestContentAfterChanges() async throws {
+    let clock = TestClock()
+    let capture = CaptureSequence(["a", "ab", "abc"])
+    let handler = ReadCommandHandler(
+      resolveProvider: { _ in .success(Self.makeTarget()) },
+      captureProvider: { _ in capture.next() },
+      clock: clock
+    )
+
+    let task = Task {
+      await handler.handle(
+        envelope: Self.makeWaitStableEnvelope(intervalMs: 100, periodMs: 300, timeoutSeconds: 1)
+      )
+    }
+    await Self.drive(clock, steps: 15)
+    let response = await task.value
+
+    #expect(response.ok)
+    let payload = try #require(try response.data?.decode(as: ReadCommandPayload.self))
+    #expect(payload.text == "abc")
+    #expect(payload.stabilized == true)
+  }
+
+  @Test func waitStableTimesOutWhenOutputKeepsChanging() async throws {
+    let clock = TestClock()
+    let counter = Counter()
+    let handler = ReadCommandHandler(
+      resolveProvider: { _ in .success(Self.makeTarget()) },
+      captureProvider: { _ in
+        ReadCaptureInput(viewportText: "v\(counter.bump())", screenText: nil)
+      },
+      clock: clock
+    )
+
+    let task = Task {
+      await handler.handle(
+        envelope: Self.makeWaitStableEnvelope(intervalMs: 100, periodMs: 300, timeoutSeconds: 1)
+      )
+    }
+    await Self.drive(clock, steps: 15)
+    let response = await task.value
+
+    #expect(response.ok)
+    let payload = try #require(try response.data?.decode(as: ReadCommandPayload.self))
+    #expect(payload.stabilized == false)
+    // timeout 1000ms / 100ms interval = 10 sleeps, plus the initial sample.
+    #expect(payload.samples == 11)
+    #expect(payload.waitedMs == 1000)
+    #expect(payload.text == "v11")
+  }
+
+  // MARK: - Wait-for-stable helpers
+
+  private static func makeWaitStableEnvelope(
+    last: Int? = nil,
+    intervalMs: Int,
+    periodMs: Int,
+    timeoutSeconds: Int
+  ) -> CommandEnvelope {
+    CommandEnvelope(
+      output: .json,
+      command: .read(
+        ReadInput(
+          selector: .none,
+          last: last,
+          waitStable: true,
+          stableIntervalMs: intervalMs,
+          stablePeriodMs: periodMs,
+          waitTimeoutSeconds: timeoutSeconds
+        ))
+    )
+  }
+
+  /// Yield to let the handler reach its first sleep, then advance the test clock one interval at a
+  /// time so each `clock.sleep(for:)` wakes and the poll loop makes progress.
+  private static func drive(_ clock: TestClock<Duration>, steps: Int) async {
+    await Task.yield()
+    for _ in 0..<steps {
+      await clock.advance(by: .milliseconds(100))
+      await Task.yield()
+    }
+  }
+
+  @MainActor
+  private final class CaptureSequence {
+    private let values: [String]
+    private var index = 0
+
+    init(_ values: [String]) {
+      self.values = values
+    }
+
+    func next() -> ReadCaptureInput {
+      let text = values[Swift.min(index, values.count - 1)]
+      index += 1
+      return ReadCaptureInput(viewportText: text, screenText: nil)
+    }
+  }
+
+  @MainActor
+  private final class Counter {
+    private var value = 0
+
+    func bump() -> Int {
+      value += 1
+      return value
+    }
   }
 }


### PR DESCRIPTION
This started as a single feature and grew into a broader prowl-cli pass while I verified it end-to-end. Four commits:

## 1. `prowl read --wait-stable` (feature)

`task.status: idle` reflects when an agent's generation ends — **not** when its TUI finished painting the reply. Reading at idle (or after a fixed `sleep`) routinely catches a half-rendered screen. Verified empirically: at the `idle` instant only ~2 of 6 sections had rendered; `--wait-stable` then waited 6.4s / 33 samples for it to settle.

```bash
prowl read --pane <id> --last 200 --wait-stable --json
prowl read --pane <id> --wait-stable \
  --stable-interval 200 --stable-period 800 --wait-timeout 10 --json
```

- App-side polling in `ReadCommandHandler` (single round-trip; CLI only forwards flags). Stability = a streak of unchanged samples (`⌈period/interval⌉`), capped by `⌈timeout/interval⌉`.
- Injectable `clock` (defaults to `ContinuousClock`) → driven by `TestClock` in tests, no real sleeping.
- Response gains `stabilized` / `waited_ms` / `samples` (Optional, `encodeIfPresent` → non-wait responses unchanged).
- Range validation: interval 50–5000ms, period 100–60000ms, timeout 1–300s; `--stable-*` require `--wait-stable`.
- **Caveat documented in the skill**: this still only sees the rendered buffer, so Claude Code's folded `⎿ +N lines` is never captured — for the complete answer, have the agent write to a file.

## 2. Harden the skill with sharp edges found while testing

Exercised every subcommand and folded the findings into `skills/prowl-cli/SKILL.md`:
- omitting `--target`/`--pane` defaults to the focused (= your own) pane;
- `send`/`key` 0/1/2 positional argument shapes; `key --repeat`; `--capture` combo constraints;
- `open` always creates a new tab+pane (even non-git paths) — use `focus` to re-focus;
- expanded error-code list (`EMPTY_INPUT`, `INVALID_ARGUMENT`, `PATH_NOT_*`, `INVALID_REPEAT`) and a warning that ArgumentParser parse errors print plaintext (not JSON), so `jq` pipelines must check the exit code;
- snake_case jq-key reminder; note there is no close/quit command.

## 3. Reframe the self-pane guidance

Replaced the blanket "never target your own pane" with two general rules: resolve the target by UUID/`cwd`/`focused` (never the free-form tab title), and know which pane is yourself — self-actions like `read`/`focus`/`cmd-k`/`send --no-enter` are legitimate; only *accidental* interrupting actions (esc/ctrl-c, send-with-Enter, omitting `--target`) are the footgun.

## 4. Track skill-discovery symlinks

`.claude/skills/` is version-controlled, but prowl-cli was only committed as `skills/prowl-cli/` — a fresh clone couldn't discover it the way other skills are. Added the relative discovery symlinks (`.claude/skills/prowl-cli`, `.agents/skills/prowl-cli`).

## Tests / verification

`make build-cli` / `test-cli-smoke` / `test-cli-integration` (43 pass) / `build-app` (0 errors) / `make check`, plus `CLIReadCommandHandlerTests` TestClock cases, **and real-machine A/B** against a live agent pane (idle-immediate read truncated at 46 lines vs `--wait-stable` settled at 56).
