### PR TITLE
Hook sync-docs into the release flow (docs before bump+tag)

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -11,20 +11,36 @@ Build, sign, notarize, and publish a Prowl release.
    - If not on main, abort and tell the user to switch first
 2. Verify working tree is clean: `git status --porcelain`
    - If dirty, list the changes and ask whether to proceed or abort
-3. Determine the version:
+3. Sync the docs to the code being released — **before** the version bump and tag:
+   - Run the `sync-docs` skill. It diffs `docs/.sync-meta.json`'s `last_synced_commit`
+     against the current `main` HEAD (the code about to ship), updates any docs whose
+     implementation changed, and sets `last_synced_commit` to the **current HEAD** —
+     the exact commit being released, recorded *before* the bump/tag.
+   - Commit the result as its own commit (only `docs/**`, which includes
+     `docs/.sync-meta.json`; never `git add .`): e.g. `git commit -m "Sync docs for <VERSION>"`.
+     This is required: `release.sh` aborts on a dirty tree, and the doc commit must land
+     on `main` *now* so it is an ancestor of the tag and ships inside the release.
+   - **Ordering is load-bearing: docs first, then bump + tag. Never tag first.** The baseline
+     points at the released code (the pre-doc-commit HEAD), not at the later doc/bump/CHANGELOG
+     commits — that is correct and intentional (those commits touch no implementation files,
+     so the next sync starts from a tight, accurate diff range).
+   - If sync-docs reports "needs human decision" items, resolve or defer them before continuing.
+   - Most releases change little or no implementation, so this step is usually a no-op doc-wise
+     (just a baseline bump). Keep it cheap — see the `sync-docs` skill's cost notes.
+4. Determine the version:
    - If `$ARGUMENTS` is provided, use it as the version (e.g., `2026.3.18`)
    - Otherwise, default to today's date format and confirm with the user before proceeding
-4. Generate release notes: `./doc-onevcat/scripts/release-notes.sh <VERSION>`
+5. Generate release notes: `./doc-onevcat/scripts/release-notes.sh <VERSION>`
    - This script compares HEAD against the previous release tag, gathers commits and
      PR descriptions, and generates user-facing notes via LLM into `build/release-notes.md`.
    - Read the generated `build/release-notes.md`, show the content to the user, and wait
      for explicit confirmation. If the user wants changes, edit the file directly.
    - **Do NOT proceed to the next step until the user confirms the release notes.**
-5. Run the release script: `./doc-onevcat/scripts/release.sh <VERSION>`
+6. Run the release script: `./doc-onevcat/scripts/release.sh <VERSION>`
    - The script reads `build/release-notes.md` (required — refuses to run without it).
    - It handles: version bump, build, sign, notarize, DMG, appcast, GitHub Release, and
      Prowl-Site update. If the tag already exists (e.g., from a prior interrupted run),
      it skips the bump step automatically.
-6. Report the GitHub release URL and remind the user to verify:
+7. Report the GitHub release URL and remind the user to verify:
    - The DMG downloads and installs correctly
    - Sparkle update check works (launch app → Check for Updates)

--- a/.claude/skills/sync-docs/SKILL.md
+++ b/.claude/skills/sync-docs/SKILL.md
@@ -118,8 +118,14 @@ The goal is to keep facts correct with **low churn**, not to perfect the prose.
 - **Standalone run:** stage and commit only `docs/**` (which includes
   `docs/.sync-meta.json`); never `git add .`. If anything in `docs/` changed and
   you're not on `main`, open a PR targeting `onevcat/Prowl`.
-- **As part of release prep:** leave the doc + `docs/.sync-meta.json` edits staged
-  so they ride along in the release commit (this is the intended integration
-  point — a docs freshness check before cutting a release).
+- **As part of release prep** (the `release` skill, on `main`): commit the doc +
+  `docs/.sync-meta.json` changes as **their own commit before the version bump and
+  tag** — e.g. `git commit -m "Sync docs for <VERSION>"`. Do **not** leave them
+  staged/uncommitted: `release.sh` aborts on a dirty working tree, and the doc
+  commit must already be on `main` so it becomes an ancestor of the tag and ships
+  inside the release. Bump/tag happen after, never before.
 - Always bump and commit `docs/.sync-meta.json` even when no doc edits were
-  needed, so the next run starts from a tight diff range.
+  needed, so the next run starts from a tight diff range. The baseline records the
+  commit the docs were verified against (the current HEAD at run time) — for a
+  release that is the code being shipped, captured before the later doc/bump/tag
+  commits, which is correct (those commits touch no implementation files).


### PR DESCRIPTION
## What

Wires the `sync-docs` skill into the `release` skill so the agent-facing manual
under `docs/` is refreshed and shipped **inside every release tag**.

## Where it's hooked (ordering is load-bearing)

New step **3** in the release skill, after the clean-tree check and **before** the
version bump + tag:

1. branch check → 2. clean-tree check → **3. sync docs + commit** → 4. version →
5. release notes → 6. `release.sh` (bump, tag, build, sign, notarize, publish) → 7. report

- `release.sh` aborts on a dirty tree and creates the tag (then force-moves it onto
  the CHANGELOG commit). So docs are committed **as their own commit on `main`
  before** `release.sh` runs — that commit is an ancestor of the tag, so the docs
  ship inside the release.
- **Never tag first.** Docs → bump → tag.

## Baseline semantics (the decision)

`last_synced_commit` is set to the **HEAD at sync time = the commit being released**,
recorded *before* the doc/bump/tag commits. Rationale:

- It's the truthful meaning of the field ("docs verified against this commit").
- The alternative (commit docs, then point the baseline at the doc commit) needs a
  *second* commit — a commit can't contain its own hash — so it's circular and wastes
  a commit.
- It makes **no difference to future diffs**: the doc/bump/CHANGELOG commits touch no
  `supacode/` / `ProwlCLI/` files (the version bump lives in
  `supacode.xcodeproj/project.pbxproj`, outside the diff scope), so the next sync's
  implementation diff is identical either way — no double-counting, no gaps.

## Also fixed

The `sync-docs` skill's "release prep" committing note previously said to leave edits
staged for a release commit — wrong for this flow (clean-tree precondition + the script
does its own commits). Updated to: commit docs as their own commit before bump/tag.

No implementation code changes; skill docs only.
