### PR TITLE
Add active agent tab title display setting

### DIFF
--- a/supacode/Features/ActiveAgents/Views/ActiveAgentRow.swift
+++ b/supacode/Features/ActiveAgents/Views/ActiveAgentRow.swift
@@ -4,7 +4,7 @@ import SwiftUI
 struct ActiveAgentRow: View {
   let entry: ActiveAgentEntry
   let repositoryName: String
-  let branchName: String
+  let subtitle: String
   let repositoryColor: RepositoryColorChoice?
   let isDimmed: Bool
   @Environment(\.accessibilityReduceMotion) private var reduceMotion
@@ -14,10 +14,11 @@ struct ActiveAgentRow: View {
       agentIcon
       VStack(alignment: .leading, spacing: 2) {
         title
-        Text(branchName)
+        Text(subtitle)
           .font(.caption)
           .foregroundStyle(.secondary)
           .lineLimit(1)
+          .truncationMode(.tail)
       }
       Spacer(minLength: 8)
       statusPill

--- a/supacode/Features/ActiveAgents/Views/ActiveAgentsPanel.swift
+++ b/supacode/Features/ActiveAgents/Views/ActiveAgentsPanel.swift
@@ -11,6 +11,7 @@ struct ActiveAgentsPanel: View {
   /// Merged "⌥⌃↑↓" hint shown while Cmd is held; `nil` hides it (bindings customized
   /// or Cmd not held). Resolved by the parent so the panel stays presentational.
   let navigationShortcutHint: String?
+  let showTabTitles: Bool
   let height: Double
   let maximumHeight: Double
   let onHeightChanged: (Double) -> Void
@@ -54,7 +55,7 @@ struct ActiveAgentsPanel: View {
                 ActiveAgentRow(
                   entry: entry,
                   repositoryName: repositoryName(for: entry),
-                  branchName: branchName(for: entry),
+                  subtitle: subtitle(for: entry),
                   repositoryColor: repositoryColor(for: entry),
                   isDimmed: isDimmed(entry)
                 )
@@ -128,6 +129,14 @@ struct ActiveAgentsPanel: View {
     rowDisplays[entry.id]?.branchName ?? entry.worktreeName
   }
 
+  private func subtitle(for entry: ActiveAgentEntry) -> String {
+    Self.subtitle(
+      for: entry,
+      branchName: branchName(for: entry),
+      showTabTitles: showTabTitles
+    )
+  }
+
   private func repositoryColor(for entry: ActiveAgentEntry) -> RepositoryColorChoice? {
     rowDisplays[entry.id]?.color
   }
@@ -145,6 +154,30 @@ struct ActiveAgentsPanel: View {
   }
 
   private func helpText(for entry: ActiveAgentEntry) -> String {
+    Self.helpText(
+      for: entry,
+      branchName: branchName(for: entry),
+      showTabTitles: showTabTitles
+    )
+  }
+
+  static func subtitle(
+    for entry: ActiveAgentEntry,
+    branchName: String,
+    showTabTitles: Bool
+  ) -> String {
+    showTabTitles ? tabTitle(for: entry) : branchName
+  }
+
+  static func helpText(
+    for entry: ActiveAgentEntry,
+    branchName: String,
+    showTabTitles: Bool
+  ) -> String {
+    showTabTitles ? branchName : tabTitle(for: entry)
+  }
+
+  static func tabTitle(for entry: ActiveAgentEntry) -> String {
     let trimmed = entry.tabTitle.trimmingCharacters(in: .whitespacesAndNewlines)
     return trimmed.isEmpty ? "Untitled tab" : trimmed
   }

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -69,6 +69,8 @@ struct AppFeature {
       repositories: RepositoriesFeature.State = .init(),
       settings: SettingsFeature.State = .init()
     ) {
+      var repositories = repositories
+      repositories.showActiveAgentTabTitles = settings.showActiveAgentTabTitles
       self.repositories = repositories
       self.settings = settings
       lastKnownSystemNotificationsEnabled = settings.systemNotificationsEnabled
@@ -622,6 +624,7 @@ struct AppFeature {
           settings.systemNotificationsEnabled && !state.lastKnownSystemNotificationsEnabled
         state.lastKnownSystemNotificationsEnabled = settings.systemNotificationsEnabled
         state.settings.keybindingUserOverrides = settings.keybindingUserOverrides
+        state.repositories.showActiveAgentTabTitles = settings.showActiveAgentTabTitles
         let agentDetectionEnabled = ActiveAgentsFeature.detectionEnabled(
           isPanelHidden: state.repositories.activeAgents.isPanelHidden,
           autoShowPanel: settings.autoShowActiveAgentsPanel

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -274,6 +274,7 @@ struct RepositoriesFeature {
     var pendingRenameBranchRequest: PendingRenameBranchRequest?
     var isSidebarDragActive = false
     var pendingSidebarNotifyReorderIDs: [Worktree.ID] = []
+    var showActiveAgentTabTitles = false
     var activeAgents = ActiveAgentsFeature.State()
     @Shared(.appStorage("sidebarCollapsedRepositoryIDs")) var collapsedRepositoryIDs: [Repository.ID] = []
     @Presents var worktreeCreationPrompt: WorktreeCreationPromptFeature.State?

--- a/supacode/Features/Repositories/Views/SidebarListView.swift
+++ b/supacode/Features/Repositories/Views/SidebarListView.swift
@@ -160,6 +160,7 @@ struct SidebarListView: View {
           rowDisplays: agentRowDisplays,
           selectedSurfaceID: selectedSurfaceID,
           navigationShortcutHint: activeAgentsShortcutHint,
+          showTabTitles: state.showActiveAgentTabTitles,
           height: panelHeight,
           maximumHeight: maximumPanelHeight,
           onHeightChanged: { height in

--- a/supacode/Features/Settings/Models/GlobalSettings.swift
+++ b/supacode/Features/Settings/Models/GlobalSettings.swift
@@ -29,6 +29,7 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
   var defaultViewMode: DefaultViewMode
   var dimUnfocusedSplits: Bool
   var autoShowActiveAgentsPanel: Bool
+  var showActiveAgentTabTitles: Bool
   var windowTintMode: WindowTintMode
   var windowTintCustomColor: TintColor
   var showRunButtonInToolbar: Bool
@@ -69,6 +70,7 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     defaultViewMode: .normal,
     dimUnfocusedSplits: true,
     autoShowActiveAgentsPanel: false,
+    showActiveAgentTabTitles: false,
     windowTintMode: .repositoryColor,
     windowTintCustomColor: .default,
     showRunButtonInToolbar: true,
@@ -110,6 +112,7 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     defaultViewMode: DefaultViewMode = .normal,
     dimUnfocusedSplits: Bool = true,
     autoShowActiveAgentsPanel: Bool = false,
+    showActiveAgentTabTitles: Bool = false,
     windowTintMode: WindowTintMode = .repositoryColor,
     windowTintCustomColor: TintColor = .default,
     showRunButtonInToolbar: Bool = true,
@@ -149,6 +152,7 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     self.defaultViewMode = defaultViewMode
     self.dimUnfocusedSplits = dimUnfocusedSplits
     self.autoShowActiveAgentsPanel = autoShowActiveAgentsPanel
+    self.showActiveAgentTabTitles = showActiveAgentTabTitles
     self.windowTintMode = windowTintMode
     self.windowTintCustomColor = windowTintCustomColor
     self.showRunButtonInToolbar = showRunButtonInToolbar
@@ -191,6 +195,7 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     try container.encode(defaultViewMode, forKey: .defaultViewMode)
     try container.encode(dimUnfocusedSplits, forKey: .dimUnfocusedSplits)
     try container.encode(autoShowActiveAgentsPanel, forKey: .autoShowActiveAgentsPanel)
+    try container.encode(showActiveAgentTabTitles, forKey: .showActiveAgentTabTitles)
     try container.encode(windowTintMode, forKey: .windowTintMode)
     try container.encode(windowTintCustomColor, forKey: .windowTintCustomColor)
     try container.encode(showRunButtonInToolbar, forKey: .showRunButtonInToolbar)
@@ -232,6 +237,7 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     case defaultViewMode
     case dimUnfocusedSplits
     case autoShowActiveAgentsPanel
+    case showActiveAgentTabTitles
     case windowTintMode
     case windowTintCustomColor
     case showRunButtonInToolbar
@@ -330,6 +336,9 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     autoShowActiveAgentsPanel =
       try container.decodeIfPresent(Bool.self, forKey: .autoShowActiveAgentsPanel)
       ?? Self.default.autoShowActiveAgentsPanel
+    showActiveAgentTabTitles =
+      try container.decodeIfPresent(Bool.self, forKey: .showActiveAgentTabTitles)
+      ?? Self.default.showActiveAgentTabTitles
     (windowTintMode, windowTintCustomColor) = try Self.decodeWindowTint(from: container)
     (shelfSpineTintFallback, shelfSpineTintFollowsRepositoryColor) = try Self.decodeShelfSpineTint(from: container)
     let toolbarAndDock = try Self.decodeToolbarAndDockSettings(from: container)

--- a/supacode/Features/Settings/Reducer/SettingsFeature.swift
+++ b/supacode/Features/Settings/Reducer/SettingsFeature.swift
@@ -36,6 +36,7 @@ struct SettingsFeature {
     var defaultViewMode: DefaultViewMode
     var dimUnfocusedSplits: Bool
     var autoShowActiveAgentsPanel: Bool
+    var showActiveAgentTabTitles: Bool
     var windowTintMode: WindowTintMode
     var shelfSpineTintFallback: ShelfSpineTintFallback
     var shelfSpineTintFollowsRepositoryColor: Bool
@@ -90,6 +91,7 @@ struct SettingsFeature {
       defaultViewMode = settings.defaultViewMode
       dimUnfocusedSplits = settings.dimUnfocusedSplits
       autoShowActiveAgentsPanel = settings.autoShowActiveAgentsPanel
+      showActiveAgentTabTitles = settings.showActiveAgentTabTitles
       windowTintMode = settings.windowTintMode
       shelfSpineTintFallback = settings.shelfSpineTintFallback
       shelfSpineTintFollowsRepositoryColor = settings.shelfSpineTintFollowsRepositoryColor
@@ -134,6 +136,7 @@ struct SettingsFeature {
         defaultViewMode: defaultViewMode,
         dimUnfocusedSplits: dimUnfocusedSplits,
         autoShowActiveAgentsPanel: autoShowActiveAgentsPanel,
+        showActiveAgentTabTitles: showActiveAgentTabTitles,
         windowTintMode: windowTintMode,
         windowTintCustomColor: TintColor(windowTintCustomColor),
         showRunButtonInToolbar: showRunButtonInToolbar,
@@ -246,6 +249,7 @@ struct SettingsFeature {
         state.defaultViewMode = normalizedSettings.defaultViewMode
         state.dimUnfocusedSplits = normalizedSettings.dimUnfocusedSplits
         state.autoShowActiveAgentsPanel = normalizedSettings.autoShowActiveAgentsPanel
+        state.showActiveAgentTabTitles = normalizedSettings.showActiveAgentTabTitles
         state.windowTintMode = normalizedSettings.windowTintMode
         state.shelfSpineTintFallback = normalizedSettings.shelfSpineTintFallback
         state.shelfSpineTintFollowsRepositoryColor = normalizedSettings.shelfSpineTintFollowsRepositoryColor

--- a/supacode/Features/Settings/Views/AppearanceSettingsView.swift
+++ b/supacode/Features/Settings/Views/AppearanceSettingsView.swift
@@ -93,9 +93,14 @@ struct AppearanceSettingsView: View {
             isOn: $store.autoShowActiveAgentsPanel
           )
           .help("Open the Active Agents panel when an agent is detected.")
-          Text("When enabled, hidden panels reopen as soon as an agent starts or updates.")
+          Text("Hidden panels reopen as soon as an agent starts or updates.")
             .foregroundStyle(.secondary)
             .font(.callout)
+          Toggle(
+            "Show tab titles in agent rows",
+            isOn: $store.showActiveAgentTabTitles
+          )
+          .help("Display each agent's tab title in the row and show the branch name on hover.")
         }
         Section("Default View") {
           Picker("Launch in", selection: $store.defaultViewMode) {

--- a/supacode/Features/Terminal/Models/TerminalTabManager.swift
+++ b/supacode/Features/Terminal/Models/TerminalTabManager.swift
@@ -31,17 +31,28 @@ final class TerminalTabManager {
     selectedTabId = id
   }
 
-  func updateTitle(_ id: TerminalTabID, title: String) {
-    guard let index = tabs.firstIndex(where: { $0.id == id }) else { return }
-    guard !tabs[index].isTitleLocked else { return }
+  /// Updates the live shell title. Returns `true` when the visible
+  /// `displayTitle` actually changed (a custom title masks live updates),
+  /// so callers can refresh derived UI like the Active Agents subtitle.
+  @discardableResult
+  func updateTitle(_ id: TerminalTabID, title: String) -> Bool {
+    guard let index = tabs.firstIndex(where: { $0.id == id }) else { return false }
+    guard !tabs[index].isTitleLocked else { return false }
+    let previousDisplayTitle = tabs[index].displayTitle
     tabs[index].title = title
+    return tabs[index].displayTitle != previousDisplayTitle
   }
 
-  func setCustomTitle(_ id: TerminalTabID, title: String) {
-    guard let index = tabs.firstIndex(where: { $0.id == id }) else { return }
-    guard !tabs[index].isTitleLocked else { return }
+  /// Sets (or clears, when blank) the user-defined title. Returns `true` when
+  /// the visible `displayTitle` actually changed.
+  @discardableResult
+  func setCustomTitle(_ id: TerminalTabID, title: String) -> Bool {
+    guard let index = tabs.firstIndex(where: { $0.id == id }) else { return false }
+    guard !tabs[index].isTitleLocked else { return false }
+    let previousDisplayTitle = tabs[index].displayTitle
     let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
     tabs[index].customTitle = trimmed.isEmpty ? nil : trimmed
+    return tabs[index].displayTitle != previousDisplayTitle
   }
 
   func beginTabRename(_ id: TerminalTabID) {

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -1220,7 +1220,9 @@ final class WorktreeTerminalState {
     view.bridge.onTitleChange = { [weak self, weak view] title in
       guard let self, let view else { return }
       if self.focusedSurfaceIdByTab[tabId] == view.id {
-        self.tabManager.updateTitle(tabId, title: title)
+        if self.tabManager.updateTitle(tabId, title: title) {
+          self.refreshAgentEntriesForTitleChange(in: tabId)
+        }
       }
       self.noteTitleForCommandDetection(title, surfaceId: view.id, tabId: tabId)
     }
@@ -1425,7 +1427,9 @@ final class WorktreeTerminalState {
         guard response == .alertFirstButtonReturn else { return }
         guard let self else { return }
         let newTitle = textField.stringValue
-        self.tabManager.setCustomTitle(tabId, title: newTitle)
+        if self.tabManager.setCustomTitle(tabId, title: newTitle) {
+          self.refreshAgentEntriesForTitleChange(in: tabId)
+        }
       }
     }
   }
@@ -1435,7 +1439,9 @@ final class WorktreeTerminalState {
       let surface = surfaces[focusedId],
       let title = surface.bridge.state.title
     else { return }
-    tabManager.updateTitle(tabId, title: title)
+    if tabManager.updateTitle(tabId, title: title) {
+      refreshAgentEntriesForTitleChange(in: tabId)
+    }
   }
 
   private func focusSurface(in tabId: TerminalTabID) {
@@ -1821,6 +1827,21 @@ final class WorktreeTerminalState {
     surfaceAgentStates[surfaceID] = PaneAgentState(lastChangedAt: Date())
     lastClaudeWorkingAtBySurface.removeValue(forKey: surfaceID)
     onAgentEntryRemoved?(surfaceID)
+  }
+
+  /// Re-emit Active Agents entries for every pane in `tabId` so the panel picks
+  /// up a fresh tab-title snapshot. Title changes (OSC-2, focus sync, manual
+  /// rename) don't move agent detection state, so without this nudge the
+  /// subtitle only refreshes on the next agent state transition.
+  private func refreshAgentEntriesForTitleChange(in tabId: TerminalTabID) {
+    let surfaceIDs = trees[tabId]?.leaves().map(\.id) ?? []
+    for surfaceID in surfaceIDs {
+      guard let state = surfaceAgentStates[surfaceID],
+        state.detectedAgent != nil,
+        state.state != .unknown
+      else { continue }
+      emitAgentEntry(surfaceID: surfaceID, tabId: tabId, state: state)
+    }
   }
 
   private func emitAgentEntry(surfaceID: UUID, tabId: TerminalTabID, state: PaneAgentState) {

--- a/supacodeTests/ActiveAgentsFeatureTests.swift
+++ b/supacodeTests/ActiveAgentsFeatureTests.swift
@@ -157,6 +157,33 @@ struct ActiveAgentsFeatureTests {
     }
   }
 
+  @Test func panelSubtitleAndHelpSwapTabTitleAndBranchWhenEnabled() {
+    let entry = entry(id: UUID(0), tabTitle: "Review issue 385", state: .idle, changedAt: Date())
+
+    #expect(
+      ActiveAgentsPanel.subtitle(for: entry, branchName: "main", showTabTitles: false)
+        == "main"
+    )
+    #expect(
+      ActiveAgentsPanel.helpText(for: entry, branchName: "main", showTabTitles: false)
+        == "Review issue 385"
+    )
+    #expect(
+      ActiveAgentsPanel.subtitle(for: entry, branchName: "main", showTabTitles: true)
+        == "Review issue 385"
+    )
+    #expect(
+      ActiveAgentsPanel.helpText(for: entry, branchName: "main", showTabTitles: true)
+        == "main"
+    )
+  }
+
+  @Test func panelTabTitleFallsBackForEmptyTitles() {
+    let entry = entry(id: UUID(0), tabTitle: "   ", state: .idle, changedAt: Date())
+
+    #expect(ActiveAgentsPanel.tabTitle(for: entry) == "Untitled tab")
+  }
+
   private func sampleEntries() -> IdentifiedArrayOf<ActiveAgentEntry> {
     let now = Date(timeIntervalSince1970: 10)
     return [
@@ -166,14 +193,19 @@ struct ActiveAgentsFeatureTests {
     ]
   }
 
-  private func entry(id: UUID, state: AgentDisplayState, changedAt: Date) -> ActiveAgentEntry {
+  private func entry(
+    id: UUID,
+    tabTitle: String = "1",
+    state: AgentDisplayState,
+    changedAt: Date
+  ) -> ActiveAgentEntry {
     ActiveAgentEntry(
       id: id,
       worktreeID: "/repo/wt",
       worktreeName: "wt",
       workingDirectory: nil,
       tabID: TerminalTabID(rawValue: UUID()),
-      tabTitle: "1",
+      tabTitle: tabTitle,
       surfaceID: id,
       paneIndex: 1,
       agent: .codex,

--- a/supacodeTests/AppFeatureSettingsChangedTests.swift
+++ b/supacodeTests/AppFeatureSettingsChangedTests.swift
@@ -17,11 +17,14 @@ struct AppFeatureSettingsChangedTests {
     settings.githubIntegrationEnabled = false
     settings.mergedWorktreeAction = .archive
     settings.moveNotifiedWorktreeToTop = false
+    settings.showActiveAgentTabTitles = true
     let store = TestStore(initialState: AppFeature.State()) {
       AppFeature()
     }
 
-    await store.send(.settings(.delegate(.settingsChanged(settings))))
+    await store.send(.settings(.delegate(.settingsChanged(settings)))) {
+      $0.repositories.showActiveAgentTabTitles = true
+    }
     await store.receive(\.repositories.githubIntegration.setGithubIntegrationEnabled) {
       $0.repositories.githubIntegrationAvailability = .disabled
     }

--- a/supacodeTests/AppFeatureSettingsChangedTests.swift
+++ b/supacodeTests/AppFeatureSettingsChangedTests.swift
@@ -99,6 +99,15 @@ struct AppFeatureSettingsChangedTests {
     }
   }
 
+  @Test func appStateInitializesActiveAgentTabTitleDisplayFromSettings() {
+    var settings = SettingsFeature.State()
+    settings.showActiveAgentTabTitles = true
+
+    let state = AppFeature.State(settings: settings)
+
+    #expect(state.repositories.showActiveAgentTabTitles == true)
+  }
+
   @Test(.dependencies) func settingsChangedRecomputesResolvedKeybindings() async {
     var settings = GlobalSettings.default
     settings.keybindingUserOverrides = KeybindingUserOverrideStore(

--- a/supacodeTests/SettingsFeatureTests.swift
+++ b/supacodeTests/SettingsFeatureTests.swift
@@ -395,6 +395,24 @@ struct SettingsFeatureTests {
     #expect(settingsFile.global.autoShowActiveAgentsPanel == true)
   }
 
+  @Test(.dependencies) func showActiveAgentTabTitlesPersistsChanges() async {
+    var initialSettings = GlobalSettings.default
+    initialSettings.showActiveAgentTabTitles = false
+    @Shared(.settingsFile) var settingsFile
+    $settingsFile.withLock { $0.global = initialSettings }
+
+    let store = TestStore(initialState: SettingsFeature.State(settings: initialSettings)) {
+      SettingsFeature()
+    }
+
+    await store.send(.binding(.set(\.showActiveAgentTabTitles, true))) {
+      $0.showActiveAgentTabTitles = true
+    }
+    await store.receive(\.delegate.settingsChanged)
+
+    #expect(settingsFile.global.showActiveAgentTabTitles == true)
+  }
+
   @Test(.dependencies) func disablingAnalyticsResetsClient() async {
     var initialSettings = GlobalSettings.default
     initialSettings.analyticsEnabled = true

--- a/supacodeTests/TerminalTabManagerTests.swift
+++ b/supacodeTests/TerminalTabManagerTests.swift
@@ -28,6 +28,42 @@ struct TerminalTabManagerTests {
     #expect(manager.tabs.first?.displayTitle == "npm test")
   }
 
+  @Test func updateTitleReportsDisplayTitleChange() {
+    let manager = TerminalTabManager()
+    let tabId = manager.createTab(title: "shell", icon: nil)
+
+    #expect(manager.updateTitle(tabId, title: "npm test") == true)
+    #expect(manager.updateTitle(tabId, title: "npm test") == false)
+  }
+
+  @Test func updateTitleReportsNoChangeWhenMaskedByCustomTitle() {
+    let manager = TerminalTabManager()
+    let tabId = manager.createTab(title: "shell", icon: nil)
+    manager.setCustomTitle(tabId, title: "build")
+
+    // Live title moves but the custom title still masks the visible display.
+    #expect(manager.updateTitle(tabId, title: "npm test") == false)
+    #expect(manager.tabs.first?.displayTitle == "build")
+  }
+
+  @Test func updateTitleReportsNoChangeForLockedTab() {
+    let manager = TerminalTabManager()
+    let tabId = manager.createTab(title: "RUN SCRIPT", icon: "play.fill", isTitleLocked: true)
+
+    #expect(manager.updateTitle(tabId, title: "npm run dev") == false)
+  }
+
+  @Test func setCustomTitleReportsDisplayTitleChange() {
+    let manager = TerminalTabManager()
+    let tabId = manager.createTab(title: "shell", icon: nil)
+
+    #expect(manager.setCustomTitle(tabId, title: "build") == true)
+    #expect(manager.setCustomTitle(tabId, title: "build") == false)
+    // Clearing the custom title restores the live title, another visible change.
+    #expect(manager.setCustomTitle(tabId, title: "   ") == true)
+    #expect(manager.tabs.first?.displayTitle == "shell")
+  }
+
   @Test func customTitleIgnoresLockedTabs() {
     let manager = TerminalTabManager()
     let tabId = manager.createTab(title: "RUN SCRIPT", icon: "play.fill", isTitleLocked: true)


### PR DESCRIPTION
## Summary

- add a persisted Active Agents setting for showing tab titles in agent rows
- keep the default branch-row display unchanged, and swap row subtitle/tooltip when the setting is enabled
- add coverage for settings persistence, app state initialization, and row subtitle/help text behavior

## Validation

- `xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -only-testing:supacodeTests/SettingsFeatureTests -only-testing:supacodeTests/AppFeatureSettingsChangedTests -only-testing:supacodeTests/ActiveAgentsFeatureTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation 2>&1 | xcsift -f toon -w`
- `make check`

Refs #385
