### PR TITLE
Tolerate login-shell noise in GitHub CLI JSON output

### DIFF
--- a/supacode/Clients/Github/GithubCLIClient.swift
+++ b/supacode/Clients/Github/GithubCLIClient.swift
@@ -2,6 +2,148 @@ import ComposableArchitecture
 import Darwin
 import Foundation
 
+// A login shell sources `.zprofile` / `.zlogin` before `gh` runs, so a banner or version-manager
+// line can prepend to captured stdout and corrupt the JSON.
+enum GithubCLIOutput {
+  // No JSON found at all: the likely cause is shell startup output polluting stdout.
+  nonisolated static let noPayloadMessage =
+    "Could not read GitHub CLI output. Your shell startup files may be printing extra output to stdout."
+
+  // Valid JSON was found but failed to decode: the likely cause is an incompatible gh version.
+  nonisolated static let undecodableMessage =
+    "Could not parse GitHub CLI output. The installed GitHub CLI version may be incompatible."
+
+  nonisolated private static let logger = SupaLogger("GithubCLI")
+
+  // Every balanced top-level JSON value ({...} or [...]) in `output`, in source order. An opener that
+  // never balances (a stray brace from shell noise) is skipped, so leading noise cannot swallow a real
+  // payload that follows.
+  nonisolated static func balancedJSONSpans(in output: String) -> [Substring] {
+    var spans: [Substring] = []
+    var searchStart = output.startIndex
+    while let start = output[searchStart...].firstIndex(where: { $0 == "{" || $0 == "[" }) {
+      let opener = output[start]
+      let closer: Character = opener == "{" ? "}" : "]"
+      var depth = 0
+      var inString = false
+      var escaped = false
+      var matchedEnd: String.Index?
+      var index = start
+      scan: while index < output.endIndex {
+        let character = output[index]
+        switch character {
+        case _ where inString && escaped:
+          escaped = false
+        case "\\" where inString:
+          escaped = true
+        case "\"" where inString:
+          inString = false
+        case _ where inString:
+          break
+        case "\"":
+          inString = true
+        case opener:
+          depth += 1
+        case closer:
+          depth -= 1
+          guard depth == 0 else { break }
+          matchedEnd = output.index(after: index)
+          break scan
+        default:
+          break
+        }
+        index = output.index(after: index)
+      }
+      guard let end = matchedEnd else {
+        // Unbalanced opener (stray bracket in noise): skip it and keep scanning.
+        searchStart = output.index(after: start)
+        continue
+      }
+      spans.append(output[start..<end])
+      searchStart = end
+    }
+    return spans
+  }
+
+  // Decodes the JSON payload from possibly noisy gh stdout, surfacing a readable error (with the raw
+  // output logged) instead of an opaque DecodingError. Throws when no payload is found at all.
+  nonisolated static func decode<T: Decodable>(
+    _ type: T.Type,
+    from output: String,
+    decoder: JSONDecoder = JSONDecoder()
+  ) throws -> T {
+    guard let value = try decodeIfPresent(T.self, from: output, decoder: decoder) else {
+      logDecodeFailure(output)
+      throw GithubCLIError.commandFailed(noPayloadMessage)
+    }
+    return value
+  }
+
+  // Returns nil when `output` carries no JSON payload at all (e.g. `gh run list` with no runs), and
+  // throws only when a payload is present but cannot be decoded. gh prints its JSON after any leading
+  // shell noise, so the last decodable span wins.
+  nonisolated static func decodeIfPresent<T: Decodable>(
+    _ type: T.Type,
+    from output: String,
+    decoder: JSONDecoder = JSONDecoder()
+  ) throws -> T? {
+    let spans = balancedJSONSpans(in: output)
+    guard !spans.isEmpty else {
+      return nil
+    }
+    var lastDecodingError: Error?
+    var sawValidJSON = false
+    for span in spans.reversed() {
+      let data = Data(span.utf8)
+      do {
+        return try decoder.decode(T.self, from: data)
+      } catch {
+        lastDecodingError = error
+        if (try? JSONSerialization.jsonObject(with: data)) != nil {
+          sawValidJSON = true
+        }
+      }
+    }
+    let detail = lastDecodingError.map { "\($0)" } ?? "unknown"
+    logger.warning("Failed to decode GitHub CLI JSON output: \(snapshot(of: output)) error=\(detail)")
+    // Valid JSON that failed to decode points at gh schema drift; otherwise the brackets were noise.
+    throw GithubCLIError.commandFailed(sawValidJSON ? undecodableMessage : noPayloadMessage)
+  }
+
+  // Logs a length-capped snapshot of the offending output so the user can retrieve it from the log
+  // stream without flooding it with a large banner.
+  nonisolated static func logDecodeFailure(_ output: String) {
+    logger.warning("Failed to read GitHub CLI JSON output: \(snapshot(of: output))")
+  }
+
+  // Caps the logged output so a large banner does not flood the log stream.
+  nonisolated private static func snapshot(of output: String) -> String {
+    let limit = 500
+    let prefix = output.prefix(limit)
+    return prefix.endIndex == output.endIndex ? String(prefix) : "\(prefix)… (truncated)"
+  }
+}
+
+enum GithubAuthStatusParsing {
+  // `hosts` is an unordered dictionary, so prefer github.com and otherwise sort the keys: the result
+  // is deterministic even when more than one host has an active account.
+  nonisolated static func activeAccount(
+    in response: GithubAuthStatusResponse
+  ) -> (host: String, login: String)? {
+    let orderedHosts = response.hosts.keys.sorted { lhs, rhs in
+      if lhs == "github.com" { return true }
+      if rhs == "github.com" { return false }
+      return lhs < rhs
+    }
+    for host in orderedHosts {
+      if let active = response.hosts[host]?.first(where: { $0.active }) {
+        return (host, active.login)
+      }
+    }
+    return nil
+  }
+}
+
 struct GithubCLIClient: Sendable {
   var defaultBranch: @Sendable (URL) async throws -> String
   var resolveRemoteInfo: @Sendable (URL) async -> GithubRemoteInfo?
@@ -76,10 +218,9 @@ nonisolated private func defaultBranchFetcher(
       arguments: ["repo", "view", "--json", "defaultBranchRef"],
       repoRoot: repoRoot
     )
-    let data = Data(output.utf8)
     let decoder = JSONDecoder()
     decoder.dateDecodingStrategy = .iso8601
-    let response = try decoder.decode(GithubRepoViewResponse.self, from: data)
+    let response = try GithubCLIOutput.decode(GithubRepoViewResponse.self, from: output, decoder: decoder)
     return response.defaultBranchRef.name
   }
 }
