### PR TITLE
Refresh hyperlink highlight on Cmd press over an unfocused split

### DIFF
--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceView+EventTranslation.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceView+EventTranslation.swift
@@ -6,6 +6,11 @@ extension GhosttySurfaceView {
   func translationState(_ event: NSEvent, surface: ghostty_surface_t) -> (
     NSEvent, NSEvent.ModifierFlags
   ) {
+    // `characters`-family APIs throw on non-key events, so skip translation for a
+    // modifier-only event (otherwise a bare Cmd aborts the send before Ghostty sees it).
+    guard event.type == .keyDown || event.type == .keyUp else {
+      return (event, event.modifierFlags)
+    }
     let translatedModsGhostty = ghostty_surface_key_translation_mods(
       surface, ghosttyMods(event.modifierFlags))
     let translatedMods = appKitMods(translatedModsGhostty)

--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceView+Mouse.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceView+Mouse.swift
@@ -148,6 +148,8 @@ extension GhosttySurfaceView {
       localEventKeyUp(event)
     case .leftMouseDown:
       localEventLeftMouseDown(event)
+    case .flagsChanged:
+      localEventFlagsChanged(event)
     default:
       event
     }
@@ -158,6 +160,15 @@ extension GhosttySurfaceView {
     guard focused else { return event }
     keyUp(with: event)
     return nil
+  }
+
+  // The responder chain delivers flagsChanged only to the first responder, so forward it to
+  // every other surface; a hovered but unfocused terminal still needs to refresh its links
+  // (e.g. holding Cmd over a link in a non-focused split, without moving the mouse).
+  func localEventFlagsChanged(_ event: NSEvent) -> NSEvent? {
+    guard window != nil, window?.firstResponder !== self else { return event }
+    flagsChanged(with: event)
+    return event
   }
 
   func localEventLeftMouseDown(_ event: NSEvent) -> NSEvent? {

--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
@@ -315,7 +315,7 @@ final class GhosttySurfaceView: NSView, Identifiable {
     }
     registerForDraggedTypes(Array(Self.dropTypes))
 
-    eventMonitor = NSEvent.addLocalMonitorForEvents(matching: [.keyUp, .leftMouseDown]) {
+    eventMonitor = NSEvent.addLocalMonitorForEvents(matching: [.keyUp, .leftMouseDown, .flagsChanged]) {
       [weak self] event in
       self?.localEventHandler(event)
     }


### PR DESCRIPTION
## Problem

Holding **Cmd** over a terminal link in a **non-focused split** didn't underline it or switch the cursor to a pointer until the mouse was moved across it again.

Confirmed repro (thanks @onevcat):
| case | result |
|---|---|
| focused split · hover link, then Cmd | ✅ highlights |
| focused split · Cmd, then move onto link | ✅ highlights |
| **non-focused split · hover link, then Cmd (no mouse move)** | ❌ **no change** |
| non-focused split · Cmd, then move onto link | ✅ (mouse move drives it) |

Bare modifier presses arrive as `flagsChanged` events, which the responder chain delivers **only to the first responder** — so a hovered but unfocused surface never saw the modifier change and only refreshed once a mouse move drove Ghostty's cursor-position callback.

Ported from upstream supacode #344 (Fixes #242).

## Fix

- **Forward `flagsChanged` to non-focused surfaces**: add `.flagsChanged` to the per-surface local event monitor mask and a `localEventFlagsChanged` that re-dispatches the event to any surface that isn't the first responder.
- **Guard `translationState` against non-key events**: the `characters`-family APIs throw on a `flagsChanged` event, which would abort the key send before Ghostty saw the modifier. (`ghosttyCharacters` already had this guard from the fork's earlier #374 work — but that half only covered the focused path; the more-frequently-hit `translationState` call and the non-focused forwarding were missing.)

## Verification

- `make build-app` ✅ · `make check` ✅
- No new unit test: `translationState` / `flagsChanged(with:)` need a live `ghostty_surface_t`, and the `GhosttyEventText` half is already covered by `MirroredTerminalKeyTests`. Verified against the confirmed repro above; please re-confirm the non-focused-split case after merge.

## Notes

The focused-terminal case already worked (fork #374), so behavior there is unchanged. No `docs/` change.
