### PR TITLE
Add Canvas layout shortcuts (Arrange/Organize)

### DIFF
--- a/supacode/App/AppShortcuts.swift
+++ b/supacode/App/AppShortcuts.swift
@@ -140,6 +140,8 @@ enum AppShortcuts {
     static let selectTerminalTab9 = "select_terminal_tab_9"
     static let renameBranch = "rename_branch"
     static let selectAllCanvasCards = "select_all_canvas_cards"
+    static let arrangeCanvasCards = "arrange_canvas_cards"
+    static let organizeCanvasCards = "organize_canvas_cards"
     static let selectPreviousTerminalTab = "select_previous_terminal_tab"
     static let selectNextTerminalTab = "select_next_terminal_tab"
     static let selectPreviousTerminalPane = "select_previous_terminal_pane"
@@ -286,6 +288,8 @@ enum AppShortcuts {
   )
   static let renameBranch = AppShortcut(key: "m", modifiers: [.command, .shift])
   static let selectAllCanvasCards = AppShortcut(key: "a", modifiers: [.command, .option])
+  static let arrangeCanvasCards = AppShortcut(key: "r", modifiers: [.command, .option])
+  static let organizeCanvasCards = AppShortcut(key: "g", modifiers: [.command, .option])
   static let worktreeSelection: [AppShortcut] = [
     selectWorktree1,
     selectWorktree2,
@@ -750,6 +754,18 @@ enum AppShortcuts {
       title: "Select All Canvas Cards",
       scope: .localInteraction,
       shortcut: selectAllCanvasCards
+    ),
+    .init(
+      id: CommandID.arrangeCanvasCards,
+      title: "Arrange Canvas Cards",
+      scope: .localInteraction,
+      shortcut: arrangeCanvasCards
+    ),
+    .init(
+      id: CommandID.organizeCanvasCards,
+      title: "Organize Canvas Cards",
+      scope: .localInteraction,
+      shortcut: organizeCanvasCards
     ),
   ]
 

--- a/supacode/Features/Canvas/Views/CanvasView.swift
+++ b/supacode/Features/Canvas/Views/CanvasView.swift
@@ -138,8 +138,10 @@ struct CanvasView: View {
       selectAllCanvasShortcut?.keyEquivalent ?? AppShortcuts.selectAllCanvasCards.keyEquivalent,
       phases: .down
     ) { keyPress in
-      let shortcutModifiers = selectAllCanvasShortcut?.modifiers ?? AppShortcuts.selectAllCanvasCards.modifiers
-      guard keyPress.modifiers == shortcutModifiers else { return .ignored }
+      // Bail when the binding is disabled in Settings (resolved shortcut is nil);
+      // otherwise the app-default key would still fire despite being unbound.
+      guard let shortcut = selectAllCanvasShortcut else { return .ignored }
+      guard keyPress.modifiers == shortcut.modifiers else { return .ignored }
       selectAllCards()
       return .handled
     }
@@ -147,8 +149,8 @@ struct CanvasView: View {
       arrangeCanvasShortcut?.keyEquivalent ?? AppShortcuts.arrangeCanvasCards.keyEquivalent,
       phases: .down
     ) { keyPress in
-      let shortcutModifiers = arrangeCanvasShortcut?.modifiers ?? AppShortcuts.arrangeCanvasCards.modifiers
-      guard keyPress.modifiers == shortcutModifiers else { return .ignored }
+      guard let shortcut = arrangeCanvasShortcut else { return .ignored }
+      guard keyPress.modifiers == shortcut.modifiers else { return .ignored }
       arrangeCardsWithFit()
       return .handled
     }
@@ -156,8 +158,8 @@ struct CanvasView: View {
       organizeCanvasShortcut?.keyEquivalent ?? AppShortcuts.organizeCanvasCards.keyEquivalent,
       phases: .down
     ) { keyPress in
-      let shortcutModifiers = organizeCanvasShortcut?.modifiers ?? AppShortcuts.organizeCanvasCards.modifiers
-      guard keyPress.modifiers == shortcutModifiers else { return .ignored }
+      guard let shortcut = organizeCanvasShortcut else { return .ignored }
+      guard keyPress.modifiers == shortcut.modifiers else { return .ignored }
       organizeCardsWithFit()
       return .handled
     }

--- a/supacode/Features/Canvas/Views/CanvasView.swift
+++ b/supacode/Features/Canvas/Views/CanvasView.swift
@@ -46,6 +46,14 @@ struct CanvasView: View {
       for: AppShortcuts.CommandID.selectAllCanvasCards,
       in: resolvedKeybindings
     )
+    let arrangeCanvasShortcut = AppShortcuts.resolvedShortcut(
+      for: AppShortcuts.CommandID.arrangeCanvasCards,
+      in: resolvedKeybindings
+    )
+    let organizeCanvasShortcut = AppShortcuts.resolvedShortcut(
+      for: AppShortcuts.CommandID.organizeCanvasCards,
+      in: resolvedKeybindings
+    )
     let _ = configReloadCounter
     CanvasScrollContainer(
       offset: $canvasOffset,
@@ -133,6 +141,24 @@ struct CanvasView: View {
       let shortcutModifiers = selectAllCanvasShortcut?.modifiers ?? AppShortcuts.selectAllCanvasCards.modifiers
       guard keyPress.modifiers == shortcutModifiers else { return .ignored }
       selectAllCards()
+      return .handled
+    }
+    .onKeyPress(
+      arrangeCanvasShortcut?.keyEquivalent ?? AppShortcuts.arrangeCanvasCards.keyEquivalent,
+      phases: .down
+    ) { keyPress in
+      let shortcutModifiers = arrangeCanvasShortcut?.modifiers ?? AppShortcuts.arrangeCanvasCards.modifiers
+      guard keyPress.modifiers == shortcutModifiers else { return .ignored }
+      arrangeCardsWithFit()
+      return .handled
+    }
+    .onKeyPress(
+      organizeCanvasShortcut?.keyEquivalent ?? AppShortcuts.organizeCanvasCards.keyEquivalent,
+      phases: .down
+    ) { keyPress in
+      let shortcutModifiers = organizeCanvasShortcut?.modifiers ?? AppShortcuts.organizeCanvasCards.modifiers
+      guard keyPress.modifiers == shortcutModifiers else { return .ignored }
+      organizeCardsWithFit()
       return .handled
     }
     .task { activateCanvas() }
@@ -434,6 +460,24 @@ struct CanvasView: View {
     layoutStore.setCardLayouts(result.layouts, zOrder: keys)
   }
 
+  /// Arrange cards (preserving sizes) and refit the viewport, animated.
+  /// Shared by the toolbar button and the keyboard shortcut.
+  private func arrangeCardsWithFit() {
+    withAnimation(.easeInOut(duration: 0.2)) {
+      arrangeCards()
+      fitToView(canvasSize: viewportSize)
+    }
+  }
+
+  /// Organize cards into a uniform grid and refit the viewport, animated.
+  /// Shared by the toolbar button and the keyboard shortcut.
+  private func organizeCardsWithFit() {
+    withAnimation(.easeInOut(duration: 0.2)) {
+      organizeCards()
+      fitToView(canvasSize: viewportSize)
+    }
+  }
+
   /// Adjust scale and offset so all cards fit within the viewport.
   private func fitToView(canvasSize: CGSize) {
     guard canvasSize.width > 0, canvasSize.height > 0 else { return }
@@ -566,30 +610,34 @@ struct CanvasView: View {
         ))
 
       Button {
-        withAnimation(.easeInOut(duration: 0.2)) {
-          arrangeCards()
-          fitToView(canvasSize: viewportSize)
-        }
+        arrangeCardsWithFit()
       } label: {
         Image(systemName: "rectangle.3.group")
           .font(.body)
           .accessibilityLabel("Arrange")
       }
       .buttonStyle(.bordered)
-      .help("Arrange cards preserving sizes")
+      .help(
+        AppShortcuts.helpText(
+          title: "Arrange cards preserving sizes",
+          commandID: AppShortcuts.CommandID.arrangeCanvasCards,
+          in: resolvedKeybindings
+        ))
 
       Button {
-        withAnimation(.easeInOut(duration: 0.2)) {
-          organizeCards()
-          fitToView(canvasSize: viewportSize)
-        }
+        organizeCardsWithFit()
       } label: {
         Image(systemName: "square.grid.2x2")
           .font(.body)
           .accessibilityLabel("Organize")
       }
       .buttonStyle(.bordered)
-      .help("Organize cards in a uniform grid")
+      .help(
+        AppShortcuts.helpText(
+          title: "Organize cards in a uniform grid",
+          commandID: AppShortcuts.CommandID.organizeCanvasCards,
+          in: resolvedKeybindings
+        ))
     }
     .padding()
   }

