### PR TITLE
Label the worktree creation Advanced fields

### DIFF
--- a/supacode/Features/Repositories/Views/WorktreeCreationPromptView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeCreationPromptView.swift
@@ -46,19 +46,30 @@ struct WorktreeCreationPromptView: View {
       }
 
       DisclosureGroup("Advanced", isExpanded: $store.showAdvancedOptions) {
-        VStack(alignment: .leading, spacing: 8) {
-          TextField(
-            "Worktree name",
-            text: $store.worktreeNameOverride,
-            prompt: Text(store.worktreeNamePlaceholder)
-          )
-          .textFieldStyle(.roundedBorder)
-          TextField(
-            "Parent folder",
-            text: $store.worktreePathOverride,
-            prompt: Text(store.defaultWorktreeBaseDirectory)
-          )
-          .textFieldStyle(.roundedBorder)
+        VStack(alignment: .leading, spacing: 12) {
+          Text("Override where the new worktree folder is created. Leave a field blank to use its default.")
+            .font(.footnote)
+            .foregroundStyle(.secondary)
+          VStack(alignment: .leading, spacing: 8) {
+            Text("Worktree name")
+              .foregroundStyle(.secondary)
+            TextField(
+              "Worktree name",
+              text: $store.worktreeNameOverride,
+              prompt: Text(store.worktreeNamePlaceholder)
+            )
+            .textFieldStyle(.roundedBorder)
+          }
+          VStack(alignment: .leading, spacing: 8) {
+            Text("Parent folder")
+              .foregroundStyle(.secondary)
+            TextField(
+              "Parent folder",
+              text: $store.worktreePathOverride,
+              prompt: Text(store.defaultWorktreeBaseDirectory)
+            )
+            .textFieldStyle(.roundedBorder)
+          }
         }
         .padding(.top, 4)
       }


### PR DESCRIPTION
## Problem

When you expand **Advanced** in the New Worktree prompt, the two fields show no
indication of what they are. The `TextField` label argument (`"Worktree name"` /
`"Parent folder"`) is **not rendered** under `.roundedBorder` style — only the
`prompt` placeholder is, and the name field's placeholder is empty until you've
typed a branch name. The result is two blank boxes with no hint of their purpose.

![before](https://github.com/user-attachments/assets/placeholder)

## Fix

Match the visible-label pattern already used by the "Branch name" field: add a
secondary `Text` label above each field, and a one-line caption explaining what
the section does and that blank fields fall back to their defaults. View-only
change; no reducer logic touched.

## Test

- `make check` — clean
- `make build-app` — succeeds
- Manual: open New Worktree → expand Advanced → both fields are now labeled with
  an explanatory caption.
