### PR TITLE
Stop reporting failed HTTP requests to Sentry

### DIFF
--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -141,6 +141,11 @@ struct SupacodeApp: App {
           if let releaseName { options.releaseName = releaseName }
           options.tracesSampleRate = 0.05
           options.enableAppHangTracking = false
+          // Don't report failed HTTP requests. The SDK swizzles URLSession to
+          // turn any 5xx response into an HTTPClientError, but every request we
+          // make goes to servers we don't own (e.g. Sparkle fetching the
+          // appcast from GitHub), so their 502s are noise, not our bugs.
+          options.enableCaptureFailedRequests = false
         }
         // Match the Sentry user id to the PostHog distinct id so an event in
         // one system can be traced to the same install in the other.


### PR DESCRIPTION
## Problem

Sentry's [`enableCaptureFailedRequests`](https://docs.sentry.io/platforms/apple/configuration/options/#enable-capture-failed-requests) is on by default, swizzling `NSURLSessionTask` to turn any 5xx HTTP response into an `HTTPClientError` event.

The recurring high-priority issue [`PROWL-MACOS-4`](https://onevs-den.sentry.io/issues/7423345064/) is exactly this: Sparkle fetching `github.com/onevcat/Prowl/releases/latest/download/appcast.xml` gets a **502** from GitHub, and the SDK reports it as our error.

Every HTTP request Prowl makes goes to servers we don't own (Sparkle → GitHub, telemetry → PostHog/Sentry). A 502 from GitHub is *their* hiccup, not our bug — pure noise.

## Fix

Set `options.enableCaptureFailedRequests = false` in the Sentry bootstrap. Crash and error reporting are unaffected; only the auto-captured network-failure events stop.

## Verification

- Confirmed `enableCaptureFailedRequests: Bool` exists in the pinned `sentry-cocoa` **9.3.0** source.
- The change lives inside `#if !DEBUG`, so the Debug `make build-app` path doesn't compile it. A full release build wasn't run here because this worktree's `ThirdParty/ghostty` submodule / `GhosttyKit.xcframework` aren't set up; the change is a single verified property assignment.
