### PR TITLE
Fix prowl read `truncated` semantics + improve prowl-cli skill guide

### DIFF
--- a/doc-onevcat/contracts/cli/read.md
+++ b/doc-onevcat/contracts/cli/read.md
@@ -101,7 +101,15 @@ This file defines the **JSON output contract** for:
   - `"scrollback"`: satisfied from scrollback/history
   - `"mixed"`: combined view when the runtime had to stitch sources together
 - `truncated`: boolean
-  - `true` when the runtime could not return the full requested text volume
+  - `true` only when the returned `text` may be **incomplete** — i.e. the runtime could not
+    retrieve the pane's full screen+scrollback buffer and the visible viewport alone held fewer
+    lines than requested, so older content may exist beyond reach.
+  - `false` when `text` holds every line the pane retains for the request. In particular,
+    receiving fewer lines than `--last N` because the pane simply has less history than `N` is
+    **not** truncation — you still got everything available.
+  - This matches the meaning of `truncated` in the `send --capture` response (`prowl.cli.send`):
+    in both, `true` signals "the captured text may be missing content", never "you got less than
+    you asked for but it is all there is".
 - `line_count`: integer
   - number of newline-delimited lines present in `text`
 - `text`: string

--- a/skills/prowl-cli/SKILL.md
+++ b/skills/prowl-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: prowl-cli
-description: Use the Prowl CLI to inspect or control a running Prowl app, especially when a user asks to read from, coordinate, focus, send text to, or send keys to Prowl worktrees, tabs, panes, or sibling agent sessions.
+description: Use the Prowl CLI (`prowl`) to inspect or control a running Prowl GUI app and the agent sessions it hosts. Prowl runs several coding agents in parallel, each in its own pane/tab/worktree, so reach for this whenever the user wants to act on a pane other than the current one — check on, coordinate, read from, focus, send text or keys to, open, or close another pane, tab, worktree, split, window, or sibling/neighboring agent. Covers colloquial framings that never say "prowl": "check what the agent in my other window is doing", "are any of my agents running side by side still working or idle?", "tell the agent in my left split to rerun the tests", "send npm run build to the build tab and grab the output", "open ~/proj in a fresh tab", "close that scratch tab I left open". Not for ordinary editing or building inside the Prowl source repo, and not for how-to questions about Prowl's settings, preferences, or keybindings — only when the task is to actually drive panes in the live Prowl app.
 ---
 
 # Prowl CLI
@@ -86,7 +86,7 @@ Prefer `read --wait-stable` for screen snapshots:
 prowl read --pane "$pane" --last 200 --wait-stable --json
 ```
 
-For polling, avoid zsh's readonly `status` variable:
+Most of the time `--wait-stable` alone is enough — it blocks until the screen stops changing. Only poll `task.status` first when you specifically need to wait for an agent to go from `working` back to `idle` (status flips before the TUI finishes painting, so still finish with `--wait-stable`). When polling in zsh, do not name the variable `status` — it is readonly there:
 
 ```bash
 for i in 1 2 3 4 5 6; do
@@ -171,6 +171,7 @@ Avoid outer double quotes around payloads containing `$PWD`, `$VAR`, backticks, 
 - `open /path` creates a new tab/pane. It is not a refocus command.
 - Focused pane is not stable; `open` and `focus` change it.
 - `read --wait-stable` sees rendered screen only. It cannot recover content folded by a TUI.
+- `read` sets `truncated: true` only when the returned text may be incomplete (the full scrollback could not be read and the viewport had fewer lines than `--last` asked for). Getting fewer lines than `--last` simply because the pane has less history is `truncated: false` — you already have everything; do not retry expecting more.
 - `send --capture` captures a screen diff; multiline input may include command echo.
 - `prowl list --json | jq ...` snippets should pass shell values with `--arg`.
 - In zsh, do not name variables `status`; it is readonly.
@@ -190,9 +191,11 @@ Common codes and recovery:
 - `APP_NOT_RUNNING`: Prowl is not reachable. Ask before restarting the app.
 - `TARGET_NOT_FOUND` / `TARGET_NOT_UNIQUE`: run `prowl list --json` again and choose an explicit pane UUID.
 - `EMPTY_INPUT`: `send` got neither argv text nor stdin.
+- `NO_ACTIVE_PANE`: no pane resolved for positional (focused-pane) targeting; pass an explicit `--pane`.
 - `INVALID_ARGUMENT`: illegal flag or flag combination, such as `--capture --no-wait`.
 - `UNSUPPORTED_KEY` / `INVALID_REPEAT`: check `prowl key --help`.
-- `WAIT_TIMEOUT`: retry with `--no-wait`, or use `--capture` only in a shell-integrated pane.
+- `CAPTURE_UNSUPPORTED`: `--capture` needs shell integration (OSC 133) on the target pane. Drop `--capture` and `read --wait-stable` instead, or redirect the command's output to a file (see "Reading Agent Output").
+- `WAIT_TIMEOUT`: command did not finish in time; retry with `--no-wait`, or raise `--timeout`.
 - `PATH_NOT_FOUND` / `PATH_NOT_DIRECTORY` / `PATH_NOT_ALLOWED`: fix the path passed to `open`.
 
 Always check the exit code before piping output into `jq`; parser-level errors print plaintext usage to stderr.

