### PR TITLE
Fix deletion of externally-created worktrees under symlinked roots

### DIFF
--- a/supacode/Clients/Git/GitClient.swift
+++ b/supacode/Clients/Git/GitClient.swift
@@ -526,7 +526,7 @@ struct GitClient {
   nonisolated func removeWorktree(_ worktree: Worktree, deleteBranch: Bool) async throws -> URL {
     let rootPath = worktree.repositoryRootURL.path(percentEncoded: false)
     let worktreeURL = worktree.workingDirectory.standardizedFileURL
-    let worktreePath = worktreeURL.path(percentEncoded: false)
+    let worktreePath = Self.canonicalWorktreePath(worktreeURL.path(percentEncoded: false))
     let registeredWorktreePaths = try await registeredWorktreePaths(rootPath: rootPath)
     guard registeredWorktreePaths.contains(worktreePath) else {
       return worktree.workingDirectory
@@ -572,7 +572,11 @@ struct GitClient {
       operation: .worktreeList,
       arguments: ["-C", rootPath, "worktree", "list", "--porcelain"]
     )
-    return Self.parseGitWorktreePorcelainPaths(output)
+    // `git worktree list --porcelain` reports the raw on-disk path (e.g. `/private/tmp/foo`),
+    // while `worktrees(for:)` stores `standardizedFileURL` paths (which resolve `/private`
+    // symlinks to `/tmp`). Canonicalize both sides identically so the removal guard matches
+    // externally-created worktrees living under symlinked roots like /tmp or /var.
+    return Set(Self.parseGitWorktreePorcelainPaths(output).map(Self.canonicalWorktreePath))
   }
 
   nonisolated func deleteLocalBranch(
@@ -872,6 +876,13 @@ struct GitClient {
   nonisolated private static func worktreeDirectoryHasGitMetadata(_ worktreeURL: URL) -> Bool {
     let gitMetadataURL = worktreeURL.appending(path: ".git")
     return FileManager.default.fileExists(atPath: gitMetadataURL.path(percentEncoded: false))
+  }
+
+  /// Normalizes a worktree path to the same canonical form `worktrees(for:)` stores, so paths
+  /// reported by git (which keep `/private` symlink prefixes) compare equal to the standardized
+  /// URLs Prowl tracks internally.
+  nonisolated static func canonicalWorktreePath(_ path: String) -> String {
+    URL(fileURLWithPath: path).standardizedFileURL.path(percentEncoded: false)
   }
 
   nonisolated static func parseGitWorktreePorcelainPaths(_ output: String) -> Set<String> {

--- a/supacodeTests/GitClientRemoveWorktreeTests.swift
+++ b/supacodeTests/GitClientRemoveWorktreeTests.swift
@@ -131,6 +131,55 @@ struct GitClientRemoveWorktreeTests {
     #expect(!calls.contains { $0.suffix(3) == ["branch", "-d", "feat"] })
   }
 
+  @Test func removeWorktreeMatchesWhenGitReportsPrivateSymlinkPath() async throws {
+    // Regression: externally-created worktrees under /tmp are reported by git as `/private/tmp/...`,
+    // but Prowl tracks them as standardized `/tmp/...` URLs. The removal guard must treat them as
+    // the same worktree, otherwise removal silently no-ops and the row reappears after a refresh.
+    let fileManager = FileManager.default
+    let name = "prowl-private-symlink-wt-\(UUID().uuidString)"
+    let standardizedURL = URL(fileURLWithPath: "/tmp/\(name)", isDirectory: true)
+    try fileManager.createDirectory(at: standardizedURL, withIntermediateDirectories: true)
+    try Data("gitdir: /tmp/repo/.git/worktrees/\(name)\n".utf8)
+      .write(to: standardizedURL.appending(path: ".git"))
+    defer {
+      try? fileManager.removeItem(at: standardizedURL)
+    }
+
+    let store = ShellCallStore()
+    let shell = ShellClient(
+      run: { _, arguments, _ in
+        await store.record(arguments)
+        if arguments.contains("--porcelain") {
+          // Git reports the raw, non-standardized path with the /private prefix.
+          return ShellOutput(
+            stdout: "worktree /private/tmp/\(name)\nHEAD abc\ndetached\n",
+            stderr: "",
+            exitCode: 0
+          )
+        }
+        return ShellOutput(stdout: "", stderr: "", exitCode: 0)
+      },
+      runLoginImpl: { _, _, _, _ in ShellOutput(stdout: "", stderr: "", exitCode: 0) }
+    )
+    let client = GitClient(shell: shell)
+    let worktree = Worktree(
+      id: standardizedURL.path(percentEncoded: false),
+      name: name,
+      detail: "../\(name)",
+      workingDirectory: standardizedURL,
+      repositoryRootURL: URL(fileURLWithPath: "/tmp/repo")
+    )
+
+    _ = try await client.removeWorktree(worktree, deleteBranch: false)
+
+    // The guard matched, so removal proceeded: the directory was relocated off its original path
+    // and git was asked to prune the now-missing worktree.
+    let stillExists = fileManager.fileExists(atPath: standardizedURL.path(percentEncoded: false))
+    #expect(!stillExists)
+    let calls = await store.calls
+    #expect(calls.contains { $0.contains("prune") })
+  }
+
   @Test func forceDeleteLocalBranchUsesForceFlag() async throws {
     let store = ShellCallStore()
     let shell = ShellClient(


### PR DESCRIPTION
## Problem

Worktrees created outside Prowl (e.g. by another CLI/app) under symlinked roots like `/tmp` could not be deleted. Right-clicking such a worktree → **Delete worktree** made the row briefly disappear from the sidebar, then immediately reappear after the next refresh — the directory was never actually removed.

Reproduced with a `/private/tmp/prowl-pr397` worktree on the current repo.

## Root cause

`GitClient.worktrees(for:)` stores each worktree's `workingDirectory` via `standardizedFileURL`, which resolves the macOS `/private` symlink (`/private/tmp/foo` → `/tmp/foo`).

The removal guard in `removeWorktree(_:deleteBranch:)` compared that standardized path against the **raw** paths returned by `git worktree list --porcelain`, which keep the `/private` prefix:

```
guard registeredWorktreePaths.contains(worktreePath) else {
  return worktree.workingDirectory   // silent no-op
}
```

`/tmp/foo` ∉ `{ /private/tmp/foo, ... }` → the guard failed, `removeWorktree` returned without relocating/pruning, and the optimistic UI removal was undone by the next worktree refresh.

Prowl-created worktrees live under `~/.prowl/...` (no symlink components), so `standardizedFileURL` is a no-op there and they matched — which is why only externally-created worktrees under `/tmp`, `/var`, etc. were affected.

## Fix

Canonicalize both sides through the same `standardizedFileURL` transform (new `GitClient.canonicalWorktreePath(_:)` helper) before comparing, so registered paths and tracked paths line up regardless of `/private` symlinks.

## Tests

- New `removeWorktreeMatchesWhenGitReportsPrivateSymlinkPath` regression test: git reports `/private/tmp/...`, Prowl tracks `/tmp/...`, and removal now actually relocates the directory and prunes.
- Existing `GitClientRemoveWorktreeTests` (including the not-registered-exactly guard test) still pass.
- `make build-app` and `make check` clean.
