### PR TITLE
Recheck window visibility before timeout diagnostics

### DIFF
--- a/supacode/App/WindowSurfacing.swift
+++ b/supacode/App/WindowSurfacing.swift
@@ -111,7 +111,7 @@ enum MainWindowSurface {
 
 @MainActor
 enum WindowLifecycleDiagnostics {
-  enum WindowlessStallReportDecision: Equatable {
+  enum WindowlessReportDecision: Equatable {
     case report
     case suppress
     case resolveVisibleMainWindow
@@ -240,7 +240,20 @@ enum WindowLifecycleDiagnostics {
 
   private static func reportWindowlessTimeoutIfNeeded(elapsed: TimeInterval) {
     guard !didReportWindowlessTimeout else { return }
-    guard windowlessContext != "launch" || NSApp.isActive else { return }
+    let windows = NSApplication.shared.windows
+    switch Self.windowlessTimeoutReportDecision(
+      appIsActive: NSApp.isActive,
+      windowlessContext: windowlessContext,
+      snapshots: MainWindowSurface.snapshots(in: windows)
+    ) {
+    case .report:
+      break
+    case .suppress:
+      return
+    case .resolveVisibleMainWindow:
+      noteMainWindowAppeared()
+      return
+    }
     didReportWindowlessTimeout = true
     captureSentryEvent(kind: "main_window_timeout", elapsed: elapsed, lag: nil)
   }
@@ -268,11 +281,25 @@ enum WindowLifecycleDiagnostics {
   static func windowlessStallReportDecision(
     appIsActive: Bool,
     snapshots: [MainWindowSurface.Snapshot]
-  ) -> WindowlessStallReportDecision {
+  ) -> WindowlessReportDecision {
     if MainWindowSurface.hasVisibleMainWindow(in: snapshots) {
       return .resolveVisibleMainWindow
     }
     guard appIsActive else { return .suppress }
+    return .report
+  }
+
+  static func windowlessTimeoutReportDecision(
+    appIsActive: Bool,
+    windowlessContext: String?,
+    snapshots: [MainWindowSurface.Snapshot]
+  ) -> WindowlessReportDecision {
+    if MainWindowSurface.hasVisibleMainWindow(in: snapshots) {
+      return .resolveVisibleMainWindow
+    }
+    guard windowlessContext != "launch" || appIsActive else {
+      return .suppress
+    }
     return .report
   }
 

--- a/supacodeTests/WindowSurfacingTests.swift
+++ b/supacodeTests/WindowSurfacingTests.swift
@@ -73,4 +73,29 @@ struct WindowSurfacingTests {
       ) == .report
     )
   }
+
+  @MainActor
+  @Test func windowlessTimeoutReportResolvesVisibleMainWindowBeforeReporting() {
+    #expect(
+      WindowLifecycleDiagnostics.windowlessTimeoutReportDecision(
+        appIsActive: true,
+        windowlessContext: "surfaceMainWindow(openWindowRequested)",
+        snapshots: [MainWindowSurface.Snapshot(identifier: WindowID.main, isVisible: true)]
+      ) == .resolveVisibleMainWindow
+    )
+    #expect(
+      WindowLifecycleDiagnostics.windowlessTimeoutReportDecision(
+        appIsActive: false,
+        windowlessContext: "launch",
+        snapshots: []
+      ) == .suppress
+    )
+    #expect(
+      WindowLifecycleDiagnostics.windowlessTimeoutReportDecision(
+        appIsActive: true,
+        windowlessContext: "surfaceMainWindow(openWindowRequested)",
+        snapshots: [MainWindowSurface.Snapshot(identifier: WindowID.main, isVisible: false)]
+      ) == .report
+    )
+  }
 }


### PR DESCRIPTION
## Summary
- Re-check visible main-window state before reporting `main_window_timeout` diagnostics.
- Resolve stale windowless tracking when a visible main window already exists.
- Keep the existing inactive launch timeout suppression and add focused tests for the decision logic.

## Why
Sentry samples for `PROWL-MACOS-AV` show many timeout events where `windows` already contains a visible main window. Those reports are stale diagnostics rather than evidence of an invisible main window. This keeps timeout reports focused on cases where no visible main window is present when the timeout fires.

## Validation
- `xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -derivedDataPath /tmp/prowl-windowless-timeout-dd -only-testing:supacodeTests/WindowSurfacingTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation 2>&1 | xcsift -f toon`
- `make check`
- `make build-app 2>&1 | xcsift -f toon`
