### PR TITLE
Keep sidebar navigation in canvas mode

### DIFF
--- a/supacode/Features/Canvas/Models/CanvasFocusRequest.swift
+++ b/supacode/Features/Canvas/Models/CanvasFocusRequest.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+struct CanvasFocusRequest: Equatable, Sendable {
+  enum Target: Equatable, Sendable {
+    case worktree(Worktree.ID)
+    case tab(TerminalTabID)
+  }
+
+  let id: Int
+  let target: Target
+}
+
+struct CanvasFocusCandidate: Equatable, Sendable {
+  let worktreeID: Worktree.ID
+  let tabID: TerminalTabID
+}
+
+enum CanvasFocusResolver {
+  static func resolve(
+    request: CanvasFocusRequest,
+    candidates: [CanvasFocusCandidate],
+    currentPrimaryTabID: TerminalTabID?
+  ) -> TerminalTabID? {
+    switch request.target {
+    case .tab(let tabID):
+      return candidates.contains { $0.tabID == tabID } ? tabID : nil
+
+    case .worktree(let worktreeID):
+      let matchingTabIDs = candidates.compactMap { candidate in
+        candidate.worktreeID == worktreeID ? candidate.tabID : nil
+      }
+      guard !matchingTabIDs.isEmpty else { return nil }
+      guard let currentPrimaryTabID,
+        let currentIndex = matchingTabIDs.firstIndex(of: currentPrimaryTabID)
+      else {
+        return matchingTabIDs[0]
+      }
+      return matchingTabIDs[(currentIndex + 1) % matchingTabIDs.count]
+    }
+  }
+}

