### PR TITLE
Focus the terminal after next/previous and history worktree navigation

### DIFF
--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+CoreReducer.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+CoreReducer.swift
@@ -589,7 +589,7 @@ extension RepositoriesFeature {
         }
       }
       guard let id = state.worktreeID(byOffset: 1) else { return .none }
-      return .send(.selectWorktree(id))
+      return .send(.selectWorktree(id, focusTerminal: true))
 
     case .selectPreviousWorktree:
       if state.isShelfActive, let worktree = state.selectedTerminalWorktree {
@@ -598,7 +598,7 @@ extension RepositoriesFeature {
         }
       }
       guard let id = state.worktreeID(byOffset: -1) else { return .none }
-      return .send(.selectWorktree(id))
+      return .send(.selectWorktree(id, focusTerminal: true))
 
     case .consumeCanvasFocusRequest(let id):
       if state.pendingCanvasFocusRequest?.id == id {

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+Selection.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+Selection.swift
@@ -184,6 +184,8 @@ func navigateWorktreeHistory(
   }
   setSingleWorktreeSelection(destinationID, state: &state, recordHistory: false)
   state.openedWorktreeIDs.insert(destinationID)
+  // Match sidebar/arrow navigation: focus the terminal of the worktree we land on.
+  state.pendingTerminalFocusWorktreeIDs.insert(destinationID)
   return .send(.delegate(.selectedWorktreeChanged(state.worktree(for: destinationID))))
 }
 

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -4812,6 +4812,7 @@ struct RepositoriesFeatureTests {
       $0.sidebarSelectedWorktreeIDs = [wt1.id]
       $0.openedWorktreeIDs = [wt1.id]
       $0.worktreeHistoryBackStack = [wt2.id]
+      $0.pendingTerminalFocusWorktreeIDs = [wt1.id]
     }
     await store.receive(\.delegate.selectedWorktreeChanged)
   }
@@ -4832,6 +4833,7 @@ struct RepositoriesFeatureTests {
       $0.sidebarSelectedWorktreeIDs = [wt2.id]
       $0.openedWorktreeIDs = [wt2.id]
       $0.worktreeHistoryBackStack = [wt1.id]
+      $0.pendingTerminalFocusWorktreeIDs = [wt2.id]
     }
     await store.receive(\.delegate.selectedWorktreeChanged)
   }
@@ -4849,6 +4851,7 @@ struct RepositoriesFeatureTests {
       $0.selection = .worktree(wt1.id)
       $0.sidebarSelectedWorktreeIDs = [wt1.id]
       $0.openedWorktreeIDs = [wt1.id]
+      $0.pendingTerminalFocusWorktreeIDs = [wt1.id]
     }
     await store.receive(\.delegate.selectedWorktreeChanged)
   }
@@ -4871,6 +4874,7 @@ struct RepositoriesFeatureTests {
       $0.sidebarSelectedWorktreeIDs = [wt2.id]
       $0.openedWorktreeIDs = [wt2.id]
       $0.worktreeHistoryBackStack = [wt1.id]
+      $0.pendingTerminalFocusWorktreeIDs = [wt2.id]
     }
     await store.receive(\.delegate.selectedWorktreeChanged)
   }
@@ -4888,6 +4892,7 @@ struct RepositoriesFeatureTests {
       $0.selection = .worktree(wt2.id)
       $0.sidebarSelectedWorktreeIDs = [wt2.id]
       $0.openedWorktreeIDs = [wt2.id]
+      $0.pendingTerminalFocusWorktreeIDs = [wt2.id]
     }
     await store.receive(\.delegate.selectedWorktreeChanged)
   }
@@ -4914,6 +4919,7 @@ struct RepositoriesFeatureTests {
       $0.selection = .worktree(worktree.id)
       $0.sidebarSelectedWorktreeIDs = [worktree.id]
       $0.openedWorktreeIDs = [worktree.id]
+      $0.pendingTerminalFocusWorktreeIDs = [worktree.id]
     }
     await store.receive(\.delegate.selectedWorktreeChanged)
   }
@@ -4938,6 +4944,7 @@ struct RepositoriesFeatureTests {
       $0.sidebarSelectedWorktreeIDs = [wt3.id]
       $0.openedWorktreeIDs = [wt3.id]
       $0.worktreeHistoryBackStack = [wt1.id]
+      $0.pendingTerminalFocusWorktreeIDs = [wt3.id]
     }
     await store.receive(\.delegate.selectedWorktreeChanged)
   }
