### PR TITLE
Fix command palette color-scheme flicker on first open

### DIFF
--- a/supacode/Features/CommandPalette/Views/CommandPaletteOverlayView.swift
+++ b/supacode/Features/CommandPalette/Views/CommandPaletteOverlayView.swift
@@ -203,10 +203,6 @@ private struct CommandPaletteCard: View {
     Color(nsColor: .windowBackgroundColor)
   }
 
-  private var colorScheme: ColorScheme {
-    NSColor.windowBackgroundColor.isLightColor ? .light : .dark
-  }
-
   var body: some View {
     VStack(alignment: .leading, spacing: 0) {
       CommandPaletteQuery(query: $query, isTextFieldFocused: isQueryFocused) { event in
@@ -233,7 +229,6 @@ private struct CommandPaletteCard: View {
     .glassEffect(.regular, in: RoundedRectangle(cornerRadius: 14))
     .shadow(radius: 32, x: 0, y: 12)
     .padding(Self.padding)
-    .environment(\.colorScheme, colorScheme)
   }
 }
 
@@ -873,10 +868,4 @@ private func commandPaletteShortcutSymbols(for index: Int) -> [String] {
 
 private func commandPaletteShortcutLabel(for index: Int) -> String {
   "Cmd+\(index + 1)"
-}
-
-extension NSColor {
-  fileprivate var isLightColor: Bool {
-    luminance > 0.5
-  }
 }


### PR DESCRIPTION
## Problem

In Light mode, opening the command palette flashed the **wrong color scheme** on the first frame (briefly dark) and only corrected after the first interaction. Reported while verifying #420's selected-row legibility fix; **pre-existing**, not caused by #420.

## Root cause

`CommandPaletteCard` forced a color scheme computed from `NSColor.windowBackgroundColor.isLightColor`, evaluated inside `body`. `windowBackgroundColor` is a dynamic catalog color that resolves against the *current drawing appearance context*, which isn't settled on the palette's first render — so it read wrong on open and only corrected on the next re-render (the first keystroke/arrow press).

## Fix

Drop the forced override entirely and let the card inherit the ambient `@Environment(\.colorScheme)`. That already reflects the window's appearance (which is what the original computation was trying to recover), is correct on the very first render, and updates reactively on appearance changes — no NSColor/appearance-context timing dependency. Removed the now-unused `isLightColor` NSColor extension (its `luminance` helper stays; still used by the Ghostty theme code). The selected-row dark-scheme override from #420 is unaffected.

> Note: an earlier revision of this branch tried `NSApp.effectiveAppearance`, which reads the *app/system* appearance rather than the *window/view* appearance and rendered the wrong scheme; replaced with the ambient environment, which is the correct source.

## Verification

- `make build-app` ✅ · `make check` ✅
- Steady-state palette rendering matches the window appearance. Please confirm on-device that opening in Light mode is stably light (no dark flash, and not stuck dark).
