### PR TITLE
Stabilize agent status detection: widen working hold, fix viewer-hint false idle

### DIFF
--- a/docs/components/agent-detection.md
+++ b/docs/components/agent-detection.md
@@ -32,9 +32,10 @@ bash, etc.) so agents launched indirectly are still found.
    Kimi's moon phases, etc.).
 
 To avoid flicker, detection **stabilizes**: it tolerates several consecutive
-misses before declaring an agent gone, and Claude specifically gets a short
-(~1.2s) hold so brief pauses between thinking and output don't drop it out of
-"working".
+misses before declaring an agent gone, and a working agent gets a short (~3s)
+hold so brief pauses between thinking and output don't drop it out of
+"working" (a genuine finish therefore reports up to ~3s late; "blocked"
+bypasses the hold and surfaces immediately).
 
 ## The state machine
 

--- a/docs/components/agent-detection.md
+++ b/docs/components/agent-detection.md
@@ -35,7 +35,9 @@ To avoid flicker, detection **stabilizes**: it tolerates several consecutive
 misses before declaring an agent gone, and a working agent gets a short (~3s)
 hold so brief pauses between thinking and output don't drop it out of
 "working" (a genuine finish therefore reports up to ~3s late; "blocked"
-bypasses the hold and surfaces immediately).
+bypasses the hold and surfaces immediately). Viewer overlays (Claude's
+transcript / history-search views) cover the live status area, so frames
+showing their chrome keep the last trusted state instead of forcing idle.
 
 ## The state machine
 

--- a/supacode/Domain/AgentDetection/PaneAgentState.swift
+++ b/supacode/Domain/AgentDetection/PaneAgentState.swift
@@ -92,12 +92,20 @@ func stabilizeAgentState(
     return .working
   case .blocked:
     return .blocked
+  case .unknown:
+    // A viewer overlay (transcript, history search) is covering the live
+    // status area, so this frame carries no signal: keep the last trusted
+    // state, and keep the working hold alive while the screen stays covered.
+    if previous == .working {
+      lastWorkingAt = now
+    }
+    return previous
   case .idle where previous == .working:
     guard let lastWorkingAt else {
       return .idle
     }
     return now.timeIntervalSince(lastWorkingAt) < workingStateHold ? .working : .idle
-  case .idle, .unknown:
+  case .idle:
     return raw
   }
 }

--- a/supacode/Domain/AgentDetection/PaneAgentState.swift
+++ b/supacode/Domain/AgentDetection/PaneAgentState.swift
@@ -67,31 +67,36 @@ struct AgentDetectionPresence: Equatable, Sendable {
   }
 }
 
