### PR TITLE
Fix Canvas new tab target

### DIFF
--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -820,7 +820,7 @@ struct AppFeature {
         return .none
 
       case .newTerminal:
-        guard let worktree = state.repositories.selectedTerminalWorktree else {
+        guard let worktree = actionTargetWorktree(repositories: state.repositories) else {
           return .none
         }
         analyticsClient.capture("terminal_tab_created", nil)
@@ -1268,7 +1268,7 @@ struct AppFeature {
         return .send(.runCustomCommand(index))
 
       case .commandPalette(.delegate(.ghosttyCommand(let action))):
-        guard let worktree = state.repositories.selectedTerminalWorktree else {
+        guard let worktree = actionTargetWorktree(repositories: state.repositories) else {
           return .none
         }
         return .run { _ in

--- a/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
+++ b/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
@@ -266,6 +266,8 @@ struct CommandPaletteFeature {
         )
       )
       items.append(contentsOf: ghosttyCommandItems(ghosttyCommands))
+    } else if worktreeActionTargetID != nil {
+      items.append(contentsOf: ghosttyCommandItems(ghosttyCommands))
     }
     if let repository = activeRepository(in: repositories) {
       items.append(

--- a/supacodeTests/AppFeatureCommandPaletteTests.swift
+++ b/supacodeTests/AppFeatureCommandPaletteTests.swift
@@ -159,6 +159,42 @@ struct AppFeatureCommandPaletteTests {
     #expect(sent.value == [.focusSelectedTab(worktree)])
   }
 
+  @Test(.dependencies) func ghosttyCommandDelegateInCanvasUsesCanvasFocusedWorktree() async {
+    let worktree = makeWorktree(
+      id: "/tmp/repo-canvas-ghostty/wt-1",
+      name: "wt-1",
+      repoRoot: "/tmp/repo-canvas-ghostty"
+    )
+    let repository = makeRepository(id: "/tmp/repo-canvas-ghostty", worktrees: [worktree])
+    var repositoriesState = RepositoriesFeature.State()
+    repositoriesState.repositories = [repository]
+    repositoriesState.selection = .canvas
+    let sent = LockIsolated<[TerminalClient.Command]>([])
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: repositoriesState,
+        settings: SettingsFeature.State()
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.canvasFocusedWorktreeID = { worktree.id }
+      $0.terminalClient.send = { command in
+        sent.withValue { $0.append(command) }
+      }
+    }
+
+    await store.send(.commandPalette(.delegate(.ghosttyCommand("new_tab"))))
+    await store.finish()
+
+    #expect(
+      sent.value == [
+        .performBindingAction(worktree, action: "new_tab"),
+        .focusSelectedTab(worktree),
+      ]
+    )
+  }
+
   @Test(.dependencies) func passiveCommandPaletteCommandRestoresSelectedTerminalFocus() async {
     let worktree = makeWorktree(
       id: "/tmp/repo-passive/wt-1",

--- a/supacodeTests/AppFeatureRunScriptTests.swift
+++ b/supacodeTests/AppFeatureRunScriptTests.swift
@@ -123,6 +123,31 @@ struct AppFeatureRunScriptTests {
     #expect(sent.value == [.runScript(worktree, script: "npm test")])
   }
 
+  @Test(.dependencies) func newTerminalUsesCanvasFocusedWorktree() async {
+    let worktree = makeWorktree()
+    var repositories = makeRepositoriesState(worktree: worktree)
+    repositories.selection = .canvas
+    let sent = LockIsolated<[TerminalClient.Command]>([])
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: repositories,
+        settings: SettingsFeature.State()
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.canvasFocusedWorktreeID = { worktree.id }
+      $0.terminalClient.send = { command in
+        sent.withValue { $0.append(command) }
+      }
+    }
+
+    await store.send(.newTerminal)
+    await store.finish()
+
+    #expect(sent.value == [.createTab(worktree, runSetupScriptIfNew: false)])
+  }
+
   private func makeWorktree() -> Worktree {
     Worktree(
       id: "/tmp/repo/wt-1",

--- a/supacodeTests/CommandPaletteFeatureTests.swift
+++ b/supacodeTests/CommandPaletteFeatureTests.swift
@@ -384,6 +384,37 @@ struct CommandPaletteFeatureTests {
     #expect(ghosttyItem?.subtitle == "Focus the split to the right.")
   }
 
+  @Test func commandPaletteItems_includeGhosttyCommandsForCanvasActionTarget() {
+    let rootPath = "/tmp/repo-canvas-new-tab"
+    let worktree = makeWorktree(id: "\(rootPath)/wt-1", name: "wt-1", repoRoot: rootPath)
+    let repository = makeRepository(rootPath: rootPath, name: "Repo", worktrees: [worktree])
+    var state = RepositoriesFeature.State(repositories: [repository])
+    state.selection = .canvas
+
+    let items = CommandPaletteFeature.commandPaletteItems(
+      from: state,
+      actionTargetWorktreeID: worktree.id,
+      ghosttyCommands: [
+        GhosttyCommand(
+          title: "New Tab",
+          description: "Open a new tab.",
+          action: "new_tab",
+          actionKey: "new_tab"
+        )
+      ]
+    )
+
+    let ghosttyItem = items.first {
+      if case .ghosttyCommand(let action) = $0.kind {
+        return action == "new_tab"
+      }
+      return false
+    }
+
+    #expect(ghosttyItem?.title == "New Tab")
+    #expect(ghosttyItem?.subtitle == "Open a new tab.")
+  }
+
   @Test func commandPaletteItems_filtersUnsupportedGhosttyCommands() {
     let rootPath = "/tmp/repo"
     let worktree = makeWorktree(id: rootPath, name: "repo", repoRoot: rootPath)


### PR DESCRIPTION
## Summary
- Route New Terminal/New Tab through the active terminal target so Canvas uses the focused card's worktree.
- Include Ghostty terminal commands in the command palette when Canvas has a focused action target.
- Cover Canvas new-tab paths with reducer and command-palette tests.

## Tests
- xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -only-testing:supacodeTests/AppFeatureRunScriptTests -only-testing:supacodeTests/CommandPaletteFeatureTests -only-testing:supacodeTests/AppFeatureCommandPaletteTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation
- make build-app
