### PR TITLE
Drop AnyView erasure in the split-tree AX container to cut re-renders

### DIFF
--- a/supacode/Features/Terminal/Views/TerminalSplitTreeView.swift
+++ b/supacode/Features/Terminal/Views/TerminalSplitTreeView.swift
@@ -391,15 +391,17 @@ struct TerminalSplitTreeAXContainer: NSViewRepresentable {
 
   func updateNSView(_ nsView: TerminalSplitAXContainerView, context: Context) {
     nsView.update(
-      rootView: AnyView(
-        TerminalSplitTreeView(
-          tree: tree,
-          activeSurfaceID: activeSurfaceID,
-          unfocusedSplitOverlay: unfocusedSplitOverlay,
-          splitDivider: splitDivider,
-          hasNotification: hasNotification,
-          action: action
-        )
+      // Concrete type (not `AnyView`): erasing the type defeats SwiftUI's
+      // diffing, forcing a full re-render of the split tree on every assignment
+      // — e.g. once per terminal notification. The concrete root lets the host
+      // skip unchanged content.
+      rootView: TerminalSplitTreeView(
+        tree: tree,
+        activeSurfaceID: activeSurfaceID,
+        unfocusedSplitOverlay: unfocusedSplitOverlay,
+        splitDivider: splitDivider,
+        hasNotification: hasNotification,
+        action: action
       ),
       panes: tree.visibleLeaves()
     )
@@ -408,12 +410,12 @@ struct TerminalSplitTreeAXContainer: NSViewRepresentable {
 
 @MainActor
 final class TerminalSplitAXContainerView: NSView {
-  private var hostingView: NSHostingView<AnyView>?
+  private var hostingView: NSHostingView<TerminalSplitTreeView>?
   private var panes: [GhosttySurfaceView] = []
   private var panesLabel: String = "Terminal split: 0 panes"
   private var lastPaneIDs: [UUID] = []
 
-  func update(rootView: AnyView, panes: [GhosttySurfaceView]) {
+  func update(rootView: TerminalSplitTreeView, panes: [GhosttySurfaceView]) {
     if let hostingView {
       hostingView.rootView = rootView
     } else {


### PR DESCRIPTION
## Problem

`TerminalSplitTreeAXContainer` hosted its SwiftUI content as `NSHostingView<AnyView>` and reassigned a fresh `AnyView(...)` on every `updateNSView`. Type erasure defeats SwiftUI's diffing, so the **entire split tree re-renders on each assignment** — e.g. once per terminal notification, since the detail body re-runs and hands the container a new root. With the fork's frequent command-finished notifications, this is wasted work on a hot path.

## Scope decision

This is the self-contained, highest-value slice inspired by upstream supacode #332. **The fork does not share that PR's underlying bug**: upstream's notification dot could go stale because its `notifications` were `@ObservationIgnored`; the fork's `notifications` are observed, so the dot is already accurate. There is no correctness bug to fix here — only re-render overhead.

Accordingly I deliberately **did not** port the full per-surface `@Observable` dot mirror (it depends on upstream infrastructure the fork lacks and wouldn't reduce invalidation without a larger refactor), and I **skipped** the more invasive "move `toolbarNotificationGroups` out of the detail body" change — it touches the Canvas toolbar path, carries regression risk, has no automated test to guard it, and there's no bug behind it. Keeping this PR to the one clean, safe win.

## Fix

Host the concrete `TerminalSplitTreeView` (`NSHostingView<TerminalSplitTreeView>`) instead of `AnyView`, so the host can diff and skip unchanged content. View content and accessibility output are unchanged.

## Tests

No new unit test — this is an `NSViewRepresentable` type-erasure removal with no logic change. Verified via `make build-app` ✅, `make check` ✅, and `SplitTreeTests` 4/4 ✅ (no regression).

## Notes

Internal rendering optimization — no change to shortcuts, settings, or the `prowl` CLI, so no `docs/` update needed.
