### PR TITLE
Fix sheet/alert dismiss flash (migrate to TCA view-side APIs)

### DIFF
--- a/supacode/App/ContentView.swift
+++ b/supacode/App/ContentView.swift
@@ -74,9 +74,9 @@ struct ContentView: View {
         )
       }
     }
-    .alert(store: repositoriesStore.scope(state: \.$alert, action: \.alert))
-    .alert(store: store.scope(state: \.$alert, action: \.alert))
-    .sheet(store: repositoriesStore.scope(state: \.$worktreeCreationPrompt, action: \.worktreeCreationPrompt)) {
+    .alert($repositoriesStore.scope(state: \.alert, action: \.alert))
+    .alert($store.scope(state: \.alert, action: \.alert))
+    .sheet(item: $repositoriesStore.scope(state: \.worktreeCreationPrompt, action: \.worktreeCreationPrompt)) {
       promptStore in
       WorktreeCreationPromptView(store: promptStore)
     }

--- a/supacode/Features/Settings/Views/SettingsView.swift
+++ b/supacode/Features/Settings/Views/SettingsView.swift
@@ -107,11 +107,19 @@ struct SettingsView: View {
       case .repository(let repositoryID):
         if let repository = repositories[id: repositoryID] {
           SettingsDetailView {
-            IfLetStore(
-              settingsStore.scope(state: \.repositorySettings, action: \.repositorySettings)
-            ) { repositorySettingsStore in
+            if let repositorySettingsStore = settingsStore.scope(
+              state: \.repositorySettings,
+              action: \.repositorySettings
+            ) {
               RepositorySettingsView(store: repositorySettingsStore)
                 .id(repository.id)
+                .navigationTitle(customTitles[repository.id] ?? repository.name)
+                .navigationSubtitle(repository.rootURL.path(percentEncoded: false))
+            } else {
+              // Settled placeholder while the scoped store is briefly nil (e.g. mid
+              // repository switch), instead of `IfLetStore` flashing an empty pane.
+              ProgressView()
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .navigationTitle(customTitles[repository.id] ?? repository.name)
                 .navigationSubtitle(repository.rootURL.path(percentEncoded: false))
             }
@@ -127,7 +135,7 @@ struct SettingsView: View {
       }
     }
     .navigationSplitViewStyle(.balanced)
-    .alert(store: settingsStore.scope(state: \.$alert, action: \.alert))
+    .alert($settingsStore.scope(state: \.alert, action: \.alert))
     .frame(minWidth: 800, minHeight: 500)
     .background {
       WindowAppearanceSetter(colorScheme: settingsStore.appearanceMode.colorScheme)


### PR DESCRIPTION
## Problem

The deprecated `.sheet(store:)` / `.alert(store:)` / `IfLetStore` APIs swap their content for `EmptyView` the instant the presentation state goes `nil` — *before* SwiftUI's dismiss animation finishes — so the content flashes empty during the close animation.

Ported from upstream supacode #310, adapted to the fork's (diverged, smaller) set of presentation sites.

## Fix

- **ContentView**
  - New-worktree sheet → `.sheet(item: $repositoriesStore.scope(...))` — **the one user-visible flash** (the prompt no longer blanks while sliding away).
  - Two alerts → `.alert($…store.scope(...))`.
- **SettingsView**
  - Repository-settings `IfLetStore` → `if let … else ProgressView()` so the detail pane shows a settled placeholder instead of blank while the scoped store is briefly `nil` (e.g. mid repository switch).
  - Alert → `.alert($settingsStore.scope(...))`.

Reducer-side `.ifLet` presentation is unchanged. `store`/`repositoriesStore`/`settingsStore` were already `@Bindable`, so the `$store.scope` bindings drop in directly.

## UX before → after

- New-worktree dialog: closing no longer flashes an empty sheet during the slide-out.
- Settings repo detail: shows a centered `ProgressView` instead of a blank pane during the brief nil window.
- The three alerts: no perceptible change (system alert dismiss is too brief to show the empty frame) — migrated to clear the deprecation and stay on the modern API.

## Verification / scope

- `make build-app` ✅ · `make check` ✅
- Pure view-layer change, no reducer logic → verified by build + manual observation; no new tests.
- The `deleteWorktreeConfirmation` `isPresented` sheet has the same latent flash but isn't store-driven; left out of scope (can be a separate small change). No `docs/` change (no shortcut/setting/CLI behavior change).
