### PR TITLE
Avoid sidebar lazy layout spin

### DIFF
--- a/supacode/Features/Repositories/Views/SidebarListView.swift
+++ b/supacode/Features/Repositories/Views/SidebarListView.swift
@@ -90,7 +90,9 @@ struct SidebarListView: View {
 
     ScrollViewReader { scrollProxy in
       ScrollView {
-        LazyVStack(spacing: 0) {
+        // Avoid LazyVStack here: after collapsing and expanding large sections,
+        // SwiftUI's lazy placement cache can spin on the main thread while scrolling.
+        VStack(spacing: 0) {
           // When there are no repositories the sidebar stays empty — the
           // detail pane's `EmptyStateView` ("Open a repository or folder")
           // carries the prompt and the Add Repository button instead.


### PR DESCRIPTION
## Summary

- replace the sidebar's top-level `LazyVStack` with `VStack`
- avoid SwiftUI lazy placement cache spinning after collapsing and expanding long sidebar sections

## Verification

- `make check`
- `make build-app`
- manually confirmed the freeze no longer reproduces after collapsing all repositories, expanding them again, then scrolling the left sidebar repeatedly
