### PR TITLE
Refactor worktree stream request API

### DIFF
--- a/supacode/Clients/Git/GitClient.swift
+++ b/supacode/Clients/Git/GitClient.swift
@@ -209,11 +209,13 @@ struct GitClient {
   ) async throws -> Worktree {
     var createdWorktree: Worktree?
     for try await event in createWorktreeStream(
-      named: name,
-      in: repoRoot,
-      baseDirectory: baseDirectory,
-      copyFiles: copyFiles,
-      baseRef: baseRef
+      GitWorktreeCreateRequest(
+        name: name,
+        repoRoot: repoRoot,
+        baseDirectory: baseDirectory,
+        copyFiles: GitWorktreeCreateRequest.CopyFiles(ignored: copyFiles.ignored, untracked: copyFiles.untracked),
+        baseRef: baseRef
+      )
     ) {
       if case .finished(let worktree) = event {
         createdWorktree = worktree
@@ -236,25 +238,20 @@ struct GitClient {
   }
 
   nonisolated func createWorktreeStream(
-    named name: String,
-    in repoRoot: URL,
-    baseDirectory: URL,
-    copyFiles: (ignored: Bool, untracked: Bool),
-    baseRef: String,
-    directoryOverride: URL? = nil
+    _ request: GitWorktreeCreateRequest
   ) -> AsyncThrowingStream<GitWorktreeCreateEvent, Error> {
     AsyncThrowingStream { continuation in
       Task {
-        let repositoryRootURL = repoRoot.standardizedFileURL
+        let repositoryRootURL = request.repoRoot.standardizedFileURL
         do {
           let wtURL = try wtScriptURL()
           let arguments = createWorktreeArguments(
-            baseDirectory: baseDirectory,
-            name: name,
-            copyIgnored: copyFiles.ignored,
-            copyUntracked: copyFiles.untracked,
-            baseRef: baseRef,
-            directoryOverride: directoryOverride
+            baseDirectory: request.baseDirectory,
+            name: request.name,
+            copyIgnored: request.copyFiles.ignored,
+            copyUntracked: request.copyFiles.untracked,
+            baseRef: request.baseRef,
+            directoryOverride: request.directoryOverride
           )
           let envURL = URL(fileURLWithPath: "/usr/bin/env")
           let localeArguments = ["LANG=C", "LC_ALL=C", "LC_MESSAGES=C"]
@@ -265,7 +262,7 @@ struct GitClient {
             for try await streamEvent in shell.runLoginStream(
               envURL,
               invocationArguments,
-              repoRoot
+              request.repoRoot
             ) {
               switch streamEvent {
               case .line(let line):
@@ -292,7 +289,7 @@ struct GitClient {
                 let createdAt = resourceValues?.creationDate ?? resourceValues?.contentModificationDate
                 let worktree = Worktree(
                   id: id,
-                  name: name,
+                  name: request.name,
                   detail: detail,
                   workingDirectory: worktreeURL,
                   repositoryRootURL: repositoryRootURL,

--- a/supacode/Clients/Git/GitClientTypes.swift
+++ b/supacode/Clients/Git/GitClientTypes.swift
@@ -39,6 +39,36 @@ enum GitClientError: LocalizedError {
   }
 }
 
+nonisolated struct GitWorktreeCreateRequest: Equatable, Sendable {
+  struct CopyFiles: Equatable, Sendable {
+    var ignored: Bool
+    var untracked: Bool
+  }
+
+  var name: String
+  var repoRoot: URL
+  var baseDirectory: URL
+  var copyFiles: CopyFiles
+  var baseRef: String
+  var directoryOverride: URL?
+
+  init(
+    name: String,
+    repoRoot: URL,
+    baseDirectory: URL,
+    copyFiles: CopyFiles,
+    baseRef: String,
+    directoryOverride: URL? = nil
+  ) {
+    self.name = name
+    self.repoRoot = repoRoot
+    self.baseDirectory = baseDirectory
+    self.copyFiles = copyFiles
+    self.baseRef = baseRef
+    self.directoryOverride = directoryOverride
+  }
+}
+
 enum GitWorktreeCreateEvent: Equatable, Sendable {
   case outputLine(ShellStreamLine)
   case finished(Worktree)

--- a/supacode/Clients/Repositories/GitClientDependency.swift
+++ b/supacode/Clients/Repositories/GitClientDependency.swift
@@ -22,16 +22,7 @@ struct GitClientDependency: Sendable {
       _ baseRef: String
     ) async throws
       -> Worktree
-  var createWorktreeStream:
-    @Sendable (
-      _ name: String,
-      _ repoRoot: URL,
-      _ baseDirectory: URL,
-      _ copyIgnored: Bool,
-      _ copyUntracked: Bool,
-      _ baseRef: String,
-      _ directoryOverride: URL?
-    ) -> AsyncThrowingStream<GitWorktreeCreateEvent, Error>
+  var createWorktreeStream: @Sendable (GitWorktreeCreateRequest) -> AsyncThrowingStream<GitWorktreeCreateEvent, Error>
   var removeWorktree: @Sendable (_ worktree: Worktree, _ deleteBranch: Bool) async throws -> URL
   var deleteLocalBranch:
     @Sendable (_ branchName: String, _ repoRoot: URL, _ force: Bool) async throws
@@ -69,15 +60,8 @@ extension GitClientDependency: DependencyKey {
         baseRef: baseRef
       )
     },
-    createWorktreeStream: { name, repoRoot, baseDirectory, copyIgnored, copyUntracked, baseRef, directoryOverride in
-      GitClient().createWorktreeStream(
-        named: name,
-        in: repoRoot,
-        baseDirectory: baseDirectory,
-        copyFiles: (ignored: copyIgnored, untracked: copyUntracked),
-        baseRef: baseRef,
-        directoryOverride: directoryOverride
-      )
+    createWorktreeStream: { request in
+      GitClient().createWorktreeStream(request)
     },
     removeWorktree: { worktree, deleteBranch in
       try await GitClient().removeWorktree(worktree, deleteBranch: deleteBranch)

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+WorktreeCreation.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+WorktreeCreation.swift
@@ -487,13 +487,14 @@ extension RepositoriesFeature {
             )
           )
           let stream = createWorktreeStream(
-            name,
-            repository.rootURL,
-            worktreeBaseDirectory,
-            copyIgnored,
-            copyUntracked,
-            resolvedBaseRef,
-            directoryOverride
+            GitWorktreeCreateRequest(
+              name: name,
+              repoRoot: repository.rootURL,
+              baseDirectory: worktreeBaseDirectory,
+              copyFiles: GitWorktreeCreateRequest.CopyFiles(ignored: copyIgnored, untracked: copyUntracked),
+              baseRef: resolvedBaseRef,
+              directoryOverride: directoryOverride
+            )
           )
           for try await event in stream {
             switch event {

--- a/supacodeTests/GitClientCreateWorktreeStreamTests.swift
+++ b/supacodeTests/GitClientCreateWorktreeStreamTests.swift
@@ -36,6 +36,27 @@ nonisolated final class GitShellInvocationRecorder: @unchecked Sendable {
 }
 
 struct GitClientCreateWorktreeStreamTests {
+  private func makeRequest(
+    name: String = "new-wt",
+    repoRoot: URL,
+    baseDirectory: URL? = nil,
+    copyFiles: GitWorktreeCreateRequest.CopyFiles = GitWorktreeCreateRequest.CopyFiles(
+      ignored: false,
+      untracked: false
+    ),
+    baseRef: String = "",
+    directoryOverride: URL? = nil
+  ) -> GitWorktreeCreateRequest {
+    GitWorktreeCreateRequest(
+      name: name,
+      repoRoot: repoRoot,
+      baseDirectory: baseDirectory ?? URL(fileURLWithPath: "/tmp/repo/.worktrees"),
+      copyFiles: copyFiles,
+      baseRef: baseRef,
+      directoryOverride: directoryOverride
+    )
+  }
+
   @Test func createWorktreeStreamAddsVerboseWhenCopyingFiles() async throws {
     let recorder = GitShellInvocationRecorder()
     let shell = ShellClient(
@@ -64,11 +85,12 @@ struct GitClientCreateWorktreeStreamTests {
     let repoRoot = URL(fileURLWithPath: "/tmp/repo")
 
     for try await _ in client.createWorktreeStream(
-      named: "swift-otter",
-      in: repoRoot,
-      baseDirectory: URL(fileURLWithPath: "/tmp/repo/.worktrees"),
-      copyFiles: (ignored: true, untracked: false),
-      baseRef: "origin/main"
+      makeRequest(
+        name: "swift-otter",
+        repoRoot: repoRoot,
+        copyFiles: GitWorktreeCreateRequest.CopyFiles(ignored: true, untracked: false),
+        baseRef: "origin/main"
+      )
     ) {}
 
     let snapshot = recorder.snapshot()
@@ -112,11 +134,11 @@ struct GitClientCreateWorktreeStreamTests {
     var outputLines: [ShellStreamLine] = []
     var finishedWorktree: Worktree?
     for try await event in client.createWorktreeStream(
-      named: "swift-otter",
-      in: repoRoot,
-      baseDirectory: URL(fileURLWithPath: "/tmp/repo/.worktrees"),
-      copyFiles: (ignored: true, untracked: true),
-      baseRef: ""
+      makeRequest(
+        name: "swift-otter",
+        repoRoot: repoRoot,
+        copyFiles: GitWorktreeCreateRequest.CopyFiles(ignored: true, untracked: true)
+      )
     ) {
       switch event {
       case .outputLine(let line):
@@ -157,11 +179,7 @@ struct GitClientCreateWorktreeStreamTests {
     let repoRoot = URL(fileURLWithPath: "/tmp/repo")
     var finishedWorktree: Worktree?
     for try await event in client.createWorktreeStream(
-      named: "new-wt",
-      in: repoRoot,
-      baseDirectory: URL(fileURLWithPath: "/tmp/repo/.worktrees"),
-      copyFiles: (ignored: false, untracked: false),
-      baseRef: ""
+      makeRequest(repoRoot: repoRoot)
     ) {
       if case .finished(let worktree) = event {
         finishedWorktree = worktree
@@ -188,11 +206,7 @@ struct GitClientCreateWorktreeStreamTests {
     var outputLines: [ShellStreamLine] = []
     var finishedWorktree: Worktree?
     for try await event in client.createWorktreeStream(
-      named: "new-wt",
-      in: repoRoot,
-      baseDirectory: URL(fileURLWithPath: "/tmp/repo/.worktrees"),
-      copyFiles: (ignored: false, untracked: false),
-      baseRef: ""
+      makeRequest(repoRoot: repoRoot)
     ) {
       switch event {
       case .outputLine(let line):
@@ -230,11 +244,7 @@ struct GitClientCreateWorktreeStreamTests {
 
     do {
       for try await _ in client.createWorktreeStream(
-        named: "new-wt",
-        in: repoRoot,
-        baseDirectory: URL(fileURLWithPath: "/tmp/repo/.worktrees"),
-        copyFiles: (ignored: false, untracked: false),
-        baseRef: ""
+        makeRequest(repoRoot: repoRoot)
       ) {}
       Issue.record("Expected createWorktreeStream to throw when stdout path is missing")
     } catch let error as GitClientError {

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -1916,7 +1916,7 @@ struct RepositoriesFeatureTests {
       $0.gitClient.automaticWorktreeBaseRef = { _ in "origin/main" }
       $0.gitClient.ignoredFileCount = { _ in 2 }
       $0.gitClient.untrackedFileCount = { _ in 1 }
-      $0.gitClient.createWorktreeStream = { _, _, _, _, _, _, _ in
+      $0.gitClient.createWorktreeStream = { _ in
         AsyncThrowingStream { continuation in
           continuation.yield(.outputLine(ShellStreamLine(source: .stderr, text: "[1/2] copy .env")))
           continuation.yield(.outputLine(ShellStreamLine(source: .stderr, text: "[2/2] copy .cache")))
@@ -1964,7 +1964,7 @@ struct RepositoriesFeatureTests {
       }
       $0.gitClient.ignoredFileCount = { _ in 0 }
       $0.gitClient.untrackedFileCount = { _ in 0 }
-      $0.gitClient.createWorktreeStream = { _, _, _, _, _, _, _ in
+      $0.gitClient.createWorktreeStream = { _ in
         events.withValue { $0.append("create") }
         return AsyncThrowingStream { continuation in
           continuation.yield(.finished(createdWorktree))
@@ -2015,7 +2015,7 @@ struct RepositoriesFeatureTests {
       }
       $0.gitClient.ignoredFileCount = { _ in 0 }
       $0.gitClient.untrackedFileCount = { _ in 0 }
-      $0.gitClient.createWorktreeStream = { _, _, _, _, _, _, _ in
+      $0.gitClient.createWorktreeStream = { _ in
         AsyncThrowingStream { continuation in
           continuation.yield(.finished(createdWorktree))
           continuation.finish()
@@ -2060,7 +2060,7 @@ struct RepositoriesFeatureTests {
       }
       $0.gitClient.ignoredFileCount = { _ in 0 }
       $0.gitClient.untrackedFileCount = { _ in 0 }
-      $0.gitClient.createWorktreeStream = { _, _, _, _, _, _, _ in
+      $0.gitClient.createWorktreeStream = { _ in
         AsyncThrowingStream { continuation in
           continuation.yield(.finished(createdWorktree))
           continuation.finish()
@@ -2105,7 +2105,7 @@ struct RepositoriesFeatureTests {
       }
       $0.gitClient.ignoredFileCount = { _ in 0 }
       $0.gitClient.untrackedFileCount = { _ in 0 }
-      $0.gitClient.createWorktreeStream = { _, _, _, _, _, _, _ in
+      $0.gitClient.createWorktreeStream = { _ in
         AsyncThrowingStream { continuation in
           continuation.yield(.finished(createdWorktree))
           continuation.finish()
@@ -2157,8 +2157,8 @@ struct RepositoriesFeatureTests {
       $0.gitClient.automaticWorktreeBaseRef = { _ in "origin/main" }
       $0.gitClient.ignoredFileCount = { _ in 0 }
       $0.gitClient.untrackedFileCount = { _ in 0 }
-      $0.gitClient.createWorktreeStream = { _, _, baseDirectory, _, _, _, _ in
-        observedBaseDirectory.withValue { $0 = baseDirectory }
+      $0.gitClient.createWorktreeStream = { request in
+        observedBaseDirectory.withValue { $0 = request.baseDirectory }
         return AsyncThrowingStream { continuation in
           continuation.yield(.finished(createdWorktree))
           continuation.finish()
@@ -2209,8 +2209,8 @@ struct RepositoriesFeatureTests {
       $0.gitClient.automaticWorktreeBaseRef = { _ in "origin/main" }
       $0.gitClient.ignoredFileCount = { _ in 0 }
       $0.gitClient.untrackedFileCount = { _ in 0 }
-      $0.gitClient.createWorktreeStream = { _, _, baseDirectory, _, _, _, _ in
-        observedBaseDirectory.withValue { $0 = baseDirectory }
+      $0.gitClient.createWorktreeStream = { request in
+        observedBaseDirectory.withValue { $0 = request.baseDirectory }
         return AsyncThrowingStream { continuation in
           continuation.yield(.finished(createdWorktree))
           continuation.finish()
@@ -2262,8 +2262,8 @@ struct RepositoriesFeatureTests {
       $0.gitClient.automaticWorktreeBaseRef = { _ in "origin/main" }
       $0.gitClient.ignoredFileCount = { _ in 0 }
       $0.gitClient.untrackedFileCount = { _ in 0 }
-      $0.gitClient.createWorktreeStream = { _, _, _, copyIgnored, copyUntracked, _, _ in
-        observedCopyFlags.withValue { $0 = (copyIgnored, copyUntracked) }
+      $0.gitClient.createWorktreeStream = { request in
+        observedCopyFlags.withValue { $0 = (request.copyFiles.ignored, request.copyFiles.untracked) }
         return AsyncThrowingStream { continuation in
           continuation.yield(.finished(createdWorktree))
           continuation.finish()
@@ -2311,8 +2311,8 @@ struct RepositoriesFeatureTests {
       $0.gitClient.automaticWorktreeBaseRef = { _ in "origin/main" }
       $0.gitClient.ignoredFileCount = { _ in 0 }
       $0.gitClient.untrackedFileCount = { _ in 0 }
-      $0.gitClient.createWorktreeStream = { _, _, _, copyIgnored, copyUntracked, _, _ in
-        observedCopyFlags.withValue { $0 = (copyIgnored, copyUntracked) }
+      $0.gitClient.createWorktreeStream = { request in
+        observedCopyFlags.withValue { $0 = (request.copyFiles.ignored, request.copyFiles.untracked) }
         return AsyncThrowingStream { continuation in
           continuation.yield(.finished(createdWorktree))
           continuation.finish()
@@ -2348,7 +2348,7 @@ struct RepositoriesFeatureTests {
       $0.gitClient.automaticWorktreeBaseRef = { _ in "origin/main" }
       $0.gitClient.ignoredFileCount = { _ in 2 }
       $0.gitClient.untrackedFileCount = { _ in 1 }
-      $0.gitClient.createWorktreeStream = { _, _, _, _, _, _, _ in
+      $0.gitClient.createWorktreeStream = { _ in
         AsyncThrowingStream { continuation in
           continuation.yield(.outputLine(ShellStreamLine(source: .stderr, text: "[1/2] copy .env")))
           continuation.finish(throwing: GitClientError.commandFailed(command: "wt sw", message: "boom"))


### PR DESCRIPTION
## Summary
- Add `GitWorktreeCreateRequest` to group worktree stream creation inputs.
- Change `GitClient.createWorktreeStream` and the TCA git dependency to accept the request type instead of positional parameters.
- Update reducer call sites and tests to inspect request fields instead of unpacking long mock signatures.

## Verification
- `xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -only-testing:supacodeTests/GitClientCreateWorktreeStreamTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation 2>&1 | xcsift -f toon`
- `xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -only-testing:supacodeTests/RepositoriesFeatureTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation 2>&1 | xcsift -f toon`
- `make check`
- `set -o pipefail; make build-app 2>&1 | xcsift -f toon -E`