@@ -96,8 +237,10 @@ nonisolated private func resolveRemoteInfoFetcher(
         arguments: ["repo", "view", "--json", "owner,name,url"],
         repoRoot: repoRoot
       )
-      let data = Data(output.utf8)
-      let response = try JSONDecoder().decode(GithubRepoViewRemoteInfoResponse.self, from: data)
+      guard let response = try GithubCLIOutput.decodeIfPresent(GithubRepoViewRemoteInfoResponse.self, from: output)
+      else {
+        return nil
+      }
       return response.remoteInfo
     } catch {
       return nil
@@ -125,14 +268,11 @@ nonisolated private func latestRunFetcher(
       ],
       repoRoot: repoRoot
     )
-    if output.isEmpty {
-      return nil
-    }
-    let data = Data(output.utf8)
     let decoder = JSONDecoder()
     decoder.dateDecodingStrategy = .iso8601
-    let runs = try decoder.decode([GithubWorkflowRun].self, from: data)
-    return runs.first
+    // nil payload means no runs; a present-but-undecodable payload still throws.
+    let runs = try GithubCLIOutput.decodeIfPresent([GithubWorkflowRun].self, from: output, decoder: decoder)
+    return runs?.first
   }
 }
 
@@ -319,10 +459,9 @@ nonisolated private func fetchCrossRepoChunk(
     }
     return CrossRepoChunkOutcome(successByRepo: [:], failedRepos: failed)
   }
-  let data = Data(output.utf8)
   let decoder = JSONDecoder()
   decoder.dateDecodingStrategy = .iso8601
-  let response = try decoder.decode(CrossRepoPullRequestResponse.self, from: data)
+  let response = try GithubCLIOutput.decode(CrossRepoPullRequestResponse.self, from: output, decoder: decoder)
 
   let errorMessagesByAlias = response.errorMessagesByAlias()
   var success: [RepoKey: [String: GithubPullRequest]] = [:]
@@ -642,14 +781,11 @@ nonisolated private func authStatusFetcher(
       arguments: ["auth", "status", "--json", "hosts"],
       repoRoot: nil
     )
-    let data = Data(output.utf8)
-    let response = try decodeAuthStatusResponse(from: data)
-    guard let (host, accounts) = response.hosts.first,
-      let activeAccount = accounts.first(where: { $0.active })
-    else {
+    let response = try GithubCLIOutput.decode(GithubAuthStatusResponse.self, from: output)
+    guard let active = GithubAuthStatusParsing.activeAccount(in: response) else {
       return nil
     }
-    return GithubAuthStatus(username: activeAccount.login, host: host)
+    return GithubAuthStatus(username: active.login, host: active.host)
   }
 }
 
@@ -772,10 +908,9 @@ nonisolated private func fetchPullRequestsChunk(
     return (chunkIndex, [:])
   }
 