@@ -4962,6 +4969,7 @@ struct RepositoriesFeatureTests {
       $0.sidebarSelectedWorktreeIDs = [wt1.id]
       $0.openedWorktreeIDs = [wt1.id]
       $0.worktreeHistoryBackStack = [wt3.id]
+      $0.pendingTerminalFocusWorktreeIDs = [wt1.id]
     }
     await store.receive(\.delegate.selectedWorktreeChanged)
   }
@@ -5012,6 +5020,7 @@ struct RepositoriesFeatureTests {
       $0.sidebarSelectedWorktreeIDs = [wt1.id]
       $0.openedWorktreeIDs = [wt1.id]
       $0.worktreeHistoryBackStack = [wt3.id]
+      $0.pendingTerminalFocusWorktreeIDs = [wt1.id]
     }
     await store.receive(\.delegate.selectedWorktreeChanged)
   }
@@ -5056,6 +5065,7 @@ struct RepositoriesFeatureTests {
       $0.openedWorktreeIDs = [wt1.id]
       $0.worktreeHistoryBackStack = []
       $0.worktreeHistoryForwardStack = [wt2.id]
+      $0.pendingTerminalFocusWorktreeIDs = [wt1.id]
     }
     await store.receive(\.delegate.selectedWorktreeChanged)
   }
@@ -5077,6 +5087,7 @@ struct RepositoriesFeatureTests {
       $0.openedWorktreeIDs = [wt2.id]
       $0.worktreeHistoryBackStack = [wt1.id]
       $0.worktreeHistoryForwardStack = []
+      $0.pendingTerminalFocusWorktreeIDs = [wt2.id]
     }
     await store.receive(\.delegate.selectedWorktreeChanged)
   }
@@ -5098,6 +5109,7 @@ struct RepositoriesFeatureTests {
       $0.openedWorktreeIDs = [wt1.id]
       $0.worktreeHistoryBackStack = []
       $0.worktreeHistoryForwardStack = [wt3.id]
+      $0.pendingTerminalFocusWorktreeIDs = [wt1.id]
     }
     await store.receive(\.delegate.selectedWorktreeChanged)
   }

--- a/supacodeTests/ShelfFeatureTests.swift
+++ b/supacodeTests/ShelfFeatureTests.swift
@@ -513,6 +513,7 @@ struct ShelfFeatureTests {
       $0.sidebarSelectedWorktreeIDs = [wt2.id]
       $0.openedWorktreeIDs = [wt2.id]
       $0.worktreeHistoryBackStack = [wt1.id]
+      $0.pendingTerminalFocusWorktreeIDs = [wt2.id]
     }
     await store.receive(\.delegate.selectedWorktreeChanged)
     await store.finish()


### PR DESCRIPTION
## Problem

Sidebar clicks and arrow selection already request terminal focus, but cycling with **Select Next/Previous Worktree** and **Back/Forward in Worktree History** landed on a worktree *without* focusing its terminal — keystrokes went nowhere until the user clicked into the pane.

Ported from upstream supacode #371, reimplemented against the fork's `pendingTerminalFocusWorktreeIDs` mechanism (the fork doesn't use upstream's row-action focus model).

## Fix

- `selectNextWorktree` / `selectPreviousWorktree` now send `.selectWorktree(id, focusTerminal: true)`. The Shelf branch (where the vertical arrows map to tab navigation) is left untouched.
- `navigateWorktreeHistory` inserts the destination worktree into `pendingTerminalFocusWorktreeIDs`, matching the sidebar/arrow path.

## Tests

- Updated the existing **exhaustive** navigation tests (9 next/previous + 3 history + 1 Shelf-cycling) to assert the new `pendingTerminalFocusWorktreeIDs` mutation — these now directly cover the change across wrap-around, collapsed-repo skipping, no-selection, and stale-history cases.
- The `selectWorktree`-with-default test (`focusTerminal: false`) is intentionally left unchanged, locking in that plain selection still does **not** steal focus.
- `make build-app` ✅ · `make check` ✅ · `RepositoriesFeatureTests` + `ShelfFeatureTests` 200/200 ✅

## Notes

Behavior fix to existing keyboard navigation; no new shortcut/setting, so no `docs/` change.
