### PR TITLE
Support per-repo GitHub CLI identities

### DIFF
--- a/docs/components/github-pull-requests.md
+++ b/docs/components/github-pull-requests.md
@@ -53,13 +53,23 @@ Open the [Command Palette](command-palette.md) (`⌘P`) on a worktree that has a
 - The **`gh` CLI** must be installed and authenticated (`gh auth login`).
 - `githubIntegrationEnabled` (global) gates all GitHub features.
 - Per repo: `fetchPullRequestState` (auto-fetch PR state; on by default — turn off
-  for big/expensive repos), `pullRequestMergeStrategy` override.
-- Settings → **GitHub** tab holds the integration options.
+  for big/expensive repos), `pullRequestMergeStrategy` override, and
+  `githubAccountOverride` for repositories that need a specific `gh` account.
+- Settings → **GitHub** tab shows every authenticated `gh` host/account and which
+  account is active for each host.
+
+When a repository has `githubAccountOverride` set, Prowl temporarily runs
+`gh auth switch --hostname <host> --user <login>` before GitHub operations for
+that repository, then switches the host back to the previously active account.
+This uses `gh`'s stored authentication state; Prowl still never reads or stores
+GitHub tokens.
 
 ## Gotchas for agents
 
 - No `gh` / not authenticated → no PR features. If a human expects PR actions and
   they're missing, check `gh auth status`.
+- If a repo is pinned to a specific GitHub identity and PR actions fail, verify
+  that `gh auth status` lists that account on the repo's host.
 - PR actions appear in the palette **only when the selected worktree's branch has a
   PR**. No PR → no actions.
 - "Copy CI Failure Logs" is the high-value loop for agents: copy logs → feed to the

--- a/docs/reference/settings-fields.md
+++ b/docs/reference/settings-fields.md
@@ -80,6 +80,7 @@ Stored at `~/.prowl/repo/<repo-name>/prowl.json` (schema v2). For the tri-state
 | `copyIgnoredOnWorktreeCreate` | Bool? | `nil` | Copy ignored files; `nil` = use global. |
 | `copyUntrackedOnWorktreeCreate` | Bool? | `nil` | Copy untracked files; `nil` = use global. |
 | `pullRequestMergeStrategy` | enum? | `nil` | PR merge strategy; `nil` = use global. |
+| `githubAccountOverride` | object? | `nil` | Optional `{ "host": "...", "login": "..." }`; Prowl temporarily switches `gh` to this account for GitHub operations in this repo. |
 | `customTitle` | String? | `nil` | Display name override for the repository. |
 | `observeLineDiffsAutomatically` | Bool? | `nil` (= on) | Keep worktree line-change badges updated; set `false` for large repos. |
 | `fetchPullRequestState` | Bool? | `nil` (= on) | Background-fetch PR state; set `false` to save GitHub rate limit. |

--- a/supacode/Clients/Github/GithubCLIClient.swift
+++ b/supacode/Clients/Github/GithubCLIClient.swift
@@ -135,8 +135,9 @@ enum GithubAuthStatusParsing {
       if rhs == "github.com" { return false }
       return lhs < rhs
     }
+    let snapshot = GithubAuthStatusSnapshot(response: response)
     for host in orderedHosts {
-      if let active = response.hosts[host]?.first(where: { $0.active }) {
+      if let active = snapshot.activeAccount(on: host) {
         return (host, active.login)
       }
     }
@@ -144,20 +145,50 @@ enum GithubAuthStatusParsing {
   }
 }
 
+actor GithubAccountSwitchLock {
+  static let shared = GithubAccountSwitchLock()
+
+  private var lockedHosts: Set<String> = []
+  private var waitersByHost: [String: [CheckedContinuation<Void, Never>]] = [:]
+
+  func acquire(host: String) async {
+    if !lockedHosts.contains(host) {
+      lockedHosts.insert(host)
+      return
+    }
+    await withCheckedContinuation { continuation in
+      waitersByHost[host, default: []].append(continuation)
+    }
+  }
+
+  func release(host: String) {
+    guard var waiters = waitersByHost[host], !waiters.isEmpty else {
+      lockedHosts.remove(host)
+      return
+    }
+    let next = waiters.removeFirst()
+    waitersByHost[host] = waiters.isEmpty ? nil : waiters
+    next.resume()
+  }
+}
+
 struct GithubCLIClient: Sendable {
   var defaultBranch: @Sendable (URL) async throws -> String
   var resolveRemoteInfo: @Sendable (URL) async -> GithubRemoteInfo?
-  var latestRun: @Sendable (URL, String) async throws -> GithubWorkflowRun?
-  var batchPullRequests: @Sendable (String, String, String, [String]) async throws -> [String: GithubPullRequest]
+  var latestRun: @Sendable (URL, String, GithubAccountOverride?) async throws -> GithubWorkflowRun?
+  var batchPullRequests:
+    @Sendable (String, String, String, [String], GithubAccountOverride?) async throws -> [String: GithubPullRequest]
   var batchPullRequestsAcrossRepositories:
-    @Sendable (String, [CrossRepoPullRequestRequest]) async throws -> CrossRepoPullRequestResult
-  var mergePullRequest: @Sendable (URL, GithubRemoteInfo, Int, PullRequestMergeStrategy) async throws -> Void
-  var closePullRequest: @Sendable (URL, GithubRemoteInfo, Int) async throws -> Void
-  var markPullRequestReady: @Sendable (URL, GithubRemoteInfo, Int) async throws -> Void
-  var rerunFailedJobs: @Sendable (URL, Int) async throws -> Void
-  var failedRunLogs: @Sendable (URL, Int) async throws -> String
-  var runLogs: @Sendable (URL, Int) async throws -> String
+    @Sendable (String, [CrossRepoPullRequestRequest], GithubAccountOverride?) async throws -> CrossRepoPullRequestResult
+  var mergePullRequest:
+    @Sendable (URL, GithubRemoteInfo, Int, PullRequestMergeStrategy, GithubAccountOverride?) async throws -> Void
+  var closePullRequest: @Sendable (URL, GithubRemoteInfo, Int, GithubAccountOverride?) async throws -> Void
+  var markPullRequestReady: @Sendable (URL, GithubRemoteInfo, Int, GithubAccountOverride?) async throws -> Void
+  var rerunFailedJobs: @Sendable (URL, Int, GithubAccountOverride?) async throws -> Void
+  var failedRunLogs: @Sendable (URL, Int, GithubAccountOverride?) async throws -> String
+  var runLogs: @Sendable (URL, Int, GithubAccountOverride?) async throws -> String
   var isAvailable: @Sendable () async -> Bool
+  var authStatusSnapshot: @Sendable () async throws -> GithubAuthStatusSnapshot
   var authStatus: @Sendable () async throws -> GithubAuthStatus?
 }
 
@@ -179,6 +210,7 @@ extension GithubCLIClient: DependencyKey {
       failedRunLogs: failedRunLogsFetcher(shell: shell, resolver: resolver),
       runLogs: runLogsFetcher(shell: shell, resolver: resolver),
       isAvailable: isAvailableFetcher(shell: shell, resolver: resolver),
+      authStatusSnapshot: authStatusSnapshotFetcher(shell: shell, resolver: resolver),
       authStatus: authStatusFetcher(shell: shell, resolver: resolver)
     )
   }
@@ -186,16 +218,33 @@ extension GithubCLIClient: DependencyKey {
   static let testValue = GithubCLIClient(
     defaultBranch: { _ in "main" },
     resolveRemoteInfo: { _ in nil },
-    latestRun: { _, _ in nil },
-    batchPullRequests: { _, _, _, _ in [:] },
-    batchPullRequestsAcrossRepositories: { _, _ in CrossRepoPullRequestResult() },
-    mergePullRequest: { _, _, _, _ in },
-    closePullRequest: { _, _, _ in },
-    markPullRequestReady: { _, _, _ in },
-    rerunFailedJobs: { _, _ in },
-    failedRunLogs: { _, _ in "" },
-    runLogs: { _, _ in "" },
+    latestRun: { _, _, _ in nil },
+    batchPullRequests: { _, _, _, _, _ in [:] },
+    batchPullRequestsAcrossRepositories: { _, _, _ in CrossRepoPullRequestResult() },
+    mergePullRequest: { _, _, _, _, _ in },
+    closePullRequest: { _, _, _, _ in },
+    markPullRequestReady: { _, _, _, _ in },
+    rerunFailedJobs: { _, _, _ in },
+    failedRunLogs: { _, _, _ in "" },
+    runLogs: { _, _, _ in "" },
     isAvailable: { true },
+    authStatusSnapshot: {
+      GithubAuthStatusSnapshot(
+        hosts: [
+          "github.com": [
+            GithubAuthAccountStatus(
+              host: "github.com",
+              login: "testuser",
+              active: true,
+              state: "success",
+              gitProtocol: "ssh",
+              scopes: nil,
+              tokenSource: nil
+            )
+          ]
+        ]
+      )
+    },
     authStatus: { GithubAuthStatus(username: "testuser", host: "github.com") }
   )
 }