-  let data = Data(output.utf8)
   let decoder = JSONDecoder()
   decoder.dateDecodingStrategy = .iso8601
-  let response = try decoder.decode(GithubGraphQLPullRequestResponse.self, from: data)
+  let response = try GithubCLIOutput.decode(GithubGraphQLPullRequestResponse.self, from: output, decoder: decoder)
   let prsByBranch = response.pullRequestsByBranch(
     aliasMap: aliasMap,
     owner: request.owner,
@@ -927,8 +1062,4 @@ nonisolated private func shouldRetryGhExecution(after error: Error) -> Bool {
     return true
   }
   return false
-}
-
-nonisolated private func decodeAuthStatusResponse(from data: Data) throws -> GithubAuthStatusResponse {
-  try JSONDecoder().decode(GithubAuthStatusResponse.self, from: data)
 }

--- a/supacodeTests/GithubCLIOutputTests.swift
+++ b/supacodeTests/GithubCLIOutputTests.swift
@@ -1,0 +1,136 @@
+import Foundation
+import Testing
+
+@testable import supacode
+
+struct GithubCLIOutputTests {
+  private struct Payload: Decodable, Equatable {
+    let name: String
+  }
+
+  // MARK: - balancedJSONSpans
+
+  @Test func findsACleanObject() {
+    let spans = GithubCLIOutput.balancedJSONSpans(in: #"{"name":"main"}"#)
+    #expect(spans.map(String.init) == [#"{"name":"main"}"#])
+  }
+
+  @Test func skipsLeadingBannerBeforeObject() {
+    let output = "nvm: version manager loaded\n{\"name\":\"main\"}"
+    let spans = GithubCLIOutput.balancedJSONSpans(in: output)
+    #expect(spans.map(String.init) == [#"{"name":"main"}"#])
+  }
+
+  @Test func skipsLeadingBannerBeforeArray() {
+    let output = "Welcome!\n[{\"name\":\"main\"}]"
+    let spans = GithubCLIOutput.balancedJSONSpans(in: output)
+    #expect(spans.map(String.init) == [#"[{"name":"main"}]"#])
+  }
+
+  @Test func ignoresBracesAndEscapedQuotesInsideStrings() {
+    let output = #"{"title":"a } b \" [c]"}"#
+    let spans = GithubCLIOutput.balancedJSONSpans(in: output)
+    #expect(spans.map(String.init) == [output])
+  }
+
+  @Test func returnsMultipleTopLevelValuesInOrder() {
+    let output = #"{"name":"a"} trailing noise {"name":"b"}"#
+    let spans = GithubCLIOutput.balancedJSONSpans(in: output)
+    #expect(spans.map(String.init) == [#"{"name":"a"}"#, #"{"name":"b"}"#])
+  }
+
+  @Test func skipsStrayUnbalancedOpenerAndKeepsScanning() {
+    // A verbose shell can emit a lone "{" that never balances; it must not
+    // swallow the real payload that follows.
+    let output = "{ partial banner\n{\"name\":\"main\"}"
+    let spans = GithubCLIOutput.balancedJSONSpans(in: output)
+    #expect(spans.map(String.init) == [#"{"name":"main"}"#])
+  }
+
+  @Test func yieldsNoSpansForNoiseEmptyOrUnterminated() {
+    #expect(GithubCLIOutput.balancedJSONSpans(in: "").isEmpty)
+    #expect(GithubCLIOutput.balancedJSONSpans(in: "just a banner, no json").isEmpty)
+    #expect(GithubCLIOutput.balancedJSONSpans(in: #"{"name":"unterminated"#).isEmpty)
+  }
+
+  // MARK: - decode / decodeIfPresent
+
+  @Test func decodesBannerPrefixedPayload() throws {
+    let output = "Loading shell config...\n{\"name\":\"main\"}"
+    let value = try GithubCLIOutput.decode(Payload.self, from: output)
+    #expect(value == Payload(name: "main"))
+  }
+
+  @Test func prefersLastDecodableSpan() throws {
+    // gh prints its JSON after any leading noise, so a leading banner-shaped
+    // object must lose to the real trailing payload.
+    let output = #"{"unrelated":"banner"} {"name":"real"}"#
+    let value = try GithubCLIOutput.decode(Payload.self, from: output)
+    #expect(value == Payload(name: "real"))
+  }
+
+  @Test func decodeIfPresentReturnsNilWhenNoPayload() throws {
+    let value = try GithubCLIOutput.decodeIfPresent(Payload.self, from: "no json here")
+    #expect(value == nil)
+  }
+
+  @Test func decodeThrowsNoPayloadMessageWhenMissing() {
+    #expect(throws: GithubCLIError.commandFailed(GithubCLIOutput.noPayloadMessage)) {
+      _ = try GithubCLIOutput.decode(Payload.self, from: "banner only")
+    }
+  }
+
+  @Test func decodeThrowsUndecodableMessageForValidButWrongShapeJSON() {
+    // Valid JSON whose shape doesn't match points at a gh version mismatch, not
+    // shell pollution.
+    #expect(throws: GithubCLIError.commandFailed(GithubCLIOutput.undecodableMessage)) {
+      _ = try GithubCLIOutput.decode(Payload.self, from: #"{"unexpected":123}"#)
+    }
+  }
+
+  // MARK: - activeAccount
+
+  private func authResponse(_ json: String) throws -> GithubAuthStatusResponse {
+    try GithubCLIOutput.decode(GithubAuthStatusResponse.self, from: json)
+  }
+
+  @Test func picksActiveAccountFromNonFirstHost() throws {
+    let response = try authResponse(
+      #"{"hosts":{"git.example.com":[{"active":true,"login":"enterprise-user"}]}}"#
+    )
+    let active = GithubAuthStatusParsing.activeAccount(in: response)
+    #expect(active?.host == "git.example.com")
+    #expect(active?.login == "enterprise-user")
+  }
+
+  @Test func prefersGithubComWhenMultipleHostsActive() throws {
+    let response = try authResponse(
+      """
+      {"hosts":{"git.example.com":[{"active":true,"login":"enterprise"}],\
+      "github.com":[{"active":true,"login":"dotcom"}]}}
+      """
+    )
+    let active = GithubAuthStatusParsing.activeAccount(in: response)
+    #expect(active?.host == "github.com")
+    #expect(active?.login == "dotcom")
+  }
+
+  @Test func sortsHostsDeterministicallyWhenGithubComAbsent() throws {
+    let response = try authResponse(
+      """
+      {"hosts":{"zeta.example.com":[{"active":true,"login":"z"}],\
+      "alpha.example.com":[{"active":true,"login":"a"}]}}
+      """
+    )
+    let active = GithubAuthStatusParsing.activeAccount(in: response)
+    #expect(active?.host == "alpha.example.com")
+    #expect(active?.login == "a")
+  }
+
+  @Test func returnsNilWhenNoActiveAccount() throws {
+    let response = try authResponse(
+      #"{"hosts":{"github.com":[{"active":false,"login":"inactive"}]}}"#
+    )
+    #expect(GithubAuthStatusParsing.activeAccount(in: response) == nil)
+  }
+}


