### PR TITLE
Show GitHub merge queue state in the PR popover, sidebar, and badges

### DIFF
--- a/docs/components/github-pull-requests.md
+++ b/docs/components/github-pull-requests.md
@@ -23,6 +23,10 @@ itself.
   expected / skipped) with failing/success counts and per-check detail URLs.
 - **Merge readiness:** Prowl evaluates blockers in order — merge conflicts,
   changes requested, failed checks, other non-mergeable states.
+- **Merge queue:** for repos that use GitHub merge queues, an open PR waiting in
+  the queue shows a brown **Queued** state in the sidebar and badges, and the PR
+  checks popover adds an "In merge queue" row with its position and estimated
+  time remaining.
 
 PR status can surface as a badge on the worktree and as a summary in the command
 palette.

--- a/supacode/Clients/Github/GithubCLIClient.swift
+++ b/supacode/Clients/Github/GithubCLIClient.swift
@@ -537,6 +537,11 @@ nonisolated private func makeCrossRepoBatchQuery(
                 name
                 owner { login }
               }
+              mergeQueueEntry {
+                position
+                estimatedTimeToMerge
+                state
+              }
               statusCheckRollup {
                 contexts(first: 100) {
                   nodes {
@@ -954,6 +959,11 @@ nonisolated private func makeBatchPullRequestsQuery(
           headRepository {
             name
             owner { login }
+          }
+          mergeQueueEntry {
+            position
+            estimatedTimeToMerge
+            state
           }
           statusCheckRollup {
             contexts(first: 100) {

--- a/supacode/Clients/Github/GithubGraphQLPullRequestResponse.swift
+++ b/supacode/Clients/Github/GithubGraphQLPullRequestResponse.swift
@@ -106,6 +106,7 @@ nonisolated struct GithubGraphQLPullRequestResponse: Decodable {
     let commits: CommitConnection?
     let author: PullRequestAuthor?
     let statusCheckRollup: GithubPullRequestStatusCheckRollup?
+    let mergeQueueEntry: GithubMergeQueueEntry?
     let headRepository: HeadRepository?
 
     var pullRequest: GithubPullRequest {
@@ -125,7 +126,8 @@ nonisolated struct GithubGraphQLPullRequestResponse: Decodable {
         baseRefName: baseRefName,
         commitsCount: commits?.totalCount,
         authorLogin: author?.login,
-        statusCheckRollup: statusCheckRollup
+        statusCheckRollup: statusCheckRollup,
+        mergeQueueEntry: mergeQueueEntry
       )
     }
 

--- a/supacode/Clients/Github/GithubMergeQueueEntry.swift
+++ b/supacode/Clients/Github/GithubMergeQueueEntry.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+nonisolated struct GithubMergeQueueEntry: Decodable, Equatable, Hashable {
+  // GitHub's queue `position` is observed to be 0-based; `displayPosition` renders it 1-based.
+  let position: Int
+  let estimatedTimeToMerge: Int?
+  let state: String?
+
+  var displayPosition: Int {
+    position + 1
+  }
+}

--- a/supacode/Clients/Github/GithubPullRequest.swift
+++ b/supacode/Clients/Github/GithubPullRequest.swift
@@ -17,4 +17,8 @@ nonisolated struct GithubPullRequest: Decodable, Equatable, Hashable {
   let commitsCount: Int?
   let authorLogin: String?
   let statusCheckRollup: GithubPullRequestStatusCheckRollup?
+  // `var` (rather than `let`) keeps it decodable and gives the memberwise init an
+  // implicit `nil` default, so existing construction sites (tests, caches) compile
+  // unchanged; only the GraphQL decode path populates it.
+  var mergeQueueEntry: GithubMergeQueueEntry?
 }

--- a/supacode/Clients/Github/PullRequestMergeQueueStatus.swift
+++ b/supacode/Clients/Github/PullRequestMergeQueueStatus.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+nonisolated struct PullRequestMergeQueueStatus: Equatable, Hashable {
+  enum State: Equatable, Hashable {
+    case queued
+    case awaitingChecks
+    case mergeable
+    case unmergeable
+    case locked
+    case unknown
+
+    init(rawValue: String?) {
+      switch rawValue?.uppercased() {
+      case "QUEUED": self = .queued
+      case "AWAITING_CHECKS": self = .awaitingChecks
+      case "MERGEABLE": self = .mergeable
+      case "UNMERGEABLE": self = .unmergeable
+      case "LOCKED": self = .locked
+      default: self = .unknown
+      }
+    }
+  }
+
+  let position: Int
+  let estimatedTimeToMerge: Int?
+  let state: State
+
+  // Only an open, non-draft PR with a live queue entry is in the merge queue, so a stale entry
+  // on a merged / draft PR never surfaces as queued across the sidebar and popover.
+  init?(pullRequest: GithubPullRequest) {
+    guard pullRequest.state.uppercased() == "OPEN",
+      !pullRequest.isDraft,
+      let entry = pullRequest.mergeQueueEntry
+    else { return nil }
+    self.position = entry.displayPosition
+    self.estimatedTimeToMerge = entry.estimatedTimeToMerge
+    self.state = State(rawValue: entry.state)
+  }
+
+  var summary: String {
+    switch state {
+    case .awaitingChecks:
+      return "Awaiting checks in merge queue"
+    case .unmergeable:
+      return "Cannot merge from queue"
+    case .locked:
+      return "Merge queue locked"
+    case .queued, .mergeable, .unknown:
+      return "In merge queue"
+    }
+  }
+
+  var positionLabel: String {
+    "Position \(position)"
+  }
+
+  var estimatedTimeLabel: String? {
+    guard let estimatedTimeToMerge, estimatedTimeToMerge > 0 else { return nil }
+    guard estimatedTimeToMerge >= 60 else { return "<1 min left" }
+    let formatted = Duration.seconds(estimatedTimeToMerge)
+      .formatted(.units(allowed: [.days, .hours, .minutes], width: .abbreviated, maximumUnitCount: 2))
+    return "~\(formatted) left"
+  }
+
+  var detail: String? {
+    let parts = [positionLabel, estimatedTimeLabel].compactMap { $0 }
+    return parts.isEmpty ? nil : parts.joined(separator: " · ")
+  }
+}

--- a/supacode/Features/Repositories/Views/PullRequestBadgeView.swift
+++ b/supacode/Features/Repositories/Views/PullRequestBadgeView.swift
@@ -3,8 +3,9 @@ import SwiftUI
 enum PullRequestBadgeStyle {
   static let mergedColor = Color.purple
   static let openColor = Color.green
+  static let queuedColor = Color.brown
 
-  static func style(state: String?, number: Int?) -> (text: String, color: Color)? {
+  static func style(state: String?, number: Int?, isQueued: Bool = false) -> (text: String, color: Color)? {
     guard let state = state?.uppercased() else {
       return nil
     }
@@ -12,7 +13,7 @@ enum PullRequestBadgeStyle {
     case "MERGED":
       return (text: number.map { "#\($0)" } ?? "MERGED", color: mergedColor)
     case "OPEN":
-      return (text: number.map { "#\($0)" } ?? "OPEN", color: openColor)
+      return (text: number.map { "#\($0)" } ?? "OPEN", color: isQueued ? queuedColor : openColor)
     default:
       return nil
     }

--- a/supacode/Features/Repositories/Views/PullRequestChecksPopoverView.swift
+++ b/supacode/Features/Repositories/Views/PullRequestChecksPopoverView.swift
@@ -84,6 +84,10 @@ struct PullRequestChecksPopoverView: View {
         }
         .font(.subheadline)
 
+        if let mergeQueueStatus = PullRequestMergeQueueStatus(pullRequest: pullRequest) {
+          PullRequestMergeQueueRow(status: mergeQueueStatus)
+        }
+
         if breakdown.total > 0 {
           HStack {
             PullRequestChecksRingView(breakdown: breakdown)
@@ -129,6 +133,29 @@ struct PullRequestChecksPopoverView: View {
       .padding()
     }
     .frame(minWidth: 260, maxWidth: 840, maxHeight: 720)
+  }
+
+  private struct PullRequestMergeQueueRow: View {
+    let status: PullRequestMergeQueueStatus
+
+    var body: some View {
+      VStack(alignment: .leading, spacing: 2) {
+        HStack(spacing: 6) {
+          Image(systemName: "arrow.triangle.merge")
+            .foregroundStyle(.brown)
+            .accessibilityHidden(true)
+          Text(status.summary)
+            .foregroundStyle(.brown)
+        }
+        .font(.subheadline)
+        if let detail = status.detail {
+          Text(detail)
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        }
+      }
+      .accessibilityElement(children: .combine)
+    }
   }
 
   private static func sortRank(for state: GithubPullRequestCheckState) -> Int {

--- a/supacode/Features/Repositories/Views/WorktreePullRequestAccessoryView.swift
+++ b/supacode/Features/Repositories/Views/WorktreePullRequestAccessoryView.swift
@@ -15,11 +15,13 @@ struct WorktreePullRequestDisplay {
     let displayPullRequest = matchesWorktree ? pullRequest : nil
     let pullRequestState = displayPullRequest?.state.uppercased()
     let pullRequestNumber = displayPullRequest?.number
+    let isQueued = displayPullRequest.flatMap(PullRequestMergeQueueStatus.init(pullRequest:)) != nil
     self.pullRequest = displayPullRequest
     self.pullRequestState = pullRequestState
     self.pullRequestBadgeStyle = PullRequestBadgeStyle.style(
       state: pullRequestState,
-      number: pullRequestNumber
+      number: pullRequestNumber,
+      isQueued: isQueued
     )
   }
 }

--- a/supacode/Features/Repositories/Views/WorktreeRow.swift
+++ b/supacode/Features/Repositories/Views/WorktreeRow.swift
@@ -35,6 +35,7 @@ struct WorktreeRow: View {
     let displayAddedLines = info?.addedLines
     let displayRemovedLines = info?.removedLines
     let mergeReadiness = pullRequestMergeReadiness(for: display.pullRequest)
+    let isQueued = display.pullRequest.flatMap(PullRequestMergeQueueStatus.init(pullRequest:)) != nil
     let hasChangeCounts = displayAddedLines != nil && displayRemovedLines != nil
     let showsPullRequestTag = display.pullRequest != nil && display.pullRequestBadgeStyle != nil
     let nameColor = colorScheme == .dark ? Color.white : Color.primary
@@ -129,6 +130,7 @@ struct WorktreeRow: View {
         pullRequestNumber: display.pullRequest?.number,
         pullRequestState: display.pullRequestState,
         mergeReadiness: mergeReadiness,
+        isQueued: isQueued,
         shortcutHint: shortcutHint,
         showsShortcutHint: showsShortcutHint
       )
@@ -179,6 +181,7 @@ private struct WorktreeRowInfoView: View {
   let pullRequestNumber: Int?
   let pullRequestState: String?
   let mergeReadiness: PullRequestMergeReadiness?
+  let isQueued: Bool
   let shortcutHint: String?
   let showsShortcutHint: Bool
 
@@ -224,6 +227,13 @@ private struct WorktreeRowInfoView: View {
       appendSeparator()
       var segment = AttributedString("Merged")
       segment.foregroundColor = PullRequestBadgeStyle.mergedColor
+      result.append(segment)
+    } else if isQueued {
+      // A queued PR is mid-merge, so the queue state takes priority over the
+      // merge-readiness label.
+      appendSeparator()
+      var segment = AttributedString("Queued")
+      segment.foregroundColor = PullRequestBadgeStyle.queuedColor
       result.append(segment)
     } else if let mergeReadiness {
       appendSeparator()

--- a/supacodeTests/PullRequestMergeQueueStatusTests.swift
+++ b/supacodeTests/PullRequestMergeQueueStatusTests.swift
@@ -1,0 +1,107 @@
+import Foundation
+import Testing
+
+@testable import supacode
+
+struct PullRequestMergeQueueStatusTests {
+  private func makePullRequest(
+    state: String = "OPEN",
+    isDraft: Bool = false,
+    mergeQueueEntry: GithubMergeQueueEntry? = nil
+  ) -> GithubPullRequest {
+    GithubPullRequest(
+      number: 1,
+      title: "PR",
+      state: state,
+      additions: 0,
+      deletions: 0,
+      isDraft: isDraft,
+      reviewDecision: nil,
+      mergeable: nil,
+      mergeStateStatus: nil,
+      updatedAt: nil,
+      url: "https://example.com/pr/1",
+      headRefName: "feature",
+      baseRefName: "main",
+      commitsCount: nil,
+      authorLogin: nil,
+      statusCheckRollup: nil,
+      mergeQueueEntry: mergeQueueEntry
+    )
+  }
+
+  private func entry(position: Int = 0, estimate: Int? = nil, state: String? = nil) -> GithubMergeQueueEntry {
+    GithubMergeQueueEntry(position: position, estimatedTimeToMerge: estimate, state: state)
+  }
+
+  // MARK: - Membership
+
+  @Test func nilWhenNoEntry() {
+    #expect(PullRequestMergeQueueStatus(pullRequest: makePullRequest()) == nil)
+  }
+
+  @Test func nilWhenNotOpenEvenWithEntry() {
+    let pullRequest = makePullRequest(state: "MERGED", mergeQueueEntry: entry())
+    #expect(PullRequestMergeQueueStatus(pullRequest: pullRequest) == nil)
+  }
+
+  @Test func nilWhenDraftEvenWithEntry() {
+    let pullRequest = makePullRequest(isDraft: true, mergeQueueEntry: entry())
+    #expect(PullRequestMergeQueueStatus(pullRequest: pullRequest) == nil)
+  }
+
+  @Test func presentForOpenNonDraftWithEntry() {
+    let pullRequest = makePullRequest(mergeQueueEntry: entry(position: 2, estimate: 120, state: "QUEUED"))
+    let status = PullRequestMergeQueueStatus(pullRequest: pullRequest)
+    #expect(status != nil)
+    // position is rendered 1-based.
+    #expect(status?.position == 3)
+    #expect(status?.state == .queued)
+  }
+
+  // MARK: - Summary
+
+  @Test func summaryByState() {
+    func summary(_ state: String?) -> String? {
+      PullRequestMergeQueueStatus(pullRequest: makePullRequest(mergeQueueEntry: entry(state: state)))?.summary
+    }
+    #expect(summary("QUEUED") == "In merge queue")
+    #expect(summary("MERGEABLE") == "In merge queue")
+    #expect(summary(nil) == "In merge queue")
+    #expect(summary("AWAITING_CHECKS") == "Awaiting checks in merge queue")
+    #expect(summary("UNMERGEABLE") == "Cannot merge from queue")
+    #expect(summary("LOCKED") == "Merge queue locked")
+  }
+
+  // MARK: - Labels
+
+  @Test func positionLabelIsOneBased() {
+    let status = PullRequestMergeQueueStatus(pullRequest: makePullRequest(mergeQueueEntry: entry(position: 0)))
+    #expect(status?.positionLabel == "Position 1")
+  }
+
+  @Test func estimatedTimeLabelEdges() {
+    func label(_ estimate: Int?) -> String? {
+      PullRequestMergeQueueStatus(pullRequest: makePullRequest(mergeQueueEntry: entry(estimate: estimate)))?
+        .estimatedTimeLabel
+    }
+    #expect(label(nil) == nil)
+    #expect(label(0) == nil)
+    #expect(label(30) == "<1 min left")
+    #expect(label(120)?.hasPrefix("~") == true)
+    #expect(label(120)?.hasSuffix("left") == true)
+  }
+
+  @Test func detailJoinsPositionAndTime() {
+    let withTime = PullRequestMergeQueueStatus(
+      pullRequest: makePullRequest(mergeQueueEntry: entry(position: 1, estimate: 120))
+    )
+    #expect(withTime?.detail?.contains("Position 2") == true)
+    #expect(withTime?.detail?.contains("·") == true)
+
+    let withoutTime = PullRequestMergeQueueStatus(
+      pullRequest: makePullRequest(mergeQueueEntry: entry(position: 1, estimate: nil))
+    )
+    #expect(withoutTime?.detail == "Position 2")
+  }
+}


### PR DESCRIPTION
## What

For repos that use **GitHub merge queues**, an open PR waiting in the queue now reads as **Queued** instead of a plain open PR:
- **Sidebar:** a brown **Queued** in the worktree summary (takes priority over the merge-readiness label).
- **PR checks popover:** an "**In merge queue**" row with **Position N** and **~X left** (estimated time).
- **Worktree PR accessory badge:** tints **brown** to match.

Ported from upstream supacode #352. You mentioned a repo that uses merge queue — this surfaces it.

## How

- Add `mergeQueueEntry { position estimatedTimeToMerge state }` to the batch PR GraphQL query (**both** the single-repo and cross-repo paths) and decode it onto `GithubPullRequest` via the new `GithubMergeQueueEntry`.
- `PullRequestMergeQueueStatus` summarizes membership for the UI: a PR is queued only when **open, non-draft, with a live entry** (a stale entry on a merged/draft PR is ignored). Position is rendered **1-based**; the estimate is "<1 min left" under a minute, "Cannot merge from queue" when unmergeable, "Merge queue locked" when locked.

## Fork adaptations / scope

- Sidebar uses `WorktreeRow`'s **text** summary ("Queued"), not upstream's icon system (the fork has no PR-icon sidebar). Label per your call.
- The popover row uses an **SF Symbol** (`arrow.triangle.merge`) instead of upstream's bundled `git-merge-queue` asset.
- The field is requested **unconditionally** — the GHES < 3.8 "retry without the field" fallback is **not** ported (github.com has supported `mergeQueueEntry` since 2023). If you point Prowl at a pre-3.8 GitHub Enterprise Server, note this.
- The toolbar status button keeps its existing color (sidebar + popover + accessory cover the surfaces); tinting it brown would require threading `isQueued` through `PullRequestStatusModel` — a small follow-up if you want it.

## Tests

- **`PullRequestMergeQueueStatusTests`** (new): membership (no entry / not-open / draft → nil; open+non-draft+entry → present, 1-based position); summary mapping per state; `positionLabel`; `estimatedTimeLabel` edges (nil / 0 / <60 / ≥60); `detail` joining.
- `GithubPullRequest.mergeQueueEntry` is a defaulted `var`, so all existing PR construction sites compile unchanged.
- `make build-app` ✅ · `make check` ✅ · new tests 8/8 ✅ · `PullRequestMergeReadinessTests` + `GithubCLIClientTests` + `BatchedPullRequestRefreshReducerTests` 39/39 ✅
- `docs/components/github-pull-requests.md` updated.