@@ -251,55 +300,64 @@ nonisolated private func resolveRemoteInfoFetcher(
 nonisolated private func latestRunFetcher(
   shell: ShellClient,
   resolver: GithubCLIExecutableResolver
-) -> @Sendable (URL, String) async throws -> GithubWorkflowRun? {
-  { repoRoot, branch in
-    let output = try await runGh(
-      shell: shell,
-      resolver: resolver,
-      arguments: [
-        "run",
-        "list",
-        "--branch",
-        branch,
-        "--limit",
-        "1",
-        "--json",
-        "databaseId,workflowName,name,displayTitle,status,conclusion,createdAt,updatedAt",
-      ],
-      repoRoot: repoRoot
-    )
-    let decoder = JSONDecoder()
-    decoder.dateDecodingStrategy = .iso8601
-    // nil payload means no runs; a present-but-undecodable payload still throws.
-    let runs = try GithubCLIOutput.decodeIfPresent([GithubWorkflowRun].self, from: output, decoder: decoder)
-    return runs?.first
+) -> @Sendable (URL, String, GithubAccountOverride?) async throws -> GithubWorkflowRun? {
+  { repoRoot, branch, accountOverride in
+    try await withExpectedGithubAccount(shell: shell, resolver: resolver, accountOverride: accountOverride) {
+      let output = try await runGh(
+        shell: shell,
+        resolver: resolver,
+        arguments: [
+          "run",
+          "list",
+          "--branch",
+          branch,
+          "--limit",
+          "1",
+          "--json",
+          "databaseId,workflowName,name,displayTitle,status,conclusion,createdAt,updatedAt",
+        ],
+        repoRoot: repoRoot
+      )
+      let decoder = JSONDecoder()
+      decoder.dateDecodingStrategy = .iso8601
+      // nil payload means no runs; a present-but-undecodable payload still throws.
+      let runs = try GithubCLIOutput.decodeIfPresent([GithubWorkflowRun].self, from: output, decoder: decoder)
+      return runs?.first
+    }
   }
 }
 
 nonisolated private func batchPullRequestsFetcher(
   shell: ShellClient,
   resolver: GithubCLIExecutableResolver
-) -> @Sendable (String, String, String, [String]) async throws -> [String: GithubPullRequest] {
-  { host, owner, repo, branches in
-    let dedupedBranches = deduplicatedBranches(branches)
-    guard !dedupedBranches.isEmpty else {
-      return [:]
-    }
-    let request = GithubPullRequestsRequest(host: host, owner: owner, repo: repo)
-    let chunks = makeBranchChunks(
-      dedupedBranches,
-      chunkSize: batchPullRequestsChunkSize
-    )
-    let chunkResults = try await loadPullRequestChunks(
+) -> @Sendable (String, String, String, [String], GithubAccountOverride?) async throws -> [String: GithubPullRequest] {
+  { host, owner, repo, branches, accountOverride in
+    try await withExpectedGithubAccount(
       shell: shell,
       resolver: resolver,
-      request: request,
-      chunks: chunks
-    )
-    return mergePullRequestChunkResults(
-      chunkResults,
-      chunkCount: chunks.count
-    )
+      host: host,
+      accountOverride: accountOverride
+    ) {
+      let dedupedBranches = deduplicatedBranches(branches)
+      guard !dedupedBranches.isEmpty else {
+        return [:]
+      }
+      let request = GithubPullRequestsRequest(host: host, owner: owner, repo: repo)
+      let chunks = makeBranchChunks(
+        dedupedBranches,
+        chunkSize: batchPullRequestsChunkSize
+      )
+      let chunkResults = try await loadPullRequestChunks(
+        shell: shell,
+        resolver: resolver,
+        request: request,
+        chunks: chunks
+      )
+      return mergePullRequestChunkResults(
+        chunkResults,
+        chunkCount: chunks.count
+      )
+    }
   }
 }
 
@@ -314,20 +372,30 @@ nonisolated private struct CrossRepoChunkOutcome: Sendable {
 nonisolated private func batchPullRequestsAcrossRepositoriesFetcher(
   shell: ShellClient,
   resolver: GithubCLIExecutableResolver
-) -> @Sendable (String, [CrossRepoPullRequestRequest]) async throws -> CrossRepoPullRequestResult {
-  { host, requests in
-    let cleaned = sanitizeCrossRepoRequests(requests)
-    guard !cleaned.isEmpty else {
-      return CrossRepoPullRequestResult()
-    }
-    let chunks = makeCrossRepoChunks(cleaned, chunkSize: crossRepoBatchAliasLimit)
-    let outcomes = try await loadCrossRepoChunks(
+)
+  -> @Sendable (String, [CrossRepoPullRequestRequest], GithubAccountOverride?) async throws ->
+  CrossRepoPullRequestResult
+{
+  { host, requests, accountOverride in
+    try await withExpectedGithubAccount(
       shell: shell,
       resolver: resolver,
       host: host,
-      chunks: chunks
-    )
-    return mergeCrossRepoChunkResults(outcomes)
+      accountOverride: accountOverride
+    ) {
+      let cleaned = sanitizeCrossRepoRequests(requests)
+      guard !cleaned.isEmpty else {
+        return CrossRepoPullRequestResult()
+      }
+      let chunks = makeCrossRepoChunks(cleaned, chunkSize: crossRepoBatchAliasLimit)
+      let outcomes = try await loadCrossRepoChunks(
+        shell: shell,
+        resolver: resolver,
+        host: host,
+        chunks: chunks
+      )
+      return mergeCrossRepoChunkResults(outcomes)
+    }
   }
 }
 
@@ -643,55 +711,76 @@ nonisolated private func rankCrossRepoPullRequests(
 nonisolated private func mergePullRequestFetcher(
   shell: ShellClient,
   resolver: GithubCLIExecutableResolver
-) -> @Sendable (URL, GithubRemoteInfo, Int, PullRequestMergeStrategy) async throws -> Void {
-  { repoRoot, remoteInfo, pullRequestNumber, strategy in
-    _ = try await runGh(
+) -> @Sendable (URL, GithubRemoteInfo, Int, PullRequestMergeStrategy, GithubAccountOverride?) async throws -> Void {
+  { repoRoot, remoteInfo, pullRequestNumber, strategy, accountOverride in
+    try await withExpectedGithubAccount(
       shell: shell,
       resolver: resolver,
-      arguments: [
-        "pr",
-        "merge",
-        "\(pullRequestNumber)",
-        "--\(strategy.ghArgument)",
-      ] + repoArgument(remoteInfo),
-      repoRoot: repoRoot
-    )
+      host: remoteInfo.host,
+      accountOverride: accountOverride
+    ) {
+      _ = try await runGh(
+        shell: shell,
+        resolver: resolver,
+        arguments: [
+          "pr",
+          "merge",
+          "\(pullRequestNumber)",
+          "--\(strategy.ghArgument)",
+        ] + repoArgument(remoteInfo),
+        repoRoot: repoRoot
+      )
+    }
   }
 }
 
 nonisolated private func closePullRequestFetcher(
   shell: ShellClient,
   resolver: GithubCLIExecutableResolver
-) -> @Sendable (URL, GithubRemoteInfo, Int) async throws -> Void {
-  { repoRoot, remoteInfo, pullRequestNumber in
-    _ = try await runGh(
+) -> @Sendable (URL, GithubRemoteInfo, Int, GithubAccountOverride?) async throws -> Void {
+  { repoRoot, remoteInfo, pullRequestNumber, accountOverride in
+    try await withExpectedGithubAccount(
       shell: shell,
       resolver: resolver,
-      arguments: [
-        "pr",
-        "close",
-        "\(pullRequestNumber)",
-      ] + repoArgument(remoteInfo),
-      repoRoot: repoRoot
-    )
+      host: remoteInfo.host,
+      accountOverride: accountOverride
+    ) {
+      _ = try await runGh(
+        shell: shell,
+        resolver: resolver,
+        arguments: [
+          "pr",
+          "close",
+          "\(pullRequestNumber)",
+        ] + repoArgument(remoteInfo),
+        repoRoot: repoRoot
+      )
+    }
   }
 }
 
 nonisolated private func markPullRequestReadyFetcher(
   shell: ShellClient,
   resolver: GithubCLIExecutableResolver
-) -> @Sendable (URL, GithubRemoteInfo, Int) async throws -> Void {
-  { repoRoot, remoteInfo, pullRequestNumber in
-    _ = try await runGh(
+) -> @Sendable (URL, GithubRemoteInfo, Int, GithubAccountOverride?) async throws -> Void {
+  { repoRoot, remoteInfo, pullRequestNumber, accountOverride in
+    try await withExpectedGithubAccount(
       shell: shell,
       resolver: resolver,
-      arguments: [
-        "pr",
-        "ready",
-        "\(pullRequestNumber)",
-      ] + repoArgument(remoteInfo),
-      repoRoot: repoRoot
-    )
+      host: remoteInfo.host,
+      accountOverride: accountOverride
+    ) {
+      _ = try await runGh(
+        shell: shell,
+        resolver: resolver,
+        arguments: [
+          "pr",
+          "ready",
+          "\(pullRequestNumber)",
+        ] + repoArgument(remoteInfo),
+        repoRoot: repoRoot
+      )
+    }
   }
 }
 
@@ -702,57 +791,63 @@ nonisolated private func repoArgument(_ remoteInfo: GithubRemoteInfo) -> [String
 nonisolated private func rerunFailedJobsFetcher(
   shell: ShellClient,
   resolver: GithubCLIExecutableResolver
-) -> @Sendable (URL, Int) async throws -> Void {
-  { repoRoot, runID in
-    _ = try await runGh(
-      shell: shell,
-      resolver: resolver,
-      arguments: [
-        "run",
-        "rerun",
-        "\(runID)",
-        "--failed",
-      ],
-      repoRoot: repoRoot
-    )
+) -> @Sendable (URL, Int, GithubAccountOverride?) async throws -> Void {
+  { repoRoot, runID, accountOverride in
+    try await withExpectedGithubAccount(shell: shell, resolver: resolver, accountOverride: accountOverride) {
+      _ = try await runGh(
+        shell: shell,
+        resolver: resolver,
+        arguments: [
+          "run",
+          "rerun",
+          "\(runID)",
+          "--failed",
+        ],
+        repoRoot: repoRoot
+      )
+    }
   }
 }
 
 nonisolated private func failedRunLogsFetcher(
   shell: ShellClient,
   resolver: GithubCLIExecutableResolver
-) -> @Sendable (URL, Int) async throws -> String {
-  { repoRoot, runID in
-    try await runGh(
-      shell: shell,
-      resolver: resolver,
-      arguments: [
-        "run",
-        "view",
-        "\(runID)",
-        "--log-failed",
-      ],
-      repoRoot: repoRoot
-    )
+) -> @Sendable (URL, Int, GithubAccountOverride?) async throws -> String {
+  { repoRoot, runID, accountOverride in
+    try await withExpectedGithubAccount(shell: shell, resolver: resolver, accountOverride: accountOverride) {
+      try await runGh(
+        shell: shell,
+        resolver: resolver,
+        arguments: [
+          "run",
+          "view",
+          "\(runID)",
+          "--log-failed",
+        ],
+        repoRoot: repoRoot
+      )
+    }
   }
 }
 
 nonisolated private func runLogsFetcher(
   shell: ShellClient,
   resolver: GithubCLIExecutableResolver
-) -> @Sendable (URL, Int) async throws -> String {
-  { repoRoot, runID in
-    try await runGh(
-      shell: shell,
-      resolver: resolver,
-      arguments: [
-        "run",
-        "view",
-        "\(runID)",
-        "--log",
-      ],
-      repoRoot: repoRoot
-    )
+) -> @Sendable (URL, Int, GithubAccountOverride?) async throws -> String {
+  { repoRoot, runID, accountOverride in
+    try await withExpectedGithubAccount(shell: shell, resolver: resolver, accountOverride: accountOverride) {
+      try await runGh(
+        shell: shell,
+        resolver: resolver,
+        arguments: [
+          "run",
+          "view",
+          "\(runID)",
+          "--log",
+        ],
+        repoRoot: repoRoot
+      )
+    }
   }
 }
 
@@ -780,17 +875,177 @@ nonisolated private func authStatusFetcher(
   resolver: GithubCLIExecutableResolver
 ) -> @Sendable () async throws -> GithubAuthStatus? {
   {
-    let output = try await runGh(
-      shell: shell,
-      resolver: resolver,
-      arguments: ["auth", "status", "--json", "hosts"],
-      repoRoot: nil
-    )
-    let response = try GithubCLIOutput.decode(GithubAuthStatusResponse.self, from: output)
+    let response = try await loadAuthStatusResponse(shell: shell, resolver: resolver)
     guard let active = GithubAuthStatusParsing.activeAccount(in: response) else {
       return nil
     }
     return GithubAuthStatus(username: active.login, host: active.host)
+  }
+}
+
+nonisolated private func authStatusSnapshotFetcher(
+  shell: ShellClient,
+  resolver: GithubCLIExecutableResolver
+) -> @Sendable () async throws -> GithubAuthStatusSnapshot {
+  {
+    let response = try await loadAuthStatusResponse(shell: shell, resolver: resolver)
+    return GithubAuthStatusSnapshot(response: response)
+  }
+}
+
+nonisolated private func loadAuthStatusResponse(
+  shell: ShellClient,
+  resolver: GithubCLIExecutableResolver,
+  host: String? = nil,
+  activeOnly: Bool = false
+) async throws -> GithubAuthStatusResponse {
+  var arguments = ["auth", "status"]
+  if activeOnly {
+    arguments.append("--active")
+  }
+  if let host {
+    arguments.append(contentsOf: ["--hostname", host])
+  }
+  arguments.append(contentsOf: ["--json", "hosts"])
+  let output = try await runGh(
+    shell: shell,
+    resolver: resolver,
+    arguments: arguments,
+    repoRoot: nil
+  )
+  return try GithubCLIOutput.decode(GithubAuthStatusResponse.self, from: output)
+}
+
+nonisolated private func withExpectedGithubAccount<Value>(
+  shell: ShellClient,
+  resolver: GithubCLIExecutableResolver,
+  host: String? = nil,
+  accountOverride: GithubAccountOverride?,
+  operation: () async throws -> Value
+) async throws -> Value {
+  guard let accountOverride = accountOverride?.normalized else {
+    return try await operation()
+  }
+  if let host, host != accountOverride.host {
+    throw GithubCLIError.commandFailed(
+      "This repository uses \(host), but its GitHub account override is configured for "
+        + "\(accountOverride.host)/\(accountOverride.login). Update the repository's GitHub identity setting."
+    )
+  }
+  await GithubAccountSwitchLock.shared.acquire(host: accountOverride.host)
+  let previousLogin: String?
+  do {
+    previousLogin = try await activeGithubLogin(
+      shell: shell,
+      resolver: resolver,
+      host: accountOverride.host
+    )
+    if previousLogin != accountOverride.login {
+      try await switchGithubAccount(
+        shell: shell,
+        resolver: resolver,
+        accountOverride: accountOverride
+      )
+    }
+  } catch {
+    await GithubAccountSwitchLock.shared.release(host: accountOverride.host)
+    throw error
+  }
+  do {
+    let value = try await operation()
+    await restoreGithubAccountIfNeeded(
+      shell: shell,
+      resolver: resolver,
+      host: accountOverride.host,
+      previousLogin: previousLogin,
+      targetLogin: accountOverride.login
+    )
+    await GithubAccountSwitchLock.shared.release(host: accountOverride.host)
+    return value
+  } catch {
+    await restoreGithubAccountIfNeeded(
+      shell: shell,
+      resolver: resolver,
+      host: accountOverride.host,
+      previousLogin: previousLogin,
+      targetLogin: accountOverride.login
+    )
+    await GithubAccountSwitchLock.shared.release(host: accountOverride.host)
+    throw error
+  }
+}
+
+nonisolated private func activeGithubLogin(
+  shell: ShellClient,
+  resolver: GithubCLIExecutableResolver,
+  host: String
+) async throws -> String? {
+  let response = try await loadAuthStatusResponse(
+    shell: shell,
+    resolver: resolver,
+    host: host,
+    activeOnly: true
+  )
+  let snapshot = GithubAuthStatusSnapshot(response: response)
+  return snapshot.activeAccount(on: host)?.login
+}
+
+nonisolated private func switchGithubAccount(
+  shell: ShellClient,
+  resolver: GithubCLIExecutableResolver,
+  accountOverride: GithubAccountOverride
+) async throws {
+  do {
+    _ = try await runGh(
+      shell: shell,
+      resolver: resolver,
+      arguments: [
+        "auth",
+        "switch",
+        "--hostname",
+        accountOverride.host,
+        "--user",
+        accountOverride.login,
+      ],
+      repoRoot: nil
+    )
+  } catch {
+    throw GithubCLIError.commandFailed(
+      "Prowl is configured to use \(accountOverride.login) on \(accountOverride.host), "
+        + "but gh could not switch to that account. Run "
+        + "`gh auth switch --hostname \(accountOverride.host) --user \(accountOverride.login)` and try again."
+    )
+  }
+}
+
+nonisolated private func restoreGithubAccountIfNeeded(
+  shell: ShellClient,
+  resolver: GithubCLIExecutableResolver,
+  host: String,
+  previousLogin: String?,
+  targetLogin: String
+) async {
+  guard let previousLogin, previousLogin != targetLogin else {
+    return
+  }
+  do {
+    _ = try await runGh(
+      shell: shell,
+      resolver: resolver,
+      arguments: [
+        "auth",
+        "switch",
+        "--hostname",
+        host,
+        "--user",
+        previousLogin,
+      ],
+      repoRoot: nil
+    )
+  } catch {
+    SupaLogger("GithubCLI").warning(
+      "Failed to restore gh active account for \(host) to \(previousLogin): \(error.localizedDescription)"
+    )
   }
 }
 

--- a/supacode/Clients/Github/GithubCLIModels.swift
+++ b/supacode/Clients/Github/GithubCLIModels.swift
@@ -1,16 +1,104 @@
 import Foundation
 
+nonisolated struct GithubAccountOverride: Codable, Equatable, Hashable, Sendable {
+  let host: String
+  let login: String
+
+  init(host: String, login: String) {
+    self.host = host
+    self.login = login
+  }
+
+  var normalized: GithubAccountOverride? {
+    let trimmedHost = host.trimmingCharacters(in: .whitespacesAndNewlines)
+    let trimmedLogin = login.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmedHost.isEmpty, !trimmedLogin.isEmpty else {
+      return nil
+    }
+    return GithubAccountOverride(host: trimmedHost, login: trimmedLogin)
+  }
+}
+
 struct GithubAuthStatus: Equatable, Sendable {
   let username: String
   let host: String
+}
+
+nonisolated struct GithubAuthStatusSnapshot: Equatable, Sendable {
+  let hosts: [String: [GithubAuthAccountStatus]]
+
+  init(hosts: [String: [GithubAuthAccountStatus]]) {
+    self.hosts = hosts
+  }
+
+  init(response: GithubAuthStatusResponse) {
+    hosts = Dictionary(
+      uniqueKeysWithValues: response.hosts.map { host, accounts in
+        let statuses = accounts.map {
+          GithubAuthAccountStatus(
+            host: $0.host.isEmpty ? host : $0.host,
+            login: $0.login,
+            active: $0.active,
+            state: $0.state,
+            gitProtocol: $0.gitProtocol,
+            scopes: $0.scopes,
+            tokenSource: $0.tokenSource
+          )
+        }
+        return (host, statuses)
+      })
+  }
+
+  var sortedHosts: [String] {
+    hosts.keys.sorted { lhs, rhs in
+      if lhs == "github.com" { return true }
+      if rhs == "github.com" { return false }
+      return lhs < rhs
+    }
+  }
+
+  var allAccounts: [GithubAuthAccountStatus] {
+    sortedHosts.flatMap { accounts(on: $0) }
+  }
+
+  func accounts(on host: String) -> [GithubAuthAccountStatus] {
+    hosts[host] ?? []
+  }
+
+  func activeAccount(on host: String) -> GithubAuthAccountStatus? {
+    accounts(on: host).first(where: \.active)
+  }
+}
+
+nonisolated struct GithubAuthAccountStatus: Equatable, Identifiable, Sendable {
+  let host: String
+  let login: String
+  let active: Bool
+  let state: String?
+  let gitProtocol: String?
+  let scopes: String?
+  let tokenSource: String?
+
+  var id: String {
+    "\(host)/\(login)"
+  }
+
+  var override: GithubAccountOverride {
+    GithubAccountOverride(host: host, login: login)
+  }
 }
 
 struct GithubAuthStatusResponse: Sendable {
   let hosts: [String: [GithubAuthAccount]]
 
   struct GithubAuthAccount: Sendable {
+    let host: String
     let active: Bool
     let login: String
+    let state: String?
+    let gitProtocol: String?
+    let scopes: String?
+    let tokenSource: String?
   }
 }
 
@@ -27,14 +115,24 @@ extension GithubAuthStatusResponse: Decodable {
 
 extension GithubAuthStatusResponse.GithubAuthAccount: Decodable {
   private enum CodingKeys: String, CodingKey {
+    case host
     case active
     case login
+    case state
+    case gitProtocol
+    case scopes
+    case tokenSource
   }
 
   nonisolated init(from decoder: any Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
+    host = try container.decodeIfPresent(String.self, forKey: .host) ?? ""
     self.active = try container.decode(Bool.self, forKey: .active)
     self.login = try container.decode(String.self, forKey: .login)
+    state = try container.decodeIfPresent(String.self, forKey: .state)
+    gitProtocol = try container.decodeIfPresent(String.self, forKey: .gitProtocol)
+    scopes = try container.decodeIfPresent(String.self, forKey: .scopes)
+    tokenSource = try container.decodeIfPresent(String.self, forKey: .tokenSource)
   }
 }
 

--- a/supacode/Features/Repositories/BusinessLogic/PullRequestRefreshCoordinator.swift
+++ b/supacode/Features/Repositories/BusinessLogic/PullRequestRefreshCoordinator.swift
@@ -9,6 +9,7 @@ final class PullRequestRefreshCoordinator {
     let host: String
     let owner: String
     let repo: String
+    let accountOverride: GithubAccountOverride?
     let branches: [String]
     let worktreeIDs: [Worktree.ID]
   }
@@ -33,10 +34,15 @@ final class PullRequestRefreshCoordinator {
   private let softTimeout: Duration
   private let resultHandler: @MainActor (Outcome) -> Void
 
-  private var pendingByHost: [String: [Repository.ID: Request]] = [:]
-  private var flushTaskByHost: [String: Task<Void, Never>] = [:]
-  private var inflightHosts: Set<String> = []
-  private var queuedByHost: [String: [Repository.ID: Request]] = [:]
+  private struct BatchKey: Hashable, Sendable {
+    let host: String
+    let accountOverride: GithubAccountOverride?
+  }
+
+  private var pendingByHost: [BatchKey: [Repository.ID: Request]] = [:]
+  private var flushTaskByHost: [BatchKey: Task<Void, Never>] = [:]
+  private var inflightHosts: Set<BatchKey> = []
+  private var queuedByHost: [BatchKey: [Repository.ID: Request]] = [:]
 
   init(
     githubCLI: GithubCLIClient,
@@ -68,23 +74,28 @@ final class PullRequestRefreshCoordinator {
       host: request.host,
       owner: request.owner,
       repo: request.repo,
+      accountOverride: request.accountOverride,
       branches: cleanedBranches,
       worktreeIDs: request.worktreeIDs
     )
 
-    if inflightHosts.contains(normalized.host) {
+    let key = BatchKey(host: normalized.host, accountOverride: normalized.accountOverride)
+    if inflightHosts.contains(key) {
       mergeRequest(normalized, into: &queuedByHost)
       return
     }
 
     mergeRequest(normalized, into: &pendingByHost)
-    rescheduleDebounce(forHost: normalized.host)
+    rescheduleDebounce(forKey: key)
   }
 
   func cancelHost(_ host: String) {
-    flushTaskByHost.removeValue(forKey: host)?.cancel()
-    pendingByHost.removeValue(forKey: host)
-    queuedByHost.removeValue(forKey: host)
+    for key in flushTaskByHost.keys where key.host == host {
+      flushTaskByHost.removeValue(forKey: key)?.cancel()
+    }
+    pendingByHost = pendingByHost.filter { $0.key.host != host }
+    queuedByHost = queuedByHost.filter { $0.key.host != host }
+    inflightHosts = inflightHosts.filter { $0.host != host }
   }
 
   func reset() {
@@ -99,9 +110,10 @@ final class PullRequestRefreshCoordinator {
 
   private func mergeRequest(
     _ request: Request,
-    into bucket: inout [String: [Repository.ID: Request]]
+    into bucket: inout [BatchKey: [Repository.ID: Request]]
   ) {
-    var hostBucket = bucket[request.host] ?? [:]
+    let key = BatchKey(host: request.host, accountOverride: request.accountOverride)
+    var hostBucket = bucket[key] ?? [:]
     if let existing = hostBucket[request.repositoryID] {
       var seen = Set<String>(existing.branches)
       var combined = existing.branches
@@ -119,44 +131,45 @@ final class PullRequestRefreshCoordinator {
         host: request.host,
         owner: request.owner,
         repo: request.repo,
+        accountOverride: request.accountOverride,
         branches: combined,
         worktreeIDs: workCombined
       )
     } else {
       hostBucket[request.repositoryID] = request
     }
-    bucket[request.host] = hostBucket
+    bucket[key] = hostBucket
   }
 
-  private func rescheduleDebounce(forHost host: String) {
-    flushTaskByHost.removeValue(forKey: host)?.cancel()
+  private func rescheduleDebounce(forKey key: BatchKey) {
+    flushTaskByHost.removeValue(forKey: key)?.cancel()
     let task = Task { [weak self, debounceWindow, clock] in
       do {
         try await clock.sleep(for: debounceWindow)
       } catch {
         return
       }
-      await self?.flush(host: host)
+      await self?.flush(key: key)
     }
-    flushTaskByHost[host] = task
+    flushTaskByHost[key] = task
   }
 
-  private func flush(host: String) async {
-    flushTaskByHost.removeValue(forKey: host)
-    guard let bucket = pendingByHost.removeValue(forKey: host), !bucket.isEmpty else {
+  private func flush(key: BatchKey) async {
+    flushTaskByHost.removeValue(forKey: key)
+    guard let bucket = pendingByHost.removeValue(forKey: key), !bucket.isEmpty else {
       return
     }
-    inflightHosts.insert(host)
+    inflightHosts.insert(key)
     let requests = Array(bucket.values)
-    await processBatch(host: host, requests: requests)
-    inflightHosts.remove(host)
-    if let queued = queuedByHost.removeValue(forKey: host), !queued.isEmpty {
-      pendingByHost[host, default: [:]].merge(queued) { _, new in new }
-      await flush(host: host)
+    await processBatch(key: key, requests: requests)
+    inflightHosts.remove(key)
+    if let queued = queuedByHost.removeValue(forKey: key), !queued.isEmpty {
+      pendingByHost[key, default: [:]].merge(queued) { _, new in new }
+      await flush(key: key)
     }
   }
 
-  private func processBatch(host: String, requests: [Request]) async {
+  private func processBatch(key: BatchKey, requests: [Request]) async {
     let groupsByKey = groupRequestsByRepo(requests)
     let crossRepoRequests = groupsByKey.values.map { group in
       CrossRepoPullRequestRequest(
@@ -166,7 +179,11 @@ final class PullRequestRefreshCoordinator {
       )
     }
     do {
-      let result = try await runBatchWithTimeout(host: host, requests: crossRepoRequests)
+      let result = try await runBatchWithTimeout(
+        host: key.host,
+        requests: crossRepoRequests,
+        accountOverride: key.accountOverride
+      )
       for (key, prsByBranch) in result.successByRepo {
         guard let group = groupsByKey[key] else {
           continue
@@ -208,14 +225,15 @@ final class PullRequestRefreshCoordinator {
 
   private func runBatchWithTimeout(
     host: String,
-    requests: [CrossRepoPullRequestRequest]
+    requests: [CrossRepoPullRequestRequest],
+    accountOverride: GithubAccountOverride?
   ) async throws -> CrossRepoPullRequestResult {
     try await withThrowingTaskGroup(of: BatchTimeoutOutcome.self) { group in
       let githubCLI = self.githubCLI
       let softTimeout = self.softTimeout
       let clock = self.clock
       group.addTask {
-        let value = try await githubCLI.batchPullRequestsAcrossRepositories(host, requests)
+        let value = try await githubCLI.batchPullRequestsAcrossRepositories(host, requests, accountOverride)
         return .completed(value)
       }
       group.addTask {
@@ -241,7 +259,8 @@ final class PullRequestRefreshCoordinator {
         group.requests[0].host,
         group.key.owner,
         group.key.repo,
-        group.branches
+        group.branches,
+        group.requests[0].accountOverride
       )
       for request in group.requests {
         resultHandler(

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+GithubIntegration.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+GithubIntegration.swift
@@ -363,6 +363,7 @@ extension RepositoriesFeature {
           }
           await send(.showToast(.inProgress("Marking PR ready…")))
           do {
+            @Shared(.repositorySettings(repoRoot)) var repositorySettings
             guard
               let remoteInfo = await Self.resolveGithubRemoteInfo(
                 repositoryRootURL: repoRoot,
@@ -375,7 +376,12 @@ extension RepositoriesFeature {
                 .presentAlert(title: "GitHub repository not resolved", message: unresolvedGithubRepositoryMessage))
               return
             }
-            try await githubCLI.markPullRequestReady(worktreeRoot, remoteInfo, pullRequest.number)
+            try await githubCLI.markPullRequestReady(
+              worktreeRoot,
+              remoteInfo,
+              pullRequest.number,
+              repositorySettings.githubAccountOverride
+            )
             await send(.showToast(.success("Pull request marked ready")))
             await send(.githubIntegration(.delayedPullRequestRefresh(worktreeID)))
           } catch {
@@ -420,7 +426,13 @@ extension RepositoriesFeature {
                 .presentAlert(title: "GitHub repository not resolved", message: unresolvedGithubRepositoryMessage))
               return
             }
-            try await githubCLI.mergePullRequest(worktreeRoot, remoteInfo, pullRequest.number, strategy)
+            try await githubCLI.mergePullRequest(
+              worktreeRoot,
+              remoteInfo,
+              pullRequest.number,
+              strategy,
+              repositorySettings.githubAccountOverride
+            )
             await send(.showToast(.success("Pull request merged")))
             await send(.worktreeInfoEvent(pullRequestRefresh))
             await send(.githubIntegration(.delayedPullRequestRefresh(worktreeID)))
@@ -451,6 +463,7 @@ extension RepositoriesFeature {
           }
           await send(.showToast(.inProgress("Closing pull request…")))
           do {
+            @Shared(.repositorySettings(repoRoot)) var repositorySettings
             guard
               let remoteInfo = await Self.resolveGithubRemoteInfo(
                 repositoryRootURL: repoRoot,
@@ -463,7 +476,12 @@ extension RepositoriesFeature {
                 .presentAlert(title: "GitHub repository not resolved", message: unresolvedGithubRepositoryMessage))
               return
             }
-            try await githubCLI.closePullRequest(worktreeRoot, remoteInfo, pullRequest.number)
+            try await githubCLI.closePullRequest(
+              worktreeRoot,
+              remoteInfo,
+              pullRequest.number,
+              repositorySettings.githubAccountOverride
+            )
             await send(.showToast(.success("Pull request closed")))
             await send(.worktreeInfoEvent(pullRequestRefresh))
             await send(.githubIntegration(.delayedPullRequestRefresh(worktreeID)))
@@ -502,7 +520,9 @@ extension RepositoriesFeature {
           }
           await send(.showToast(.inProgress("Fetching CI logs…")))
           do {
-            guard let run = try await githubCLI.latestRun(worktreeRoot, branchName) else {
+            @Shared(.repositorySettings(repoRoot)) var repositorySettings
+            let accountOverride = repositorySettings.githubAccountOverride
+            guard let run = try await githubCLI.latestRun(worktreeRoot, branchName, accountOverride) else {
               await send(.dismissToast)
               await send(
                 .presentAlert(
@@ -522,10 +542,10 @@ extension RepositoriesFeature {
               )
               return
             }
-            let failedLogs = try await githubCLI.failedRunLogs(worktreeRoot, run.databaseId)
+            let failedLogs = try await githubCLI.failedRunLogs(worktreeRoot, run.databaseId, accountOverride)
             let logs =
               if failedLogs.isEmpty {
-                try await githubCLI.runLogs(worktreeRoot, run.databaseId)
+                try await githubCLI.runLogs(worktreeRoot, run.databaseId, accountOverride)
               } else {
                 failedLogs
               }
@@ -579,7 +599,9 @@ extension RepositoriesFeature {
           }
           await send(.showToast(.inProgress("Re-running failed jobs…")))
           do {
-            guard let run = try await githubCLI.latestRun(worktreeRoot, branchName) else {
+            @Shared(.repositorySettings(repoRoot)) var repositorySettings
+            let accountOverride = repositorySettings.githubAccountOverride
+            guard let run = try await githubCLI.latestRun(worktreeRoot, branchName, accountOverride) else {
               await send(.dismissToast)
               await send(
                 .presentAlert(
@@ -599,7 +621,7 @@ extension RepositoriesFeature {
               )
               return
             }
-            try await githubCLI.rerunFailedJobs(worktreeRoot, run.databaseId)
+            try await githubCLI.rerunFailedJobs(worktreeRoot, run.databaseId, accountOverride)
             await send(.showToast(.success("Failed jobs re-run started")))
             await send(.githubIntegration(.delayedPullRequestRefresh(worktreeID)))
           } catch {
@@ -719,6 +741,7 @@ extension RepositoriesFeature {
         await send(.githubIntegration(.repositoryPullRequestRefreshCompleted(repositoryID)))
         return
       }
+      @Shared(.repositorySettings(repositoryRootURL)) var repositorySettings
       coordinatorClient.enqueue(
         PullRequestRefreshCoordinator.Request(
           repositoryID: repositoryID,
@@ -726,6 +749,7 @@ extension RepositoriesFeature {
           host: info.host,
           owner: info.owner,
           repo: info.repo,
+          accountOverride: repositorySettings.githubAccountOverride,
           branches: branches,
           worktreeIDs: worktreeIDs
         )

--- a/supacode/Features/RepositorySettings/Reducer/RepositorySettingsFeature.swift
+++ b/supacode/Features/RepositorySettings/Reducer/RepositorySettingsFeature.swift
@@ -288,6 +288,7 @@ struct RepositorySettingsFeature {
           .trimmingCharacters(in: .whitespacesAndNewlines)
         normalizedSettings.customTitle =
           (trimmedCustomTitle?.isEmpty ?? true) ? nil : trimmedCustomTitle
+        normalizedSettings.githubAccountOverride = normalizedSettings.githubAccountOverride?.normalized
         @Shared(.repositorySettings(rootURL)) var repositorySettings
         @Shared(.userRepositorySettings(rootURL)) var userRepositorySettings
         $repositorySettings.withLock { $0 = normalizedSettings }

--- a/supacode/Features/Settings/Models/RepositorySettings.swift
+++ b/supacode/Features/Settings/Models/RepositorySettings.swift
@@ -15,6 +15,7 @@ nonisolated struct RepositorySettings: Codable, Equatable, Sendable {
   var copyIgnoredOnWorktreeCreate: Bool?
   var copyUntrackedOnWorktreeCreate: Bool?
   var pullRequestMergeStrategy: PullRequestMergeStrategy?
+  var githubAccountOverride: GithubAccountOverride?
   var customTitle: String?
   /// When `nil` (unset) or `true`, Prowl keeps the worktree line-change badges
   /// up to date in the background. Set to `false` to skip the periodic `git diff`
@@ -37,6 +38,7 @@ nonisolated struct RepositorySettings: Codable, Equatable, Sendable {
     case copyIgnoredOnWorktreeCreate
     case copyUntrackedOnWorktreeCreate
     case pullRequestMergeStrategy
+    case githubAccountOverride
     case customTitle
     case observeLineDiffsAutomatically
     case fetchPullRequestState
@@ -52,6 +54,7 @@ nonisolated struct RepositorySettings: Codable, Equatable, Sendable {
     copyIgnoredOnWorktreeCreate: nil,
     copyUntrackedOnWorktreeCreate: nil,
     pullRequestMergeStrategy: nil,
+    githubAccountOverride: nil,
     customTitle: nil,
     observeLineDiffsAutomatically: nil,
     fetchPullRequestState: nil
@@ -67,6 +70,7 @@ nonisolated struct RepositorySettings: Codable, Equatable, Sendable {
     copyIgnoredOnWorktreeCreate: Bool? = nil,
     copyUntrackedOnWorktreeCreate: Bool? = nil,
     pullRequestMergeStrategy: PullRequestMergeStrategy? = nil,
+    githubAccountOverride: GithubAccountOverride? = nil,
     customTitle: String? = nil,
     observeLineDiffsAutomatically: Bool? = nil,
     fetchPullRequestState: Bool? = nil
@@ -80,6 +84,7 @@ nonisolated struct RepositorySettings: Codable, Equatable, Sendable {
     self.copyIgnoredOnWorktreeCreate = copyIgnoredOnWorktreeCreate
     self.copyUntrackedOnWorktreeCreate = copyUntrackedOnWorktreeCreate
     self.pullRequestMergeStrategy = pullRequestMergeStrategy
+    self.githubAccountOverride = githubAccountOverride?.normalized
     self.customTitle = customTitle
     self.observeLineDiffsAutomatically = observeLineDiffsAutomatically
     self.fetchPullRequestState = fetchPullRequestState
@@ -113,6 +118,8 @@ nonisolated struct RepositorySettings: Codable, Equatable, Sendable {
       try container.decodeIfPresent(Bool.self, forKey: .observeLineDiffsAutomatically)
     fetchPullRequestState =
       try container.decodeIfPresent(Bool.self, forKey: .fetchPullRequestState)
+    githubAccountOverride =
+      try container.decodeIfPresent(GithubAccountOverride.self, forKey: .githubAccountOverride)?.normalized
     if decodedSchemaVersion >= Self.currentSchemaVersion {
       copyIgnoredOnWorktreeCreate =
         try container.decodeIfPresent(

--- a/supacode/Features/Settings/Views/GithubSettingsView.swift
+++ b/supacode/Features/Settings/Views/GithubSettingsView.swift
@@ -8,7 +8,7 @@ final class GithubSettingsViewModel {
     case unavailable
     case outdated
     case notAuthenticated
-    case authenticated(username: String, host: String)
+    case authenticated(GithubAuthStatusSnapshot)
     case error(String)
   }
 
@@ -29,8 +29,9 @@ final class GithubSettingsViewModel {
     }
 
     do {
-      if let status = try await githubCLI.authStatus() {
-        state = .authenticated(username: status.username, host: status.host)
+      let snapshot = try await githubCLI.authStatusSnapshot()
+      if snapshot.allAccounts.contains(where: { $0.active }) {
+        state = .authenticated(snapshot)
       } else {
         state = .notAuthenticated
       }
@@ -100,14 +101,30 @@ struct GithubSettingsView: View {
                 .font(.callout)
             }
 
-          case .authenticated(let username, let host):
-            LabeledContent("Signed in as") {
-              Text(username)
-                .font(.body)
-            }
-            LabeledContent("Host") {
-              Text(host)
-                .font(.body)
+          case .authenticated(let snapshot):
+            ForEach(snapshot.sortedHosts, id: \.self) { host in
+              let accounts = snapshot.accounts(on: host)
+              VStack(alignment: .leading, spacing: 8) {
+                LabeledContent("Host") {
+                  Text(host)
+                    .font(.body)
+                }
+                ForEach(accounts) { account in
+                  HStack {
+                    Text(account.login)
+                    if account.active {
+                      Text("Active")
+                        .foregroundStyle(.secondary)
+                    }
+                    Spacer()
+                    if let state = account.state {
+                      Text(state)
+                        .foregroundStyle(.secondary)
+                    }
+                  }
+                  .font(.body)
+                }
+              }
             }
 
           case .error(let message):

--- a/supacode/Features/Settings/Views/GithubSettingsView.swift
+++ b/supacode/Features/Settings/Views/GithubSettingsView.swift
@@ -117,9 +117,10 @@ struct GithubSettingsView: View {
                         .foregroundStyle(.secondary)
                     }
                     Spacer()
-                    if let state = account.state {
-                      Text(state)
-                        .foregroundStyle(.secondary)
+                    if let status = GithubAuthAccountStatusDisplay(account.state) {
+                      Text(status.title)
+                        .foregroundStyle(status.style)
+                        .help(status.help)
                     }
                   }
                   .font(.body)
@@ -181,6 +182,32 @@ struct GithubSettingsView: View {
       Task {
         await viewModel.load()
       }
+    }
+  }
+}
+
+private struct GithubAuthAccountStatusDisplay {
+  let title: String
+  let help: String
+  let style: Color
+
+  init?(_ state: String?) {
+    guard let state else { return nil }
+    switch state.lowercased() {
+    case "success":
+      return nil
+    case "timeout":
+      title = "Timed out"
+      help = "gh could not verify this account in time."
+      style = .orange
+    case "error":
+      title = "Needs attention"
+      help = "gh could not verify this account."
+      style = .red
+    default:
+      title = "Check failed"
+      help = "gh reported an authentication issue."
+      style = .orange
     }
   }
 }

--- a/supacode/Features/Settings/Views/RepositorySettingsView.swift
+++ b/supacode/Features/Settings/Views/RepositorySettingsView.swift
@@ -6,6 +6,7 @@ struct RepositorySettingsView: View {
   @Bindable var store: StoreOf<RepositorySettingsFeature>
   @State private var isBranchPickerPresented = false
   @State private var branchSearchText = ""
+  @State private var githubIdentityViewModel = RepositoryGithubIdentityViewModel()
 
   @State var selectedCustomCommandID: UserCustomCommand.ID?
   @State var recordingCustomCommandID: UserCustomCommand.ID?
@@ -222,6 +223,24 @@ struct RepositorySettingsView: View {
                 + "Disable to skip background GitHub queries and save API rate limit."
             )
 
+            Picker(selection: settings.githubAccountOverride) {
+              Text("Automatic").tag(GithubAccountOverride?.none)
+              if let override = store.settings.githubAccountOverride,
+                !githubIdentityViewModel.accounts.contains(where: { $0.override == override })
+              {
+                Text("\(override.login) @ \(override.host)")
+                  .tag(GithubAccountOverride?.some(override))
+              }
+              ForEach(githubIdentityViewModel.accounts) { account in
+                Text("\(account.login) @ \(account.host)")
+                  .tag(GithubAccountOverride?.some(account.override))
+              }
+            } label: {
+              Text("GitHub identity")
+              Text("Account Prowl switches to before running gh for this repository.")
+            }
+            .help("Select the gh account Prowl should use for this repository.")
+
             Picker(selection: settings.pullRequestMergeStrategy) {
               Text(
                 "Global \(Text(store.globalPullRequestMergeStrategy.title).foregroundStyle(.secondary))"
@@ -325,6 +344,7 @@ struct RepositorySettingsView: View {
     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     .task {
       store.send(.task)
+      await githubIdentityViewModel.load()
       syncSelectedCommandID(with: store.userSettings.customCommands)
     }
     .onChange(of: store.userSettings.customCommands) { _, commands in
@@ -375,6 +395,23 @@ struct RepositorySettingsView: View {
         "“\(conflict.newCommandTitle)” and “\(conflict.existingCommandTitle)” both use \(conflict.shortcutDisplay)."
           + "\n\nChoose Replace to keep the new shortcut and clear the conflicting command."
       )
+    }
+  }
+}
+
+@MainActor @Observable
+private final class RepositoryGithubIdentityViewModel {
+  var accounts: [GithubAuthAccountStatus] = []
+
+  @ObservationIgnored
+  @Dependency(GithubCLIClient.self) private var githubCLI
+
+  func load() async {
+    do {
+      let snapshot = try await githubCLI.authStatusSnapshot()
+      accounts = snapshot.allAccounts
+    } catch {
+      accounts = []
     }
   }
 }

--- a/supacodeTests/BatchedPullRequestRefreshReducerTests.swift
+++ b/supacodeTests/BatchedPullRequestRefreshReducerTests.swift
@@ -21,7 +21,7 @@ struct BatchedPullRequestRefreshReducerTests {
         Issue.record("Should not resolve when cache hit")
         return nil
       }
-      $0.githubCLI.batchPullRequests = { _, _, _, _ in
+      $0.githubCLI.batchPullRequests = { _, _, _, _, _ in
         Issue.record("Legacy batchPullRequests should not run on coordinator path")
         return [:]
       }

--- a/supacodeTests/GithubCLIClientTests.swift
+++ b/supacodeTests/GithubCLIClientTests.swift
@@ -124,9 +124,9 @@ struct GithubCLIClientTests {
     )
     let client = GithubCLIClient.live(shell: shell)
 
-    try await client.mergePullRequest(repoRoot, remoteInfo, 12, .squash)
-    try await client.closePullRequest(repoRoot, remoteInfo, 13)
-    try await client.markPullRequestReady(repoRoot, remoteInfo, 14)
+    try await client.mergePullRequest(repoRoot, remoteInfo, 12, .squash, nil)
+    try await client.closePullRequest(repoRoot, remoteInfo, 13, nil)
+    try await client.markPullRequestReady(repoRoot, remoteInfo, 14, nil)
 
     let calls = await probe.snapshot()
     #expect(
@@ -136,6 +136,83 @@ struct GithubCLIClientTests {
         ["pr", "ready", "14", "--repo", "github.enterprise.test/octo/repo"],
       ])
     #expect(calls.allSatisfy { $0.currentDirectoryURL == repoRoot })
+  }
+
+  @Test func pullRequestMutationChecksExpectedAccountBeforeCommand() async throws {
+    let repoRoot = URL(fileURLWithPath: "/tmp/private")
+    let remoteInfo = GithubRemoteInfo(host: "github.com", owner: "octo", repo: "repo")
+    let account = GithubAccountOverride(host: "github.com", login: "work")
+    let probe = GithubCommandProbe()
+    let shell = ShellClient(
+      run: { executableURL, _, _ in
+        if executableURL.lastPathComponent == "which" {
+          return ShellOutput(stdout: "/usr/bin/gh", stderr: "", exitCode: 0)
+        }
+        return ShellOutput(stdout: "", stderr: "", exitCode: 0)
+      },
+      runLoginImpl: { executableURL, arguments, currentDirectoryURL, _ in
+        guard executableURL.lastPathComponent == "gh" else {
+          return ShellOutput(stdout: "", stderr: "", exitCode: 0)
+        }
+        await probe.record(arguments: arguments, currentDirectoryURL: currentDirectoryURL)
+        if arguments.starts(with: ["auth", "status"]) {
+          return ShellOutput(
+            stdout: #"{"hosts":{"github.com":[{"active":true,"login":"work","state":"success"}]}}"#,
+            stderr: "",
+            exitCode: 0
+          )
+        }
+        return ShellOutput(stdout: "", stderr: "", exitCode: 0)
+      }
+    )
+    let client = GithubCLIClient.live(shell: shell)
+
+    try await client.mergePullRequest(repoRoot, remoteInfo, 12, .squash, account)
+
+    let calls = await probe.snapshot()
+    #expect(
+      calls.map(\.arguments) == [
+        ["auth", "status", "--active", "--hostname", "github.com", "--json", "hosts"],
+        ["pr", "merge", "12", "--squash", "--repo", "github.com/octo/repo"],
+      ])
+  }
+
+  @Test func pullRequestMutationSwitchesAndRestoresExpectedAccount() async throws {
+    let repoRoot = URL(fileURLWithPath: "/tmp/private")
+    let remoteInfo = GithubRemoteInfo(host: "github.com", owner: "octo", repo: "repo")
+    let account = GithubAccountOverride(host: "github.com", login: "work")
+    let probe = GithubCommandProbe()
+    let shell = ShellClient(
+      run: { executableURL, _, _ in
+        if executableURL.lastPathComponent == "which" {
+          return ShellOutput(stdout: "/usr/bin/gh", stderr: "", exitCode: 0)
+        }
+        return ShellOutput(stdout: "", stderr: "", exitCode: 0)
+      },
+      runLoginImpl: { executableURL, arguments, currentDirectoryURL, _ in
+        guard executableURL.lastPathComponent == "gh" else {
+          return ShellOutput(stdout: "", stderr: "", exitCode: 0)
+        }
+        await probe.record(arguments: arguments, currentDirectoryURL: currentDirectoryURL)
+        return ShellOutput(
+          stdout: #"{"hosts":{"github.com":[{"active":true,"login":"personal","state":"success"}]}}"#,
+          stderr: "",
+          exitCode: 0
+        )
+      }
+    )
+    let client = GithubCLIClient.live(shell: shell)
+
+    try await client.mergePullRequest(repoRoot, remoteInfo, 12, .squash, account)
+
+    let calls = await probe.snapshot()
+    #expect(
+      calls.map(\.arguments) == [
+        ["auth", "status", "--active", "--hostname", "github.com", "--json", "hosts"],
+        ["auth", "switch", "--hostname", "github.com", "--user", "work"],
+        ["pr", "merge", "12", "--squash", "--repo", "github.com/octo/repo"],
+        ["auth", "switch", "--hostname", "github.com", "--user", "personal"],
+      ])
   }
 
   @Test func batchPullRequestsCapsConcurrencyAtThree() async throws {
@@ -169,7 +246,7 @@ struct GithubCLIClientTests {
     let client = GithubCLIClient.live(shell: shell)
     let branches = (0..<100).map { "feature-\($0)" }
 
-    _ = try await client.batchPullRequests("github.com", "khoi", "repo", branches)
+    _ = try await client.batchPullRequests("github.com", "khoi", "repo", branches, nil)
 
     let snapshot = await probe.snapshot()
     #expect(snapshot.ghCallCount == 4)
@@ -219,7 +296,7 @@ struct GithubCLIClientTests {
     let branches = (0..<30).map { "feature-\($0)" }
 
     do {
-      _ = try await client.batchPullRequests("github.com", "khoi", "repo", branches)
+      _ = try await client.batchPullRequests("github.com", "khoi", "repo", branches, nil)
       Issue.record("Expected batchPullRequests to throw")
     } catch let error as GithubCLIError {
       switch error {
@@ -259,7 +336,7 @@ struct GithubCLIClientTests {
     let uniqueBranches = (0..<30).map { "feature-\($0)" }
     let branches = uniqueBranches + ["feature-0", "feature-1", "feature-2", "", ""]
 
-    let result = try await client.batchPullRequests("github.com", "khoi", "repo", branches)
+    let result = try await client.batchPullRequests("github.com", "khoi", "repo", branches, nil)
 
     #expect(result.isEmpty)
     let snapshot = await probe.snapshot()
@@ -275,7 +352,7 @@ struct GithubCLIClientTests {
     }
     let client = GithubCLIClient.live(shell: shell)
 
-    let result = try await client.batchPullRequestsAcrossRepositories("github.com", [])
+    let result = try await client.batchPullRequestsAcrossRepositories("github.com", [], nil)
 
     #expect(result.successByRepo.isEmpty)
     #expect(result.failedRepos.isEmpty)
@@ -295,7 +372,7 @@ struct GithubCLIClientTests {
       CrossRepoPullRequestRequest(owner: "khoi", repo: "beta", branches: ["", "  "]),
     ]
 
-    let result = try await client.batchPullRequestsAcrossRepositories("github.com", requests)
+    let result = try await client.batchPullRequestsAcrossRepositories("github.com", requests, nil)
 
     #expect(result.successByRepo.isEmpty)
     #expect(result.failedRepos.isEmpty)
@@ -316,7 +393,7 @@ struct GithubCLIClientTests {
       CrossRepoPullRequestRequest(owner: "supabit", repo: "beta", branches: ["feat-3"]),
     ]
 
-    let result = try await client.batchPullRequestsAcrossRepositories("github.com", requests)
+    let result = try await client.batchPullRequestsAcrossRepositories("github.com", requests, nil)
 
     #expect(result.successByRepo[RepoKey(owner: "khoi", repo: "alpha")] != nil)
     #expect(result.successByRepo[RepoKey(owner: "supabit", repo: "beta")] != nil)
@@ -339,7 +416,7 @@ struct GithubCLIClientTests {
       CrossRepoPullRequestRequest(owner: "octo", repo: "ghe-repo", branches: ["main"])
     ]
 
-    _ = try await client.batchPullRequestsAcrossRepositories("github.enterprise.test", requests)
+    _ = try await client.batchPullRequestsAcrossRepositories("github.enterprise.test", requests, nil)
 
     let invocations = await observedArguments.snapshot()
     #expect(invocations.count == 1)
@@ -363,7 +440,7 @@ struct GithubCLIClientTests {
       CrossRepoPullRequestRequest(owner: "supabit", repo: "beta", branches: ["feat-2"]),
     ]
 
-    _ = try await client.batchPullRequestsAcrossRepositories("github.com", requests)
+    _ = try await client.batchPullRequestsAcrossRepositories("github.com", requests, nil)
 
     let invocations = await observedArguments.snapshot()
     let queryArgument = try #require(invocations.first?.first(where: { $0.hasPrefix("query=") }))
@@ -393,7 +470,7 @@ struct GithubCLIClientTests {
       )
     ]
 
-    _ = try await client.batchPullRequestsAcrossRepositories("github.com", requests)
+    _ = try await client.batchPullRequestsAcrossRepositories("github.com", requests, nil)
 
     let invocations = await observedArguments.snapshot()
     let queryArgument = try #require(invocations.first?.first(where: { $0.hasPrefix("query=") }))
@@ -414,7 +491,7 @@ struct GithubCLIClientTests {
       CrossRepoPullRequestRequest(owner: "khoi", repo: "repo-\(index)", branches: ["main"])
     }
 
-    let result = try await client.batchPullRequestsAcrossRepositories("github.com", requests)
+    let result = try await client.batchPullRequestsAcrossRepositories("github.com", requests, nil)
 
     let snapshot = await probe.snapshot()
     #expect(snapshot.ghCallCount == 2)
@@ -443,7 +520,7 @@ struct GithubCLIClientTests {
       CrossRepoPullRequestRequest(owner: "khoi", repo: "repo-\(index)", branches: ["main"])
     }
 
-    _ = try await client.batchPullRequestsAcrossRepositories("github.com", requests)
+    _ = try await client.batchPullRequestsAcrossRepositories("github.com", requests, nil)
 
     let snapshot = await probe.snapshot()
     #expect(snapshot.ghCallCount == 4)
@@ -463,7 +540,7 @@ struct GithubCLIClientTests {
       CrossRepoPullRequestRequest(owner: "supabit", repo: "beta", branches: ["feat-2"]),
     ]
 
-    let result = try await client.batchPullRequestsAcrossRepositories("github.com", requests)
+    let result = try await client.batchPullRequestsAcrossRepositories("github.com", requests, nil)
 
     #expect(result.successByRepo[RepoKey(owner: "khoi", repo: "alpha")] != nil)
     #expect(result.successByRepo[RepoKey(owner: "supabit", repo: "beta")] != nil)
@@ -485,7 +562,7 @@ struct GithubCLIClientTests {
       CrossRepoPullRequestRequest(owner: "supabit", repo: "beta", branches: ["feat-3"]),
     ]
 
-    let result = try await client.batchPullRequestsAcrossRepositories("github.com", requests)
+    let result = try await client.batchPullRequestsAcrossRepositories("github.com", requests, nil)
 
     #expect(result.failedRepos[RepoKey(owner: "khoi", repo: "alpha")] != nil)
     #expect(result.successByRepo[RepoKey(owner: "supabit", repo: "beta")] != nil)
@@ -506,7 +583,7 @@ struct GithubCLIClientTests {
       CrossRepoPullRequestRequest(owner: "supabit", repo: "beta", branches: ["feat-2"]),
     ]
 
-    let result = try await client.batchPullRequestsAcrossRepositories("github.com", requests)
+    let result = try await client.batchPullRequestsAcrossRepositories("github.com", requests, nil)
 
     #expect(result.successByRepo.isEmpty)
     #expect(result.failedRepos.count == 2)
@@ -528,7 +605,7 @@ struct GithubCLIClientTests {
     ]
 
     do {
-      _ = try await client.batchPullRequestsAcrossRepositories("github.com", requests)
+      _ = try await client.batchPullRequestsAcrossRepositories("github.com", requests, nil)
       Issue.record("Expected batchPullRequestsAcrossRepositories to throw")
     } catch let error as GithubCLIError {
       switch error {
@@ -558,7 +635,7 @@ struct GithubCLIClientTests {
       )
     ]
 
-    _ = try await client.batchPullRequestsAcrossRepositories("github.com", requests)
+    _ = try await client.batchPullRequestsAcrossRepositories("github.com", requests, nil)
 
     let invocations = await observedArguments.snapshot()
     let queryArgument = try #require(invocations.first?.first(where: { $0.hasPrefix("query=") }))
@@ -582,7 +659,7 @@ struct GithubCLIClientTests {
       CrossRepoPullRequestRequest(owner: "khoi", repo: "alpha", branches: ["feat-1"])
     ]
 
-    let result = try await client.batchPullRequestsAcrossRepositories("github.com", requests)
+    let result = try await client.batchPullRequestsAcrossRepositories("github.com", requests, nil)
 
     let alphaPRs = try #require(result.successByRepo[RepoKey(owner: "khoi", repo: "alpha")])
     let pullRequest = try #require(alphaPRs["feat-1"])

--- a/supacodeTests/GithubCLIOutputTests.swift
+++ b/supacodeTests/GithubCLIOutputTests.swift
@@ -94,6 +94,29 @@ struct GithubCLIOutputTests {
     try GithubCLIOutput.decode(GithubAuthStatusResponse.self, from: json)
   }
 
+  @Test func authStatusPreservesAllHostsAndAccounts() throws {
+    let response = try authResponse(
+      """
+      {"hosts":{
+        "github.com":[
+          {"active":false,"login":"work","state":"success","gitProtocol":"ssh","tokenSource":"keyring"},
+          {"active":true,"login":"personal","state":"success","gitProtocol":"ssh","tokenSource":"keyring"}
+        ],
+        "enterprise.internal":[
+          {"active":true,"login":"enterprise","state":"success","gitProtocol":"https","tokenSource":"keyring"}
+        ]
+      }}
+      """
+    )
+
+    let snapshot = GithubAuthStatusSnapshot(response: response)
+
+    #expect(snapshot.hosts.count == 2)
+    #expect(snapshot.accounts(on: "github.com").map(\.login) == ["work", "personal"])
+    #expect(snapshot.activeAccount(on: "github.com")?.login == "personal")
+    #expect(snapshot.activeAccount(on: "enterprise.internal")?.login == "enterprise")
+  }
+
   @Test func picksActiveAccountFromNonFirstHost() throws {
     let response = try authResponse(
       #"{"hosts":{"git.example.com":[{"active":true,"login":"enterprise-user"}]}}"#

--- a/supacodeTests/PullRequestRefreshCoordinatorTests.swift
+++ b/supacodeTests/PullRequestRefreshCoordinatorTests.swift
@@ -69,6 +69,28 @@ struct PullRequestRefreshCoordinatorTests {
     #expect(hosts == ["github.com", "ghe.example"])
   }
 
+  @Test func sameHostWithDifferentAccountsTriggersIndependentBatches() async throws {
+    let clock = TestClock()
+    let probe = CoordinatorProbe()
+    let outcomes = OutcomeCollector()
+    let coordinator = makeCoordinator(
+      probe: probe, clock: clock, outcomes: outcomes,
+      batched: { _, requests in successResult(for: requests) }
+    )
+
+    coordinator.enqueue(
+      request(repo: "alpha", accountOverride: GithubAccountOverride(host: "github.com", login: "one")))
+    coordinator.enqueue(request(repo: "beta", accountOverride: GithubAccountOverride(host: "github.com", login: "two")))
+
+    await clock.advance(by: .milliseconds(250))
+    await Task.yield()
+    await Task.yield()
+
+    let calls = await probe.batchedCalls()
+    #expect(calls.count == 2)
+    #expect(Set(calls.compactMap(\.accountOverride?.login)) == ["one", "two"])
+  }
+
   @Test func partialErrorTriggersPerRepoFallback() async throws {
     let clock = TestClock()
     let probe = CoordinatorProbe()
@@ -494,11 +516,11 @@ private func makeCoordinator(
     [String: GithubPullRequest] = { _, _, _, _ in [:] }
 ) -> PullRequestRefreshCoordinator {
   var client = GithubCLIClient.testValue
-  client.batchPullRequestsAcrossRepositories = { host, requests in
-    await probe.recordBatched(host: host, requests: requests)
+  client.batchPullRequestsAcrossRepositories = { host, requests, accountOverride in
+    await probe.recordBatched(host: host, requests: requests, accountOverride: accountOverride)
     return try await batched(host, requests)
   }
-  client.batchPullRequests = { host, owner, repo, branches in
+  client.batchPullRequests = { host, owner, repo, branches, _ in
     await probe.recordLegacy(host: host, owner: owner, repo: repo, branches: branches)
     return try await legacy(host, owner, repo, branches)
   }
@@ -530,6 +552,7 @@ nonisolated private func request(
   repositoryID: Repository.ID? = nil,
   rootPath: String? = nil,
   host: String = "github.com",
+  accountOverride: GithubAccountOverride? = nil,
   branches: [String] = ["feat-1"],
   worktreeIDs: [Worktree.ID]? = nil
 ) -> PullRequestRefreshCoordinator.Request {
@@ -540,6 +563,7 @@ nonisolated private func request(
     host: host,
     owner: "khoi",
     repo: repo,
+    accountOverride: accountOverride,
     branches: branches,
     worktreeIDs: worktreeIDs ?? ["\(resolvedRepositoryID)-wt"]
   )
@@ -580,6 +604,7 @@ actor CoordinatorProbe {
   struct BatchedCall: Sendable {
     let host: String
     let requests: [CrossRepoPullRequestRequest]
+    let accountOverride: GithubAccountOverride?
   }
 
   struct LegacyCall: Sendable {
@@ -592,8 +617,12 @@ actor CoordinatorProbe {
   private var batched: [BatchedCall] = []
   private var legacy: [LegacyCall] = []
 
-  func recordBatched(host: String, requests: [CrossRepoPullRequestRequest]) {
-    batched.append(BatchedCall(host: host, requests: requests))
+  func recordBatched(
+    host: String,
+    requests: [CrossRepoPullRequestRequest],
+    accountOverride: GithubAccountOverride?
+  ) {
+    batched.append(BatchedCall(host: host, requests: requests, accountOverride: accountOverride))
   }
 
   func recordLegacy(host: String, owner: String, repo: String, branches: [String]) {

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -3941,7 +3941,7 @@ struct RepositoriesFeatureTests {
     } withDependencies: {
       $0.githubIntegration.isAvailable = { true }
       $0.githubCLI.resolveRemoteInfo = { _ in upstreamRemoteInfo }
-      $0.githubCLI.mergePullRequest = { _, _, number, _ in
+      $0.githubCLI.mergePullRequest = { _, _, number, _, _ in
         mergedNumbers.withValue { $0.append(number) }
       }
     }
@@ -3993,7 +3993,7 @@ struct RepositoriesFeatureTests {
     } withDependencies: {
       $0.githubIntegration.isAvailable = { true }
       $0.githubCLI.resolveRemoteInfo = { _ in upstreamRemoteInfo }
-      $0.githubCLI.mergePullRequest = { _, _, _, strategy in
+      $0.githubCLI.mergePullRequest = { _, _, _, strategy, _ in
         mergedStrategies.withValue { $0.append(strategy) }
       }
     }
@@ -4042,7 +4042,7 @@ struct RepositoriesFeatureTests {
         Issue.record("gh resolveRemoteInfo should not run when git remote resolves")
         return nil
       }
-      $0.githubCLI.mergePullRequest = { root, remoteInfo, number, _ in
+      $0.githubCLI.mergePullRequest = { root, remoteInfo, number, _, _ in
         #expect(root == featureWorktree.workingDirectory)
         #expect(number == 12)
         mutationRemoteInfos.withValue { $0.append(remoteInfo) }
@@ -4086,7 +4086,7 @@ struct RepositoriesFeatureTests {
       $0.githubIntegration.isAvailable = { true }
       $0.githubCLI.resolveRemoteInfo = { _ in nil }
       $0.gitClient.remoteInfo = { _ in nil }
-      $0.githubCLI.mergePullRequest = { _, _, _, _ in
+      $0.githubCLI.mergePullRequest = { _, _, _, _, _ in
         mergeAttempts.withValue { $0 += 1 }
       }
     }
@@ -4141,7 +4141,7 @@ struct RepositoriesFeatureTests {
     } withDependencies: {
       $0.githubIntegration.isAvailable = { true }
       $0.githubCLI.resolveRemoteInfo = { _ in upstreamRemoteInfo }
-      $0.githubCLI.closePullRequest = { _, _, number in
+      $0.githubCLI.closePullRequest = { _, _, number, _ in
         closedNumbers.withValue { $0.append(number) }
       }
     }
@@ -4311,7 +4311,7 @@ struct RepositoriesFeatureTests {
       RepositoriesFeature()
     } withDependencies: {
       $0.gitClient.remoteInfo = { _ in nil }
-      $0.githubCLI.batchPullRequests = { _, _, _, _ in
+      $0.githubCLI.batchPullRequests = { _, _, _, _, _ in
         Issue.record("batchPullRequests should not run when remoteInfo is unavailable")
         return [:]
       }
@@ -4351,7 +4351,7 @@ struct RepositoriesFeatureTests {
         Issue.record("remoteInfo should not be requested when GitHub integration is unavailable")
         return nil
       }
-      $0.githubCLI.batchPullRequests = { _, _, _, _ in
+      $0.githubCLI.batchPullRequests = { _, _, _, _, _ in
         Issue.record("batchPullRequests should not run when GitHub integration is unavailable")
         return [:]
       }
@@ -4439,7 +4439,7 @@ struct RepositoriesFeatureTests {
       RepositoriesFeature()
     } withDependencies: {
       $0.gitClient.remoteInfo = { _ in nil }
-      $0.githubCLI.batchPullRequests = { _, _, _, _ in
+      $0.githubCLI.batchPullRequests = { _, _, _, _, _ in
         Issue.record("batchPullRequests should not run when remoteInfo is unavailable")
         return [:]
       }
@@ -4537,7 +4537,7 @@ struct RepositoriesFeatureTests {
       RepositoriesFeature()
     } withDependencies: {
       $0.gitClient.remoteInfo = { _ in nil }
-      $0.githubCLI.batchPullRequests = { _, _, _, _ in
+      $0.githubCLI.batchPullRequests = { _, _, _, _, _ in
         Issue.record("batchPullRequests should not run when remoteInfo is unavailable")
         return [:]
       }

--- a/supacodeTests/RepositorySettingsFeatureTests.swift
+++ b/supacodeTests/RepositorySettingsFeatureTests.swift
@@ -7,6 +7,16 @@ import Testing
 
 @MainActor
 struct RepositorySettingsFeatureTests {
+  @Test func githubAccountOverrideRoundTripsThroughRepositorySettings() throws {
+    var settings = RepositorySettings.default
+    settings.githubAccountOverride = GithubAccountOverride(host: "github.com", login: "work")
+
+    let data = try JSONEncoder().encode(settings)
+    let decoded = try JSONDecoder().decode(RepositorySettings.self, from: data)
+
+    #expect(decoded.githubAccountOverride == GithubAccountOverride(host: "github.com", login: "work"))
+  }
+
   @Test(.dependencies) func plainFolderTaskLoadsWithoutGitRequests() async throws {
     let rootURL = URL(fileURLWithPath: "/tmp/folder-\(UUID().uuidString)")
     let settingsStorage = SettingsTestStorage()


### PR DESCRIPTION
## Summary
- Show all authenticated GitHub CLI hosts/accounts in GitHub settings instead of flattening to one account
- Add a per-repository GitHub identity override and use scoped `gh auth switch` around GitHub operations
- Split background PR refresh batches by host and selected identity to avoid mixing accounts
- Document the new setting and multi-account behavior

## Verification
- `xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -only-testing:supacodeTests/GithubCLIOutputTests -only-testing:supacodeTests/GithubCLIClientTests -only-testing:supacodeTests/RepositorySettingsFeatureTests -only-testing:supacodeTests/PullRequestRefreshCoordinatorTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation 2>&1 | xcsift -f toon`
- `make check 2>&1 | xcsift -f toon -w`
- `make build-app 2>&1 | xcsift -f toon -w`
