### PR TITLE
Add workspace metadata mode

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -43,6 +43,7 @@ its keyboard shortcuts, detailed behavior, settings, and gotchas.
 | File | What it covers |
 |------|----------------|
 | [`components/repositories-and-worktrees.md`](components/repositories-and-worktrees.md) | The sidebar: adding repositories, creating / opening / archiving / deleting git worktrees, plain (non-git) folders, pinning, ordering, repository icons & colors. |
+| [`components/workspaces.md`](components/workspaces.md) | Multi-repo workspaces: one agent terminal rooted at a shared folder, with `.prowl/workspace.json` metadata describing the repositories in scope. |
 | [`components/terminal.md`](components/terminal.md) | Terminal tabs, splits/panes, surfaces, the Ghostty engine, tab titles & icons, shell integration, scrollback, font size. |
 | [`components/canvas.md`](components/canvas.md) | Canvas view — a zoomable board of live terminal cards, multi-select, and **broadcast a command to every agent at once**. |
 | [`components/shelf.md`](components/shelf.md) | Shelf view — worktrees as vertical "book spines" you flip through from the keyboard. |
@@ -70,6 +71,7 @@ its keyboard shortcuts, detailed behavior, settings, and gotchas.
 | I want to… | Read |
 |------------|------|
 | Run many agents side by side and see them all | [`components/canvas.md`](components/canvas.md), [`components/shelf.md`](components/shelf.md) |
+| Give one agent a task that spans several repos | [`components/workspaces.md`](components/workspaces.md) |
 | Send one command to every agent simultaneously | [`components/canvas.md`](components/canvas.md) (broadcast) |
 | Spin up a new branch/worktree for a new agent | [`components/repositories-and-worktrees.md`](components/repositories-and-worktrees.md) |
 | Find / run any action by name | [`components/command-palette.md`](components/command-palette.md) |

--- a/docs/components/cli.md
+++ b/docs/components/cli.md
@@ -66,7 +66,7 @@ Snapshot of all worktrees → tabs → panes. No selectors.
 prowl list --json
 ```
 Each item contains:
-- `worktree`: `id`, `name`, `path`, `root_path`, `kind` (`git`|`plain`)
+- `worktree`: `id`, `name`, `path`, `root_path`, `kind` (`git`|`plain`|`workspace`)
 - `tab`: `id`, `title`, `selected`
 - `pane`: `id`, `title`, `cwd`, `focused`
 - `task`: `status` (`running` | `idle` | null)

--- a/docs/components/workspaces.md
+++ b/docs/components/workspaces.md
@@ -1,0 +1,111 @@
+# Workspaces
+
+**Keywords:** workspace, multi-repo, many repositories, agent cwd, `.prowl/workspace.json`, workspace metadata, `prowl list`
+
+Workspaces let one agent work on a task that spans several repositories. A
+workspace is a folder added to Prowl as a runnable project, with metadata at
+`.prowl/workspace.json` describing the repositories inside it.
+
+When you open a workspace in Prowl:
+
+- The terminal starts in the workspace root.
+- The sidebar/detail view uses the workspace title and repository list from
+  `.prowl/workspace.json`.
+- The `prowl` CLI reports the runnable target's `worktree.kind` as `workspace`.
+- Git worktree, branch, diff, and PR controls remain per-repository features; a
+  workspace is intentionally a multi-repo working directory rather than a single
+  git repository.
+
+## Folder layout
+
+Create or clone the repositories into a shared folder first, then add that
+folder to Prowl.
+
+```text
+my-feature-workspace/
+├─ .prowl/
+│  └─ workspace.json
+├─ app/
+├─ api/
+└─ shared-package/
+```
+
+Prowl currently reads the metadata and opens the workspace root. It does not yet
+clone remote repositories or materialize git worktrees from the metadata by
+itself, so those directories should already exist when the agent starts.
+
+## Metadata
+
+Example `.prowl/workspace.json`:
+
+```json
+{
+  "title": "Checkout Flow",
+  "description": "Update app UI, API contract, and shared package together.",
+  "task_links": [
+    "https://github.com/onevcat/Prowl/issues/123"
+  ],
+  "repositories": [
+    {
+      "name": "App",
+      "role": "macOS app",
+      "path": "app",
+      "source_kind": "local_repository",
+      "source_location": "/Users/mikoto/Documents/Repos/github/Prowl",
+      "branch_name": "codex/checkout-flow"
+    },
+    {
+      "name": "API",
+      "role": "backend",
+      "path": "api",
+      "source_kind": "remote",
+      "source_location": "git@github.com:onevcat/api.git",
+      "base_ref": "main"
+    },
+    {
+      "name": "Shared Package",
+      "role": "library",
+      "path": "shared-package",
+      "source_kind": "bare_repository",
+      "source_location": "/Users/mikoto/Documents/Repos/bare/shared-package.git",
+      "branch_name": "codex/checkout-flow"
+    }
+  ]
+}
+```
+
+Top-level fields:
+
+- `id` — optional stable identifier. Defaults to the workspace root path.
+- `title` — display title. Defaults to the folder name.
+- `description` — optional task summary shown in the detail view.
+- `task_links` — optional links or identifiers for the work item.
+- `repositories` — repo entries that belong to the workspace.
+- `created_at` / `updated_at` — optional ISO-8601 timestamps.
+
+Repository entry fields:
+
+- `id` — optional stable identifier. Defaults to `path`.
+- `name` — display name. Defaults to the last path component.
+- `role` — optional short role such as `app`, `backend`, or `docs`.
+- `path` — relative path under the workspace root, or an absolute path.
+- `source_kind` — `existing_path`, `remote`, `local_repository`, or
+  `bare_repository`.
+- `source_location` — optional remote URL, local repository path, or bare repo
+  path.
+- `branch_name` — optional branch/worktree name expected for the task.
+- `base_ref` — optional base branch or ref.
+
+## Agent usage
+
+Because the terminal cwd is the workspace root, agents can inspect and modify
+all listed repositories in one session:
+
+```bash
+git -C app status
+git -C api status
+git -C shared-package status
+```
+
+Use the metadata as the contract: it tells the agent which repos are in scope,
+where they are on disk, and what role each repo plays in the task.

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -10,16 +10,21 @@
 Prowl nests four levels. Everything in the app refers back to these.
 
 ```
