### PR TITLE
Narrow windowless stall diagnostics

### DIFF
--- a/supacode/App/WindowSurfacing.swift
+++ b/supacode/App/WindowSurfacing.swift
@@ -54,26 +54,30 @@ enum MainWindowSurface {
     let isVisible: Bool
   }
 
+  static func snapshots(in windows: [NSWindow]) -> [Snapshot] {
+    windows.map(snapshot(for:))
+  }
+
   static func mainWindowCandidate(in windows: [NSWindow]) -> NSWindow? {
-    let snapshots = windows.map(snapshot(for:))
+    let snapshots = snapshots(in: windows)
     guard let index = mainWindowIndex(in: snapshots) else { return nil }
     return windows[index]
   }
 
   static func hasVisibleMainWindow(in windows: [NSWindow]) -> Bool {
-    hasVisibleMainWindow(in: windows.map(snapshot(for:)))
+    hasVisibleMainWindow(in: snapshots(in: windows))
   }
 
   static func mainWindowCount(in windows: [NSWindow]) -> Int {
-    mainWindowCount(in: windows.map(snapshot(for:)))
+    mainWindowCount(in: snapshots(in: windows))
   }
 
   static func visibleMainWindowCount(in windows: [NSWindow]) -> Int {
-    visibleMainWindowCount(in: windows.map(snapshot(for:)))
+    visibleMainWindowCount(in: snapshots(in: windows))
   }
 
   static func visibleWindowCount(in windows: [NSWindow]) -> Int {
-    visibleWindowCount(in: windows.map(snapshot(for:)))
+    visibleWindowCount(in: snapshots(in: windows))
   }
 
   static func mainWindowIndex(in snapshots: [Snapshot]) -> Int? {
@@ -107,6 +111,12 @@ enum MainWindowSurface {
 
 @MainActor
 enum WindowLifecycleDiagnostics {
+  enum WindowlessStallReportDecision: Equatable {
+    case report
+    case suppress
+    case resolveVisibleMainWindow
+  }
+
   private static let logger = SupaLogger("WindowLifecycle")
   private static let heartbeatInterval: TimeInterval = 1.0
   private static let stallThreshold: TimeInterval = 0.3
@@ -237,9 +247,33 @@ enum WindowLifecycleDiagnostics {
 
   private static func reportWindowlessStallIfNeeded(lag: TimeInterval) {
     guard !didReportWindowlessStall else { return }
+    let windows = NSApplication.shared.windows
+    switch Self.windowlessStallReportDecision(
+      appIsActive: NSApp.isActive,
+      snapshots: MainWindowSurface.snapshots(in: windows)
+    ) {
+    case .report:
+      break
+    case .suppress:
+      return
+    case .resolveVisibleMainWindow:
+      noteMainWindowAppeared()
+      return
+    }
     didReportWindowlessStall = true
     let elapsed = windowlessSince.map { Date.now.timeIntervalSince($0) } ?? 0
     captureSentryEvent(kind: "windowless_main_thread_stall", elapsed: elapsed, lag: lag)
+  }
+
+  static func windowlessStallReportDecision(
+    appIsActive: Bool,
+    snapshots: [MainWindowSurface.Snapshot]
+  ) -> WindowlessStallReportDecision {
+    if MainWindowSurface.hasVisibleMainWindow(in: snapshots) {
+      return .resolveVisibleMainWindow
+    }
+    guard appIsActive else { return .suppress }
+    return .report
   }
 
   private static func captureSentryEvent(kind: String, elapsed: TimeInterval, lag: TimeInterval?) {

--- a/supacodeTests/WindowSurfacingTests.swift
+++ b/supacodeTests/WindowSurfacingTests.swift
@@ -51,4 +51,26 @@ struct WindowSurfacingTests {
     #expect(MainWindowSurface.visibleMainWindowCount(in: snapshots) == 1)
     #expect(MainWindowSurface.visibleWindowCount(in: snapshots) == 3)
   }
+
+  @MainActor
+  @Test func windowlessStallReportRequiresActiveAppWithoutVisibleMainWindow() {
+    #expect(
+      WindowLifecycleDiagnostics.windowlessStallReportDecision(
+        appIsActive: false,
+        snapshots: []
+      ) == .suppress
+    )
+    #expect(
+      WindowLifecycleDiagnostics.windowlessStallReportDecision(
+        appIsActive: true,
+        snapshots: [MainWindowSurface.Snapshot(identifier: WindowID.main, isVisible: true)]
+      ) == .resolveVisibleMainWindow
+    )
+    #expect(
+      WindowLifecycleDiagnostics.windowlessStallReportDecision(
+        appIsActive: true,
+        snapshots: [MainWindowSurface.Snapshot(identifier: WindowID.main, isVisible: false)]
+      ) == .report
+    )
+  }
 }


### PR DESCRIPTION
## Summary
- Suppress windowless main-thread stall diagnostics while the app is inactive.
- Re-check visible main-window state before reporting a stall and resolve stale windowless tracking when a visible main window already exists.
- Add focused tests for the stall-reporting decision.

## Why
Sentry issue PROWL-MACOS-AW is dominated by inactive/background launch samples and can include stale windowless state even when the main window is visible. This keeps the diagnostic focused on active sessions where a missing main window is actionable.

## Validation
- `xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -derivedDataPath /tmp/prowl-windowless-stall-dd -only-testing:supacodeTests/WindowSurfacingTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation 2>&1 | xcsift -f toon`
- `make check`
- `make build-app 2>&1 | xcsift -f toon`
