### PR TITLE
Harden CLI socket access

### DIFF
--- a/supacode/CLIService/CLISocketServer.swift
+++ b/supacode/CLIService/CLISocketServer.swift
@@ -33,10 +33,7 @@ final class CLISocketServer {
   func start() throws {
     // Ensure parent directory exists (e.g. ~/Library/Application Support/com.onevcat.prowl)
     let parentDir = (socketPath as NSString).deletingLastPathComponent
-    try? FileManager.default.createDirectory(
-      atPath: parentDir,
-      withIntermediateDirectories: true
-    )
+    try ensureSocketDirectory(at: parentDir)
 
     var addr = try Self.socketAddress(for: socketPath)
 
@@ -83,6 +80,13 @@ final class CLISocketServer {
       releaseSocketLock()
       throw CLIServiceError.bindFailed
     }
+    guard chmod(socketPath, S_IRUSR | S_IWUSR) == 0 else {
+      close(serverFD)
+      serverFD = -1
+      unlink(socketPath)
+      releaseSocketLock()
+      throw CLIServiceError.permissionFailed
+    }
 
     // Listen
     guard listen(serverFD, 5) == 0 else {
@@ -125,6 +129,10 @@ final class CLISocketServer {
     guard lockFD >= 0 else {
       throw CLIServiceError.lockFailed
     }
+    guard fchmod(lockFD, S_IRUSR | S_IWUSR) == 0 else {
+      releaseSocketLock()
+      throw CLIServiceError.lockFailed
+    }
     do {
       try Self.setCloseOnExec(lockFD)
     } catch {
@@ -142,6 +150,23 @@ final class CLISocketServer {
     flock(lockFD, LOCK_UN)
     close(lockFD)
     lockFD = -1
+  }
+
+  private func ensureSocketDirectory(at parentDir: String) throws {
+    let fileManager = FileManager.default
+    let existed = fileManager.fileExists(atPath: parentDir)
+    try fileManager.createDirectory(
+      atPath: parentDir,
+      withIntermediateDirectories: true,
+      attributes: [.posixPermissions: 0o700]
+    )
+
+    // Avoid chmod'ing arbitrary existing custom parents such as /tmp or $HOME
+    // when PROWL_CLI_SOCKET is overridden.
+    guard !existed || parentDir == Self.defaultSocketDirectory else { return }
+    guard chmod(parentDir, S_IRWXU) == 0 else {
+      throw CLIServiceError.permissionFailed
+    }
   }
 
   // MARK: - Accept loop (runs on acceptQueue, NOT in Swift concurrency)
@@ -167,6 +192,8 @@ final class CLISocketServer {
     defer { Darwin.close(clientFD) }
 
     do {
+      guard Self.clientHasCurrentUser(clientFD) else { return }
+
       // Read length-prefixed request
       let lengthData = try Self.fdRead(fildes: clientFD, count: 4)
       let length = lengthData.withUnsafeBytes {
@@ -194,6 +221,23 @@ final class CLISocketServer {
     } catch {
       // Connection-level errors are silently dropped
     }
+  }
+
+  static func isAllowedPeerUID(_ peerUID: uid_t, currentUID: uid_t = geteuid()) -> Bool {
+    peerUID == currentUID
+  }
+
+  private static func clientHasCurrentUser(_ clientFD: Int32) -> Bool {
+    #if canImport(Darwin)
+      var peerUID = uid_t()
+      var peerGID = gid_t()
+      guard getpeereid(clientFD, &peerUID, &peerGID) == 0 else {
+        return false
+      }
+      return isAllowedPeerUID(peerUID)
+    #else
+      return true
+    #endif
   }
 
   // MARK: - Low-level I/O using Darwin read/write
@@ -254,6 +298,14 @@ final class CLISocketServer {
     return result == 0
   }
 
+  private static var defaultSocketDirectory: String {
+    FileManager.default.homeDirectoryForCurrentUser
+      .appending(path: "Library", directoryHint: .isDirectory)
+      .appending(path: "Application Support", directoryHint: .isDirectory)
+      .appending(path: "com.onevcat.prowl", directoryHint: .isDirectory)
+      .path(percentEncoded: false)
+  }
+
   private static func socketAddress(for socketPath: String) throws -> sockaddr_un {
     var addr = sockaddr_un()
     addr.sun_family = sa_family_t(AF_UNIX)
@@ -286,6 +338,7 @@ enum CLIServiceError: Error, Equatable {
   case socketAlreadyOwned
   case lockFailed
   case closeOnExecFailed
+  case permissionFailed
   case bindFailed
   case listenFailed
   case readFailed

--- a/supacodeTests/CLISocketServerTests.swift
+++ b/supacodeTests/CLISocketServerTests.swift
@@ -66,16 +66,45 @@ struct CLISocketServerTests {
     #expect(isCloseOnExec(descriptors.lock))
   }
 
+  @Test func socketFilesAreOwnerOnly() throws {
+    let socketPath = temporarySocketPath(suffix: "permissions")
+    let socketDirectory = (socketPath as NSString).deletingLastPathComponent
+    let lockPath = "\(socketPath).lock"
+    let server = CLISocketServer(router: CLICommandRouter(), socketPath: socketPath)
+    try server.start()
+    defer { server.stop() }
+
+    #expect(fileMode(at: socketDirectory) == 0o700)
+    #expect(fileMode(at: socketPath) == 0o600)
+    #expect(fileMode(at: lockPath) == 0o600)
+  }
+
+  @Test func peerUIDMustMatchCurrentUser() {
+    #expect(CLISocketServer.isAllowedPeerUID(501, currentUID: 501))
+    #expect(!CLISocketServer.isAllowedPeerUID(502, currentUID: 501))
+  }
+
   private func temporarySocketPath(suffix: String) -> String {
     URL(fileURLWithPath: "/tmp", isDirectory: true)
+      .appending(path: "prowl-cli-tests-\(UUID().uuidString.prefix(8))", directoryHint: .isDirectory)
       .appending(
         path: "prowl-\(suffix)-\(UUID().uuidString.prefix(8)).sock", directoryHint: .notDirectory
       )
       .path(percentEncoded: false)
   }
 
+  private func fileMode(at path: String) -> mode_t? {
+    var statValue = stat()
+    guard stat(path, &statValue) == 0 else { return nil }
+    return statValue.st_mode & mode_t(0o777)
+  }
+
   private func createStaleSocket(at socketPath: String) throws {
     unlink(socketPath)
+    try FileManager.default.createDirectory(
+      atPath: (socketPath as NSString).deletingLastPathComponent,
+      withIntermediateDirectories: true
+    )
     let socketFD = socket(AF_UNIX, SOCK_STREAM, 0)
     guard socketFD >= 0 else {
       throw CLIServiceError.socketCreationFailed


### PR DESCRIPTION
## Summary
- restrict the CLI socket directory, socket file, and lock file to owner-only permissions where Prowl owns the path
- reject Unix socket clients whose peer uid does not match the Prowl process uid
- add CLISocketServer coverage for owner-only permissions and peer uid matching

## Verification
- xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -only-testing:supacodeTests/CLISocketServerTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation
- make build-app
- make check