--- a/supacode/Features/Canvas/Views/CanvasView.swift
+++ b/supacode/Features/Canvas/Views/CanvasView.swift
@@ -31,6 +31,7 @@ struct CanvasView: View {
   @State private var viewportSize: CGSize = .zero
   @State private var showsCanvasHelp = false
   @State private var configReloadCounter = 0
+  @State private var focusViewportAnimationID = 0
 
   private let minCardWidth: CGFloat = 300
   private let minCardHeight: CGFloat = 200
@@ -114,6 +115,7 @@ struct CanvasView: View {
       }
       .contentShape(.rect)
       .simultaneousGesture(canvasZoomGesture)
+      .animation(.easeInOut(duration: 0.22), value: focusViewportAnimationID)
       .onGeometryChange(for: CGSize.self) { proxy in
         proxy.size
       } action: { newSize in
@@ -760,12 +762,11 @@ struct CanvasView: View {
       width: viewportSize.width / 2 - layout.position.x * targetScale,
       height: (viewportSize.height - bottomToolbarReserve) / 2 - layout.position.y * targetScale
     )
-    withAnimation(.easeInOut(duration: 0.22)) {
-      canvasScale = targetScale
-      canvasOffset = targetOffset
-      lastCanvasScale = targetScale
-      lastCanvasOffset = targetOffset
-    }
+    canvasScale = targetScale
+    canvasOffset = targetOffset
+    lastCanvasScale = targetScale
+    lastCanvasOffset = targetOffset
+    focusViewportAnimationID &+= 1
   }
 
   private func handleSelectionShieldTap(

--- a/supacode/Features/Canvas/Views/CanvasView.swift
+++ b/supacode/Features/Canvas/Views/CanvasView.swift
@@ -12,8 +12,10 @@ struct CanvasView: View {
   /// bar without subscribing to per-repo settings files on the
   /// per-frame canvas hot path.
   var repositoryCustomTitles: [Repository.ID: String] = [:]
+  var focusRequest: CanvasFocusRequest?
   var onExitToTab: () -> Void = {}
   var onFocusedWorktreeChanged: (Worktree.ID?) -> Void = { _ in }
+  var onFocusRequestConsumed: (Int) -> Void = { _ in }
   @State private var layoutStore = CanvasLayoutStore()
   @Shared(.repositoryAppearances) private var repositoryAppearances
 
@@ -78,6 +80,7 @@ struct CanvasView: View {
             }
             pruneSelection(previousOrder: [], currentOrder: allTabIDs, states: activeStates)
             syncBroadcastCallbacks(states: activeStates)
+            fulfillPendingFocusRequest(focusRequest, states: activeStates)
           }
           .onChange(of: allCardKeys) { _, newKeys in
             if newKeys.isEmpty {
@@ -93,9 +96,14 @@ struct CanvasView: View {
               layoutStore.ensureZOrder(for: newKeys)
             }
             syncBroadcastCallbacks(states: activeStates)
+            fulfillPendingFocusRequest(focusRequest, states: activeStates)
           }
           .onChange(of: allTabIDs) { oldTabIDs, newTabIDs in
             pruneSelection(previousOrder: oldTabIDs, currentOrder: newTabIDs, states: activeStates)
+            fulfillPendingFocusRequest(focusRequest, states: activeStates)
+          }
+          .onChange(of: focusRequest) { _, newRequest in
+            fulfillPendingFocusRequest(newRequest, states: activeStates)
           }
           .contentShape(.rect)
           .accessibilityAddTraits(.isButton)
@@ -231,7 +239,7 @@ struct CanvasView: View {
         if cmdHeld {
           handleSelectionShieldTap(tab.id, surfaceState: state, states: activeStates)
         } else {
-          focusSingleCard(tab.id, surfaceState: state, states: activeStates)
+          focusSingleCard(tab.id, states: activeStates)
         }
       },
       onSelectionTap: {
@@ -258,7 +266,7 @@ struct CanvasView: View {
         let wasAlreadyFocused =
           selectionState.primaryTabID == tab.id
           && selectionState.selectedTabIDs.count <= 1
-        focusSingleCard(tab.id, surfaceState: state, states: activeStates)
+        focusSingleCard(tab.id, states: activeStates)
         let now = Date()
         if wasAlreadyFocused,
           now.timeIntervalSince(lastTitleBarTapDate) <= NSEvent.doubleClickInterval
@@ -268,7 +276,7 @@ struct CanvasView: View {
         lastTitleBarTapDate = now
       },
       onExpand: {
-        focusSingleCard(tab.id, surfaceState: state, states: activeStates)
+        focusSingleCard(tab.id, states: activeStates)
         onExitToTab()
       },
       onClose: {
@@ -425,6 +433,16 @@ struct CanvasView: View {
     states.flatMap { state in
       state.tabManager.tabs.compactMap { tab in
         state.surfaceView(for: tab.id) != nil ? tab.id : nil
+      }
+    }
+  }
+
+  private func collectFocusCandidates(from states: [WorktreeTerminalState]) -> [CanvasFocusCandidate] {
+    states.flatMap { state in
+      state.tabManager.tabs.compactMap { tab in
+        state.surfaceView(for: tab.id) != nil
+          ? CanvasFocusCandidate(worktreeID: state.worktreeID, tabID: tab.id)
+          : nil
       }
     }
   }
@@ -695,13 +713,56 @@ struct CanvasView: View {
 
   private func focusSingleCard(
     _ tabID: TerminalTabID,
-    surfaceState _: WorktreeTerminalState,
     states: [WorktreeTerminalState]
   ) {
     layoutStore.moveToFront(tabID.rawValue.uuidString)
     mutateSelection(states: states) { state in
       state.focusSingle(tabID)
     }
+  }
+
+  private func fulfillPendingFocusRequest(
+    _ request: CanvasFocusRequest?,
+    states: [WorktreeTerminalState]
+  ) {
+    guard let request else { return }
+    let tabID = CanvasFocusResolver.resolve(
+      request: request,
+      candidates: collectFocusCandidates(from: states),
+      currentPrimaryTabID: selectionState.primaryTabID
+    )
+    guard let tabID else { return }
+    focusSingleCard(tabID, states: states)
+    focusViewport(on: tabID)
+    onFocusRequestConsumed(request.id)
+  }
+
+  private func focusViewport(on tabID: TerminalTabID) {
+    guard viewportSize.width > 0, viewportSize.height > 0 else { return }
+    let cardKey = tabID.rawValue.uuidString
+    guard let layout = layoutStore.cardLayouts[cardKey] else { return }
+
+    let horizontalPadding: CGFloat = 80
+    let verticalPadding: CGFloat = 80 + bottomToolbarReserve
+    let availableWidth = max(1, viewportSize.width - horizontalPadding)
+    let availableHeight = max(1, viewportSize.height - verticalPadding)
+    let targetScale = max(
+      0.25,
+      min(
+        1.25,
+        min(
+          availableWidth / layout.size.width,
+          availableHeight / (layout.size.height + titleBarHeight)
+        )
+      )
+    )
+    canvasScale = targetScale
+    canvasOffset = CGSize(
+      width: viewportSize.width / 2 - layout.position.x * targetScale,
+      height: (viewportSize.height - bottomToolbarReserve) / 2 - layout.position.y * targetScale
+    )
+    lastCanvasScale = targetScale
+    lastCanvasOffset = canvasOffset
   }
 
   private func handleSelectionShieldTap(

--- a/supacode/Features/Canvas/Views/CanvasView.swift
+++ b/supacode/Features/Canvas/Views/CanvasView.swift
@@ -756,13 +756,16 @@ struct CanvasView: View {
         )
       )
     )
-    canvasScale = targetScale
-    canvasOffset = CGSize(
+    let targetOffset = CGSize(
       width: viewportSize.width / 2 - layout.position.x * targetScale,
       height: (viewportSize.height - bottomToolbarReserve) / 2 - layout.position.y * targetScale
     )
-    lastCanvasScale = targetScale
-    lastCanvasOffset = canvasOffset
+    withAnimation(.easeInOut(duration: 0.22)) {
+      canvasScale = targetScale
+      canvasOffset = targetOffset
+      lastCanvasScale = targetScale
+      lastCanvasOffset = targetOffset
+    }
   }
 
   private func handleSelectionShieldTap(

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -347,6 +347,8 @@ struct RepositoriesFeature {
     case setSidebarSelectedWorktreeIDs(Set<Worktree.ID>)
     case selectRepository(Repository.ID?)
     case selectWorktree(Worktree.ID?, focusTerminal: Bool = false, recordHistory: Bool = true)
+    case focusCanvasRepository(Repository.ID)
+    case focusCanvasWorktree(Worktree.ID)
     case selectNextWorktree
     case selectPreviousWorktree
     case consumeCanvasFocusRequest(Int)
@@ -969,13 +971,6 @@ struct RepositoriesFeature {
           let selectRepoToken = repositoriesLogger.beginInterval("reducer.selectRepository")
           defer { repositoriesLogger.endInterval(selectRepoToken) }
           guard let repositoryID, state.repositories[id: repositoryID] != nil else { return .none }
-          if state.isShowingCanvas {
-            guard let worktree = state.canvasNavigationWorktree(forRepositoryID: repositoryID) else { return .none }
-            requestCanvasFocus(.worktree(worktree.id), openedWorktreeID: worktree.id, state: &state)
-            return .run { _ in
-              await terminalClient.send(.ensureInitialTab(worktree, runSetupScriptIfNew: false, focusing: false))
-            }
-          }
           recordWorktreeHistoryTransition(from: state.selectedWorktreeID, to: nil, state: &state)
           state.selection = .repository(repositoryID)
           state.sidebarSelectedWorktreeIDs = []
@@ -988,13 +983,6 @@ struct RepositoriesFeature {
         case .selectWorktree(let worktreeID, let focusTerminal, let recordHistory):
           let selectWtToken = repositoriesLogger.beginInterval("reducer.selectWorktree")
           defer { repositoriesLogger.endInterval(selectWtToken) }
-          if state.isShowingCanvas {
-            guard let worktree = state.worktree(for: worktreeID) else { return .none }
-            requestCanvasFocus(.worktree(worktree.id), openedWorktreeID: worktree.id, state: &state)
-            return .run { _ in
-              await terminalClient.send(.ensureInitialTab(worktree, runSetupScriptIfNew: false, focusing: false))
-            }
-          }
           setSingleWorktreeSelection(worktreeID, state: &state, recordHistory: recordHistory)
           if focusTerminal, let worktreeID {
             state.pendingTerminalFocusWorktreeIDs.insert(worktreeID)
@@ -1004,6 +992,28 @@ struct RepositoriesFeature {
           }
           let selectedWorktree = state.worktree(for: worktreeID)
           return .send(.delegate(.selectedWorktreeChanged(selectedWorktree)))
+
+        case .focusCanvasRepository(let repositoryID):
+          guard state.isShowingCanvas,
+            let worktree = state.canvasNavigationWorktree(forRepositoryID: repositoryID)
+          else {
+            return .none
+          }
+          requestCanvasFocus(.worktree(worktree.id), openedWorktreeID: worktree.id, state: &state)
+          return .run { _ in
+            await terminalClient.send(.ensureInitialTab(worktree, runSetupScriptIfNew: false, focusing: false))
+          }
+
+        case .focusCanvasWorktree(let worktreeID):
+          guard state.isShowingCanvas,
+            let worktree = state.worktree(for: worktreeID)
+          else {
+            return .none
+          }
+          requestCanvasFocus(.worktree(worktree.id), openedWorktreeID: worktree.id, state: &state)
+          return .run { _ in
+            await terminalClient.send(.ensureInitialTab(worktree, runSetupScriptIfNew: false, focusing: false))
+          }
 
         case .selectNextWorktree:
           // In Shelf, the vertical arrow pair maps to tab navigation

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -275,6 +275,8 @@ struct RepositoriesFeature {
     var isSidebarDragActive = false
     var pendingSidebarNotifyReorderIDs: [Worktree.ID] = []
     var showActiveAgentTabTitles = false
+    var nextCanvasFocusRequestID = 0
+    var pendingCanvasFocusRequest: CanvasFocusRequest?
     var activeAgents = ActiveAgentsFeature.State()
     @Shared(.appStorage("sidebarCollapsedRepositoryIDs")) var collapsedRepositoryIDs: [Repository.ID] = []
     @Presents var worktreeCreationPrompt: WorktreeCreationPromptFeature.State?
@@ -347,6 +349,7 @@ struct RepositoriesFeature {
     case selectWorktree(Worktree.ID?, focusTerminal: Bool = false, recordHistory: Bool = true)
     case selectNextWorktree
     case selectPreviousWorktree
+    case consumeCanvasFocusRequest(Int)
     case worktreeHistoryBack
     case worktreeHistoryForward
     case revealSelectedWorktreeInSidebar
@@ -446,6 +449,12 @@ struct RepositoriesFeature {
 
         case .activeAgents(.entryTapped(let id)):
           guard let entry = state.activeAgents.entries[id: id] else { return .none }
+          if state.isShowingCanvas {
+            requestCanvasFocus(.tab(entry.tabID), openedWorktreeID: entry.worktreeID, state: &state)
+            return .run { _ in
+              _ = await terminalClient.focusSurface(entry.worktreeID, entry.surfaceID)
+            }
+          }
           let isPlainFolder =
             state.repositories[id: entry.worktreeID]?.kind == .plain
           if isPlainFolder {
@@ -960,6 +969,13 @@ struct RepositoriesFeature {
           let selectRepoToken = repositoriesLogger.beginInterval("reducer.selectRepository")
           defer { repositoriesLogger.endInterval(selectRepoToken) }
           guard let repositoryID, state.repositories[id: repositoryID] != nil else { return .none }
+          if state.isShowingCanvas {
+            guard let worktree = state.canvasNavigationWorktree(forRepositoryID: repositoryID) else { return .none }
+            requestCanvasFocus(.worktree(worktree.id), openedWorktreeID: worktree.id, state: &state)
+            return .run { _ in
+              await terminalClient.send(.ensureInitialTab(worktree, runSetupScriptIfNew: false, focusing: false))
+            }
+          }
           recordWorktreeHistoryTransition(from: state.selectedWorktreeID, to: nil, state: &state)
           state.selection = .repository(repositoryID)
           state.sidebarSelectedWorktreeIDs = []
@@ -972,6 +988,13 @@ struct RepositoriesFeature {
         case .selectWorktree(let worktreeID, let focusTerminal, let recordHistory):
           let selectWtToken = repositoriesLogger.beginInterval("reducer.selectWorktree")
           defer { repositoriesLogger.endInterval(selectWtToken) }
+          if state.isShowingCanvas {
+            guard let worktree = state.worktree(for: worktreeID) else { return .none }
+            requestCanvasFocus(.worktree(worktree.id), openedWorktreeID: worktree.id, state: &state)
+            return .run { _ in
+              await terminalClient.send(.ensureInitialTab(worktree, runSetupScriptIfNew: false, focusing: false))
+            }
+          }
           setSingleWorktreeSelection(worktreeID, state: &state, recordHistory: recordHistory)
           if focusTerminal, let worktreeID {
             state.pendingTerminalFocusWorktreeIDs.insert(worktreeID)
@@ -1002,6 +1025,12 @@ struct RepositoriesFeature {
           }
           guard let id = state.worktreeID(byOffset: -1) else { return .none }
           return .send(.selectWorktree(id))
+
+        case .consumeCanvasFocusRequest(let id):
+          if state.pendingCanvasFocusRequest?.id == id {
+            state.pendingCanvasFocusRequest = nil
+          }
+          return .none
 
         case .worktreeHistoryBack:
           return navigateWorktreeHistory(direction: .backward, state: &state)
@@ -1808,6 +1837,23 @@ extension RepositoriesFeature.State {
     return nil
   }
 
+  func canvasNavigationWorktree(forRepositoryID repositoryID: Repository.ID) -> Worktree? {
+    guard let repository = repositories[id: repositoryID] else { return nil }
+    if repository.capabilities.supportsWorktrees {
+      return worktreeRows(in: repository)
+        .compactMap { worktree(for: $0.id) }
+        .first
+    }
+    guard repository.capabilities.supportsRunnableFolderActions else { return nil }
+    return Worktree(
+      id: repository.id,
+      name: repository.name,
+      detail: repository.rootURL.path(percentEncoded: false),
+      workingDirectory: repository.rootURL,
+      repositoryRootURL: repository.rootURL
+    )
+  }
+
   func pendingWorktree(for id: Worktree.ID?) -> PendingWorktree? {
     guard let id else { return nil }
     return pendingWorktrees.first(where: { $0.id == id })
@@ -2130,6 +2176,19 @@ struct FailedWorktreeCleanup {
 
 func removePendingWorktree(_ id: String, state: inout RepositoriesFeature.State) {
   state.pendingWorktrees.removeAll { $0.id == id }
+}
+
+func requestCanvasFocus(
+  _ target: CanvasFocusRequest.Target,
+  openedWorktreeID: Worktree.ID,
+  state: inout RepositoriesFeature.State
+) {
+  state.nextCanvasFocusRequestID += 1
+  state.pendingCanvasFocusRequest = CanvasFocusRequest(
+    id: state.nextCanvasFocusRequestID,
+    target: target
+  )
+  state.openedWorktreeIDs.insert(openedWorktreeID)
 }
 
 func updatePendingWorktreeProgress(

--- a/supacode/Features/Repositories/Views/SidebarListView.swift
+++ b/supacode/Features/Repositories/Views/SidebarListView.swift
@@ -449,12 +449,14 @@ struct SidebarListView: View {
       }
       sidebarSelections = []
       if store.state.isShowingCanvas {
-        store.send(.selectRepository(repository.id))
+        store.send(.focusCanvasRepository(repository.id))
       }
     } else {
       sidebarSelections = [.repository(repository.id)]
-      store.send(.selectRepository(repository.id))
-      if !store.state.isShowingCanvas {
+      if store.state.isShowingCanvas {
+        store.send(.focusCanvasRepository(repository.id))
+      } else {
+        store.send(.selectRepository(repository.id))
         focusTerminalAfterSidebarSelection(worktreeID: store.state.selectedTerminalWorktree?.id)
       }
     }

--- a/supacode/Features/Repositories/Views/SidebarListView.swift
+++ b/supacode/Features/Repositories/Views/SidebarListView.swift
@@ -448,12 +448,9 @@ struct SidebarListView: View {
         }
       }
       sidebarSelections = []
-      if store.state.isShowingCanvas {
-        store.send(.focusCanvasRepository(repository.id))
-      }
     } else {
       sidebarSelections = [.repository(repository.id)]
-      if store.state.isShowingCanvas {
+      if store.state.isShowingCanvas, Self.repositoryHeaderOpensCanvasTarget(repository) {
         store.send(.focusCanvasRepository(repository.id))
       } else {
         store.send(.selectRepository(repository.id))
@@ -502,6 +499,10 @@ struct SidebarListView: View {
       selectedWorktreeIDs.insert(selectedWorktreeID)
     }
     return selectedWorktreeIDs
+  }
+
+  static func repositoryHeaderOpensCanvasTarget(_ repository: Repository) -> Bool {
+    repository.capabilities.supportsRunnableFolderActions && !repository.capabilities.supportsWorktrees
   }
 
   static func activeAgentWorktreeMetadata(

--- a/supacode/Features/Repositories/Views/SidebarListView.swift
+++ b/supacode/Features/Repositories/Views/SidebarListView.swift
@@ -448,10 +448,15 @@ struct SidebarListView: View {
         }
       }
       sidebarSelections = []
+      if store.state.isShowingCanvas {
+        store.send(.selectRepository(repository.id))
+      }
     } else {
       sidebarSelections = [.repository(repository.id)]
       store.send(.selectRepository(repository.id))
-      focusTerminalAfterSidebarSelection(worktreeID: store.state.selectedTerminalWorktree?.id)
+      if !store.state.isShowingCanvas {
+        focusTerminalAfterSidebarSelection(worktreeID: store.state.selectedTerminalWorktree?.id)
+      }
     }
   }
 

--- a/supacode/Features/Repositories/Views/WorktreeDetailView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailView.swift
@@ -384,11 +384,15 @@ struct WorktreeDetailView: View {
       CanvasView(
         terminalManager: terminalManager,
         repositoryCustomTitles: repositories.repositoryCustomTitles,
+        focusRequest: repositories.pendingCanvasFocusRequest,
         onExitToTab: {
           store.send(.repositories(.toggleCanvas))
         },
         onFocusedWorktreeChanged: { worktreeID in
           store.send(.canvasFocusedWorktreeChanged(worktreeID))
+        },
+        onFocusRequestConsumed: { requestID in
+          store.send(.repositories(.consumeCanvasFocusRequest(requestID)))
         }
       )
       // Canvas tints the nav (leading) only; the toolbar is left untinted so

--- a/supacode/Features/Repositories/Views/WorktreeRowsView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeRowsView.swift
@@ -288,8 +288,10 @@ struct WorktreeRowsView: View {
       return
     }
 
-    store.send(.selectWorktree(worktreeID, focusTerminal: true))
-    if !store.state.isShowingCanvas {
+    if store.state.isShowingCanvas {
+      store.send(.focusCanvasWorktree(worktreeID))
+    } else {
+      store.send(.selectWorktree(worktreeID, focusTerminal: true))
       focusTerminalAfterSelection(worktreeID: worktreeID)
     }
   }

--- a/supacode/Features/Repositories/Views/WorktreeRowsView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeRowsView.swift
@@ -289,7 +289,9 @@ struct WorktreeRowsView: View {
     }
 
     store.send(.selectWorktree(worktreeID, focusTerminal: true))
-    focusTerminalAfterSelection(worktreeID: worktreeID)
+    if !store.state.isShowingCanvas {
+      focusTerminalAfterSelection(worktreeID: worktreeID)
+    }
   }
 
   private func focusTerminalAfterSelection(worktreeID: Worktree.ID) {

--- a/supacodeTests/CanvasFocusResolverTests.swift
+++ b/supacodeTests/CanvasFocusResolverTests.swift
@@ -1,0 +1,86 @@
+import Foundation
+import Testing
+
+@testable import supacode
+
+struct CanvasFocusResolverTests {
+  @Test func worktreeTargetSelectsFirstCardWhenNothingIsFocused() {
+    let worktreeID = "/tmp/repo/main"
+    let first = TerminalTabID(rawValue: UUID())
+    let second = TerminalTabID(rawValue: UUID())
+
+    let resolved = CanvasFocusResolver.resolve(
+      request: CanvasFocusRequest(id: 1, target: .worktree(worktreeID)),
+      candidates: [
+        CanvasFocusCandidate(worktreeID: worktreeID, tabID: first),
+        CanvasFocusCandidate(worktreeID: worktreeID, tabID: second),
+      ],
+      currentPrimaryTabID: nil
+    )
+
+    #expect(resolved == first)
+  }
+
+  @Test func worktreeTargetCyclesFromFocusedCardToNextMatch() {
+    let worktreeID = "/tmp/repo/main"
+    let first = TerminalTabID(rawValue: UUID())
+    let second = TerminalTabID(rawValue: UUID())
+    let other = TerminalTabID(rawValue: UUID())
+
+    let resolved = CanvasFocusResolver.resolve(
+      request: CanvasFocusRequest(id: 1, target: .worktree(worktreeID)),
+      candidates: [
+        CanvasFocusCandidate(worktreeID: worktreeID, tabID: first),
+        CanvasFocusCandidate(worktreeID: "/tmp/other/main", tabID: other),
+        CanvasFocusCandidate(worktreeID: worktreeID, tabID: second),
+      ],
+      currentPrimaryTabID: first
+    )
+
+    #expect(resolved == second)
+  }
+
+  @Test func worktreeTargetWrapsFromLastFocusedCardToFirstMatch() {
+    let worktreeID = "/tmp/repo/main"
+    let first = TerminalTabID(rawValue: UUID())
+    let second = TerminalTabID(rawValue: UUID())
+
+    let resolved = CanvasFocusResolver.resolve(
+      request: CanvasFocusRequest(id: 1, target: .worktree(worktreeID)),
+      candidates: [
+        CanvasFocusCandidate(worktreeID: worktreeID, tabID: first),
+        CanvasFocusCandidate(worktreeID: worktreeID, tabID: second),
+      ],
+      currentPrimaryTabID: second
+    )
+
+    #expect(resolved == first)
+  }
+
+  @Test func tabTargetSelectsExactVisibleCard() {
+    let requested = TerminalTabID(rawValue: UUID())
+
+    let resolved = CanvasFocusResolver.resolve(
+      request: CanvasFocusRequest(id: 1, target: .tab(requested)),
+      candidates: [
+        CanvasFocusCandidate(worktreeID: "/tmp/repo/main", tabID: TerminalTabID(rawValue: UUID())),
+        CanvasFocusCandidate(worktreeID: "/tmp/repo/main", tabID: requested),
+      ],
+      currentPrimaryTabID: nil
+    )
+
+    #expect(resolved == requested)
+  }
+
+  @Test func tabTargetWaitsWhenExactCardIsNotVisibleYet() {
+    let resolved = CanvasFocusResolver.resolve(
+      request: CanvasFocusRequest(id: 1, target: .tab(TerminalTabID(rawValue: UUID()))),
+      candidates: [
+        CanvasFocusCandidate(worktreeID: "/tmp/repo/main", tabID: TerminalTabID(rawValue: UUID()))
+      ],
+      currentPrimaryTabID: nil
+    )
+
+    #expect(resolved == nil)
+  }
+}

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -1119,7 +1119,7 @@ struct RepositoriesFeatureTests {
     await store.receive(\.delegate.selectedWorktreeChanged)
   }
 
-  @Test func selectRepositoryInCanvasRequestsCanvasFocusWithoutLeavingCanvas() async {
+  @Test func focusCanvasRepositoryRequestsCanvasFocusWithoutLeavingCanvas() async {
     let worktree = makeWorktree(id: "/tmp/repo/main", name: "main", repoRoot: "/tmp/repo")
     let repository = makeRepository(id: "/tmp/repo", worktrees: [worktree])
     var initialState = makeState(repositories: [repository])
@@ -1134,7 +1134,8 @@ struct RepositoriesFeatureTests {
       }
     }
 
-    await store.send(.selectRepository(repository.id)) {
+    await store.send(.focusCanvasRepository(repository.id)) {
+      $0.nextCanvasFocusRequestID = 1
       $0.pendingCanvasFocusRequest = CanvasFocusRequest(
         id: 1,
         target: .worktree(worktree.id)
@@ -1151,7 +1152,7 @@ struct RepositoriesFeatureTests {
     )
   }
 
-  @Test func selectPlainRepositoryInCanvasRequestsCanvasFocusWithoutLeavingCanvas() async {
+  @Test func focusCanvasPlainRepositoryRequestsCanvasFocusWithoutLeavingCanvas() async {
     let repository = makeRepository(
       id: "/tmp/folder",
       name: "folder",
@@ -1177,7 +1178,8 @@ struct RepositoriesFeatureTests {
       }
     }
 
-    await store.send(.selectRepository(repository.id)) {
+    await store.send(.focusCanvasRepository(repository.id)) {
+      $0.nextCanvasFocusRequestID = 1
       $0.pendingCanvasFocusRequest = CanvasFocusRequest(
         id: 1,
         target: .worktree(repository.id)
@@ -1190,6 +1192,39 @@ struct RepositoriesFeatureTests {
     #expect(
       sentCommands.value == [
         .ensureInitialTab(expectedWorktree, runSetupScriptIfNew: false, focusing: false)
+      ]
+    )
+  }
+
+  @Test func focusCanvasWorktreeRequestsCanvasFocusWithoutLeavingCanvas() async {
+    let worktree = makeWorktree(id: "/tmp/repo/main", name: "main", repoRoot: "/tmp/repo")
+    let repository = makeRepository(id: "/tmp/repo", worktrees: [worktree])
+    var initialState = makeState(repositories: [repository])
+    initialState.selection = .canvas
+
+    let sentCommands = LockIsolated<[TerminalClient.Command]>([])
+    let store = TestStore(initialState: initialState) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in
+        sentCommands.withValue { $0.append(command) }
+      }
+    }
+
+    await store.send(.focusCanvasWorktree(worktree.id)) {
+      $0.nextCanvasFocusRequestID = 1
+      $0.pendingCanvasFocusRequest = CanvasFocusRequest(
+        id: 1,
+        target: .worktree(worktree.id)
+      )
+      $0.openedWorktreeIDs = [worktree.id]
+    }
+    await store.finish()
+
+    #expect(store.state.selection == .canvas)
+    #expect(
+      sentCommands.value == [
+        .ensureInitialTab(worktree, runSetupScriptIfNew: false, focusing: false)
       ]
     )
   }
@@ -1229,6 +1264,7 @@ struct RepositoriesFeatureTests {
 
     await store.send(.activeAgents(.entryTapped(entry.id))) {
       $0.activeAgents.focusedSurfaceID = surfaceID
+      $0.nextCanvasFocusRequestID = 1
       $0.pendingCanvasFocusRequest = CanvasFocusRequest(
         id: 1,
         target: .tab(tabID)
@@ -1322,6 +1358,59 @@ struct RepositoriesFeatureTests {
       $0.openedWorktreeIDs = [repository.id]
     }
     await store.receive(\.delegate.selectedWorktreeChanged)
+  }
+
+  @Test func selectTabbedFromCanvasExitsCanvasInsteadOfFocusingCard() async {
+    let worktree = makeWorktree(id: "/tmp/repo/main", name: "main", repoRoot: "/tmp/repo")
+    let repository = makeRepository(id: "/tmp/repo", worktrees: [worktree])
+    var initialState = makeState(repositories: [repository])
+    initialState.selection = .canvas
+
+    let store = TestStore(initialState: initialState) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.terminalClient.canvasFocusedWorktreeID = { worktree.id }
+    }
+
+    await store.send(.setTopSegment(.tabbed))
+    await store.receive(\.selectTabbed)
+    await store.receive(\.toggleCanvas)
+    await store.receive(\.selectWorktree) {
+      $0.selection = .worktree(worktree.id)
+      $0.sidebarSelectedWorktreeIDs = [worktree.id]
+      $0.pendingTerminalFocusWorktreeIDs = [worktree.id]
+      $0.openedWorktreeIDs = [worktree.id]
+    }
+    await store.receive(\.delegate.selectedWorktreeChanged)
+    #expect(store.state.pendingCanvasFocusRequest == nil)
+  }
+
+  @Test func selectShelfFromCanvasExitsCanvasInsteadOfFocusingCard() async {
+    let worktree = makeWorktree(id: "/tmp/repo/main", name: "main", repoRoot: "/tmp/repo")
+    let repository = makeRepository(id: "/tmp/repo", worktrees: [worktree])
+    var initialState = makeState(repositories: [repository])
+    initialState.selection = .canvas
+
+    let store = TestStore(initialState: initialState) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.terminalClient.canvasFocusedWorktreeID = { worktree.id }
+    }
+
+    await store.send(.setTopSegment(.shelf))
+    await store.receive(\.selectShelf)
+    await store.receive(\.toggleShelf) {
+      $0.isShelfActive = true
+    }
+    await store.receive(\.selectWorktree) {
+      $0.selection = .worktree(worktree.id)
+      $0.sidebarSelectedWorktreeIDs = [worktree.id]
+      $0.pendingTerminalFocusWorktreeIDs = [worktree.id]
+      $0.openedWorktreeIDs = [worktree.id]
+    }
+    await store.receive(\.delegate.selectedWorktreeChanged)
+    #expect(store.state.pendingCanvasFocusRequest == nil)
+    #expect(store.state.isShowingShelf)
   }
 
   @Test func selectCanvasSeedsInitialTabForSelectedWorktree() async {

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -1119,6 +1119,129 @@ struct RepositoriesFeatureTests {
     await store.receive(\.delegate.selectedWorktreeChanged)
   }
 
+  @Test func selectRepositoryInCanvasRequestsCanvasFocusWithoutLeavingCanvas() async {
+    let worktree = makeWorktree(id: "/tmp/repo/main", name: "main", repoRoot: "/tmp/repo")
+    let repository = makeRepository(id: "/tmp/repo", worktrees: [worktree])
+    var initialState = makeState(repositories: [repository])
+    initialState.selection = .canvas
+
+    let sentCommands = LockIsolated<[TerminalClient.Command]>([])
+    let store = TestStore(initialState: initialState) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in
+        sentCommands.withValue { $0.append(command) }
+      }
+    }
+
+    await store.send(.selectRepository(repository.id)) {
+      $0.pendingCanvasFocusRequest = CanvasFocusRequest(
+        id: 1,
+        target: .worktree(worktree.id)
+      )
+      $0.openedWorktreeIDs = [worktree.id]
+    }
+    await store.finish()
+
+    #expect(store.state.selection == .canvas)
+    #expect(
+      sentCommands.value == [
+        .ensureInitialTab(worktree, runSetupScriptIfNew: false, focusing: false)
+      ]
+    )
+  }
+
+  @Test func selectPlainRepositoryInCanvasRequestsCanvasFocusWithoutLeavingCanvas() async {
+    let repository = makeRepository(
+      id: "/tmp/folder",
+      name: "folder",
+      kind: .plain,
+      worktrees: []
+    )
+    var initialState = makeState(repositories: [repository])
+    initialState.selection = .canvas
+
+    let expectedWorktree = Worktree(
+      id: repository.id,
+      name: repository.name,
+      detail: repository.rootURL.path(percentEncoded: false),
+      workingDirectory: repository.rootURL,
+      repositoryRootURL: repository.rootURL
+    )
+    let sentCommands = LockIsolated<[TerminalClient.Command]>([])
+    let store = TestStore(initialState: initialState) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in
+        sentCommands.withValue { $0.append(command) }
+      }
+    }
+
+    await store.send(.selectRepository(repository.id)) {
+      $0.pendingCanvasFocusRequest = CanvasFocusRequest(
+        id: 1,
+        target: .worktree(repository.id)
+      )
+      $0.openedWorktreeIDs = [repository.id]
+    }
+    await store.finish()
+
+    #expect(store.state.selection == .canvas)
+    #expect(
+      sentCommands.value == [
+        .ensureInitialTab(expectedWorktree, runSetupScriptIfNew: false, focusing: false)
+      ]
+    )
+  }
+
+  @Test func activeAgentEntryTappedInCanvasRequestsExactCardFocusWithoutLeavingCanvas() async {
+    let worktree = makeWorktree(id: "/tmp/repo/main", name: "main", repoRoot: "/tmp/repo")
+    let repository = makeRepository(id: "/tmp/repo", worktrees: [worktree])
+    var state = makeState(repositories: [repository])
+    state.selection = .canvas
+    let surfaceID = UUID()
+    let tabID = TerminalTabID(rawValue: UUID())
+    let entry = ActiveAgentEntry(
+      id: surfaceID,
+      worktreeID: worktree.id,
+      worktreeName: worktree.name,
+      workingDirectory: nil,
+      tabID: tabID,
+      tabTitle: "agent",
+      surfaceID: surfaceID,
+      paneIndex: 0,
+      agent: .codex,
+      rawState: .working,
+      displayState: .working,
+      lastChangedAt: Date(timeIntervalSince1970: 0)
+    )
+    state.activeAgents.entries = [entry]
+
+    let focusedSurface = LockIsolated<(Worktree.ID, UUID)?>(nil)
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.terminalClient.focusSurface = { worktreeID, surface in
+        focusedSurface.setValue((worktreeID, surface))
+        return true
+      }
+    }
+
+    await store.send(.activeAgents(.entryTapped(entry.id))) {
+      $0.activeAgents.focusedSurfaceID = surfaceID
+      $0.pendingCanvasFocusRequest = CanvasFocusRequest(
+        id: 1,
+        target: .tab(tabID)
+      )
+      $0.openedWorktreeIDs = [worktree.id]
+    }
+    await store.finish()
+
+    #expect(store.state.selection == .canvas)
+    #expect(focusedSurface.value?.0 == worktree.id)
+    #expect(focusedSurface.value?.1 == surfaceID)
+  }
+
   @Test func selectPlainRepositorySendsPlainFolderTerminalTargetDelegate() async {
     let repository = makeRepository(
       id: "/tmp/folder",

--- a/supacodeTests/RepositorySectionViewTests.swift
+++ b/supacodeTests/RepositorySectionViewTests.swift
@@ -85,6 +85,26 @@ struct RepositorySectionViewTests {
     #expect(SidebarListView.selectedWorktreeIDs(in: state) == [worktree.id])
   }
 
+  @Test func repositoryHeaderDoesNotOpenCanvasTargetForExpandableGitRepositories() {
+    let gitRepository = Repository(
+      id: "/tmp/git",
+      rootURL: URL(fileURLWithPath: "/tmp/git"),
+      name: "git",
+      kind: .git,
+      worktrees: []
+    )
+    let plainRepository = Repository(
+      id: "/tmp/plain",
+      rootURL: URL(fileURLWithPath: "/tmp/plain"),
+      name: "plain",
+      kind: .plain,
+      worktrees: []
+    )
+
+    #expect(!SidebarListView.repositoryHeaderOpensCanvasTarget(gitRepository))
+    #expect(SidebarListView.repositoryHeaderOpensCanvasTarget(plainRepository))
+  }
+
   @Test func activeAgentWorktreeMetadataUsesCustomRepositoryTitleAndCurrentBranchName() {
     let repositoryRootURL = URL(fileURLWithPath: "/tmp/prowl")
     let worktree = Worktree(


### PR DESCRIPTION
## Summary
- keep Canvas selected when sidebar repo/worktree/folder rows or Active Agents entries are clicked
- add Canvas focus requests that create a missing card when needed, select/cycle matching cards, and center/scale the focused card
- cover Canvas focus request routing and card selection resolution with tests

## Verification
- make format-changed
- xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -only-testing:supacodeTests/RepositoriesFeatureTests/selectRepositoryInCanvasRequestsCanvasFocusWithoutLeavingCanvas -only-testing:supacodeTests/RepositoriesFeatureTests/selectPlainRepositoryInCanvasRequestsCanvasFocusWithoutLeavingCanvas -only-testing:supacodeTests/RepositoriesFeatureTests/activeAgentEntryTappedInCanvasRequestsExactCardFocusWithoutLeavingCanvas CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation 2>&1 | xcsift
- xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -only-testing:supacodeTests/CanvasFocusResolverTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation 2>&1 | xcsift
- make build-app 2>&1 | xcsift
