### PR TITLE
[review] Shelf agent status + trackpad navigation, with wrap-around restored

### DIFF
--- a/docs/components/active-agents.md
+++ b/docs/components/active-agents.md
@@ -56,6 +56,8 @@ When nothing is running: "New agents will appear here".
 
 - `autoShowActiveAgentsPanel` — pop the panel open when an agent appears.
 - `showActiveAgentTabTitles` — show each agent's tab title instead of its branch.
+- `showActiveAgentStatusInShelf` — show detected agent status markers on Shelf
+  tab icons.
 - Panel height and hidden/shown state are persisted automatically.
 
 ## Relationship to other features
@@ -66,9 +68,10 @@ When nothing is running: "New agents will appear here".
   events — which usually coincides with, but is not the same as, a detected finish.
 - **Canvas** ([canvas](canvas.md)) is the spatial counterpart — cards light up on
   that same notification/unread signal, not on the detected status itself.
-- **Shelf** ([shelf](shelf.md)) mirrors detected agents as compact status badges
-  at the bottom of each owning spine; clicking a badge uses the same jump-to-agent
-  behavior as clicking a panel row.
+- **Shelf** ([shelf](shelf.md)) mirrors detected agents as status markers on
+  each owning tab icon; clicking a marked tab uses the same jump-to-agent behavior
+  as clicking a panel row. This can be turned off with
+  `showActiveAgentStatusInShelf`.
 
 ## Gotchas for agents
 

--- a/docs/components/active-agents.md
+++ b/docs/components/active-agents.md
@@ -66,6 +66,9 @@ When nothing is running: "New agents will appear here".
   events — which usually coincides with, but is not the same as, a detected finish.
 - **Canvas** ([canvas](canvas.md)) is the spatial counterpart — cards light up on
   that same notification/unread signal, not on the detected status itself.
+- **Shelf** ([shelf](shelf.md)) mirrors detected agents as compact status badges
+  at the bottom of each owning spine; clicking a badge uses the same jump-to-agent
+  behavior as clicking a panel row.
 
 ## Gotchas for agents
 

--- a/docs/components/shelf.md
+++ b/docs/components/shelf.md
@@ -66,10 +66,10 @@ selection.
 - **Unread notification:** a tab slot highlights orange; the spine header shows an
   orange dot.
 - **Detected agents:** status markers appear on the owning tab slot. Marker
-  color/status follows the Active Agents states (Working, Blocked, Done, Idle);
-  blocked agents are prioritized first when a split tab contains multiple agents.
-  Shelf keeps agent detection active while visible, even if the Active Agents
-  panel is hidden.
+  color/status follows the Active Agents states (Working, Blocked, Done); idle
+  agents tint the slot but show no corner glyph. Blocked agents are prioritized
+  first when a split tab contains multiple agents. Shelf keeps agent detection
+  active while visible, even if the Active Agents panel is hidden.
 - Spine tint follows the **repository color** when set (toggle
   `shelfSpineTintFollowsRepositoryColor`); otherwise a fallback
   (`shelfSpineTintFallback`: neutral or system tint) is used.

--- a/docs/components/shelf.md
+++ b/docs/components/shelf.md
@@ -33,9 +33,11 @@ otherwise it's a no-op.
 So `⌘⌃←/→` moves **between agents**, and `⌘⌃↑/↓` moves **between that agent's
 tabs** — triage six in-flight agents one keystroke at a time.
 
-Two-finger horizontal swipes on the trackpad also flip between books. Vertical
-scrolling inside the terminal keeps working normally; Shelf only consumes a swipe
-after the horizontal movement clearly dominates.
+Two-finger horizontal swipes on the trackpad also flip between books: swipe left
+to move to the book on the right, and swipe right to move to the book on the
+left. Book switching is bounded at the shelf edges; it does not wrap around.
+Vertical scrolling inside the terminal keeps working normally; Shelf only
+consumes a swipe after the horizontal movement clearly dominates.
 
 ## Interacting with spines
 
@@ -100,5 +102,5 @@ See [view-modes](view-modes.md).
   running from a different working directory, the full Active Agents panel still
   shows the resolved repository/branch context.
 - Closing the last tab of a book removes the book from the shelf.
-- The book-cycling keys (`⌘⌃←/→`) and tab-cycling keys (`⌘⌃↑/↓`) differ only by
-  arrow direction — be precise when describing them.
+- The book-switching keys (`⌘⌃←/→`) and tab-cycling keys (`⌘⌃↑/↓`) differ only
+  by arrow direction — be precise when describing them.

--- a/docs/components/shelf.md
+++ b/docs/components/shelf.md
@@ -35,7 +35,7 @@ tabs** — triage six in-flight agents one keystroke at a time.
 
 Hold `⌘` and use a two-finger trackpad swipe for directional navigation:
 horizontal swipes flip between books, and vertical swipes cycle tabs in the open
-book. Book switching is bounded at the shelf edges; it does not wrap around.
+book. Both axes wrap around, matching the `⌘⌃` arrow keys.
 Plain scrolling inside the terminal keeps working normally because Shelf only
 consumes the gesture while `⌘` is held.
 
@@ -105,5 +105,5 @@ See [view-modes](view-modes.md).
   an agent is running from a different working directory, the full Active Agents
   panel still shows the resolved repository/branch context.
 - Closing the last tab of a book removes the book from the shelf.
-- The book-switching keys (`⌘⌃←/→`) and tab-cycling keys (`⌘⌃↑/↓`) differ only
-  by arrow direction — be precise when describing them.
+- The book-cycling keys (`⌘⌃←/→`) and tab-cycling keys (`⌘⌃↑/↓`) differ only by
+  arrow direction — be precise when describing them.

--- a/docs/components/shelf.md
+++ b/docs/components/shelf.md
@@ -5,13 +5,15 @@
 
 **Keywords:** shelf, book, spine, vertical tabs, flip, cycle books, cycle tabs, triage, proximity, stack
 
-**Related:** [view-modes](view-modes.md) · [canvas](canvas.md) · [terminal](terminal.md) · [keyboard-shortcuts](../reference/keyboard-shortcuts.md)
+**Related:** [view-modes](view-modes.md) · [canvas](canvas.md) · [terminal](terminal.md) · [active-agents](active-agents.md) · [keyboard-shortcuts](../reference/keyboard-shortcuts.md)
 
 ## What it is
 
 Shelf lays your worktrees out as thin vertical **spines** ("books") on the sides,
 with the currently open book's terminal filling the center. Each spine shows the
 project icon/name (rotated) and a column of its **tabs** as small icon slots.
+When Prowl detects agents in that book, the bottom of the spine also shows compact
+agent badges with their current status.
 Books near the open one are brighter; distant ones fade — so you always know where
 you are in the stack.
 
@@ -38,6 +40,8 @@ tabs** — triage six in-flight agents one keystroke at a time.
 - **Select a tab:** click a tab slot on the open book's spine.
 - **New tab:** the **+** at the bottom of a spine. On a closed book, **+** opens
   the book and creates the tab.
+- **Jump to an agent:** click an agent badge at the bottom of a spine. It focuses
+  that agent's worktree, tab, and pane.
 - **Split:** the open book's spine has **split-vertical** and **split-horizontal**
   buttons (Ghostty `new_split:right` / `new_split:down`).
 - **Close a tab:** hover a tab slot → its **×**.
@@ -55,6 +59,10 @@ selection.
   progressively — a proximity ladder that keeps the stack readable.
 - **Unread notification:** a tab slot highlights orange; the spine header shows an
   orange dot.
+- **Detected agents:** compact badges appear at the bottom of the owning spine.
+  Badge color/status follows the Active Agents states (Working, Blocked, Done,
+  Idle); blocked agents are prioritized first. Shelf keeps agent detection active
+  while visible, even if the Active Agents panel is hidden.
 - Spine tint follows the **repository color** when set (toggle
   `shelfSpineTintFollowsRepositoryColor`); otherwise a fallback
   (`shelfSpineTintFallback`: neutral or system tint) is used.
@@ -84,6 +92,9 @@ See [view-modes](view-modes.md).
 ## Gotchas for agents
 
 - A "book" is a **worktree**; a tab slot is a **tab** within it.
+- Agent badges belong to the terminal surface's owning worktree. If an agent is
+  running from a different working directory, the full Active Agents panel still
+  shows the resolved repository/branch context.
 - Closing the last tab of a book removes the book from the shelf.
 - The book-cycling keys (`⌘⌃←/→`) and tab-cycling keys (`⌘⌃↑/↓`) differ only by
   arrow direction — be precise when describing them.

--- a/docs/components/shelf.md
+++ b/docs/components/shelf.md
@@ -12,8 +12,8 @@
 Shelf lays your worktrees out as thin vertical **spines** ("books") on the sides,
 with the currently open book's terminal filling the center. Each spine shows the
 project icon/name (rotated) and a column of its **tabs** as small icon slots.
-When Prowl detects agents in that book, the bottom of the spine also shows compact
-agent badges with their current status.
+When Prowl detects an agent in a tab, that tab slot shows the agent status as a
+small colored marker.
 Books near the open one are brighter; distant ones fade — so you always know where
 you are in the stack.
 
@@ -33,11 +33,11 @@ otherwise it's a no-op.
 So `⌘⌃←/→` moves **between agents**, and `⌘⌃↑/↓` moves **between that agent's
 tabs** — triage six in-flight agents one keystroke at a time.
 
-Two-finger horizontal swipes on the trackpad also flip between books: swipe left
-to move to the book on the right, and swipe right to move to the book on the
-left. Book switching is bounded at the shelf edges; it does not wrap around.
-Vertical scrolling inside the terminal keeps working normally; Shelf only
-consumes a swipe after the horizontal movement clearly dominates.
+Hold `⌘` and use a two-finger trackpad swipe for directional navigation:
+horizontal swipes flip between books, and vertical swipes cycle tabs in the open
+book. Book switching is bounded at the shelf edges; it does not wrap around.
+Plain scrolling inside the terminal keeps working normally because Shelf only
+consumes the gesture while `⌘` is held.
 
 ## Interacting with spines
 
@@ -46,7 +46,7 @@ consumes a swipe after the horizontal movement clearly dominates.
 - **Select a tab:** click a tab slot on the open book's spine.
 - **New tab:** the **+** at the bottom of a spine. On a closed book, **+** opens
   the book and creates the tab.
-- **Jump to an agent:** click an agent badge at the bottom of a spine. It focuses
+- **Jump to an agent:** click a tab slot with an agent status marker. It focuses
   that agent's worktree, tab, and pane.
 - **Split:** the open book's spine has **split-vertical** and **split-horizontal**
   buttons (Ghostty `new_split:right` / `new_split:down`).
@@ -65,10 +65,11 @@ selection.
   progressively — a proximity ladder that keeps the stack readable.
 - **Unread notification:** a tab slot highlights orange; the spine header shows an
   orange dot.
-- **Detected agents:** compact badges appear at the bottom of the owning spine.
-  Badge color/status follows the Active Agents states (Working, Blocked, Done,
-  Idle); blocked agents are prioritized first. Shelf keeps agent detection active
-  while visible, even if the Active Agents panel is hidden.
+- **Detected agents:** status markers appear on the owning tab slot. Marker
+  color/status follows the Active Agents states (Working, Blocked, Done, Idle);
+  blocked agents are prioritized first when a split tab contains multiple agents.
+  Shelf keeps agent detection active while visible, even if the Active Agents
+  panel is hidden.
 - Spine tint follows the **repository color** when set (toggle
   `shelfSpineTintFollowsRepositoryColor`); otherwise a fallback
   (`shelfSpineTintFallback`: neutral or system tint) is used.
@@ -83,6 +84,8 @@ spines stay visible so you can pick one.
 ## Settings that affect Shelf
 
 - `defaultViewMode` — launch directly into Shelf.
