### PR TITLE
Let users override the new worktree's name and parent directory

### DIFF
--- a/docs/components/repositories-and-worktrees.md
+++ b/docs/components/repositories-and-worktrees.md
@@ -53,6 +53,16 @@ By default a **creation prompt** appears (controlled by
 - choose the **base ref** (branch/tag) to branch from,
 - optionally **fetch the remote first**.
 
+An optional, default-collapsed **Advanced** section lets you override where the
+worktree lands:
+- **Worktree name** — the leaf folder name (defaults to the branch name).
+- **Parent folder** — the directory it's created in (defaults to the repo's
+  resolved base directory).
+
+Leave both blank to keep the default `base/<branch>` placement. The footer shows
+the full destination path as you type, or an inline error (the worktree name is a
+single folder, so slashes, `.`/`..`, and `.git` are rejected).
+
 Press **↩** to create, **Esc** to cancel. Branch names are validated live
 (`git check-ref-format`).
 

--- a/supacode/Clients/Git/GitClient.swift
+++ b/supacode/Clients/Git/GitClient.swift
@@ -240,7 +240,8 @@ struct GitClient {
     in repoRoot: URL,
     baseDirectory: URL,
     copyFiles: (ignored: Bool, untracked: Bool),
-    baseRef: String
+    baseRef: String,
+    directoryOverride: URL? = nil
   ) -> AsyncThrowingStream<GitWorktreeCreateEvent, Error> {
     AsyncThrowingStream { continuation in
       Task {
@@ -252,7 +253,8 @@ struct GitClient {
             name: name,
             copyIgnored: copyFiles.ignored,
             copyUntracked: copyFiles.untracked,
-            baseRef: baseRef
+            baseRef: baseRef,
+            directoryOverride: directoryOverride
           )
           let envURL = URL(fileURLWithPath: "/usr/bin/env")
           let localeArguments = ["LANG=C", "LC_ALL=C", "LC_MESSAGES=C"]
@@ -323,7 +325,8 @@ struct GitClient {
     name: String,
     copyIgnored: Bool,
     copyUntracked: Bool,
-    baseRef: String
+    baseRef: String,
+    directoryOverride: URL? = nil
   ) -> [String] {
     var arguments = ["--base-dir", baseDirectory.path(percentEncoded: false), "sw"]
     if copyIgnored {
@@ -335,6 +338,10 @@ struct GitClient {
     if !baseRef.isEmpty {
       arguments.append("--from")
       arguments.append(baseRef)
+    }
+    if let directoryOverride {
+      arguments.append("--path")
+      arguments.append(directoryOverride.path(percentEncoded: false))
     }
     if copyIgnored || copyUntracked {
       arguments.append("--verbose")

--- a/supacode/Clients/Repositories/GitClientDependency.swift
+++ b/supacode/Clients/Repositories/GitClientDependency.swift
@@ -29,7 +29,8 @@ struct GitClientDependency: Sendable {
       _ baseDirectory: URL,
       _ copyIgnored: Bool,
       _ copyUntracked: Bool,
-      _ baseRef: String
+      _ baseRef: String,
+      _ directoryOverride: URL?
     ) -> AsyncThrowingStream<GitWorktreeCreateEvent, Error>
   var removeWorktree: @Sendable (_ worktree: Worktree, _ deleteBranch: Bool) async throws -> URL
   var deleteLocalBranch:
@@ -68,13 +69,14 @@ extension GitClientDependency: DependencyKey {
         baseRef: baseRef
       )
     },
-    createWorktreeStream: { name, repoRoot, baseDirectory, copyIgnored, copyUntracked, baseRef in
+    createWorktreeStream: { name, repoRoot, baseDirectory, copyIgnored, copyUntracked, baseRef, directoryOverride in
       GitClient().createWorktreeStream(
         named: name,
         in: repoRoot,
         baseDirectory: baseDirectory,
         copyFiles: (ignored: copyIgnored, untracked: copyUntracked),
-        baseRef: baseRef
+        baseRef: baseRef,
+        directoryOverride: directoryOverride
       )
     },
     removeWorktree: { worktree, deleteBranch in

--- a/supacode/Features/Repositories/Models/WorktreePlacementOverride.swift
+++ b/supacode/Features/Repositories/Models/WorktreePlacementOverride.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// Optional per-creation overrides from the New Worktree dialog's Advanced
+/// section. `name` is the leaf folder name (default: the branch name); `path`
+/// is the parent directory (default: the resolved base directory). Both `nil`
+/// keeps `wt`'s default `base/<branch>` placement.
+struct WorktreePlacementOverride: Equatable {
+  var name: String?
+  var path: String?
+}
+
+extension WorktreePlacementOverride {
+  /// Validates a worktree-name leaf override. Returns an error message when the
+  /// name would escape the parent folder or collide with git internals, or
+  /// `nil` when it is empty (use the default) or acceptable. Shared by the
+  /// prompt and the reducer create path.
+  nonisolated static func nameValidationError(_ name: String?) -> String? {
+    let trimmed = (name ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else {
+      return nil
+    }
+    guard !trimmed.contains("/"), !trimmed.contains("\\") else {
+      return "Worktree name can't contain slashes."
+    }
+    guard trimmed != ".", trimmed != "..", trimmed.lowercased() != ".git" else {
+      return "Worktree name is invalid."
+    }
+    return nil
+  }
+}

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+CoreReducer.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+CoreReducer.swift
@@ -698,14 +698,15 @@ extension RepositoriesFeature {
       return .send(.worktreeCreation(.promptCanceled))
 
     case .worktreeCreationPrompt(
-      .presented(.delegate(.submit(let repositoryID, let branchName, let baseRef)))
+      .presented(.delegate(.submit(let repositoryID, let branchName, let baseRef, let placement)))
     ):
       return .send(
         .worktreeCreation(
           .startPromptedWorktreeCreation(
             repositoryID: repositoryID,
             branchName: branchName,
-            baseRef: baseRef
+            baseRef: baseRef,
+            placement: placement
           )
         )
       )

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+WorktreeCreation.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+WorktreeCreation.swift
@@ -139,19 +139,27 @@ extension RepositoriesFeature {
         return .none
       }
       @Shared(.settingsFile) var settingsFile
+      @Shared(.repositorySettings(repository.rootURL)) var repositorySettings
+      let defaultWorktreeBaseDirectory = SupacodePaths.worktreeBaseDirectory(
+        for: repository.rootURL,
+        globalDefaultPath: settingsFile.global.defaultWorktreeBaseDirectoryPath,
+        repositoryOverridePath: repositorySettings.worktreeBaseDirectoryPath
+      )
       state.worktreeCreationPrompt = WorktreeCreationPromptFeature.State(
         repositoryID: repository.id,
+        repositoryRootURL: repository.rootURL,
         repositoryName: repository.name,
         automaticBaseRef: automaticBaseRef,
         baseRefOptions: baseRefOptions,
         branchName: "",
         selectedBaseRef: selectedBaseRef,
         fetchRemote: settingsFile.global.fetchOriginBeforeWorktreeCreation,
+        defaultWorktreeBaseDirectory: defaultWorktreeBaseDirectory.path(percentEncoded: false),
         validationMessage: nil
       )
       return .none
 
-    case .startPromptedWorktreeCreation(let repositoryID, let branchName, let baseRef):
+    case .startPromptedWorktreeCreation(let repositoryID, let branchName, let baseRef, let placement):
       guard let repository = state.repositories[id: repositoryID] else {
         state.worktreeCreationPrompt = nil
         state.alert = messageAlert(
@@ -186,6 +194,7 @@ extension RepositoriesFeature {
               branchName: branchName,
               baseRef: baseRef,
               fetchRemote: fetchRemote,
+              placement: placement,
               duplicateMessage: duplicateMessage
             )
           )
@@ -198,6 +207,7 @@ extension RepositoriesFeature {
       let branchName,
       let baseRef,
       let fetchRemote,
+      let placement,
       let duplicateMessage
     ):
       guard let prompt = state.worktreeCreationPrompt, prompt.repositoryID == repositoryID else {
@@ -215,12 +225,14 @@ extension RepositoriesFeature {
             repositoryID: repositoryID,
             nameSource: .explicit(branchName),
             baseRefSource: .explicit(baseRef),
-            fetchRemote: fetchRemote
+            fetchRemote: fetchRemote,
+            placement: placement
           )
         )
       )
 
-    case .createWorktreeInRepository(let repositoryID, let nameSource, let baseRefSource, let fetchRemote):
+    case .createWorktreeInRepository(
+      let repositoryID, let nameSource, let baseRefSource, let fetchRemote, let placement):
       guard let repository = state.repositories[id: repositoryID] else {
         state.alert = messageAlert(
           title: "Unable to create worktree",
@@ -448,13 +460,23 @@ extension RepositoriesFeature {
             copyIgnored ? ((try? await gitClient.ignoredFileCount(repository.rootURL)) ?? 0) : 0
           progress.untrackedFilesToCopyCount =
             copyUntracked ? ((try? await gitClient.untrackedFileCount(repository.rootURL)) ?? 0) : 0
+          // Resolve an explicit destination from the dialog's name / parent-folder
+          // overrides; nil keeps `wt`'s default `base/<branch>` placement.
+          let directoryOverride = SupacodePaths.resolvedWorktreeDirectory(
+            defaultBaseDirectory: worktreeBaseDirectory,
+            repositoryRootURL: repository.rootURL,
+            nameOverride: placement.name,
+            pathOverride: placement.path,
+            branchName: name
+          )
           progress.stage = .creatingWorktree
           progress.commandText = worktreeCreateCommand(
             baseDirectoryURL: worktreeBaseDirectory,
             name: name,
             copyIgnored: copyIgnored,
             copyUntracked: copyUntracked,
-            baseRef: resolvedBaseRef
+            baseRef: resolvedBaseRef,
+            directoryOverride: directoryOverride
           )
           await send(
             .worktreeCreation(
@@ -470,7 +492,8 @@ extension RepositoriesFeature {
             worktreeBaseDirectory,
             copyIgnored,
             copyUntracked,
-            resolvedBaseRef
+            resolvedBaseRef,
+            directoryOverride
           )
           for try await event in stream {
             switch event {

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+WorktreeState.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+WorktreeState.swift
@@ -184,7 +184,8 @@ nonisolated func worktreeCreateCommand(
   name: String,
   copyIgnored: Bool,
   copyUntracked: Bool,
-  baseRef: String
+  baseRef: String,
+  directoryOverride: URL? = nil
 ) -> String {
   let baseDir = baseDirectoryURL.path(percentEncoded: false)
   var parts = ["wt", "--base-dir", baseDir, "sw"]
@@ -197,6 +198,10 @@ nonisolated func worktreeCreateCommand(
   if !baseRef.isEmpty {
     parts.append("--from")
     parts.append(baseRef)
+  }
+  if let directoryOverride {
+    parts.append("--path")
+    parts.append(directoryOverride.path(percentEncoded: false))
   }
   if copyIgnored || copyUntracked {
     parts.append("--verbose")

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -96,7 +96,8 @@ struct RepositoriesFeature {
       repositoryID: Repository.ID,
       nameSource: WorktreeCreationNameSource,
       baseRefSource: WorktreeCreationBaseRefSource,
-      fetchRemote: Bool
+      fetchRemote: Bool,
+      placement: WorktreePlacementOverride = WorktreePlacementOverride()
     )
     case promptedWorktreeCreationDataLoaded(
       repositoryID: Repository.ID,
@@ -107,13 +108,15 @@ struct RepositoriesFeature {
     case startPromptedWorktreeCreation(
       repositoryID: Repository.ID,
       branchName: String,
-      baseRef: String?
+      baseRef: String?,
+      placement: WorktreePlacementOverride = WorktreePlacementOverride()
     )
     case promptedWorktreeCreationChecked(
       repositoryID: Repository.ID,
       branchName: String,
       baseRef: String?,
       fetchRemote: Bool,
+      placement: WorktreePlacementOverride = WorktreePlacementOverride(),
       duplicateMessage: String?
     )
     case pendingWorktreeProgressUpdated(id: Worktree.ID, progress: WorktreeCreationProgress)

--- a/supacode/Features/Repositories/Reducer/WorktreeCreationPromptFeature.swift
+++ b/supacode/Features/Repositories/Reducer/WorktreeCreationPromptFeature.swift
@@ -6,17 +6,52 @@ struct WorktreeCreationPromptFeature {
   @ObservableState
   struct State: Equatable {
     let repositoryID: Repository.ID
+    /// Canonical repository root, used to resolve relative path overrides in the
+    /// preview the same way the reducer does (not reconstructed from the ID).
+    let repositoryRootURL: URL
     let repositoryName: String
     let automaticBaseRef: String
     let baseRefOptions: [String]
     var branchName: String
     var selectedBaseRef: String?
     var fetchRemote: Bool
+    /// Resolved default base directory, used to compute the location preview.
+    let defaultWorktreeBaseDirectory: String
+    /// Leaf folder name override; empty falls back to the branch name.
+    var worktreeNameOverride: String = ""
+    /// Parent directory override; empty falls back to `defaultWorktreeBaseDirectory`.
+    var worktreePathOverride: String = ""
+    /// Disclosure state for the advanced placement section. Collapsed by default.
+    var showAdvancedOptions: Bool = false
     var validationMessage: String?
     var isValidating = false
 
     var automaticBaseRefLabel: String {
       automaticBaseRef.isEmpty ? "Automatic" : "Automatic (\(automaticBaseRef))"
+    }
+
+    /// Default leaf folder name shown as the name-override placeholder.
+    var worktreeNamePlaceholder: String {
+      branchName.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// Live validity of the current name override, so the footer can flag an
+    /// invalid leaf instead of previewing a destination submit will reject.
+    var worktreeNameValidationError: String? {
+      WorktreePlacementOverride.nameValidationError(worktreeNameOverride)
+    }
+
+    /// Full destination path the worktree will be created at, mirroring the
+    /// reducer's resolution.
+    var resolvedWorktreeLocationPreview: String {
+      SupacodePaths.previewWorktreeDirectory(
+        defaultBaseDirectory: URL(filePath: defaultWorktreeBaseDirectory, directoryHint: .isDirectory),
+        repositoryRootURL: repositoryRootURL,
+        nameOverride: worktreeNameOverride,
+        pathOverride: worktreePathOverride,
+        branchName: branchName
+      )
+      .path(percentEncoded: false)
     }
   }
 
@@ -32,7 +67,12 @@ struct WorktreeCreationPromptFeature {
   @CasePathable
   enum Delegate: Equatable {
     case cancel
-    case submit(repositoryID: Repository.ID, branchName: String, baseRef: String?)
+    case submit(
+      repositoryID: Repository.ID,
+      branchName: String,
+      baseRef: String?,
+      placement: WorktreePlacementOverride
+    )
   }
 
   var body: some Reducer<State, Action> {
@@ -56,13 +96,23 @@ struct WorktreeCreationPromptFeature {
           state.validationMessage = "Branch names can't contain spaces."
           return .none
         }
+        let nameOverride = state.worktreeNameOverride.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let nameError = WorktreePlacementOverride.nameValidationError(nameOverride) {
+          state.validationMessage = nameError
+          return .none
+        }
         state.validationMessage = nil
+        let pathOverride = state.worktreePathOverride.trimmingCharacters(in: .whitespacesAndNewlines)
         return .send(
           .delegate(
             .submit(
               repositoryID: state.repositoryID,
               branchName: trimmed,
-              baseRef: state.selectedBaseRef
+              baseRef: state.selectedBaseRef,
+              placement: WorktreePlacementOverride(
+                name: nameOverride.isEmpty ? nil : nameOverride,
+                path: pathOverride.isEmpty ? nil : pathOverride
+              )
             )
           )
         )

--- a/supacode/Features/Repositories/Views/WorktreeCreationPromptView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeCreationPromptView.swift
@@ -45,10 +45,39 @@ struct WorktreeCreationPromptView: View {
           .foregroundStyle(.secondary)
       }
 
-      if let validationMessage = store.validationMessage, !validationMessage.isEmpty {
-        Text(validationMessage)
+      DisclosureGroup("Advanced", isExpanded: $store.showAdvancedOptions) {
+        VStack(alignment: .leading, spacing: 8) {
+          TextField(
+            "Worktree name",
+            text: $store.worktreeNameOverride,
+            prompt: Text(store.worktreeNamePlaceholder)
+          )
+          .textFieldStyle(.roundedBorder)
+          TextField(
+            "Parent folder",
+            text: $store.worktreePathOverride,
+            prompt: Text(store.defaultWorktreeBaseDirectory)
+          )
+          .textFieldStyle(.roundedBorder)
+        }
+        .padding(.top, 4)
+      }
+
+      // Footer: surface a validation error, otherwise preview the full destination
+      // path the worktree will be created at (mirrors the reducer's resolution).
+      if let message = store.validationMessage ?? store.worktreeNameValidationError, !message.isEmpty {
+        Text(message)
           .font(.footnote)
           .foregroundStyle(.red)
+      } else {
+        Text(store.resolvedWorktreeLocationPreview)
+          .font(.footnote)
+          .monospaced()
+          .foregroundStyle(.secondary)
+          .textSelection(.enabled)
+          .lineLimit(2)
+          .truncationMode(.middle)
+          .frame(maxWidth: .infinity, alignment: .leading)
       }
 
       HStack {

--- a/supacode/Support/SupacodePaths.swift
+++ b/supacode/Support/SupacodePaths.swift
@@ -76,6 +76,80 @@ nonisolated enum SupacodePaths {
     )
   }
 
+  /// Resolves an explicit worktree directory from the dialog's optional name /
+  /// path overrides. Returns `nil` when neither is set so callers keep `wt`'s
+  /// default `base/<branch>` placement. The path override sets the parent
+  /// directory (default: the resolved base); the name override sets the leaf
+  /// folder (default: the branch name).
+  static func resolvedWorktreeDirectory(
+    defaultBaseDirectory: URL,
+    repositoryRootURL: URL,
+    nameOverride: String?,
+    pathOverride: String?,
+    branchName: String
+  ) -> URL? {
+    let trimmedName = nameOverride?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    let trimmedPath = pathOverride?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    guard !trimmedName.isEmpty || !trimmedPath.isEmpty else {
+      return nil
+    }
+    return worktreePlacement(
+      defaultBaseDirectory: defaultBaseDirectory,
+      repositoryRootURL: repositoryRootURL,
+      trimmedName: trimmedName,
+      trimmedPath: trimmedPath,
+      branchName: branchName
+    )
+  }
+
+  /// Always-concrete counterpart to `resolvedWorktreeDirectory` for the dialog's
+  /// live destination preview. Falls back to the default base and branch name
+  /// when the overrides are empty.
+  static func previewWorktreeDirectory(
+    defaultBaseDirectory: URL,
+    repositoryRootURL: URL,
+    nameOverride: String?,
+    pathOverride: String?,
+    branchName: String
+  ) -> URL {
+    worktreePlacement(
+      defaultBaseDirectory: defaultBaseDirectory,
+      repositoryRootURL: repositoryRootURL,
+      trimmedName: nameOverride?.trimmingCharacters(in: .whitespacesAndNewlines) ?? "",
+      trimmedPath: pathOverride?.trimmingCharacters(in: .whitespacesAndNewlines) ?? "",
+      branchName: branchName
+    )
+  }
+
+  /// Shared base + leaf join for both resolvers. `trimmedName` / `trimmedPath`
+  /// are expected pre-trimmed by callers; only the branch-name fallback is
+  /// re-trimmed defensively.
+  private static func worktreePlacement(
+    defaultBaseDirectory: URL,
+    repositoryRootURL: URL,
+    trimmedName: String,
+    trimmedPath: String,
+    branchName: String
+  ) -> URL {
+    let baseURL: URL
+    if let normalizedPath = normalizedWorktreeBaseDirectoryPath(
+      trimmedPath,
+      repositoryRootURL: repositoryRootURL
+    ) {
+      baseURL = URL(filePath: normalizedPath, directoryHint: .isDirectory).standardizedFileURL
+    } else {
+      baseURL = defaultBaseDirectory.standardizedFileURL
+    }
+    let leaf =
+      trimmedName.isEmpty
+      ? branchName.trimmingCharacters(in: .whitespacesAndNewlines)
+      : trimmedName
+    guard !leaf.isEmpty else {
+      return baseURL
+    }
+    return baseURL.appending(path: leaf, directoryHint: .isDirectory).standardizedFileURL
+  }
+
   static func worktreeBaseDirectory(
     for repositoryRootURL: URL,
     globalDefaultPath: String?,

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -1610,12 +1610,18 @@ struct RepositoriesFeatureTests {
     await store.receive(\.worktreeCreation.promptedWorktreeCreationDataLoaded) {
       $0.worktreeCreationPrompt = WorktreeCreationPromptFeature.State(
         repositoryID: repository.id,
+        repositoryRootURL: repository.rootURL,
         repositoryName: repository.name,
         automaticBaseRef: "origin/main",
         baseRefOptions: ["origin/dev", "origin/main"],
         branchName: "",
         selectedBaseRef: nil,
         fetchRemote: true,
+        defaultWorktreeBaseDirectory: SupacodePaths.worktreeBaseDirectory(
+          for: repository.rootURL,
+          globalDefaultPath: nil,
+          repositoryOverridePath: nil
+        ).path(percentEncoded: false),
         validationMessage: nil
       )
     }
@@ -1628,12 +1634,14 @@ struct RepositoriesFeatureTests {
     var state = makeState(repositories: [repository])
     state.worktreeCreationPrompt = WorktreeCreationPromptFeature.State(
       repositoryID: repository.id,
+      repositoryRootURL: repository.rootURL,
       repositoryName: repository.name,
       automaticBaseRef: "origin/main",
       baseRefOptions: ["origin/main"],
       branchName: "feature/new-branch",
       selectedBaseRef: nil,
       fetchRemote: true,
+      defaultWorktreeBaseDirectory: "",
       validationMessage: nil
     )
     let store = TestStore(initialState: state) {
@@ -1653,12 +1661,14 @@ struct RepositoriesFeatureTests {
     var state = makeState(repositories: [repository])
     state.worktreeCreationPrompt = WorktreeCreationPromptFeature.State(
       repositoryID: repository.id,
+      repositoryRootURL: repository.rootURL,
       repositoryName: repository.name,
       automaticBaseRef: "origin/main",
       baseRefOptions: ["origin/main"],
       branchName: "feature/existing",
       selectedBaseRef: nil,
       fetchRemote: true,
+      defaultWorktreeBaseDirectory: "",
       validationMessage: nil
     )
     let store = TestStore(initialState: state) {
@@ -1736,12 +1746,18 @@ struct RepositoriesFeatureTests {
     await store.receive(\.worktreeCreation.promptedWorktreeCreationDataLoaded) {
       $0.worktreeCreationPrompt = WorktreeCreationPromptFeature.State(
         repositoryID: repoB.id,
+        repositoryRootURL: repoB.rootURL,
         repositoryName: repoB.name,
         automaticBaseRef: "origin/main",
         baseRefOptions: ["origin/main"],
         branchName: "",
         selectedBaseRef: nil,
         fetchRemote: true,
+        defaultWorktreeBaseDirectory: SupacodePaths.worktreeBaseDirectory(
+          for: repoB.rootURL,
+          globalDefaultPath: nil,
+          repositoryOverridePath: nil
+        ).path(percentEncoded: false),
         validationMessage: nil
       )
     }
@@ -1756,12 +1772,14 @@ struct RepositoriesFeatureTests {
     var state = makeState(repositories: [repository])
     state.worktreeCreationPrompt = WorktreeCreationPromptFeature.State(
       repositoryID: repository.id,
+      repositoryRootURL: repository.rootURL,
       repositoryName: repository.name,
       automaticBaseRef: "origin/main",
       baseRefOptions: ["origin/main"],
       branchName: "feature/new-branch",
       selectedBaseRef: nil,
       fetchRemote: true,
+      defaultWorktreeBaseDirectory: "",
       validationMessage: nil
     )
     let store = TestStore(initialState: state) {
@@ -1898,7 +1916,7 @@ struct RepositoriesFeatureTests {
       $0.gitClient.automaticWorktreeBaseRef = { _ in "origin/main" }
       $0.gitClient.ignoredFileCount = { _ in 2 }
       $0.gitClient.untrackedFileCount = { _ in 1 }
-      $0.gitClient.createWorktreeStream = { _, _, _, _, _, _ in
+      $0.gitClient.createWorktreeStream = { _, _, _, _, _, _, _ in
         AsyncThrowingStream { continuation in
           continuation.yield(.outputLine(ShellStreamLine(source: .stderr, text: "[1/2] copy .env")))
           continuation.yield(.outputLine(ShellStreamLine(source: .stderr, text: "[2/2] copy .cache")))
@@ -1946,7 +1964,7 @@ struct RepositoriesFeatureTests {
       }
       $0.gitClient.ignoredFileCount = { _ in 0 }
       $0.gitClient.untrackedFileCount = { _ in 0 }
-      $0.gitClient.createWorktreeStream = { _, _, _, _, _, _ in
+      $0.gitClient.createWorktreeStream = { _, _, _, _, _, _, _ in
         events.withValue { $0.append("create") }
         return AsyncThrowingStream { continuation in
           continuation.yield(.finished(createdWorktree))
@@ -1997,7 +2015,7 @@ struct RepositoriesFeatureTests {
       }
       $0.gitClient.ignoredFileCount = { _ in 0 }
       $0.gitClient.untrackedFileCount = { _ in 0 }
-      $0.gitClient.createWorktreeStream = { _, _, _, _, _, _ in
+      $0.gitClient.createWorktreeStream = { _, _, _, _, _, _, _ in
         AsyncThrowingStream { continuation in
           continuation.yield(.finished(createdWorktree))
           continuation.finish()
@@ -2042,7 +2060,7 @@ struct RepositoriesFeatureTests {
       }
       $0.gitClient.ignoredFileCount = { _ in 0 }
       $0.gitClient.untrackedFileCount = { _ in 0 }
-      $0.gitClient.createWorktreeStream = { _, _, _, _, _, _ in
+      $0.gitClient.createWorktreeStream = { _, _, _, _, _, _, _ in
         AsyncThrowingStream { continuation in
           continuation.yield(.finished(createdWorktree))
           continuation.finish()
@@ -2087,7 +2105,7 @@ struct RepositoriesFeatureTests {
       }
       $0.gitClient.ignoredFileCount = { _ in 0 }
       $0.gitClient.untrackedFileCount = { _ in 0 }
-      $0.gitClient.createWorktreeStream = { _, _, _, _, _, _ in
+      $0.gitClient.createWorktreeStream = { _, _, _, _, _, _, _ in
         AsyncThrowingStream { continuation in
           continuation.yield(.finished(createdWorktree))
           continuation.finish()
@@ -2139,7 +2157,7 @@ struct RepositoriesFeatureTests {
       $0.gitClient.automaticWorktreeBaseRef = { _ in "origin/main" }
       $0.gitClient.ignoredFileCount = { _ in 0 }
       $0.gitClient.untrackedFileCount = { _ in 0 }
-      $0.gitClient.createWorktreeStream = { _, _, baseDirectory, _, _, _ in
+      $0.gitClient.createWorktreeStream = { _, _, baseDirectory, _, _, _, _ in
         observedBaseDirectory.withValue { $0 = baseDirectory }
         return AsyncThrowingStream { continuation in
           continuation.yield(.finished(createdWorktree))
@@ -2191,7 +2209,7 @@ struct RepositoriesFeatureTests {
       $0.gitClient.automaticWorktreeBaseRef = { _ in "origin/main" }
       $0.gitClient.ignoredFileCount = { _ in 0 }
       $0.gitClient.untrackedFileCount = { _ in 0 }
-      $0.gitClient.createWorktreeStream = { _, _, baseDirectory, _, _, _ in
+      $0.gitClient.createWorktreeStream = { _, _, baseDirectory, _, _, _, _ in
         observedBaseDirectory.withValue { $0 = baseDirectory }
         return AsyncThrowingStream { continuation in
           continuation.yield(.finished(createdWorktree))
@@ -2244,7 +2262,7 @@ struct RepositoriesFeatureTests {
       $0.gitClient.automaticWorktreeBaseRef = { _ in "origin/main" }
       $0.gitClient.ignoredFileCount = { _ in 0 }
       $0.gitClient.untrackedFileCount = { _ in 0 }
-      $0.gitClient.createWorktreeStream = { _, _, _, copyIgnored, copyUntracked, _ in
+      $0.gitClient.createWorktreeStream = { _, _, _, copyIgnored, copyUntracked, _, _ in
         observedCopyFlags.withValue { $0 = (copyIgnored, copyUntracked) }
         return AsyncThrowingStream { continuation in
           continuation.yield(.finished(createdWorktree))
@@ -2293,7 +2311,7 @@ struct RepositoriesFeatureTests {
       $0.gitClient.automaticWorktreeBaseRef = { _ in "origin/main" }
       $0.gitClient.ignoredFileCount = { _ in 0 }
       $0.gitClient.untrackedFileCount = { _ in 0 }
-      $0.gitClient.createWorktreeStream = { _, _, _, copyIgnored, copyUntracked, _ in
+      $0.gitClient.createWorktreeStream = { _, _, _, copyIgnored, copyUntracked, _, _ in
         observedCopyFlags.withValue { $0 = (copyIgnored, copyUntracked) }
         return AsyncThrowingStream { continuation in
           continuation.yield(.finished(createdWorktree))
@@ -2330,7 +2348,7 @@ struct RepositoriesFeatureTests {
       $0.gitClient.automaticWorktreeBaseRef = { _ in "origin/main" }
       $0.gitClient.ignoredFileCount = { _ in 2 }
       $0.gitClient.untrackedFileCount = { _ in 1 }
-      $0.gitClient.createWorktreeStream = { _, _, _, _, _, _ in
+      $0.gitClient.createWorktreeStream = { _, _, _, _, _, _, _ in
         AsyncThrowingStream { continuation in
           continuation.yield(.outputLine(ShellStreamLine(source: .stderr, text: "[1/2] copy .env")))
           continuation.finish(throwing: GitClientError.commandFailed(command: "wt sw", message: "boom"))

--- a/supacodeTests/WorktreeCreationPlacementTests.swift
+++ b/supacodeTests/WorktreeCreationPlacementTests.swift
@@ -1,0 +1,194 @@
+import ComposableArchitecture
+import Foundation
+import Testing
+
+@testable import supacode
+
+struct WorktreeCreationPlacementTests {
+  // MARK: - Name validation
+
+  @Test func emptyNameIsValid() {
+    #expect(WorktreePlacementOverride.nameValidationError(nil) == nil)
+    #expect(WorktreePlacementOverride.nameValidationError("") == nil)
+    #expect(WorktreePlacementOverride.nameValidationError("   ") == nil)
+  }
+
+  @Test func plainNameIsValid() {
+    #expect(WorktreePlacementOverride.nameValidationError("my-worktree") == nil)
+  }
+
+  @Test func slashesAreRejected() {
+    #expect(WorktreePlacementOverride.nameValidationError("a/b") != nil)
+    #expect(WorktreePlacementOverride.nameValidationError("a\\b") != nil)
+  }
+
+  @Test func dotSegmentsAndGitAreRejected() {
+    #expect(WorktreePlacementOverride.nameValidationError(".") != nil)
+    #expect(WorktreePlacementOverride.nameValidationError("..") != nil)
+    #expect(WorktreePlacementOverride.nameValidationError(".git") != nil)
+    #expect(WorktreePlacementOverride.nameValidationError(".GIT") != nil)
+  }
+
+  // MARK: - resolvedWorktreeDirectory
+
+  private let defaultBase = URL(filePath: "/tmp/base", directoryHint: .isDirectory)
+  private let repoRoot = URL(filePath: "/tmp/repo", directoryHint: .isDirectory)
+
+  /// Compares paths ignoring a trailing slash. The resolved URLs use
+  /// `directoryHint: .isDirectory`, so `path(percentEncoded:)` may keep a
+  /// trailing slash — harmless for `wt --path` and the preview, but we don't
+  /// want the assertions to depend on it.
+  private func path(_ url: URL?) -> String? {
+    guard let value = url?.path(percentEncoded: false) else { return nil }
+    return value.count > 1 && value.hasSuffix("/") ? String(value.dropLast()) : value
+  }
+
+  @Test func noOverridesResolvesToNil() {
+    let resolved = SupacodePaths.resolvedWorktreeDirectory(
+      defaultBaseDirectory: defaultBase,
+      repositoryRootURL: repoRoot,
+      nameOverride: nil,
+      pathOverride: nil,
+      branchName: "feature/x"
+    )
+    #expect(resolved == nil)
+  }
+
+  @Test func nameOnlyOverridesLeafUnderDefaultBase() {
+    let resolved = SupacodePaths.resolvedWorktreeDirectory(
+      defaultBaseDirectory: defaultBase,
+      repositoryRootURL: repoRoot,
+      nameOverride: "custom-leaf",
+      pathOverride: nil,
+      branchName: "feature/x"
+    )
+    #expect(path(resolved) == "/tmp/base/custom-leaf")
+  }
+
+  @Test func pathOnlyOverridesParentKeepingBranchLeaf() {
+    let resolved = SupacodePaths.resolvedWorktreeDirectory(
+      defaultBaseDirectory: defaultBase,
+      repositoryRootURL: repoRoot,
+      nameOverride: nil,
+      pathOverride: "/other/parent",
+      branchName: "mybranch"
+    )
+    #expect(path(resolved) == "/other/parent/mybranch")
+  }
+
+  @Test func bothOverridesCombineParentAndLeaf() {
+    let resolved = SupacodePaths.resolvedWorktreeDirectory(
+      defaultBaseDirectory: defaultBase,
+      repositoryRootURL: repoRoot,
+      nameOverride: "leaf",
+      pathOverride: "/other/parent",
+      branchName: "mybranch"
+    )
+    #expect(path(resolved) == "/other/parent/leaf")
+  }
+
+  @Test func whitespaceOnlyOverridesResolveToNil() {
+    let resolved = SupacodePaths.resolvedWorktreeDirectory(
+      defaultBaseDirectory: defaultBase,
+      repositoryRootURL: repoRoot,
+      nameOverride: "  ",
+      pathOverride: "  ",
+      branchName: "feature/x"
+    )
+    #expect(resolved == nil)
+  }
+
+  // MARK: - previewWorktreeDirectory
+
+  @Test func previewFallsBackToDefaultBaseAndBranchWhenEmpty() {
+    let preview = SupacodePaths.previewWorktreeDirectory(
+      defaultBaseDirectory: defaultBase,
+      repositoryRootURL: repoRoot,
+      nameOverride: "",
+      pathOverride: "",
+      branchName: "feature-x"
+    )
+    #expect(path(preview) == "/tmp/base/feature-x")
+  }
+
+  @Test func previewReflectsOverrides() {
+    let preview = SupacodePaths.previewWorktreeDirectory(
+      defaultBaseDirectory: defaultBase,
+      repositoryRootURL: repoRoot,
+      nameOverride: "leaf",
+      pathOverride: "/p",
+      branchName: "feature-x"
+    )
+    #expect(path(preview) == "/p/leaf")
+  }
+}
+
+@MainActor
+struct WorktreeCreationPromptPlacementTests {
+  private func makeState(
+    nameOverride: String = "",
+    pathOverride: String = ""
+  ) -> WorktreeCreationPromptFeature.State {
+    WorktreeCreationPromptFeature.State(
+      repositoryID: "/tmp/repo",
+      repositoryRootURL: URL(filePath: "/tmp/repo", directoryHint: .isDirectory),
+      repositoryName: "repo",
+      automaticBaseRef: "origin/main",
+      baseRefOptions: ["origin/main"],
+      branchName: "feature/x",
+      selectedBaseRef: nil,
+      fetchRemote: false,
+      defaultWorktreeBaseDirectory: "/tmp/base",
+      worktreeNameOverride: nameOverride,
+      worktreePathOverride: pathOverride,
+      validationMessage: nil
+    )
+  }
+
+  @Test func createCarriesPlacementOverridesInSubmit() async {
+    let store = TestStore(initialState: makeState(nameOverride: "leaf", pathOverride: "/parent")) {
+      WorktreeCreationPromptFeature()
+    }
+
+    await store.send(.createButtonTapped)
+    await store.receive(
+      .delegate(
+        .submit(
+          repositoryID: "/tmp/repo",
+          branchName: "feature/x",
+          baseRef: nil,
+          placement: WorktreePlacementOverride(name: "leaf", path: "/parent")
+        )
+      )
+    )
+  }
+
+  @Test func createWithoutOverridesSubmitsEmptyPlacement() async {
+    let store = TestStore(initialState: makeState()) {
+      WorktreeCreationPromptFeature()
+    }
+
+    await store.send(.createButtonTapped)
+    await store.receive(
+      .delegate(
+        .submit(
+          repositoryID: "/tmp/repo",
+          branchName: "feature/x",
+          baseRef: nil,
+          placement: WorktreePlacementOverride(name: nil, path: nil)
+        )
+      )
+    )
+  }
+
+  @Test func invalidNameOverrideBlocksSubmit() async {
+    let store = TestStore(initialState: makeState(nameOverride: "bad/leaf")) {
+      WorktreeCreationPromptFeature()
+    }
+
+    await store.send(.createButtonTapped) {
+      $0.validationMessage = "Worktree name can't contain slashes."
+    }
+    // No delegate.submit is emitted.
+  }
+}


### PR DESCRIPTION
## What

Adds a default-collapsed **Advanced** section to the New Worktree dialog with two optional overrides:
- **Worktree name** — the leaf folder name (placeholder: the branch name).
- **Parent folder** — the directory it's created in (placeholder: the repo's resolved base directory).

Both blank keeps `wt`'s default `base/<branch>` placement (zero behavior change). The footer previews the full destination path live, or shows an inline validation error.

Ported from upstream supacode #351 (GUI only).

## Why

Previously the worktree folder always landed at `<defaultBase>/<branch>`, with no per-creation control — the only way to change location was the global / per-repo default base directory (coarse, affects everything). This gives fine-grained, opt-in placement.

## How

- **`WorktreePlacementOverride`** — optional `name` / `path`; `nameValidationError` rejects slashes, `.`/`..`, `.git` (the leaf is a single folder). Shared by the prompt and the reducer's create path.
- **`SupacodePaths`** — `resolvedWorktreeDirectory` (returns `nil` when no override, so callers keep the default) and `previewWorktreeDirectory` (always concrete, for the live preview).
- The override threads `submit → startPromptedWorktreeCreation → promptedWorktreeCreationChecked → createWorktreeInRepository` as a **defaulted** `placement` (so the random-worktree path is untouched), and is applied via **`wt sw --path <dir>`** — the branch stays the positional arg, so the sidebar name still tracks the branch. The progress command preview includes `--path` too.
- Dialog uses a `DisclosureGroup` (fork's prompt is a hand-built `VStack`, not a `Form`); the fork's bundled `wt` already supports `sw --path`.

Not ported: upstream's `worktree-new --name/--location` CLI and `repo/.../worktree/new` deeplink params — the fork's `prowl` CLI has no worktree-management commands and there's no deeplink subsystem.

## Tests

- **`WorktreeCreationPlacementTests`** (new): `nameValidationError` (empty / plain / slashes / dot-segments / `.git`); `resolvedWorktreeDirectory` & `previewWorktreeDirectory` (no-override → nil, name-only, path-only, both, whitespace, preview fallback). Slash-insensitive path comparison (the URLs are directory-hinted).
- **`WorktreeCreationPromptPlacementTests`** (new): create carries overrides in `submit`; empty overrides → empty placement; invalid name blocks submit with the inline message.
- Updated existing `RepositoriesFeatureTests` for the new prompt-state fields and 7-arg `createWorktreeStream` closures.
- `make build-app` ✅ · `make check` ✅ · new tests 14/14 ✅ · `RepositoriesFeatureTests` 173/173 ✅
- `docs/components/repositories-and-worktrees.md` updated for the Advanced section.