--- a/supacode/Features/Settings/Views/ShortcutsSettingsView.swift
+++ b/supacode/Features/Settings/Views/ShortcutsSettingsView.swift
@@ -937,6 +937,8 @@ private enum ShortcutGroup: String, CaseIterable, Identifiable {
       AppShortcuts.CommandID.selectShelfBook8,
       AppShortcuts.CommandID.selectShelfBook9,
       AppShortcuts.CommandID.selectAllCanvasCards,
+      AppShortcuts.CommandID.arrangeCanvasCards,
+      AppShortcuts.CommandID.organizeCanvasCards,
       AppShortcuts.CommandID.archivedWorktrees:
       return .scripts
 

--- a/supacodeTests/AppShortcutsTests.swift
+++ b/supacodeTests/AppShortcutsTests.swift
@@ -441,6 +441,30 @@ struct AppShortcutsTests {
     #expect(arguments.contains("--keybind=super+;=unbind") == false)
   }
 
+  @Test func disabledCanvasLayoutOverridesResolveToNil() {
+    let overrides = KeybindingUserOverrideStore(
+      overrides: [
+        AppShortcuts.CommandID.arrangeCanvasCards: KeybindingUserOverride(
+          binding: Keybinding(key: "r", modifiers: .init(command: true, option: true)),
+          isEnabled: false
+        ),
+        AppShortcuts.CommandID.organizeCanvasCards: KeybindingUserOverride(
+          binding: Keybinding(key: "g", modifiers: .init(command: true, option: true)),
+          isEnabled: false
+        ),
+      ]
+    )
+    let resolved = KeybindingResolver.resolve(
+      schema: .appResolverSchema(),
+      userOverrides: overrides
+    )
+
+    // When disabled the resolved shortcut must be nil so CanvasView's handler bails
+    // instead of falling back to the app-default ⌘⌥R / ⌘⌥G key.
+    #expect(AppShortcuts.resolvedShortcut(for: AppShortcuts.CommandID.arrangeCanvasCards, in: resolved) == nil)
+    #expect(AppShortcuts.resolvedShortcut(for: AppShortcuts.CommandID.organizeCanvasCards, in: resolved) == nil)
+  }
+
   @Test func resolvedShortcutFallsBackToDefaultWhenCommandMissingInResolvedMap() {
     let resolved = ResolvedKeybindingMap(bindingsByCommandID: [:])
 

--- a/supacodeTests/AppShortcutsTests.swift
+++ b/supacodeTests/AppShortcutsTests.swift
@@ -172,12 +172,29 @@ struct AppShortcutsTests {
       idToDisplay["select_all_canvas_cards"],
       AppShortcuts.selectAllCanvasCards.display
     )
+    expectNoDifference(
+      idToDisplay["arrange_canvas_cards"],
+      AppShortcuts.arrangeCanvasCards.display
+    )
+    expectNoDifference(
+      idToDisplay["organize_canvas_cards"],
+      AppShortcuts.organizeCanvasCards.display
+    )
 
     #expect(idToScope["command_palette"] == .configurableAppAction)
     #expect(idToScope["toggle_active_agents_panel"] == .configurableAppAction)
     #expect(idToScope["quit_application"] == .systemFixedAppAction)
     #expect(idToScope["rename_branch"] == .localInteraction)
     #expect(idToScope["select_all_canvas_cards"] == .localInteraction)
+    #expect(idToScope["arrange_canvas_cards"] == .localInteraction)
+    #expect(idToScope["organize_canvas_cards"] == .localInteraction)
+  }
+
+  @Test func canvasLayoutShortcutsUseCommandOptionFamily() {
+    expectNoDifference(AppShortcuts.arrangeCanvasCards.display, "⌘⌥R")
+    expectNoDifference(AppShortcuts.organizeCanvasCards.display, "⌘⌥G")
+    #expect(AppShortcuts.arrangeCanvasCards.modifiers == [.command, .option])
+    #expect(AppShortcuts.organizeCanvasCards.modifiers == [.command, .option])
   }
 
   @Test func userOverrideConflictsDetectsReservedAppShortcuts() {


### PR DESCRIPTION
## 背景

closes #392

Canvas 底部的两个布局按钮目前只能鼠标点击，多 agent 并行场景下打断键盘流。本 PR 为它们补上快捷键。

## 键位选择

提案的 `Cmd+Shift+R` 已被 `refreshWorktrees` 占用，因此改为归入既有 **Canvas `Cmd+Option` 家族**（与 `toggleCanvas` = `⌘⌥↩`、`selectAllCanvasCards` = `⌘⌥A` 一致），两者均未占用：

| Action | 快捷键 |
|---|---|
| Arrange cards preserving sizes | `⌘⌥R`（R = Rearrange） |
| Organize cards in a uniform grid | `⌘⌥G`（G = Grid） |

## 改动

- `AppShortcuts.swift`：新增 `arrangeCanvasCards` / `organizeCanvasCards` 的 `CommandID`、`AppShortcut` 常量，并以 `.localInteraction` scope 注册进 `bindings`。因 `allowUserOverride = scope != .systemFixedAppAction`，它们自动进入 keybinding schema 且 **`allowUserOverride == true`**，所以在现有的 **Settings → Shortcuts recorder 里当场即可重绑**（无需等任何后续 milestone）。
- `ShortcutsSettingsView.swift`：在 `ShortcutGroup.resolve` 中把这两个 action 归到 `.scripts`（"Scripts & Panels"）分组，与 "Select All Canvas Cards" 并列，避免 fallthrough 到 General 组造成 Canvas 操作分散。
- `CanvasView.swift`：
  - 通过 `.onKeyPress` 处理两个快捷键。处理器位于 `CanvasView.body` 内，只在 Canvas 可见时挂载，**作用域严格限制在 Canvas，不会逃逸到其他面板**（与 `selectAllCanvasCards` 同机制）。
  - 抽出 `arrangeCardsWithFit()` / `organizeCardsWithFit()` 动画 helper，按钮与快捷键共用，避免重复。
  - 工具栏按钮 tooltip 改用 `AppShortcuts.helpText`，显示对应快捷键提示。

## 测试

- `AppShortcutsTests`：新增对两个 binding 的 registry 注册、scope、display（`⌘⌥R` / `⌘⌥G`）断言；全部 21 项通过。
- `make build-app` ✅
- `make check` ✅（format + swift-format lint + swiftlint 均干净）

> 快捷键的 `.onKeyPress` 触发与 recorder 的 `NSEvent` 录制均属 SwiftUI/AppKit 视图交互，无法在单元测试中模拟；逻辑层（packing/grid、schema 生成）为既有或已覆盖代码。
