### PR TITLE
Fix canvas terminal resize animation

### DIFF
--- a/supacode/Features/Canvas/Views/CanvasCardView.swift
+++ b/supacode/Features/Canvas/Views/CanvasCardView.swift
@@ -228,16 +228,15 @@ struct CanvasCardView: View {
   }
 
   private var terminalContent: some View {
-    TerminalSplitTreeView(
+    AnimatedTerminalSplitTreeView(
       tree: tree,
-      pinnedSize: cardSize,
+      size: cardSize,
       activeSurfaceID: activeSurfaceID,
       unfocusedSplitOverlay: unfocusedSplitOverlay,
       splitDivider: splitDivider,
       hasNotification: { _ in false },
       action: onSplitOperation
     )
-    .frame(width: cardSize.width, height: cardSize.height)
     .allowsHitTesting(isFocused && !showsSelectionShield)
   }
 
@@ -367,6 +366,36 @@ struct CanvasCardView: View {
       x: (alignment == .bottomTrailing || alignment == .topTrailing) ? cornerSide / 3 : -cornerSide / 3,
       y: (alignment == .topLeading || alignment == .topTrailing) ? -cornerSide / 3 : cornerSide / 3
     )
+  }
+}
+
+private struct AnimatedTerminalSplitTreeView: View, Animatable {
+  let tree: SplitTree<GhosttySurfaceView>
+  var size: CGSize
+  let activeSurfaceID: UUID?
+  let unfocusedSplitOverlay: (fill: Color?, opacity: Double)
+  var splitDivider: (color: Color?, width: CGFloat?)
+  let hasNotification: (UUID) -> Bool
+  let action: (TerminalSplitTreeView.Operation) -> Void
+
+  var animatableData: AnimatablePair<CGFloat, CGFloat> {
+    get { AnimatablePair(size.width, size.height) }
+    set {
+      size = CGSize(width: newValue.first, height: newValue.second)
+    }
+  }
+
+  var body: some View {
+    TerminalSplitTreeView(
+      tree: tree,
+      pinnedSize: size,
+      activeSurfaceID: activeSurfaceID,
+      unfocusedSplitOverlay: unfocusedSplitOverlay,
+      splitDivider: splitDivider,
+      hasNotification: hasNotification,
+      action: action
+    )
+    .frame(width: size.width, height: size.height)
   }
 }
 

--- a/supacode/Features/Canvas/Views/CanvasCardView.swift
+++ b/supacode/Features/Canvas/Views/CanvasCardView.swift
@@ -23,6 +23,7 @@ struct CanvasCardView: View {
   let isSelected: Bool
   let hasUnseenNotification: Bool
   let cardSize: CGSize
+  let animatesSizeChanges: Bool
   let canvasScale: CGFloat
   let showsSelectionShield: Bool
   let onTap: () -> Void
@@ -237,6 +238,7 @@ struct CanvasCardView: View {
       hasNotification: { _ in false },
       action: onSplitOperation
     )
+    .animation(animatesSizeChanges ? .easeInOut(duration: 0.2) : nil, value: cardSize)
     .allowsHitTesting(isFocused && !showsSelectionShield)
   }
 

--- a/supacode/Features/Canvas/Views/CanvasView.swift
+++ b/supacode/Features/Canvas/Views/CanvasView.swift
@@ -234,6 +234,7 @@ struct CanvasView: View {
       isSelected: selectionState.selectedTabIDs.contains(tab.id),
       hasUnseenNotification: state.hasUnseenNotification(for: tab.id),
       cardSize: resized.size,
+      animatesSizeChanges: activeResize[tab.id] == nil,
       canvasScale: canvasScale,
       showsSelectionShield: showsSelectionShield(for: tab.id),
       onTap: {


### PR DESCRIPTION
## Summary
- animate the Canvas terminal subtree's pinned size during card resize transitions
- explicitly animate terminal size changes for non-interactive Canvas refits, so Organize/Arrange keeps terminal content in sync with the card title bar when the canvas offset changes
- keep drag-resize immediate by disabling that explicit size animation while a resize gesture is active

## Verification
- make build-app
- make check

## Manual verification
1. Open Canvas with at least one card.
2. Resize a card away from the default size.
3. Click "Organize cards in a uniform grid" and confirm the terminal content and title bar resize together.
4. Move or resize a card so Organize must also refit/scroll the canvas, then click "Organize cards in a uniform grid" and confirm the terminal content no longer jumps to the final size.
