### PR TITLE
Add CLI tab and pane close commands

### DIFF
--- a/ProwlCLI/Commands/PaneCommand.swift
+++ b/ProwlCLI/Commands/PaneCommand.swift
@@ -1,0 +1,34 @@
+// ProwlCLI/Commands/PaneCommand.swift
+
+import ArgumentParser
+import ProwlCLIShared
+
+struct PaneCommand: ParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "pane",
+    abstract: "Manage terminal panes.",
+    subcommands: [
+      PaneCloseCommand.self,
+    ]
+  )
+}
+
+struct PaneCloseCommand: ParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "close",
+    abstract: "Close a terminal pane."
+  )
+
+  @OptionGroup var selector: SelectorOptions
+  @OptionGroup var options: GlobalOptions
+
+  mutating func run() throws {
+    try CLIExecution.run(command: "pane", output: options.outputMode, colorEnabled: options.colorEnabled) {
+      let envelope = CommandEnvelope(
+        output: options.outputMode,
+        command: .pane(PaneInput(action: .close, selector: try selector.resolve()))
+      )
+      try CLIRunner.execute(envelope)
+    }
+  }
+}

--- a/ProwlCLI/Commands/PaneCommand.swift
+++ b/ProwlCLI/Commands/PaneCommand.swift
@@ -22,11 +22,21 @@ struct PaneCloseCommand: ParsableCommand {
   @OptionGroup var selector: SelectorOptions
   @OptionGroup var options: GlobalOptions
 
+  @Flag(name: .long, help: "Close without prompting for protected panes.")
+  var force = false
+
   mutating func run() throws {
     try CLIExecution.run(command: "pane", output: options.outputMode, colorEnabled: options.colorEnabled) {
+      let resolvedSelector = try selector.resolve()
+      guard !resolvedSelector.isNone else {
+        throw ExitError(
+          code: CLIErrorCode.invalidArgument,
+          message: "pane close requires an explicit target selector."
+        )
+      }
       let envelope = CommandEnvelope(
         output: options.outputMode,
-        command: .pane(PaneInput(action: .close, selector: try selector.resolve()))
+        command: .pane(PaneInput(action: .close, selector: resolvedSelector, force: force))
       )
       try CLIRunner.execute(envelope)
     }

--- a/ProwlCLI/Commands/ProwlCommand.swift
+++ b/ProwlCLI/Commands/ProwlCommand.swift
@@ -17,6 +17,8 @@ struct ProwlCommand: ParsableCommand {
       SendCommand.self,
       KeyCommand.self,
       ReadCommand.self,
+      TabCommand.self,
+      PaneCommand.self,
     ],
     defaultSubcommand: OpenCommand.self
   )

--- a/ProwlCLI/Commands/TabCommand.swift
+++ b/ProwlCLI/Commands/TabCommand.swift
@@ -55,11 +55,21 @@ struct TabCloseCommand: ParsableCommand {
   @OptionGroup var selector: SelectorOptions
   @OptionGroup var options: GlobalOptions
 
+  @Flag(name: .long, help: "Close without prompting for protected panes.")
+  var force = false
+
   mutating func run() throws {
     try CLIExecution.run(command: "tab", output: options.outputMode, colorEnabled: options.colorEnabled) {
+      let resolvedSelector = try selector.resolve()
+      guard !resolvedSelector.isNone else {
+        throw ExitError(
+          code: CLIErrorCode.invalidArgument,
+          message: "tab close requires an explicit target selector."
+        )
+      }
       let envelope = CommandEnvelope(
         output: options.outputMode,
-        command: .tab(TabInput(action: .close, selector: try selector.resolve()))
+        command: .tab(TabInput(action: .close, selector: resolvedSelector, force: force))
       )
       try CLIRunner.execute(envelope)
     }

--- a/ProwlCLI/Commands/TabCommand.swift
+++ b/ProwlCLI/Commands/TabCommand.swift
@@ -1,0 +1,77 @@
+// ProwlCLI/Commands/TabCommand.swift
+
+import ArgumentParser
+import Foundation
+import ProwlCLIShared
+
+struct TabCommand: ParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "tab",
+    abstract: "Create or close terminal tabs.",
+    subcommands: [
+      TabCreateCommand.self,
+      TabCloseCommand.self,
+    ]
+  )
+}
+
+struct TabCreateCommand: ParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "create",
+    abstract: "Create a new terminal tab."
+  )
+
+  @OptionGroup var selector: SelectorOptions
+  @OptionGroup var options: GlobalOptions
+
+  @Option(name: .long, help: "Working directory for the new tab.")
+  var path: String?
+
+  mutating func run() throws {
+    try CLIExecution.run(command: "tab", output: options.outputMode, colorEnabled: options.colorEnabled) {
+      let envelope = CommandEnvelope(
+        output: options.outputMode,
+        command: .tab(TabInput(action: .create, selector: try selector.resolve(), path: normalizedPath()))
+      )
+      try CLIRunner.execute(envelope)
+    }
+  }
+
+  private func normalizedPath() -> String? {
+    guard let path else { return nil }
+    return URL(fileURLWithPath: path, isDirectory: true)
+      .standardizedFileURL
+      .path(percentEncoded: false)
+      .trimmingTrailingSlash()
+  }
+}
+
+struct TabCloseCommand: ParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "close",
+    abstract: "Close a terminal tab."
+  )
+
+  @OptionGroup var selector: SelectorOptions
+  @OptionGroup var options: GlobalOptions
+
+  mutating func run() throws {
+    try CLIExecution.run(command: "tab", output: options.outputMode, colorEnabled: options.colorEnabled) {
+      let envelope = CommandEnvelope(
+        output: options.outputMode,
+        command: .tab(TabInput(action: .close, selector: try selector.resolve()))
+      )
+      try CLIRunner.execute(envelope)
+    }
+  }
+}
+
+extension String {
+  fileprivate func trimmingTrailingSlash() -> String {
+    var value = self
+    while value.count > 1, value.hasSuffix("/") {
+      value.removeLast()
+    }
+    return value
+  }
+}

--- a/ProwlCLI/Output/OutputRenderer.swift
+++ b/ProwlCLI/Output/OutputRenderer.swift
@@ -81,6 +81,22 @@ enum OutputRenderer {
         return
       }
 
+      if response.command == "tab",
+         let data = response.data,
+         let payload = try? data.decode(as: TabCommandPayload.self)
+      {
+        print(renderTab(payload))
+        return
+      }
+
+      if response.command == "pane",
+         let data = response.data,
+         let payload = try? data.decode(as: PaneCommandPayload.self)
+      {
+        print(renderPane(payload))
+        return
+      }
+
       if response.command == "open" {
         return
       }
@@ -176,6 +192,49 @@ enum OutputRenderer {
       }
     }
 
+    return lines.joined(separator: "\n")
+  }
+
+  private static func renderTab(_ payload: TabCommandPayload) -> String {
+    let wt = payload.target.worktree
+    let tab = payload.target.tab
+    let pane = payload.target.pane
+    let projectName = projectName(from: wt.path)
+    let verb =
+      switch payload.action {
+      case .create: "Created tab"
+      case .close: "Closed tab"
+      }
+
+    var lines: [String] = []
+    lines.append(
+      "\(verb) \(projectName.cyan.bold)\(":".dim)\(wt.name) → \(tab.title.yellow)"
+      + "  \(tab.id.dim)"
+    )
+    lines.append("  \("pane:".dim) \(pane.title.green)  \(pane.id.dim)")
+    if let cwd = pane.cwd {
+      lines.append("  \("cwd:".dim) \(cwd)")
+    }
+    return lines.joined(separator: "\n")
+  }
+
+  private static func renderPane(_ payload: PaneCommandPayload) -> String {
+    let wt = payload.target.worktree
+    let pane = payload.target.pane
+    let projectName = projectName(from: wt.path)
+    let verb =
+      switch payload.action {
+      case .close: "Closed pane"
+      }
+
+    var lines: [String] = []
+    lines.append(
+      "\(verb) \(projectName.cyan.bold)\(":".dim)\(wt.name) → \(pane.title.green)"
+      + "  \(pane.id.dim)"
+    )
+    if let cwd = pane.cwd {
+      lines.append("  \("cwd:".dim) \(cwd)")
+    }
     return lines.joined(separator: "\n")
   }
 

--- a/ProwlCLITests/ProwlCLIIntegrationTests.swift
+++ b/ProwlCLITests/ProwlCLIIntegrationTests.swift
@@ -155,6 +155,83 @@ final class ProwlCLIIntegrationTests: XCTestCase {
     }
   }
 
