### PR TITLE
Fix Prowl CLI socket ownership

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,16 @@ run-app: build-app # Build then launch (Debug) with log streaming
 		echo "error: failed to resolve app path from build settings"; \
 		exit 1; \
 	fi; \
-	"$$build_dir/$$product/Contents/MacOS/$$exec_name"
+	app_path="$$build_dir/$$product/Contents/MacOS/$$exec_name"; \
+	if [ "$${ALLOW_MULTIPLE_PROWL:-0}" != "1" ]; then \
+		existing_pid="$$(ps -axww -o pid= -o command= | awk '$$2 ~ /\/Prowl\.app\/Contents\/MacOS\/ProwlApp$$/ { print $$1; exit }')"; \
+		if [ -n "$$existing_pid" ]; then \
+			echo "error: another Prowl app instance is already running (pid $$existing_pid). Quit it before make run-app."; \
+			echo "       Direct debug launches share app state and the CLI socket. Set ALLOW_MULTIPLE_PROWL=1 only if you need a second GUI instance."; \
+			exit 1; \
+		fi; \
+	fi; \
+	"$$app_path"
 
 install-dev-build: build-app # install dev build to /Applications
 	@set -euo pipefail; \

--- a/ProwlCLI/AppLauncher.swift
+++ b/ProwlCLI/AppLauncher.swift
@@ -2,13 +2,15 @@
 // Launches Prowl.app when CLI detects the app is not running, then waits
 // for the CLI socket to become available.
 
-#if canImport(Darwin)
-import Darwin
-#elseif canImport(Glibc)
-import Glibc
-#endif
+import AppKit
 import Foundation
 import ProwlCLIShared