### PR DESCRIPTION
## Problem

A login shell sources `.zprofile` / `.zlogin` before `gh` runs, so a banner or version-manager line (nvm, mise, etc.) can prepend to captured stdout and corrupt the JSON. `JSONDecoder` then throws an opaque `DecodingError` that surfaces in the GitHub settings pane as **"The data couldn't be read because it isn't in the correct format"** — even though `gh` is installed, authed, and returns valid JSON in the user's terminal.

(onevcat runs zsh startup scripts, so this is a high-probability hit.)

Ported from upstream supacode #378, adapted to the fork's GitHub client (which keeps a fork-specific `CrossRepoPullRequestResponse` PR decode path).

## Fix

- **`GithubCLIOutput`**: enumerate every balanced top-level JSON value (`{...}` / `[...]`) in the output — skipping a stray unbalanced opener so leading noise can't swallow a real payload — and decode the **last** decodable span (gh prints its JSON after any leading noise). A missing payload throws a readable shell-pollution message; a present-but-undecodable one throws a version-incompatibility message; the raw output is logged (length-capped).
- Route all **six** gh JSON decode sites through it. `latestRun` and `resolveRemoteInfo` use `decodeIfPresent`, so a no-payload result stays `nil` (no runs / no remote) while leading noise is still tolerated.
- **`GithubAuthStatusParsing.activeAccount`**: prefer `github.com`, then a stable sort — fixing the latent multi-host bug where auth status scanned an arbitrary dictionary entry (non-deterministic with >1 active host).

## Tests

- New `GithubCLIOutputTests` (16 cases): balanced-span scanner (clean / banner-prefixed object & array / braces & escaped quotes in strings / two values in order / stray opener skipped / noise·empty·unterminated → none); `decode`/`decodeIfPresent` (banner-prefixed, prefer last span, nil when absent, no-payload vs undecodable messages); `activeAccount` (non-first host, prefer github.com, deterministic sort, no active account).
- `make build-app` ✅ · `make check` ✅ · `GithubCLIOutputTests` + `GithubCLIClientTests` 36/36 ✅

## Notes

User-visible only as a better error/diagnostic path (no shortcut/settings/CLI behavior change), so no `docs/` update. `SupaLogger` has no `error` level in the fork, so decode failures log at `warning`.
