### PR TITLE
Focus canvas cards from command palette

### DIFF
--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -1157,6 +1157,14 @@ struct AppFeature {
         return restoreCommandPaletteTerminalFocusEffect(repositories: state.repositories)
 
       case .commandPalette(.delegate(.selectWorktree(let worktreeID))):
+        if state.repositories.isShowingCanvas {
+          if state.repositories.worktree(for: worktreeID) == nil,
+            state.repositories.repositories[id: worktreeID]?.kind == .plain
+          {
+            return .send(.repositories(.focusCanvasRepository(worktreeID)))
+          }
+          return .send(.repositories(.focusCanvasWorktree(worktreeID)))
+        }
         return .send(.repositories(.selectWorktree(worktreeID)))
 
       case .commandPalette(.delegate(.checkForUpdates)):

--- a/supacodeTests/AppFeatureCommandPaletteTests.swift
+++ b/supacodeTests/AppFeatureCommandPaletteTests.swift
@@ -256,6 +256,67 @@ struct AppFeatureCommandPaletteTests {
     #expect(!sent.value.contains(.focusSelectedTab(worktree)))
   }
 
+  @Test(.dependencies) func selectingWorktreeInCanvasFocusesCanvasCard() async {
+    let worktree = makeWorktree(
+      id: "/tmp/repo-select-canvas/wt-1",
+      name: "wt-1",
+      repoRoot: "/tmp/repo-select-canvas"
+    )
+    let repository = makeRepository(id: "/tmp/repo-select-canvas", worktrees: [worktree])
+    var repositoriesState = RepositoriesFeature.State()
+    repositoriesState.repositories = [repository]
+    repositoriesState.selection = .canvas
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: repositoriesState,
+        settings: SettingsFeature.State()
+      )
+    ) {
+      AppFeature()
+    }
+
+    await store.send(.commandPalette(.delegate(.selectWorktree(worktree.id))))
+    await store.receive(\.repositories.focusCanvasWorktree) {
+      $0.repositories.nextCanvasFocusRequestID = 1
+      $0.repositories.pendingCanvasFocusRequest = CanvasFocusRequest(
+        id: 1,
+        target: .worktree(worktree.id)
+      )
+      $0.repositories.openedWorktreeIDs = [worktree.id]
+    }
+  }
+
+  @Test(.dependencies) func selectingPlainFolderInCanvasFocusesCanvasCard() async {
+    let repository = Repository(
+      id: "/tmp/folder-select-canvas",
+      rootURL: URL(fileURLWithPath: "/tmp/folder-select-canvas"),
+      name: "folder-select-canvas",
+      kind: .plain,
+      worktrees: []
+    )
+    var repositoriesState = RepositoriesFeature.State()
+    repositoriesState.repositories = [repository]
+    repositoriesState.selection = .canvas
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: repositoriesState,
+        settings: SettingsFeature.State()
+      )
+    ) {
+      AppFeature()
+    }
+
+    await store.send(.commandPalette(.delegate(.selectWorktree(repository.id))))
+    await store.receive(\.repositories.focusCanvasRepository) {
+      $0.repositories.nextCanvasFocusRequestID = 1
+      $0.repositories.pendingCanvasFocusRequest = CanvasFocusRequest(
+        id: 1,
+        target: .worktree(repository.id)
+      )
+      $0.repositories.openedWorktreeIDs = [repository.id]
+    }
+  }
+
   @Test(.dependencies) func openSettingsShowsWindow() async {
     let shown = LockIsolated(false)
     var state = AppFeature.State()

--- a/supacodeTests/BatchedPullRequestRefreshReducerTests.swift
+++ b/supacodeTests/BatchedPullRequestRefreshReducerTests.swift
@@ -49,11 +49,11 @@ struct BatchedPullRequestRefreshReducerTests {
 
     let snapshot = enqueued.value
     #expect(snapshot.count == 1)
-    let request = try? #require(snapshot.first)
-    #expect(request?.host == "github.com")
-    #expect(request?.owner == "khoi")
-    #expect(request?.repo == "alpha")
-    #expect(request?.branches == ["main", "feature"])
+    let request = snapshot[0]
+    #expect(request.host == "github.com")
+    #expect(request.owner == "khoi")
+    #expect(request.repo == "alpha")
+    #expect(request.branches == ["main", "feature"])
   }
 
   @Test func refreshResolvesAndCachesRemoteInfoOnFirstRun() async {

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -2521,7 +2521,7 @@ struct RepositoriesFeatureTests {
   @Test(.dependencies) func requestDeleteProwlCreatedWorktreeCanPreselectBranchDeletion() async {
     let worktree = makeWorktree(id: "/tmp/wt", name: "owl")
     let repository = makeRepository(id: "/tmp/repo", worktrees: [worktree])
-    var state = makeState(repositories: [repository])
+    let state = makeState(repositories: [repository])
     state.$prowlCreatedWorktreeIDs.withLock {
       $0 = [worktree.id]
     }
@@ -2601,7 +2601,7 @@ struct RepositoriesFeatureTests {
     #expect(forceDeleteAttempts.value == [false, true])
   }
 
-  @Test(.dependencies, .serialized) func worktreeDeletedPresentsQueuedForceDeleteBranchPromptsInOrder() async {
+  @Test(.dependencies) func worktreeDeletedPresentsQueuedForceDeleteBranchPromptsInOrder() async {
     let repoRoot = "/tmp/repo"
     let firstRequest = ForceDeleteBranchRequest(
       branchName: "first",


### PR DESCRIPTION
## Summary
- keep Command Palette worktree/folder selection inside Canvas mode
- route Canvas selections to `focusCanvasWorktree` / `focusCanvasRepository` instead of Normal selection
- add AppFeature coverage for worktree and plain folder command palette selections in Canvas

## Verification
- xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" '-only-testing:supacodeTests/AppFeatureCommandPaletteTests/selectingWorktreeInCanvasFocusesCanvasCard()' '-only-testing:supacodeTests/AppFeatureCommandPaletteTests/selectingPlainFolderInCanvasFocusesCanvasCard()' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation 2>&1 | xcsift
- xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" '-only-testing:supacodeTests/AppFeatureCommandPaletteTests/selectingWorktreeInCanvasFocusesCanvasCard()' '-only-testing:supacodeTests/AppFeatureCommandPaletteTests/selectingPlainFolderInCanvasFocusesCanvasCard()' '-only-testing:supacodeTests/RepositoriesFeatureTests/focusCanvasWorktreeRequestsCanvasFocusWithoutLeavingCanvas()' '-only-testing:supacodeTests/RepositoriesFeatureTests/focusCanvasPlainRepositoryRequestsCanvasFocusWithoutLeavingCanvas()' '-only-testing:supacodeTests/CanvasFocusResolverTests' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation 2>&1 | xcsift
- make format-changed
- make build-app 2>&1 | xcsift