+
+#if canImport(Darwin)
+  import Darwin
+#elseif canImport(Glibc)
+  import Glibc
+#endif
 
 enum AppLauncher {
   /// Maximum time to wait for the socket after launching the app.
@@ -29,7 +31,7 @@ enum AppLauncher {
   static func ensureAppRunning() throws -> Bool {
     // If a custom socket path is set, skip auto-launch entirely.
     if let override = ProcessInfo.processInfo.environment[ProwlSocket.environmentKey],
-       !override.isEmpty
+      !override.isEmpty
     {
       return false
     }
@@ -54,20 +56,11 @@ enum AppLauncher {
 
   // MARK: - Process detection
 
-  /// Check whether a Prowl process is currently running via `pgrep`.
+  /// Check whether a Prowl app instance is currently running.
   private static func isAppProcessRunning() -> Bool {
-    let process = Process()
-    process.executableURL = URL(fileURLWithPath: "/usr/bin/pgrep")
-    process.arguments = ["-x", "Prowl"]
-    process.standardOutput = FileHandle.nullDevice
-    process.standardError = FileHandle.nullDevice
-    do {
-      try process.run()
-      process.waitUntilExit()
-    } catch {
-      return false
+    NSWorkspace.shared.runningApplications.contains { application in
+      application.bundleIdentifier == "com.onevcat.prowl"
     }
-    return process.terminationStatus == 0
   }
 
   // MARK: - App launch
@@ -98,7 +91,7 @@ enum AppLauncher {
   private static func launchArguments() -> [String] {
     var args = ["-a", "Prowl"]
     if let openPath = ProcessInfo.processInfo.environment[ProwlSocket.cliOpenPathEnvironmentKey],
-       !openPath.isEmpty
+      !openPath.isEmpty
     {
       args.append(contentsOf: ["--args", ProwlSocket.cliOpenPathArgument, openPath])
     }

--- a/supacode/CLIService/CLISocketServer.swift
+++ b/supacode/CLIService/CLISocketServer.swift
@@ -61,6 +61,14 @@ final class CLISocketServer {
       releaseSocketLock()
       throw CLIServiceError.socketCreationFailed
     }
+    do {
+      try Self.setCloseOnExec(serverFD)
+    } catch {
+      close(serverFD)
+      serverFD = -1
+      releaseSocketLock()
+      throw CLIServiceError.socketCreationFailed
+    }
 
     // Bind
     let bindResult = withUnsafePointer(to: &addr) { ptr in
@@ -115,6 +123,12 @@ final class CLISocketServer {
     guard lockFD < 0 else { return }
     lockFD = open(lockPath, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR)
     guard lockFD >= 0 else {
+      throw CLIServiceError.lockFailed
+    }
+    do {
+      try Self.setCloseOnExec(lockFD)
+    } catch {
+      releaseSocketLock()
       throw CLIServiceError.lockFailed
     }
     guard flock(lockFD, LOCK_EX | LOCK_NB) == 0 else {
@@ -214,6 +228,16 @@ final class CLISocketServer {
     }
   }
 
+  private static func setCloseOnExec(_ fileDescriptor: Int32) throws {
+    let flags = fcntl(fileDescriptor, F_GETFD)
+    guard flags >= 0 else {
+      throw CLIServiceError.closeOnExecFailed
+    }
+    guard fcntl(fileDescriptor, F_SETFD, flags | FD_CLOEXEC) == 0 else {
+      throw CLIServiceError.closeOnExecFailed
+    }
+  }
+
   private static func canConnect(to socketPath: String) -> Bool {
     let socketFD = socket(AF_UNIX, SOCK_STREAM, 0)
     guard socketFD >= 0 else { return false }
@@ -246,6 +270,12 @@ final class CLISocketServer {
     }
     return addr
   }
+
+  #if DEBUG
+    var debugFileDescriptors: (server: Int32, lock: Int32) {
+      (serverFD, lockFD)
+    }
+  #endif
 }
 
 // MARK: - Errors
@@ -255,6 +285,7 @@ enum CLIServiceError: Error, Equatable {
   case socketPathTooLong
   case socketAlreadyOwned
   case lockFailed
+  case closeOnExecFailed
   case bindFailed
   case listenFailed
   case readFailed

--- a/supacode/CLIService/CLISocketServer.swift
+++ b/supacode/CLIService/CLISocketServer.swift
@@ -13,13 +13,20 @@ import Foundation
 final class CLISocketServer {
   private let router: CLICommandRouter
   private let socketPath: String
+  private let lockPath: String
   private var serverFD: Int32 = -1
+  private var lockFD: Int32 = -1
+  private var ownsSocket = false
   private var isRunning = false
-  private let acceptQueue = DispatchQueue(label: "com.onevcat.prowl.cli-accept", qos: .userInitiated)
+  private let acceptQueue = DispatchQueue(
+    label: "com.onevcat.prowl.cli-accept", qos: .userInitiated)
 
-  init(router: CLICommandRouter, socketPath: String = ProwlSocket.defaultPath) {
+  init(
+    router: CLICommandRouter, socketPath: String = ProwlSocket.defaultPath, lockPath: String? = nil
+  ) {
     self.router = router
     self.socketPath = socketPath
+    self.lockPath = lockPath ?? "\(socketPath).lock"
   }
 
   /// Start listening for CLI connections.
@@ -31,28 +38,31 @@ final class CLISocketServer {
       withIntermediateDirectories: true
     )
 
-    // Clean up stale socket file
+    var addr = try Self.socketAddress(for: socketPath)
+
+    try acquireSocketLock()
+    do {
+      // A reachable socket belongs to an already-running app, including older
+      // builds that do not hold the lock. Never unlink a live owner.
+      guard !Self.canConnect(to: socketPath) else {
+        throw CLIServiceError.socketAlreadyOwned
+      }
+    } catch {
+      releaseSocketLock()
+      throw error
+    }
+
+    // Clean up stale socket files only while holding the lock.
     unlink(socketPath)
 
     // Create socket
     serverFD = socket(AF_UNIX, SOCK_STREAM, 0)
     guard serverFD >= 0 else {
+      releaseSocketLock()
       throw CLIServiceError.socketCreationFailed
     }
 
     // Bind
-    var addr = sockaddr_un()
-    addr.sun_family = sa_family_t(AF_UNIX)
-    let pathBytes = Array(socketPath.utf8)
-    let maxLen = MemoryLayout.size(ofValue: addr.sun_path) - 1
-    let copyLen = min(pathBytes.count, maxLen)
-    withUnsafeMutableBytes(of: &addr.sun_path) { sunPathPtr in
-      for idx in 0..<copyLen {
-        sunPathPtr[idx] = pathBytes[idx]
-      }
-      sunPathPtr[copyLen] = 0
-    }
-
     let bindResult = withUnsafePointer(to: &addr) { ptr in
       ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockPtr in
         bind(serverFD, sockPtr, socklen_t(MemoryLayout<sockaddr_un>.size))
@@ -61,16 +71,22 @@ final class CLISocketServer {
 
     guard bindResult == 0 else {
       close(serverFD)
+      serverFD = -1
+      releaseSocketLock()
       throw CLIServiceError.bindFailed
     }
 
     // Listen
     guard listen(serverFD, 5) == 0 else {
       close(serverFD)
+      serverFD = -1
+      unlink(socketPath)
+      releaseSocketLock()
       throw CLIServiceError.listenFailed
     }
 
     isRunning = true
+    ownsSocket = true
 
     // Run the blocking accept loop on a dedicated dispatch queue so it does
     // not occupy a Swift cooperative-thread-pool thread (which would starve
@@ -88,7 +104,30 @@ final class CLISocketServer {
       close(serverFD)
       serverFD = -1
     }
-    unlink(socketPath)
+    if ownsSocket {
+      unlink(socketPath)
+      ownsSocket = false
+    }
+    releaseSocketLock()
+  }
+
+  private func acquireSocketLock() throws {
+    guard lockFD < 0 else { return }
+    lockFD = open(lockPath, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR)
+    guard lockFD >= 0 else {
+      throw CLIServiceError.lockFailed
+    }
+    guard flock(lockFD, LOCK_EX | LOCK_NB) == 0 else {
+      releaseSocketLock()
+      throw CLIServiceError.socketAlreadyOwned
+    }
+  }
+
+  private func releaseSocketLock() {
+    guard lockFD >= 0 else { return }
+    flock(lockFD, LOCK_UN)
+    close(lockFD)
+    lockFD = -1
   }
 
   // MARK: - Accept loop (runs on acceptQueue, NOT in Swift concurrency)
@@ -166,20 +205,56 @@ final class CLISocketServer {
   private static func fdWrite(fildes: Int32, buffer: UnsafeRawBufferPointer) throws {
     var offset = 0
     while offset < buffer.count {
-      let written = Darwin.write(fildes, buffer.baseAddress!.advanced(by: offset), buffer.count - offset)
+      let written = Darwin.write(
+        fildes, buffer.baseAddress!.advanced(by: offset), buffer.count - offset)
       guard written > 0 else {
         throw CLIServiceError.writeFailed
       }
       offset += written
     }
   }
+
+  private static func canConnect(to socketPath: String) -> Bool {
+    let socketFD = socket(AF_UNIX, SOCK_STREAM, 0)
+    guard socketFD >= 0 else { return false }
+    defer { close(socketFD) }
+
+    guard let addr = try? socketAddress(for: socketPath) else {
+      return false
+    }
+    let result = withUnsafePointer(to: addr) { ptr in
+      ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockPtr in
+        connect(socketFD, sockPtr, socklen_t(MemoryLayout<sockaddr_un>.size))
+      }
+    }
+    return result == 0
+  }
+
+  private static func socketAddress(for socketPath: String) throws -> sockaddr_un {
+    var addr = sockaddr_un()
+    addr.sun_family = sa_family_t(AF_UNIX)
+    let pathBytes = Array(socketPath.utf8)
+    let maxLen = MemoryLayout.size(ofValue: addr.sun_path) - 1
+    guard pathBytes.count <= maxLen else {
+      throw CLIServiceError.socketPathTooLong
+    }
+    withUnsafeMutableBytes(of: &addr.sun_path) { sunPathPtr in
+      for idx in 0..<pathBytes.count {
+        sunPathPtr[idx] = pathBytes[idx]
+      }
+      sunPathPtr[pathBytes.count] = 0
+    }
+    return addr
+  }
 }
 
 // MARK: - Errors
 
-enum CLIServiceError: Error {
+enum CLIServiceError: Error, Equatable {
   case socketCreationFailed
   case socketPathTooLong
+  case socketAlreadyOwned
+  case lockFailed
   case bindFailed
   case listenFailed
   case readFailed

--- a/supacodeTests/CLISocketServerTests.swift
+++ b/supacodeTests/CLISocketServerTests.swift
@@ -55,6 +55,17 @@ struct CLISocketServerTests {
     #expect(canConnect(to: socketPath))
   }
 
+  @Test func ownedDescriptorsAreClosedOnExec() throws {
+    let socketPath = temporarySocketPath(suffix: "cloexec")
+    let server = CLISocketServer(router: CLICommandRouter(), socketPath: socketPath)
+    try server.start()
+    defer { server.stop() }
+
+    let descriptors = server.debugFileDescriptors
+    #expect(isCloseOnExec(descriptors.server))
+    #expect(isCloseOnExec(descriptors.lock))
+  }
+
   private func temporarySocketPath(suffix: String) -> String {
     URL(fileURLWithPath: "/tmp", isDirectory: true)
       .appending(
@@ -97,6 +108,11 @@ struct CLISocketServerTests {
     guard result == 0 else {
       throw CLIServiceError.bindFailed
     }
+  }
+
+  private func isCloseOnExec(_ fileDescriptor: Int32) -> Bool {
+    let flags = fcntl(fileDescriptor, F_GETFD)
+    return flags >= 0 && (flags & FD_CLOEXEC) == FD_CLOEXEC
   }
 
   private func withSocketAddress<Result>(

--- a/supacodeTests/CLISocketServerTests.swift
+++ b/supacodeTests/CLISocketServerTests.swift
@@ -1,0 +1,121 @@
+import Foundation
+import Testing
+
+@testable import supacode
+
+#if canImport(Darwin)
+  import Darwin
+#elseif canImport(Glibc)
+  import Glibc
+#endif
+
+@MainActor
+struct CLISocketServerTests {
+  @Test func secondServerDoesNotReplaceReachableSocket() throws {
+    let socketPath = temporarySocketPath(suffix: "reachable-owner")
+    let first = CLISocketServer(router: CLICommandRouter(), socketPath: socketPath)
+    try first.start()
+    defer { first.stop() }
+
+    #expect(canConnect(to: socketPath))
+
+    let second = CLISocketServer(router: CLICommandRouter(), socketPath: socketPath)
+    #expect(throws: CLIServiceError.socketAlreadyOwned) {
+      try second.start()
+    }
+
+    #expect(canConnect(to: socketPath))
+  }
+
+  @Test func ownerCanReplaceStaleSocketPath() throws {
+    let socketPath = temporarySocketPath(suffix: "stale-owner")
+    try createStaleSocket(at: socketPath)
+    #expect(FileManager.default.fileExists(atPath: socketPath))
+    #expect(!canConnect(to: socketPath))
+
+    let server = CLISocketServer(router: CLICommandRouter(), socketPath: socketPath)
+    try server.start()
+    defer { server.stop() }
+
+    #expect(canConnect(to: socketPath))
+  }
+
+  @Test func nonOwnerStopDoesNotRemoveOwnedSocketPath() throws {
+    let socketPath = temporarySocketPath(suffix: "non-owner-stop")
+    let first = CLISocketServer(router: CLICommandRouter(), socketPath: socketPath)
+    try first.start()
+    defer { first.stop() }
+
+    let second = CLISocketServer(router: CLICommandRouter(), socketPath: socketPath)
+    #expect(throws: CLIServiceError.socketAlreadyOwned) {
+      try second.start()
+    }
+    second.stop()
+
+    #expect(canConnect(to: socketPath))
+  }
+
+  private func temporarySocketPath(suffix: String) -> String {
+    URL(fileURLWithPath: "/tmp", isDirectory: true)
+      .appending(
+        path: "prowl-\(suffix)-\(UUID().uuidString.prefix(8)).sock", directoryHint: .notDirectory
+      )
+      .path(percentEncoded: false)
+  }
+
+  private func createStaleSocket(at socketPath: String) throws {
+    unlink(socketPath)
+    let socketFD = socket(AF_UNIX, SOCK_STREAM, 0)
+    guard socketFD >= 0 else {
+      throw CLIServiceError.socketCreationFailed
+    }
+    defer { close(socketFD) }
+    try bindSocket(socketFD, to: socketPath)
+  }
+
+  private func canConnect(to socketPath: String) -> Bool {
+    let socketFD = socket(AF_UNIX, SOCK_STREAM, 0)
+    guard socketFD >= 0 else { return false }
+    defer { close(socketFD) }
+    return withSocketAddress(socketPath) { address in
+      withUnsafePointer(to: address) { pointer in
+        pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { socketPointer in
+          connect(socketFD, socketPointer, socklen_t(MemoryLayout<sockaddr_un>.size))
+        }
+      }
+    } == 0
+  }
+
+  private func bindSocket(_ socketFD: Int32, to socketPath: String) throws {
+    let result = withSocketAddress(socketPath) { address in
+      withUnsafePointer(to: address) { pointer in
+        pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { socketPointer in
+          bind(socketFD, socketPointer, socklen_t(MemoryLayout<sockaddr_un>.size))
+        }
+      }
+    }
+    guard result == 0 else {
+      throw CLIServiceError.bindFailed
+    }
+  }
+
+  private func withSocketAddress<Result>(
+    _ socketPath: String, _ body: (sockaddr_un) throws -> Result
+  ) rethrows
+    -> Result
+  {
+    var address = sockaddr_un()
+    address.sun_family = sa_family_t(AF_UNIX)
+    let pathBytes = Array(socketPath.utf8)
+    let maxLength = MemoryLayout.size(ofValue: address.sun_path) - 1
+    precondition(pathBytes.count <= maxLength)
+    let copyLength = min(pathBytes.count, maxLength)
+    withUnsafeMutableBytes(of: &address.sun_path) { buffer in
+      for index in 0..<copyLength {
+        buffer[index] = pathBytes[index]
+      }
+      buffer[copyLength] = 0
+    }
+    return try body(address)
+  }
+}


### PR DESCRIPTION
## Summary

- guard the Prowl CLI socket with a per-socket lock so secondary app instances cannot unlink or replace a live owner
- only clean stale socket paths while holding ownership, and only unlink on shutdown when this server owns the socket
- prevent `make run-app` from launching another Prowl GUI instance by default
- detect running Prowl apps by bundle identifier instead of `pgrep -x Prowl`

## Validation

- `make build-cli`
- `make test-cli-smoke`
- `make test-cli-integration`
- `xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -only-testing:supacodeTests/CLISocketServerTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation`
- `swift-format lint --strict --configuration ./.swift-format.json ProwlCLI/AppLauncher.swift supacode/CLIService/CLISocketServer.swift supacodeTests/CLISocketServerTests.swift`
- `mise exec -- swiftlint lint --quiet --config .swiftlint.yml ProwlCLI/AppLauncher.swift supacode/CLIService/CLISocketServer.swift supacodeTests/CLISocketServerTests.swift`
- `make build-app`

`make check` was not run because the local worktree contains an unrelated unstaged Swift change outside this PR; scoped format/lint was run for the files in this PR.