--- a/supacode/CLIService/ReadCommandHandler.swift
+++ b/supacode/CLIService/ReadCommandHandler.swift
@@ -227,6 +227,9 @@ final class ReadCommandHandler: CommandHandler {
     }
 
     guard let screenText else {
+      // The full screen+scrollback buffer could not be read, so we only have the visible
+      // viewport. If it holds fewer lines than requested, older history may exist beyond our
+      // reach — the result may be incomplete, which is exactly what `truncated` should signal.
       return ReadCapture(
         text: joinLines(viewportLines.suffix(min(requestedLineCount, viewportLines.count))),
         source: .mixed,
@@ -236,6 +239,9 @@ final class ReadCommandHandler: CommandHandler {
 
     let screenLines = splitLines(screenText)
     if screenLines.count < viewportLines.count {
+      // The full-buffer read returned fewer lines than the viewport itself — an unreliable
+      // capture. We fall back to the viewport and, as above, cannot vouch for completeness
+      // when it is shorter than requested.
       return ReadCapture(
         text: joinLines(viewportLines.suffix(min(requestedLineCount, viewportLines.count))),
         source: .mixed,
@@ -246,10 +252,15 @@ final class ReadCommandHandler: CommandHandler {
     let source: ReadSource = screenLines.count > viewportLines.count ? .scrollback : .screen
     let text = joinLines(screenLines.suffix(min(requestedLineCount, screenLines.count)))
 
+    // The full screen+scrollback buffer was retrievable, so `text` already holds every line
+    // the pane retains. Returning fewer lines than `--last` requested here only means the
+    // pane has less history than asked for — not that content was lost — so it is complete,
+    // not truncated. `truncated` stays reserved for cases where content may be unreachable
+    // (see the viewport-only fallbacks above).
     return ReadCapture(
       text: text,
       source: source,
-      truncated: screenLines.count < requestedLineCount
+      truncated: false
     )
   }
 

--- a/supacodeTests/CLIReadCommandHandlerTests.swift
+++ b/supacodeTests/CLIReadCommandHandlerTests.swift
@@ -124,7 +124,7 @@ struct CLIReadCommandHandlerTests {
     #expect(payload.text == "b\nc\nd")
   }
 
-  @Test func lastMarksTruncatedWhenScreenInsufficient() async throws {
+  @Test func lastReturnsFullBufferWithoutTruncationWhenHistoryShorterThanRequest() async throws {
     let handler = ReadCommandHandler(
       resolveProvider: { _ in .success(Self.makeTarget()) },
       captureProvider: { _ in
@@ -140,7 +140,10 @@ struct CLIReadCommandHandlerTests {
     #expect(response.ok)
     let payload = try #require(try response.data?.decode(as: ReadCommandPayload.self))
     #expect(payload.source == .scrollback)
-    #expect(payload.truncated == true)
+    // The full screen+scrollback buffer was retrievable and holds only 4 lines, so the
+    // response contains everything the pane retains. Fewer lines than `--last 10` requested
+    // does not mean content was lost, so it must not be flagged truncated.
+    #expect(payload.truncated == false)
     #expect(payload.lineCount == 4)
     #expect(payload.text == "one\ntwo\nthree\nfour")
   }


### PR DESCRIPTION
## What

Two related changes from a skill-evaluation pass on `prowl-cli`.

### 1. Fix `prowl read` `truncated` semantics (bug)

`prowl read --last N` flagged `truncated: true` whenever it returned fewer lines than requested — including when the **full screen+scrollback buffer was retrievable and simply held less history than N**. That's backwards: the response contained *everything the pane retains*, yet the flag implied data loss and invited pointless retries.

`truncated` now means **"the returned text may be incomplete"**:

| case | before | after |
|---|---|---|
| viewport ≥ N | false | false |
| full buffer retrievable, but < N lines | **true** | **false** ✅ (you got everything that exists) |
| full buffer unreadable, viewport < N | true | true (older content may be unreachable) |
| full-buffer read unreliable (< viewport), viewport < N | true | true |
| snapshot | false | false |

Only the third branch in `captureLast` changed (`screenLines.count < requestedLineCount` → `false`). This also aligns read's `truncated` with `send --capture`'s, where `true` already means "captured text may be missing content".

Updates `doc-onevcat/contracts/cli/read.md` and the handler test that pinned the old behavior.

### 2. Improve the `prowl-cli` skill guide

- Broaden the description to trigger on parallel / side-by-side agents, splits, and colloquial framings ("the agent in my left split", "are my agents idle?"), while excluding settings/keybindings how-to questions.
- Document the real error codes `CAPTURE_UNSUPPORTED` and `NO_ACTIVE_PANE`; correct the `WAIT_TIMEOUT` recovery advice.
- Reframe the polling recipe (`--wait-stable` is usually enough; poll `task.status` only for working→idle).
- Clarify the `read` `truncated` pitfall to match the corrected semantics.

## Testing

- `CLIReadCommandHandlerTests` — pass (renamed branch-4 test now asserts `truncated == false`; viewport-only true-cases retained).
- `make build-app` — 0 errors / 0 warnings.
- `make test-cli-integration` — 43 tests, 0 failures.
- `make check` — clean.