-private let claudeWorkingHold: TimeInterval = 1.2
+// Agents briefly clear their working indicators between steps (output gaps,
+// tool-call boundaries), so a raw working → idle flip is only trusted after
+// the screen has read idle for this long. Keeps Working from flapping to
+// Done and back during those pauses, at the cost of reporting a genuine
+// finish up to this much later.
+private let workingStateHold: TimeInterval = 3.0
 
 func stabilizeAgentState(
   agent: DetectedAgent?,
   previous: AgentRawState,
   raw: AgentRawState,
   now: Date,
-  lastClaudeWorkingAt: inout Date?
+  lastWorkingAt: inout Date?
 ) -> AgentRawState {
-  guard agent == .claude else {
-    lastClaudeWorkingAt = nil
+  guard agent != nil else {
+    lastWorkingAt = nil
     return raw
   }
 
   switch raw {
   case .working:
-    lastClaudeWorkingAt = now
+    lastWorkingAt = now
     return .working
   case .blocked:
     return .blocked
   case .idle where previous == .working:
-    guard let lastClaudeWorkingAt else {
+    guard let lastWorkingAt else {
       return .idle
     }
-    return now.timeIntervalSince(lastClaudeWorkingAt) < claudeWorkingHold ? .working : .idle
+    return now.timeIntervalSince(lastWorkingAt) < workingStateHold ? .working : .idle
   case .idle, .unknown:
     return raw
   }

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState+AgentDetection.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState+AgentDetection.swift
@@ -78,15 +78,15 @@ extension WorktreeTerminalState {
     let raw = agent.detectState(in: activeText)
     guard surfaces[surfaceID] != nil else { return }
 
-    var lastClaudeWorkingAt = lastClaudeWorkingAtBySurface[surfaceID]
+    var lastWorkingAt = lastWorkingAtBySurface[surfaceID]
     let stabilized = stabilizeAgentState(
       agent: agent,
       previous: previous.state,
       raw: raw,
       now: now,
-      lastClaudeWorkingAt: &lastClaudeWorkingAt
+      lastWorkingAt: &lastWorkingAt
     )
-    lastClaudeWorkingAtBySurface[surfaceID] = lastClaudeWorkingAt
+    lastWorkingAtBySurface[surfaceID] = lastWorkingAt
 
     let isForeground = isSelected() && isFocusedSurface(surfaceID)
     let becameIdleFromActive =
@@ -143,7 +143,7 @@ extension WorktreeTerminalState {
   func removeAgentEntryIfNeeded(surfaceID: UUID) {
     guard surfaceAgentStates[surfaceID]?.detectedAgent != nil else { return }
     surfaceAgentStates[surfaceID] = PaneAgentState(lastChangedAt: Date())
-    lastClaudeWorkingAtBySurface.removeValue(forKey: surfaceID)
+    lastWorkingAtBySurface.removeValue(forKey: surfaceID)
     onAgentEntryRemoved?(surfaceID)
   }
 
@@ -203,7 +203,7 @@ extension WorktreeTerminalState {
     agentDetectionTasks.removeValue(forKey: surfaceId)
     surfaceAgentStates.removeValue(forKey: surfaceId)
     agentDetectionPresenceBySurface.removeValue(forKey: surfaceId)
-    lastClaudeWorkingAtBySurface.removeValue(forKey: surfaceId)
+    lastWorkingAtBySurface.removeValue(forKey: surfaceId)
     lastAgentDetectionDiagnosticsBySurface.removeValue(forKey: surfaceId)
     onAgentEntryRemoved?(surfaceId)
   }
@@ -216,7 +216,7 @@ extension WorktreeTerminalState {
     agentDetectionTasks.removeAll()
     surfaceAgentStates.removeAll()
     agentDetectionPresenceBySurface.removeAll()
-    lastClaudeWorkingAtBySurface.removeAll()
+    lastWorkingAtBySurface.removeAll()
     lastAgentDetectionDiagnosticsBySurface.removeAll()
     for id in removedIDs {
       onAgentEntryRemoved?(id)

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -72,7 +72,7 @@ final class WorktreeTerminalState {
   var surfaceAgentStates: [UUID: PaneAgentState] = [:]
   var agentDetectionTasks: [UUID: Task<Void, Never>] = [:]
   var agentDetectionPresenceBySurface: [UUID: AgentDetectionPresence] = [:]
-  var lastClaudeWorkingAtBySurface: [UUID: Date] = [:]
+  var lastWorkingAtBySurface: [UUID: Date] = [:]
   var lastAgentDetectionDiagnosticsBySurface: [UUID: String] = [:]
   var agentDetectionEnabled = true
   var tabIsRunningById: [TerminalTabID: Bool] = [:]

--- a/supacode/Infrastructure/AgentDetection/ScreenHeuristics.swift
+++ b/supacode/Infrastructure/AgentDetection/ScreenHeuristics.swift
@@ -56,10 +56,8 @@ nonisolated private func detectPi(_ content: String) -> AgentRawState {
 }
 
 nonisolated private func detectClaude(_ content: String) -> AgentRawState {
-  let lower = content.lowercased()
-
-  if content.contains("⌕ Search…") || lower.contains("ctrl+r to toggle") {
-    return .idle
+  if hasClaudeViewerChrome(content) {
+    return .unknown
   }
   let currentInteraction = claudeCurrentInteractionRegion(content)
   if hasClaudeBlockedPrompt(content: currentInteraction, lower: currentInteraction.lowercased()) {
@@ -233,6 +231,22 @@ nonisolated private func detectAmp(_ content: String) -> AgentRawState {
     return .working
   }
   return .idle
+}
+
+// Transcript (ctrl+r/ctrl+o) and history-search views cover the live status
+// area, so a frame showing their chrome carries no task-state signal — the
+// caller maps `.unknown` to "keep the previous state". The hint strings are
+// only trusted on the bottom chrome lines: matching them anywhere on screen
+// misreads conversation text that merely quotes them (e.g. a discussion
+// about these very heuristics).
+nonisolated private func hasClaudeViewerChrome(_ content: String) -> Bool {
+  let bottomLines = content.split(separator: "\n", omittingEmptySubsequences: false)
+    .map { $0.trimmingCharacters(in: .whitespaces) }
+    .filter { !$0.isEmpty }
+    .suffix(3)
+  return bottomLines.contains { line in
+    line.contains("⌕ Search…") || line.lowercased().contains("ctrl+r to toggle")
+  }
 }
 
 nonisolated private func contentAbovePromptBox(_ content: String) -> String {

--- a/supacodeTests/PaneAgentStateTests.swift
+++ b/supacodeTests/PaneAgentStateTests.swift
@@ -18,58 +18,59 @@ struct PaneAgentStateTests {
     #expect(state.displayState == .idle)
   }
 
-  @Test func claudeWorkingIsStickyForShortIdleGap() {
+  @Test(arguments: [DetectedAgent.claude, .codex, .gemini])
+  func workingIsStickyForShortIdleGap(agent: DetectedAgent) {
     let now = Date(timeIntervalSince1970: 100)
     var lastWorking: Date?
 
     let working = stabilizeAgentState(
-      agent: .claude,
+      agent: agent,
       previous: .idle,
       raw: .working,
       now: now,
-      lastClaudeWorkingAt: &lastWorking
+      lastWorkingAt: &lastWorking
     )
     #expect(working == .working)
 
     let stillWorking = stabilizeAgentState(
-      agent: .claude,
+      agent: agent,
       previous: .working,
       raw: .idle,
-      now: now.addingTimeInterval(0.4),
-      lastClaudeWorkingAt: &lastWorking
+      now: now.addingTimeInterval(2.9),
+      lastWorkingAt: &lastWorking
     )
     #expect(stillWorking == .working)
   }
 
-  @Test func claudeTransitionsToIdleAfterStickyWindow() {
+  @Test(arguments: [DetectedAgent.claude, .codex])
+  func transitionsToIdleAfterStickyWindow(agent: DetectedAgent) {
     let now = Date(timeIntervalSince1970: 100)
     var lastWorking: Date? = now
 
     let idle = stabilizeAgentState(
-      agent: .claude,
+      agent: agent,
       previous: .working,
       raw: .idle,
-      now: now.addingTimeInterval(1.201),
-      lastClaudeWorkingAt: &lastWorking
+      now: now.addingTimeInterval(3.001),
+      lastWorkingAt: &lastWorking
     )
 
     #expect(idle == .idle)
   }
 
-  @Test func nonClaudeDoesNotUseStickyWindow() {
+  @Test func blockedBypassesStickyWindow() {
     let now = Date(timeIntervalSince1970: 100)
     var lastWorking: Date? = now
 
-    let idle = stabilizeAgentState(
-      agent: .codex,
+    let blocked = stabilizeAgentState(
+      agent: .claude,
       previous: .working,
-      raw: .idle,
-      now: now,
-      lastClaudeWorkingAt: &lastWorking
+      raw: .blocked,
+      now: now.addingTimeInterval(0.3),
+      lastWorkingAt: &lastWorking
     )
 
-    #expect(idle == .idle)
-    #expect(lastWorking == nil)
+    #expect(blocked == .blocked)
   }
 
   @Test func presenceRequiresSixMissesBeforeRelease() {

--- a/supacodeTests/PaneAgentStateTests.swift
+++ b/supacodeTests/PaneAgentStateTests.swift
@@ -73,6 +73,50 @@ struct PaneAgentStateTests {
     #expect(blocked == .blocked)
   }
 
+  @Test func unknownObservationKeepsPreviousStateAndRefreshesHold() {
+    let now = Date(timeIntervalSince1970: 100)
+    var lastWorking: Date? = now
+    let later = now.addingTimeInterval(10)
+
+    let held = stabilizeAgentState(
+      agent: .claude,
+      previous: .working,
+      raw: .unknown,
+      now: later,
+      lastWorkingAt: &lastWorking
+    )
+
+    #expect(held == .working)
+    #expect(lastWorking == later)
+
+    var noHistory: Date?
+    let idle = stabilizeAgentState(
+      agent: .claude,
+      previous: .idle,
+      raw: .unknown,
+      now: later,
+      lastWorkingAt: &noHistory
+    )
+
+    #expect(idle == .idle)
+    #expect(noHistory == nil)
+  }
+
+  @Test func unknownObservationWithoutHistoryStaysUnknown() {
+    let now = Date(timeIntervalSince1970: 100)
+    var lastWorking: Date?
+
+    let unknown = stabilizeAgentState(
+      agent: .claude,
+      previous: .unknown,
+      raw: .unknown,
+      now: now,
+      lastWorkingAt: &lastWorking
+    )
+
+    #expect(unknown == .unknown)
+  }
+
   @Test func presenceRequiresSixMissesBeforeRelease() {
     var presence = AgentDetectionPresence(currentAgent: .codex)
 

--- a/supacodeTests/ScreenHeuristicsTests.swift
+++ b/supacodeTests/ScreenHeuristicsTests.swift
@@ -177,6 +177,49 @@ struct ScreenHeuristicsTests {
     )
   }
 
+  @Test func claudeViewerChromeAtBottomCarriesNoSignal() {
+    #expect(
+      DetectedAgent.claude.detectState(
+        in: """
+          ✻ Tempering… (12s · esc to interrupt)
+          older transcript content
+          ctrl+r to toggle
+          """
+      ) == .unknown
+    )
+    #expect(
+      DetectedAgent.claude.detectState(
+        in: """
+          Task complete.
+          ⌕ Search…
+          ↑↓ to navigate
+          """
+      ) == .unknown
+    )
+  }
+
+  @Test func claudeQuotedViewerHintMidConversationDoesNotForceIdle() {
+    // Regression: a chat message quoting "ctrl+r to toggle" used to force
+    // idle while the spinner below showed Claude still working.
+    #expect(
+      DetectedAgent.claude.detectState(
+        in: """
+          ⏺ 收尾完成,现状如下:
+
+          ❯ 3. 修一个我们现存的 bug:detectClaude 里 ctrl+r to toggle → 强制 idle,意味着
+            Claude working 时按 ctrl+o/ctrl+r 看 transcript 会闪成 Done。
+
+            这个仔细看看，你觉得有必要的话，可以修一下
+
+          ✻ Twisting… (34s · ↓ 1.8k tokens · thinking more with xhigh effort)
+          ─────────
+          ❯
+          ─────────
+          """
+      ) == .working
+    )
+  }
+
   @Test func codexDetection() {
     #expect(DetectedAgent.codex.detectState(in: "press enter to confirm or esc to cancel") == .blocked)
     #expect(DetectedAgent.codex.detectState(in: "• Working (12s)\nesc to interrupt") == .working)


### PR DESCRIPTION
Two fixes for Active Agents status stability, addressing two distinct false-idle classes.

## 1. Working → Done → Working flapping (widened hold)

Agents briefly clear their on-screen working cues (spinner, "esc to interrupt") between steps, so the raw screen-heuristic state flips to idle and back. The stabilization hold for this was **Claude-only** and only **1.2s** — too short for real inter-step gaps, and other agents (Codex, Gemini, …) had no hold at all.

- Generalize the working → idle hold in `stabilizeAgentState` to **all detected agents** (`claudeWorkingHold` → `workingStateHold`, `lastClaudeWorkingAtBySurface` → `lastWorkingAtBySurface`).
- Widen the hold from **1.2s to 3.0s**.
- `blocked` still bypasses the hold so permission prompts surface immediately.

Trade-off: a genuine finish reports Done up to ~3s late, in exchange for no more flapping.

## 2. Viewer hints quoted in conversation pinned a working agent to Idle

`detectClaude` treated `ctrl+r to toggle` / `⌕ Search…` as transcript-view chrome **anywhere on screen** and short-circuited to forced idle. Chat content merely quoting those strings (observed live: a conversation *about* these heuristics) kept the pane pinned to Idle for as long as the text stayed in the last 24 lines — no hold duration can save that, since the raw state stays idle for minutes while the agent works.

- Trust the hint strings only on the **bottom chrome lines** (last 3 non-blank), where real viewer chrome lives; quoted text in the content area no longer matches.
- A frame showing viewer chrome now returns `.unknown` ("screen carries no signal") instead of forced idle; the stabilizer keeps the last trusted state and its working hold while the transcript/search view stays open. This also fixes the related bug where opening ctrl+r/ctrl+o during work flashed the agent to Done.

## Tests

- `PaneAgentStateTests`: sticky window parameterized over claude/codex/gemini, 3s boundary, blocked bypass, unknown-keeps-previous (+hold refresh), unknown-without-history.
- `ScreenHeuristicsTests`: real-screen regression fixture (quoted "ctrl+r to toggle" + live spinner → working), viewer chrome at bottom → no signal.
- `make check` and `make build-app` clean. Docs (`docs/components/agent-detection.md`) updated.
