### PR TITLE
Three small UX fixes: window persistence, palette legibility, search hint

### DIFF
--- a/supacode/App/WindowTabbingDisabler.swift
+++ b/supacode/App/WindowTabbingDisabler.swift
@@ -21,6 +21,9 @@ final class WindowTabbingView: NSView, NSWindowDelegate {
     guard let window else { return }
     window.tabbingMode = .disallowed
     window.identifier = NSUserInterfaceItemIdentifier(WindowID.main)
+    // Persist the main window's position and size across launches. Idempotent:
+    // re-associating the same autosave name on later passes is a no-op.
+    window.setFrameAutosaveName(NSWindow.FrameAutosaveName(WindowID.main))
     window.isExcludedFromWindowsMenu = true
     if window.delegate !== self {
       window.delegate = self

--- a/supacode/Commands/TerminalCommands.swift
+++ b/supacode/Commands/TerminalCommands.swift
@@ -77,7 +77,7 @@ struct TerminalCommands: Commands {
         navigateSearchNextAction?()
       }
       .modifier(
-        KeyboardShortcutModifier(shortcut: ghosttyShortcuts.keyboardShortcut(for: "search:next"))
+        KeyboardShortcutModifier(shortcut: ghosttyShortcuts.keyboardShortcut(for: "navigate_search:next"))
       )
       .disabled(navigateSearchNextAction == nil)
 
@@ -85,7 +85,7 @@ struct TerminalCommands: Commands {
         navigateSearchPreviousAction?()
       }
       .modifier(
-        KeyboardShortcutModifier(shortcut: ghosttyShortcuts.keyboardShortcut(for: "search:previous"))
+        KeyboardShortcutModifier(shortcut: ghosttyShortcuts.keyboardShortcut(for: "navigate_search:previous"))
       )
       .disabled(navigateSearchPreviousAction == nil)
 

--- a/supacode/Features/CommandPalette/Views/CommandPaletteOverlayView.swift
+++ b/supacode/Features/CommandPalette/Views/CommandPaletteOverlayView.swift
@@ -697,6 +697,11 @@ private struct CommandPaletteRowView: View {
         }
       }
       .padding(8)
+      // The selected row paints an accent background; force a dark color scheme
+      // for its content so the label and symbols stay legible in light mode.
+      .transformEnvironment(\.colorScheme) { colorScheme in
+        if isSelected { colorScheme = .dark }
+      }
       .background(rowBackground)
       .clipShape(.rect(cornerRadius: 14))
     }


### PR DESCRIPTION
Three independent low-risk UX fixes (one commit each), grouped to keep the PR queue light.

## 1. Persist the main window's position and size (`02e13192`) — upstream #313
The main window didn't restore its frame across launches (only the diff window did). Set `frameAutosaveName` on it in `disallowTabbing()`; the call is idempotent.

## 2. Keep the selected command palette row legible in light mode (`3b499662`) — upstream #353
The selected row paints an accent background, but its label/shortcut symbols kept the ambient color scheme and washed out in light mode. Force a dark color scheme for the selected row's content via `transformEnvironment`.

## 3. Fix empty shortcut hint on Find Next/Previous (`838b1405`) — upstream #318
The Find Next / Find Previous menu items looked up their shortcut hint under `search:next` / `search:previous`, but the fork's search navigation binds `navigate_search:next` / `navigate_search:previous` (`GhosttySearchNavigation`), so the lookup missed and the menu showed **no shortcut**. Corrected the binding action names. (A latent fork bug; upstream #318 fixed the same thing in its own menu.)

## Tests / verification

All three are UI / menu-plumbing changes with no unit-testable logic (an `NSWindow` autosave flag, a SwiftUI environment modifier, and a shortcut-hint lookup string), so they're verified by:
- `make build-app` ✅ · `make check` (swift-format + swiftlint strict) ✅

## Notes

No new shortcuts/settings/CLI behavior, so no `docs/` update. Each fix is a separate commit and can be reverted independently.