-Repository            a git repo (or a plain folder) you've added to Prowl
+Repository            a git repo, workspace, or plain folder added to Prowl
 └─ Worktree           a git worktree = one branch checked out in its own directory
    └─ Tab             a terminal tab inside that worktree
       └─ Pane         one terminal surface; a tab can be split into several panes
 ```
 
-- **Repository** — a project you added to the sidebar. Two kinds:
+- **Repository** — a project you added to the sidebar. Two persisted kinds, plus
+  a workspace overlay:
   - **`git`** — a real git repository; supports worktrees, branches, diff, PRs.
   - **`plain`** — a non-git folder; you can open a terminal and run scripts in it,
     but there are no worktrees, branches, diff, or PR features.
+  - **Workspace** — a plain runnable folder with `.prowl/workspace.json`
+    metadata. One agent starts in the workspace root and can work across several
+    repositories listed in that file. The `prowl` CLI reports this runnable
+    target's `worktree.kind` as `workspace`.
 - **Worktree** — a git *worktree*: a branch checked out into its own working
   directory, so several branches are live on disk at once. This is the unit you
   hand to an agent. The repository's root directory is the **main worktree**
@@ -73,6 +78,7 @@ all agents and their statuses is the
 - **Global settings:** `~/.prowl/settings.json`
 - **Per-repository settings:** `~/.prowl/repo/<repo-name>/prowl.json`
 - **Per-repository user custom commands:** `~/.prowl/repo/<repo-name>/prowl.onevcat.json`
+- **Per-workspace metadata:** `<workspace>/.prowl/workspace.json`
 - **CLI socket:** `~/Library/Application Support/com.onevcat.prowl/cli.sock`
   (overridable with `PROWL_CLI_SOCKET`)
 - Legacy `~/.supacode` is migrated to `~/.prowl` on first launch. (Prowl is a fork
@@ -94,6 +100,8 @@ tabs, worktrees, views — are Prowl's. See
 
 - **Worktree** — a git branch checked out in its own directory; the unit you give
   an agent.
+- **Workspace** — a folder whose terminal root contains several repositories for
+  one agent to handle together, described by `.prowl/workspace.json`.
 - **Book / spine** — Shelf-view name for a worktree shown as a vertical strip.
 - **Card** — Canvas-view name for one terminal tab shown as a floating tile.
 - **Broadcast** — typing into one Canvas card and mirroring it to all selected

--- a/supacode/CLIService/ListRuntimeSnapshotBuilder.swift
+++ b/supacode/CLIService/ListRuntimeSnapshotBuilder.swift
@@ -86,7 +86,7 @@ enum ListRuntimeSnapshotBuilder {
               name: worktree.name,
               path: worktree.workingDirectory.path(percentEncoded: false),
               rootPath: worktree.repositoryRootURL.path(percentEncoded: false),
-              kind: repository.kind == .git ? ListCommandWorktree.Kind.git : .plain
+              kind: listCommandKind(for: repository)
             )
           )
         }
@@ -101,7 +101,7 @@ enum ListRuntimeSnapshotBuilder {
             name: repository.name,
             path: rootPath,
             rootPath: rootPath,
-            kind: repository.kind == .git ? ListCommandWorktree.Kind.git : .plain
+            kind: listCommandKind(for: repository)
           )
         )
       }
@@ -113,5 +113,12 @@ enum ListRuntimeSnapshotBuilder {
   private static func normalizeAbsolutePath(_ value: String?) -> String? {
     guard let value else { return nil }
     return value.hasPrefix("/") ? value : nil
+  }
+
+  private static func listCommandKind(for repository: Repository) -> ListCommandWorktree.Kind {
+    if repository.isWorkspace {
+      return .workspace
+    }
+    return repository.kind == .git ? .git : .plain
   }
 }

--- a/supacode/CLIService/Shared/ListCommandPayload.swift
+++ b/supacode/CLIService/Shared/ListCommandPayload.swift
@@ -33,6 +33,7 @@ public struct ListCommandWorktree: Codable, Equatable {
   public enum Kind: String, Codable, Equatable {
     case git
     case plain
+    case workspace
   }
 
   public let id: String

--- a/supacode/Clients/Repositories/RepositoryPersistenceClient.swift
+++ b/supacode/Clients/Repositories/RepositoryPersistenceClient.swift
@@ -270,12 +270,14 @@ extension RepositorySnapshotCachePayload {
     let name: String
     let kind: Repository.Kind
     let worktrees: [SnapshotWorktree]
+    let workspace: ProjectWorkspace?
 
     init(repository: Repository) {
       rootPath = repository.rootURL.path(percentEncoded: false)
       name = repository.name
       kind = repository.kind
       worktrees = repository.worktrees.map { SnapshotWorktree(worktree: $0) }
+      workspace = repository.workspace
     }
 
     func restore(
@@ -310,7 +312,8 @@ extension RepositorySnapshotCachePayload {
         rootURL: rootURL,
         name: repositoryName.isEmpty ? Repository.name(for: rootURL) : repositoryName,
         kind: kind,
-        worktrees: IdentifiedArray(restoredWorktrees, uniquingIDsWith: { current, _ in current })
+        worktrees: IdentifiedArray(restoredWorktrees, uniquingIDsWith: { current, _ in current }),
+        workspace: workspace?.normalized(relativeTo: rootURL)
       )
     }
   }

--- a/supacode/Domain/ProjectWorkspace.swift
+++ b/supacode/Domain/ProjectWorkspace.swift
@@ -1,0 +1,196 @@
+import Foundation
+
+nonisolated enum ProjectWorkspaceRepositorySourceKind: String, Codable, Equatable, Hashable, Sendable {
+  case remote
+  case localRepository = "local_repository"
+  case bareRepository = "bare_repository"
+  case existingPath = "existing_path"
+}
+
+nonisolated struct ProjectWorkspaceRepositoryEntry: Codable, Equatable, Hashable, Sendable, Identifiable {
+  var id: String
+  var name: String
+  var role: String?
+  var path: String
+  var sourceKind: ProjectWorkspaceRepositorySourceKind
+  var sourceLocation: String?
+  var branchName: String?
+  var baseRef: String?
+
+  enum CodingKeys: String, CodingKey {
+    case id
+    case name
+    case role
+    case path
+    case sourceKind = "source_kind"
+    case sourceLocation = "source_location"
+    case branchName = "branch_name"
+    case baseRef = "base_ref"
+  }
+
+  init(
+    id: String = "",
+    name: String = "",
+    role: String? = nil,
+    path: String = "",
+    sourceKind: ProjectWorkspaceRepositorySourceKind = .existingPath,
+    sourceLocation: String? = nil,
+    branchName: String? = nil,
+    baseRef: String? = nil
+  ) {
+    self.id = id
+    self.name = name
+    self.role = role
+    self.path = path
+    self.sourceKind = sourceKind
+    self.sourceLocation = sourceLocation
+    self.branchName = branchName
+    self.baseRef = baseRef
+  }
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    id = try container.decodeIfPresent(String.self, forKey: .id) ?? ""
+    name = try container.decodeIfPresent(String.self, forKey: .name) ?? ""
+    role = try container.decodeIfPresent(String.self, forKey: .role)
+    path =
+      try container.decodeIfPresent(String.self, forKey: .path)
+      ?? name.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+      ?? id.trimmingCharacters(in: .whitespacesAndNewlines)
+    sourceKind =
+      try container.decodeIfPresent(ProjectWorkspaceRepositorySourceKind.self, forKey: .sourceKind)
+      ?? .existingPath
+    sourceLocation = try container.decodeIfPresent(String.self, forKey: .sourceLocation)
+    branchName = try container.decodeIfPresent(String.self, forKey: .branchName)
+    baseRef = try container.decodeIfPresent(String.self, forKey: .baseRef)
+  }
+
+  func resolvedURL(relativeTo workspaceRootURL: URL) -> URL {
+    let trimmedPath = path.trimmingCharacters(in: .whitespacesAndNewlines)
+    if trimmedPath.hasPrefix("/") {
+      return URL(fileURLWithPath: trimmedPath).standardizedFileURL
+    }
+    return workspaceRootURL.appending(path: trimmedPath).standardizedFileURL
+  }
+}
+
+nonisolated struct ProjectWorkspace: Codable, Equatable, Hashable, Sendable {
+  typealias RepositorySourceKind = ProjectWorkspaceRepositorySourceKind
+  typealias RepositoryEntry = ProjectWorkspaceRepositoryEntry
+
+  nonisolated static let metadataDirectoryName = ".prowl"
+  nonisolated static let metadataFileName = "workspace.json"
+
+  var id: String
+  var title: String
+  var description: String
+  var taskLinks: [String]
+  var repositories: [RepositoryEntry]
+  var createdAt: Date?
+  var updatedAt: Date?
+
+  enum CodingKeys: String, CodingKey {
+    case id
+    case title
+    case description
+    case taskLinks = "task_links"
+    case repositories
+    case createdAt = "created_at"
+    case updatedAt = "updated_at"
+  }
+
+  init(
+    id: String = "",
+    title: String = "",
+    description: String = "",
+    taskLinks: [String] = [],
+    repositories: [RepositoryEntry] = [],
+    createdAt: Date? = nil,
+    updatedAt: Date? = nil
+  ) {
+    self.id = id
+    self.title = title
+    self.description = description
+    self.taskLinks = taskLinks
+    self.repositories = repositories
+    self.createdAt = createdAt
+    self.updatedAt = updatedAt
+  }
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    id = try container.decodeIfPresent(String.self, forKey: .id) ?? ""
+    title = try container.decodeIfPresent(String.self, forKey: .title) ?? ""
+    description = try container.decodeIfPresent(String.self, forKey: .description) ?? ""
+    taskLinks = try container.decodeIfPresent([String].self, forKey: .taskLinks) ?? []
+    repositories = try container.decodeIfPresent([RepositoryEntry].self, forKey: .repositories) ?? []
+    createdAt = try container.decodeIfPresent(Date.self, forKey: .createdAt)
+    updatedAt = try container.decodeIfPresent(Date.self, forKey: .updatedAt)
+  }
+
+  static func metadataURL(for rootURL: URL) -> URL {
+    rootURL
+      .appending(path: metadataDirectoryName)
+      .appending(path: metadataFileName)
+  }
+
+  static func load(from rootURL: URL) -> ProjectWorkspace? {
+    let metadataURL = metadataURL(for: rootURL)
+    guard let data = try? Data(contentsOf: metadataURL) else {
+      return nil
+    }
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+    guard var workspace = try? decoder.decode(ProjectWorkspace.self, from: data) else {
+      return nil
+    }
+    let normalizedRoot = rootURL.standardizedFileURL.path(percentEncoded: false)
+    if workspace.id.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+      workspace.id = normalizedRoot
+    }
+    if workspace.title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+      workspace.title = rootURL.lastPathComponent.isEmpty ? normalizedRoot : rootURL.lastPathComponent
+    }
+    return workspace.normalized(relativeTo: rootURL)
+  }
+
+  func normalized(relativeTo rootURL: URL) -> ProjectWorkspace {
+    var copy = self
+    let normalizedRoot = rootURL.standardizedFileURL.path(percentEncoded: false)
+    if copy.id.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+      copy.id = normalizedRoot
+    }
+    copy.title = copy.title.trimmingCharacters(in: .whitespacesAndNewlines)
+    if copy.title.isEmpty {
+      copy.title = rootURL.lastPathComponent.isEmpty ? normalizedRoot : rootURL.lastPathComponent
+    }
+    copy.description = copy.description.trimmingCharacters(in: .whitespacesAndNewlines)
+    copy.taskLinks = copy.taskLinks.map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+      .filter { !$0.isEmpty }
+    copy.repositories = copy.repositories.map { entry in
+      var entry = entry
+      entry.id = entry.id.trimmingCharacters(in: .whitespacesAndNewlines)
+      entry.name = entry.name.trimmingCharacters(in: .whitespacesAndNewlines)
+      entry.path = entry.path.trimmingCharacters(in: .whitespacesAndNewlines)
+      if entry.id.isEmpty {
+        entry.id = entry.path.isEmpty ? entry.name : entry.path
+      }
+      if entry.name.isEmpty {
+        let resolvedURL = entry.resolvedURL(relativeTo: rootURL)
+        entry.name = resolvedURL.lastPathComponent.isEmpty ? entry.id : resolvedURL.lastPathComponent
+      }
+      entry.role = entry.role?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+      entry.sourceLocation = entry.sourceLocation?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+      entry.branchName = entry.branchName?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+      entry.baseRef = entry.baseRef?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+      return entry
+    }
+    return copy
+  }
+}
+
+extension String {
+  nonisolated fileprivate var nilIfEmpty: String? {
+    isEmpty ? nil : self
+  }
+}

--- a/supacode/Domain/Repository.swift
+++ b/supacode/Domain/Repository.swift
@@ -45,19 +45,22 @@ nonisolated struct Repository: Identifiable, Hashable, Sendable {
   let name: String
   let kind: Kind
   let worktrees: IdentifiedArrayOf<Worktree>
+  let workspace: ProjectWorkspace?
 
   init(
     id: String,
     rootURL: URL,
     name: String,
     kind: Kind = .git,
-    worktrees: IdentifiedArrayOf<Worktree>
+    worktrees: IdentifiedArrayOf<Worktree>,
+    workspace: ProjectWorkspace? = nil
   ) {
     self.id = id
     self.rootURL = rootURL
     self.name = name
     self.kind = kind
     self.worktrees = worktrees
+    self.workspace = workspace
   }
 
   var initials: String {
@@ -71,6 +74,10 @@ nonisolated struct Repository: Identifiable, Hashable, Sendable {
     case .plain:
       .plain
     }
+  }
+
+  var isWorkspace: Bool {
+    workspace != nil
   }
 
   static func name(for rootURL: URL) -> String {

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+RepositoryLoading.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+RepositoryLoading.swift
@@ -64,6 +64,9 @@ extension RepositoriesFeature {
           let normalizedPath = URL(fileURLWithPath: entry.path)
             .standardizedFileURL
             .path(percentEncoded: false)
+          if ProjectWorkspace.load(from: URL(fileURLWithPath: normalizedPath)) != nil {
+            return (index, PersistedRepositoryEntry(path: normalizedPath, kind: .plain))
+          }
           do {
             let repoRoot = try await gitClient.repoRoot(URL(fileURLWithPath: normalizedPath))
             let normalizedRepoRoot = repoRoot.standardizedFileURL.path(percentEncoded: false)
@@ -183,14 +186,16 @@ extension RepositoriesFeature {
               )
             }
           case .plain:
+            let workspace = ProjectWorkspace.load(from: rootURL)
             return WorktreesFetchResult(
               entry: entry,
               repository: Repository(
                 id: rootURL.path(percentEncoded: false),
                 rootURL: rootURL,
-                name: Repository.name(for: rootURL),
+                name: workspace?.title ?? Repository.name(for: rootURL),
                 kind: .plain,
-                worktrees: IdentifiedArray()
+                worktrees: IdentifiedArray(),
+                workspace: workspace
               ),
               errorMessage: nil
             )

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+RepositoryManagement.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+RepositoryManagement.swift
@@ -17,6 +17,16 @@ extension RepositoriesFeature {
         var invalidRoots: [String] = []
         var openFailures: [String] = []
         for url in urls {
+          let normalizedURL = url.standardizedFileURL
+          if ProjectWorkspace.load(from: normalizedURL) != nil {
+            resolvedEntries.append(
+              PersistedRepositoryEntry(
+                path: normalizedURL.path(percentEncoded: false),
+                kind: .plain
+              )
+            )
+            continue
+          }
           do {
             let root = try await gitClient.repoRoot(url)
             resolvedEntries.append(

--- a/supacode/Features/Repositories/Views/DetailToolbarTitle.swift
+++ b/supacode/Features/Repositories/Views/DetailToolbarTitle.swift
@@ -4,13 +4,14 @@ struct DetailToolbarTitle: Equatable {
   enum Kind: Equatable {
     case branch(name: String)
     case folder(name: String)
+    case workspace(name: String)
   }
 
   let kind: Kind
 
   var text: String {
     switch kind {
-    case .branch(let name), .folder(let name):
+    case .branch(let name), .folder(let name), .workspace(let name):
       return name
     }
   }
@@ -19,6 +20,8 @@ struct DetailToolbarTitle: Equatable {
     switch kind {
     case .branch:
       return "arrow.trianglehead.branch"
+    case .workspace:
+      return "folder.badge.person.crop"
     case .folder:
       return "folder"
     }
@@ -40,6 +43,9 @@ struct DetailToolbarTitle: Equatable {
     }
     guard let repository, repository.kind == .plain else {
       return nil
+    }
+    if repository.isWorkspace {
+      return DetailToolbarTitle(kind: .workspace(name: repository.name))
     }
     return DetailToolbarTitle(kind: .folder(name: repository.name))
   }

--- a/supacode/Features/Repositories/Views/RepositoryDetailView.swift
+++ b/supacode/Features/Repositories/Views/RepositoryDetailView.swift
@@ -7,6 +7,14 @@ struct RepositoryDetailView: View {
   var customTitle: String?
 
   var body: some View {
+    if let workspace = repository.workspace {
+      WorkspaceDetailView(repository: repository, workspace: workspace)
+    } else {
+      repositoryDetail
+    }
+  }
+
+  private var repositoryDetail: some View {
     VStack(spacing: 12) {
       Image(systemName: repository.kind == .git ? "folder.badge.gearshape" : "folder")
         .font(.largeTitle)

--- a/supacode/Features/Repositories/Views/RepositorySectionView.swift
+++ b/supacode/Features/Repositories/Views/RepositorySectionView.swift
@@ -54,7 +54,7 @@ struct RepositorySectionView: View {
           repositoryRootURL: repository.rootURL,
           nameTooltip: repository.capabilities.supportsWorktrees
             ? (isExpanded ? "Collapse" : "Expand")
-            : "Open terminal in folder"
+            : (repository.isWorkspace ? "Open terminal in workspace" : "Open terminal in folder")
         )
         RepoHeaderTabCountBadge(
           repository: repository,

--- a/supacode/Features/Repositories/Views/WorkspaceDetailView.swift
+++ b/supacode/Features/Repositories/Views/WorkspaceDetailView.swift
@@ -1,0 +1,107 @@
+import SwiftUI
+
+struct WorkspaceDetailView: View {
+  let repository: Repository
+  let workspace: ProjectWorkspace
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 18) {
+      header
+      if !workspace.description.isEmpty {
+        Text(workspace.description)
+          .font(.callout)
+          .foregroundStyle(.secondary)
+          .textSelection(.enabled)
+      }
+      if !workspace.taskLinks.isEmpty {
+        taskLinks
+      }
+      repositoriesTable
+      Spacer(minLength: 0)
+    }
+    .padding(24)
+    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    .background(Color(nsColor: .windowBackgroundColor))
+  }
+
+  private var header: some View {
+    HStack(alignment: .top, spacing: 12) {
+      Image(systemName: "folder.badge.person.crop")
+        .font(.largeTitle)
+        .foregroundStyle(.secondary)
+        .accessibilityHidden(true)
+      VStack(alignment: .leading, spacing: 4) {
+        Text(workspace.title)
+          .font(.title3.weight(.semibold))
+          .textSelection(.enabled)
+        Text(repository.rootURL.path(percentEncoded: false))
+          .font(.subheadline.monospaced())
+          .foregroundStyle(.secondary)
+          .textSelection(.enabled)
+        Text("\(workspace.repositories.count) repositories")
+          .font(.subheadline)
+          .foregroundStyle(.tertiary)
+      }
+    }
+  }
+
+  private var taskLinks: some View {
+    VStack(alignment: .leading, spacing: 6) {
+      Text("Task Links")
+        .font(.headline)
+      ForEach(workspace.taskLinks, id: \.self) { link in
+        Text(link)
+          .font(.subheadline.monospaced())
+          .foregroundStyle(.secondary)
+          .textSelection(.enabled)
+      }
+    }
+  }
+
+  private var repositoriesTable: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      Text("Repositories")
+        .font(.headline)
+      if workspace.repositories.isEmpty {
+        Text("No repositories are declared in this workspace metadata.")
+          .font(.callout)
+          .foregroundStyle(.secondary)
+      } else {
+        Grid(alignment: .leading, horizontalSpacing: 16, verticalSpacing: 8) {
+          GridRow {
+            tableHeader("Name")
+            tableHeader("Role")
+            tableHeader("Branch")
+            tableHeader("Path")
+          }
+          Divider()
+            .gridCellUnsizedAxes(.horizontal)
+          ForEach(workspace.repositories) { entry in
+            GridRow(alignment: .firstTextBaseline) {
+              Text(entry.name)
+                .font(.subheadline.weight(.medium))
+              Text(entry.role ?? " ")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+              Text(entry.branchName ?? entry.baseRef ?? " ")
+                .font(.subheadline.monospaced())
+                .foregroundStyle(.secondary)
+              Text(entry.resolvedURL(relativeTo: repository.rootURL).path(percentEncoded: false))
+                .font(.subheadline.monospaced())
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .truncationMode(.middle)
+                .textSelection(.enabled)
+            }
+          }
+        }
+      }
+    }
+  }
+
+  private func tableHeader(_ title: String) -> some View {
+    Text(title)
+      .font(.caption.weight(.semibold))
+      .foregroundStyle(.tertiary)
+  }
+}

--- a/supacode/Features/Settings/BusinessLogic/RepositoryPersistenceKeys.swift
+++ b/supacode/Features/Settings/BusinessLogic/RepositoryPersistenceKeys.swift
@@ -205,6 +205,9 @@ nonisolated enum RepositoryEntryNormalizer {
 
     return order.compactMap { path in
       guard let kind = kindByPath[path] else { return nil }
+      if ProjectWorkspace.load(from: URL(fileURLWithPath: path)) != nil {
+        return PersistedRepositoryEntry(path: path, kind: .plain)
+      }
       return PersistedRepositoryEntry(path: path, kind: kind)
     }
   }

--- a/supacodeTests/DetailToolbarTitleTests.swift
+++ b/supacodeTests/DetailToolbarTitleTests.swift
@@ -42,4 +42,24 @@ struct DetailToolbarTitleTests {
     #expect(title?.systemImage == "folder")
     #expect(title?.supportsRename == false)
   }
+
+  @Test func workspaceSelectionUsesWorkspaceTitle() {
+    let repository = Repository(
+      id: "/tmp/workspace",
+      rootURL: URL(fileURLWithPath: "/tmp/workspace"),
+      name: "workspace",
+      kind: .plain,
+      worktrees: [],
+      workspace: ProjectWorkspace(title: "workspace")
+    )
+
+    let title = DetailToolbarTitle.forSelection(
+      worktree: nil,
+      repository: repository
+    )
+
+    #expect(title?.kind == .workspace(name: "workspace"))
+    #expect(title?.systemImage == "folder.badge.person.crop")
+    #expect(title?.supportsRename == false)
+  }
 }

--- a/supacodeTests/ProjectWorkspaceTests.swift
+++ b/supacodeTests/ProjectWorkspaceTests.swift
@@ -1,0 +1,161 @@
+import Foundation
+import IdentifiedCollections
+import Testing
+
+@testable import supacode
+
+@MainActor
+struct ProjectWorkspaceTests {
+  @Test func loadsWorkspaceMetadataWithDefaultsAndSnakeCaseSources() throws {
+    let rootURL = try makeTemporaryWorkspaceRoot()
+    defer { try? FileManager.default.removeItem(at: rootURL) }
+
+    try writeWorkspaceJSON(
+      """
+      {
+        "title": "Multi Repo Task",
+        "repositories": [
+          {
+            "role": "backend",
+            "path": "api",
+            "source_kind": "bare_repository",
+            "source_location": "/Users/mikoto/Repos/api.git",
+            "branch_name": "feature/workspace"
+          },
+          {
+            "id": "web",
+            "name": "Web",
+            "path": "/tmp/web",
+            "source_kind": "remote",
+            "source_location": "git@github.com:onevcat/web.git"
+          },
+          {
+            "name": "Shared",
+            "path": "shared"
+          }
+        ]
+      }
+      """,
+      to: rootURL
+    )
+
+    let workspace = try #require(ProjectWorkspace.load(from: rootURL))
+    let rootPath = rootURL.standardizedFileURL.path(percentEncoded: false)
+
+    #expect(workspace.id == rootPath)
+    #expect(workspace.title == "Multi Repo Task")
+    #expect(workspace.description == "")
+    #expect(workspace.taskLinks == [])
+    try #require(workspace.repositories.count == 3)
+
+    let api = workspace.repositories[0]
+    #expect(api.id == "api")
+    #expect(api.name == "api")
+    #expect(api.role == "backend")
+    #expect(api.sourceKind == .bareRepository)
+    #expect(api.sourceLocation == "/Users/mikoto/Repos/api.git")
+    #expect(api.branchName == "feature/workspace")
+    #expect(
+      api.resolvedURL(relativeTo: rootURL).path(percentEncoded: false)
+        == rootURL.appending(path: "api").standardizedFileURL.path(percentEncoded: false)
+    )
+
+    let web = workspace.repositories[1]
+    #expect(web.id == "web")
+    #expect(web.name == "Web")
+    #expect(web.sourceKind == .remote)
+    #expect(
+      web.resolvedURL(relativeTo: rootURL).path(percentEncoded: false)
+        == URL(fileURLWithPath: "/tmp/web").standardizedFileURL.path(percentEncoded: false)
+    )
+
+    let shared = workspace.repositories[2]
+    #expect(shared.id == "shared")
+    #expect(shared.name == "Shared")
+    #expect(shared.sourceKind == .existingPath)
+  }
+
+  @Test func normalizesEmptyWorkspaceAndRepositoryFields() throws {
+    let rootURL = URL(fileURLWithPath: "/tmp/prowl-workspace")
+
+    let workspace = ProjectWorkspace(
+      id: " ",
+      title: " ",
+      description: "  Touch app and API together  ",
+      taskLinks: [" https://github.com/onevcat/Prowl/issues/1 ", " "],
+      repositories: [
+        ProjectWorkspace.RepositoryEntry(
+          id: " ",
+          name: " ",
+          role: " ",
+          path: " app ",
+          sourceKind: .localRepository,
+          sourceLocation: " ",
+          branchName: " feature/workspace ",
+          baseRef: " "
+        )
+      ]
+    )
+    .normalized(relativeTo: rootURL)
+
+    #expect(workspace.id == "/tmp/prowl-workspace")
+    #expect(workspace.title == "prowl-workspace")
+    #expect(workspace.description == "Touch app and API together")
+    #expect(workspace.taskLinks == ["https://github.com/onevcat/Prowl/issues/1"])
+
+    let entry = try #require(workspace.repositories.first)
+    #expect(entry.id == "app")
+    #expect(entry.name == "app")
+    #expect(entry.role == nil)
+    #expect(entry.sourceKind == .localRepository)
+    #expect(entry.sourceLocation == nil)
+    #expect(entry.branchName == "feature/workspace")
+    #expect(entry.baseRef == nil)
+  }
+
+  @Test func repositoryEntryNormalizerKeepsWorkspacePathPlain() throws {
+    let rootURL = try makeTemporaryWorkspaceRoot()
+    defer { try? FileManager.default.removeItem(at: rootURL) }
+    try writeWorkspaceJSON("{}", to: rootURL)
+
+    let rootPath = rootURL.standardizedFileURL.path(percentEncoded: false)
+    let normalized = RepositoryEntryNormalizer.normalize([
+      PersistedRepositoryEntry(path: rootPath, kind: .git)
+    ])
+
+    #expect(normalized == [PersistedRepositoryEntry(path: rootPath, kind: .plain)])
+  }
+
+  @Test func listRuntimeContextsReportWorkspaceKind() {
+    let rootURL = URL(fileURLWithPath: "/tmp/workspace")
+    let repository = Repository(
+      id: rootURL.path(percentEncoded: false),
+      rootURL: rootURL,
+      name: "Workspace",
+      kind: .plain,
+      worktrees: [],
+      workspace: ProjectWorkspace(title: "Workspace")
+    )
+    var state = RepositoriesFeature.State()
+    state.repositories = [repository]
+    state.repositoryRoots = [rootURL]
+
+    let contexts = ListRuntimeSnapshotBuilder.orderedWorktreeContexts(from: state)
+
+    #expect(contexts.map(\.kind) == [.workspace])
+    #expect(contexts.first?.id == repository.id)
+  }
+
+  private func makeTemporaryWorkspaceRoot() throws -> URL {
+    let rootURL = FileManager.default.temporaryDirectory
+      .appending(path: "prowl-workspace-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+    return rootURL
+  }
+
+  private func writeWorkspaceJSON(_ json: String, to rootURL: URL) throws {
+    let metadataDirectoryURL = rootURL.appending(path: ProjectWorkspace.metadataDirectoryName)
+    try FileManager.default.createDirectory(at: metadataDirectoryURL, withIntermediateDirectories: true)
+    try Data(json.utf8).write(to: ProjectWorkspace.metadataURL(for: rootURL))
+  }
+}

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -507,6 +507,71 @@ struct RepositoriesFeatureTests {
     await store.finish()
   }
 
+  @Test func loadPersistedRepositoriesLoadsWorkspaceMetadataAsPlainRepository() async throws {
+    let rootURL = FileManager.default.temporaryDirectory
+      .appending(path: "prowl-workspace-\(UUID().uuidString)")
+      .standardizedFileURL
+    defer { try? FileManager.default.removeItem(at: rootURL) }
+
+    try FileManager.default.createDirectory(
+      at: rootURL.appending(path: ProjectWorkspace.metadataDirectoryName),
+      withIntermediateDirectories: true
+    )
+    try Data(
+      """
+      {
+        "title": "Multi Repo Workspace",
+        "repositories": [
+          {
+            "name": "App",
+            "role": "client",
+            "path": "app",
+            "source_kind": "existing_path"
+          }
+        ]
+      }
+      """.utf8
+    )
+    .write(to: ProjectWorkspace.metadataURL(for: rootURL))
+
+    let rootPath = rootURL.path(percentEncoded: false)
+    let workspace = try #require(ProjectWorkspace.load(from: rootURL))
+    let repository = makeRepository(
+      id: rootPath,
+      name: "Multi Repo Workspace",
+      kind: .plain,
+      worktrees: [],
+      workspace: workspace
+    )
+
+    let store = TestStore(initialState: RepositoriesFeature.State()) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.repositoryPersistence.loadRepositoryEntries = {
+        [PersistedRepositoryEntry(path: rootPath, kind: .plain)]
+      }
+      $0.repositoryPersistence.saveRepositorySnapshot = { _ in }
+      $0.gitClient.repoRoot = { url in
+        Issue.record("workspace should load as plain without git probing: \(url.path(percentEncoded: false))")
+        return url
+      }
+      $0.gitClient.worktrees = { url in
+        Issue.record("workspace should not load git worktrees: \(url.path(percentEncoded: false))")
+        return []
+      }
+    }
+
+    await store.send(.loadPersistedRepositories)
+    await store.receive(\.repositoriesLoaded) {
+      $0.repositories = [repository]
+      $0.repositoryRoots = [rootURL]
+      $0.isInitialLoadComplete = true
+      $0.snapshotPersistencePhase = .active
+    }
+    await store.receive(\.delegate.repositoriesChanged)
+    await store.finish()
+  }
+
   @Test func loadPersistedRepositoriesAutoUpgradesPlainFolderWhenItBecomesGitRoot() async {
     let root = "/tmp/folder"
     let worktree = makeWorktree(id: root, name: "folder", repoRoot: root)
@@ -5301,14 +5366,16 @@ struct RepositoriesFeatureTests {
     id: String,
     name: String = "repo",
     kind: Repository.Kind = .git,
-    worktrees: [Worktree]
+    worktrees: [Worktree],
+    workspace: ProjectWorkspace? = nil
   ) -> Repository {
     Repository(
       id: id,
       rootURL: URL(fileURLWithPath: id),
       name: name,
       kind: kind,
-      worktrees: IdentifiedArray(uniqueElements: worktrees)
+      worktrees: IdentifiedArray(uniqueElements: worktrees),
+      workspace: workspace
     )
   }
 


### PR DESCRIPTION
## Summary
- Add `.prowl/workspace.json` metadata support for multi-repo workspace folders.
- Load workspaces as runnable plain folders with a workspace detail view and CLI `worktree.kind = workspace`.
- Preserve workspace metadata through repository snapshots and document the workspace schema.

## Verification
- `make check`
- `xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -only-testing:supacodeTests/ProjectWorkspaceTests -only-testing:supacodeTests/DetailToolbarTitleTests -only-testing:supacodeTests/RepositoriesFeatureTests/loadPersistedRepositoriesLoadsWorkspaceMetadataAsPlainRepository CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation`
- `make build-app`