+- `showActiveAgentStatusInShelf` — overlay detected agent status on Shelf tab
+  icons.
 - `shelfSpineTintFollowsRepositoryColor` — color spines by repo color.
 - `shelfSpineTintFallback` — `neutral` or `systemTint` when a repo has no color.
 - `windowTintMode` / repository colors — chrome tinting.
@@ -98,9 +101,9 @@ See [view-modes](view-modes.md).
 ## Gotchas for agents
 
 - A "book" is a **worktree**; a tab slot is a **tab** within it.
-- Agent badges belong to the terminal surface's owning worktree. If an agent is
-  running from a different working directory, the full Active Agents panel still
-  shows the resolved repository/branch context.
+- Agent status markers belong to the terminal surface's owning tab/worktree. If
+  an agent is running from a different working directory, the full Active Agents
+  panel still shows the resolved repository/branch context.
 - Closing the last tab of a book removes the book from the shelf.
 - The book-switching keys (`⌘⌃←/→`) and tab-cycling keys (`⌘⌃↑/↓`) differ only
   by arrow direction — be precise when describing them.

--- a/docs/components/shelf.md
+++ b/docs/components/shelf.md
@@ -33,6 +33,10 @@ otherwise it's a no-op.
 So `⌘⌃←/→` moves **between agents**, and `⌘⌃↑/↓` moves **between that agent's
 tabs** — triage six in-flight agents one keystroke at a time.
 
