### PR TITLE
Canvas: expand a card in place (magic-move), with scrim, gesture lock, shortcut & palette

### DIFF
--- a/supacode/App/AppShortcuts.swift
+++ b/supacode/App/AppShortcuts.swift
@@ -142,6 +142,7 @@ enum AppShortcuts {
     static let selectAllCanvasCards = "select_all_canvas_cards"
     static let arrangeCanvasCards = "arrange_canvas_cards"
     static let organizeCanvasCards = "organize_canvas_cards"
+    static let expandCanvasCard = "expand_canvas_card"
     static let selectPreviousTerminalTab = "select_previous_terminal_tab"
     static let selectNextTerminalTab = "select_next_terminal_tab"
     static let selectPreviousTerminalPane = "select_previous_terminal_pane"
@@ -290,6 +291,7 @@ enum AppShortcuts {
   static let selectAllCanvasCards = AppShortcut(key: "a", modifiers: [.command, .option])
   static let arrangeCanvasCards = AppShortcut(key: "r", modifiers: [.command, .option])
   static let organizeCanvasCards = AppShortcut(key: "g", modifiers: [.command, .option])
+  static let expandCanvasCard = AppShortcut(key: "e", modifiers: [.command, .option])
   static let worktreeSelection: [AppShortcut] = [
     selectWorktree1,
     selectWorktree2,
@@ -766,6 +768,12 @@ enum AppShortcuts {
       title: "Organize Canvas Cards",
       scope: .localInteraction,
       shortcut: organizeCanvasCards
+    ),
+    .init(
+      id: CommandID.expandCanvasCard,
+      title: "Expand / Restore Canvas Card",
+      scope: .localInteraction,
+      shortcut: expandCanvasCard
     ),
   ]
 

--- a/supacode/Domain/WindowChromeTint.swift
+++ b/supacode/Domain/WindowChromeTint.swift
@@ -215,8 +215,11 @@ extension View {
   /// behind full-bleed chrome, while the toolbar itself must also have an
   /// explicit background because macOS can stop sampling that content when
   /// a window is zoomed or fullscreen.
-  func windowToolbarChromeBackground(_ fill: WindowChromeTint.Fill?) -> some View {
-    modifier(WindowToolbarChromeBackgroundModifier(fill: fill))
+  func windowToolbarChromeBackground(
+    _ fill: WindowChromeTint.Fill?,
+    forceMaterialScrim: Bool = false
+  ) -> some View {
+    modifier(WindowToolbarChromeBackgroundModifier(fill: fill, forceMaterialScrim: forceMaterialScrim))
   }
 }
 
@@ -274,17 +277,27 @@ private struct WindowChromeTintModifier: ViewModifier {
 
 private struct WindowToolbarChromeBackgroundModifier: ViewModifier {
   let fill: WindowChromeTint.Fill?
+  /// When true (a Canvas card is expanded in place), forces a neutral material
+  /// scrim onto the otherwise-transparent Canvas toolbar so the background cards
+  /// don't show through above the expanded card. Crucially this stays the same
+  /// modifier (only its inputs change), so toggling it never re-creates the
+  /// detail content / Canvas view.
+  let forceMaterialScrim: Bool
   @Environment(\.colorScheme) private var colorScheme
   @State private var isFullScreen = false
 
   @ViewBuilder
   func body(content: Content) -> some View {
-    let background = WindowChromeTint.fullscreenToolbarBackgroundComponents(
+    let colorBackground = WindowChromeTint.fullscreenToolbarBackgroundComponents(
       fill: fill,
       colorScheme: colorScheme
     ).color
+    // `.bar` is a theme-adaptive material (light → pale grey, dark → dark grey).
+    let background: AnyShapeStyle =
+      forceMaterialScrim ? AnyShapeStyle(.bar) : AnyShapeStyle(colorBackground)
     let visibility: Visibility =
-      WindowChromeTint.usesExplicitToolbarBackground(isFullScreen: isFullScreen) ? .visible : .hidden
+      forceMaterialScrim || WindowChromeTint.usesExplicitToolbarBackground(isFullScreen: isFullScreen)
+      ? .visible : .hidden
 
     content
       .toolbarBackground(background, for: .windowToolbar)

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -1207,6 +1207,18 @@ struct AppFeature {
       case .commandPalette(.delegate(.toggleCanvas)):
         return .send(.repositories(.toggleCanvas))
 
+      case .commandPalette(.delegate(.expandCanvasCard)):
+        return .send(.repositories(.requestCanvasCommand(.toggleExpand)))
+
+      case .commandPalette(.delegate(.arrangeCanvasCards)):
+        return .send(.repositories(.requestCanvasCommand(.arrange)))
+
+      case .commandPalette(.delegate(.organizeCanvasCards)):
+        return .send(.repositories(.requestCanvasCommand(.organize)))
+
+      case .commandPalette(.delegate(.selectAllCanvasCards)):
+        return .send(.repositories(.requestCanvasCommand(.selectAll)))
+
       case .commandPalette(.delegate(.toggleShelf)):
         return .send(.repositories(.toggleShelf))
 

--- a/supacode/Features/Canvas/Models/CanvasExpandGeometry.swift
+++ b/supacode/Features/Canvas/Models/CanvasExpandGeometry.swift
@@ -1,16 +1,16 @@
 import CoreGraphics
 
 /// Geometry for the canvas "expand-in-place" interaction: a card is temporarily
-/// blown up to a near-fullscreen size at canvas scale 1 (so its terminal renders
-/// at the same font size as Normal/Shelf mode), centered in the viewport with a
-/// padding margin and the bottom toolbar reserve avoided.
+/// blown up to a near-fullscreen size at scale 1 (so its terminal renders at the
+/// same font size as Normal/Shelf mode), covering the viewport with a padding
+/// margin and avoiding the bottom toolbar reserve. The expanded card transforms
+/// on its own; the canvas pan/zoom is left untouched so the background is frozen.
 enum CanvasExpandGeometry {
   /// Layout metrics for an expanded card.
   struct Metrics {
     /// Margin kept on every side of the expanded card.
     var padding: CGFloat
-    /// Extra height reserved at the bottom for the help/layout toolbar (matches
-    /// `fitToView`'s vertical centering).
+    /// Extra height reserved at the bottom for the help/layout toolbar.
     var bottomReserve: CGFloat
     /// Height of the card title bar, added on top of the content height.
     var titleBarHeight: CGFloat
@@ -18,30 +18,13 @@ enum CanvasExpandGeometry {
     var minSize: CGSize
   }
 
-  /// Compute the expanded card's content size (excluding the title bar) and the
-  /// canvas offset that centers it, assuming canvas scale is fixed at 1.
-  ///
-  /// - Parameters:
-  ///   - viewport: The canvas viewport size.
-  ///   - cardCenter: The card's center in canvas coordinates (its stored layout
-  ///     position, unchanged by expand).
-  ///   - metrics: Padding / reserve / title-bar / min-size metrics.
-  static func expandedFrame(
-    viewport: CGSize,
-    cardCenter: CGPoint,
-    metrics: Metrics
-  ) -> (size: CGSize, offset: CGSize) {
+  /// The expanded card's content size (excluding the title bar): the viewport
+  /// minus the padding margin, the bottom reserve, and the title bar, clamped to
+  /// `minSize`.
+  static func expandedSize(viewport: CGSize, metrics: Metrics) -> CGSize {
     let width = max(metrics.minSize.width, viewport.width - metrics.padding * 2)
     let totalHeight = viewport.height - metrics.padding * 2 - metrics.bottomReserve
     let height = max(metrics.minSize.height, totalHeight - metrics.titleBarHeight)
-
-    // Scale is 1, so screen position == cardCenter + offset. Center the card
-    // horizontally and vertically within the toolbar-adjusted viewport.
-    let offset = CGSize(
-      width: viewport.width / 2 - cardCenter.x,
-      height: (viewport.height - metrics.bottomReserve) / 2 - cardCenter.y
-    )
-
-    return (CGSize(width: width, height: height), offset)
+    return CGSize(width: width, height: height)
   }
 }

--- a/supacode/Features/Canvas/Models/CanvasExpandGeometry.swift
+++ b/supacode/Features/Canvas/Models/CanvasExpandGeometry.swift
@@ -1,0 +1,47 @@
+import CoreGraphics
+
+/// Geometry for the canvas "expand-in-place" interaction: a card is temporarily
+/// blown up to a near-fullscreen size at canvas scale 1 (so its terminal renders
+/// at the same font size as Normal/Shelf mode), centered in the viewport with a
+/// padding margin and the bottom toolbar reserve avoided.
+enum CanvasExpandGeometry {
+  /// Layout metrics for an expanded card.
+  struct Metrics {
+    /// Margin kept on every side of the expanded card.
+    var padding: CGFloat
+    /// Extra height reserved at the bottom for the help/layout toolbar (matches
+    /// `fitToView`'s vertical centering).
+    var bottomReserve: CGFloat
+    /// Height of the card title bar, added on top of the content height.
+    var titleBarHeight: CGFloat
+    /// Lower bound for the content size on tiny viewports.
+    var minSize: CGSize
+  }
+
+  /// Compute the expanded card's content size (excluding the title bar) and the
+  /// canvas offset that centers it, assuming canvas scale is fixed at 1.
+  ///
+  /// - Parameters:
+  ///   - viewport: The canvas viewport size.
+  ///   - cardCenter: The card's center in canvas coordinates (its stored layout
+  ///     position, unchanged by expand).
+  ///   - metrics: Padding / reserve / title-bar / min-size metrics.
+  static func expandedFrame(
+    viewport: CGSize,
+    cardCenter: CGPoint,
+    metrics: Metrics
+  ) -> (size: CGSize, offset: CGSize) {
+    let width = max(metrics.minSize.width, viewport.width - metrics.padding * 2)
+    let totalHeight = viewport.height - metrics.padding * 2 - metrics.bottomReserve
+    let height = max(metrics.minSize.height, totalHeight - metrics.titleBarHeight)
+
+    // Scale is 1, so screen position == cardCenter + offset. Center the card
+    // horizontally and vertically within the toolbar-adjusted viewport.
+    let offset = CGSize(
+      width: viewport.width / 2 - cardCenter.x,
+      height: (viewport.height - metrics.bottomReserve) / 2 - cardCenter.y
+    )
+
+    return (CGSize(width: width, height: height), offset)
+  }
+}

--- a/supacode/Features/Canvas/Models/CanvasFocusRequest.swift
+++ b/supacode/Features/Canvas/Models/CanvasFocusRequest.swift
@@ -15,6 +15,22 @@ struct CanvasFocusCandidate: Equatable, Sendable {
   let tabID: TerminalTabID
 }
 
+/// A reducer-driven request to run one of CanvasView's view-local commands
+/// (which live in CanvasView's `@State`, not the reducer) — e.g. triggered from
+/// the command palette. CanvasView observes it, runs the command, and reports
+/// the id back to clear it (the same one-shot pattern as `CanvasFocusRequest`).
+struct CanvasCommandRequest: Equatable, Sendable {
+  enum Command: Equatable, Sendable {
+    case toggleExpand
+    case arrange
+    case organize
+    case selectAll
+  }
+
+  let id: Int
+  let command: Command
+}
+
 enum CanvasFocusResolver {
   static func resolve(
     request: CanvasFocusRequest,

--- a/supacode/Features/Canvas/Views/CanvasCardView.swift
+++ b/supacode/Features/Canvas/Views/CanvasCardView.swift
@@ -23,7 +23,6 @@ struct CanvasCardView: View {
   let isSelected: Bool
   let hasUnseenNotification: Bool
   let cardSize: CGSize
-  let animatesSizeChanges: Bool
   /// Whether this card is currently expanded in place (near-fullscreen). When
   /// true the title-bar button restores instead of expands, resize handles and
   /// title-bar dragging are disabled, and the action buttons stay visible.
@@ -247,7 +246,10 @@ struct CanvasCardView: View {
       hasNotification: { _ in false },
       action: onSplitOperation
     )
-    .animation(animatesSizeChanges ? .easeInOut(duration: 0.2) : nil, value: cardSize)
+    // No own size animation: the canvas drives every size change inside a
+    // withAnimation (expand/restore, resize commit, arrange), so the terminal
+    // refit stays in lock-step with the card's offset/scale. Without a wrapping
+    // animation (live resize drag) the size tracks the gesture 1:1.
     .allowsHitTesting(isFocused && !showsSelectionShield)
   }
 

--- a/supacode/Features/Canvas/Views/CanvasCardView.swift
+++ b/supacode/Features/Canvas/Views/CanvasCardView.swift
@@ -24,6 +24,10 @@ struct CanvasCardView: View {
   let hasUnseenNotification: Bool
   let cardSize: CGSize
   let animatesSizeChanges: Bool
+  /// Whether this card is currently expanded in place (near-fullscreen). When
+  /// true the title-bar button restores instead of expands, resize handles and
+  /// title-bar dragging are disabled, and the action buttons stay visible.
+  let isExpanded: Bool
   let canvasScale: CGFloat
   let showsSelectionShield: Bool
   let onTap: () -> Void
@@ -75,7 +79,7 @@ struct CanvasCardView: View {
       ZStack {
         RoundedRectangle(cornerRadius: cornerRadius)
           .stroke(borderColor, lineWidth: borderLineWidth)
-        if !showsSelectionShield {
+        if !showsSelectionShield && !isExpanded {
           resizeHandles
         }
         if showsSelectionShield {
@@ -162,7 +166,8 @@ struct CanvasCardView: View {
               width: value.translation.width / canvasScale,
               height: value.translation.height / canvasScale
             ))
-        }
+        },
+      isEnabled: !isExpanded
     )
   }
 
@@ -171,15 +176,19 @@ struct CanvasCardView: View {
       Button {
         onExpand()
       } label: {
-        Image(systemName: "arrow.up.left.and.arrow.down.right")
-          .font(.caption2.weight(.semibold))
-          .frame(width: 18, height: 18)
-          .contentShape(.rect)
+        Image(
+          systemName: isExpanded
+            ? "arrow.down.right.and.arrow.up.left"
+            : "arrow.up.left.and.arrow.down.right"
+        )
+        .font(.caption2.weight(.semibold))
+        .frame(width: 18, height: 18)
+        .contentShape(.rect)
       }
       .buttonStyle(.plain)
       .foregroundStyle(.secondary)
-      .help("Expand to tab view")
-      .accessibilityLabel("Expand card")
+      .help(isExpanded ? "Restore card size" : "Expand card")
+      .accessibilityLabel(isExpanded ? "Restore card size" : "Expand card")
 
       Button {
         onClose()
@@ -194,8 +203,8 @@ struct CanvasCardView: View {
       .help("Close card")
       .accessibilityLabel("Close card")
     }
-    .opacity(isHoveringTitleBar ? 1 : 0)
-    .allowsHitTesting(isHoveringTitleBar)
+    .opacity(isExpanded || isHoveringTitleBar ? 1 : 0)
+    .allowsHitTesting(isExpanded || isHoveringTitleBar)
     .animation(.easeInOut(duration: 0.15), value: isHoveringTitleBar)
   }
 

--- a/supacode/Features/Canvas/Views/CanvasCardView.swift
+++ b/supacode/Features/Canvas/Views/CanvasCardView.swift
@@ -27,6 +27,9 @@ struct CanvasCardView: View {
   /// true the title-bar button restores instead of expands, resize handles and
   /// title-bar dragging are disabled, and the action buttons stay visible.
   let isExpanded: Bool
+  /// Tooltip for the expand/restore button, including the bound shortcut (the
+  /// parent resolves it since CanvasCardView has no keybindings context).
+  let expandHelp: String
   let canvasScale: CGFloat
   let showsSelectionShield: Bool
   let onTap: () -> Void
@@ -186,7 +189,7 @@ struct CanvasCardView: View {
       }
       .buttonStyle(.plain)
       .foregroundStyle(.secondary)
-      .help(isExpanded ? "Restore card size" : "Expand card")
+      .help(expandHelp)
       .accessibilityLabel(isExpanded ? "Restore card size" : "Expand card")
 
       Button {

--- a/supacode/Features/Canvas/Views/CanvasView.swift
+++ b/supacode/Features/Canvas/Views/CanvasView.swift
@@ -219,7 +219,10 @@ struct CanvasView: View {
   /// reaching the NSView, keeping terminal grid stable during zoom.
   @ViewBuilder
   private func cardsLayer(activeStates: [WorktreeTerminalState]) -> some View {
-    ZStack {
+    // Pin to .topLeading and fill the viewport so each card's `.offset()` keeps
+    // the same (0,0) origin it had under GeometryReader — otherwise the scrim's
+    // full-size frame would resize the stack and shift the cards' base position.
+    ZStack(alignment: .topLeading) {
       ForEach(activeStates, id: \.worktreeID) { state in
         ForEach(state.tabManager.tabs) { tab in
           if state.surfaceView(for: tab.id) != nil {
@@ -242,6 +245,7 @@ struct CanvasView: View {
           .transition(.opacity)
       }
     }
+    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
   }
 
   @ViewBuilder

--- a/supacode/Features/Canvas/Views/CanvasView.swift
+++ b/supacode/Features/Canvas/Views/CanvasView.swift
@@ -34,6 +34,10 @@ struct CanvasView: View {
   /// The tab currently expanded in place (near-fullscreen overlay) on canvas,
   /// or nil when no card is expanded.
   @State private var expandedTabID: TerminalTabID?
+  /// The tab playing its restore (collapse) animation. Kept set for the
+  /// animation's duration so the card's terminal size refit stays driven by the
+  /// single expand `withAnimation` transaction instead of its own.
+  @State private var collapsingTabID: TerminalTabID?
 
   private let minCardWidth: CGFloat = 300
   private let minCardHeight: CGFloat = 200
@@ -284,7 +288,11 @@ struct CanvasView: View {
       isSelected: selectionState.selectedTabIDs.contains(tab.id),
       hasUnseenNotification: state.hasUnseenNotification(for: tab.id),
       cardSize: resized.size,
-      animatesSizeChanges: activeResize[tab.id] == nil,
+      // While expanding/restoring this card, defer its size animation to the
+      // single expand `withAnimation` so offset/scale/size/terminal stay in
+      // lock-step (a true magic-move from the card's origin, not the center).
+      animatesSizeChanges: activeResize[tab.id] == nil && expandedTabID != tab.id
+        && collapsingTabID != tab.id,
       isExpanded: isCardExpanded,
       canvasScale: appliedScale,
       showsSelectionShield: showsSelectionShield(for: tab.id),
@@ -831,17 +839,23 @@ struct CanvasView: View {
     guard viewportSize.width > 0, viewportSize.height > 0,
       layoutStore.cardLayouts[tabID.rawValue.uuidString] != nil
     else { return }
+    collapsingTabID = nil
     focusSingleCard(tabID, states: states)
     withAnimation(expandAnimation) {
       expandedTabID = tabID
     }
   }
 
-  /// Restore the expanded card back into the (unchanged) canvas.
+  /// Restore the expanded card back into the (unchanged) canvas. Marks the tab
+  /// as collapsing for the animation's duration so its terminal size refit is
+  /// driven by this single transaction, keeping the magic-move in sync.
   private func collapseExpand() {
-    guard expandedTabID != nil else { return }
+    guard let tabID = expandedTabID else { return }
+    collapsingTabID = tabID
     withAnimation(expandAnimation) {
       expandedTabID = nil
+    } completion: {
+      if collapsingTabID == tabID { collapsingTabID = nil }
     }
   }
 
@@ -849,6 +863,7 @@ struct CanvasView: View {
   /// (Arrange/Organize) takes over the canvas.
   private func cancelExpandForRelayout() {
     expandedTabID = nil
+    collapsingTabID = nil
   }
 
   private func fulfillPendingFocusRequest(
@@ -1056,6 +1071,7 @@ struct CanvasView: View {
 
   private func deactivateCanvas() {
     expandedTabID = nil
+    collapsingTabID = nil
     let activeStates = terminalManager.activeWorktreeStates
     for state in activeStates {
       state.isCanvasManaged = false

--- a/supacode/Features/Canvas/Views/CanvasView.swift
+++ b/supacode/Features/Canvas/Views/CanvasView.swift
@@ -34,10 +34,6 @@ struct CanvasView: View {
   /// The tab currently expanded in place (near-fullscreen overlay) on canvas,
   /// or nil when no card is expanded.
   @State private var expandedTabID: TerminalTabID?
-  /// Drives the expand/restore magic-move for `expandedTabID`: 0 = collapsed
-  /// into the canvas, 1 = covering the viewport. Animating this single value
-  /// keeps the card's size, center, and scale in perfect lock-step.
-  @State private var expandProgress: CGFloat = 0
 
   private let minCardWidth: CGFloat = 300
   private let minCardHeight: CGFloat = 200
@@ -262,9 +258,9 @@ struct CanvasView: View {
     let cardKey = tab.id.rawValue.uuidString
     let baseLayout = layoutStore.cardLayouts[cardKey] ?? CanvasCardLayout(position: .zero)
     let isCardExpanded = expandedTabID == tab.id
-    // An expanded card transforms on its own — size/center/scale interpolated by
-    // expandProgress — independent of the canvas pan/zoom, so the background is
-    // frozen. Non-expanded cards keep their normal resize-aware geometry.
+    // An expanded card transforms on its own — full-viewport size/center at
+    // scale 1 — independent of the canvas pan/zoom, so the background is frozen.
+    // Non-expanded cards keep their normal resize-aware geometry.
     let geometry = cardScreenGeometry(for: tab.id, baseLayout: baseLayout)
     let renderSize = geometry.size
     let appliedScale = geometry.scale
@@ -289,10 +285,6 @@ struct CanvasView: View {
       isSelected: selectionState.selectedTabIDs.contains(tab.id),
       hasUnseenNotification: state.hasUnseenNotification(for: tab.id),
       cardSize: renderSize,
-      // The expanded card already receives the exact interpolated size each
-      // frame (driven by expandProgress), so disable its own size animation to
-      // avoid a second, competing one.
-      animatesSizeChanges: !isCardExpanded && activeResize[tab.id] == nil,
       isExpanded: isCardExpanded,
       canvasScale: appliedScale,
       showsSelectionShield: showsSelectionShield(for: tab.id),
@@ -756,9 +748,13 @@ struct CanvasView: View {
     guard activeResize[tabID] != nil else { return }
     if var layout = layoutStore.cardLayouts[cardKey] {
       let resized = resizedFrame(for: tabID, baseLayout: layout)
-      layout.position = resized.center
-      layout.size = resized.size
-      layoutStore.cardLayouts[cardKey] = layout
+      // Settle the card into its committed size with a short animation (cards
+      // no longer animate size on their own; the canvas drives it explicitly).
+      withAnimation(.easeInOut(duration: 0.2)) {
+        layout.position = resized.center
+        layout.size = resized.size
+        layoutStore.cardLayouts[cardKey] = layout
+      }
     }
     activeResize[tabID] = nil
     for surface in surfaces {
@@ -812,11 +808,10 @@ struct CanvasView: View {
     var scale: CGFloat
   }
 
-  /// Screen-space size/center/scale for a card, interpolated by `expandProgress`
-  /// when it's the expanded one. Driving all three from the single progress
-  /// value keeps them in perfect lock-step — a magic-move from the card's own
-  /// in-canvas frame (progress 0) to the full viewport (progress 1) — while the
-  /// canvas transform (and thus every other card) stays frozen.
+  /// Screen-space size/center/scale for a card. The expanded card snaps to the
+  /// full-viewport frame at scale 1; the change is animated by the single
+  /// `withAnimation` in `expandCard`/`collapseExpand`. Because the canvas
+  /// transform is never touched, every other card stays frozen.
   private func cardScreenGeometry(
     for tabID: TerminalTabID,
     baseLayout: CanvasCardLayout
@@ -829,21 +824,10 @@ struct CanvasView: View {
         scale: canvasScale
       )
     }
-
-    let progress = expandProgress
-    let fromSize = baseLayout.size
-    let toSize = CanvasExpandGeometry.expandedSize(viewport: viewportSize, metrics: expandMetrics)
-    let fromCenter = screenPosition(for: baseLayout.position)
-    let toCenter = expandedScreenCenter
-
-    func lerp(_ start: CGFloat, _ end: CGFloat) -> CGFloat { start + (end - start) * progress }
     return CardScreenGeometry(
-      size: CGSize(
-        width: lerp(fromSize.width, toSize.width),
-        height: lerp(fromSize.height, toSize.height)
-      ),
-      center: CGPoint(x: lerp(fromCenter.x, toCenter.x), y: lerp(fromCenter.y, toCenter.y)),
-      scale: lerp(canvasScale, 1)
+      size: CanvasExpandGeometry.expandedSize(viewport: viewportSize, metrics: expandMetrics),
+      center: expandedScreenCenter,
+      scale: 1
     )
   }
 
@@ -857,30 +841,27 @@ struct CanvasView: View {
     }
   }
 
-  /// Expand a card in place: raise it to the top, then animate the single
-  /// `expandProgress` from 0 → 1 so the card grows, on its own, from its current
-  /// canvas frame to cover the whole viewport at scale 1. The canvas transform
-  /// is left untouched, so every other card stays exactly where it was.
+  /// Expand a card in place: raise it to the top, then flip `expandedTabID`
+  /// inside one `withAnimation` so the card's size, center, and scale all
+  /// interpolate together from its in-canvas frame to the full viewport at
+  /// scale 1 — a magic-move from where the card actually sits. The canvas
+  /// transform is left untouched, so every other card stays exactly where it
+  /// was, behind a dimming scrim.
   private func expandCard(_ tabID: TerminalTabID, states: [WorktreeTerminalState]) {
     guard viewportSize.width > 0, viewportSize.height > 0,
       layoutStore.cardLayouts[tabID.rawValue.uuidString] != nil
     else { return }
     focusSingleCard(tabID, states: states)
-    expandedTabID = tabID
-    expandProgress = 0
     withAnimation(expandAnimation) {
-      expandProgress = 1
+      expandedTabID = tabID
     }
   }
 
-  /// Restore the expanded card back into the (unchanged) canvas, then drop the
-  /// expanded marker once the animation completes.
+  /// Restore the expanded card back into the (unchanged) canvas.
   private func collapseExpand() {
     guard expandedTabID != nil else { return }
     withAnimation(expandAnimation) {
-      expandProgress = 0
-    } completion: {
-      if expandProgress == 0 { expandedTabID = nil }
+      expandedTabID = nil
     }
   }
 
@@ -888,7 +869,6 @@ struct CanvasView: View {
   /// (Arrange/Organize) takes over the canvas.
   private func cancelExpandForRelayout() {
     expandedTabID = nil
-    expandProgress = 0
   }
 
   private func fulfillPendingFocusRequest(
@@ -1096,7 +1076,6 @@ struct CanvasView: View {
 
   private func deactivateCanvas() {
     expandedTabID = nil
-    expandProgress = 0
     let activeStates = terminalManager.activeWorktreeStates
     for state in activeStates {
       state.isCanvasManaged = false

--- a/supacode/Features/Canvas/Views/CanvasView.swift
+++ b/supacode/Features/Canvas/Views/CanvasView.swift
@@ -34,9 +34,6 @@ struct CanvasView: View {
   /// The tab currently expanded in place (near-fullscreen overlay) on canvas,
   /// or nil when no card is expanded.
   @State private var expandedTabID: TerminalTabID?
-  /// Canvas scale/offset captured when entering expand, restored on collapse.
-  @State private var preExpandScale: CGFloat?
-  @State private var preExpandOffset: CGSize?
 
   private let minCardWidth: CGFloat = 300
   private let minCardHeight: CGFloat = 200
@@ -257,7 +254,12 @@ struct CanvasView: View {
     let cardKey = tab.id.rawValue.uuidString
     let baseLayout = layoutStore.cardLayouts[cardKey] ?? CanvasCardLayout(position: .zero)
     let resized = resizedFrame(for: tab.id, baseLayout: baseLayout)
-    let screenCenter = screenPosition(for: resized.center)
+    // An expanded card transforms on its own — scale 1, centered in the
+    // viewport — independent of the canvas pan/zoom, so the background is frozen.
+    let isCardExpanded = expandedTabID == tab.id
+    let appliedScale = isCardExpanded ? 1 : canvasScale
+    let screenCenter =
+      isCardExpanded ? expandedScreenCenter : screenPosition(for: resized.center)
     let cardTotalHeight = resized.size.height + titleBarHeight
     let unfocusedSplitOverlay = terminalManager.unfocusedSplitOverlay()
     let splitDivider = terminalManager.splitDividerAppearance()
@@ -279,8 +281,8 @@ struct CanvasView: View {
       hasUnseenNotification: state.hasUnseenNotification(for: tab.id),
       cardSize: resized.size,
       animatesSizeChanges: activeResize[tab.id] == nil,
-      isExpanded: expandedTabID == tab.id,
-      canvasScale: canvasScale,
+      isExpanded: isCardExpanded,
+      canvasScale: appliedScale,
       showsSelectionShield: showsSelectionShield(for: tab.id),
       onTap: {
         let cmdHeld = NSEvent.modifierFlags.contains(.command)
@@ -330,7 +332,7 @@ struct CanvasView: View {
         state.closeTab(tab.id)
       }
     )
-    .scaleEffect(canvasScale, anchor: .center)
+    .scaleEffect(appliedScale, anchor: .center)
     .offset(
       x: screenCenter.x - resized.size.width / 2,
       y: screenCenter.y - cardTotalHeight / 2
@@ -431,10 +433,10 @@ struct CanvasView: View {
     for tabID: TerminalTabID,
     baseLayout: CanvasCardLayout
   ) -> (center: CGPoint, size: CGSize) {
-    // An expanded card renders at its near-fullscreen size, centered via the
-    // canvas offset; resize is disabled while expanded.
-    if expandedTabID == tabID, let frame = expandLayout(for: tabID) {
-      return (baseLayout.position, frame.size)
+    // An expanded card renders at its near-fullscreen size, positioned by the
+    // card view independently of the canvas transform; resize is disabled.
+    if let size = expandedSize(for: tabID) {
+      return (baseLayout.position, size)
     }
 
     var centerX = baseLayout.position.x
@@ -782,8 +784,6 @@ struct CanvasView: View {
 
   // MARK: - Expand In Place
 
-  /// Expanded size + centering offset for a card, or nil when the viewport or
-  /// the card's stored layout isn't available yet.
   private var expandMetrics: CanvasExpandGeometry.Metrics {
     CanvasExpandGeometry.Metrics(
       padding: expandPadding,
@@ -793,15 +793,19 @@ struct CanvasView: View {
     )
   }
 
-  private func expandLayout(for tabID: TerminalTabID) -> (size: CGSize, offset: CGSize)? {
-    guard viewportSize.width > 0, viewportSize.height > 0,
-      let layout = layoutStore.cardLayouts[tabID.rawValue.uuidString]
+  /// Content size (excluding title bar) for the card currently expanded, or nil
+  /// when `tabID` isn't expanded or the viewport isn't measured yet.
+  private func expandedSize(for tabID: TerminalTabID) -> CGSize? {
+    guard expandedTabID == tabID, viewportSize.width > 0, viewportSize.height > 0
     else { return nil }
-    return CanvasExpandGeometry.expandedFrame(
-      viewport: viewportSize,
-      cardCenter: layout.position,
-      metrics: expandMetrics
-    )
+    return CanvasExpandGeometry.expandedSize(viewport: viewportSize, metrics: expandMetrics)
+  }
+
+  /// Screen-space center for an expanded card: horizontally centered and within
+  /// the toolbar-adjusted viewport. Independent of canvas pan/zoom, so the card
+  /// covers the whole viewport regardless of the (unchanged) background.
+  private var expandedScreenCenter: CGPoint {
+    CGPoint(x: viewportSize.width / 2, y: (viewportSize.height - bottomToolbarReserve) / 2)
   }
 
   /// Toggle expand/restore for a card — used by the title-bar button and the
@@ -814,53 +818,33 @@ struct CanvasView: View {
     }
   }
 
-  /// Expand a card in place: capture the current canvas transform, raise the
-  /// card to the top, snap scale to 1 (native font size), and grow it to
-  /// near-fullscreen centered in the viewport. Other cards keep running behind
-  /// a dimming scrim.
+  /// Expand a card in place: raise it to the top and let it animate, on its own,
+  /// from its current canvas position/size to scale 1 covering the whole
+  /// viewport (with padding). The canvas transform is left untouched, so every
+  /// other card stays exactly where it was — the expanded card simply floats
+  /// above a dimming scrim.
   private func expandCard(_ tabID: TerminalTabID, states: [WorktreeTerminalState]) {
-    guard let frame = expandLayout(for: tabID) else { return }
-    if expandedTabID == nil {
-      preExpandScale = canvasScale
-      preExpandOffset = canvasOffset
-    }
+    guard viewportSize.width > 0, viewportSize.height > 0,
+      layoutStore.cardLayouts[tabID.rawValue.uuidString] != nil
+    else { return }
     focusSingleCard(tabID, states: states)
     withAnimation(expandAnimation) {
       expandedTabID = tabID
-      canvasScale = 1
-      canvasOffset = frame.offset
-      lastCanvasScale = 1
-      lastCanvasOffset = frame.offset
     }
   }
 
-  /// Restore the expanded card to its prior size and the canvas to its prior
-  /// scale/offset.
+  /// Restore the expanded card back into the (unchanged) canvas.
   private func collapseExpand() {
     guard expandedTabID != nil else { return }
-    let restoreScale = preExpandScale
-    let restoreOffset = preExpandOffset
     withAnimation(expandAnimation) {
       expandedTabID = nil
-      if let restoreScale {
-        canvasScale = restoreScale
-        lastCanvasScale = restoreScale
-      }
-      if let restoreOffset {
-        canvasOffset = restoreOffset
-        lastCanvasOffset = restoreOffset
-      }
     }
-    preExpandScale = nil
-    preExpandOffset = nil
   }
 
-  /// Drop expand state without restoring the transform — used right before a
-  /// relayout (Arrange/Organize) takes over the canvas.
+  /// Drop expand state without animation — used right before a relayout
+  /// (Arrange/Organize) takes over the canvas.
   private func cancelExpandForRelayout() {
     expandedTabID = nil
-    preExpandScale = nil
-    preExpandOffset = nil
   }
 
   private func fulfillPendingFocusRequest(
@@ -1068,8 +1052,6 @@ struct CanvasView: View {
 
   private func deactivateCanvas() {
     expandedTabID = nil
-    preExpandScale = nil
-    preExpandOffset = nil
     let activeStates = terminalManager.activeWorktreeStates
     for state in activeStates {
       state.isCanvasManaged = false

--- a/supacode/Features/Canvas/Views/CanvasView.swift
+++ b/supacode/Features/Canvas/Views/CanvasView.swift
@@ -13,8 +13,12 @@ struct CanvasView: View {
   /// per-frame canvas hot path.
   var repositoryCustomTitles: [Repository.ID: String] = [:]
   var focusRequest: CanvasFocusRequest?
+  /// A one-shot, reducer-driven request to run a view-local canvas command
+  /// (expand/arrange/organize/select-all), e.g. from the command palette.
+  var commandRequest: CanvasCommandRequest?
   var onFocusedWorktreeChanged: (Worktree.ID?) -> Void = { _ in }
   var onFocusRequestConsumed: (Int) -> Void = { _ in }
+  var onCommandConsumed: (Int) -> Void = { _ in }
   /// Reports whether a card is currently expanded in place, so the parent can
   /// give the window toolbar a matching scrim (it can't be covered from here).
   var onExpandedChange: (Bool) -> Void = { _ in }
@@ -80,6 +84,10 @@ struct CanvasView: View {
     )
     let organizeCanvasShortcut = AppShortcuts.resolvedShortcut(
       for: AppShortcuts.CommandID.organizeCanvasCards,
+      in: resolvedKeybindings
+    )
+    let expandCanvasShortcut = AppShortcuts.resolvedShortcut(
+      for: AppShortcuts.CommandID.expandCanvasCard,
       in: resolvedKeybindings
     )
     let _ = configReloadCounter
@@ -202,8 +210,20 @@ struct CanvasView: View {
       organizeCardsWithFit()
       return .handled
     }
+    .onKeyPress(
+      expandCanvasShortcut?.keyEquivalent ?? AppShortcuts.expandCanvasCard.keyEquivalent,
+      phases: .down
+    ) { keyPress in
+      guard let shortcut = expandCanvasShortcut else { return .ignored }
+      guard keyPress.modifiers == shortcut.modifiers else { return .ignored }
+      toggleExpandFocusedCard()
+      return .handled
+    }
     .onChange(of: expandedTabID) { _, newValue in
       onExpandedChange(newValue != nil)
+    }
+    .onChange(of: commandRequest) { _, newRequest in
+      fulfillCommandRequest(newRequest)
     }
     .task { activateCanvas() }
     .onReceive(NotificationCenter.default.publisher(for: .ghosttyRuntimeConfigDidChange)) { _ in
@@ -854,6 +874,33 @@ struct CanvasView: View {
     } else {
       expandCard(tabID, states: states)
     }
+  }
+
+  /// Toggle expand/restore for the focused (primary) card. Used by the keyboard
+  /// shortcut and the command palette, which target whichever card is focused.
+  private func toggleExpandFocusedCard() {
+    if expandedTabID != nil {
+      collapseExpand()
+    } else if let tabID = selectionState.primaryTabID {
+      expandCard(tabID, states: terminalManager.activeWorktreeStates)
+    }
+  }
+
+  /// Run a reducer-driven canvas command (from the command palette) and clear
+  /// the one-shot request.
+  private func fulfillCommandRequest(_ request: CanvasCommandRequest?) {
+    guard let request else { return }
+    switch request.command {
+    case .toggleExpand:
+      toggleExpandFocusedCard()
+    case .arrange:
+      arrangeCardsWithFit()
+    case .organize:
+      organizeCardsWithFit()
+    case .selectAll:
+      selectAllCards()
+    }
+    onCommandConsumed(request.id)
   }
 
   /// Expand a card in place: raise it to the top, then flip `expandedTabID`

--- a/supacode/Features/Canvas/Views/CanvasView.swift
+++ b/supacode/Features/Canvas/Views/CanvasView.swift
@@ -13,7 +13,6 @@ struct CanvasView: View {
   /// per-frame canvas hot path.
   var repositoryCustomTitles: [Repository.ID: String] = [:]
   var focusRequest: CanvasFocusRequest?
-  var onExitToTab: () -> Void = {}
   var onFocusedWorktreeChanged: (Worktree.ID?) -> Void = { _ in }
   var onFocusRequestConsumed: (Int) -> Void = { _ in }
   @State private var layoutStore = CanvasLayoutStore()
@@ -32,6 +31,12 @@ struct CanvasView: View {
   @State private var showsCanvasHelp = false
   @State private var configReloadCounter = 0
   @State private var focusViewportAnimationID = 0
+  /// The tab currently expanded in place (near-fullscreen overlay) on canvas,
+  /// or nil when no card is expanded.
+  @State private var expandedTabID: TerminalTabID?
+  /// Canvas scale/offset captured when entering expand, restored on collapse.
+  @State private var preExpandScale: CGFloat?
+  @State private var preExpandOffset: CGSize?
 
   private let minCardWidth: CGFloat = 300
   private let minCardHeight: CGFloat = 200
@@ -43,6 +48,12 @@ struct CanvasView: View {
   /// layout toolbar so cards don't sit underneath them after auto-fit.
   /// Cards end up shifted upward by half of this amount.
   private let bottomToolbarReserve: CGFloat = 50
+  /// Margin kept on every side of a card temporarily expanded to near-fullscreen.
+  private let expandPadding: CGFloat = 40
+  /// Shared animation for expand / restore / relayout. Matches the easeInOut
+  /// 0.2s that `CanvasCardView` uses to animate `cardSize`, so the canvas
+  /// scale/offset stays in lock-step with the card's terminal size refit.
+  private let expandAnimation: Animation = .easeInOut(duration: 0.2)
 
   /// Width of the screen hosting the canvas window, used to scale the default
   /// card size. Falls back to the large-screen reference when unknown.
@@ -115,6 +126,9 @@ struct CanvasView: View {
           }
           .onChange(of: allTabIDs) { oldTabIDs, newTabIDs in
             pruneSelection(previousOrder: oldTabIDs, currentOrder: newTabIDs, states: activeStates)
+            if let expandedTabID, !newTabIDs.contains(expandedTabID) {
+              collapseExpand()
+            }
             fulfillPendingFocusRequest(focusRequest, states: activeStates)
           }
           .onChange(of: focusRequest) { _, newRequest in
@@ -208,11 +222,27 @@ struct CanvasView: View {
   /// reaching the NSView, keeping terminal grid stable during zoom.
   @ViewBuilder
   private func cardsLayer(activeStates: [WorktreeTerminalState]) -> some View {
-    ForEach(activeStates, id: \.worktreeID) { state in
-      ForEach(state.tabManager.tabs) { tab in
-        if state.surfaceView(for: tab.id) != nil {
-          cardView(for: tab, in: state, activeStates: activeStates)
+    ZStack {
+      ForEach(activeStates, id: \.worktreeID) { state in
+        ForEach(state.tabManager.tabs) { tab in
+          if state.surfaceView(for: tab.id) != nil {
+            cardView(for: tab, in: state, activeStates: activeStates)
+          }
         }
+      }
+
+      // Dimming scrim behind the expanded card (above all other cards). Tapping
+      // it — i.e. anywhere outside the expanded card, including the padding —
+      // restores the layout.
+      if expandedTabID != nil {
+        Color.black.opacity(0.3)
+          .frame(maxWidth: .infinity, maxHeight: .infinity)
+          .contentShape(.rect)
+          .accessibilityAddTraits(.isButton)
+          .accessibilityLabel("Restore expanded card")
+          .onTapGesture { collapseExpand() }
+          .zIndex(5_000)
+          .transition(.opacity)
       }
     }
   }
@@ -249,6 +279,7 @@ struct CanvasView: View {
       hasUnseenNotification: state.hasUnseenNotification(for: tab.id),
       cardSize: resized.size,
       animatesSizeChanges: activeResize[tab.id] == nil,
+      isExpanded: expandedTabID == tab.id,
       canvasScale: canvasScale,
       showsSelectionShield: showsSelectionShield(for: tab.id),
       onTap: {
@@ -288,13 +319,12 @@ struct CanvasView: View {
         if wasAlreadyFocused,
           now.timeIntervalSince(lastTitleBarTapDate) <= NSEvent.doubleClickInterval
         {
-          onExitToTab()
+          toggleExpand(tab.id, states: activeStates)
         }
         lastTitleBarTapDate = now
       },
       onExpand: {
-        focusSingleCard(tab.id, states: activeStates)
-        onExitToTab()
+        toggleExpand(tab.id, states: activeStates)
       },
       onClose: {
         state.closeTab(tab.id)
@@ -401,6 +431,12 @@ struct CanvasView: View {
     for tabID: TerminalTabID,
     baseLayout: CanvasCardLayout
   ) -> (center: CGPoint, size: CGSize) {
+    // An expanded card renders at its near-fullscreen size, centered via the
+    // canvas offset; resize is disabled while expanded.
+    if expandedTabID == tabID, let frame = expandLayout(for: tabID) {
+      return (baseLayout.position, frame.size)
+    }
+
     var centerX = baseLayout.position.x
     var centerY = baseLayout.position.y
     var width = baseLayout.size.width
@@ -505,6 +541,7 @@ struct CanvasView: View {
   /// Shared by the toolbar button and the keyboard shortcut.
   private func arrangeCardsWithFit() {
     withAnimation(.easeInOut(duration: 0.2)) {
+      cancelExpandForRelayout()
       arrangeCards()
       fitToView(canvasSize: viewportSize)
     }
@@ -514,6 +551,7 @@ struct CanvasView: View {
   /// Shared by the toolbar button and the keyboard shortcut.
   private func organizeCardsWithFit() {
     withAnimation(.easeInOut(duration: 0.2)) {
+      cancelExpandForRelayout()
       organizeCards()
       fitToView(canvasSize: viewportSize)
     }
@@ -742,6 +780,89 @@ struct CanvasView: View {
     }
   }
 
+  // MARK: - Expand In Place
+
+  /// Expanded size + centering offset for a card, or nil when the viewport or
+  /// the card's stored layout isn't available yet.
+  private var expandMetrics: CanvasExpandGeometry.Metrics {
+    CanvasExpandGeometry.Metrics(
+      padding: expandPadding,
+      bottomReserve: bottomToolbarReserve,
+      titleBarHeight: titleBarHeight,
+      minSize: CGSize(width: minCardWidth, height: minCardHeight)
+    )
+  }
+
+  private func expandLayout(for tabID: TerminalTabID) -> (size: CGSize, offset: CGSize)? {
+    guard viewportSize.width > 0, viewportSize.height > 0,
+      let layout = layoutStore.cardLayouts[tabID.rawValue.uuidString]
+    else { return nil }
+    return CanvasExpandGeometry.expandedFrame(
+      viewport: viewportSize,
+      cardCenter: layout.position,
+      metrics: expandMetrics
+    )
+  }
+
+  /// Toggle expand/restore for a card — used by the title-bar button and the
+  /// title-bar double-click.
+  private func toggleExpand(_ tabID: TerminalTabID, states: [WorktreeTerminalState]) {
+    if expandedTabID == tabID {
+      collapseExpand()
+    } else {
+      expandCard(tabID, states: states)
+    }
+  }
+
+  /// Expand a card in place: capture the current canvas transform, raise the
+  /// card to the top, snap scale to 1 (native font size), and grow it to
+  /// near-fullscreen centered in the viewport. Other cards keep running behind
+  /// a dimming scrim.
+  private func expandCard(_ tabID: TerminalTabID, states: [WorktreeTerminalState]) {
+    guard let frame = expandLayout(for: tabID) else { return }
+    if expandedTabID == nil {
+      preExpandScale = canvasScale
+      preExpandOffset = canvasOffset
+    }
+    focusSingleCard(tabID, states: states)
+    withAnimation(expandAnimation) {
+      expandedTabID = tabID
+      canvasScale = 1
+      canvasOffset = frame.offset
+      lastCanvasScale = 1
+      lastCanvasOffset = frame.offset
+    }
+  }
+
+  /// Restore the expanded card to its prior size and the canvas to its prior
+  /// scale/offset.
+  private func collapseExpand() {
+    guard expandedTabID != nil else { return }
+    let restoreScale = preExpandScale
+    let restoreOffset = preExpandOffset
+    withAnimation(expandAnimation) {
+      expandedTabID = nil
+      if let restoreScale {
+        canvasScale = restoreScale
+        lastCanvasScale = restoreScale
+      }
+      if let restoreOffset {
+        canvasOffset = restoreOffset
+        lastCanvasOffset = restoreOffset
+      }
+    }
+    preExpandScale = nil
+    preExpandOffset = nil
+  }
+
+  /// Drop expand state without restoring the transform — used right before a
+  /// relayout (Arrange/Organize) takes over the canvas.
+  private func cancelExpandForRelayout() {
+    expandedTabID = nil
+    preExpandScale = nil
+    preExpandOffset = nil
+  }
+
   private func fulfillPendingFocusRequest(
     _ request: CanvasFocusRequest?,
     states: [WorktreeTerminalState]
@@ -946,6 +1067,9 @@ struct CanvasView: View {
   }
 
   private func deactivateCanvas() {
+    expandedTabID = nil
+    preExpandScale = nil
+    preExpandOffset = nil
     let activeStates = terminalManager.activeWorktreeStates
     for state in activeStates {
       state.isCanvasManaged = false

--- a/supacode/Features/Canvas/Views/CanvasView.swift
+++ b/supacode/Features/Canvas/Views/CanvasView.swift
@@ -34,10 +34,10 @@ struct CanvasView: View {
   /// The tab currently expanded in place (near-fullscreen overlay) on canvas,
   /// or nil when no card is expanded.
   @State private var expandedTabID: TerminalTabID?
-  /// The tab playing its restore (collapse) animation. Kept set for the
-  /// animation's duration so the card's terminal size refit stays driven by the
-  /// single expand `withAnimation` transaction instead of its own.
-  @State private var collapsingTabID: TerminalTabID?
+  /// Drives the expand/restore magic-move for `expandedTabID`: 0 = collapsed
+  /// into the canvas, 1 = covering the viewport. Animating this single value
+  /// keeps the card's size, center, and scale in perfect lock-step.
+  @State private var expandProgress: CGFloat = 0
 
   private let minCardWidth: CGFloat = 300
   private let minCardHeight: CGFloat = 200
@@ -128,7 +128,7 @@ struct CanvasView: View {
           .onChange(of: allTabIDs) { oldTabIDs, newTabIDs in
             pruneSelection(previousOrder: oldTabIDs, currentOrder: newTabIDs, states: activeStates)
             if let expandedTabID, !newTabIDs.contains(expandedTabID) {
-              collapseExpand()
+              cancelExpandForRelayout()
             }
             fulfillPendingFocusRequest(focusRequest, states: activeStates)
           }
@@ -261,14 +261,15 @@ struct CanvasView: View {
     let tree = state.splitTree(for: tab.id)
     let cardKey = tab.id.rawValue.uuidString
     let baseLayout = layoutStore.cardLayouts[cardKey] ?? CanvasCardLayout(position: .zero)
-    let resized = resizedFrame(for: tab.id, baseLayout: baseLayout)
-    // An expanded card transforms on its own — scale 1, centered in the
-    // viewport — independent of the canvas pan/zoom, so the background is frozen.
     let isCardExpanded = expandedTabID == tab.id
-    let appliedScale = isCardExpanded ? 1 : canvasScale
-    let screenCenter =
-      isCardExpanded ? expandedScreenCenter : screenPosition(for: resized.center)
-    let cardTotalHeight = resized.size.height + titleBarHeight
+    // An expanded card transforms on its own — size/center/scale interpolated by
+    // expandProgress — independent of the canvas pan/zoom, so the background is
+    // frozen. Non-expanded cards keep their normal resize-aware geometry.
+    let geometry = cardScreenGeometry(for: tab.id, baseLayout: baseLayout)
+    let renderSize = geometry.size
+    let appliedScale = geometry.scale
+    let screenCenter = geometry.center
+    let cardTotalHeight = renderSize.height + titleBarHeight
     let unfocusedSplitOverlay = terminalManager.unfocusedSplitOverlay()
     let splitDivider = terminalManager.splitDividerAppearance()
     let repositoryAppearance = appearance(for: state.repositoryRootURL)
@@ -287,12 +288,11 @@ struct CanvasView: View {
       isFocused: selectionState.primaryTabID == tab.id,
       isSelected: selectionState.selectedTabIDs.contains(tab.id),
       hasUnseenNotification: state.hasUnseenNotification(for: tab.id),
-      cardSize: resized.size,
-      // While expanding/restoring this card, defer its size animation to the
-      // single expand `withAnimation` so offset/scale/size/terminal stay in
-      // lock-step (a true magic-move from the card's origin, not the center).
-      animatesSizeChanges: activeResize[tab.id] == nil && expandedTabID != tab.id
-        && collapsingTabID != tab.id,
+      cardSize: renderSize,
+      // The expanded card already receives the exact interpolated size each
+      // frame (driven by expandProgress), so disable its own size animation to
+      // avoid a second, competing one.
+      animatesSizeChanges: !isCardExpanded && activeResize[tab.id] == nil,
       isExpanded: isCardExpanded,
       canvasScale: appliedScale,
       showsSelectionShield: showsSelectionShield(for: tab.id),
@@ -346,7 +346,7 @@ struct CanvasView: View {
     )
     .scaleEffect(appliedScale, anchor: .center)
     .offset(
-      x: screenCenter.x - resized.size.width / 2,
+      x: screenCenter.x - renderSize.width / 2,
       y: screenCenter.y - cardTotalHeight / 2
     )
     .zIndex(zIndex(for: tab.id, cardKey: cardKey))
@@ -445,12 +445,6 @@ struct CanvasView: View {
     for tabID: TerminalTabID,
     baseLayout: CanvasCardLayout
   ) -> (center: CGPoint, size: CGSize) {
-    // An expanded card renders at its near-fullscreen size, positioned by the
-    // card view independently of the canvas transform; resize is disabled.
-    if let size = expandedSize(for: tabID) {
-      return (baseLayout.position, size)
-    }
-
     var centerX = baseLayout.position.x
     var centerY = baseLayout.position.y
     var width = baseLayout.size.width
@@ -805,19 +799,52 @@ struct CanvasView: View {
     )
   }
 
-  /// Content size (excluding title bar) for the card currently expanded, or nil
-  /// when `tabID` isn't expanded or the viewport isn't measured yet.
-  private func expandedSize(for tabID: TerminalTabID) -> CGSize? {
-    guard expandedTabID == tabID, viewportSize.width > 0, viewportSize.height > 0
-    else { return nil }
-    return CanvasExpandGeometry.expandedSize(viewport: viewportSize, metrics: expandMetrics)
-  }
-
-  /// Screen-space center for an expanded card: horizontally centered and within
-  /// the toolbar-adjusted viewport. Independent of canvas pan/zoom, so the card
-  /// covers the whole viewport regardless of the (unchanged) background.
+  /// Screen-space center for a fully expanded card: horizontally centered and
+  /// within the toolbar-adjusted viewport. Independent of canvas pan/zoom.
   private var expandedScreenCenter: CGPoint {
     CGPoint(x: viewportSize.width / 2, y: (viewportSize.height - bottomToolbarReserve) / 2)
+  }
+
+  /// Screen-space transform for a card on canvas.
+  private struct CardScreenGeometry {
+    var size: CGSize
+    var center: CGPoint
+    var scale: CGFloat
+  }
+
+  /// Screen-space size/center/scale for a card, interpolated by `expandProgress`
+  /// when it's the expanded one. Driving all three from the single progress
+  /// value keeps them in perfect lock-step — a magic-move from the card's own
+  /// in-canvas frame (progress 0) to the full viewport (progress 1) — while the
+  /// canvas transform (and thus every other card) stays frozen.
+  private func cardScreenGeometry(
+    for tabID: TerminalTabID,
+    baseLayout: CanvasCardLayout
+  ) -> CardScreenGeometry {
+    guard expandedTabID == tabID, viewportSize.width > 0, viewportSize.height > 0 else {
+      let resized = resizedFrame(for: tabID, baseLayout: baseLayout)
+      return CardScreenGeometry(
+        size: resized.size,
+        center: screenPosition(for: resized.center),
+        scale: canvasScale
+      )
+    }
+
+    let progress = expandProgress
+    let fromSize = baseLayout.size
+    let toSize = CanvasExpandGeometry.expandedSize(viewport: viewportSize, metrics: expandMetrics)
+    let fromCenter = screenPosition(for: baseLayout.position)
+    let toCenter = expandedScreenCenter
+
+    func lerp(_ start: CGFloat, _ end: CGFloat) -> CGFloat { start + (end - start) * progress }
+    return CardScreenGeometry(
+      size: CGSize(
+        width: lerp(fromSize.width, toSize.width),
+        height: lerp(fromSize.height, toSize.height)
+      ),
+      center: CGPoint(x: lerp(fromCenter.x, toCenter.x), y: lerp(fromCenter.y, toCenter.y)),
+      scale: lerp(canvasScale, 1)
+    )
   }
 
   /// Toggle expand/restore for a card — used by the title-bar button and the
@@ -830,32 +857,30 @@ struct CanvasView: View {
     }
   }
 
-  /// Expand a card in place: raise it to the top and let it animate, on its own,
-  /// from its current canvas position/size to scale 1 covering the whole
-  /// viewport (with padding). The canvas transform is left untouched, so every
-  /// other card stays exactly where it was — the expanded card simply floats
-  /// above a dimming scrim.
+  /// Expand a card in place: raise it to the top, then animate the single
+  /// `expandProgress` from 0 → 1 so the card grows, on its own, from its current
+  /// canvas frame to cover the whole viewport at scale 1. The canvas transform
+  /// is left untouched, so every other card stays exactly where it was.
   private func expandCard(_ tabID: TerminalTabID, states: [WorktreeTerminalState]) {
     guard viewportSize.width > 0, viewportSize.height > 0,
       layoutStore.cardLayouts[tabID.rawValue.uuidString] != nil
     else { return }
-    collapsingTabID = nil
     focusSingleCard(tabID, states: states)
+    expandedTabID = tabID
+    expandProgress = 0
     withAnimation(expandAnimation) {
-      expandedTabID = tabID
+      expandProgress = 1
     }
   }
 
-  /// Restore the expanded card back into the (unchanged) canvas. Marks the tab
-  /// as collapsing for the animation's duration so its terminal size refit is
-  /// driven by this single transaction, keeping the magic-move in sync.
+  /// Restore the expanded card back into the (unchanged) canvas, then drop the
+  /// expanded marker once the animation completes.
   private func collapseExpand() {
-    guard let tabID = expandedTabID else { return }
-    collapsingTabID = tabID
+    guard expandedTabID != nil else { return }
     withAnimation(expandAnimation) {
-      expandedTabID = nil
+      expandProgress = 0
     } completion: {
-      if collapsingTabID == tabID { collapsingTabID = nil }
+      if expandProgress == 0 { expandedTabID = nil }
     }
   }
 
@@ -863,7 +888,7 @@ struct CanvasView: View {
   /// (Arrange/Organize) takes over the canvas.
   private func cancelExpandForRelayout() {
     expandedTabID = nil
-    collapsingTabID = nil
+    expandProgress = 0
   }
 
   private func fulfillPendingFocusRequest(
@@ -1071,7 +1096,7 @@ struct CanvasView: View {
 
   private func deactivateCanvas() {
     expandedTabID = nil
-    collapsingTabID = nil
+    expandProgress = 0
     let activeStates = terminalManager.activeWorktreeStates
     for state in activeStates {
       state.isCanvasManaged = false

--- a/supacode/Features/Canvas/Views/CanvasView.swift
+++ b/supacode/Features/Canvas/Views/CanvasView.swift
@@ -258,95 +258,94 @@ struct CanvasView: View {
     let cardKey = tab.id.rawValue.uuidString
     let baseLayout = layoutStore.cardLayouts[cardKey] ?? CanvasCardLayout(position: .zero)
     let isCardExpanded = expandedTabID == tab.id
-    // An expanded card transforms on its own — full-viewport size/center at
-    // scale 1 — independent of the canvas pan/zoom, so the background is frozen.
-    // Non-expanded cards keep their normal resize-aware geometry.
-    let geometry = cardScreenGeometry(for: tab.id, baseLayout: baseLayout)
-    let renderSize = geometry.size
-    let appliedScale = geometry.scale
-    let screenCenter = geometry.center
-    let cardTotalHeight = renderSize.height + titleBarHeight
+    // The expanded card magic-moves between its in-canvas frame and the full
+    // viewport. AnimatedExpandableCard drives every sub-value (size, center,
+    // scale) from one animatable progress, so they advance frame by frame in
+    // lock-step. The canvas transform is never touched → background frozen.
+    let fromGeometry = nonExpandedGeometry(for: tab.id, baseLayout: baseLayout)
+    let toGeometry = expandedGeometry()
     let unfocusedSplitOverlay = terminalManager.unfocusedSplitOverlay()
     let splitDivider = terminalManager.splitDividerAppearance()
     let repositoryAppearance = appearance(for: state.repositoryRootURL)
     let resolvedRepositoryName = repositoryDisplayName(for: state.repositoryRootURL)
 
-    CanvasCardView(
-      repositoryName: resolvedRepositoryName,
-      worktreeName: tab.displayTitle,
-      repositoryIcon: repositoryAppearance.icon,
-      repositoryColor: repositoryAppearance.color?.color,
-      repositoryRootURL: state.repositoryRootURL,
-      tree: tree,
-      activeSurfaceID: state.activeSurfaceID(for: tab.id),
-      unfocusedSplitOverlay: unfocusedSplitOverlay,
-      splitDivider: splitDivider,
-      isFocused: selectionState.primaryTabID == tab.id,
-      isSelected: selectionState.selectedTabIDs.contains(tab.id),
-      hasUnseenNotification: state.hasUnseenNotification(for: tab.id),
-      cardSize: renderSize,
-      isExpanded: isCardExpanded,
-      canvasScale: appliedScale,
-      showsSelectionShield: showsSelectionShield(for: tab.id),
-      onTap: {
-        let cmdHeld = NSEvent.modifierFlags.contains(.command)
-        if cmdHeld {
+    AnimatedExpandableCard(
+      progress: isCardExpanded ? 1 : 0,
+      collapsed: fromGeometry,
+      expanded: toGeometry,
+      titleBarHeight: titleBarHeight
+    ) { renderSize in
+      CanvasCardView(
+        repositoryName: resolvedRepositoryName,
+        worktreeName: tab.displayTitle,
+        repositoryIcon: repositoryAppearance.icon,
+        repositoryColor: repositoryAppearance.color?.color,
+        repositoryRootURL: state.repositoryRootURL,
+        tree: tree,
+        activeSurfaceID: state.activeSurfaceID(for: tab.id),
+        unfocusedSplitOverlay: unfocusedSplitOverlay,
+        splitDivider: splitDivider,
+        isFocused: selectionState.primaryTabID == tab.id,
+        isSelected: selectionState.selectedTabIDs.contains(tab.id),
+        hasUnseenNotification: state.hasUnseenNotification(for: tab.id),
+        cardSize: renderSize,
+        isExpanded: isCardExpanded,
+        canvasScale: isCardExpanded ? 1 : canvasScale,
+        showsSelectionShield: showsSelectionShield(for: tab.id),
+        onTap: {
+          let cmdHeld = NSEvent.modifierFlags.contains(.command)
+          if cmdHeld {
+            handleSelectionShieldTap(tab.id, surfaceState: state, states: activeStates)
+          } else {
+            focusSingleCard(tab.id, states: activeStates)
+          }
+        },
+        onSelectionTap: {
           handleSelectionShieldTap(tab.id, surfaceState: state, states: activeStates)
-        } else {
-          focusSingleCard(tab.id, states: activeStates)
-        }
-      },
-      onSelectionTap: {
-        handleSelectionShieldTap(tab.id, surfaceState: state, states: activeStates)
-      },
-      onDragCommit: { translation in commitDrag(for: cardKey, translation: translation) },
-      onResize: { edge, translation in
-        activeResize[tab.id] = ActiveResize(
-          edge: edge,
-          translation: CGSize(
-            width: translation.width / canvasScale,
-            height: translation.height / canvasScale
+        },
+        onDragCommit: { translation in commitDrag(for: cardKey, translation: translation) },
+        onResize: { edge, translation in
+          activeResize[tab.id] = ActiveResize(
+            edge: edge,
+            translation: CGSize(
+              width: translation.width / canvasScale,
+              height: translation.height / canvasScale
+            )
           )
-        )
-      },
-      onResizeEnd: { commitResize(for: tab.id, cardKey: cardKey, surfaces: tree.leaves()) },
-      onSplitOperation: { operation in
-        state.performSplitOperation(operation, in: tab.id)
-        if selectionState.isBroadcasting {
-          syncBroadcastCallbacks(states: activeStates)
-        }
-      },
-      onTitleBarTap: {
-        let wasAlreadyFocused =
-          selectionState.primaryTabID == tab.id
-          && selectionState.selectedTabIDs.count <= 1
-        focusSingleCard(tab.id, states: activeStates)
-        let now = Date()
-        if wasAlreadyFocused,
-          now.timeIntervalSince(lastTitleBarTapDate) <= NSEvent.doubleClickInterval
-        {
+        },
+        onResizeEnd: { commitResize(for: tab.id, cardKey: cardKey, surfaces: tree.leaves()) },
+        onSplitOperation: { operation in
+          state.performSplitOperation(operation, in: tab.id)
+          if selectionState.isBroadcasting {
+            syncBroadcastCallbacks(states: activeStates)
+          }
+        },
+        onTitleBarTap: {
+          let wasAlreadyFocused =
+            selectionState.primaryTabID == tab.id
+            && selectionState.selectedTabIDs.count <= 1
+          focusSingleCard(tab.id, states: activeStates)
+          let now = Date()
+          if wasAlreadyFocused,
+            now.timeIntervalSince(lastTitleBarTapDate) <= NSEvent.doubleClickInterval
+          {
+            toggleExpand(tab.id, states: activeStates)
+          }
+          lastTitleBarTapDate = now
+        },
+        onExpand: {
           toggleExpand(tab.id, states: activeStates)
+        },
+        onClose: {
+          state.closeTab(tab.id)
         }
-        lastTitleBarTapDate = now
-      },
-      onExpand: {
-        toggleExpand(tab.id, states: activeStates)
-      },
-      onClose: {
-        state.closeTab(tab.id)
-      }
-    )
-    .scaleEffect(appliedScale, anchor: .center)
-    .offset(
-      x: screenCenter.x - renderSize.width / 2,
-      y: screenCenter.y - cardTotalHeight / 2
-    )
-    // Explicitly animate the expand/restore transition on this card. A plain
-    // withAnimation around expandedTabID doesn't reach here (the GeometryReader's
-    // value-scoped .animation intercepts the implicit transaction), so bind the
-    // animation directly to this card's expanded state. It drives size, center,
-    // scale, and the terminal refit together — a magic-move from the card's
-    // in-canvas frame. Only the toggled card sees the change, so the rest stay put.
+      )
+    }
+    // Animatable progress is interpolated by binding the animation to this
+    // card's expanded state. A plain withAnimation around expandedTabID doesn't
+    // reach here (the GeometryReader's value-scoped .animation swallows the
+    // implicit transaction), so drive it explicitly. Only the toggled card's
+    // value changes, so the rest stay put.
     .animation(expandAnimation, value: isCardExpanded)
     .zIndex(zIndex(for: tab.id, cardKey: cardKey))
   }
@@ -808,30 +807,26 @@ struct CanvasView: View {
     CGPoint(x: viewportSize.width / 2, y: (viewportSize.height - bottomToolbarReserve) / 2)
   }
 
-  /// Screen-space transform for a card on canvas.
-  private struct CardScreenGeometry {
-    var size: CGSize
-    var center: CGPoint
-    var scale: CGFloat
-  }
-
-  /// Screen-space size/center/scale for a card. The expanded card snaps to the
-  /// full-viewport frame at scale 1; the change is animated by the single
-  /// `withAnimation` in `expandCard`/`collapseExpand`. Because the canvas
-  /// transform is never touched, every other card stays frozen.
-  private func cardScreenGeometry(
+  /// A card's normal (non-expanded) on-screen frame, following the canvas
+  /// pan/zoom and any in-progress resize. This is the `progress = 0` endpoint of
+  /// the expand magic-move.
+  private func nonExpandedGeometry(
     for tabID: TerminalTabID,
     baseLayout: CanvasCardLayout
   ) -> CardScreenGeometry {
-    guard expandedTabID == tabID, viewportSize.width > 0, viewportSize.height > 0 else {
-      let resized = resizedFrame(for: tabID, baseLayout: baseLayout)
-      return CardScreenGeometry(
-        size: resized.size,
-        center: screenPosition(for: resized.center),
-        scale: canvasScale
-      )
-    }
+    let resized = resizedFrame(for: tabID, baseLayout: baseLayout)
     return CardScreenGeometry(
+      size: resized.size,
+      center: screenPosition(for: resized.center),
+      scale: canvasScale
+    )
+  }
+
+  /// The full-viewport expanded frame at scale 1 — the `progress = 1` endpoint.
+  /// Independent of the canvas transform, so it covers the viewport regardless
+  /// of the (frozen) background.
+  private func expandedGeometry() -> CardScreenGeometry {
+    CardScreenGeometry(
       size: CanvasExpandGeometry.expandedSize(viewport: viewportSize, metrics: expandMetrics),
       center: expandedScreenCenter,
       scale: 1
@@ -1463,5 +1458,57 @@ private class CanvasScrollContainerView: NSView {
     tearDownMonitor()
     tearDownMiddleButtonMonitor()
     super.removeFromSuperview()
+  }
+}
+
+/// Screen-space transform for a card on canvas.
+private struct CardScreenGeometry {
+  var size: CGSize
+  var center: CGPoint
+  var scale: CGFloat
+}
+
+/// An `Animatable` container that interpolates a card between its in-canvas
+/// frame (`progress` 0) and the full-viewport expanded frame (`progress` 1).
+///
+/// Because `animatableData` is `progress`, SwiftUI re-evaluates `body` on every
+/// frame of the transition, so the card's size, center, and scale advance
+/// together and the terminal re-flows in lock-step with the offset/scale — a
+/// true magic-move from where the card sits. This sidesteps SwiftUI's implicit
+/// per-modifier interpolation, which only reached the Animatable terminal and
+/// left offset/scale to snap (the "grows from the center" / "no animation" bugs).
+private struct AnimatedExpandableCard<Content: View>: View, Animatable {
+  var progress: CGFloat
+  var collapsed: CardScreenGeometry
+  var expanded: CardScreenGeometry
+  let titleBarHeight: CGFloat
+  @ViewBuilder let content: (CGSize) -> Content
+
+  var animatableData: CGFloat {
+    get { progress }
+    set { progress = newValue }
+  }
+
+  var body: some View {
+    let fraction = max(0, min(1, progress))
+    let size = CGSize(
+      width: lerp(collapsed.size.width, expanded.size.width, fraction),
+      height: lerp(collapsed.size.height, expanded.size.height, fraction)
+    )
+    let center = CGPoint(
+      x: lerp(collapsed.center.x, expanded.center.x, fraction),
+      y: lerp(collapsed.center.y, expanded.center.y, fraction)
+    )
+    let scale = lerp(collapsed.scale, expanded.scale, fraction)
+    content(size)
+      .scaleEffect(scale, anchor: .center)
+      .offset(
+        x: center.x - size.width / 2,
+        y: center.y - (size.height + titleBarHeight) / 2
+      )
+  }
+
+  private func lerp(_ start: CGFloat, _ end: CGFloat, _ fraction: CGFloat) -> CGFloat {
+    start + (end - start) * fraction
   }
 }

--- a/supacode/Features/Canvas/Views/CanvasView.swift
+++ b/supacode/Features/Canvas/Views/CanvasView.swift
@@ -84,7 +84,8 @@ struct CanvasView: View {
       offset: $canvasOffset,
       lastOffset: $lastCanvasOffset,
       scale: $canvasScale,
-      lastScale: $lastCanvasScale
+      lastScale: $lastCanvasScale,
+      isInteractionEnabled: expandedTabID == nil
     ) {
       GeometryReader { _ in
         let activeStates = terminalManager.activeWorktreeStates
@@ -134,12 +135,12 @@ struct CanvasView: View {
           .contentShape(.rect)
           .accessibilityAddTraits(.isButton)
           .onTapGesture { clearSelection(states: activeStates) }
-          .gesture(canvasPanGesture)
+          .gesture(canvasPanGesture, isEnabled: expandedTabID == nil)
 
         cardsLayer(activeStates: activeStates)
       }
       .contentShape(.rect)
-      .simultaneousGesture(canvasZoomGesture)
+      .simultaneousGesture(canvasZoomGesture, isEnabled: expandedTabID == nil)
       .animation(.easeInOut(duration: 0.22), value: focusViewportAnimationID)
       .onGeometryChange(for: CGSize.self) { proxy in
         proxy.size
@@ -235,7 +236,11 @@ struct CanvasView: View {
       // it — i.e. anywhere outside the expanded card, including the padding —
       // restores the layout.
       if expandedTabID != nil {
-        Color.black.opacity(0.3)
+        // Material gives a GPU-efficient backdrop blur (the background cards stay
+        // faintly visible / running); the black overlay adds the dim on top.
+        Rectangle()
+          .fill(.ultraThinMaterial)
+          .overlay(Color.black.opacity(0.2))
           .frame(maxWidth: .infinity, maxHeight: .infinity)
           .contentShape(.rect)
           .accessibilityAddTraits(.isButton)
@@ -1136,6 +1141,7 @@ private struct CanvasScrollContainer<Content: View>: NSViewRepresentable {
   @Binding var lastOffset: CGSize
   @Binding var scale: CGFloat
   @Binding var lastScale: CGFloat
+  var isInteractionEnabled: Bool
   @ViewBuilder var content: Content
 
   func makeCoordinator() -> CanvasScrollCoordinator {
@@ -1162,6 +1168,7 @@ private struct CanvasScrollContainer<Content: View>: NSViewRepresentable {
     context.coordinator.lastOffset = $lastOffset
     context.coordinator.scale = $scale
     context.coordinator.lastScale = $lastScale
+    nsView.isInteractionEnabled = isInteractionEnabled
     if let hosting = nsView.subviews.first as? NSHostingView<Content> {
       hosting.rootView = content
     }
@@ -1242,6 +1249,15 @@ enum CanvasZoomMath {
 
 private class CanvasScrollContainerView: NSView {
   var scrollCoordinator: CanvasScrollCoordinator?
+  /// When false (a card is expanded), the container ignores scroll/zoom/
+  /// middle-drag so the canvas can't pan or zoom behind the expanded card.
+  var isInteractionEnabled = true {
+    didSet {
+      guard !isInteractionEnabled, oldValue else { return }
+      if isMiddlePanning { endMiddlePan() }
+      isPanning = false
+    }
+  }
 
   /// Whether the container is actively redirecting scroll events to canvas
   /// panning (as opposed to the brief bounce period after a gesture ends).
@@ -1262,6 +1278,10 @@ private class CanvasScrollContainerView: NSView {
   private var hasPushedPanCursor = false
 
   override func scrollWheel(with event: NSEvent) {
+    guard isInteractionEnabled else {
+      super.scrollWheel(with: event)
+      return
+    }
     if handleZoomEventIfNeeded(event) { return }
     if event.phase == .began {
       startPanning()
@@ -1277,6 +1297,7 @@ private class CanvasScrollContainerView: NSView {
   /// Used by both the direct `scrollWheel` override and the local monitor so
   /// pressing Cmd mid-gesture switches behavior immediately.
   fileprivate func handleZoomEventIfNeeded(_ event: NSEvent) -> Bool {
+    guard isInteractionEnabled else { return false }
     guard event.modifierFlags.contains(.command), event.scrollingDeltaY != 0 else { return false }
     let viewLocation = convert(event.locationInWindow, from: nil)
     let anchor = CGPoint(x: viewLocation.x, y: bounds.height - viewLocation.y)
@@ -1303,6 +1324,7 @@ private class CanvasScrollContainerView: NSView {
   private func installMonitor() {
     scrollMonitor = NSEvent.addLocalMonitorForEvents(matching: .scrollWheel) { [weak self] event in
       guard let self, event.window === self.window else { return event }
+      guard self.isInteractionEnabled else { return event }
 
       // Cmd toggled mid-gesture — switch to zoom for this event.
       if self.handleZoomEventIfNeeded(event) { return nil }
@@ -1396,6 +1418,7 @@ private class CanvasScrollContainerView: NSView {
     let mask: NSEvent.EventTypeMask = [.otherMouseDown, .otherMouseDragged, .otherMouseUp]
     middleButtonMonitor = NSEvent.addLocalMonitorForEvents(matching: mask) { [weak self] event in
       guard let self, event.window === self.window, event.buttonNumber == 2 else { return event }
+      guard self.isInteractionEnabled else { return event }
 
       switch event.type {
       case .otherMouseDown:

--- a/supacode/Features/Canvas/Views/CanvasView.swift
+++ b/supacode/Features/Canvas/Views/CanvasView.swift
@@ -341,6 +341,13 @@ struct CanvasView: View {
       x: screenCenter.x - renderSize.width / 2,
       y: screenCenter.y - cardTotalHeight / 2
     )
+    // Explicitly animate the expand/restore transition on this card. A plain
+    // withAnimation around expandedTabID doesn't reach here (the GeometryReader's
+    // value-scoped .animation intercepts the implicit transaction), so bind the
+    // animation directly to this card's expanded state. It drives size, center,
+    // scale, and the terminal refit together — a magic-move from the card's
+    // in-canvas frame. Only the toggled card sees the change, so the rest stay put.
+    .animation(expandAnimation, value: isCardExpanded)
     .zIndex(zIndex(for: tab.id, cardKey: cardKey))
   }
 

--- a/supacode/Features/Canvas/Views/CanvasView.swift
+++ b/supacode/Features/Canvas/Views/CanvasView.swift
@@ -291,6 +291,11 @@ struct CanvasView: View {
     let cardKey = tab.id.rawValue.uuidString
     let baseLayout = layoutStore.cardLayouts[cardKey] ?? CanvasCardLayout(position: .zero)
     let isCardExpanded = expandedTabID == tab.id
+    let expandHelp = AppShortcuts.helpText(
+      title: isCardExpanded ? "Restore card size" : "Expand card",
+      commandID: AppShortcuts.CommandID.expandCanvasCard,
+      in: resolvedKeybindings
+    )
     // The expanded card magic-moves between its in-canvas frame and the full
     // viewport. AnimatedExpandableCard drives every sub-value (size, center,
     // scale) from one animatable progress, so they advance frame by frame in
@@ -323,6 +328,7 @@ struct CanvasView: View {
         hasUnseenNotification: state.hasUnseenNotification(for: tab.id),
         cardSize: renderSize,
         isExpanded: isCardExpanded,
+        expandHelp: expandHelp,
         canvasScale: isCardExpanded ? 1 : canvasScale,
         showsSelectionShield: showsSelectionShield(for: tab.id),
         onTap: {
@@ -662,7 +668,11 @@ struct CanvasView: View {
   }
 
   private var canvasHelpContent: some View {
-    VStack(alignment: .leading, spacing: 14) {
+    let expandShortcut = AppShortcuts.display(
+      for: AppShortcuts.CommandID.expandCanvasCard,
+      in: resolvedKeybindings
+    )
+    return VStack(alignment: .leading, spacing: 14) {
       Text("Canvas Navigation")
         .font(.headline)
 
@@ -676,6 +686,12 @@ struct CanvasView: View {
           icon: "hand.draw",
           title: "Pan canvas",
           detail: "Drag empty area, middle-click drag, or two-finger swipe"
+        )
+        canvasHelpRow(
+          icon: "arrow.up.left.and.arrow.down.right",
+          title: "Expand / restore card",
+          detail: expandShortcut.map { "\($0), or the card's title-bar button" }
+            ?? "Use the card's title-bar button"
         )
       }
     }

--- a/supacode/Features/Canvas/Views/CanvasView.swift
+++ b/supacode/Features/Canvas/Views/CanvasView.swift
@@ -15,6 +15,9 @@ struct CanvasView: View {
   var focusRequest: CanvasFocusRequest?
   var onFocusedWorktreeChanged: (Worktree.ID?) -> Void = { _ in }
   var onFocusRequestConsumed: (Int) -> Void = { _ in }
+  /// Reports whether a card is currently expanded in place, so the parent can
+  /// give the window toolbar a matching scrim (it can't be covered from here).
+  var onExpandedChange: (Bool) -> Void = { _ in }
   @State private var layoutStore = CanvasLayoutStore()
   @Shared(.repositoryAppearances) private var repositoryAppearances
 
@@ -199,6 +202,9 @@ struct CanvasView: View {
       organizeCardsWithFit()
       return .handled
     }
+    .onChange(of: expandedTabID) { _, newValue in
+      onExpandedChange(newValue != nil)
+    }
     .task { activateCanvas() }
     .onReceive(NotificationCenter.default.publisher(for: .ghosttyRuntimeConfigDidChange)) { _ in
       configReloadCounter &+= 1
@@ -236,11 +242,13 @@ struct CanvasView: View {
       // it — i.e. anywhere outside the expanded card, including the padding —
       // restores the layout.
       if expandedTabID != nil {
-        // Material gives a GPU-efficient backdrop blur (the background cards stay
-        // faintly visible / running); the black overlay adds the dim on top.
+        // Material gives a GPU-efficient backdrop blur; a small black overlay
+        // adds the dim. The whole scrim is kept partly transparent so the
+        // background cards stay clearly visible (still running) behind it.
         Rectangle()
           .fill(.ultraThinMaterial)
-          .overlay(Color.black.opacity(0.2))
+          .overlay(Color.black.opacity(0.1))
+          .opacity(0.7)
           .frame(maxWidth: .infinity, maxHeight: .infinity)
           .contentShape(.rect)
           .accessibilityAddTraits(.isButton)

--- a/supacode/Features/CommandPalette/CommandPaletteItem.swift
+++ b/supacode/Features/CommandPalette/CommandPaletteItem.swift
@@ -64,6 +64,10 @@ struct CommandPaletteItem: Identifiable, Equatable {
     case toggleLeftSidebar
     case toggleActiveAgentsPanel
     case toggleCanvas
+    case expandCanvasCard
+    case arrangeCanvasCards
+    case organizeCanvasCards
+    case selectAllCanvasCards
     case toggleShelf
     case showDiff
     case revealInFinder
@@ -120,6 +124,14 @@ struct CommandPaletteItem: Identifiable, Equatable {
       return AppShortcuts.CommandID.toggleActiveAgentsPanel
     case .toggleCanvas:
       return AppShortcuts.CommandID.toggleCanvas
+    case .expandCanvasCard:
+      return AppShortcuts.CommandID.expandCanvasCard
+    case .arrangeCanvasCards:
+      return AppShortcuts.CommandID.arrangeCanvasCards
+    case .organizeCanvasCards:
+      return AppShortcuts.CommandID.organizeCanvasCards
+    case .selectAllCanvasCards:
+      return AppShortcuts.CommandID.selectAllCanvasCards
     case .toggleShelf:
       return AppShortcuts.CommandID.toggleShelf
     case .showDiff:

--- a/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
+++ b/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
@@ -54,6 +54,10 @@ struct CommandPaletteFeature {
     case toggleLeftSidebar
     case toggleActiveAgentsPanel
     case toggleCanvas
+    case expandCanvasCard
+    case arrangeCanvasCards
+    case organizeCanvasCards
+    case selectAllCanvasCards
     case toggleShelf
     case showDiff
     case revealInFinder
@@ -224,6 +228,9 @@ struct CommandPaletteFeature {
       repositories.repositories.isEmpty
       || repositories.repositories.contains { $0.capabilities.supportsWorktrees }
     var items = globalCommandItems(showsNewWorktreeAction: showsNewWorktreeAction)
+    if repositories.isShowingCanvas {
+      items.append(contentsOf: canvasCommandItems())
+    }
     let worktreeActionTargetID = actionTargetWorktreeID ?? repositories.selectedWorktreeID
     if repositories.selectedWorktreeID != nil {
       items.append(
@@ -580,6 +587,39 @@ private func viewToggleCommandItems() -> [CommandPaletteItem] {
   ]
 }
 
+private func canvasCommandItems() -> [CommandPaletteItem] {
+  [
+    .appShortcut(
+      id: CommandPaletteItemID.globalExpandCanvasCard,
+      title: "Expand / Restore Canvas Card",
+      category: .view,
+      kind: .expandCanvasCard,
+      keywords: ["canvas", "expand", "restore", "focus", "fullscreen", "card"]
+    ),
+    .appShortcut(
+      id: CommandPaletteItemID.globalArrangeCanvasCards,
+      title: "Arrange Canvas Cards",
+      category: .view,
+      kind: .arrangeCanvasCards,
+      keywords: ["canvas", "arrange", "layout", "pack", "fit"]
+    ),
+    .appShortcut(
+      id: CommandPaletteItemID.globalOrganizeCanvasCards,
+      title: "Organize Canvas Cards",
+      category: .view,
+      kind: .organizeCanvasCards,
+      keywords: ["canvas", "organize", "grid", "tidy", "uniform"]
+    ),
+    .appShortcut(
+      id: CommandPaletteItemID.globalSelectAllCanvasCards,
+      title: "Select All Canvas Cards",
+      category: .view,
+      kind: .selectAllCanvasCards,
+      keywords: ["canvas", "select all", "broadcast"]
+    ),
+  ]
+}
+
 private func selectedCodeHostItems(
   from repositories: RepositoriesFeature.State
 ) -> [CommandPaletteItem] {
@@ -858,6 +898,10 @@ private enum CommandPaletteItemID {
   static let globalToggleLeftSidebar = "global.toggle-left-sidebar"
   static let globalToggleActiveAgentsPanel = "global.toggle-active-agents-panel"
   static let globalToggleCanvas = "global.toggle-canvas"
+  static let globalExpandCanvasCard = "global.expand-canvas-card"
+  static let globalArrangeCanvasCards = "global.arrange-canvas-cards"
+  static let globalOrganizeCanvasCards = "global.organize-canvas-cards"
+  static let globalSelectAllCanvasCards = "global.select-all-canvas-cards"
   static let globalToggleShelf = "global.toggle-shelf"
   static let globalShowDiff = "global.show-diff"
   static let globalRevealInFinder = "global.reveal-in-finder"
@@ -890,6 +934,10 @@ private enum CommandPaletteItemID {
       globalToggleLeftSidebar,
       globalToggleActiveAgentsPanel,
       globalToggleCanvas,
+      globalExpandCanvasCard,
+      globalArrangeCanvasCards,
+      globalOrganizeCanvasCards,
+      globalSelectAllCanvasCards,
       globalToggleShelf,
       globalShowDiff,
       globalRevealInFinder,
@@ -1021,6 +1069,10 @@ private func delegateAction(for kind: CommandPaletteItem.Kind) -> CommandPalette
     .toggleLeftSidebar,
     .toggleActiveAgentsPanel,
     .toggleCanvas,
+    .expandCanvasCard,
+    .arrangeCanvasCards,
+    .organizeCanvasCards,
+    .selectAllCanvasCards,
     .toggleShelf,
     .showDiff,
     .revealInFinder,
@@ -1089,6 +1141,14 @@ private func viewDelegateAction(for kind: CommandPaletteItem.Kind) -> CommandPal
     return .toggleActiveAgentsPanel
   case .toggleCanvas:
     return .toggleCanvas
+  case .expandCanvasCard:
+    return .expandCanvasCard
+  case .arrangeCanvasCards:
+    return .arrangeCanvasCards
+  case .organizeCanvasCards:
+    return .organizeCanvasCards
+  case .selectAllCanvasCards:
+    return .selectAllCanvasCards
   case .toggleShelf:
     return .toggleShelf
   case .showDiff:
@@ -1133,6 +1193,10 @@ private func pullRequestDelegateAction(
     .toggleLeftSidebar,
     .toggleActiveAgentsPanel,
     .toggleCanvas,
+    .expandCanvasCard,
+    .arrangeCanvasCards,
+    .organizeCanvasCards,
+    .selectAllCanvasCards,
     .toggleShelf,
     .showDiff,
     .revealInFinder,

--- a/supacode/Features/CommandPalette/Views/CommandPaletteOverlayView.swift
+++ b/supacode/Features/CommandPalette/Views/CommandPaletteOverlayView.swift
@@ -526,7 +526,9 @@ private struct CommandPaletteRowView: View {
       .copyFailingJobURL,
       .copyCiFailureLogs,
       .rerunFailedJobs, .openFailingCheckDetails, .worktreeSelect, .changeFocusedTabIcon,
-      .toggleLeftSidebar, .toggleActiveAgentsPanel, .toggleCanvas, .toggleShelf, .showDiff,
+      .toggleLeftSidebar, .toggleActiveAgentsPanel, .toggleCanvas,
+      .expandCanvasCard, .arrangeCanvasCards, .organizeCanvasCards, .selectAllCanvasCards,
+      .toggleShelf, .showDiff,
       .revealInFinder, .copyPath, .revealInSidebar,
       .runScript, .stopRunScript, .togglePinWorktree, .renameBranch,
       .openRepositorySettings, .runCustomCommand:
@@ -586,6 +588,14 @@ private struct CommandPaletteRowView: View {
       return "person.crop.rectangle.stack"
     case .toggleCanvas:
       return "square.grid.2x2"
+    case .expandCanvasCard:
+      return "arrow.up.left.and.arrow.down.right"
+    case .arrangeCanvasCards:
+      return "rectangle.3.group"
+    case .organizeCanvasCards:
+      return "square.grid.2x2"
+    case .selectAllCanvasCards:
+      return "checkmark.rectangle.stack"
     case .toggleShelf:
       return "books.vertical"
     case .showDiff:
@@ -629,7 +639,9 @@ private struct CommandPaletteRowView: View {
       .copyFailingJobURL,
       .copyCiFailureLogs,
       .rerunFailedJobs, .openFailingCheckDetails, .changeFocusedTabIcon,
-      .toggleLeftSidebar, .toggleActiveAgentsPanel, .toggleCanvas, .toggleShelf, .showDiff,
+      .toggleLeftSidebar, .toggleActiveAgentsPanel, .toggleCanvas,
+      .expandCanvasCard, .arrangeCanvasCards, .organizeCanvasCards, .selectAllCanvasCards,
+      .toggleShelf, .showDiff,
       .revealInFinder, .copyPath, .revealInSidebar,
       .runScript, .stopRunScript, .togglePinWorktree, .renameBranch,
       .openRepositorySettings,
@@ -754,6 +766,14 @@ private struct CommandPaletteRowView: View {
       base = "Toggle Active Agents Panel"
     case .toggleCanvas:
       base = "Toggle Canvas"
+    case .expandCanvasCard:
+      base = "Expand / Restore Canvas Card"
+    case .arrangeCanvasCards:
+      base = "Arrange Canvas Cards"
+    case .organizeCanvasCards:
+      base = "Organize Canvas Cards"
+    case .selectAllCanvasCards:
+      base = "Select All Canvas Cards"
     case .toggleShelf:
       base = "Toggle Shelf"
     case .showDiff:

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -277,6 +277,8 @@ struct RepositoriesFeature {
     var showActiveAgentTabTitles = false
     var nextCanvasFocusRequestID = 0
     var pendingCanvasFocusRequest: CanvasFocusRequest?
+    var nextCanvasCommandRequestID = 0
+    var pendingCanvasCommandRequest: CanvasCommandRequest?
     var activeAgents = ActiveAgentsFeature.State()
     @Shared(.appStorage("sidebarCollapsedRepositoryIDs")) var collapsedRepositoryIDs: [Repository.ID] = []
     @Presents var worktreeCreationPrompt: WorktreeCreationPromptFeature.State?
@@ -352,6 +354,8 @@ struct RepositoriesFeature {
     case selectNextWorktree
     case selectPreviousWorktree
     case consumeCanvasFocusRequest(Int)
+    case requestCanvasCommand(CanvasCommandRequest.Command)
+    case consumeCanvasCommandRequest(Int)
     case worktreeHistoryBack
     case worktreeHistoryForward
     case revealSelectedWorktreeInSidebar
@@ -1039,6 +1043,20 @@ struct RepositoriesFeature {
         case .consumeCanvasFocusRequest(let id):
           if state.pendingCanvasFocusRequest?.id == id {
             state.pendingCanvasFocusRequest = nil
+          }
+          return .none
+
+        case .requestCanvasCommand(let command):
+          state.nextCanvasCommandRequestID += 1
+          state.pendingCanvasCommandRequest = CanvasCommandRequest(
+            id: state.nextCanvasCommandRequestID,
+            command: command
+          )
+          return .none
+
+        case .consumeCanvasCommandRequest(let id):
+          if state.pendingCanvasCommandRequest?.id == id {
+            state.pendingCanvasCommandRequest = nil
           }
           return .none
 

--- a/supacode/Features/Repositories/Views/WorktreeDetailView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailView.swift
@@ -399,11 +399,15 @@ struct WorktreeDetailView: View {
         terminalManager: terminalManager,
         repositoryCustomTitles: repositories.repositoryCustomTitles,
         focusRequest: repositories.pendingCanvasFocusRequest,
+        commandRequest: repositories.pendingCanvasCommandRequest,
         onFocusedWorktreeChanged: { worktreeID in
           store.send(.canvasFocusedWorktreeChanged(worktreeID))
         },
         onFocusRequestConsumed: { requestID in
           store.send(.repositories(.consumeCanvasFocusRequest(requestID)))
+        },
+        onCommandConsumed: { requestID in
+          store.send(.repositories(.consumeCanvasCommandRequest(requestID)))
         },
         onExpandedChange: { expanded in
           isCanvasCardExpanded = expanded

--- a/supacode/Features/Repositories/Views/WorktreeDetailView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailView.swift
@@ -393,9 +393,6 @@ struct WorktreeDetailView: View {
         terminalManager: terminalManager,
         repositoryCustomTitles: repositories.repositoryCustomTitles,
         focusRequest: repositories.pendingCanvasFocusRequest,
-        onExitToTab: {
-          store.send(.repositories(.toggleCanvas))
-        },
         onFocusedWorktreeChanged: { worktreeID in
           store.send(.canvasFocusedWorktreeChanged(worktreeID))
         },

--- a/supacode/Features/Repositories/Views/WorktreeDetailView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailView.swift
@@ -132,9 +132,9 @@ struct WorktreeDetailView: View {
         )
       }
     }
-    .windowToolbarChromeBackground(toolbarChromeFill(repositories: repositories))
-    .modifier(
-      CanvasExpandedToolbarScrim(isActive: repositories.isShowingCanvas && isCanvasCardExpanded)
+    .windowToolbarChromeBackground(
+      toolbarChromeFill(repositories: repositories),
+      forceMaterialScrim: repositories.isShowingCanvas && isCanvasCardExpanded
     )
     let actions = makeFocusedActions(
       repositories: repositories,
@@ -1292,25 +1292,6 @@ private struct CanvasToolbarPreview: View {
         }
     }
     .frame(width: 900, height: 300)
-  }
-}
-
-/// Gives the window toolbar a neutral material scrim while a Canvas card is
-/// expanded in place, so the otherwise-transparent Canvas toolbar doesn't show
-/// the (dimmed/blurred) background cards through it. `.bar` adapts to the app
-/// theme (light → pale grey, dark → dark grey).
-private struct CanvasExpandedToolbarScrim: ViewModifier {
-  let isActive: Bool
-
-  @ViewBuilder
-  func body(content: Content) -> some View {
-    if isActive {
-      content
-        .toolbarBackground(.bar, for: .windowToolbar)
-        .toolbarBackgroundVisibility(.visible, for: .windowToolbar)
-    } else {
-      content
-    }
   }
 }
 

--- a/supacode/Features/Repositories/Views/WorktreeDetailView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailView.swift
@@ -39,6 +39,9 @@ struct WorktreeDetailView: View {
   /// Drive the chrome (nav + toolbar) tint for Normal and Canvas modes.
   @Shared(.repositoryAppearances) private var repositoryAppearances
   @Shared(.settingsFile) private var settingsFile
+  /// True while a Canvas card is expanded in place, so the otherwise-transparent
+  /// Canvas toolbar gets a matching material scrim instead of showing through.
+  @State private var isCanvasCardExpanded = false
 
   var body: some View {
     detailBody(state: store.state)
@@ -130,6 +133,9 @@ struct WorktreeDetailView: View {
       }
     }
     .windowToolbarChromeBackground(toolbarChromeFill(repositories: repositories))
+    .modifier(
+      CanvasExpandedToolbarScrim(isActive: repositories.isShowingCanvas && isCanvasCardExpanded)
+    )
     let actions = makeFocusedActions(
       repositories: repositories,
       hasActiveWorktree: hasActiveTerminalTarget,
@@ -398,6 +404,9 @@ struct WorktreeDetailView: View {
         },
         onFocusRequestConsumed: { requestID in
           store.send(.repositories(.consumeCanvasFocusRequest(requestID)))
+        },
+        onExpandedChange: { expanded in
+          isCanvasCardExpanded = expanded
         }
       )
       // Canvas tints the nav (leading) only; the toolbar is left untinted so
@@ -1283,6 +1292,25 @@ private struct CanvasToolbarPreview: View {
         }
     }
     .frame(width: 900, height: 300)
+  }
+}
+
+/// Gives the window toolbar a neutral material scrim while a Canvas card is
+/// expanded in place, so the otherwise-transparent Canvas toolbar doesn't show
+/// the (dimmed/blurred) background cards through it. `.bar` adapts to the app
+/// theme (light → pale grey, dark → dark grey).
+private struct CanvasExpandedToolbarScrim: ViewModifier {
+  let isActive: Bool
+
+  @ViewBuilder
+  func body(content: Content) -> some View {
+    if isActive {
+      content
+        .toolbarBackground(.bar, for: .windowToolbar)
+        .toolbarBackgroundVisibility(.visible, for: .windowToolbar)
+    } else {
+      content
+    }
   }
 }
 

--- a/supacodeTests/CanvasExpandGeometryTests.swift
+++ b/supacodeTests/CanvasExpandGeometryTests.swift
@@ -5,8 +5,6 @@ import Testing
 @testable import supacode
 
 struct CanvasExpandGeometryTests {
-  private let viewport = CGSize(width: 2000, height: 1400)
-  private let center = CGPoint(x: 500, y: 300)
   private let metrics = CanvasExpandGeometry.Metrics(
     padding: 40,
     bottomReserve: 50,
@@ -15,36 +13,22 @@ struct CanvasExpandGeometryTests {
   )
 
   @Test func sizeFillsViewportMinusPaddingAndBottomReserve() {
-    let result = CanvasExpandGeometry.expandedFrame(
-      viewport: viewport,
-      cardCenter: center,
+    let size = CanvasExpandGeometry.expandedSize(
+      viewport: CGSize(width: 2000, height: 1400),
       metrics: metrics
     )
     let expectedWidth: CGFloat = 2000 - 40 * 2
     let expectedHeight: CGFloat = 1400 - 40 * 2 - 50 - 28
-    #expect(result.size.width == expectedWidth)
-    #expect(result.size.height == expectedHeight)
-  }
-
-  @Test func offsetCentersCardAtScaleOne() {
-    let result = CanvasExpandGeometry.expandedFrame(
-      viewport: viewport,
-      cardCenter: center,
-      metrics: metrics
-    )
-    // At scale 1, the card's screen center is cardCenter + offset; it should
-    // land at the horizontal middle and the toolbar-adjusted vertical middle.
-    #expect(center.x + result.offset.width == viewport.width / 2)
-    #expect(center.y + result.offset.height == (viewport.height - 50) / 2)
+    #expect(size.width == expectedWidth)
+    #expect(size.height == expectedHeight)
   }
 
   @Test func clampsToMinSizeOnTinyViewport() {
-    let result = CanvasExpandGeometry.expandedFrame(
+    let size = CanvasExpandGeometry.expandedSize(
       viewport: CGSize(width: 200, height: 150),
-      cardCenter: .zero,
       metrics: metrics
     )
-    #expect(result.size.width == metrics.minSize.width)
-    #expect(result.size.height == metrics.minSize.height)
+    #expect(size.width == metrics.minSize.width)
+    #expect(size.height == metrics.minSize.height)
   }
 }

--- a/supacodeTests/CanvasExpandGeometryTests.swift
+++ b/supacodeTests/CanvasExpandGeometryTests.swift
@@ -1,0 +1,50 @@
+import CoreGraphics
+import Foundation
+import Testing
+
+@testable import supacode
+
+struct CanvasExpandGeometryTests {
+  private let viewport = CGSize(width: 2000, height: 1400)
+  private let center = CGPoint(x: 500, y: 300)
+  private let metrics = CanvasExpandGeometry.Metrics(
+    padding: 40,
+    bottomReserve: 50,
+    titleBarHeight: 28,
+    minSize: CGSize(width: 300, height: 200)
+  )
+
+  @Test func sizeFillsViewportMinusPaddingAndBottomReserve() {
+    let result = CanvasExpandGeometry.expandedFrame(
+      viewport: viewport,
+      cardCenter: center,
+      metrics: metrics
+    )
+    let expectedWidth: CGFloat = 2000 - 40 * 2
+    let expectedHeight: CGFloat = 1400 - 40 * 2 - 50 - 28
+    #expect(result.size.width == expectedWidth)
+    #expect(result.size.height == expectedHeight)
+  }
+
+  @Test func offsetCentersCardAtScaleOne() {
+    let result = CanvasExpandGeometry.expandedFrame(
+      viewport: viewport,
+      cardCenter: center,
+      metrics: metrics
+    )
+    // At scale 1, the card's screen center is cardCenter + offset; it should
+    // land at the horizontal middle and the toolbar-adjusted vertical middle.
+    #expect(center.x + result.offset.width == viewport.width / 2)
+    #expect(center.y + result.offset.height == (viewport.height - 50) / 2)
+  }
+
+  @Test func clampsToMinSizeOnTinyViewport() {
+    let result = CanvasExpandGeometry.expandedFrame(
+      viewport: CGSize(width: 200, height: 150),
+      cardCenter: .zero,
+      metrics: metrics
+    )
+    #expect(result.size.width == metrics.minSize.width)
+    #expect(result.size.height == metrics.minSize.height)
+  }
+}

--- a/supacodeTests/CommandPaletteFeatureTests.swift
+++ b/supacodeTests/CommandPaletteFeatureTests.swift
@@ -46,6 +46,25 @@ struct CommandPaletteFeatureTests {
     #expect(items.contains { $0.id == "global.show-diff" })
   }
 
+  @Test func commandPaletteItems_includesCanvasCommandsInCanvasMode() {
+    var state = RepositoriesFeature.State()
+    state.selection = .canvas
+
+    let ids = CommandPaletteFeature.commandPaletteItems(from: state).map(\.id)
+    #expect(ids.contains("global.expand-canvas-card"))
+    #expect(ids.contains("global.arrange-canvas-cards"))
+    #expect(ids.contains("global.organize-canvas-cards"))
+    #expect(ids.contains("global.select-all-canvas-cards"))
+  }
+
+  @Test func commandPaletteItems_omitsCanvasCommandsOutsideCanvas() {
+    let ids = CommandPaletteFeature.commandPaletteItems(from: RepositoriesFeature.State()).map(\.id)
+    #expect(!ids.contains("global.expand-canvas-card"))
+    #expect(!ids.contains("global.arrange-canvas-cards"))
+    #expect(!ids.contains("global.organize-canvas-cards"))
+    #expect(!ids.contains("global.select-all-canvas-cards"))
+  }
+
   @Test func commandPaletteItems_omitsShowDiffWithoutSelectedWorktree() {
     let items = CommandPaletteFeature.commandPaletteItems(from: RepositoriesFeature.State())
     #expect(!items.contains { $0.id == "global.show-diff" })
@@ -1701,7 +1720,9 @@ private func testCategory(for kind: CommandPaletteItem.Kind) -> CommandPaletteIt
     return .pullRequest
   case .ghosttyCommand:
     return .terminal
-  case .toggleLeftSidebar, .toggleActiveAgentsPanel, .toggleCanvas, .toggleShelf, .showDiff:
+  case .toggleLeftSidebar, .toggleActiveAgentsPanel, .toggleCanvas,
+    .expandCanvasCard, .arrangeCanvasCards, .organizeCanvasCards, .selectAllCanvasCards,
+    .toggleShelf, .showDiff:
     return .view
   #if DEBUG
     case .debugTestToast, .debugSimulateUpdateFound, .debugLightDockNotificationDot:
@@ -1716,7 +1737,9 @@ private func testDefaultSuggestion(for kind: CommandPaletteItem.Kind) -> Bool {
     .newWorktree, .refreshWorktrees, .viewArchivedWorktrees, .jumpToLatestUnread,
     .openPullRequest, .markPullRequestReady, .mergePullRequest, .closePullRequest,
     .copyFailingJobURL, .copyCiFailureLogs, .rerunFailedJobs, .openFailingCheckDetails,
-    .toggleLeftSidebar, .toggleActiveAgentsPanel, .toggleCanvas, .toggleShelf, .showDiff,
+    .toggleLeftSidebar, .toggleActiveAgentsPanel, .toggleCanvas,
+    .expandCanvasCard, .arrangeCanvasCards, .organizeCanvasCards, .selectAllCanvasCards,
+    .toggleShelf, .showDiff,
     .revealInFinder, .copyPath, .revealInSidebar,
     .runScript, .stopRunScript, .togglePinWorktree, .renameBranch,
     .openRepositorySettings:

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -11,6 +11,37 @@ import Testing
 
 @MainActor
 struct RepositoriesFeatureTests {
+  @Test func requestCanvasCommandSetsPendingRequestWithIncrementingID() async {
+    let store = TestStore(initialState: RepositoriesFeature.State()) {
+      RepositoriesFeature()
+    }
+
+    await store.send(.requestCanvasCommand(.toggleExpand)) {
+      $0.nextCanvasCommandRequestID = 1
+      $0.pendingCanvasCommandRequest = CanvasCommandRequest(id: 1, command: .toggleExpand)
+    }
+    await store.send(.requestCanvasCommand(.arrange)) {
+      $0.nextCanvasCommandRequestID = 2
+      $0.pendingCanvasCommandRequest = CanvasCommandRequest(id: 2, command: .arrange)
+    }
+  }
+
+  @Test func consumeCanvasCommandRequestClearsOnlyMatchingID() async {
+    var initialState = RepositoriesFeature.State()
+    initialState.nextCanvasCommandRequestID = 5
+    initialState.pendingCanvasCommandRequest = CanvasCommandRequest(id: 5, command: .organize)
+    let store = TestStore(initialState: initialState) {
+      RepositoriesFeature()
+    }
+
+    // A stale id is ignored.
+    await store.send(.consumeCanvasCommandRequest(4))
+    // The matching id clears the request.
+    await store.send(.consumeCanvasCommandRequest(5)) {
+      $0.pendingCanvasCommandRequest = nil
+    }
+  }
+
   @Test func refreshWorktreesSetsRefreshingStateUntilLoadCompletes() async {
     let worktree = makeWorktree(id: "/tmp/repo/main", name: "main")
     let repository = makeRepository(id: "/tmp/repo", worktrees: [worktree])


### PR DESCRIPTION
## What

Replaces the card title-bar "expand to tab view" stopgap (which left Canvas and switched back to Normal) with a mature **expand-in-place**: the card magic-moves from where it sits to cover the viewport at scale 1, the background stays frozen behind a dimmed/blurred scrim, and it's all reversible. Plus a keyboard shortcut and command-palette entries.

## Behavior

- **Expand**: raises the card to the top and animates **only that card** — from its in-canvas frame to **scale 1 covering the viewport** (with padding). At scale 1 the terminal renders at the same font size as Normal/Shelf.
- **Background frozen**: the canvas pan/zoom is never touched, so every other card stays put; they recede behind a blurred, dimmed scrim and keep running.
- **Restore**: the button toggles to Restore; clicking it, tapping the scrim/padding, or double-clicking the title bar animates the card back.
- **Relayout**: Arrange/Organize while expanded cancels expand and lays out with that mode.
- **Locked**: while expanded, canvas pan/pinch/scroll/middle-drag are disabled so the background can't shift.
- **Toolbar**: the (otherwise transparent) Canvas toolbar gets a theme-adaptive `.bar` scrim while expanded so cards don't show through above it.

## How the animation works

The move is driven by an `Animatable` container (`AnimatedExpandableCard`, `animatableData = progress`) so SwiftUI re-evaluates it **every frame** — size, center, and scale all interpolate from one value and the terminal reflows in lock-step. (Earlier attempts that relied on implicit per-modifier interpolation or a plain `@State` progress either grew from the center or didn't animate; the journal is in the commit history.) The canvas transform is never mutated, which is what keeps the background frozen.

## Shortcut & command palette

- **⌥⌘E** toggles Expand/Restore for the focused card (matches the existing ⌥⌘A/R/G canvas shortcuts; avoids the system ⌥⌘M = Minimize All).
- Command palette (Canvas mode only): **Expand / Restore**, **Arrange**, **Organize**, **Select All** Canvas Cards. These are CanvasView view-local actions, so they're routed via a one-shot reducer→view trigger (`CanvasCommandRequest`, modeled on `CanvasFocusRequest`): request in `RepositoriesFeature`, mapped from the palette delegates in `AppFeature`, observed+consumed in `CanvasView`.

## Notable files

- `CanvasView` / `CanvasCardView`: `AnimatedExpandableCard`, scrim, gesture lock, shortcut + command dispatch.
- `WindowChromeTint` / `WorktreeDetailView`: `forceMaterialScrim` toolbar flag (folded into the existing modifier so toggling never restructures the view tree / rebuilds CanvasView).
- `CanvasExpandGeometry` (+ tests): expanded-size geometry.
- `CommandPaletteFeature` / `CommandPaletteItem` / `AppShortcuts` / `RepositoriesFeature` / `AppFeature`: palette + shortcut wiring.

## Testing

- `make build-app` ✅ (0 warnings) · `make check` ✅
- `CanvasExpandGeometryTests`, palette-item tests (present in Canvas / absent otherwise), and request/consume reducer tests ✅
- Manual: expand/restore animation, frozen background, scrim, gesture lock, toolbar scrim, ⌥⌘E, and palette entries.