+  func testTabCreateCommandRoundTripsOverSocket() throws {
+    let socketPath = temporarySocketPath(suffix: "tab-create")
+    let response = try CommandResponse(
+      ok: true,
+      command: "tab",
+      schemaVersion: "prowl.cli.tab.v1",
+      data: RawJSON(encoding: makeTabPayload(action: .create))
+    )
+
+    let (requestData, result) = try runWithMockServer(
+      socketPath: socketPath,
+      response: response,
+      args: ["tab", "create", "--worktree", "App", "--path", "/Projects/App", "--json"]
+    )
+
+    XCTAssertEqual(result.exitCode, 0)
+    let envelope = try JSONDecoder().decode(CommandEnvelope.self, from: requestData)
+    if case .tab(let input) = envelope.command {
+      XCTAssertEqual(input.action, .create)
+      XCTAssertEqual(input.selector, .worktree("App"))
+      XCTAssertEqual(input.path, "/Projects/App")
+    } else {
+      XCTFail("Expected tab command envelope")
+    }
+  }
+
+  func testTabCloseCommandRoundTripsOverSocket() throws {
+    let socketPath = temporarySocketPath(suffix: "tab-close")
+    let response = try CommandResponse(
+      ok: true,
+      command: "tab",
+      schemaVersion: "prowl.cli.tab.v1",
+      data: RawJSON(encoding: makeTabPayload(action: .close))
+    )
+
+    let (requestData, result) = try runWithMockServer(
+      socketPath: socketPath,
+      response: response,
+      args: ["tab", "close", "--tab", "tab-123", "--json"]
+    )
+
+    XCTAssertEqual(result.exitCode, 0)
+    let envelope = try JSONDecoder().decode(CommandEnvelope.self, from: requestData)
+    if case .tab(let input) = envelope.command {
+      XCTAssertEqual(input.action, .close)
+      XCTAssertEqual(input.selector, .tab("tab-123"))
+      XCTAssertNil(input.path)
+    } else {
+      XCTFail("Expected tab command envelope")
+    }
+  }
+
+  func testPaneCloseCommandRoundTripsOverSocket() throws {
+    let socketPath = temporarySocketPath(suffix: "pane-close")
+    let response = try CommandResponse(
+      ok: true,
+      command: "pane",
+      schemaVersion: "prowl.cli.pane.v1",
+      data: RawJSON(encoding: makePanePayload(action: .close))
+    )
+
+    let (requestData, result) = try runWithMockServer(
+      socketPath: socketPath,
+      response: response,
+      args: ["pane", "close", "--pane", "pane-123", "--json"]
+    )
+
+    XCTAssertEqual(result.exitCode, 0)
+    let envelope = try JSONDecoder().decode(CommandEnvelope.self, from: requestData)
+    if case .pane(let input) = envelope.command {
+      XCTAssertEqual(input.action, .close)
+      XCTAssertEqual(input.selector, .pane("pane-123"))
+    } else {
+      XCTFail("Expected pane command envelope")
+    }
+  }
+
   func testFocusRejectsMultipleSelectorsBeforeTransport() throws {
     let result = try runProwl(args: ["focus", "--worktree", "Prowl", "--pane", "pane-123", "--json"])
 
@@ -1238,6 +1315,28 @@ final class ProwlCLIIntegrationTests: XCTestCase {
 
     let requestData = try XCTUnwrap(server.waitForRequest(timeout: 2.0), "No request received by mock server")
     return (requestData, result)
+  }
+
+  private func makeTabPayload(action: TabAction) -> TabCommandPayload {
+    TabCommandPayload(action: action, target: makeTabTarget())
+  }
+
+  private func makePanePayload(action: PaneAction) -> PaneCommandPayload {
+    PaneCommandPayload(action: action, target: makeTabTarget())
+  }
+
+  private func makeTabTarget() -> TabTarget {
+    TabTarget(
+      worktree: TabTargetWorktree(
+        id: "App:/Projects/App",
+        name: "App",
+        path: "/Projects/App",
+        rootPath: "/Projects/App",
+        kind: "git"
+      ),
+      tab: TabTargetTab(id: "tab-123", title: "App 1", selected: true),
+      pane: TabTargetPane(id: "pane-123", title: "zsh", cwd: "/Projects/App", focused: true)
+    )
   }
 
   private func runProwl(

--- a/ProwlCLITests/ProwlCLIIntegrationTests.swift
+++ b/ProwlCLITests/ProwlCLIIntegrationTests.swift
@@ -193,7 +193,7 @@ final class ProwlCLIIntegrationTests: XCTestCase {
     let (requestData, result) = try runWithMockServer(
       socketPath: socketPath,
       response: response,
-      args: ["tab", "close", "--tab", "tab-123", "--json"]
+      args: ["tab", "close", "--tab", "tab-123", "--force", "--json"]
     )
 
     XCTAssertEqual(result.exitCode, 0)
@@ -202,9 +202,21 @@ final class ProwlCLIIntegrationTests: XCTestCase {
       XCTAssertEqual(input.action, .close)
       XCTAssertEqual(input.selector, .tab("tab-123"))
       XCTAssertNil(input.path)
+      XCTAssertTrue(input.force)
     } else {
       XCTFail("Expected tab command envelope")
     }
+  }
+
+  func testTabCloseRejectsMissingTargetBeforeTransport() throws {
+    let result = try runProwl(args: ["tab", "close", "--json"])
+
+    XCTAssertNotEqual(result.exitCode, 0)
+    let payload = try jsonObject(from: result.stdout)
+    XCTAssertEqual(payload["ok"] as? Bool, false)
+    XCTAssertEqual(payload["command"] as? String, "tab")
+    let error = try XCTUnwrap(payload["error"] as? [String: Any])
+    XCTAssertEqual(error["code"] as? String, CLIErrorCode.invalidArgument)
   }
 
   func testPaneCloseCommandRoundTripsOverSocket() throws {
@@ -219,7 +231,7 @@ final class ProwlCLIIntegrationTests: XCTestCase {
     let (requestData, result) = try runWithMockServer(
       socketPath: socketPath,
       response: response,
-      args: ["pane", "close", "--pane", "pane-123", "--json"]
+      args: ["pane", "close", "--pane", "pane-123", "--force", "--json"]
     )
 
     XCTAssertEqual(result.exitCode, 0)
@@ -227,9 +239,21 @@ final class ProwlCLIIntegrationTests: XCTestCase {
     if case .pane(let input) = envelope.command {
       XCTAssertEqual(input.action, .close)
       XCTAssertEqual(input.selector, .pane("pane-123"))
+      XCTAssertTrue(input.force)
     } else {
       XCTFail("Expected pane command envelope")
     }
+  }
+
+  func testPaneCloseRejectsMissingTargetBeforeTransport() throws {
+    let result = try runProwl(args: ["pane", "close", "--json"])
+
+    XCTAssertNotEqual(result.exitCode, 0)
+    let payload = try jsonObject(from: result.stdout)
+    XCTAssertEqual(payload["ok"] as? Bool, false)
+    XCTAssertEqual(payload["command"] as? String, "pane")
+    let error = try XCTUnwrap(payload["error"] as? [String: Any])
+    XCTAssertEqual(error["code"] as? String, CLIErrorCode.invalidArgument)
   }
 
   func testFocusRejectsMultipleSelectorsBeforeTransport() throws {

--- a/skills/prowl-cli/SKILL.md
+++ b/skills/prowl-cli/SKILL.md
@@ -78,6 +78,12 @@ prowl pane close --pane "$pane" --json
 prowl tab close --tab "$tab" --json
 ```
 
+`tab close` and `pane close` require an explicit `--tab`, `--pane`, `--worktree`, or `--target`; they intentionally do not default to the currently focused pane. If the target has protected agent work or a long-running command, Prowl may ask for GUI confirmation. Use `--force` only after you have positively identified the target:
+
+```bash
+prowl pane close --pane "$pane" --force --json
+```
+
 ## Reading Agent Output
 
 `task.status` is useful for coordination but is not enough to prove the screen finished rendering. `idle` can arrive before a TUI has painted its final response.

--- a/skills/prowl-cli/SKILL.md
+++ b/skills/prowl-cli/SKILL.md
@@ -35,14 +35,14 @@ prowl key --pane "$pane" enter --json
 
 ## Common Recipes
 
-Open a fresh pane for a project, then verify it is not yourself:
+Create a fresh tab for the current project, then verify it is not yourself:
 
 ```bash
-pane="$(prowl open /path/to/project --json | jq -r '.data.target.pane.id')"
+pane="$(prowl tab create --worktree /path/to/project --json | jq -r '.data.target.pane.id')"
 test "$pane" != "$self_pane"
 ```
 
-`open` always creates a new tab/pane for a path and brings Prowl forward. To select an already-open pane, use `focus`, not `open`.
+`prowl open /path` opens or focuses a matching project/path and may create a tab when needed. It is not guaranteed to create a new pane. Use `prowl tab create` for deterministic new terminal sessions.
 
 Run a command and capture its result:
 
@@ -71,10 +71,11 @@ Send multiline input from stdin:
 printf '%s\n' 'echo first' 'echo second' | prowl send --pane "$pane" --capture --timeout 30 --json
 ```
 
-Close a temporary tab/pane when done. There is no `prowl close` command:
+Close a temporary tab/pane when done:
 
 ```bash
-prowl key --pane "$pane" cmd-w --json
+prowl pane close --pane "$pane" --json
+prowl tab close --tab "$tab" --json
 ```
 
 ## Reading Agent Output
@@ -169,7 +170,8 @@ Avoid outer double quotes around payloads containing `$PWD`, `$VAR`, backticks, 
 
 - Never target by tab title alone; use `pane.id` plus path/cwd.
 - Never omit `--pane` for `send`, `key`, `read`, or `focus` in automation.
-- `open /path` creates a new tab/pane. It is not a refocus command.
+- `open /path` is a project/path navigation command. It may refocus an existing pane and is not a deterministic create command.
+- Use `tab create` when automation needs a fresh shell, and capture the returned `pane.id` before sending input.
 - Focused pane is not stable; `open` and `focus` change it.
 - `read --wait-stable` sees rendered screen only. It cannot recover content folded by a TUI.
 - `read` returning fewer lines than `--last` requested is normally `truncated: false` — the pane simply has less history and you already have it all, so do not retry for more. `truncated: true` flags a possibly-incomplete result (the full scrollback could not be read).
@@ -203,4 +205,4 @@ Always check the exit code before piping output into `jq`; parser-level errors p
 
 ## Command Set
 
-Current commands: `list`, `read`, `send`, `key`, `focus`, and `open` (default). There is no CLI `close` or `quit`; use key shortcuts such as `cmd-w` only after explicit target verification.
+Current commands: `list`, `read`, `send`, `key`, `focus`, `tab create`, `tab close`, `pane close`, and `open` (default). There is no CLI `quit`; close temporary tabs or panes with explicit `tab close` / `pane close` targets.

--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -464,13 +464,77 @@ struct SupacodeApp: App {
         return KeyDeliveryResult(attempted: repeatCount, delivered: delivered)
       }
     )
+    let tabHandler = TabCommandHandler(
+      resolveProvider: { selector in
+        let resolver = TargetResolver {
+          TargetResolutionSnapshotBuilder.makeSnapshot(
+            repositoriesState: appStore.state.repositories,
+            terminalManager: terminalManager
+          )
+        }
+        return resolver.resolve(selector).map { TabResolvedTarget(from: $0) }
+      },
+      createTab: { target, path in
+        let repositories = Array(appStore.state.repositories.repositories)
+        guard let worktree = resolveCLITerminalWorktree(id: target.worktreeID, repositories: repositories) else {
+          return nil
+        }
+        selectCLIWorktreeContext(
+          worktreeID: target.worktreeID,
+          appStore: appStore,
+          terminalManager: terminalManager
+        )
+        let state = terminalManager.state(for: worktree)
+        let directory = path.map { URL(fileURLWithPath: $0, isDirectory: true) }
+        guard let tabID = state.createTab(workingDirectoryOverride: directory) else {
+          return nil
+        }
+        let resolver = makeTargetResolver(appStore: appStore, terminalManager: terminalManager)
+        switch resolver.resolve(.tab(tabID.rawValue.uuidString)) {
+        case .success(let resolved):
+          return TabResolvedTarget(from: resolved)
+        case .failure:
+          return nil
+        }
+      },
+      closeTab: { target in
+        guard let tabUUID = UUID(uuidString: target.tabID),
+          let state = terminalManager.stateIfExists(for: target.worktreeID)
+        else {
+          return false
+        }
+        return state.closeTab(TerminalTabID(rawValue: tabUUID))
+      }
+    )
+    let paneHandler = PaneCommandHandler(
+      resolveProvider: { selector in
+        let resolver = TargetResolver {
+          TargetResolutionSnapshotBuilder.makeSnapshot(
+            repositoriesState: appStore.state.repositories,
+            terminalManager: terminalManager
+          )
+        }
+        return resolver.resolve(selector).map { TabResolvedTarget(from: $0) }
+      },
+      closePane: { target in
+        guard let paneID = UUID(uuidString: target.paneID),
+          let state = terminalManager.stateIfExists(for: target.worktreeID)
+        else {
+          return false
+        }
+        guard state.focusSurface(id: paneID) else { return false }
+        return state.closeFocusedSurface()
+      }
+    )
     return CLICommandRouter(
       openHandler: openHandler,
       listHandler: listHandler,
       focusHandler: focusHandler,
       sendHandler: sendHandler,
       keyHandler: keyHandler,
-      readHandler: readHandler
+      readHandler: readHandler,
+      tabHandler: tabHandler,
+      paneHandler: paneHandler
     )
   }
 

--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -497,13 +497,16 @@ struct SupacodeApp: App {
           return nil
         }
       },
-      closeTab: { target in
+      closeTab: { target, force in
         guard let tabUUID = UUID(uuidString: target.tabID),
           let state = terminalManager.stateIfExists(for: target.worktreeID)
         else {
           return false
         }
-        return state.closeTab(TerminalTabID(rawValue: tabUUID))
+        return state.closeTab(
+          TerminalTabID(rawValue: tabUUID),
+          confirmation: force ? .skip : .prompt(.tab)
+        )
       }
     )
     let paneHandler = PaneCommandHandler(
@@ -516,14 +519,16 @@ struct SupacodeApp: App {
         }
         return resolver.resolve(selector).map { TabResolvedTarget(from: $0) }
       },
-      closePane: { target in
+      closePane: { target, force in
         guard let paneID = UUID(uuidString: target.paneID),
           let state = terminalManager.stateIfExists(for: target.worktreeID)
         else {
           return false
         }
-        guard state.focusSurface(id: paneID) else { return false }
-        return state.closeFocusedSurface()
+        return state.closeSurface(
+          id: paneID,
+          confirmation: force ? .skip : .prompt(.pane)
+        )
       }
     )
     return CLICommandRouter(

--- a/supacode/CLIService/CLICommandRouter.swift
+++ b/supacode/CLIService/CLICommandRouter.swift
@@ -11,6 +11,8 @@ final class CLICommandRouter {
   private let sendHandler: any CommandHandler
   private let keyHandler: any CommandHandler
   private let readHandler: any CommandHandler
+  private let tabHandler: any CommandHandler
+  private let paneHandler: any CommandHandler
 
   init(
     openHandler: any CommandHandler = StubCommandHandler(command: "open"),
@@ -18,7 +20,9 @@ final class CLICommandRouter {
     focusHandler: any CommandHandler = StubCommandHandler(command: "focus"),
     sendHandler: any CommandHandler = StubCommandHandler(command: "send"),
     keyHandler: any CommandHandler = StubCommandHandler(command: "key"),
-    readHandler: any CommandHandler = StubCommandHandler(command: "read")
+    readHandler: any CommandHandler = StubCommandHandler(command: "read"),
+    tabHandler: any CommandHandler = StubCommandHandler(command: "tab"),
+    paneHandler: any CommandHandler = StubCommandHandler(command: "pane")
   ) {
     self.openHandler = openHandler
     self.listHandler = listHandler
@@ -26,6 +30,8 @@ final class CLICommandRouter {
     self.sendHandler = sendHandler
     self.keyHandler = keyHandler
     self.readHandler = readHandler
+    self.tabHandler = tabHandler
+    self.paneHandler = paneHandler
   }
 
   func route(_ envelope: CommandEnvelope) async -> CommandResponse {
@@ -37,6 +43,8 @@ final class CLICommandRouter {
     case .send: handler = sendHandler
     case .key: handler = keyHandler
     case .read: handler = readHandler
+    case .tab: handler = tabHandler
+    case .pane: handler = paneHandler
     }
     return await handler.handle(envelope: envelope)
   }

--- a/supacode/CLIService/PaneCommandHandler.swift
+++ b/supacode/CLIService/PaneCommandHandler.swift
@@ -5,7 +5,7 @@ import Foundation
 @MainActor
 final class PaneCommandHandler: CommandHandler {
   typealias ResolveProvider = @MainActor (TargetSelector) -> Result<TabResolvedTarget, TargetResolverError>
-  typealias ClosePaneProvider = @MainActor (TabResolvedTarget) -> Bool
+  typealias ClosePaneProvider = @MainActor (TabResolvedTarget, Bool) -> Bool
 
   private let resolveProvider: ResolveProvider
   private let closePane: ClosePaneProvider
@@ -24,6 +24,13 @@ final class PaneCommandHandler: CommandHandler {
       return errorResponse(code: CLIErrorCode.paneFailed, message: "Invalid command.")
     }
 
+    if input.action == .close, input.selector.isNone {
+      return errorResponse(
+        code: CLIErrorCode.invalidArgument,
+        message: "pane close requires an explicit target selector."
+      )
+    }
+
     let target: TabResolvedTarget
     switch resolveProvider(input.selector) {
     case .success(let resolved):
@@ -34,7 +41,7 @@ final class PaneCommandHandler: CommandHandler {
 
     switch input.action {
     case .close:
-      guard closePane(target) else {
+      guard closePane(target, input.force) else {
         return errorResponse(code: CLIErrorCode.paneFailed, message: "Failed to close pane.")
       }
       return success(action: .close, target: target)

--- a/supacode/CLIService/PaneCommandHandler.swift
+++ b/supacode/CLIService/PaneCommandHandler.swift
@@ -1,0 +1,97 @@
+// supacode/CLIService/PaneCommandHandler.swift
+
+import Foundation
+
+@MainActor
+final class PaneCommandHandler: CommandHandler {
+  typealias ResolveProvider = @MainActor (TargetSelector) -> Result<TabResolvedTarget, TargetResolverError>
+  typealias ClosePaneProvider = @MainActor (TabResolvedTarget) -> Bool
+
+  private let resolveProvider: ResolveProvider
+  private let closePane: ClosePaneProvider
+
+  init(
+    resolveProvider: @escaping ResolveProvider,
+    closePane: @escaping ClosePaneProvider
+  ) {
+    self.resolveProvider = resolveProvider
+    self.closePane = closePane
+  }
+
+  // swiftlint:disable:next async_without_await
+  func handle(envelope: CommandEnvelope) async -> CommandResponse {
+    guard case .pane(let input) = envelope.command else {
+      return errorResponse(code: CLIErrorCode.paneFailed, message: "Invalid command.")
+    }
+
+    let target: TabResolvedTarget
+    switch resolveProvider(input.selector) {
+    case .success(let resolved):
+      target = resolved
+    case .failure(let error):
+      return mapResolverError(error)
+    }
+
+    switch input.action {
+    case .close:
+      guard closePane(target) else {
+        return errorResponse(code: CLIErrorCode.paneFailed, message: "Failed to close pane.")
+      }
+      return success(action: .close, target: target)
+    }
+  }
+
+  private func success(action: PaneAction, target: TabResolvedTarget) -> CommandResponse {
+    do {
+      return try CommandResponse(
+        ok: true,
+        command: "pane",
+        schemaVersion: "prowl.cli.pane.v1",
+        data: RawJSON(encoding: PaneCommandPayload(action: action, target: makePayloadTarget(from: target)))
+      )
+    } catch {
+      return errorResponse(code: CLIErrorCode.paneFailed, message: "Failed to encode response.")
+    }
+  }
+
+  private func makePayloadTarget(from target: TabResolvedTarget) -> TabTarget {
+    TabTarget(
+      worktree: TabTargetWorktree(
+        id: target.worktreeID,
+        name: target.worktreeName,
+        path: target.worktreePath,
+        rootPath: target.worktreeRootPath,
+        kind: target.worktreeKind
+      ),
+      tab: TabTargetTab(
+        id: target.tabID,
+        title: target.tabTitle,
+        selected: target.tabSelected
+      ),
+      pane: TabTargetPane(
+        id: target.paneID,
+        title: target.paneTitle,
+        cwd: target.paneCWD,
+        focused: target.paneFocused
+      )
+    )
+  }
+
+  private func mapResolverError(_ error: TargetResolverError) -> CommandResponse {
+    switch error {
+    case .notFound(let message):
+      return errorResponse(code: CLIErrorCode.targetNotFound, message: message)
+    case .notUnique(let message):
+      return errorResponse(code: CLIErrorCode.targetNotUnique, message: message)
+    }
+  }
+
+  private func errorResponse(code: String, message: String) -> CommandResponse {
+    CommandResponse(
+      ok: false,
+      command: "pane",
+      schemaVersion: "prowl.cli.pane.v1",
+      error: CommandError(code: code, message: message)
+    )
+  }
+}

--- a/supacode/CLIService/Shared/CommandEnvelope.swift
+++ b/supacode/CLIService/Shared/CommandEnvelope.swift
@@ -20,6 +20,8 @@ public enum Command: Codable, Sendable {
   case send(SendInput)
   case key(KeyInput)
   case read(ReadInput)
+  case tab(TabInput)
+  case pane(PaneInput)
 
   public var name: String {
     switch self {
@@ -29,6 +31,8 @@ public enum Command: Codable, Sendable {
     case .send: "send"
     case .key: "key"
     case .read: "read"
+    case .tab: "tab"
+    case .pane: "pane"
     }
   }
 }

--- a/supacode/CLIService/Shared/ErrorCodes.swift
+++ b/supacode/CLIService/Shared/ErrorCodes.swift
@@ -38,6 +38,12 @@ public enum CLIErrorCode {
   // Read
   public static let readFailed = "READ_FAILED"
 
+  // Tab
+  public static let tabFailed = "TAB_FAILED"
+
+  // Pane
+  public static let paneFailed = "PANE_FAILED"
+
   // Transport
   public static let transportFailed = "TRANSPORT_FAILED"
   public static let timeout = "TIMEOUT"

--- a/supacode/CLIService/Shared/InputModels.swift
+++ b/supacode/CLIService/Shared/InputModels.swift
@@ -143,11 +143,28 @@ public struct TabInput: Codable, Sendable {
   public let action: TabAction
   public let selector: TargetSelector
   public let path: String?
+  public let force: Bool
 
-  public init(action: TabAction, selector: TargetSelector = .none, path: String? = nil) {
+  enum CodingKeys: String, CodingKey {
+    case action
+    case selector
+    case path
+    case force
+  }
+
+  public init(action: TabAction, selector: TargetSelector = .none, path: String? = nil, force: Bool = false) {
     self.action = action
     self.selector = selector
     self.path = path
+    self.force = force
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    self.action = try container.decode(TabAction.self, forKey: .action)
+    self.selector = try container.decode(TargetSelector.self, forKey: .selector)
+    self.path = try container.decodeIfPresent(String.self, forKey: .path)
+    self.force = try container.decodeIfPresent(Bool.self, forKey: .force) ?? false
   }
 }
 
@@ -158,9 +175,24 @@ public enum PaneAction: String, Codable, Sendable {
 public struct PaneInput: Codable, Sendable {
   public let action: PaneAction
   public let selector: TargetSelector
+  public let force: Bool
 
-  public init(action: PaneAction, selector: TargetSelector = .none) {
+  enum CodingKeys: String, CodingKey {
+    case action
+    case selector
+    case force
+  }
+
+  public init(action: PaneAction, selector: TargetSelector = .none, force: Bool = false) {
     self.action = action
     self.selector = selector
+    self.force = force
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    self.action = try container.decode(PaneAction.self, forKey: .action)
+    self.selector = try container.decode(TargetSelector.self, forKey: .selector)
+    self.force = try container.decodeIfPresent(Bool.self, forKey: .force) ?? false
   }
 }

--- a/supacode/CLIService/Shared/InputModels.swift
+++ b/supacode/CLIService/Shared/InputModels.swift
@@ -133,3 +133,34 @@ public struct ReadInput: Codable, Sendable {
     self.waitTimeoutSeconds = waitTimeoutSeconds
   }
 }
+
+public enum TabAction: String, Codable, Sendable {
+  case create
+  case close
+}
+
+public struct TabInput: Codable, Sendable {
+  public let action: TabAction
+  public let selector: TargetSelector
+  public let path: String?
+
+  public init(action: TabAction, selector: TargetSelector = .none, path: String? = nil) {
+    self.action = action
+    self.selector = selector
+    self.path = path
+  }
+}
+
+public enum PaneAction: String, Codable, Sendable {
+  case close
+}
+
+public struct PaneInput: Codable, Sendable {
+  public let action: PaneAction
+  public let selector: TargetSelector
+
+  public init(action: PaneAction, selector: TargetSelector = .none) {
+    self.action = action
+    self.selector = selector
+  }
+}

--- a/supacode/CLIService/Shared/PaneCommandPayload.swift
+++ b/supacode/CLIService/Shared/PaneCommandPayload.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+public struct PaneCommandPayload: Codable, Sendable, Equatable {
+  public let action: PaneAction
+  public let target: TabTarget
+
+  public init(action: PaneAction, target: TabTarget) {
+    self.action = action
+    self.target = target
+  }
+}

--- a/supacode/CLIService/Shared/TabCommandPayload.swift
+++ b/supacode/CLIService/Shared/TabCommandPayload.swift
@@ -1,0 +1,73 @@
+import Foundation
+
+public struct TabCommandPayload: Codable, Sendable, Equatable {
+  public let action: TabAction
+  public let target: TabTarget
+
+  public init(action: TabAction, target: TabTarget) {
+    self.action = action
+    self.target = target
+  }
+}
+
+public struct TabTarget: Codable, Sendable, Equatable {
+  public let worktree: TabTargetWorktree
+  public let tab: TabTargetTab
+  public let pane: TabTargetPane
+
+  public init(worktree: TabTargetWorktree, tab: TabTargetTab, pane: TabTargetPane) {
+    self.worktree = worktree
+    self.tab = tab
+    self.pane = pane
+  }
+}
+
+public struct TabTargetWorktree: Codable, Sendable, Equatable {
+  public let id: String
+  public let name: String
+  public let path: String
+  public let rootPath: String
+  public let kind: String
+
+  enum CodingKeys: String, CodingKey {
+    case id
+    case name
+    case path
+    case rootPath = "root_path"
+    case kind
+  }
+
+  public init(id: String, name: String, path: String, rootPath: String, kind: String) {
+    self.id = id
+    self.name = name
+    self.path = path
+    self.rootPath = rootPath
+    self.kind = kind
+  }
+}
+
+public struct TabTargetTab: Codable, Sendable, Equatable {
+  public let id: String
+  public let title: String
+  public let selected: Bool
+
+  public init(id: String, title: String, selected: Bool) {
+    self.id = id
+    self.title = title
+    self.selected = selected
+  }
+}
+
+public struct TabTargetPane: Codable, Sendable, Equatable {
+  public let id: String
+  public let title: String
+  public let cwd: String?
+  public let focused: Bool
+
+  public init(id: String, title: String, cwd: String?, focused: Bool) {
+    self.id = id
+    self.title = title
+    self.cwd = cwd
+    self.focused = focused
+  }
+}

--- a/supacode/CLIService/Shared/TargetSelector.swift
+++ b/supacode/CLIService/Shared/TargetSelector.swift
@@ -11,4 +11,9 @@ public enum TargetSelector: Codable, Sendable, Equatable {
   case tab(String)
   case pane(String)
   case auto(String)
+
+  public var isNone: Bool {
+    if case .none = self { return true }
+    return false
+  }
 }

--- a/supacode/CLIService/TabCommandHandler.swift
+++ b/supacode/CLIService/TabCommandHandler.swift
@@ -1,0 +1,181 @@
+// supacode/CLIService/TabCommandHandler.swift
+
+import Foundation
+
+struct TabResolvedTarget: Sendable, Equatable {
+  let worktreeID: String
+  let worktreeName: String
+  let worktreePath: String
+  let worktreeRootPath: String
+  let worktreeKind: String
+  let tabID: String
+  let tabTitle: String
+  let tabSelected: Bool
+  let paneID: String
+  let paneTitle: String
+  let paneCWD: String?
+  let paneFocused: Bool
+}
+
+extension TabResolvedTarget {
+  init(from resolved: ResolvedTarget) {
+    self.worktreeID = resolved.worktreeID
+    self.worktreeName = resolved.worktreeName
+    self.worktreePath = resolved.worktreePath
+    self.worktreeRootPath = resolved.worktreeRootPath
+    self.worktreeKind = resolved.worktreeKind.rawValue
+    self.tabID = resolved.tabID.uuidString
+    self.tabTitle = resolved.tabTitle
+    self.tabSelected = resolved.tabSelected
+    self.paneID = resolved.paneID.uuidString
+    self.paneTitle = resolved.paneTitle
+    self.paneCWD = resolved.paneCWD
+    self.paneFocused = resolved.paneFocused
+  }
+}
+
+@MainActor
+final class TabCommandHandler: CommandHandler {
+  typealias ResolveProvider = @MainActor (TargetSelector) -> Result<TabResolvedTarget, TargetResolverError>
+  typealias CreateTabProvider = @MainActor (TabResolvedTarget, String?) -> TabResolvedTarget?
+  typealias CloseTabProvider = @MainActor (TabResolvedTarget) -> Bool
+
+  private let resolveProvider: ResolveProvider
+  private let createTab: CreateTabProvider
+  private let closeTab: CloseTabProvider
+
+  init(
+    resolveProvider: @escaping ResolveProvider,
+    createTab: @escaping CreateTabProvider,
+    closeTab: @escaping CloseTabProvider
+  ) {
+    self.resolveProvider = resolveProvider
+    self.createTab = createTab
+    self.closeTab = closeTab
+  }
+
+  // swiftlint:disable:next async_without_await
+  func handle(envelope: CommandEnvelope) async -> CommandResponse {
+    guard case .tab(let input) = envelope.command else {
+      return errorResponse(code: CLIErrorCode.tabFailed, message: "Invalid command.")
+    }
+
+    let target: TabResolvedTarget
+    switch resolveProvider(input.selector) {
+    case .success(let resolved):
+      target = resolved
+    case .failure(let error):
+      return mapResolverError(error)
+    }
+
+    switch input.action {
+    case .create:
+      return handleCreate(input: input, target: target)
+    case .close:
+      return handleClose(target: target)
+    }
+  }
+
+  private func handleCreate(input: TabInput, target: TabResolvedTarget) -> CommandResponse {
+    let path = normalizedAllowedPath(input.path, worktreePath: target.worktreePath)
+    guard input.path == nil || path != nil else {
+      return errorResponse(
+        code: CLIErrorCode.pathNotAllowed,
+        message: "Tab path must be inside the resolved worktree."
+      )
+    }
+
+    guard let createdTarget = createTab(target, path) else {
+      return errorResponse(code: CLIErrorCode.tabFailed, message: "Failed to create tab.")
+    }
+    return success(action: .create, target: createdTarget)
+  }
+
+  private func handleClose(target: TabResolvedTarget) -> CommandResponse {
+    guard closeTab(target) else {
+      return errorResponse(code: CLIErrorCode.tabFailed, message: "Failed to close tab.")
+    }
+    return success(action: .close, target: target)
+  }
+
+  private func normalizedAllowedPath(_ path: String?, worktreePath: String) -> String? {
+    guard let path else { return nil }
+    let normalizedPath = normalize(path)
+    let normalizedWorktree = normalize(worktreePath)
+    guard normalizedPath == normalizedWorktree || normalizedPath.hasPrefix(normalizedWorktree + "/") else {
+      return nil
+    }
+    return normalizedPath
+  }
+
+  private func normalize(_ path: String) -> String {
+    URL(fileURLWithPath: path, isDirectory: true)
+      .standardizedFileURL
+      .path(percentEncoded: false)
+      .trimmingTrailingSlash()
+  }
+
+  private func success(action: TabAction, target: TabResolvedTarget) -> CommandResponse {
+    do {
+      return try CommandResponse(
+        ok: true,
+        command: "tab",
+        schemaVersion: "prowl.cli.tab.v1",
+        data: RawJSON(encoding: TabCommandPayload(action: action, target: makePayloadTarget(from: target)))
+      )
+    } catch {
+      return errorResponse(code: CLIErrorCode.tabFailed, message: "Failed to encode response.")
+    }
+  }
+
+  private func makePayloadTarget(from target: TabResolvedTarget) -> TabTarget {
+    TabTarget(
+      worktree: TabTargetWorktree(
+        id: target.worktreeID,
+        name: target.worktreeName,
+        path: target.worktreePath,
+        rootPath: target.worktreeRootPath,
+        kind: target.worktreeKind
+      ),
+      tab: TabTargetTab(
+        id: target.tabID,
+        title: target.tabTitle,
+        selected: target.tabSelected
+      ),
+      pane: TabTargetPane(
+        id: target.paneID,
+        title: target.paneTitle,
+        cwd: target.paneCWD,
+        focused: target.paneFocused
+      )
+    )
+  }
+
+  private func mapResolverError(_ error: TargetResolverError) -> CommandResponse {
+    switch error {
+    case .notFound(let message):
+      return errorResponse(code: CLIErrorCode.targetNotFound, message: message)
+    case .notUnique(let message):
+      return errorResponse(code: CLIErrorCode.targetNotUnique, message: message)
+    }
+  }
+
+  private func errorResponse(code: String, message: String) -> CommandResponse {
+    CommandResponse(
+      ok: false,
+      command: "tab",
+      schemaVersion: "prowl.cli.tab.v1",
+      error: CommandError(code: code, message: message)
+    )
+  }
+}
+
+extension String {
+  fileprivate func trimmingTrailingSlash() -> String {
+    var value = self
+    while value.count > 1, value.hasSuffix("/") {
+      value.removeLast()
+    }
+    return value
+  }
+}

--- a/supacode/CLIService/TabCommandHandler.swift
+++ b/supacode/CLIService/TabCommandHandler.swift
@@ -38,7 +38,7 @@ extension TabResolvedTarget {
 final class TabCommandHandler: CommandHandler {
   typealias ResolveProvider = @MainActor (TargetSelector) -> Result<TabResolvedTarget, TargetResolverError>
   typealias CreateTabProvider = @MainActor (TabResolvedTarget, String?) -> TabResolvedTarget?
-  typealias CloseTabProvider = @MainActor (TabResolvedTarget) -> Bool
+  typealias CloseTabProvider = @MainActor (TabResolvedTarget, Bool) -> Bool
 
   private let resolveProvider: ResolveProvider
   private let createTab: CreateTabProvider
@@ -60,6 +60,13 @@ final class TabCommandHandler: CommandHandler {
       return errorResponse(code: CLIErrorCode.tabFailed, message: "Invalid command.")
     }
 
+    if input.action == .close, input.selector.isNone {
+      return errorResponse(
+        code: CLIErrorCode.invalidArgument,
+        message: "tab close requires an explicit target selector."
+      )
+    }
+
     let target: TabResolvedTarget
     switch resolveProvider(input.selector) {
     case .success(let resolved):
@@ -72,7 +79,7 @@ final class TabCommandHandler: CommandHandler {
     case .create:
       return handleCreate(input: input, target: target)
     case .close:
-      return handleClose(target: target)
+      return handleClose(input: input, target: target)
     }
   }
 
@@ -91,8 +98,8 @@ final class TabCommandHandler: CommandHandler {
     return success(action: .create, target: createdTarget)
   }
 
-  private func handleClose(target: TabResolvedTarget) -> CommandResponse {
-    guard closeTab(target) else {
+  private func handleClose(input: TabInput, target: TabResolvedTarget) -> CommandResponse {
+    guard closeTab(target, input.force) else {
       return errorResponse(code: CLIErrorCode.tabFailed, message: "Failed to close tab.")
     }
     return success(action: .close, target: target)

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState+Surfaces.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState+Surfaces.swift
@@ -763,20 +763,31 @@ extension WorktreeTerminalState {
     }
   }
 
-  func handleCloseRequest(for view: GhosttySurfaceView, processAlive: Bool) {
-    guard surfaces[view.id] != nil else { return }
-    if processAlive {
-      guard confirmCloseIfNeeded(surfaceIDs: [view.id], mode: .prompt(.pane)) else { return }
-    }
+  @discardableResult
+  func closeSurface(id surfaceID: UUID, confirmation: TerminalCloseConfirmationMode = .prompt(.pane)) -> Bool {
+    guard let view = surfaces[surfaceID] else { return false }
+    return closeSurface(view, confirmation: confirmation)
+  }
+
+  @discardableResult
+  func handleCloseRequest(for view: GhosttySurfaceView, processAlive: Bool) -> Bool {
+    let confirmation: TerminalCloseConfirmationMode = processAlive ? .prompt(.pane) : .skip
+    return closeSurface(view, confirmation: confirmation)
+  }
+
+  @discardableResult
+  private func closeSurface(_ view: GhosttySurfaceView, confirmation: TerminalCloseConfirmationMode) -> Bool {
+    guard surfaces[view.id] != nil else { return false }
+    guard confirmCloseIfNeeded(surfaceIDs: [view.id], mode: confirmation) else { return false }
     guard let tabId = tabId(containing: view.id), let tree = trees[tabId] else {
       view.closeSurface()
       forgetSurface(view.id)
-      return
+      return true
     }
     guard let node = tree.find(id: view.id) else {
       view.closeSurface()
       forgetSurface(view.id)
-      return
+      return true
     }
     let nextSurface =
       focusedSurfaceIdByTab[tabId] == view.id
@@ -798,7 +809,7 @@ extension WorktreeTerminalState {
       // Shelf's "retire the book when its last tab closes" logic
       // never saw this very common path.
       onTabClosed?()
-      return
+      return true
     }
     updateTree(newTree, for: tabId)
     updateRunningState(for: tabId)
@@ -809,6 +820,7 @@ extension WorktreeTerminalState {
         focusedSurfaceIdByTab.removeValue(forKey: tabId)
       }
     }
+    return true
   }
 
   func handleGotoTabRequest(_ target: ghostty_action_goto_tab_e) -> Bool {

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -543,7 +543,7 @@ final class WorktreeTerminalState {
   }
 
   @discardableResult
-  private func closeTab(_ tabId: TerminalTabID, confirmation: TerminalCloseConfirmationMode) -> Bool {
+  func closeTab(_ tabId: TerminalTabID, confirmation: TerminalCloseConfirmationMode) -> Bool {
     guard confirmCloseIfNeeded(tabIds: [tabId], mode: confirmation) else { return false }
     let wasRunScriptTab = tabId == runScriptTabId
     removeTree(for: tabId)

--- a/supacodeTests/CLICommandEnvelopeTests.swift
+++ b/supacodeTests/CLICommandEnvelopeTests.swift
@@ -139,6 +139,47 @@ struct CLICommandEnvelopeTests {
       #expect(input.action == .create)
       #expect(input.selector == .worktree("wt-main"))
       #expect(input.path == "/Projects/App")
+      #expect(input.force == false)
+    } else {
+      Issue.record("Expected .tab command")
+    }
+  }
+
+  @Test func envelopeTabCloseForceRoundTrips() throws {
+    let envelope = CommandEnvelope(
+      output: .json,
+      command: .tab(TabInput(action: .close, selector: .tab("tab-1"), force: true))
+    )
+    let data = try JSONEncoder().encode(envelope)
+    let decoded = try JSONDecoder().decode(CommandEnvelope.self, from: data)
+    if case .tab(let input) = decoded.command {
+      #expect(input.action == .close)
+      #expect(input.selector == .tab("tab-1"))
+      #expect(input.force == true)
+    } else {
+      Issue.record("Expected .tab command")
+    }
+  }
+
+  @Test func envelopeTabInputDecodesMissingForceAsFalse() throws {
+    let json = """
+      {
+        "output": "json",
+        "command": {
+          "tab": {
+            "_0": {
+              "action": "close",
+              "selector": { "tab": { "_0": "tab-1" } }
+            }
+          }
+        }
+      }
+      """
+    let decoded = try JSONDecoder().decode(CommandEnvelope.self, from: Data(json.utf8))
+    if case .tab(let input) = decoded.command {
+      #expect(input.action == .close)
+      #expect(input.selector == .tab("tab-1"))
+      #expect(input.force == false)
     } else {
       Issue.record("Expected .tab command")
     }
@@ -147,13 +188,38 @@ struct CLICommandEnvelopeTests {
   @Test func envelopePaneCloseRoundTrips() throws {
     let envelope = CommandEnvelope(
       output: .text,
-      command: .pane(PaneInput(action: .close, selector: .pane("pane-1")))
+      command: .pane(PaneInput(action: .close, selector: .pane("pane-1"), force: true))
     )
     let data = try JSONEncoder().encode(envelope)
     let decoded = try JSONDecoder().decode(CommandEnvelope.self, from: data)
     if case .pane(let input) = decoded.command {
       #expect(input.action == .close)
       #expect(input.selector == .pane("pane-1"))
+      #expect(input.force == true)
+    } else {
+      Issue.record("Expected .pane command")
+    }
+  }
+
+  @Test func envelopePaneInputDecodesMissingForceAsFalse() throws {
+    let json = """
+      {
+        "output": "json",
+        "command": {
+          "pane": {
+            "_0": {
+              "action": "close",
+              "selector": { "pane": { "_0": "pane-1" } }
+            }
+          }
+        }
+      }
+      """
+    let decoded = try JSONDecoder().decode(CommandEnvelope.self, from: Data(json.utf8))
+    if case .pane(let input) = decoded.command {
+      #expect(input.action == .close)
+      #expect(input.selector == .pane("pane-1"))
+      #expect(input.force == false)
     } else {
       Issue.record("Expected .pane command")
     }

--- a/supacodeTests/CLICommandEnvelopeTests.swift
+++ b/supacodeTests/CLICommandEnvelopeTests.swift
@@ -128,6 +128,37 @@ struct CLICommandEnvelopeTests {
     }
   }
 
+  @Test func envelopeTabCreateRoundTrips() throws {
+    let envelope = CommandEnvelope(
+      output: .json,
+      command: .tab(TabInput(action: .create, selector: .worktree("wt-main"), path: "/Projects/App"))
+    )
+    let data = try JSONEncoder().encode(envelope)
+    let decoded = try JSONDecoder().decode(CommandEnvelope.self, from: data)
+    if case .tab(let input) = decoded.command {
+      #expect(input.action == .create)
+      #expect(input.selector == .worktree("wt-main"))
+      #expect(input.path == "/Projects/App")
+    } else {
+      Issue.record("Expected .tab command")
+    }
+  }
+
+  @Test func envelopePaneCloseRoundTrips() throws {
+    let envelope = CommandEnvelope(
+      output: .text,
+      command: .pane(PaneInput(action: .close, selector: .pane("pane-1")))
+    )
+    let data = try JSONEncoder().encode(envelope)
+    let decoded = try JSONDecoder().decode(CommandEnvelope.self, from: data)
+    if case .pane(let input) = decoded.command {
+      #expect(input.action == .close)
+      #expect(input.selector == .pane("pane-1"))
+    } else {
+      Issue.record("Expected .pane command")
+    }
+  }
+
   // MARK: - Command name
 
   @Test func commandNameReturnsCorrectStrings() {
@@ -138,6 +169,8 @@ struct CLICommandEnvelopeTests {
       (.send(SendInput(text: "x")), "send"),
       (.key(KeyInput(rawToken: "tab", token: "tab")), "key"),
       (.read(ReadInput()), "read"),
+      (.tab(TabInput(action: .create)), "tab"),
+      (.pane(PaneInput(action: .close)), "pane"),
     ]
     for (command, expected) in commands {
       #expect(command.name == expected)
@@ -154,6 +187,8 @@ struct CLICommandEnvelopeTests {
       .send(SendInput(text: "test")),
       .key(KeyInput(rawToken: "enter", token: "enter")),
       .read(ReadInput()),
+      .tab(TabInput(action: .create)),
+      .pane(PaneInput(action: .close)),
     ]
     for cmd in commands {
       let envelope = CommandEnvelope(output: .json, command: cmd)

--- a/supacodeTests/CLICommandRouterTests.swift
+++ b/supacodeTests/CLICommandRouterTests.swift
@@ -77,6 +77,28 @@ struct CLICommandRouterTests {
     #expect(response.command == "read")
   }
 
+  @MainActor
+  @Test func routerDispatchesTabToTabHandler() async {
+    let router = CLICommandRouter()
+    let envelope = CommandEnvelope(
+      output: .json,
+      command: .tab(TabInput(action: .create))
+    )
+    let response = await router.route(envelope)
+    #expect(response.command == "tab")
+  }
+
+  @MainActor
+  @Test func routerDispatchesPaneToPaneHandler() async {
+    let router = CLICommandRouter()
+    let envelope = CommandEnvelope(
+      output: .json,
+      command: .pane(PaneInput(action: .close))
+    )
+    let response = await router.route(envelope)
+    #expect(response.command == "pane")
+  }
+
   // MARK: - Custom handler injection
 
   @MainActor
@@ -106,6 +128,8 @@ struct CLICommandRouterTests {
       .send(SendInput(text: "x")),
       .key(KeyInput(rawToken: "tab", token: "tab")),
       .read(ReadInput()),
+      .tab(TabInput(action: .create)),
+      .pane(PaneInput(action: .close)),
     ]
     let router = CLICommandRouter()
     for cmd in commands {

--- a/supacodeTests/CLIPaneCommandHandlerTests.swift
+++ b/supacodeTests/CLIPaneCommandHandlerTests.swift
@@ -8,14 +8,16 @@ struct CLIPaneCommandHandlerTests {
   @Test func closeResolvesTargetAndClosesPane() async throws {
     let target = makeTarget(tabID: "tab-1", paneID: "pane-to-close")
     var closedTarget: TabResolvedTarget?
+    var closeForce: Bool?
 
     let handler = PaneCommandHandler(
       resolveProvider: { selector in
         #expect(selector == .pane("pane-to-close"))
         return .success(target)
       },
-      closePane: { target in
+      closePane: { target, force in
         closedTarget = target
+        closeForce = force
         return true
       }
     )
@@ -23,12 +25,13 @@ struct CLIPaneCommandHandlerTests {
     let response = await handler.handle(
       envelope: CommandEnvelope(
         output: .json,
-        command: .pane(PaneInput(action: .close, selector: .pane("pane-to-close")))
+        command: .pane(PaneInput(action: .close, selector: .pane("pane-to-close"), force: true))
       )
     )
 
     #expect(response.ok == true)
     #expect(closedTarget == target)
+    #expect(closeForce == true)
     let data = try #require(response.data)
     let payload = try data.decode(as: PaneCommandPayload.self)
     #expect(payload.action == .close)
@@ -38,7 +41,32 @@ struct CLIPaneCommandHandlerTests {
   @Test func closeReturnsFailureWhenCloseActionFails() async {
     let handler = PaneCommandHandler(
       resolveProvider: { _ in .success(makeTarget()) },
-      closePane: { _ in false }
+      closePane: { _, _ in false }
+    )
+
+    let response = await handler.handle(
+      envelope: CommandEnvelope(
+        output: .json,
+        command: .pane(PaneInput(action: .close, selector: .pane("pane-1")))
+      )
+    )
+
+    #expect(response.ok == false)
+    #expect(response.error?.code == CLIErrorCode.paneFailed)
+  }
+
+  @Test func closeRejectsMissingExplicitTarget() async {
+    var didResolve = false
+    var didClose = false
+    let handler = PaneCommandHandler(
+      resolveProvider: { _ in
+        didResolve = true
+        return .success(makeTarget())
+      },
+      closePane: { _, _ in
+        didClose = true
+        return true
+      }
     )
 
     let response = await handler.handle(
@@ -49,7 +77,9 @@ struct CLIPaneCommandHandlerTests {
     )
 
     #expect(response.ok == false)
-    #expect(response.error?.code == CLIErrorCode.paneFailed)
+    #expect(response.error?.code == CLIErrorCode.invalidArgument)
+    #expect(didResolve == false)
+    #expect(didClose == false)
   }
 
   private func makeTarget(

--- a/supacodeTests/CLIPaneCommandHandlerTests.swift
+++ b/supacodeTests/CLIPaneCommandHandlerTests.swift
@@ -1,0 +1,84 @@
+import Foundation
+import Testing
+
+@testable import supacode
+
+@MainActor
+struct CLIPaneCommandHandlerTests {
+  @Test func closeResolvesTargetAndClosesPane() async throws {
+    let target = makeTarget(tabID: "tab-1", paneID: "pane-to-close")
+    var closedTarget: TabResolvedTarget?
+
+    let handler = PaneCommandHandler(
+      resolveProvider: { selector in
+        #expect(selector == .pane("pane-to-close"))
+        return .success(target)
+      },
+      closePane: { target in
+        closedTarget = target
+        return true
+      }
+    )
+
+    let response = await handler.handle(
+      envelope: CommandEnvelope(
+        output: .json,
+        command: .pane(PaneInput(action: .close, selector: .pane("pane-to-close")))
+      )
+    )
+
+    #expect(response.ok == true)
+    #expect(closedTarget == target)
+    let data = try #require(response.data)
+    let payload = try data.decode(as: PaneCommandPayload.self)
+    #expect(payload.action == .close)
+    #expect(payload.target.pane.id == "pane-to-close")
+  }
+
+  @Test func closeReturnsFailureWhenCloseActionFails() async {
+    let handler = PaneCommandHandler(
+      resolveProvider: { _ in .success(makeTarget()) },
+      closePane: { _ in false }
+    )
+
+    let response = await handler.handle(
+      envelope: CommandEnvelope(
+        output: .json,
+        command: .pane(PaneInput(action: .close, selector: .none))
+      )
+    )
+
+    #expect(response.ok == false)
+    #expect(response.error?.code == CLIErrorCode.paneFailed)
+  }
+
+  private func makeTarget(
+    worktreeID: String = "App:/Projects/App",
+    worktreeName: String = "App",
+    worktreePath: String = "/Projects/App",
+    worktreeRootPath: String = "/Projects/App",
+    worktreeKind: String = "git",
+    tabID: String = "tab-1",
+    tabTitle: String = "App 1",
+    tabSelected: Bool = true,
+    paneID: String = "pane-1",
+    paneTitle: String = "zsh",
+    paneCWD: String? = "/Projects/App",
+    paneFocused: Bool = true
+  ) -> TabResolvedTarget {
+    TabResolvedTarget(
+      worktreeID: worktreeID,
+      worktreeName: worktreeName,
+      worktreePath: worktreePath,
+      worktreeRootPath: worktreeRootPath,
+      worktreeKind: worktreeKind,
+      tabID: tabID,
+      tabTitle: tabTitle,
+      tabSelected: tabSelected,
+      paneID: paneID,
+      paneTitle: paneTitle,
+      paneCWD: paneCWD,
+      paneFocused: paneFocused
+    )
+  }
+}

--- a/supacodeTests/CLITabCommandHandlerTests.swift
+++ b/supacodeTests/CLITabCommandHandlerTests.swift
@@ -1,0 +1,153 @@
+import Foundation
+import Testing
+
+@testable import supacode
+
+@MainActor
+struct CLITabCommandHandlerTests {
+  @Test func createResolvesWorktreeCreatesTabAndReturnsNewTarget() async throws {
+    let base = makeTarget(tabID: "base-tab", paneID: "base-pane")
+    let created = makeTarget(tabID: "new-tab", tabTitle: "App 2", paneID: "new-pane", paneTitle: "zsh")
+    var resolvedSelector: TargetSelector?
+    var createBase: TabResolvedTarget?
+    var createPath: String?
+
+    let handler = TabCommandHandler(
+      resolveProvider: { selector in
+        resolvedSelector = selector
+        return .success(base)
+      },
+      createTab: { target, path in
+        createBase = target
+        createPath = path
+        return created
+      },
+      closeTab: { _ in true }
+    )
+
+    let response = await handler.handle(
+      envelope: CommandEnvelope(
+        output: .json,
+        command: .tab(TabInput(action: .create, selector: .worktree("App"), path: "/Projects/App"))
+      )
+    )
+
+    #expect(response.ok == true)
+    #expect(response.command == "tab")
+    #expect(resolvedSelector == .worktree("App"))
+    #expect(createBase == base)
+    #expect(createPath == "/Projects/App")
+
+    let data = try #require(response.data)
+    let payload = try data.decode(as: TabCommandPayload.self)
+    #expect(payload.action == .create)
+    #expect(payload.target.tab.id == "new-tab")
+    #expect(payload.target.pane.id == "new-pane")
+  }
+
+  @Test func createRejectsPathOutsideResolvedWorktree() async throws {
+    var didCreate = false
+    let handler = TabCommandHandler(
+      resolveProvider: { _ in .success(makeTarget(worktreePath: "/Projects/App")) },
+      createTab: { _, _ in
+        didCreate = true
+        return nil
+      },
+      closeTab: { _ in true }
+    )
+
+    let response = await handler.handle(
+      envelope: CommandEnvelope(
+        output: .json,
+        command: .tab(TabInput(action: .create, selector: .worktree("App"), path: "/Projects/Other"))
+      )
+    )
+
+    #expect(response.ok == false)
+    #expect(response.error?.code == CLIErrorCode.pathNotAllowed)
+    #expect(didCreate == false)
+  }
+
+  @Test func createAllowsOmittedPath() async throws {
+    var createPath: String?
+    let handler = TabCommandHandler(
+      resolveProvider: { _ in .success(makeTarget(worktreePath: "/Projects/App")) },
+      createTab: { _, path in
+        createPath = path
+        return makeTarget(tabID: "created-tab", paneID: "created-pane")
+      },
+      closeTab: { _ in true }
+    )
+
+    let response = await handler.handle(
+      envelope: CommandEnvelope(
+        output: .json,
+        command: .tab(TabInput(action: .create, selector: .none))
+      )
+    )
+
+    #expect(response.ok == true)
+    #expect(createPath == nil)
+  }
+
+  @Test func closeResolvesTargetAndClosesTab() async throws {
+    let target = makeTarget(tabID: "tab-to-close", paneID: "pane-in-tab")
+    var closedTarget: TabResolvedTarget?
+
+    let handler = TabCommandHandler(
+      resolveProvider: { selector in
+        #expect(selector == .tab("tab-to-close"))
+        return .success(target)
+      },
+      createTab: { _, _ in nil },
+      closeTab: { target in
+        closedTarget = target
+        return true
+      }
+    )
+
+    let response = await handler.handle(
+      envelope: CommandEnvelope(
+        output: .json,
+        command: .tab(TabInput(action: .close, selector: .tab("tab-to-close")))
+      )
+    )
+
+    #expect(response.ok == true)
+    #expect(closedTarget == target)
+    let data = try #require(response.data)
+    let payload = try data.decode(as: TabCommandPayload.self)
+    #expect(payload.action == .close)
+    #expect(payload.target.tab.id == "tab-to-close")
+  }
+
+  private func makeTarget(
+    worktreeID: String = "App:/Projects/App",
+    worktreeName: String = "App",
+    worktreePath: String = "/Projects/App",
+    worktreeRootPath: String = "/Projects/App",
+    worktreeKind: String = "git",
+    tabID: String = "tab-1",
+    tabTitle: String = "App 1",
+    tabSelected: Bool = true,
+    paneID: String = "pane-1",
+    paneTitle: String = "zsh",
+    paneCWD: String? = "/Projects/App",
+    paneFocused: Bool = true
+  ) -> TabResolvedTarget {
+    TabResolvedTarget(
+      worktreeID: worktreeID,
+      worktreeName: worktreeName,
+      worktreePath: worktreePath,
+      worktreeRootPath: worktreeRootPath,
+      worktreeKind: worktreeKind,
+      tabID: tabID,
+      tabTitle: tabTitle,
+      tabSelected: tabSelected,
+      paneID: paneID,
+      paneTitle: paneTitle,
+      paneCWD: paneCWD,
+      paneFocused: paneFocused
+    )
+  }
+}

--- a/supacodeTests/CLITabCommandHandlerTests.swift
+++ b/supacodeTests/CLITabCommandHandlerTests.swift
@@ -22,7 +22,7 @@ struct CLITabCommandHandlerTests {
         createPath = path
         return created
       },
-      closeTab: { _ in true }
+      closeTab: { _, _ in true }
     )
 
     let response = await handler.handle(
@@ -53,7 +53,7 @@ struct CLITabCommandHandlerTests {
         didCreate = true
         return nil
       },
-      closeTab: { _ in true }
+      closeTab: { _, _ in true }
     )
 
     let response = await handler.handle(
@@ -76,7 +76,7 @@ struct CLITabCommandHandlerTests {
         createPath = path
         return makeTarget(tabID: "created-tab", paneID: "created-pane")
       },
-      closeTab: { _ in true }
+      closeTab: { _, _ in true }
     )
 
     let response = await handler.handle(
@@ -93,6 +93,7 @@ struct CLITabCommandHandlerTests {
   @Test func closeResolvesTargetAndClosesTab() async throws {
     let target = makeTarget(tabID: "tab-to-close", paneID: "pane-in-tab")
     var closedTarget: TabResolvedTarget?
+    var closeForce: Bool?
 
     let handler = TabCommandHandler(
       resolveProvider: { selector in
@@ -100,8 +101,9 @@ struct CLITabCommandHandlerTests {
         return .success(target)
       },
       createTab: { _, _ in nil },
-      closeTab: { target in
+      closeTab: { target, force in
         closedTarget = target
+        closeForce = force
         return true
       }
     )
@@ -109,16 +111,45 @@ struct CLITabCommandHandlerTests {
     let response = await handler.handle(
       envelope: CommandEnvelope(
         output: .json,
-        command: .tab(TabInput(action: .close, selector: .tab("tab-to-close")))
+        command: .tab(TabInput(action: .close, selector: .tab("tab-to-close"), force: true))
       )
     )
 
     #expect(response.ok == true)
     #expect(closedTarget == target)
+    #expect(closeForce == true)
     let data = try #require(response.data)
     let payload = try data.decode(as: TabCommandPayload.self)
     #expect(payload.action == .close)
     #expect(payload.target.tab.id == "tab-to-close")
+  }
+
+  @Test func closeRejectsMissingExplicitTarget() async throws {
+    var didResolve = false
+    var didClose = false
+    let handler = TabCommandHandler(
+      resolveProvider: { _ in
+        didResolve = true
+        return .success(makeTarget())
+      },
+      createTab: { _, _ in nil },
+      closeTab: { _, _ in
+        didClose = true
+        return true
+      }
+    )
+
+    let response = await handler.handle(
+      envelope: CommandEnvelope(
+        output: .json,
+        command: .tab(TabInput(action: .close, selector: .none))
+      )
+    )
+
+    #expect(response.ok == false)
+    #expect(response.error?.code == CLIErrorCode.invalidArgument)
+    #expect(didResolve == false)
+    #expect(didClose == false)
   }
 
   private func makeTarget(

--- a/supacodeTests/WorktreeTerminalManagerTests.swift
+++ b/supacodeTests/WorktreeTerminalManagerTests.swift
@@ -135,6 +135,20 @@ struct WorktreeTerminalManagerTests {
     #expect(state.surfaceView(for: tabId) == nil)
   }
 
+  @Test func closeSurfaceReturnsActualRemovalResult() throws {
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    let worktree = makeWorktree()
+    let state = manager.state(for: worktree)
+
+    let tabId = try #require(state.createTab())
+    let surfaceId = try #require(state.focusedSurfaceId(in: tabId))
+
+    #expect(state.closeSurface(id: surfaceId, confirmation: .skip) == true)
+    #expect(state.surfaceView(for: surfaceId) == nil)
+    #expect(state.tabManager.tabs.isEmpty)
+    #expect(state.closeSurface(id: surfaceId, confirmation: .skip) == false)
+  }
+
   @Test func notificationIndicatorUsesCurrentCountOnStreamStart() async {
     let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
     let worktree = makeWorktree()


### PR DESCRIPTION
## Summary
- add `prowl tab create` and `prowl tab close` commands
- add `prowl pane close` for closing a targeted pane
- wire tab/pane command handlers through the app CLI router and return new tab/pane target payloads
- update the `prowl-cli` skill to treat `open` as navigation and `tab create` as the deterministic fresh-shell command

## Verification
- swift test
- xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -only-testing:supacodeTests/CLICommandEnvelopeTests -only-testing:supacodeTests/CLICommandRouterTests -only-testing:supacodeTests/CLITabCommandHandlerTests -only-testing:supacodeTests/CLIPaneCommandHandlerTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation
- make check
- make build-app
- make build-cli
- make test-cli-smoke
- make test-cli-integration

Closes #399