+Two-finger horizontal swipes on the trackpad also flip between books. Vertical
+scrolling inside the terminal keeps working normally; Shelf only consumes a swipe
+after the horizontal movement clearly dominates.
+
 ## Interacting with spines
 
 - **Open a book:** click anywhere on a closed spine (it activates and shows its

--- a/docs/reference/settings-fields.md
+++ b/docs/reference/settings-fields.md
@@ -54,6 +54,7 @@ JSON is pretty-printed with sorted keys. Legacy `~/.supacode` is migrated to
 | `dimUnfocusedSplits` | Bool | `true` | Dim panes that aren't focused. |
 | `autoShowActiveAgentsPanel` | Bool | `false` | Auto-open the Active Agents panel on a new agent. |
 | `showActiveAgentTabTitles` | Bool | `false` | Show tab titles (vs. branch) in the agents panel. |
+| `showActiveAgentStatusInShelf` | Bool | `true` | Show agent status markers on Shelf tab icons. |
 | `windowTintMode` | enum (`none`/`repositoryColor`/`custom`) | `repositoryColor` | How the window chrome is tinted. |
 | `windowTintCustomColor` | color | default | The custom tint color (when `windowTintMode = custom`). |
 | `showRunButtonInToolbar` | Bool | `true` | Show the Run Script button in the toolbar. |

--- a/supacode/Features/ActiveAgents/Reducer/ActiveAgentsFeature.swift
+++ b/supacode/Features/ActiveAgents/Reducer/ActiveAgentsFeature.swift
@@ -128,7 +128,11 @@ struct ActiveAgentsFeature {
     max(minimumPanelHeight, min(maximumPanelHeight, height - reservedSidebarListHeight))
   }
 
-  static func detectionEnabled(isPanelHidden: Bool, autoShowPanel: Bool) -> Bool {
-    !isPanelHidden || autoShowPanel
+  static func detectionEnabled(
+    isPanelHidden: Bool,
+    autoShowPanel: Bool,
+    isShelfVisible: Bool
+  ) -> Bool {
+    isShelfVisible || !isPanelHidden || autoShowPanel
   }
 }

--- a/supacode/Features/ActiveAgents/Views/ActiveAgentRow.swift
+++ b/supacode/Features/ActiveAgents/Views/ActiveAgentRow.swift
@@ -116,7 +116,7 @@ struct BaguaWorkingIndicator: View {
 }
 
 extension AgentDisplayState {
-  fileprivate var label: String {
+  var label: String {
     switch self {
     case .working:
       return "Working"
@@ -129,7 +129,7 @@ extension AgentDisplayState {
     }
   }
 
-  fileprivate var foregroundStyle: Color {
+  var foregroundStyle: Color {
     switch self {
     case .working:
       return .orange

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -76,6 +76,7 @@ struct AppFeature {
     case endSearch
     case systemNotificationsPermissionFailed(errorMessage: String?)
     case systemNotificationTapped(worktreeID: Worktree.ID, surfaceID: UUID)
+    case syncAgentDetectionEnabled
     case alert(PresentationAction<Alert>)
     case terminalEvent(TerminalClient.Event)
   }
@@ -98,6 +99,27 @@ struct AppFeature {
   @Dependency(WorktreeInfoWatcherClient.self) var worktreeInfoWatcher
   @Dependency(CustomShortcutRegistryClient.self) var customShortcutRegistryClient
 
+  func agentDetectionEnabled(
+    state: State,
+    autoShowPanel: Bool? = nil
+  ) -> Bool {
+    ActiveAgentsFeature.detectionEnabled(
+      isPanelHidden: state.repositories.activeAgents.isPanelHidden,
+      autoShowPanel: autoShowPanel ?? state.settings.autoShowActiveAgentsPanel,
+      isShelfVisible: state.repositories.isShowingShelf
+    )
+  }
+
+  static func repositoriesActionMayChangeShelfVisibility(_ action: RepositoriesFeature.Action) -> Bool {
+    switch action {
+    case .selectArchivedWorktrees, .selectCanvas, .selectShelf, .selectTabbed, .setTopSegment, .toggleCanvas,
+      .toggleShelf:
+      return true
+    default:
+      return false
+    }
+  }
+
   var body: some Reducer<State, Action> {
     let core = Reduce<State, Action> { state, action in
       switch action {
@@ -106,10 +128,7 @@ struct AppFeature {
         appLogger.info("[LayoutRestore] appLaunched: launchRestoreMode=\(String(describing: state.launchRestoreMode))")
         state.launchedAt = now
         state.repositories.launchRestoreMode = state.launchRestoreMode
-        let agentDetectionEnabled = ActiveAgentsFeature.detectionEnabled(
-          isPanelHidden: state.repositories.activeAgents.isPanelHidden,
-          autoShowPanel: state.settings.autoShowActiveAgentsPanel
-        )
+        let agentDetectionEnabled = agentDetectionEnabled(state: state)
         analyticsClient.capture("app_launched", nil)
         return .merge(
           .send(.repositories(.task)),
@@ -382,10 +401,8 @@ struct AppFeature {
         state.lastKnownSystemNotificationsEnabled = settings.systemNotificationsEnabled
         state.settings.keybindingUserOverrides = settings.keybindingUserOverrides
         state.repositories.showActiveAgentTabTitles = settings.showActiveAgentTabTitles
-        let agentDetectionEnabled = ActiveAgentsFeature.detectionEnabled(
-          isPanelHidden: state.repositories.activeAgents.isPanelHidden,
-          autoShowPanel: settings.autoShowActiveAgentsPanel
-        )
+        let agentDetectionEnabled = agentDetectionEnabled(
+          state: state, autoShowPanel: settings.autoShowActiveAgentsPanel)
         if let selectedWorktree = state.repositories.selectedTerminalWorktree {
           let rootURL = selectedWorktree.repositoryRootURL
           @Shared(.repositorySettings(rootURL)) var repositorySettings
@@ -871,6 +888,12 @@ struct AppFeature {
           }
         )
 
+      case .syncAgentDetectionEnabled:
+        let agentDetectionEnabled = agentDetectionEnabled(state: state)
+        return .run { _ in
+          await terminalClient.send(.setAgentDetectionEnabled(agentDetectionEnabled))
+        }
+
       case .alert(.dismiss):
         state.alert = nil
         return .none
@@ -889,11 +912,15 @@ struct AppFeature {
         let nextIsPanelHidden = !state.repositories.activeAgents.isPanelHidden
         let agentDetectionEnabled = ActiveAgentsFeature.detectionEnabled(
           isPanelHidden: nextIsPanelHidden,
-          autoShowPanel: state.settings.autoShowActiveAgentsPanel
+          autoShowPanel: state.settings.autoShowActiveAgentsPanel,
+          isShelfVisible: state.repositories.isShowingShelf
         )
         return .run { _ in
           await terminalClient.send(.setAgentDetectionEnabled(agentDetectionEnabled))
         }
+
+      case .repositories(let action) where Self.repositoriesActionMayChangeShelfVisibility(action):
+        return .send(.syncAgentDetectionEnabled)
 
       case .repositories:
         return .none

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -101,12 +101,15 @@ struct AppFeature {
 
   func agentDetectionEnabled(
     state: State,
-    autoShowPanel: Bool? = nil
+    autoShowPanel: Bool? = nil,
+    showShelfStatus: Bool? = nil
   ) -> Bool {
-    ActiveAgentsFeature.detectionEnabled(
+    let shelfStatusVisible =
+      state.repositories.isShowingShelf && (showShelfStatus ?? state.settings.showActiveAgentStatusInShelf)
+    return ActiveAgentsFeature.detectionEnabled(
       isPanelHidden: state.repositories.activeAgents.isPanelHidden,
       autoShowPanel: autoShowPanel ?? state.settings.autoShowActiveAgentsPanel,
-      isShelfVisible: state.repositories.isShowingShelf
+      isShelfVisible: shelfStatusVisible
     )
   }
 
@@ -402,7 +405,10 @@ struct AppFeature {
         state.settings.keybindingUserOverrides = settings.keybindingUserOverrides
         state.repositories.showActiveAgentTabTitles = settings.showActiveAgentTabTitles
         let agentDetectionEnabled = agentDetectionEnabled(
-          state: state, autoShowPanel: settings.autoShowActiveAgentsPanel)
+          state: state,
+          autoShowPanel: settings.autoShowActiveAgentsPanel,
+          showShelfStatus: settings.showActiveAgentStatusInShelf
+        )
         if let selectedWorktree = state.repositories.selectedTerminalWorktree {
           let rootURL = selectedWorktree.repositoryRootURL
           @Shared(.repositorySettings(rootURL)) var repositorySettings
@@ -913,7 +919,7 @@ struct AppFeature {
         let agentDetectionEnabled = ActiveAgentsFeature.detectionEnabled(
           isPanelHidden: nextIsPanelHidden,
           autoShowPanel: state.settings.autoShowActiveAgentsPanel,
-          isShelfVisible: state.repositories.isShowingShelf
+          isShelfVisible: state.repositories.isShowingShelf && state.settings.showActiveAgentStatusInShelf
         )
         return .run { _ in
           await terminalClient.send(.setAgentDetectionEnabled(agentDetectionEnabled))

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -118,6 +118,11 @@ struct AppFeature {
     case .selectArchivedWorktrees, .selectCanvas, .selectShelf, .selectTabbed, .setTopSegment, .toggleCanvas,
       .toggleShelf:
       return true
+    // `isShowingShelf` also requires a non-empty repository list, so actions
+    // that add or remove repositories can flip it without touching `isShelfActive`.
+    case .repositoriesLoaded, .repositoryManagement(.repositoryRemoved),
+      .repositoryManagement(.openRepositoriesFinished):
+      return true
     default:
       return false
     }

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+Selection.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+Selection.swift
@@ -84,9 +84,10 @@ func replacementBookAfterClosing(
 }
 
 /// Returns the Shelf book at `offset` positions from the currently open
-/// book (wrapping around the book list). Returns nil if there are no
-/// books. When there is no open book, offset > 0 picks the first book
-/// and offset < 0 picks the last.
+/// book. Returns nil at the list edges instead of wrapping around, so
+/// Shelf navigation behaves like bounded horizontal movement. When
+/// there is no open book, offset > 0 picks the first book and offset < 0
+/// picks the last.
 func shelfBook(
   atOffset offset: Int,
   state: RepositoriesFeature.State
@@ -96,7 +97,8 @@ func shelfBook(
   if let currentID = state.openShelfBookID,
     let currentIndex = books.firstIndex(where: { $0.id == currentID })
   {
-    let nextIndex = (currentIndex + offset + books.count) % books.count
+    let nextIndex = currentIndex + offset
+    guard books.indices.contains(nextIndex) else { return nil }
     return books[nextIndex]
   }
   return offset > 0 ? books.first : books.last

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+Selection.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+Selection.swift
@@ -84,10 +84,9 @@ func replacementBookAfterClosing(
 }
 
 /// Returns the Shelf book at `offset` positions from the currently open
-/// book. Returns nil at the list edges instead of wrapping around, so
-/// Shelf navigation behaves like bounded horizontal movement. When
-/// there is no open book, offset > 0 picks the first book and offset < 0
-/// picks the last.
+/// book (wrapping around the book list). Returns nil if there are no
+/// books. When there is no open book, offset > 0 picks the first book
+/// and offset < 0 picks the last.
 func shelfBook(
   atOffset offset: Int,
   state: RepositoriesFeature.State
@@ -97,8 +96,7 @@ func shelfBook(
   if let currentID = state.openShelfBookID,
     let currentIndex = books.firstIndex(where: { $0.id == currentID })
   {
-    let nextIndex = currentIndex + offset
-    guard books.indices.contains(nextIndex) else { return nil }
+    let nextIndex = (currentIndex + offset + books.count) % books.count
     return books[nextIndex]
   }
   return offset > 0 ? books.first : books.last

--- a/supacode/Features/Settings/Models/GlobalSettings.swift
+++ b/supacode/Features/Settings/Models/GlobalSettings.swift
@@ -30,6 +30,7 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
   var dimUnfocusedSplits: Bool
   var autoShowActiveAgentsPanel: Bool
   var showActiveAgentTabTitles: Bool
+  var showActiveAgentStatusInShelf: Bool
   var windowTintMode: WindowTintMode
   var windowTintCustomColor: TintColor
   var showRunButtonInToolbar: Bool
@@ -71,6 +72,7 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     dimUnfocusedSplits: true,
     autoShowActiveAgentsPanel: false,
     showActiveAgentTabTitles: false,
+    showActiveAgentStatusInShelf: true,
     windowTintMode: .repositoryColor,
     windowTintCustomColor: .default,
     showRunButtonInToolbar: true,
@@ -113,6 +115,7 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     dimUnfocusedSplits: Bool = true,
     autoShowActiveAgentsPanel: Bool = false,
     showActiveAgentTabTitles: Bool = false,
+    showActiveAgentStatusInShelf: Bool = true,
     windowTintMode: WindowTintMode = .repositoryColor,
     windowTintCustomColor: TintColor = .default,
     showRunButtonInToolbar: Bool = true,
@@ -153,6 +156,7 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     self.dimUnfocusedSplits = dimUnfocusedSplits
     self.autoShowActiveAgentsPanel = autoShowActiveAgentsPanel
     self.showActiveAgentTabTitles = showActiveAgentTabTitles
+    self.showActiveAgentStatusInShelf = showActiveAgentStatusInShelf
     self.windowTintMode = windowTintMode
     self.windowTintCustomColor = windowTintCustomColor
     self.showRunButtonInToolbar = showRunButtonInToolbar
@@ -196,6 +200,7 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     try container.encode(dimUnfocusedSplits, forKey: .dimUnfocusedSplits)
     try container.encode(autoShowActiveAgentsPanel, forKey: .autoShowActiveAgentsPanel)
     try container.encode(showActiveAgentTabTitles, forKey: .showActiveAgentTabTitles)
+    try container.encode(showActiveAgentStatusInShelf, forKey: .showActiveAgentStatusInShelf)
     try container.encode(windowTintMode, forKey: .windowTintMode)
     try container.encode(windowTintCustomColor, forKey: .windowTintCustomColor)
     try container.encode(showRunButtonInToolbar, forKey: .showRunButtonInToolbar)
@@ -238,6 +243,7 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     case dimUnfocusedSplits
     case autoShowActiveAgentsPanel
     case showActiveAgentTabTitles
+    case showActiveAgentStatusInShelf
     case windowTintMode
     case windowTintCustomColor
     case showRunButtonInToolbar
@@ -339,6 +345,9 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     showActiveAgentTabTitles =
       try container.decodeIfPresent(Bool.self, forKey: .showActiveAgentTabTitles)
       ?? Self.default.showActiveAgentTabTitles
+    showActiveAgentStatusInShelf =
+      try container.decodeIfPresent(Bool.self, forKey: .showActiveAgentStatusInShelf)
+      ?? Self.default.showActiveAgentStatusInShelf
     (windowTintMode, windowTintCustomColor) = try Self.decodeWindowTint(from: container)
     (shelfSpineTintFallback, shelfSpineTintFollowsRepositoryColor) = try Self.decodeShelfSpineTint(from: container)
     let toolbarAndDock = try Self.decodeToolbarAndDockSettings(from: container)

--- a/supacode/Features/Settings/Reducer/SettingsFeature.swift
+++ b/supacode/Features/Settings/Reducer/SettingsFeature.swift
@@ -37,6 +37,7 @@ struct SettingsFeature {
     var dimUnfocusedSplits: Bool
     var autoShowActiveAgentsPanel: Bool
     var showActiveAgentTabTitles: Bool
+    var showActiveAgentStatusInShelf: Bool
     var windowTintMode: WindowTintMode
     var shelfSpineTintFallback: ShelfSpineTintFallback
     var shelfSpineTintFollowsRepositoryColor: Bool
@@ -92,6 +93,7 @@ struct SettingsFeature {
       dimUnfocusedSplits = settings.dimUnfocusedSplits
       autoShowActiveAgentsPanel = settings.autoShowActiveAgentsPanel
       showActiveAgentTabTitles = settings.showActiveAgentTabTitles
+      showActiveAgentStatusInShelf = settings.showActiveAgentStatusInShelf
       windowTintMode = settings.windowTintMode
       shelfSpineTintFallback = settings.shelfSpineTintFallback
       shelfSpineTintFollowsRepositoryColor = settings.shelfSpineTintFollowsRepositoryColor
@@ -137,6 +139,7 @@ struct SettingsFeature {
         dimUnfocusedSplits: dimUnfocusedSplits,
         autoShowActiveAgentsPanel: autoShowActiveAgentsPanel,
         showActiveAgentTabTitles: showActiveAgentTabTitles,
+        showActiveAgentStatusInShelf: showActiveAgentStatusInShelf,
         windowTintMode: windowTintMode,
         windowTintCustomColor: TintColor(windowTintCustomColor),
         showRunButtonInToolbar: showRunButtonInToolbar,
@@ -250,6 +253,7 @@ struct SettingsFeature {
         state.dimUnfocusedSplits = normalizedSettings.dimUnfocusedSplits
         state.autoShowActiveAgentsPanel = normalizedSettings.autoShowActiveAgentsPanel
         state.showActiveAgentTabTitles = normalizedSettings.showActiveAgentTabTitles
+        state.showActiveAgentStatusInShelf = normalizedSettings.showActiveAgentStatusInShelf
         state.windowTintMode = normalizedSettings.windowTintMode
         state.shelfSpineTintFallback = normalizedSettings.shelfSpineTintFallback
         state.shelfSpineTintFollowsRepositoryColor = normalizedSettings.shelfSpineTintFollowsRepositoryColor

--- a/supacode/Features/Settings/Views/AppearanceSettingsView.swift
+++ b/supacode/Features/Settings/Views/AppearanceSettingsView.swift
@@ -101,6 +101,11 @@ struct AppearanceSettingsView: View {
             isOn: $store.showActiveAgentTabTitles
           )
           .help("Display each agent's tab title in the row and show the branch name on hover.")
+          Toggle(
+            "Show agent status in Shelf tabs",
+            isOn: $store.showActiveAgentStatusInShelf
+          )
+          .help("Overlay detected agent status on the owning tab icon in Shelf View.")
         }
         Section("Default View") {
           Picker("Launch in", selection: $store.defaultViewMode) {

--- a/supacode/Features/Shelf/Views/ShelfSpineView.swift
+++ b/supacode/Features/Shelf/Views/ShelfSpineView.swift
@@ -231,31 +231,29 @@ struct ShelfSpineView: View {
     // caller sequences `selectWorktree` → `newTerminal`). Splits only
     // make sense against a focused surface, so they stay scoped to the
     // open book.
-    if hasBottomControls {
-      if let onNewTab {
-        ShelfSpineControlButton(
-          systemImage: "plus",
-          label: "New Tab",
-          shortcut: ghosttyShortcuts.display(for: "new_tab"),
-          action: onNewTab
-        )
-      }
-      if let onSplitVertical {
-        ShelfSpineControlButton(
-          systemImage: "square.split.2x1",
-          label: "Split Vertically",
-          shortcut: ghosttyShortcuts.display(for: "new_split:right"),
-          action: onSplitVertical
-        )
-      }
-      if let onSplitHorizontal {
-        ShelfSpineControlButton(
-          systemImage: "square.split.1x2",
-          label: "Split Horizontally",
-          shortcut: ghosttyShortcuts.display(for: "new_split:down"),
-          action: onSplitHorizontal
-        )
-      }
+    if let onNewTab {
+      ShelfSpineControlButton(
+        systemImage: "plus",
+        label: "New Tab",
+        shortcut: ghosttyShortcuts.display(for: "new_tab"),
+        action: onNewTab
+      )
+    }
+    if let onSplitVertical {
+      ShelfSpineControlButton(
+        systemImage: "square.split.2x1",
+        label: "Split Vertically",
+        shortcut: ghosttyShortcuts.display(for: "new_split:right"),
+        action: onSplitVertical
+      )
+    }
+    if let onSplitHorizontal {
+      ShelfSpineControlButton(
+        systemImage: "square.split.1x2",
+        label: "Split Horizontally",
+        shortcut: ghosttyShortcuts.display(for: "new_split:down"),
+        action: onSplitHorizontal
+      )
     }
   }
 

--- a/supacode/Features/Shelf/Views/ShelfSpineView.swift
+++ b/supacode/Features/Shelf/Views/ShelfSpineView.swift
@@ -602,14 +602,18 @@ private struct ShelfSpineTabSlot: View {
 
   @ViewBuilder
   private func statusMarker(for entry: ActiveAgentEntry) -> some View {
-    Image(systemName: entry.displayState.shelfSpineStatusSymbol)
-      .font(.caption2.weight(.bold))
-      .foregroundStyle(entry.displayState.foregroundStyle)
-      .frame(
-        width: ShelfMetrics.agentStatusMarkerSize,
-        height: ShelfMetrics.agentStatusMarkerSize
-      )
-      .accessibilityHidden(true)
+    if let symbol = entry.displayState.shelfSpineStatusSymbol {
+      Image(systemName: symbol)
+        .font(.caption2.weight(.bold))
+        .foregroundStyle(entry.displayState.foregroundStyle)
+        // Thin halo so the bare glyph stays legible over the tab icon's strokes.
+        .shadow(color: .black.opacity(0.4), radius: 1)
+        .frame(
+          width: ShelfMetrics.agentStatusMarkerSize,
+          height: ShelfMetrics.agentStatusMarkerSize
+        )
+        .accessibilityHidden(true)
+    }
   }
 
   private var helpText: String {
@@ -686,12 +690,14 @@ extension AgentDisplayState {
     }
   }
 
-  fileprivate var shelfSpineStatusSymbol: String {
+  /// `nil` hides the marker: idle is the steady state, so badging it would
+  /// keep a permanent glyph on every agent tab and dilute the actionable ones.
+  fileprivate var shelfSpineStatusSymbol: String? {
     switch self {
     case .working: return "bolt.fill"
     case .blocked: return "exclamationmark"
     case .done: return "checkmark"
-    case .idle: return "circle.fill"
+    case .idle: return nil
     }
   }
 }

--- a/supacode/Features/Shelf/Views/ShelfSpineView.swift
+++ b/supacode/Features/Shelf/Views/ShelfSpineView.swift
@@ -20,12 +20,14 @@ struct ShelfSpineView: View {
   /// glance instead of every non-open spine looking identical.
   let distanceFromOpen: Int?
   let terminalState: WorktreeTerminalState?
+  let activeAgentEntries: [ActiveAgentEntry]
   let tintFallback: ShelfSpineTintFallback
   let followsRepositoryColor: Bool
   let onOpenBook: () -> Void
   let onSelectTab: (TerminalTabID) -> Void
-  /// Bottom controls — provided only for the open book's spine. `nil`
-  /// suppresses the trio entirely.
+  let onSelectAgent: (ActiveAgentEntry.ID) -> Void
+  /// Bottom controls. New Tab is available on every spine; split actions
+  /// are only provided for the open book's spine.
   let onNewTab: (() -> Void)?
   let onSplitVertical: (() -> Void)?
   let onSplitHorizontal: (() -> Void)?
@@ -55,7 +57,7 @@ struct ShelfSpineView: View {
     VStack(spacing: 0) {
       headerButton
       tabList
-      bottomControls
+      footer
     }
     .frame(width: ShelfMetrics.spineWidth)
     // `maxHeight: .infinity` binds the spine to the parent Shelf's
@@ -189,6 +191,66 @@ struct ShelfSpineView: View {
     }
   }
 
+  private var prioritizedActiveAgentEntries: [ActiveAgentEntry] {
+    activeAgentEntries.sorted { lhs, rhs in
+      let lhsPriority = lhs.displayState.shelfSpinePriority
+      let rhsPriority = rhs.displayState.shelfSpinePriority
+      if lhsPriority != rhsPriority {
+        return lhsPriority < rhsPriority
+      }
+      return lhs.lastChangedAt > rhs.lastChangedAt
+    }
+  }
+
+  private var visibleActiveAgentEntries: [ActiveAgentEntry] {
+    let entries = prioritizedActiveAgentEntries
+    guard entries.count > ShelfMetrics.maximumVisibleAgentBadges else { return entries }
+    return Array(entries.prefix(ShelfMetrics.maximumVisibleAgentBadges - 1))
+  }
+
+  private var hiddenActiveAgentCount: Int {
+    max(0, activeAgentEntries.count - visibleActiveAgentEntries.count)
+  }
+
+  private var hasBottomControls: Bool {
+    onNewTab != nil || onSplitVertical != nil || onSplitHorizontal != nil
+  }
+
+  @ViewBuilder
+  private var footer: some View {
+    // The footer stays pinned under the scrollable tab list. Active agents
+    // share the same compact slot language as tabs/controls so each spine
+    // remains a quick vertical scan instead of becoming a second panel.
+    if !activeAgentEntries.isEmpty || hasBottomControls {
+      VStack(spacing: ShelfMetrics.slotSpacing) {
+        Divider().opacity(0.3)
+        activeAgentBadges
+        if !activeAgentEntries.isEmpty && hasBottomControls {
+          Divider().opacity(0.3)
+        }
+        bottomControls
+      }
+      .padding(.horizontal, ShelfMetrics.slotHorizontalPadding)
+      .padding(.top, ShelfMetrics.sectionGap)
+      .padding(.bottom, ShelfMetrics.slotSpacing)
+    }
+  }
+
+  @ViewBuilder
+  private var activeAgentBadges: some View {
+    if !activeAgentEntries.isEmpty {
+      ForEach(visibleActiveAgentEntries) { entry in
+        ShelfSpineAgentBadge(
+          entry: entry,
+          action: { onSelectAgent(entry.id) }
+        )
+      }
+      if hiddenActiveAgentCount > 0 {
+        ShelfSpineAgentOverflowBadge(count: hiddenActiveAgentCount)
+      }
+    }
+  }
+
   @ViewBuilder
   private var bottomControls: some View {
     // `+` is shown on every spine, not just the open one: clicking it on a
@@ -196,37 +258,31 @@ struct ShelfSpineView: View {
     // caller sequences `selectWorktree` → `newTerminal`). Splits only
     // make sense against a focused surface, so they stay scoped to the
     // open book.
-    if onNewTab != nil || onSplitVertical != nil || onSplitHorizontal != nil {
-      VStack(spacing: ShelfMetrics.slotSpacing) {
-        Divider().opacity(0.3)
-        if let onNewTab {
-          ShelfSpineControlButton(
-            systemImage: "plus",
-            label: "New Tab",
-            shortcut: ghosttyShortcuts.display(for: "new_tab"),
-            action: onNewTab
-          )
-        }
-        if let onSplitVertical {
-          ShelfSpineControlButton(
-            systemImage: "square.split.2x1",
-            label: "Split Vertically",
-            shortcut: ghosttyShortcuts.display(for: "new_split:right"),
-            action: onSplitVertical
-          )
-        }
-        if let onSplitHorizontal {
-          ShelfSpineControlButton(
-            systemImage: "square.split.1x2",
-            label: "Split Horizontally",
-            shortcut: ghosttyShortcuts.display(for: "new_split:down"),
-            action: onSplitHorizontal
-          )
-        }
+    if hasBottomControls {
+      if let onNewTab {
+        ShelfSpineControlButton(
+          systemImage: "plus",
+          label: "New Tab",
+          shortcut: ghosttyShortcuts.display(for: "new_tab"),
+          action: onNewTab
+        )
       }
-      .padding(.horizontal, ShelfMetrics.slotHorizontalPadding)
-      .padding(.top, ShelfMetrics.sectionGap)
-      .padding(.bottom, ShelfMetrics.slotSpacing)
+      if let onSplitVertical {
+        ShelfSpineControlButton(
+          systemImage: "square.split.2x1",
+          label: "Split Vertically",
+          shortcut: ghosttyShortcuts.display(for: "new_split:right"),
+          action: onSplitVertical
+        )
+      }
+      if let onSplitHorizontal {
+        ShelfSpineControlButton(
+          systemImage: "square.split.1x2",
+          label: "Split Horizontally",
+          shortcut: ghosttyShortcuts.display(for: "new_split:down"),
+          action: onSplitHorizontal
+        )
+      }
     }
   }
 
@@ -542,6 +598,97 @@ private struct ShelfSpineTabSlot: View {
   }
 }
 
+private struct ShelfSpineAgentBadge: View {
+  let entry: ActiveAgentEntry
+  let action: () -> Void
+
+  var body: some View {
+    Button(action: action) {
+      ZStack(alignment: .bottomTrailing) {
+        RoundedRectangle(cornerRadius: ShelfMetrics.slotCornerRadius, style: .continuous)
+          .fill(entry.displayState.foregroundStyle.opacity(0.12))
+          .overlay {
+            RoundedRectangle(cornerRadius: ShelfMetrics.slotCornerRadius, style: .continuous)
+              .stroke(entry.displayState.foregroundStyle.opacity(0.45), lineWidth: 1)
+          }
+
+        agentIcon
+          .frame(width: ShelfMetrics.slotSize, height: ShelfMetrics.slotSize)
+
+        statusMarker
+          .offset(x: 2, y: 2)
+      }
+      .frame(width: ShelfMetrics.slotSize, height: ShelfMetrics.slotSize)
+      .contentShape(.rect)
+    }
+    .buttonStyle(.plain)
+    .help(helpText)
+    .accessibilityLabel(Text(accessibilityLabel))
+  }
+
+  @ViewBuilder
+  private var agentIcon: some View {
+    if let icon = CommandIconMap.iconForFirstToken(entry.agent.iconLookupToken) {
+      TabIconImage(
+        rawName: icon.storageString,
+        pointSize: ShelfMetrics.agentBadgeIconPointSize
+      )
+      .foregroundStyle(.primary)
+    } else {
+      Image(systemName: "sparkle")
+        .imageScale(.small)
+        .foregroundStyle(.primary)
+        .accessibilityHidden(true)
+    }
+  }
+
+  private var statusMarker: some View {
+    Image(systemName: entry.displayState.shelfSpineStatusSymbol)
+      .font(.caption2.weight(.bold))
+      .foregroundStyle(entry.displayState.foregroundStyle)
+      .frame(
+        width: ShelfMetrics.agentStatusMarkerSize,
+        height: ShelfMetrics.agentStatusMarkerSize
+      )
+      .background {
+        Circle().fill(.background)
+      }
+      .accessibilityHidden(true)
+  }
+
+  private var helpText: String {
+    let tabTitle = ActiveAgentsPanel.tabTitle(for: entry)
+    return "Jump to \(entry.agent.displayName): \(entry.displayState.label) - \(tabTitle)"
+  }
+
+  private var accessibilityLabel: String {
+    "Jump to \(entry.agent.displayName), \(entry.displayState.label)"
+  }
+}
+
+private struct ShelfSpineAgentOverflowBadge: View {
+  let count: Int
+
+  var body: some View {
+    Text("+\(count)")
+      .font(.caption2.weight(.semibold).monospacedDigit())
+      .foregroundStyle(.secondary)
+      .lineLimit(1)
+      .minimumScaleFactor(0.7)
+      .frame(width: ShelfMetrics.slotSize, height: ShelfMetrics.slotSize)
+      .background {
+        RoundedRectangle(cornerRadius: ShelfMetrics.slotCornerRadius, style: .continuous)
+          .fill(Color.primary.opacity(0.06))
+      }
+      .help(helpText)
+      .accessibilityLabel(Text(helpText))
+  }
+
+  private var helpText: String {
+    "\(count) more active agents"
+  }
+}
+
 private struct ShelfSpineControlButton: View {
   let systemImage: String
   let label: String
@@ -582,6 +729,9 @@ enum ShelfMetrics {
   /// doesn't crowd into the divider above the `+` button.
   static let sectionGap: CGFloat = 10
   static let aggregatedDotSize: CGFloat = 6
+  static let maximumVisibleAgentBadges = 4
+  static let agentBadgeIconPointSize: CGFloat = 15
+  static let agentStatusMarkerSize: CGFloat = 11
   /// Max pre-rotation width (i.e. visual height after 90° rotation) of the
   /// spine header title. Texts longer than this get middle-truncated.
   static let headerMaxLength: CGFloat = 160
@@ -591,4 +741,24 @@ enum ShelfMetrics {
   /// (`.font(.system(size:))`) and the asset (`.frame`) branches so
   /// branded artwork visually matches the SF-Symbol fallback.
   static let tabIconPointSize: CGFloat = 18
+}
+
+extension AgentDisplayState {
+  fileprivate var shelfSpinePriority: Int {
+    switch self {
+    case .blocked: return 0
+    case .working: return 1
+    case .done: return 2
+    case .idle: return 3
+    }
+  }
+
+  fileprivate var shelfSpineStatusSymbol: String {
+    switch self {
+    case .working: return "bolt.fill"
+    case .blocked: return "exclamationmark"
+    case .done: return "checkmark"
+    case .idle: return "circle.fill"
+    }
+  }
 }

--- a/supacode/Features/Shelf/Views/ShelfSpineView.swift
+++ b/supacode/Features/Shelf/Views/ShelfSpineView.swift
@@ -160,6 +160,20 @@ struct ShelfSpineView: View {
     repositoryAppearances[book.repositoryID] ?? .empty
   }
 
+  private var activeAgentEntryByTabID: [TerminalTabID: ActiveAgentEntry] {
+    var result: [TerminalTabID: ActiveAgentEntry] = [:]
+    for entry in activeAgentEntries {
+      guard let existing = result[entry.tabID] else {
+        result[entry.tabID] = entry
+        continue
+      }
+      if entry.hasHigherShelfSpinePriority(than: existing) {
+        result[entry.tabID] = entry
+      }
+    }
+    return result
+  }
+
   /// Active-tab highlight fades more gently than the spine background —
   /// the tab-selection indicator has to stay legible even on far-away
   /// books so users can still see which tab would open. Uses absolute
@@ -191,63 +205,22 @@ struct ShelfSpineView: View {
     }
   }
 
-  private var prioritizedActiveAgentEntries: [ActiveAgentEntry] {
-    activeAgentEntries.sorted { lhs, rhs in
-      let lhsPriority = lhs.displayState.shelfSpinePriority
-      let rhsPriority = rhs.displayState.shelfSpinePriority
-      if lhsPriority != rhsPriority {
-        return lhsPriority < rhsPriority
-      }
-      return lhs.lastChangedAt > rhs.lastChangedAt
-    }
-  }
-
-  private var visibleActiveAgentEntries: [ActiveAgentEntry] {
-    let entries = prioritizedActiveAgentEntries
-    guard entries.count > ShelfMetrics.maximumVisibleAgentBadges else { return entries }
-    return Array(entries.prefix(ShelfMetrics.maximumVisibleAgentBadges - 1))
-  }
-
-  private var hiddenActiveAgentCount: Int {
-    max(0, activeAgentEntries.count - visibleActiveAgentEntries.count)
-  }
-
   private var hasBottomControls: Bool {
     onNewTab != nil || onSplitVertical != nil || onSplitHorizontal != nil
   }
 
   @ViewBuilder
   private var footer: some View {
-    // The footer stays pinned under the scrollable tab list. Active agents
-    // share the same compact slot language as tabs/controls so each spine
-    // remains a quick vertical scan instead of becoming a second panel.
-    if !activeAgentEntries.isEmpty || hasBottomControls {
+    // The footer stays pinned under the scrollable tab list so the spine's
+    // tab column can scroll independently from the per-book tab/split controls.
+    if hasBottomControls {
       VStack(spacing: ShelfMetrics.slotSpacing) {
         Divider().opacity(0.3)
-        activeAgentBadges
-        if !activeAgentEntries.isEmpty && hasBottomControls {
-          Divider().opacity(0.3)
-        }
         bottomControls
       }
       .padding(.horizontal, ShelfMetrics.slotHorizontalPadding)
       .padding(.top, ShelfMetrics.sectionGap)
       .padding(.bottom, ShelfMetrics.slotSpacing)
-    }
-  }
-
-  @ViewBuilder
-  private var activeAgentBadges: some View {
-    if !activeAgentEntries.isEmpty {
-      ForEach(visibleActiveAgentEntries) { entry in
-        ShelfSpineAgentBadge(
-          entry: entry,
-          action: { onSelectAgent(entry.id) }
-        )
-      }
-      if hiddenActiveAgentCount > 0 {
-        ShelfSpineAgentOverflowBadge(count: hiddenActiveAgentCount)
-      }
     }
   }
 
@@ -328,6 +301,7 @@ struct ShelfSpineView: View {
 
   @ViewBuilder
   private func tabListContent(state terminalState: WorktreeTerminalState) -> some View {
+    let agentByTabID = activeAgentEntryByTabID
     VStack(spacing: ShelfMetrics.slotSpacing) {
       ForEach(Array(terminalState.tabManager.tabs.enumerated()), id: \.element.id) { index, tab in
         // 1-based hotkey number that matches Cmd+1..9. Tabs at
@@ -345,7 +319,9 @@ struct ShelfSpineView: View {
           hasUnseenNotification: terminalState.hasUnseenNotification(for: tab.id),
           activeHighlightTint: effectiveTintColor,
           activeHighlightAlpha: activeTabHighlightAlpha,
+          activeAgentEntry: agentByTabID[tab.id],
           onTap: { onSelectTab(tab.id) },
+          onSelectAgent: { onSelectAgent($0) },
           onClose: { terminalState.closeTab(tab.id) }
         )
         .terminalTabContextMenu(
@@ -502,14 +478,20 @@ private struct ShelfSpineTabSlot: View {
   /// notification tint is left untouched so unread signals remain
   /// attention-grabbing regardless of distance.
   let activeHighlightAlpha: Double
+  /// Highest-priority agent currently detected in this tab, when the Shelf
+  /// status overlay is enabled. Split tabs can contain more than one agent;
+  /// the spine surfaces the most actionable one and the full Active Agents
+  /// panel remains the detailed roster.
+  let activeAgentEntry: ActiveAgentEntry?
   let onTap: () -> Void
+  let onSelectAgent: (ActiveAgentEntry.ID) -> Void
   let onClose: () -> Void
 
   @Environment(CommandKeyObserver.self) private var commandKeyObserver
   @State private var isHovering = false
 
   var body: some View {
-    Button(action: onTap) {
+    Button(action: primaryAction) {
       ZStack {
         backgroundFill
         slotContent
@@ -539,7 +521,16 @@ private struct ShelfSpineTabSlot: View {
     .onHover { hovering in
       isHovering = hovering
     }
-    .help(tab.displayTitle)
+    .help(helpText)
+    .accessibilityLabel(Text(accessibilityLabel))
+  }
+
+  private func primaryAction() {
+    if let activeAgentEntry {
+      onSelectAgent(activeAgentEntry.id)
+    } else {
+      onTap()
+    }
   }
 
   /// When ⌘ is held AND this tab has a `Cmd+N` hotkey AND this slot is
@@ -561,17 +552,24 @@ private struct ShelfSpineTabSlot: View {
       }
       .accessibilityHidden(true)
     } else {
-      TabIconImage(
-        rawName: tab.icon ?? ShelfMetrics.defaultTabIcon,
-        pointSize: ShelfMetrics.tabIconPointSize
-      )
-      .foregroundStyle(foregroundTint)
-      // Dim tabs without a hotkey when ⌘ is held — but only on the open
-      // book, where the dimming pairs with the visible ⌘N glyphs on its
-      // siblings. On closed books no glyph appears, so dimming would be
-      // a stray visual change with no story behind it.
-      .opacity(commandKeyObserver.isPressed && hotkeyIndex == nil && isOpenBook ? 0.45 : 1)
-      .accessibilityHidden(true)
+      ZStack(alignment: .bottomTrailing) {
+        TabIconImage(
+          rawName: tab.icon ?? ShelfMetrics.defaultTabIcon,
+          pointSize: ShelfMetrics.tabIconPointSize
+        )
+        .foregroundStyle(foregroundTint)
+        // Dim tabs without a hotkey when ⌘ is held — but only on the open
+        // book, where the dimming pairs with the visible ⌘N glyphs on its
+        // siblings. On closed books no glyph appears, so dimming would be
+        // a stray visual change with no story behind it.
+        .opacity(commandKeyObserver.isPressed && hotkeyIndex == nil && isOpenBook ? 0.45 : 1)
+        .accessibilityHidden(true)
+
+        if let activeAgentEntry {
+          statusMarker(for: activeAgentEntry)
+            .offset(x: 3, y: 3)
+        }
+      }
     }
   }
 
@@ -586,6 +584,13 @@ private struct ShelfSpineTabSlot: View {
     } else if isActive {
       RoundedRectangle(cornerRadius: ShelfMetrics.slotCornerRadius, style: .continuous)
         .fill(activeHighlightTint.opacity(activeHighlightAlpha))
+    } else if let activeAgentEntry {
+      RoundedRectangle(cornerRadius: ShelfMetrics.slotCornerRadius, style: .continuous)
+        .fill(activeAgentEntry.displayState.foregroundStyle.opacity(0.12))
+        .overlay {
+          RoundedRectangle(cornerRadius: ShelfMetrics.slotCornerRadius, style: .continuous)
+            .stroke(activeAgentEntry.displayState.foregroundStyle.opacity(0.45), lineWidth: 1)
+        }
     } else {
       Color.clear
     }
@@ -596,53 +601,9 @@ private struct ShelfSpineTabSlot: View {
     if isActive { return .primary }
     return .secondary
   }
-}
-
-private struct ShelfSpineAgentBadge: View {
-  let entry: ActiveAgentEntry
-  let action: () -> Void
-
-  var body: some View {
-    Button(action: action) {
-      ZStack(alignment: .bottomTrailing) {
-        RoundedRectangle(cornerRadius: ShelfMetrics.slotCornerRadius, style: .continuous)
-          .fill(entry.displayState.foregroundStyle.opacity(0.12))
-          .overlay {
-            RoundedRectangle(cornerRadius: ShelfMetrics.slotCornerRadius, style: .continuous)
-              .stroke(entry.displayState.foregroundStyle.opacity(0.45), lineWidth: 1)
-          }
-
-        agentIcon
-          .frame(width: ShelfMetrics.slotSize, height: ShelfMetrics.slotSize)
-
-        statusMarker
-          .offset(x: 2, y: 2)
-      }
-      .frame(width: ShelfMetrics.slotSize, height: ShelfMetrics.slotSize)
-      .contentShape(.rect)
-    }
-    .buttonStyle(.plain)
-    .help(helpText)
-    .accessibilityLabel(Text(accessibilityLabel))
-  }
 
   @ViewBuilder
-  private var agentIcon: some View {
-    if let icon = CommandIconMap.iconForFirstToken(entry.agent.iconLookupToken) {
-      TabIconImage(
-        rawName: icon.storageString,
-        pointSize: ShelfMetrics.agentBadgeIconPointSize
-      )
-      .foregroundStyle(.primary)
-    } else {
-      Image(systemName: "sparkle")
-        .imageScale(.small)
-        .foregroundStyle(.primary)
-        .accessibilityHidden(true)
-    }
-  }
-
-  private var statusMarker: some View {
+  private func statusMarker(for entry: ActiveAgentEntry) -> some View {
     Image(systemName: entry.displayState.shelfSpineStatusSymbol)
       .font(.caption2.weight(.bold))
       .foregroundStyle(entry.displayState.foregroundStyle)
@@ -657,35 +618,14 @@ private struct ShelfSpineAgentBadge: View {
   }
 
   private var helpText: String {
-    let tabTitle = ActiveAgentsPanel.tabTitle(for: entry)
-    return "Jump to \(entry.agent.displayName): \(entry.displayState.label) - \(tabTitle)"
+    guard let activeAgentEntry else { return tab.displayTitle }
+    let tabTitle = ActiveAgentsPanel.tabTitle(for: activeAgentEntry)
+    return "Jump to \(activeAgentEntry.agent.displayName): \(activeAgentEntry.displayState.label) - \(tabTitle)"
   }
 
   private var accessibilityLabel: String {
-    "Jump to \(entry.agent.displayName), \(entry.displayState.label)"
-  }
-}
-
-private struct ShelfSpineAgentOverflowBadge: View {
-  let count: Int
-
-  var body: some View {
-    Text("+\(count)")
-      .font(.caption2.weight(.semibold).monospacedDigit())
-      .foregroundStyle(.secondary)
-      .lineLimit(1)
-      .minimumScaleFactor(0.7)
-      .frame(width: ShelfMetrics.slotSize, height: ShelfMetrics.slotSize)
-      .background {
-        RoundedRectangle(cornerRadius: ShelfMetrics.slotCornerRadius, style: .continuous)
-          .fill(Color.primary.opacity(0.06))
-      }
-      .help(helpText)
-      .accessibilityLabel(Text(helpText))
-  }
-
-  private var helpText: String {
-    "\(count) more active agents"
+    guard let activeAgentEntry else { return tab.displayTitle }
+    return "Jump to \(activeAgentEntry.agent.displayName), \(activeAgentEntry.displayState.label)"
   }
 }
 
@@ -729,8 +669,6 @@ enum ShelfMetrics {
   /// doesn't crowd into the divider above the `+` button.
   static let sectionGap: CGFloat = 10
   static let aggregatedDotSize: CGFloat = 6
-  static let maximumVisibleAgentBadges = 4
-  static let agentBadgeIconPointSize: CGFloat = 15
   static let agentStatusMarkerSize: CGFloat = 11
   /// Max pre-rotation width (i.e. visual height after 90° rotation) of the
   /// spine header title. Texts longer than this get middle-truncated.
@@ -760,5 +698,16 @@ extension AgentDisplayState {
     case .done: return "checkmark"
     case .idle: return "circle.fill"
     }
+  }
+}
+
+extension ActiveAgentEntry {
+  fileprivate func hasHigherShelfSpinePriority(than other: ActiveAgentEntry) -> Bool {
+    let priority = displayState.shelfSpinePriority
+    let otherPriority = other.displayState.shelfSpinePriority
+    if priority != otherPriority {
+      return priority < otherPriority
+    }
+    return lastChangedAt > other.lastChangedAt
   }
 }

--- a/supacode/Features/Shelf/Views/ShelfSpineView.swift
+++ b/supacode/Features/Shelf/Views/ShelfSpineView.swift
@@ -609,9 +609,6 @@ private struct ShelfSpineTabSlot: View {
         width: ShelfMetrics.agentStatusMarkerSize,
         height: ShelfMetrics.agentStatusMarkerSize
       )
-      .background {
-        Circle().fill(.background)
-      }
       .accessibilityHidden(true)
   }
 

--- a/supacode/Features/Shelf/Views/ShelfView.swift
+++ b/supacode/Features/Shelf/Views/ShelfView.swift
@@ -43,9 +43,10 @@ struct ShelfView: View {
     let openIndex = openBook.flatMap { book in
       books.firstIndex(where: { $0.id == book.id })
     }
-    let activeAgentEntriesByWorktreeID = Dictionary(grouping: state.activeAgents.entries) { entry in
-      entry.worktreeID
-    }
+    let activeAgentEntriesByWorktreeID =
+      settingsFile.global.showActiveAgentStatusInShelf
+      ? Dictionary(grouping: state.activeAgents.entries) { entry in entry.worktreeID }
+      : [:]
     // Color identity of the open book's repo (nil ⇒ neutral surface). Shared
     // by the spine fill and the toolbar band so they read as one "L".
     let openColor = openBook.flatMap { repositoryAppearances[$0.repositoryID]?.color }
@@ -85,12 +86,16 @@ struct ShelfView: View {
     // and the toolbar all read as one continuous color.
     .windowChromeTint(chromeFill, edges: [.top, .leading])
     .overlay {
-      ShelfSwipeEventMonitor(isEnabled: books.count > 1) { direction in
-        switch direction {
-        case .next:
+      ShelfSwipeEventMonitor(isEnabled: !books.isEmpty) { action in
+        switch action {
+        case .nextBook:
           store.send(.selectNextShelfBook)
-        case .previous:
+        case .previousBook:
           store.send(.selectPreviousShelfBook)
+        case .nextTab:
+          store.send(.selectNextWorktree)
+        case .previousTab:
+          store.send(.selectPreviousWorktree)
         }
       }
       .accessibilityHidden(true)
@@ -261,14 +266,36 @@ struct ShelfView: View {
   }
 }
 
-private enum ShelfSwipeDirection {
-  case next
-  case previous
+enum ShelfSwipeNavigationAction: Equatable {
+  case nextBook
+  case previousBook
+  case nextTab
+  case previousTab
+}
+
+struct ShelfSwipeGestureClassifier {
+  static let swipeThreshold: CGFloat = 80
+  static let axisDominanceRatio: CGFloat = 1.6
+
+  static func action(
+    accumulatedDeltaX: CGFloat,
+    accumulatedDeltaY: CGFloat
+  ) -> ShelfSwipeNavigationAction? {
+    let absX = abs(accumulatedDeltaX)
+    let absY = abs(accumulatedDeltaY)
+    if absX >= swipeThreshold, absX > absY * axisDominanceRatio {
+      return accumulatedDeltaX > 0 ? .previousBook : .nextBook
+    }
+    if absY >= swipeThreshold, absY > absX * axisDominanceRatio {
+      return accumulatedDeltaY > 0 ? .previousTab : .nextTab
+    }
+    return nil
+  }
 }
 
 private struct ShelfSwipeEventMonitor: NSViewRepresentable {
   let isEnabled: Bool
-  let onSwipe: (ShelfSwipeDirection) -> Void
+  let onSwipe: (ShelfSwipeNavigationAction) -> Void
 
   func makeCoordinator() -> Coordinator {
     Coordinator()
@@ -296,7 +323,7 @@ private struct ShelfSwipeEventMonitor: NSViewRepresentable {
   final class Coordinator {
     weak var view: NSView?
     var isEnabled = false
-    var onSwipe: (ShelfSwipeDirection) -> Void = { _ in }
+    var onSwipe: (ShelfSwipeNavigationAction) -> Void = { _ in }
 
     private var monitor: Any?
     private var accumulatedDeltaX: CGFloat = 0
@@ -304,8 +331,6 @@ private struct ShelfSwipeEventMonitor: NSViewRepresentable {
     private var lastEventTimestamp: TimeInterval = 0
     private var didTriggerCurrentGesture = false
 
-    private let swipeThreshold: CGFloat = 80
-    private let horizontalDominanceRatio: CGFloat = 1.6
     private let eventGapResetInterval: TimeInterval = 0.25
 
     func installIfNeeded() {
@@ -332,6 +357,11 @@ private struct ShelfSwipeEventMonitor: NSViewRepresentable {
         return event
       }
 
+      guard event.modifierFlags.intersection(.deviceIndependentFlagsMask).contains(.command) else {
+        resetGesture()
+        return event
+      }
+
       if event.phase.contains(.began)
         || event.timestamp - lastEventTimestamp > eventGapResetInterval
       {
@@ -345,33 +375,29 @@ private struct ShelfSwipeEventMonitor: NSViewRepresentable {
         {
           resetGesture()
         }
-        return isHorizontallyDominant(event) ? nil : event
+        return nil
       }
 
       guard event.momentumPhase.isEmpty else {
-        return event
+        return nil
       }
 
       accumulatedDeltaX += event.scrollingDeltaX
       accumulatedDeltaY += event.scrollingDeltaY
 
-      guard abs(accumulatedDeltaX) >= swipeThreshold,
-        abs(accumulatedDeltaX) > abs(accumulatedDeltaY) * horizontalDominanceRatio
+      guard
+        let action = ShelfSwipeGestureClassifier.action(
+          accumulatedDeltaX: accumulatedDeltaX,
+          accumulatedDeltaY: accumulatedDeltaY
+        )
       else {
-        return event
+        return nil
       }
 
-      let direction: ShelfSwipeDirection = accumulatedDeltaX > 0 ? .previous : .next
       resetAccumulatedDeltas()
       didTriggerCurrentGesture = true
-      onSwipe(direction)
+      onSwipe(action)
       return nil
-    }
-
-    private func isHorizontallyDominant(_ event: NSEvent) -> Bool {
-      let absDeltaX = abs(event.scrollingDeltaX)
-      let absDeltaY = abs(event.scrollingDeltaY)
-      return absDeltaX > 0 && absDeltaX > absDeltaY * horizontalDominanceRatio
     }
 
     private func resetGesture() {

--- a/supacode/Features/Shelf/Views/ShelfView.swift
+++ b/supacode/Features/Shelf/Views/ShelfView.swift
@@ -42,6 +42,9 @@ struct ShelfView: View {
     let openIndex = openBook.flatMap { book in
       books.firstIndex(where: { $0.id == book.id })
     }
+    let activeAgentEntriesByWorktreeID = Dictionary(grouping: state.activeAgents.entries) { entry in
+      entry.worktreeID
+    }
     // Color identity of the open book's repo (nil ⇒ neutral surface). Shared
     // by the spine fill and the toolbar band so they read as one "L".
     let openColor = openBook.flatMap { repositoryAppearances[$0.repositoryID]?.color }
@@ -59,7 +62,12 @@ struct ShelfView: View {
 
     HStack(spacing: 0) {
       ForEach(Array(books.enumerated()), id: \.element.id) { index, book in
-        spine(book: book, index: index, openIndex: openIndex)
+        spine(
+          book: book,
+          index: index,
+          openIndex: openIndex,
+          activeAgentEntries: activeAgentEntriesByWorktreeID[book.id] ?? []
+        )
         if book.id == openBookID {
           openBookArea(for: book, state: state)
         }
@@ -83,7 +91,12 @@ struct ShelfView: View {
   }
 
   @ViewBuilder
-  private func spine(book: ShelfBook, index: Int, openIndex: Int?) -> some View {
+  private func spine(
+    book: ShelfBook,
+    index: Int,
+    openIndex: Int?,
+    activeAgentEntries: [ActiveAgentEntry]
+  ) -> some View {
     let distance = openIndex.map { abs(index - $0) }
     let open = index == openIndex
     ShelfSpineView(
@@ -91,10 +104,14 @@ struct ShelfView: View {
       isOpen: open,
       distanceFromOpen: distance,
       terminalState: terminalManager.stateIfExists(for: book.id),
+      activeAgentEntries: activeAgentEntries,
       tintFallback: settingsFile.global.shelfSpineTintFallback,
       followsRepositoryColor: settingsFile.global.shelfSpineTintFollowsRepositoryColor,
       onOpenBook: { openBook(book, selectingTab: nil) },
       onSelectTab: { tabID in openBook(book, selectingTab: tabID) },
+      onSelectAgent: { agentID in
+        store.send(.activeAgents(.entryTapped(agentID)))
+      },
       onNewTab: {
         // On a closed spine, `+` doubles as "pull this book out and
         // start a fresh tab". Sequencing is fine because TCA runs

--- a/supacode/Features/Shelf/Views/ShelfView.swift
+++ b/supacode/Features/Shelf/Views/ShelfView.swift
@@ -361,7 +361,7 @@ private struct ShelfSwipeEventMonitor: NSViewRepresentable {
         return event
       }
 
-      let direction: ShelfSwipeDirection = accumulatedDeltaX > 0 ? .next : .previous
+      let direction: ShelfSwipeDirection = accumulatedDeltaX > 0 ? .previous : .next
       resetAccumulatedDeltas()
       didTriggerCurrentGesture = true
       onSwipe(direction)

--- a/supacode/Features/Shelf/Views/ShelfView.swift
+++ b/supacode/Features/Shelf/Views/ShelfView.swift
@@ -303,7 +303,6 @@ private struct ShelfSwipeEventMonitor: NSViewRepresentable {
 
   func makeNSView(context: Context) -> NSView {
     let view = NSView()
-    view.postsFrameChangedNotifications = true
     context.coordinator.view = view
     context.coordinator.installIfNeeded()
     return view

--- a/supacode/Features/Shelf/Views/ShelfView.swift
+++ b/supacode/Features/Shelf/Views/ShelfView.swift
@@ -302,12 +302,11 @@ private struct ShelfSwipeEventMonitor: NSViewRepresentable {
     private var accumulatedDeltaX: CGFloat = 0
     private var accumulatedDeltaY: CGFloat = 0
     private var lastEventTimestamp: TimeInterval = 0
-    private var cooldownUntil: TimeInterval = 0
+    private var didTriggerCurrentGesture = false
 
     private let swipeThreshold: CGFloat = 80
     private let horizontalDominanceRatio: CGFloat = 1.6
     private let eventGapResetInterval: TimeInterval = 0.25
-    private let triggerCooldown: TimeInterval = 0.35
 
     func installIfNeeded() {
       guard monitor == nil else { return }
@@ -329,22 +328,34 @@ private struct ShelfSwipeEventMonitor: NSViewRepresentable {
         event.window === window,
         view.bounds.contains(view.convert(event.locationInWindow, from: nil))
       else {
-        resetAccumulatedDeltas()
+        resetGesture()
         return event
       }
 
       if event.phase.contains(.began)
         || event.timestamp - lastEventTimestamp > eventGapResetInterval
       {
-        resetAccumulatedDeltas()
+        resetGesture()
       }
       lastEventTimestamp = event.timestamp
+
+      if didTriggerCurrentGesture {
+        if event.phase.contains(.ended) || event.phase.contains(.cancelled)
+          || event.momentumPhase.contains(.ended) || event.momentumPhase.contains(.cancelled)
+        {
+          resetGesture()
+        }
+        return isHorizontallyDominant(event) ? nil : event
+      }
+
+      guard event.momentumPhase.isEmpty else {
+        return event
+      }
 
       accumulatedDeltaX += event.scrollingDeltaX
       accumulatedDeltaY += event.scrollingDeltaY
 
-      guard event.timestamp >= cooldownUntil,
-        abs(accumulatedDeltaX) >= swipeThreshold,
+      guard abs(accumulatedDeltaX) >= swipeThreshold,
         abs(accumulatedDeltaX) > abs(accumulatedDeltaY) * horizontalDominanceRatio
       else {
         return event
@@ -352,9 +363,20 @@ private struct ShelfSwipeEventMonitor: NSViewRepresentable {
 
       let direction: ShelfSwipeDirection = accumulatedDeltaX > 0 ? .next : .previous
       resetAccumulatedDeltas()
-      cooldownUntil = event.timestamp + triggerCooldown
+      didTriggerCurrentGesture = true
       onSwipe(direction)
       return nil
+    }
+
+    private func isHorizontallyDominant(_ event: NSEvent) -> Bool {
+      let absDeltaX = abs(event.scrollingDeltaX)
+      let absDeltaY = abs(event.scrollingDeltaY)
+      return absDeltaX > 0 && absDeltaX > absDeltaY * horizontalDominanceRatio
+    }
+
+    private func resetGesture() {
+      resetAccumulatedDeltas()
+      didTriggerCurrentGesture = false
     }
 
     private func resetAccumulatedDeltas() {

--- a/supacode/Features/Shelf/Views/ShelfView.swift
+++ b/supacode/Features/Shelf/Views/ShelfView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import ComposableArchitecture
 import Sharing
 import SwiftUI
@@ -83,6 +84,19 @@ struct ShelfView: View {
     // the glass blends the leading band in, the nav panel, the open spine,
     // and the toolbar all read as one continuous color.
     .windowChromeTint(chromeFill, edges: [.top, .leading])
+    .overlay {
+      ShelfSwipeEventMonitor(isEnabled: books.count > 1) { direction in
+        switch direction {
+        case .next:
+          store.send(.selectNextShelfBook)
+        case .previous:
+          store.send(.selectPreviousShelfBook)
+        }
+      }
+      .accessibilityHidden(true)
+      .allowsHitTesting(false)
+      .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
     // Animate on every openBookID change — covers both Shelf-originated
     // book switches (which also set their own TCA animation) and
     // left-nav-originated switches, so the spine flow is consistent
@@ -243,6 +257,109 @@ struct ShelfView: View {
       // if the user has opened it before. For first-time opens the tab
       // manager seeds a default tab which we won't override.
       terminalManager.stateIfExists(for: book.id)?.tabManager.selectTab(tabID)
+    }
+  }
+}
+
+private enum ShelfSwipeDirection {
+  case next
+  case previous
+}
+
+private struct ShelfSwipeEventMonitor: NSViewRepresentable {
+  let isEnabled: Bool
+  let onSwipe: (ShelfSwipeDirection) -> Void
+
+  func makeCoordinator() -> Coordinator {
+    Coordinator()
+  }
+
+  func makeNSView(context: Context) -> NSView {
+    let view = NSView()
+    view.postsFrameChangedNotifications = true
+    context.coordinator.view = view
+    context.coordinator.installIfNeeded()
+    return view
+  }
+
+  func updateNSView(_ nsView: NSView, context: Context) {
+    context.coordinator.view = nsView
+    context.coordinator.isEnabled = isEnabled
+    context.coordinator.onSwipe = onSwipe
+    context.coordinator.installIfNeeded()
+  }
+
+  static func dismantleNSView(_ nsView: NSView, coordinator: Coordinator) {
+    coordinator.removeMonitor()
+  }
+
+  final class Coordinator {
+    weak var view: NSView?
+    var isEnabled = false
+    var onSwipe: (ShelfSwipeDirection) -> Void = { _ in }
+
+    private var monitor: Any?
+    private var accumulatedDeltaX: CGFloat = 0
+    private var accumulatedDeltaY: CGFloat = 0
+    private var lastEventTimestamp: TimeInterval = 0
+    private var cooldownUntil: TimeInterval = 0
+
+    private let swipeThreshold: CGFloat = 80
+    private let horizontalDominanceRatio: CGFloat = 1.6
+    private let eventGapResetInterval: TimeInterval = 0.25
+    private let triggerCooldown: TimeInterval = 0.35
+
+    func installIfNeeded() {
+      guard monitor == nil else { return }
+      monitor = NSEvent.addLocalMonitorForEvents(matching: .scrollWheel) { [weak self] event in
+        self?.handle(event) ?? event
+      }
+    }
+
+    func removeMonitor() {
+      guard let monitor else { return }
+      NSEvent.removeMonitor(monitor)
+      self.monitor = nil
+    }
+
+    private func handle(_ event: NSEvent) -> NSEvent? {
+      guard isEnabled,
+        let view,
+        let window = view.window,
+        event.window === window,
+        view.bounds.contains(view.convert(event.locationInWindow, from: nil))
+      else {
+        resetAccumulatedDeltas()
+        return event
+      }
+
+      if event.phase.contains(.began)
+        || event.timestamp - lastEventTimestamp > eventGapResetInterval
+      {
+        resetAccumulatedDeltas()
+      }
+      lastEventTimestamp = event.timestamp
+
+      accumulatedDeltaX += event.scrollingDeltaX
+      accumulatedDeltaY += event.scrollingDeltaY
+
+      guard event.timestamp >= cooldownUntil,
+        abs(accumulatedDeltaX) >= swipeThreshold,
+        abs(accumulatedDeltaX) > abs(accumulatedDeltaY) * horizontalDominanceRatio
+      else {
+        return event
+      }
+
+      let direction: ShelfSwipeDirection = accumulatedDeltaX > 0 ? .next : .previous
+      resetAccumulatedDeltas()
+      cooldownUntil = event.timestamp + triggerCooldown
+      onSwipe(direction)
+      return nil
+    }
+
+    private func resetAccumulatedDeltas() {
+      accumulatedDeltaX = 0
+      accumulatedDeltaY = 0
     }
   }
 }

--- a/supacodeTests/ActiveAgentsFeatureTests.swift
+++ b/supacodeTests/ActiveAgentsFeatureTests.swift
@@ -69,6 +69,37 @@ struct ActiveAgentsFeatureTests {
     #expect(ActiveAgentsFeature.maximumPanelHeight(forContainerHeight: 250) == 120)
   }
 
+  @Test func detectionStaysEnabledForVisiblePanelAutoShowOrShelf() {
+    #expect(
+      ActiveAgentsFeature.detectionEnabled(
+        isPanelHidden: false,
+        autoShowPanel: false,
+        isShelfVisible: false
+      )
+    )
+    #expect(
+      ActiveAgentsFeature.detectionEnabled(
+        isPanelHidden: true,
+        autoShowPanel: true,
+        isShelfVisible: false
+      )
+    )
+    #expect(
+      ActiveAgentsFeature.detectionEnabled(
+        isPanelHidden: true,
+        autoShowPanel: false,
+        isShelfVisible: true
+      )
+    )
+    #expect(
+      !ActiveAgentsFeature.detectionEnabled(
+        isPanelHidden: true,
+        autoShowPanel: false,
+        isShelfVisible: false
+      )
+    )
+  }
+
   @Test func navigationReturnsNilForEmptyList() {
     let entries: IdentifiedArrayOf<ActiveAgentEntry> = []
     #expect(ActiveAgentsFeature.entryID(navigatingFrom: nil, direction: .next, in: entries) == nil)

--- a/supacodeTests/AppFeatureArchivedSelectionTests.swift
+++ b/supacodeTests/AppFeatureArchivedSelectionTests.swift
@@ -45,6 +45,9 @@ struct AppFeatureArchivedSelectionTests {
       $0.repositories.worktreeHistoryBackStack = [worktree.id]
       $0.repositories.selection = .archivedWorktrees
     }
+    // Leaving the worktree view can flip Shelf visibility, so AppFeature
+    // resyncs agent detection alongside the selection change.
+    await store.receive(\.syncAgentDetectionEnabled)
     await store.receive(\.repositories.delegate.selectedWorktreeChanged)
     await store.finish()
     #expect(saved.value.isEmpty)

--- a/supacodeTests/AppFeatureSettingsChangedTests.swift
+++ b/supacodeTests/AppFeatureSettingsChangedTests.swift
@@ -126,6 +126,31 @@ struct AppFeatureSettingsChangedTests {
     #expect(sentTerminalCommands.value == [.setAgentDetectionEnabled(true)])
   }
 
+  @Test(.dependencies) func syncAgentDetectionDisablesShelfOnlyDetectionWhenShelfStatusOptedOut() async {
+    let worktree = makeWorktree()
+    let repository = makeRepository(worktrees: [worktree])
+    let sentTerminalCommands = LockIsolated<[TerminalClient.Command]>([])
+    var settings = SettingsFeature.State()
+    settings.autoShowActiveAgentsPanel = false
+    settings.showActiveAgentStatusInShelf = false
+    var state = AppFeature.State(settings: settings)
+    state.repositories.repositories = [repository]
+    state.repositories.isShelfActive = true
+    state.repositories.activeAgents.$isPanelHidden.withLock { $0 = true }
+    let store = TestStore(initialState: state) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in
+        sentTerminalCommands.withValue { $0.append(command) }
+      }
+    }
+
+    await store.send(.syncAgentDetectionEnabled)
+    await store.finish()
+
+    #expect(sentTerminalCommands.value == [.setAgentDetectionEnabled(false)])
+  }
+
   @Test func appStateInitializesActiveAgentTabTitleDisplayFromSettings() {
     var settings = SettingsFeature.State()
     settings.showActiveAgentTabTitles = true

--- a/supacodeTests/AppFeatureSettingsChangedTests.swift
+++ b/supacodeTests/AppFeatureSettingsChangedTests.swift
@@ -151,6 +151,25 @@ struct AppFeatureSettingsChangedTests {
     #expect(sentTerminalCommands.value == [.setAgentDetectionEnabled(false)])
   }
 
+  @Test func repositoryListChangesTriggerShelfVisibilityResync() {
+    // `isShowingShelf` requires a non-empty repository list, so adding or
+    // removing repositories must resync detection even though `isShelfActive`
+    // is untouched.
+    #expect(
+      AppFeature.repositoriesActionMayChangeShelfVisibility(
+        .repositoryManagement(.repositoryRemoved("/tmp/repo", selectionWasRemoved: false))
+      )
+    )
+    #expect(
+      AppFeature.repositoriesActionMayChangeShelfVisibility(
+        .repositoriesLoaded([], failures: [], roots: [], animated: false)
+      )
+    )
+    #expect(
+      !AppFeature.repositoriesActionMayChangeShelfVisibility(.selectNextShelfBook)
+    )
+  }
+
   @Test func appStateInitializesActiveAgentTabTitleDisplayFromSettings() {
     var settings = SettingsFeature.State()
     settings.showActiveAgentTabTitles = true

--- a/supacodeTests/AppFeatureSettingsChangedTests.swift
+++ b/supacodeTests/AppFeatureSettingsChangedTests.swift
@@ -102,6 +102,30 @@ struct AppFeatureSettingsChangedTests {
     }
   }
 
+  @Test(.dependencies) func syncAgentDetectionKeepsDetectionEnabledWhenShelfVisible() async {
+    let worktree = makeWorktree()
+    let repository = makeRepository(worktrees: [worktree])
+    let sentTerminalCommands = LockIsolated<[TerminalClient.Command]>([])
+    var settings = SettingsFeature.State()
+    settings.autoShowActiveAgentsPanel = false
+    var state = AppFeature.State(settings: settings)
+    state.repositories.repositories = [repository]
+    state.repositories.isShelfActive = true
+    state.repositories.activeAgents.$isPanelHidden.withLock { $0 = true }
+    let store = TestStore(initialState: state) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in
+        sentTerminalCommands.withValue { $0.append(command) }
+      }
+    }
+
+    await store.send(.syncAgentDetectionEnabled)
+    await store.finish()
+
+    #expect(sentTerminalCommands.value == [.setAgentDetectionEnabled(true)])
+  }
+
   @Test func appStateInitializesActiveAgentTabTitleDisplayFromSettings() {
     var settings = SettingsFeature.State()
     settings.showActiveAgentTabTitles = true
@@ -182,6 +206,25 @@ struct AppFeatureSettingsChangedTests {
       rawState: .working,
       displayState: .working,
       lastChangedAt: Date(timeIntervalSince1970: 10)
+    )
+  }
+
+  private func makeWorktree() -> Worktree {
+    Worktree(
+      id: "/tmp/repo/wt-1",
+      name: "wt-1",
+      detail: "",
+      workingDirectory: URL(fileURLWithPath: "/tmp/repo/wt-1"),
+      repositoryRootURL: URL(fileURLWithPath: "/tmp/repo")
+    )
+  }
+
+  private func makeRepository(worktrees: [Worktree]) -> Repository {
+    Repository(
+      id: "/tmp/repo",
+      rootURL: URL(fileURLWithPath: "/tmp/repo"),
+      name: "repo",
+      worktrees: IdentifiedArray(uniqueElements: worktrees)
     )
   }
 

--- a/supacodeTests/SettingsFeatureTests.swift
+++ b/supacodeTests/SettingsFeatureTests.swift
@@ -413,6 +413,24 @@ struct SettingsFeatureTests {
     #expect(settingsFile.global.showActiveAgentTabTitles == true)
   }
 
+  @Test(.dependencies) func showActiveAgentStatusInShelfPersistsChanges() async {
+    var initialSettings = GlobalSettings.default
+    initialSettings.showActiveAgentStatusInShelf = true
+    @Shared(.settingsFile) var settingsFile
+    $settingsFile.withLock { $0.global = initialSettings }
+
+    let store = TestStore(initialState: SettingsFeature.State(settings: initialSettings)) {
+      SettingsFeature()
+    }
+
+    await store.send(.binding(.set(\.showActiveAgentStatusInShelf, false))) {
+      $0.showActiveAgentStatusInShelf = false
+    }
+    await store.receive(\.delegate.settingsChanged)
+
+    #expect(settingsFile.global.showActiveAgentStatusInShelf == false)
+  }
+
   @Test(.dependencies) func disablingAnalyticsResetsClient() async {
     var initialSettings = GlobalSettings.default
     initialSettings.analyticsEnabled = true

--- a/supacodeTests/SettingsFilePersistenceTests.swift
+++ b/supacodeTests/SettingsFilePersistenceTests.swift
@@ -93,6 +93,7 @@ struct SettingsFilePersistenceTests {
       $settings.withLock {
         $0.global.shelfSpineTintFallback = .systemTint
         $0.global.shelfSpineTintFollowsRepositoryColor = false
+        $0.global.showActiveAgentStatusInShelf = false
       }
     }
 
@@ -105,6 +106,7 @@ struct SettingsFilePersistenceTests {
 
     #expect(reloaded.global.shelfSpineTintFallback == .systemTint)
     #expect(reloaded.global.shelfSpineTintFollowsRepositoryColor == false)
+    #expect(reloaded.global.showActiveAgentStatusInShelf == false)
   }
 
   @Test(.dependencies) func invalidJSONResetsToDefaults() throws {
@@ -169,6 +171,7 @@ struct SettingsFilePersistenceTests {
     #expect(settings.global.showDefaultEditorInToolbar == true)
     #expect(settings.global.dockBounceMode == .off)
     #expect(settings.global.showNotificationDotOnDock == false)
+    #expect(settings.global.showActiveAgentStatusInShelf == true)
     #expect(settings.global.shelfSpineTintFallback == .neutral)
     #expect(settings.global.shelfSpineTintFollowsRepositoryColor == true)
     #expect(settings.repositoryRoots.isEmpty)

--- a/supacodeTests/ShelfFeatureTests.swift
+++ b/supacodeTests/ShelfFeatureTests.swift
@@ -470,6 +470,27 @@ struct ShelfFeatureTests {
     #expect(sentCommands.value == [.performBindingAction(wt1, action: "previous_tab")])
   }
 
+  @Test func shelfSwipeGestureClassifierMapsAxesToShelfNavigation() {
+    #expect(
+      ShelfSwipeGestureClassifier.action(accumulatedDeltaX: -90, accumulatedDeltaY: 10) == .nextBook
+    )
+    #expect(
+      ShelfSwipeGestureClassifier.action(accumulatedDeltaX: 90, accumulatedDeltaY: 10) == .previousBook
+    )
+    #expect(
+      ShelfSwipeGestureClassifier.action(accumulatedDeltaX: 10, accumulatedDeltaY: -90) == .nextTab
+    )
+    #expect(
+      ShelfSwipeGestureClassifier.action(accumulatedDeltaX: 10, accumulatedDeltaY: 90) == .previousTab
+    )
+  }
+
+  @Test func shelfSwipeGestureClassifierIgnoresSmallOrAmbiguousScrolls() {
+    #expect(ShelfSwipeGestureClassifier.action(accumulatedDeltaX: -79, accumulatedDeltaY: 0) == nil)
+    #expect(ShelfSwipeGestureClassifier.action(accumulatedDeltaX: 60, accumulatedDeltaY: 60) == nil)
+    #expect(ShelfSwipeGestureClassifier.action(accumulatedDeltaX: 90, accumulatedDeltaY: 70) == nil)
+  }
+
   @Test(.dependencies) func worktreeHistoryIsUnavailableWhileShelfIsActive() async {
     let fixture = threeWorktreeFixture()
     var state = RepositoriesFeature.State(repositories: [fixture.repo])

--- a/supacodeTests/ShelfFeatureTests.swift
+++ b/supacodeTests/ShelfFeatureTests.swift
@@ -336,7 +336,7 @@ struct ShelfFeatureTests {
     await store.finish()
   }
 
-  @Test(.dependencies) func selectNextShelfBookWrapsAround() async {
+  @Test(.dependencies) func selectNextShelfBookAtEndIsNoOp() async {
     let rootURL = URL(fileURLWithPath: "/tmp/repo")
     let wt1 = Worktree(
       id: "/tmp/repo",
@@ -368,13 +368,41 @@ struct ShelfFeatureTests {
     }
 
     await store.send(.selectNextShelfBook)
-    // Wrapping: next-after-last lands back on the first book.
-    await store.receive(\.selectWorktree) {
-      $0.selection = .worktree(wt1.id)
-      $0.sidebarSelectedWorktreeIDs = [wt1.id]
-      $0.pendingTerminalFocusWorktreeIDs = [wt1.id]
+    await store.finish()
+  }
+
+  @Test(.dependencies) func selectPreviousShelfBookAtStartIsNoOp() async {
+    let rootURL = URL(fileURLWithPath: "/tmp/repo")
+    let wt1 = Worktree(
+      id: "/tmp/repo",
+      name: "main",
+      detail: "",
+      workingDirectory: rootURL,
+      repositoryRootURL: rootURL
+    )
+    let wt2 = Worktree(
+      id: "/tmp/repo/feature",
+      name: "feature",
+      detail: "",
+      workingDirectory: URL(fileURLWithPath: "/tmp/repo/feature"),
+      repositoryRootURL: rootURL
+    )
+    let repo = Repository(
+      id: rootURL.path(percentEncoded: false),
+      rootURL: rootURL,
+      name: "repo",
+      worktrees: IdentifiedArray(uniqueElements: [wt1, wt2])
+    )
+    var state = RepositoriesFeature.State(repositories: [repo])
+    state.repositoryRoots = [rootURL]
+    state.repositoryOrderIDs = [repo.id]
+    state.selection = .worktree(wt1.id)  // Currently on the first book.
+    state.openedWorktreeIDs = [wt1.id, wt2.id]
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
     }
-    await store.receive(\.delegate.selectedWorktreeChanged)
+
+    await store.send(.selectPreviousShelfBook)
     await store.finish()
   }
 

--- a/supacodeTests/ShelfFeatureTests.swift
+++ b/supacodeTests/ShelfFeatureTests.swift
@@ -336,7 +336,7 @@ struct ShelfFeatureTests {
     await store.finish()
   }
 
-  @Test(.dependencies) func selectNextShelfBookAtEndIsNoOp() async {
+  @Test(.dependencies) func selectNextShelfBookWrapsAround() async {
     let rootURL = URL(fileURLWithPath: "/tmp/repo")
     let wt1 = Worktree(
       id: "/tmp/repo",
@@ -368,10 +368,17 @@ struct ShelfFeatureTests {
     }
 
     await store.send(.selectNextShelfBook)
+    // Wrapping: next-after-last lands back on the first book.
+    await store.receive(\.selectWorktree) {
+      $0.selection = .worktree(wt1.id)
+      $0.sidebarSelectedWorktreeIDs = [wt1.id]
+      $0.pendingTerminalFocusWorktreeIDs = [wt1.id]
+    }
+    await store.receive(\.delegate.selectedWorktreeChanged)
     await store.finish()
   }
 
-  @Test(.dependencies) func selectPreviousShelfBookAtStartIsNoOp() async {
+  @Test(.dependencies) func selectPreviousShelfBookWrapsAround() async {
     let rootURL = URL(fileURLWithPath: "/tmp/repo")
     let wt1 = Worktree(
       id: "/tmp/repo",
@@ -403,6 +410,13 @@ struct ShelfFeatureTests {
     }
 
     await store.send(.selectPreviousShelfBook)
+    // Wrapping: previous-before-first lands on the last book.
+    await store.receive(\.selectWorktree) {
+      $0.selection = .worktree(wt2.id)
+      $0.sidebarSelectedWorktreeIDs = [wt2.id]
+      $0.pendingTerminalFocusWorktreeIDs = [wt2.id]
+    }
+    await store.receive(\.delegate.selectedWorktreeChanged)
     await store.finish()
   }
 


### PR DESCRIPTION
## Summary

Builds on #432 (all original commits included unchanged) and applies review fixes on top:

- **Restore wrap-around for Shelf book navigation.** `shelfBook(atOffset:)` is shared by the
  `⌘⌃←/→` keyboard shortcuts and the new `⌘`+swipe gesture, so the bounded-edge change in #432
  silently removed the long-standing keyboard wrap. Both input paths wrap again, and the
  wrap-around tests are restored (plus a new previous-direction wrap test).
- **Resync agent detection when the repository list changes.** `isShowingShelf` requires a
  non-empty repository list, so removing the last repository could leave shelf-driven detection
  running with no shelf on screen.
- **Cleanups:** drop the unused `postsFrameChangedNotifications` flag in `ShelfSwipeEventMonitor`
  and the redundant `hasBottomControls` guard inside `bottomControls`.

Merging this PR also lands #432 (same commit SHAs, contributor authorship preserved).

## Validation

- `make check`
- `ShelfFeatureTests` + `AppFeatureSettingsChangedTests` (80 passed, TEST SUCCEEDED)
- `make build-app`
