### PR TITLE
Stabilize progress clock tests

### DIFF
--- a/supacodeTests/GhosttySurfaceBridgeTests.swift
+++ b/supacodeTests/GhosttySurfaceBridgeTests.swift
@@ -77,7 +77,7 @@ struct GhosttySurfaceBridgeTests {
     #expect(callbackCount == 1)
 
     // One throttle tick flushes only the latest coalesced value.
-    await clock.advance(by: .milliseconds(50))
+    await advanceProgressClock(clock, by: .milliseconds(50))
     #expect(bridge.state.progressValue == 50)
     #expect(callbackCount == 2)
   }
@@ -97,7 +97,7 @@ struct GhosttySurfaceBridgeTests {
     #expect(bridge.state.progressState == GHOSTTY_PROGRESS_STATE_INDETERMINATE)
 
     // No further reports: the driver synthesizes a REMOVE once the window lapses.
-    await clock.advance(by: .milliseconds(200))
+    await advanceProgressClock(clock, by: .milliseconds(200))
     #expect(bridge.state.progressState == nil)
     #expect(lastState == GHOSTTY_PROGRESS_STATE_REMOVE)
   }
@@ -118,7 +118,7 @@ struct GhosttySurfaceBridgeTests {
     // keep resetting even though the value never changes.
     for _ in 0..<6 {
       bridge.ingestProgressReport(state: GHOSTTY_PROGRESS_STATE_INDETERMINATE, value: nil)
-      await clock.advance(by: .milliseconds(50))
+      await advanceProgressClock(clock, by: .milliseconds(50))
     }
     #expect(bridge.state.progressState == GHOSTTY_PROGRESS_STATE_INDETERMINATE)
     #expect(lastState == GHOSTTY_PROGRESS_STATE_INDETERMINATE)
@@ -137,14 +137,14 @@ struct GhosttySurfaceBridgeTests {
     bridge.ingestProgressReport(state: GHOSTTY_PROGRESS_STATE_INDETERMINATE, value: nil)
     // No further reports: the stale window synthesizes a REMOVE and tears down
     // the driver.
-    await clock.advance(by: .milliseconds(100))
+    await advanceProgressClock(clock, by: .milliseconds(100))
     #expect(bridge.state.progressState == nil)
 
     // A report after the stale REMOVE must re-arm the driver, not freeze.
     bridge.ingestProgressReport(state: GHOSTTY_PROGRESS_STATE_SET, value: 30)
     #expect(bridge.state.progressValue == 30)
     bridge.ingestProgressReport(state: GHOSTTY_PROGRESS_STATE_SET, value: 60)
-    await clock.advance(by: .milliseconds(50))
+    await advanceProgressClock(clock, by: .milliseconds(50))
     #expect(bridge.state.progressValue == 60)
   }
 
@@ -163,7 +163,7 @@ struct GhosttySurfaceBridgeTests {
 
     // Sit idle well past the throttle window, then a fresh value must paint on
     // its leading edge instead of waiting for a slow idle tick.
-    await clock.advance(by: .seconds(1))
+    await advanceProgressClock(clock, by: .seconds(1))
     bridge.ingestProgressReport(state: GHOSTTY_PROGRESS_STATE_SET, value: 80)
     #expect(bridge.state.progressValue == 80)
   }
@@ -186,7 +186,7 @@ struct GhosttySurfaceBridgeTests {
     // the downstream callback fires exactly once across the whole stream.
     for _ in 0..<10 {
       bridge.ingestProgressReport(state: GHOSTTY_PROGRESS_STATE_INDETERMINATE, value: nil)
-      await clock.advance(by: .milliseconds(50))
+      await advanceProgressClock(clock, by: .milliseconds(50))
     }
     #expect(callbackCount == 1)
     #expect(bridge.state.progressState == GHOSTTY_PROGRESS_STATE_INDETERMINATE)
@@ -211,5 +211,12 @@ struct GhosttySurfaceBridgeTests {
     #expect(bridge.state.progressState == nil)
     #expect(bridge.state.progressValue == nil)
     #expect(states == [GHOSTTY_PROGRESS_STATE_SET, GHOSTTY_PROGRESS_STATE_REMOVE])
+  }
+
+  private func advanceProgressClock(_ clock: TestClock<Duration>, by duration: Duration) async {
+    // Let background progress tasks register and wake around TestClock advancement.
+    await Task.yield()
+    await clock.advance(by: duration)
+    await Task.yield()
   }
 }


### PR DESCRIPTION
## Summary

- Add a progress-clock advancement helper for `GhosttySurfaceBridgeTests`
- Yield before and after advancing `TestClock` so background progress tasks can register and wake deterministically
- Keep the fix scoped to tests; production progress handling is unchanged

## Verification

- `xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -only-testing:supacodeTests/GhosttySurfaceBridgeTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation`
- `xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -only-testing:supacodeTests/GhosttySurfaceBridgeTests/progressDriverRestartsAfterStaleRemoval -test-iterations 20 CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation`
- `make check`
- `make build-app`
