### PR TITLE
Add prowl agents CLI command

### DIFF
--- a/.claude/skills/self-verify-prowl/SKILL.md
+++ b/.claude/skills/self-verify-prowl/SKILL.md
@@ -23,46 +23,101 @@ Use this after changes that affect:
 
 Do not use this as a replacement for unit tests, `make check`, `make build-app`, or CLI integration tests. It is an end-to-end manual validation layer on top of those checks.
 
+## First Step — Read the prowl-cli Skill
+
+**Before writing any `prowl` command, load and read the `prowl-cli` skill.** This is not optional. `prowl-cli` is the authoritative reference for JSON field names, targeting rules, quoting, argument semantics, error codes, and common pitfalls. This skill covers the self-verify workflow; `prowl-cli` covers how to use `prowl` correctly. Do not guess field names — get them from `prowl-cli`.
+
+Concretely: invoke the `prowl-cli` skill (or read its SKILL.md) before proceeding to the Launch step. If you skip this, you will likely use wrong JSON paths, miss quoting rules, or hit avoidable pitfalls.
+
 ## Preconditions
 
 - Work from the Prowl repository root.
 - Preserve unrelated user changes. Do not close or kill the user's normal Prowl app.
 - If the CLI changed, build and use the repo CLI, usually `./.build/debug/prowl`.
 - If the CLI did not change, an installed `prowl` may be usable, but the repo-built CLI keeps the app/CLI protocol aligned.
-- **Read the `prowl-cli` skill before writing any CLI commands.** It is the authoritative reference for JSON field names, targeting rules, quoting, argument semantics, error codes, and common pitfalls. This skill covers the self-verify workflow; `prowl-cli` covers how to use `prowl` correctly. Do not guess field names — get them from `prowl-cli`.
 
 ## Launch A Separate App
 
-Start the debug app with a dedicated socket so it does not fight the normal installed Prowl instance for the default socket:
+The debug app uses a fixed socket at `/tmp/prowl-self-verify.sock`. This path is stable across shell invocations, so every step can reference it directly without intermediate files or re-sourcing.
+
+Clean up any stale socket from a previous run, then start the debug app:
 
 ```bash
-socket="$(mktemp -u /tmp/prowl-self-verify.XXXXXX).sock"
-printf '%s\n' "$socket" > /tmp/prowl-self-verify.socket
-PROWL_CLI_SOCKET="$socket" make run-app
+rm -f /tmp/prowl-self-verify.sock /tmp/prowl-self-verify.sock.lock
+PROWL_CLI_SOCKET=/tmp/prowl-self-verify.sock make run-app
 ```
 
 Keep that command running in its own shell session. If plain `make run-app` reports a socket ownership problem, relaunch with a custom `PROWL_CLI_SOCKET`; the installed app may already own the standard socket.
 
+**Agent mode** — CLI agents do not have a persistent foreground shell, so `make run-app` cannot block. After building, launch the binary directly in the background:
+
+```bash
+rm -f /tmp/prowl-self-verify.sock /tmp/prowl-self-verify.sock.lock
+make build-app
+app_bin="$(xcodebuild -project supacode.xcodeproj -scheme supacode \
+  -configuration Debug -showBuildSettings -json 2>/dev/null \
+  | jq -er '.[0].buildSettings.BUILT_PRODUCTS_DIR + "/" +
+            .[0].buildSettings.FULL_PRODUCT_NAME + "/Contents/MacOS/" +
+            .[0].buildSettings.EXECUTABLE_NAME')"
+PROWL_CLI_SOCKET=/tmp/prowl-self-verify.sock "$app_bin" &
+disown
+```
+
+Then wait for the socket in the reusable setup block as usual.
+
 When `PROWL_CLI_SOCKET` is set, CLI auto-launch is disabled. The debug app and every CLI invocation must use the same socket value.
 
-If your shell does not preserve variables across separate command invocations (many agent tool harnesses start a fresh shell each call), `$socket`, `$cli`, `$pane`, and `$tab` will not survive between steps. Persist the socket path as shown above and re-run the setup block below at the top of every later command. The debug app shares the installed app's `~/Library` data, so it loads the real repository list and looks identical to the installed window; never identify the debug instance by appearance. Target it by socket plus pane or tab UUID.
+The debug app shares the installed app's `~/Library` data, so it loads the real repository list and looks identical to the installed window; never identify the debug instance by appearance. Target it by socket plus pane or tab UUID.
 
 ## Reusable Shell Setup
 
-Use this block in each shell command after the debug app has started:
+Paste this block at the top of each shell command after the debug app has started. Because the socket path is fixed, no file reads or variable recovery are needed:
 
 ```bash
-socket="$(cat /tmp/prowl-self-verify.socket)"
+socket="/tmp/prowl-self-verify.sock"
 cli="./.build/debug/prowl"
 
 prowl_debug() {
   PROWL_CLI_SOCKET="$socket" "$cli" "$@"
 }
 
+# List all debug-build ProwlApp PIDs (may include helper/child processes).
 debug_pids() {
   for pid in $(pgrep -f "DerivedData/.*/Debug/Prowl.app/Contents/MacOS/ProwlApp"); do
     [ "$(ps -p "$pid" -o comm= 2>/dev/null | sed 's#.*/##')" = "ProwlApp" ] && echo "$pid"
   done
+}
+
+# Return the single debug PID that owns a visible window.
+# macOS apps can fork helper processes that match the same path but have no
+# windows; always use this for screenshot and window-level operations.
+debug_pid_with_window() {
+  local script='/tmp/prowl-self-verify/winid_check.swift'
+  mkdir -p /tmp/prowl-self-verify
+  cat > "$script" <<'SWIFT'
+import CoreGraphics
+import Foundation
+let pid = Int32(CommandLine.arguments[1]) ?? -1
+let list = (CGWindowListCopyWindowInfo([.excludeDesktopElements], kCGNullWindowID) as? [[String: Any]]) ?? []
+for w in list where (w[kCGWindowOwnerPID as String] as? Int32) == pid {
+  if w[kCGWindowNumber as String] is Int { print(pid); break }
+}
+SWIFT
+  for pid in $(debug_pids); do
+    swift "$script" "$pid" 2>/dev/null | grep -q . && echo "$pid" && return
+  done
+}
+
+# Parse prowl --json output tolerantly. Terminal text can contain raw control
+# characters (U+0000–U+001F) that break jq. This helper accepts a jq filter
+# and uses Python to absorb the control characters before passing to jq.
+# Usage: echo "$json" | prowl_jq '.data.text'
+prowl_jq() {
+  python3 -c "
+import sys, json, subprocess
+d = json.JSONDecoder(strict=False).decode(sys.stdin.read())
+subprocess.run(['jq'] + sys.argv[1:], input=json.dumps(d, ensure_ascii=False), text=True)
+" "$@"
 }
 
 for attempt in 1 2 3 4 5 6 7 8 9 10; do
@@ -73,6 +128,8 @@ test -S "$socket"
 ```
 
 Use `prowl_debug ...` for all CLI commands below. Keep `PROWL_CLI_SOCKET` explicit if you inline commands instead of using the helper.
+
+When parsing `--json` output that may contain terminal text, use `prowl_jq` instead of `jq` to avoid control-character parse failures (see [#444](https://github.com/onevcat/Prowl/issues/444)).
 
 ## Drive With Prowl CLI
 
@@ -87,15 +144,15 @@ Then seed the debug app and create a deterministic temporary pane:
 
 ```bash
 opened="$(prowl_debug open . --json)"
-worktree="$(echo "$opened" | jq -r '.data.target.worktree.id')"
+worktree="$(echo "$opened" | prowl_jq -r '.data.target.worktree.id')"
 created="$(prowl_debug tab create --worktree "$worktree" --json)"
-pane="$(echo "$created" | jq -r '.data.target.pane.id')"
-tab="$(echo "$created" | jq -r '.data.target.tab.id')"
+pane="$(echo "$created" | prowl_jq -r '.data.target.pane.id')"
+tab="$(echo "$created" | prowl_jq -r '.data.target.tab.id')"
 
 prowl_debug send --pane "$pane" 'printf "SELF_VERIFY:%s\n" "$PWD"' --capture --timeout 30 --json \
-  | jq -r '.data.capture.text'
+  | prowl_jq -r '.data.capture.text'
 prowl_debug read --pane "$pane" --last 80 --wait-stable --json \
-  | jq -r '.data.text'
+  | prowl_jq -r '.data.text'
 ```
 
 Prefer targeting by pane or tab UUIDs from JSON output. Avoid relying on titles when multiple Prowl instances or similar tabs exist.
@@ -127,11 +184,11 @@ Example command scenario:
 result="$(prowl_debug send --pane "$pane" \
   'printf "SELF_VERIFY:%s\n" "$PWD"' \
   --capture --timeout 30 --json)"
-echo "$result" | jq -r '.data.capture.text'
-echo "$result" | jq -r '.data.wait.exit_code'
+echo "$result" | prowl_jq -r '.data.capture.text'
+echo "$result" | prowl_jq -r '.data.wait.exit_code'
 
 prowl_debug read --pane "$pane" --last 80 --wait-stable --json \
-  | jq -r '.data.text'
+  | prowl_jq -r '.data.text'
 ```
 
 Example long-running scenario:
@@ -142,7 +199,7 @@ prowl_debug send --pane "$pane" \
   --no-wait --json
 
 prowl_debug read --pane "$pane" --last 120 --json \
-  | jq -r '.data.text'
+  | prowl_jq -r '.data.text'
 ```
 
 If the scenario uses another agent, keep it scoped and reversible. Short non-interactive agent tasks can finish before they are sampled; use an interactive session only when the behavior under test requires observing an active retained pane.
@@ -151,19 +208,21 @@ If the scenario uses another agent, keep it scoped and reversible. Short non-int
 
 `prowl` is the primary control surface, but it cannot verify every visual detail. Use a screenshot when CLI output cannot prove the behavior.
 
-Capture only the debug app's window, not the whole screen. The current Prowl session usually sits in front of the debug instance, so a full-screen `screencapture -x` would show the wrong window. Resolve the debug app's window id from its PID and capture just that window:
+Capture only the debug app's window, not the whole screen. The current Prowl session usually sits in front of the debug instance, so a full-screen `screencapture -x` would show the wrong window. Use `debug_pid_with_window` from the reusable setup block to find the PID that actually owns a window, then resolve its window id:
 
 ```bash
 mkdir -p /tmp/prowl-self-verify
-debug_pid="$(debug_pids | head -1)"
+debug_pid="$(debug_pid_with_window)"
 test -n "$debug_pid"
 cat > /tmp/prowl-self-verify/winid.swift <<'SWIFT'
 import CoreGraphics
 import Foundation
 let pid = Int32(CommandLine.arguments[1]) ?? -1
-let list = (CGWindowListCopyWindowInfo([.optionOnScreenOnly, .excludeDesktopElements], kCGNullWindowID) as? [[String: Any]]) ?? []
+let list = (CGWindowListCopyWindowInfo([.excludeDesktopElements], kCGNullWindowID) as? [[String: Any]]) ?? []
 for w in list where (w[kCGWindowOwnerPID as String] as? Int32) == pid {
-  if let n = w[kCGWindowNumber as String] as? Int { print(n); break }
+  if let n = w[kCGWindowNumber as String] as? Int, let name = w[kCGWindowName as String] as? String, !name.isEmpty {
+    print(n); break
+  }
 }
 SWIFT
 wid="$(swift /tmp/prowl-self-verify/winid.swift "$debug_pid" | head -1)"
@@ -171,7 +230,7 @@ test -n "$wid"
 screencapture -o -l"$wid" /tmp/prowl-self-verify/prowl-debug-window.png
 ```
 
-Match on the `Debug/Prowl.app` path so you target the debug instance, never the installed app. `screencapture -o -l<windowid>` grabs just that window without its shadow. Then use `view_image` or another image inspection tool to review it.
+`debug_pid_with_window` iterates all debug PIDs and returns only the one that owns a visible window, avoiding helper/child processes that match the same binary path. `screencapture -o -l<windowid>` grabs just that window without its shadow. Then use `view_image` or another image inspection tool to review it.
 
 Browser or computer-use skills are useful for web and localhost targets, but do not provide reliable control over arbitrary macOS apps. Prefer the Prowl CLI first, then a single-window screenshot for visual gaps.
 
@@ -197,8 +256,7 @@ alive="$(debug_pids | tr '\n' ' ')"
 `SIGTERM` does not run the app's normal socket teardown, so the custom socket and its lock can remain. Remove them yourself, along with any screenshots:
 
 ```bash
-rm -f "$socket" "$socket.lock"
-rm -f /tmp/prowl-self-verify.socket
+rm -f /tmp/prowl-self-verify.sock /tmp/prowl-self-verify.sock.lock
 rm -rf /tmp/prowl-self-verify
 ```
 
@@ -206,8 +264,7 @@ rm -rf /tmp/prowl-self-verify
 
 In the final report, include the essentials:
 
-- The socket path used for the debug app.
-- The CLI binary used.
+- The CLI binary used (repo-built or installed).
 - The scenario performed and the concrete observed result.
 - Cleanup status.
 

--- a/.claude/skills/self-verify-prowl/SKILL.md
+++ b/.claude/skills/self-verify-prowl/SKILL.md
@@ -65,69 +65,33 @@ disown
 
 Then wait for the socket in the reusable setup block as usual.
 
+If the socket appears but `prowl_debug list --json` returns `APP_NOT_RUNNING`, the app likely exited and left a stale socket/lock behind. Remove both socket files, confirm no debug `ProwlApp` PID is still alive, then relaunch. In agent sessions where the direct binary exits immediately, use a PTY-backed `PROWL_CLI_SOCKET=/tmp/prowl-self-verify.sock make run-app` session instead.
+
 When `PROWL_CLI_SOCKET` is set, CLI auto-launch is disabled. The debug app and every CLI invocation must use the same socket value.
 
 The debug app shares the installed app's `~/Library` data, so it loads the real repository list and looks identical to the installed window; never identify the debug instance by appearance. Target it by socket plus pane or tab UUID.
 
 ## Reusable Shell Setup
 
-Paste this block at the top of each shell command after the debug app has started. Because the socket path is fixed, no file reads or variable recovery are needed:
+Available script:
+
+- `scripts/helpers.sh` — Source-only helpers for the dedicated socket, tolerant JSON parsing, debug PID lookup, health checks, and PID-scoped screenshots.
+
+Use the bundled helper script instead of re-pasting shell functions. Source it after the debug app has started, then run its health check before driving the app:
 
 ```bash
-socket="/tmp/prowl-self-verify.sock"
-cli="./.build/debug/prowl"
-
-prowl_debug() {
-  PROWL_CLI_SOCKET="$socket" "$cli" "$@"
-}
-
-# List all debug-build ProwlApp PIDs (may include helper/child processes).
-debug_pids() {
-  for pid in $(pgrep -f "DerivedData/.*/Debug/Prowl.app/Contents/MacOS/ProwlApp"); do
-    [ "$(ps -p "$pid" -o comm= 2>/dev/null | sed 's#.*/##')" = "ProwlApp" ] && echo "$pid"
-  done
-}
-
-# Return the single debug PID that owns a visible window.
-# macOS apps can fork helper processes that match the same path but have no
-# windows; always use this for screenshot and window-level operations.
-debug_pid_with_window() {
-  local script='/tmp/prowl-self-verify/winid_check.swift'
-  mkdir -p /tmp/prowl-self-verify
-  cat > "$script" <<'SWIFT'
-import CoreGraphics
-import Foundation
-let pid = Int32(CommandLine.arguments[1]) ?? -1
-let list = (CGWindowListCopyWindowInfo([.excludeDesktopElements], kCGNullWindowID) as? [[String: Any]]) ?? []
-for w in list where (w[kCGWindowOwnerPID as String] as? Int32) == pid {
-  if w[kCGWindowNumber as String] is Int { print(pid); break }
-}
-SWIFT
-  for pid in $(debug_pids); do
-    swift "$script" "$pid" 2>/dev/null | grep -q . && echo "$pid" && return
-  done
-}
-
-# Parse prowl --json output tolerantly. Terminal text can contain raw control
-# characters (U+0000–U+001F) that break jq. This helper accepts a jq filter
-# and uses Python to absorb the control characters before passing to jq.
-# Usage: echo "$json" | prowl_jq '.data.text'
-prowl_jq() {
-  python3 -c "
-import sys, json, subprocess
-d = json.JSONDecoder(strict=False).decode(sys.stdin.read())
-subprocess.run(['jq'] + sys.argv[1:], input=json.dumps(d, ensure_ascii=False), text=True)
-" "$@"
-}
-
-for attempt in 1 2 3 4 5 6 7 8 9 10; do
-  [ -S "$socket" ] && break
-  sleep 1
-done
-test -S "$socket"
+. .claude/skills/self-verify-prowl/scripts/helpers.sh
+wait_for_prowl_debug
 ```
 
-Use `prowl_debug ...` for all CLI commands below. Keep `PROWL_CLI_SOCKET` explicit if you inline commands instead of using the helper.
+For each later shell command, source the helper and rerun the health check before driving the app:
+
+```bash
+. .claude/skills/self-verify-prowl/scripts/helpers.sh
+wait_for_prowl_debug
+```
+
+Use `prowl_debug ...`, `prowl_jq ...`, and `debug_window_id` from `scripts/helpers.sh` for the commands below. Keep `PROWL_CLI_SOCKET` explicit if you inline commands instead of using the helper.
 
 When parsing `--json` output that may contain terminal text, use `prowl_jq` instead of `jq` to avoid control-character parse failures (see [#444](https://github.com/onevcat/Prowl/issues/444)).
 
@@ -208,29 +172,16 @@ If the scenario uses another agent, keep it scoped and reversible. Short non-int
 
 `prowl` is the primary control surface, but it cannot verify every visual detail. Use a screenshot when CLI output cannot prove the behavior.
 
-Capture only the debug app's window, not the whole screen. The current Prowl session usually sits in front of the debug instance, so a full-screen `screencapture -x` would show the wrong window. Use `debug_pid_with_window` from the reusable setup block to find the PID that actually owns a window, then resolve its window id:
+Capture only the debug app's window, not the whole screen. The current Prowl session usually sits in front of the debug instance, so a full-screen `screencapture -x` would show the wrong window. Use `debug_window_id` from the reusable setup block to resolve a PID-scoped window id:
 
 ```bash
-mkdir -p /tmp/prowl-self-verify
-debug_pid="$(debug_pid_with_window)"
-test -n "$debug_pid"
-cat > /tmp/prowl-self-verify/winid.swift <<'SWIFT'
-import CoreGraphics
-import Foundation
-let pid = Int32(CommandLine.arguments[1]) ?? -1
-let list = (CGWindowListCopyWindowInfo([.excludeDesktopElements], kCGNullWindowID) as? [[String: Any]]) ?? []
-for w in list where (w[kCGWindowOwnerPID as String] as? Int32) == pid {
-  if let n = w[kCGWindowNumber as String] as? Int, let name = w[kCGWindowName as String] as? String, !name.isEmpty {
-    print(n); break
-  }
-}
-SWIFT
-wid="$(swift /tmp/prowl-self-verify/winid.swift "$debug_pid" | head -1)"
+. .claude/skills/self-verify-prowl/scripts/helpers.sh
+wid="$(debug_window_id)"
 test -n "$wid"
 screencapture -o -l"$wid" /tmp/prowl-self-verify/prowl-debug-window.png
 ```
 
-`debug_pid_with_window` iterates all debug PIDs and returns only the one that owns a visible window, avoiding helper/child processes that match the same binary path. `screencapture -o -l<windowid>` grabs just that window without its shadow. Then use `view_image` or another image inspection tool to review it.
+`debug_window_id` compiles its tiny CoreGraphics helper on first screenshot use and reuses it for later screenshots in the same run. `screencapture -o -l<windowid>` grabs just that window without its shadow. Then use `view_image` or another image inspection tool to review it.
 
 Browser or computer-use skills are useful for web and localhost targets, but do not provide reliable control over arbitrary macOS apps. Prefer the Prowl CLI first, then a single-window screenshot for visual gaps.
 

--- a/.claude/skills/self-verify-prowl/SKILL.md
+++ b/.claude/skills/self-verify-prowl/SKILL.md
@@ -64,7 +64,11 @@ The debug app shares the installed app's `~/Library` data, so it loads the real 
 
 The `make run-app` log is the third verification surface, alongside `prowl read` and screenshots. Capture it to `/tmp/prowl-self-verify/run-app.log` as shown above instead of streaming the full output into the agent context.
 
-Before a scenario, record the current log line count. After the scenario, inspect only the new lines:
+This is especially useful when you add your own logging during development or debugging. The recommended workflow is:
+
+1. Add `SupaLogger` calls in the code you are changing to emit markers you can search for later.
+2. Rebuild and relaunch the debug app so the new logs take effect.
+3. Before running a scenario, record the current log line count. After the scenario, inspect only the new lines, filtering for the markers you added:
 
 ```bash
 log=/tmp/prowl-self-verify/run-app.log
@@ -75,10 +79,12 @@ before="$(wc -l <"$log" | tr -d ' ')"
 sleep 3
 after="$(wc -l <"$log" | tr -d ' ')"
 sed -n "$((before + 1)),${after}p" "$log" \
-  | rg "CLIService|WindowLifecycle|Terminal\\]|SurfaceFocus|terminalEvent|tabCreated|tabClosed|taskStatusChanged|Shell|error|warning"
+  | rg "YourMarker|error|warning"
 ```
 
-Use the log to corroborate app-side behavior: socket startup, window surfacing, terminal state creation, focus changes, tab creation/closure, task status changes, and warnings/errors. Logs can arrive a few seconds after the CLI command returns, so wait briefly and re-check before concluding an event is missing.
+Replace `YourMarker` with whatever log prefix or keyword you introduced in step 1. Do not hard-code a fixed set of log patterns — choose search terms that match the specific behavior you are verifying.
+
+Logs can arrive a few seconds after the CLI command returns, so wait briefly and re-check before concluding an event is missing.
 
 Do not treat the log as the primary proof of terminal contents or CLI response shape. Use `prowl read` for terminal text, ordinary `jq` for CLI JSON, and screenshots for visual gaps.
 

--- a/.claude/skills/self-verify-prowl/SKILL.md
+++ b/.claude/skills/self-verify-prowl/SKILL.md
@@ -44,7 +44,8 @@ Clean up any stale socket from a previous run, then start the debug app in a per
 
 ```bash
 rm -f /tmp/prowl-self-verify.sock /tmp/prowl-self-verify.sock.lock
-PROWL_CLI_SOCKET=/tmp/prowl-self-verify.sock make run-app
+mkdir -p /tmp/prowl-self-verify
+PROWL_CLI_SOCKET=/tmp/prowl-self-verify.sock make run-app >/tmp/prowl-self-verify/run-app.log 2>&1
 ```
 
 Keep that command running in its own shell or PTY session for the whole validation run.
@@ -58,6 +59,28 @@ If the socket appears but `prowl_debug list --json` returns `APP_NOT_RUNNING`, t
 When `PROWL_CLI_SOCKET` is set, CLI auto-launch is disabled. The debug app and every CLI invocation must use the same socket value.
 
 The debug app shares the installed app's `~/Library` data, so it loads the real repository list and looks identical to the installed window; never identify the debug instance by appearance. Target it by socket plus pane or tab UUID.
+
+## Use The Run-App Log
+
+The `make run-app` log is the third verification surface, alongside `prowl read` and screenshots. Capture it to `/tmp/prowl-self-verify/run-app.log` as shown above instead of streaming the full output into the agent context.
+
+Before a scenario, record the current log line count. After the scenario, inspect only the new lines:
+
+```bash
+log=/tmp/prowl-self-verify/run-app.log
+before="$(wc -l <"$log" | tr -d ' ')"
+
+# Run prowl_debug open/tab/send/read operations here.
+
+sleep 3
+after="$(wc -l <"$log" | tr -d ' ')"
+sed -n "$((before + 1)),${after}p" "$log" \
+  | rg "CLIService|WindowLifecycle|Terminal\\]|SurfaceFocus|terminalEvent|tabCreated|tabClosed|taskStatusChanged|Shell|error|warning"
+```
+
+Use the log to corroborate app-side behavior: socket startup, window surfacing, terminal state creation, focus changes, tab creation/closure, task status changes, and warnings/errors. Logs can arrive a few seconds after the CLI command returns, so wait briefly and re-check before concluding an event is missing.
+
+Do not treat the log as the primary proof of terminal contents or CLI response shape. Use `prowl read` for terminal text, ordinary `jq` for CLI JSON, and screenshots for visual gaps.
 
 ## Reusable Shell Setup
 
@@ -81,7 +104,9 @@ wait_for_prowl_debug
 
 Use `prowl_debug ...` and `debug_window_id` from `scripts/helpers.sh` for the commands below. Keep `PROWL_CLI_SOCKET` explicit if you inline commands instead of using the helper.
 
-Parse `--json` output with ordinary `jq`. If `jq` reports invalid control characters for CLI JSON, treat it as a CLI regression rather than working around it in this skill.
+Parse `--json` output with ordinary `jq`. Do not pipe shell variables through `echo "$json" | jq`: zsh can interpret JSON escape sequences such as `\u001B` and turn them back into raw control characters. Use direct CLI pipes, files, or `printf '%s\n' "$json" | jq`.
+
+If `jq` reports invalid control characters while parsing direct CLI stdout or a captured file, treat it as a CLI regression rather than working around it in this skill.
 
 ## Drive With Prowl CLI
 
@@ -96,10 +121,10 @@ Then seed the debug app and create a deterministic temporary pane:
 
 ```bash
 opened="$(prowl_debug open . --json)"
-worktree="$(echo "$opened" | jq -r '.data.target.worktree.id')"
+worktree="$(printf '%s\n' "$opened" | jq -r '.data.target.worktree.id')"
 created="$(prowl_debug tab create --worktree "$worktree" --json)"
-pane="$(echo "$created" | jq -r '.data.target.pane.id')"
-tab="$(echo "$created" | jq -r '.data.target.tab.id')"
+pane="$(printf '%s\n' "$created" | jq -r '.data.target.pane.id')"
+tab="$(printf '%s\n' "$created" | jq -r '.data.target.tab.id')"
 
 prowl_debug send --pane "$pane" 'printf "SELF_VERIFY:%s\n" "$PWD"' --capture --timeout 30 --json \
   | jq -r '.data.capture.text'
@@ -134,8 +159,8 @@ Example command scenario:
 result="$(prowl_debug send --pane "$pane" \
   'printf "SELF_VERIFY:%s\n" "$PWD"' \
   --capture --timeout 30 --json)"
-echo "$result" | jq -r '.data.capture.text'
-echo "$result" | jq -r '.data.wait.exit_code'
+printf '%s\n' "$result" | jq -r '.data.capture.text'
+printf '%s\n' "$result" | jq -r '.data.wait.exit_code'
 
 prowl_debug read --pane "$pane" --last 80 --wait-stable --json \
   | jq -r '.data.text'

--- a/.claude/skills/self-verify-prowl/SKILL.md
+++ b/.claude/skills/self-verify-prowl/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: self-verify-prowl
-description: Bootstrap-verify Prowl changes by launching a debug app with a dedicated PROWL_CLI_SOCKET and driving it from the current Prowl session. Use after implementing Prowl app, terminal, Active Agents, or CLI changes when Codex should validate behavior end-to-end in a separate Prowl instance, including opening worktrees, creating tabs, running commands or agent sessions, reading panes, and falling back to screenshots or macOS Accessibility inspection when the prowl CLI is insufficient.
+description: Bootstrap-verify Prowl changes by launching a debug app with a dedicated PROWL_CLI_SOCKET and driving it from the current Prowl session. Use after implementing Prowl app, terminal, Active Agents, or CLI changes when Codex should validate behavior end-to-end in a separate Prowl instance, including opening worktrees, creating tabs, running commands or agent sessions, reading panes, and falling back to a single-window screenshot of the debug app when the prowl CLI is insufficient.
 ---
 
 # Self Verify Prowl
@@ -9,7 +9,7 @@ description: Bootstrap-verify Prowl changes by launching a debug app with a dedi
 
 Use this skill to validate a Prowl change from inside Prowl itself: start a freshly built debug app, point it at a temporary CLI socket, and use `prowl` from the current session to drive that separate app instance.
 
-Prefer `prowl` CLI operations because they are scriptable and leave useful evidence. When CLI coverage is not enough, use screenshots and macOS Accessibility inspection as secondary checks.
+Prefer `prowl` CLI operations because they are scriptable and leave useful evidence. When CLI coverage is not enough, fall back to a single-window screenshot of the debug app as a secondary check.
 
 ## When To Use
 
@@ -58,7 +58,7 @@ Then operate the debug app through the custom socket:
 ```bash
 PROWL_CLI_SOCKET="$socket" "$cli" open .
 PROWL_CLI_SOCKET="$socket" "$cli" list --json
-PROWL_CLI_SOCKET="$socket" "$cli" tab create --title "Self Verify" --json
+PROWL_CLI_SOCKET="$socket" "$cli" tab create --json
 PROWL_CLI_SOCKET="$socket" "$cli" send --pane "$pane" 'printf "SELF_VERIFY:%s\n" "$PWD"' --capture --timeout 30 --json
 PROWL_CLI_SOCKET="$socket" "$cli" read --pane "$pane" --last 80 --wait-stable --json
 ```
@@ -98,27 +98,29 @@ If the scenario uses another agent, keep it scoped and reversible. Short non-int
 
 ## Fallback Checks
 
-`prowl` is the primary control surface, but it cannot verify every visual or accessibility detail. Use fallbacks when CLI output cannot prove the behavior.
+`prowl` is the primary control surface, but it cannot verify every visual detail. Use a screenshot when CLI output cannot prove the behavior.
 
-For screenshots:
+Capture only the debug app's window, not the whole screen. The current Prowl session usually sits in front of the debug instance, so a full-screen `screencapture -x` would show the wrong window. Resolve the debug app's window id from its PID and capture just that window:
 
 ```bash
 mkdir -p /tmp/prowl-self-verify
-screencapture -x /tmp/prowl-self-verify/prowl-screen.png
+pid="$(ps aux | grep "Debug/Prowl.app/Contents/MacOS/Prowl" | grep -v grep | awk '{print $2}' | head -1)"
+cat > /tmp/prowl-self-verify/winid.swift <<'SWIFT'
+import CoreGraphics
+import Foundation
+let pid = Int32(CommandLine.arguments[1]) ?? -1
+let list = (CGWindowListCopyWindowInfo([.optionOnScreenOnly, .excludeDesktopElements], kCGNullWindowID) as? [[String: Any]]) ?? []
+for w in list where (w[kCGWindowOwnerPID as String] as? Int32) == pid {
+  if let n = w[kCGWindowNumber as String] as? Int { print(n); break }
+}
+SWIFT
+wid="$(swift /tmp/prowl-self-verify/winid.swift "$pid" | head -1)"
+screencapture -o -l"$wid" /tmp/prowl-self-verify/prowl-debug-window.png
 ```
 
-Use `view_image` or another available image inspection tool when visual review matters.
+Match on the `Debug/Prowl.app` path so you target the debug instance, never the installed app. `screencapture -o -l<windowid>` grabs just that window without its shadow. Then use `view_image` or another image inspection tool to review it.
 
-For a shallow macOS Accessibility inspection:
-
-```bash
-osascript -e 'tell application "System Events" to tell process "Prowl" to get name of windows'
-osascript -e 'tell application "System Events" to tell process "Prowl" to get {role, subrole, name} of UI elements of window 1'
-```
-
-Accessibility inspection may require macOS Accessibility permission for the controlling process, and SwiftUI often exposes broad `AXHostingView` nodes rather than a rich semantic tree. Treat AX output as supporting evidence, not a complete substitute for CLI checks or direct screenshots.
-
-Browser or computer-use skills are useful for web and localhost targets, but they do not automatically provide reliable control over arbitrary macOS apps. Prefer Prowl CLI first, then screenshots or AX inspection for gaps.
+Browser or computer-use skills are useful for web and localhost targets, but do not provide reliable control over arbitrary macOS apps. Prefer the Prowl CLI first, then a single-window screenshot for visual gaps.
 
 ## Cleanup
 
@@ -128,9 +130,18 @@ Close tabs or panes created for verification:
 PROWL_CLI_SOCKET="$socket" "$cli" tab close --tab "$tab" --force --json
 ```
 
-Stop the `make run-app` session when validation is done. If you must terminate manually, target only the debug app launched from DerivedData and do not kill `/Applications/Prowl.app`.
+Stop the `make run-app` session when validation is done. If you must terminate manually, target only the debug app launched from DerivedData and do not kill `/Applications/Prowl.app`:
 
-Remove temporary screenshots or socket files when they are no longer useful.
+```bash
+pkill -f "DerivedData/.*/Debug/Prowl.app/Contents/MacOS/Prowl"
+```
+
+Remove the temporary files this skill created. The app never cleans up the custom socket or its lock: `CLISocketServer` only `unlink`s the socket on a clean `stop()` and never unlinks the `.lock` file at all, so a killed debug app leaves both `$socket` and `$socket.lock` behind. Delete them yourself, along with any screenshots:
+
+```bash
+rm -f "$socket" "$socket.lock"
+rm -rf /tmp/prowl-self-verify
+```
 
 ## Report Results
 
@@ -140,5 +151,5 @@ In the final report, include:
 - Which CLI binary was used and why.
 - The concrete CLI operations and agent tasks performed.
 - The relevant observed app or agent states.
-- Any screenshot or AX fallback evidence.
+- Any single-window screenshot evidence.
 - Cleanup performed and any remaining limitations.

--- a/.claude/skills/self-verify-prowl/SKILL.md
+++ b/.claude/skills/self-verify-prowl/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: self-verify-prowl
+description: Bootstrap-verify Prowl changes by launching a debug app with a dedicated PROWL_CLI_SOCKET and driving it from the current Prowl session. Use after implementing Prowl app, terminal, Active Agents, or CLI changes when Codex should validate behavior end-to-end in a separate Prowl instance, including opening worktrees, creating tabs, running commands or agent sessions, reading panes, and falling back to screenshots or macOS Accessibility inspection when the prowl CLI is insufficient.
+---
+
+# Self Verify Prowl
+
+## Overview
+
+Use this skill to validate a Prowl change from inside Prowl itself: start a freshly built debug app, point it at a temporary CLI socket, and use `prowl` from the current session to drive that separate app instance.
+
+Prefer `prowl` CLI operations because they are scriptable and leave useful evidence. When CLI coverage is not enough, use screenshots and macOS Accessibility inspection as secondary checks.
+
+## When To Use
+
+Use this after changes that affect:
+
+- Prowl app behavior that needs a real running GUI instance.
+- Terminal tabs, panes, focus, worktrees, or command routing.
+- Active Agents detection or roster presentation.
+- `ProwlCLI/`, CLI payloads, socket transport, or CLI docs.
+- Workflows where one Prowl-hosted agent should verify another Prowl instance.
+
+Do not use this as a replacement for unit tests, `make check`, `make build-app`, or CLI integration tests. It is an end-to-end manual validation layer on top of those checks.
+
+## Preconditions
+
+- Work from the Prowl repository root.
+- Preserve unrelated user changes. Do not close or kill the user's normal Prowl app.
+- If the CLI changed, build and use the repo CLI, usually `./.build/debug/prowl`.
+- If the CLI did not change, an installed `prowl` may be usable, but the repo-built CLI keeps the app/CLI protocol aligned.
+- For detailed CLI targeting and recipes, consult the dedicated `prowl-cli` skill first when needed.
+
+## Launch A Separate App
+
+Start the debug app with a dedicated socket so it does not fight the normal installed Prowl instance for the default socket:
+
+```bash
+socket="/tmp/prowl-self-verify-$$.sock"
+PROWL_CLI_SOCKET="$socket" make run-app
+```
+
+Keep that command running in its own shell session. If plain `make run-app` reports a socket ownership problem, relaunch with a custom `PROWL_CLI_SOCKET`; the installed app may already own the standard socket.
+
+When `PROWL_CLI_SOCKET` is set, CLI auto-launch is disabled. The debug app and every CLI invocation must use the same socket value.
+
+## Drive With Prowl CLI
+
+Use the new CLI when CLI behavior changed:
+
+```bash
+make build-cli
+cli="./.build/debug/prowl"
+```
+
+Then operate the debug app through the custom socket:
+
+```bash
+PROWL_CLI_SOCKET="$socket" "$cli" open .
+PROWL_CLI_SOCKET="$socket" "$cli" list --json
+PROWL_CLI_SOCKET="$socket" "$cli" tab create --title "Self Verify" --json
+PROWL_CLI_SOCKET="$socket" "$cli" send --pane "$pane" 'printf "SELF_VERIFY:%s\n" "$PWD"' --capture --timeout 30 --json
+PROWL_CLI_SOCKET="$socket" "$cli" read --pane "$pane" --last 80 --wait-stable --json
+```
+
+Prefer targeting by pane or tab UUIDs from JSON output. Avoid relying on titles when multiple Prowl instances or similar tabs exist.
+
+## Verify Active Agents
+
+For Active Agents behavior, create a fresh tab or pane, start a small agent task, then query the roster:
+
+```bash
+PROWL_CLI_SOCKET="$socket" "$cli" send --pane "$pane" \
+  'codex --sandbox read-only "Reply exactly SELF_VERIFY_OK. Do not modify files."' \
+  --no-wait --json
+
+PROWL_CLI_SOCKET="$socket" "$cli" agents --json
+PROWL_CLI_SOCKET="$socket" "$cli" agents --no-color
+```
+
+Use the returned `data.agents[].pane.id` to inspect or control the agent's pane:
+
+```bash
+agent_pane="$(PROWL_CLI_SOCKET="$socket" "$cli" agents --json | jq -r '.data.agents[0].pane.id')"
+PROWL_CLI_SOCKET="$socket" "$cli" read --pane "$agent_pane" --last 120 --wait-stable --json
+```
+
+Short non-interactive agent tasks can finish before the roster is sampled. If the goal is to observe `working` to `idle` transitions or retained Active Agents entries, use an interactive agent session in a dedicated tab and sample `prowl agents` repeatedly.
+
+## Fallback Checks
+
+`prowl` is the primary control surface, but it cannot verify every visual or accessibility detail. Use fallbacks when CLI output cannot prove the behavior.
+
+For screenshots:
+
+```bash
+mkdir -p /tmp/prowl-self-verify
+screencapture -x /tmp/prowl-self-verify/prowl-screen.png
+```
+
+Use `view_image` or another available image inspection tool when visual review matters.
+
+For a shallow macOS Accessibility inspection:
+
+```bash
+osascript -e 'tell application "System Events" to tell process "Prowl" to get name of windows'
+osascript -e 'tell application "System Events" to tell process "Prowl" to get {role, subrole, name} of UI elements of window 1'
+```
+
+Accessibility inspection may require macOS Accessibility permission for the controlling process, and SwiftUI often exposes broad `AXHostingView` nodes rather than a rich semantic tree. Treat AX output as supporting evidence, not a complete substitute for CLI checks or direct screenshots.
+
+Browser or computer-use skills are useful for web and localhost targets, but they do not automatically provide reliable control over arbitrary macOS apps. Prefer Prowl CLI first, then screenshots or AX inspection for gaps.
+
+## Cleanup
+
+Close tabs or panes created for verification:
+
+```bash
+PROWL_CLI_SOCKET="$socket" "$cli" tab close --tab "$tab" --force --json
+```
+
+Stop the `make run-app` session when validation is done. If you must terminate manually, target only the debug app launched from DerivedData and do not kill `/Applications/Prowl.app`.
+
+Remove temporary screenshots or socket files when they are no longer useful.
+
+## Report Results
+
+In the final report, include:
+
+- The socket path used for the debug app.
+- Which CLI binary was used and why.
+- The concrete CLI operations and agent tasks performed.
+- The relevant observed app or agent states.
+- Any screenshot or AX fallback evidence.
+- Cleanup performed and any remaining limitations.

--- a/.claude/skills/self-verify-prowl/SKILL.md
+++ b/.claude/skills/self-verify-prowl/SKILL.md
@@ -36,13 +36,43 @@ Do not use this as a replacement for unit tests, `make check`, `make build-app`,
 Start the debug app with a dedicated socket so it does not fight the normal installed Prowl instance for the default socket:
 
 ```bash
-socket="/tmp/prowl-self-verify-$$.sock"
+socket="$(mktemp -u /tmp/prowl-self-verify.XXXXXX).sock"
+printf '%s\n' "$socket" > /tmp/prowl-self-verify.socket
 PROWL_CLI_SOCKET="$socket" make run-app
 ```
 
 Keep that command running in its own shell session. If plain `make run-app` reports a socket ownership problem, relaunch with a custom `PROWL_CLI_SOCKET`; the installed app may already own the standard socket.
 
 When `PROWL_CLI_SOCKET` is set, CLI auto-launch is disabled. The debug app and every CLI invocation must use the same socket value.
+
+If your shell does not preserve variables across separate command invocations (many agent tool harnesses start a fresh shell each call), `$socket`, `$cli`, `$pane`, and `$tab` will not survive between steps. Persist the socket path as shown above and re-run the setup block below at the top of every later command. The debug app shares the installed app's `~/Library` data, so it loads the real repository list and looks identical to the installed window; never identify the debug instance by appearance. Target it by socket plus pane or tab UUID.
+
+## Reusable Shell Setup
+
+Use this block in each shell command after the debug app has started:
+
+```bash
+socket="$(cat /tmp/prowl-self-verify.socket)"
+cli="./.build/debug/prowl"
+
+prowl_debug() {
+  PROWL_CLI_SOCKET="$socket" "$cli" "$@"
+}
+
+debug_pids() {
+  for pid in $(pgrep -f "DerivedData/.*/Debug/Prowl.app/Contents/MacOS/ProwlApp"); do
+    [ "$(ps -p "$pid" -o comm= 2>/dev/null | sed 's#.*/##')" = "ProwlApp" ] && echo "$pid"
+  done
+}
+
+for attempt in 1 2 3 4 5 6 7 8 9 10; do
+  [ -S "$socket" ] && break
+  sleep 1
+done
+test -S "$socket"
+```
+
+Use `prowl_debug ...` for all CLI commands below. Keep `PROWL_CLI_SOCKET` explicit if you inline commands instead of using the helper.
 
 ## Drive With Prowl CLI
 
@@ -53,17 +83,24 @@ make build-cli
 cli="./.build/debug/prowl"
 ```
 
-Then operate the debug app through the custom socket:
+Then seed the debug app and create a deterministic temporary pane:
 
 ```bash
-PROWL_CLI_SOCKET="$socket" "$cli" open .
-PROWL_CLI_SOCKET="$socket" "$cli" list --json
-PROWL_CLI_SOCKET="$socket" "$cli" tab create --json
-PROWL_CLI_SOCKET="$socket" "$cli" send --pane "$pane" 'printf "SELF_VERIFY:%s\n" "$PWD"' --capture --timeout 30 --json
-PROWL_CLI_SOCKET="$socket" "$cli" read --pane "$pane" --last 80 --wait-stable --json
+opened="$(prowl_debug open . --json)"
+worktree="$(echo "$opened" | jq -r '.data.target.worktree.id')"
+created="$(prowl_debug tab create --worktree "$worktree" --json)"
+pane="$(echo "$created" | jq -r '.data.target.pane.id')"
+tab="$(echo "$created" | jq -r '.data.target.tab.id')"
+
+prowl_debug send --pane "$pane" 'printf "SELF_VERIFY:%s\n" "$PWD"' --capture --timeout 30 --json
+prowl_debug read --pane "$pane" --last 80 --wait-stable --json
 ```
 
 Prefer targeting by pane or tab UUIDs from JSON output. Avoid relying on titles when multiple Prowl instances or similar tabs exist.
+
+Always seed the debug instance with `prowl_debug open . --json` before expecting panes. A fresh debug app can start windowless and return an empty `list`; `open .` creates or focuses a worktree tab that later commands can target. Prefer creating an extra temporary tab for the scenario, then close that tab during cleanup.
+
+`send --timeout` is in seconds (1–300, default 30): the maximum time to wait for the command to finish. The `wait.duration_ms` in the response is how long the command actually took, not the timeout — do not read a small `duration_ms` as the timeout being ignored.
 
 ## Run Observable Scenarios
 
@@ -77,21 +114,21 @@ Turn the change into one or more observable scenarios. Prefer small checks that 
 Example command scenario:
 
 ```bash
-PROWL_CLI_SOCKET="$socket" "$cli" send --pane "$pane" \
+prowl_debug send --pane "$pane" \
   'printf "SELF_VERIFY:%s\n" "$PWD"' \
   --capture --timeout 30 --json
 
-PROWL_CLI_SOCKET="$socket" "$cli" read --pane "$pane" --last 80 --wait-stable --json
+prowl_debug read --pane "$pane" --last 80 --wait-stable --json
 ```
 
 Example long-running scenario:
 
 ```bash
-PROWL_CLI_SOCKET="$socket" "$cli" send --pane "$pane" \
+prowl_debug send --pane "$pane" \
   'for i in 1 2 3; do echo "SELF_VERIFY_STEP:$i"; sleep 1; done' \
   --no-wait --json
 
-PROWL_CLI_SOCKET="$socket" "$cli" read --pane "$pane" --last 120 --json
+prowl_debug read --pane "$pane" --last 120 --json
 ```
 
 If the scenario uses another agent, keep it scoped and reversible. Short non-interactive agent tasks can finish before they are sampled; use an interactive session only when the behavior under test requires observing an active retained pane.
@@ -104,7 +141,8 @@ Capture only the debug app's window, not the whole screen. The current Prowl ses
 
 ```bash
 mkdir -p /tmp/prowl-self-verify
-pid="$(ps aux | grep "Debug/Prowl.app/Contents/MacOS/Prowl" | grep -v grep | awk '{print $2}' | head -1)"
+debug_pid="$(debug_pids | head -1)"
+test -n "$debug_pid"
 cat > /tmp/prowl-self-verify/winid.swift <<'SWIFT'
 import CoreGraphics
 import Foundation
@@ -114,7 +152,8 @@ for w in list where (w[kCGWindowOwnerPID as String] as? Int32) == pid {
   if let n = w[kCGWindowNumber as String] as? Int { print(n); break }
 }
 SWIFT
-wid="$(swift /tmp/prowl-self-verify/winid.swift "$pid" | head -1)"
+wid="$(swift /tmp/prowl-self-verify/winid.swift "$debug_pid" | head -1)"
+test -n "$wid"
 screencapture -o -l"$wid" /tmp/prowl-self-verify/prowl-debug-window.png
 ```
 
@@ -127,29 +166,35 @@ Browser or computer-use skills are useful for web and localhost targets, but do 
 Close tabs or panes created for verification:
 
 ```bash
-PROWL_CLI_SOCKET="$socket" "$cli" tab close --tab "$tab" --force --json
+prowl_debug tab close --tab "$tab" --force --json
 ```
 
-Stop the `make run-app` session when validation is done. If you must terminate manually, target only the debug app launched from DerivedData and do not kill `/Applications/Prowl.app`:
+Stop the `make run-app` session when validation is done. If you cannot stop that shell directly, terminate only the debug app launched from DerivedData and never the installed `/Applications/Prowl.app`. The Mach-O executable is named `ProwlApp` (not `Prowl`), and a plain `SIGTERM` is enough.
+
+Do not use `pkill -f "<path-pattern>"`: `-f` can also match the shell or helper process carrying that pattern. Use `debug_pids` from the reusable setup block so only processes whose executable basename is `ProwlApp` are signaled:
 
 ```bash
-pkill -f "DerivedData/.*/Debug/Prowl.app/Contents/MacOS/Prowl"
+for pid in $(debug_pids); do kill "$pid"; done
+sleep 2
+alive="$(debug_pids | tr '\n' ' ')"
+[ -n "$alive" ] && echo "debug still alive:$alive" || echo "debug app stopped"
 ```
 
-Remove the temporary files this skill created. The app never cleans up the custom socket or its lock: `CLISocketServer` only `unlink`s the socket on a clean `stop()` and never unlinks the `.lock` file at all, so a killed debug app leaves both `$socket` and `$socket.lock` behind. Delete them yourself, along with any screenshots:
+`SIGTERM` does not run the app's normal socket teardown, so the custom socket and its lock can remain. Remove them yourself, along with any screenshots:
 
 ```bash
 rm -f "$socket" "$socket.lock"
+rm -f /tmp/prowl-self-verify.socket
 rm -rf /tmp/prowl-self-verify
 ```
 
 ## Report Results
 
-In the final report, include:
+In the final report, include the essentials:
 
 - The socket path used for the debug app.
-- Which CLI binary was used and why.
-- The concrete CLI operations and agent tasks performed.
-- The relevant observed app or agent states.
-- Any single-window screenshot evidence.
-- Cleanup performed and any remaining limitations.
+- The CLI binary used.
+- The scenario performed and the concrete observed result.
+- Cleanup status.
+
+Add optional details only when they matter: pane or tab UUIDs, agent task state, screenshot path, build/check output, or remaining limitations.

--- a/.claude/skills/self-verify-prowl/SKILL.md
+++ b/.claude/skills/self-verify-prowl/SKILL.md
@@ -65,27 +65,36 @@ PROWL_CLI_SOCKET="$socket" "$cli" read --pane "$pane" --last 80 --wait-stable --
 
 Prefer targeting by pane or tab UUIDs from JSON output. Avoid relying on titles when multiple Prowl instances or similar tabs exist.
 
-## Verify Active Agents
+## Run Observable Scenarios
 
-For Active Agents behavior, create a fresh tab or pane, start a small agent task, then query the roster:
+Turn the change into one or more observable scenarios. Prefer small checks that prove the behavior directly:
+
+- For command routing, run a command that prints the cwd, environment, or a unique marker.
+- For tab, pane, focus, or worktree behavior, create an isolated tab or pane and inspect `list --json` before and after the action.
+- For long-running task behavior, start a controlled command with visible output, then sample the pane with `read`.
+- For agent-specific behavior, start a short agent session and use `agents --json` only when the changed behavior involves the Active Agents roster.
+
+Example command scenario:
 
 ```bash
 PROWL_CLI_SOCKET="$socket" "$cli" send --pane "$pane" \
-  'codex --sandbox read-only "Reply exactly SELF_VERIFY_OK. Do not modify files."' \
-  --no-wait --json
+  'printf "SELF_VERIFY:%s\n" "$PWD"' \
+  --capture --timeout 30 --json
 
-PROWL_CLI_SOCKET="$socket" "$cli" agents --json
-PROWL_CLI_SOCKET="$socket" "$cli" agents --no-color
+PROWL_CLI_SOCKET="$socket" "$cli" read --pane "$pane" --last 80 --wait-stable --json
 ```
 
-Use the returned `data.agents[].pane.id` to inspect or control the agent's pane:
+Example long-running scenario:
 
 ```bash
-agent_pane="$(PROWL_CLI_SOCKET="$socket" "$cli" agents --json | jq -r '.data.agents[0].pane.id')"
-PROWL_CLI_SOCKET="$socket" "$cli" read --pane "$agent_pane" --last 120 --wait-stable --json
+PROWL_CLI_SOCKET="$socket" "$cli" send --pane "$pane" \
+  'for i in 1 2 3; do echo "SELF_VERIFY_STEP:$i"; sleep 1; done' \
+  --no-wait --json
+
+PROWL_CLI_SOCKET="$socket" "$cli" read --pane "$pane" --last 120 --json
 ```
 
-Short non-interactive agent tasks can finish before the roster is sampled. If the goal is to observe `working` to `idle` transitions or retained Active Agents entries, use an interactive agent session in a dedicated tab and sample `prowl agents` repeatedly.
+If the scenario uses another agent, keep it scoped and reversible. Short non-interactive agent tasks can finish before they are sampled; use an interactive session only when the behavior under test requires observing an active retained pane.
 
 ## Fallback Checks
 

--- a/.claude/skills/self-verify-prowl/SKILL.md
+++ b/.claude/skills/self-verify-prowl/SKILL.md
@@ -29,7 +29,7 @@ Do not use this as a replacement for unit tests, `make check`, `make build-app`,
 - Preserve unrelated user changes. Do not close or kill the user's normal Prowl app.
 - If the CLI changed, build and use the repo CLI, usually `./.build/debug/prowl`.
 - If the CLI did not change, an installed `prowl` may be usable, but the repo-built CLI keeps the app/CLI protocol aligned.
-- For detailed CLI targeting and recipes, consult the dedicated `prowl-cli` skill first when needed.
+- **Read the `prowl-cli` skill before writing any CLI commands.** It is the authoritative reference for JSON field names, targeting rules, quoting, argument semantics, error codes, and common pitfalls. This skill covers the self-verify workflow; `prowl-cli` covers how to use `prowl` correctly. Do not guess field names — get them from `prowl-cli`.
 
 ## Launch A Separate App
 
@@ -92,11 +92,21 @@ created="$(prowl_debug tab create --worktree "$worktree" --json)"
 pane="$(echo "$created" | jq -r '.data.target.pane.id')"
 tab="$(echo "$created" | jq -r '.data.target.tab.id')"
 
-prowl_debug send --pane "$pane" 'printf "SELF_VERIFY:%s\n" "$PWD"' --capture --timeout 30 --json
-prowl_debug read --pane "$pane" --last 80 --wait-stable --json
+prowl_debug send --pane "$pane" 'printf "SELF_VERIFY:%s\n" "$PWD"' --capture --timeout 30 --json \
+  | jq -r '.data.capture.text'
+prowl_debug read --pane "$pane" --last 80 --wait-stable --json \
+  | jq -r '.data.text'
 ```
 
 Prefer targeting by pane or tab UUIDs from JSON output. Avoid relying on titles when multiple Prowl instances or similar tabs exist.
+
+Key JSON fields (see `prowl-cli` skill for the full reference):
+
+- `read --json` → terminal text is `.data.text`, not `.content` or `.output`.
+- `send --capture --json` → captured output is `.data.capture.text`; exit code is `.data.wait.exit_code`.
+- `list --json` → pane list is `.data.items[]`, not `.worktrees[]`; each item has `.pane.id`, `.tab.id`, `.worktree.id`, `.task.status`.
+
+CLI JSON responses can contain terminal control characters (in `.pane.title` or `.data.text`) that cause `jq` to fail with a parse error. When this happens, use `python3 -c "import sys,json; d=json.loads(sys.stdin.read()); ..."` instead — Python's JSON parser tolerates embedded control characters.
 
 Always seed the debug instance with `prowl_debug open . --json` before expecting panes. A fresh debug app can start windowless and return an empty `list`; `open .` creates or focuses a worktree tab that later commands can target. Prefer creating an extra temporary tab for the scenario, then close that tab during cleanup.
 
@@ -114,11 +124,14 @@ Turn the change into one or more observable scenarios. Prefer small checks that 
 Example command scenario:
 
 ```bash
-prowl_debug send --pane "$pane" \
+result="$(prowl_debug send --pane "$pane" \
   'printf "SELF_VERIFY:%s\n" "$PWD"' \
-  --capture --timeout 30 --json
+  --capture --timeout 30 --json)"
+echo "$result" | jq -r '.data.capture.text'
+echo "$result" | jq -r '.data.wait.exit_code'
 
-prowl_debug read --pane "$pane" --last 80 --wait-stable --json
+prowl_debug read --pane "$pane" --last 80 --wait-stable --json \
+  | jq -r '.data.text'
 ```
 
 Example long-running scenario:
@@ -128,7 +141,8 @@ prowl_debug send --pane "$pane" \
   'for i in 1 2 3; do echo "SELF_VERIFY_STEP:$i"; sleep 1; done' \
   --no-wait --json
 
-prowl_debug read --pane "$pane" --last 120 --json
+prowl_debug read --pane "$pane" --last 120 --json \
+  | jq -r '.data.text'
 ```
 
 If the scenario uses another agent, keep it scoped and reversible. Short non-interactive agent tasks can finish before they are sampled; use an interactive session only when the behavior under test requires observing an active retained pane.

--- a/.claude/skills/self-verify-prowl/SKILL.md
+++ b/.claude/skills/self-verify-prowl/SKILL.md
@@ -91,9 +91,9 @@ For each later shell command, source the helper and rerun the health check befor
 wait_for_prowl_debug
 ```
 
-Use `prowl_debug ...`, `prowl_jq ...`, and `debug_window_id` from `scripts/helpers.sh` for the commands below. Keep `PROWL_CLI_SOCKET` explicit if you inline commands instead of using the helper.
+Use `prowl_debug ...` and `debug_window_id` from `scripts/helpers.sh` for the commands below. Keep `PROWL_CLI_SOCKET` explicit if you inline commands instead of using the helper.
 
-When parsing `--json` output that may contain terminal text, use `prowl_jq` instead of `jq` to avoid control-character parse failures (see [#444](https://github.com/onevcat/Prowl/issues/444)).
+Parse `--json` output with ordinary `jq`. If `jq` reports invalid control characters for CLI JSON, treat it as a CLI regression rather than working around it in this skill.
 
 ## Drive With Prowl CLI
 
@@ -108,15 +108,15 @@ Then seed the debug app and create a deterministic temporary pane:
 
 ```bash
 opened="$(prowl_debug open . --json)"
-worktree="$(echo "$opened" | prowl_jq -r '.data.target.worktree.id')"
+worktree="$(echo "$opened" | jq -r '.data.target.worktree.id')"
 created="$(prowl_debug tab create --worktree "$worktree" --json)"
-pane="$(echo "$created" | prowl_jq -r '.data.target.pane.id')"
-tab="$(echo "$created" | prowl_jq -r '.data.target.tab.id')"
+pane="$(echo "$created" | jq -r '.data.target.pane.id')"
+tab="$(echo "$created" | jq -r '.data.target.tab.id')"
 
 prowl_debug send --pane "$pane" 'printf "SELF_VERIFY:%s\n" "$PWD"' --capture --timeout 30 --json \
-  | prowl_jq -r '.data.capture.text'
+  | jq -r '.data.capture.text'
 prowl_debug read --pane "$pane" --last 80 --wait-stable --json \
-  | prowl_jq -r '.data.text'
+  | jq -r '.data.text'
 ```
 
 Prefer targeting by pane or tab UUIDs from JSON output. Avoid relying on titles when multiple Prowl instances or similar tabs exist.
@@ -126,8 +126,6 @@ Key JSON fields (see `prowl-cli` skill for the full reference):
 - `read --json` → terminal text is `.data.text`, not `.content` or `.output`.
 - `send --capture --json` → captured output is `.data.capture.text`; exit code is `.data.wait.exit_code`.
 - `list --json` → pane list is `.data.items[]`, not `.worktrees[]`; each item has `.pane.id`, `.tab.id`, `.worktree.id`, `.task.status`.
-
-CLI JSON responses can contain terminal control characters (in `.pane.title` or `.data.text`) that cause `jq` to fail with a parse error. When this happens, use `python3 -c "import sys,json; d=json.loads(sys.stdin.read()); ..."` instead — Python's JSON parser tolerates embedded control characters.
 
 Always seed the debug instance with `prowl_debug open . --json` before expecting panes. A fresh debug app can start windowless and return an empty `list`; `open .` creates or focuses a worktree tab that later commands can target. Prefer creating an extra temporary tab for the scenario, then close that tab during cleanup.
 
@@ -148,11 +146,11 @@ Example command scenario:
 result="$(prowl_debug send --pane "$pane" \
   'printf "SELF_VERIFY:%s\n" "$PWD"' \
   --capture --timeout 30 --json)"
-echo "$result" | prowl_jq -r '.data.capture.text'
-echo "$result" | prowl_jq -r '.data.wait.exit_code'
+echo "$result" | jq -r '.data.capture.text'
+echo "$result" | jq -r '.data.wait.exit_code'
 
 prowl_debug read --pane "$pane" --last 80 --wait-stable --json \
-  | prowl_jq -r '.data.text'
+  | jq -r '.data.text'
 ```
 
 Example long-running scenario:
@@ -163,7 +161,7 @@ prowl_debug send --pane "$pane" \
   --no-wait --json
 
 prowl_debug read --pane "$pane" --last 120 --json \
-  | prowl_jq -r '.data.text'
+  | jq -r '.data.text'
 ```
 
 If the scenario uses another agent, keep it scoped and reversible. Short non-interactive agent tasks can finish before they are sampled; use an interactive session only when the behavior under test requires observing an active retained pane.

--- a/.claude/skills/self-verify-prowl/SKILL.md
+++ b/.claude/skills/self-verify-prowl/SKILL.md
@@ -40,32 +40,20 @@ Concretely: invoke the `prowl-cli` skill (or read its SKILL.md) before proceedin
 
 The debug app uses a fixed socket at `/tmp/prowl-self-verify.sock`. This path is stable across shell invocations, so every step can reference it directly without intermediate files or re-sourcing.
 
-Clean up any stale socket from a previous run, then start the debug app:
+Clean up any stale socket from a previous run, then start the debug app in a persistent shell session:
 
 ```bash
 rm -f /tmp/prowl-self-verify.sock /tmp/prowl-self-verify.sock.lock
 PROWL_CLI_SOCKET=/tmp/prowl-self-verify.sock make run-app
 ```
 
-Keep that command running in its own shell session. If plain `make run-app` reports a socket ownership problem, relaunch with a custom `PROWL_CLI_SOCKET`; the installed app may already own the standard socket.
+Keep that command running in its own shell or PTY session for the whole validation run.
 
-**Agent mode** — CLI agents do not have a persistent foreground shell, so `make run-app` cannot block. After building, launch the binary directly in the background:
+Do not launch the built `ProwlApp` binary directly in the background from an agent shell. Once that shell exits, the app can exit and leave a stale socket behind.
 
-```bash
-rm -f /tmp/prowl-self-verify.sock /tmp/prowl-self-verify.sock.lock
-make build-app
-app_bin="$(xcodebuild -project supacode.xcodeproj -scheme supacode \
-  -configuration Debug -showBuildSettings -json 2>/dev/null \
-  | jq -er '.[0].buildSettings.BUILT_PRODUCTS_DIR + "/" +
-            .[0].buildSettings.FULL_PRODUCT_NAME + "/Contents/MacOS/" +
-            .[0].buildSettings.EXECUTABLE_NAME')"
-PROWL_CLI_SOCKET=/tmp/prowl-self-verify.sock "$app_bin" &
-disown
-```
+If plain `make run-app` reports a socket ownership problem, relaunch with the custom `PROWL_CLI_SOCKET`; the installed app may already own the standard socket.
 
-Then wait for the socket in the reusable setup block as usual.
-
-If the socket appears but `prowl_debug list --json` returns `APP_NOT_RUNNING`, the app likely exited and left a stale socket/lock behind. Remove both socket files, confirm no debug `ProwlApp` PID is still alive, then relaunch. In agent sessions where the direct binary exits immediately, use a PTY-backed `PROWL_CLI_SOCKET=/tmp/prowl-self-verify.sock make run-app` session instead.
+If the socket appears but `prowl_debug list --json` returns `APP_NOT_RUNNING`, the app likely exited and left a stale socket/lock behind. Remove both socket files, confirm no debug `ProwlApp` PID is still alive, then relaunch with `PROWL_CLI_SOCKET=/tmp/prowl-self-verify.sock make run-app` in a persistent shell session.
 
 When `PROWL_CLI_SOCKET` is set, CLI auto-launch is disabled. The debug app and every CLI invocation must use the same socket value.
 

--- a/.claude/skills/self-verify-prowl/agents/openai.yaml
+++ b/.claude/skills/self-verify-prowl/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Self Verify Prowl"
+  short_description: "Bootstrap-verify Prowl with its CLI"
+  default_prompt: "Use $self-verify-prowl to validate this Prowl change against a debug app instance."

--- a/.claude/skills/self-verify-prowl/scripts/helpers.sh
+++ b/.claude/skills/self-verify-prowl/scripts/helpers.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+
+# Source this file from the Prowl repository root while using the
+# self-verify-prowl skill in zsh or bash. It intentionally does not execute
+# a scenario when sourced.
+
+socket="${PROWL_SELF_VERIFY_SOCKET:-/tmp/prowl-self-verify.sock}"
+cli="${PROWL_SELF_VERIFY_CLI:-./.build/debug/prowl}"
+scratch_dir="${PROWL_SELF_VERIFY_DIR:-/tmp/prowl-self-verify}"
+
+prowl_debug() {
+  PROWL_CLI_SOCKET="$socket" "$cli" "$@"
+}
+
+# List all debug-build ProwlApp PIDs (may include helper/child processes).
+debug_pids() {
+  for pid in $(pgrep -f "DerivedData/.*/Debug/Prowl.app/Contents/MacOS/ProwlApp"); do
+    [ "$(ps -p "$pid" -o comm= 2>/dev/null | sed 's#.*/##')" = "ProwlApp" ] && echo "$pid"
+  done
+}
+
+# Compile a PID-scoped CoreGraphics window lookup helper on first screenshot use.
+# Keep this CoreGraphics-based instead of osascript by default: it targets the
+# debug app by PID instead of frontmost app state, window title, or UI scripting.
+debug_window_id_tool() {
+  local tool="$scratch_dir/window-id"
+  local src="$scratch_dir/window-id.swift"
+  mkdir -p "$scratch_dir"
+  if [ ! -x "$tool" ]; then
+    cat > "$src" <<'SWIFT'
+import CoreGraphics
+import Foundation
+let pid = Int32(CommandLine.arguments[1]) ?? -1
+let list = (CGWindowListCopyWindowInfo([.excludeDesktopElements], kCGNullWindowID) as? [[String: Any]]) ?? []
+for w in list where (w[kCGWindowOwnerPID as String] as? Int32) == pid {
+  if let n = w[kCGWindowNumber as String] as? Int, let name = w[kCGWindowName as String] as? String, !name.isEmpty {
+    print(n)
+    exit(0)
+  }
+}
+for w in list where (w[kCGWindowOwnerPID as String] as? Int32) == pid {
+  if let n = w[kCGWindowNumber as String] as? Int {
+    print(n)
+    exit(0)
+  }
+}
+exit(1)
+SWIFT
+    swiftc "$src" -o "$tool"
+  fi
+  printf '%s\n' "$tool"
+}
+
+# Return the single debug PID that owns a visible window.
+# macOS apps can fork helper processes that match the same path but have no
+# windows; always use this for screenshot and window-level operations.
+debug_pid_with_window() {
+  local tool
+  tool="$(debug_window_id_tool)" || return
+  for pid in $(debug_pids); do
+    "$tool" "$pid" >/dev/null 2>&1 && echo "$pid" && return
+  done
+}
+
+debug_window_id() {
+  local tool pid
+  tool="$(debug_window_id_tool)" || return
+  pid="${1:-$(debug_pid_with_window)}"
+  [ -n "$pid" ] || return
+  "$tool" "$pid" | head -1
+}
+
+# Parse prowl --json output tolerantly. Terminal text can contain raw control
+# characters (U+0000-U+001F) that break jq. This helper accepts a jq filter
+# and uses Python to absorb the control characters before passing to jq.
+# Usage: echo "$json" | prowl_jq '.data.text'
+prowl_jq() {
+  python3 -c "
+import sys, json, subprocess
+d = json.JSONDecoder(strict=False).decode(sys.stdin.read())
+subprocess.run(['jq'] + sys.argv[1:], input=json.dumps(d, ensure_ascii=False), text=True)
+" "$@"
+}
+
+wait_for_prowl_debug() {
+  for attempt in 1 2 3 4 5 6 7 8 9 10; do
+    [ -S "$socket" ] && break
+    sleep 1
+  done
+  test -S "$socket" || return 1
+
+  # A socket file alone can be stale. Require a live debug app and a successful
+  # no-op CLI round trip before running scenario commands.
+  test -n "$(debug_pids | head -1)" || return 1
+  health="$(prowl_debug list --json)"
+  test "$(echo "$health" | prowl_jq -r '.ok')" = "true" || {
+    echo "$health" | prowl_jq -r '.error.code? // "unknown"'
+    return 1
+  }
+}

--- a/.claude/skills/self-verify-prowl/scripts/helpers.sh
+++ b/.claude/skills/self-verify-prowl/scripts/helpers.sh
@@ -70,18 +70,6 @@ debug_window_id() {
   "$tool" "$pid" | head -1
 }
 
-# Parse prowl --json output tolerantly. Terminal text can contain raw control
-# characters (U+0000-U+001F) that break jq. This helper accepts a jq filter
-# and uses Python to absorb the control characters before passing to jq.
-# Usage: echo "$json" | prowl_jq '.data.text'
-prowl_jq() {
-  python3 -c "
-import sys, json, subprocess
-d = json.JSONDecoder(strict=False).decode(sys.stdin.read())
-subprocess.run(['jq'] + sys.argv[1:], input=json.dumps(d, ensure_ascii=False), text=True)
-" "$@"
-}
-
 wait_for_prowl_debug() {
   for attempt in 1 2 3 4 5 6 7 8 9 10; do
     [ -S "$socket" ] && break
@@ -93,8 +81,8 @@ wait_for_prowl_debug() {
   # no-op CLI round trip before running scenario commands.
   test -n "$(debug_pids | head -1)" || return 1
   health="$(prowl_debug list --json)"
-  test "$(echo "$health" | prowl_jq -r '.ok')" = "true" || {
-    echo "$health" | prowl_jq -r '.error.code? // "unknown"'
+  test "$(echo "$health" | jq -r '.ok')" = "true" || {
+    echo "$health" | jq -r '.error.code? // "unknown"'
     return 1
   }
 }

--- a/.codex/skills
+++ b/.codex/skills
@@ -1,0 +1,1 @@
+../.claude/skills

--- a/ProwlCLI/Commands/AgentsCommand.swift
+++ b/ProwlCLI/Commands/AgentsCommand.swift
@@ -1,0 +1,23 @@
+// ProwlCLI/Commands/AgentsCommand.swift
+
+import ArgumentParser
+import ProwlCLIShared
+
+struct AgentsCommand: ParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "agents",
+    abstract: "List detected agent panes."
+  )
+
+  @OptionGroup var options: GlobalOptions
+
+  mutating func run() throws {
+    try CLIExecution.run(command: "agents", output: options.outputMode, colorEnabled: options.colorEnabled) {
+      let envelope = CommandEnvelope(
+        output: options.outputMode,
+        command: .agents(AgentsInput())
+      )
+      try CLIRunner.execute(envelope)
+    }
+  }
+}

--- a/ProwlCLI/Commands/ProwlCommand.swift
+++ b/ProwlCLI/Commands/ProwlCommand.swift
@@ -13,6 +13,7 @@ struct ProwlCommand: ParsableCommand {
     subcommands: [
       OpenCommand.self,
       ListCommand.self,
+      AgentsCommand.self,
       FocusCommand.self,
       SendCommand.self,
       KeyCommand.self,

--- a/ProwlCLI/Output/OutputRenderer.swift
+++ b/ProwlCLI/Output/OutputRenderer.swift
@@ -57,6 +57,14 @@ enum OutputRenderer {
         return
       }
 
+      if response.command == "agents",
+         let data = response.data,
+         let payload = try? data.decode(as: AgentsCommandPayload.self)
+      {
+        print(renderAgents(payload))
+        return
+      }
+
       if response.command == "focus",
          let data = response.data,
          let payload = try? data.decode(as: FocusCommandPayload.self)
@@ -193,6 +201,47 @@ enum OutputRenderer {
     }
 
     return lines.joined(separator: "\n")
+  }
+
+  private static func renderAgents(_ payload: AgentsCommandPayload) -> String {
+    guard !payload.agents.isEmpty else {
+      return "No agents found."
+    }
+
+    let order: [AgentsCommandStatus: Int] = [
+      .blocked: 0,
+      .working: 1,
+      .done: 2,
+      .idle: 3,
+    ]
+    let indexedAgents = payload.agents.enumerated()
+    let sortedAgents = indexedAgents.sorted { left, right in
+      let leftRank = order[left.element.status] ?? Int.max
+      let rightRank = order[right.element.status] ?? Int.max
+      if leftRank != rightRank {
+        return leftRank < rightRank
+      }
+      return left.offset < right.offset
+    }.map(\.element)
+
+    return sortedAgents.map { agent in
+      let statusLabel = agentStatusLabel(agent.status)
+      let projectLabel = "\(agent.project.name):\(agent.project.branch)"
+      return "\(statusLabel)  \(agent.name)  \(projectLabel)  \(agent.tab.title)  \(agent.pane.id)"
+    }.joined(separator: "\n")
+  }
+
+  private static func agentStatusLabel(_ status: AgentsCommandStatus) -> String {
+    switch status {
+    case .blocked:
+      return "Blocked".red.bold
+    case .working:
+      return "Working".green
+    case .done:
+      return "Done".dim
+    case .idle:
+      return "Idle".dim
+    }
   }
 
   private static func renderTab(_ payload: TabCommandPayload) -> String {

--- a/ProwlCLITests/ProwlCLIIntegrationTests.swift
+++ b/ProwlCLITests/ProwlCLIIntegrationTests.swift
@@ -14,6 +14,21 @@ final class ProwlCLIIntegrationTests: XCTestCase {
       .deletingLastPathComponent()
   }
 
+  /// Backstop cleanup for mock-server socket files. `MockSocketServer.stop()`
+  /// (run via `defer`) covers the normal and throwing paths, but a test process
+  /// killed mid-run (timeout, Ctrl-C) skips both `defer` and `deinit` and leaks
+  /// the bound socket. Sweep any leftover `prowl-cli-*` from the socket
+  /// directory after each test so they cannot accumulate. Matched by prefix
+  /// only (no `.sock` suffix), so a truncated name would still be caught.
+  override func tearDownWithError() throws {
+    let dir = Self.socketDirectory
+    for name in (try? FileManager.default.contentsOfDirectory(atPath: dir)) ?? []
+    where name.hasPrefix("prowl-cli-") {
+      unlink((dir as NSString).appendingPathComponent(name))
+    }
+    try super.tearDownWithError()
+  }
+
   func testHelpAndVersionSmoke() throws {
     let version = try runProwl(args: ["--version"])
     XCTAssertEqual(version.exitCode, 0)
@@ -1432,6 +1447,7 @@ final class ProwlCLIIntegrationTests: XCTestCase {
     encoder.outputFormatting = [.sortedKeys]
     let responseData = try encoder.encode(response)
     let server = try MockSocketServer(socketPath: socketPath, responseData: responseData)
+    defer { server.stop() }
     try server.start()
 
     let result = try runProwl(
@@ -1575,10 +1591,22 @@ final class ProwlCLIIntegrationTests: XCTestCase {
     return try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
   }
 
+  /// Directory for mock-server socket files, kept deliberately short. AF_UNIX
+  /// `sun_path` is capped at ~104 bytes; `NSTemporaryDirectory()` alone is ~49,
+  /// so `prowl-cli-<suffix>-<uuid>.sock` overflows and `bind()` silently
+  /// truncates the path. A truncated path would not match the string we pass to
+  /// `unlink()`, leaking the socket file. `/tmp` keeps the full path well under
+  /// the limit (and matches the CLI's own socket convention).
+  private static let socketDirectory = "/tmp"
+
   private func temporarySocketPath(suffix: String) -> String {
     let uuid = UUID().uuidString.lowercased()
     let filename = "prowl-cli-\(suffix)-\(uuid).sock"
-    return (NSTemporaryDirectory() as NSString).appendingPathComponent(filename)
+    let path = (Self.socketDirectory as NSString).appendingPathComponent(filename)
+    // Fail fast if a future suffix pushes the path past the sun_path limit,
+    // rather than letting bind() truncate and leak the socket again.
+    precondition(path.utf8.count <= 103, "Socket path exceeds AF_UNIX sun_path limit: \(path)")
+    return path
   }
 }
 
@@ -1914,9 +1942,16 @@ private final class MockSocketServer: @unchecked Sendable {
     self.responseData = responseData
   }
 
-  deinit {
+  deinit { stop() }
+
+  /// Idempotent teardown: closes the listening socket and removes its file.
+  /// Invoked via `defer` from the test helper so cleanup does not rely on
+  /// non-deterministic `deinit` timing — the accept loop runs on a background
+  /// queue, which can delay ARC release and leave the bound socket file behind.
+  func stop() {
     if serverFD >= 0 {
       close(serverFD)
+      serverFD = -1
     }
     unlink(socketPath)
   }

--- a/ProwlCLITests/ProwlCLIIntegrationTests.swift
+++ b/ProwlCLITests/ProwlCLIIntegrationTests.swift
@@ -38,6 +38,34 @@ final class ProwlCLIIntegrationTests: XCTestCase {
     XCTAssertEqual(error["code"] as? String, CLIErrorCode.appNotRunning)
   }
 
+  func testAgentsCommandRoundTripsOverSocket() throws {
+    let socketPath = temporarySocketPath(suffix: "agents")
+    let response = try CommandResponse(
+      ok: true,
+      command: "agents",
+      schemaVersion: "prowl.cli.agents.v1",
+      data: RawJSON(encoding: AgentsResponseData(count: 0, agents: []))
+    )
+
+    let (requestData, result) = try runWithMockServer(
+      socketPath: socketPath,
+      response: response,
+      args: ["agents", "--json"]
+    )
+
+    XCTAssertEqual(result.exitCode, 0)
+    let envelope = try JSONDecoder().decode(CommandEnvelope.self, from: requestData)
+    if case .agents = envelope.command {
+      // expected
+    } else {
+      XCTFail("Expected agents command envelope")
+    }
+
+    let payload = try jsonObject(from: result.stdout)
+    XCTAssertEqual(payload["ok"] as? Bool, true)
+    XCTAssertEqual(payload["command"] as? String, "agents")
+  }
+
   func testOpenCommandRoundTripsOverSocket() throws {
     let socketPath = temporarySocketPath(suffix: "open")
     let response = try CommandResponse(
@@ -381,6 +409,80 @@ final class ProwlCLIIntegrationTests: XCTestCase {
 
     XCTAssertEqual(result.exitCode, 0)
     XCTAssertTrue(result.stdout.contains("No panes found."), "Expected empty message: \(result.stdout)")
+  }
+
+  func testAgentsCommandTextRenderingFromSocket() throws {
+    let socketPath = temporarySocketPath(suffix: "agents-text")
+    let response = try CommandResponse(
+      ok: true,
+      command: "agents",
+      schemaVersion: "prowl.cli.agents.v1",
+      data: RawJSON(encoding: AgentsResponseData(
+        count: 3,
+        agents: [
+          makeAgentResponse(
+            id: "done-pane",
+            name: "codex",
+            status: "done",
+            projectName: "Prowl",
+            branch: "main",
+            tabTitle: "Done tab"
+          ),
+          makeAgentResponse(
+            id: "blocked-pane",
+            name: "omp",
+            status: "blocked",
+            projectName: "Prowl",
+            branch: "feature/cli-agents",
+            tabTitle: "issue 330"
+          ),
+          makeAgentResponse(
+            id: "working-pane",
+            name: "claude",
+            status: "working",
+            projectName: "Notes",
+            branch: "main",
+            tabTitle: "review"
+          ),
+        ]
+      ))
+    )
+
+    let (_, result) = try runWithMockServer(
+      socketPath: socketPath,
+      response: response,
+      args: ["agents"]
+    )
+
+    XCTAssertEqual(result.exitCode, 0)
+    let lines = result.stdout.split(separator: "\n").map(String.init)
+    XCTAssertEqual(lines.count, 3, "Unexpected agents output: \(result.stdout)")
+    XCTAssertTrue(lines[0].contains("Blocked"), "Expected blocked first: \(result.stdout)")
+    XCTAssertTrue(lines[0].contains("omp"), "Missing agent name: \(result.stdout)")
+    XCTAssertTrue(lines[0].contains("Prowl:feature/cli-agents"), "Missing project label: \(result.stdout)")
+    XCTAssertTrue(lines[0].contains("issue 330"), "Missing tab title: \(result.stdout)")
+    XCTAssertTrue(lines[0].contains("blocked-pane"), "Missing pane id: \(result.stdout)")
+    XCTAssertTrue(lines[1].contains("Working"), "Expected working second: \(result.stdout)")
+    XCTAssertTrue(lines[2].contains("Done"), "Expected done third: \(result.stdout)")
+  }
+
+  func testAgentsEmptyPayloadShowsNoAgentsFound() throws {
+    let socketPath = temporarySocketPath(suffix: "agents-empty")
+    let response = try CommandResponse(
+      ok: true,
+      command: "agents",
+      schemaVersion: "prowl.cli.agents.v1",
+      data: RawJSON(encoding: AgentsResponseData(count: 0, agents: []))
+    )
+
+    let (_, result) = try runWithMockServer(
+      socketPath: socketPath,
+      response: response,
+      args: ["agents"]
+    )
+
+    XCTAssertEqual(result.exitCode, 0)
+    XCTAssertTrue(result.stdout.contains("No agents found."), "Expected empty message: \(result.stdout)")
   }
 
   func testListMultipleWorktreesGroupedWithBlankLine() throws {
@@ -1349,6 +1451,34 @@ final class ProwlCLIIntegrationTests: XCTestCase {
     PaneCommandPayload(action: action, target: makeTabTarget())
   }
 
+  private func makeAgentResponse(
+    id: String,
+    name: String,
+    status: String,
+    projectName: String,
+    branch: String,
+    tabTitle: String
+  ) -> AgentsResponseAgent {
+    AgentsResponseAgent(
+      id: id,
+      type: name,
+      name: name,
+      status: status,
+      rawState: status,
+      lastChangedAt: "2026-06-13T04:12:25Z",
+      project: AgentsResponseProject(name: projectName, branch: branch, path: "/Projects/\(projectName)"),
+      worktree: ListWorktree(
+        id: "\(projectName):/Projects/\(projectName)",
+        name: branch,
+        path: "/Projects/\(projectName)",
+        rootPath: "/Projects/\(projectName)",
+        kind: "git"
+      ),
+      tab: ListTab(id: "\(id)-tab", title: tabTitle, selected: true),
+      pane: AgentsResponsePane(id: id, index: 1, title: name, cwd: "/Projects/\(projectName)", focused: false)
+    )
+  }
+
   private func makeTabTarget() -> TabTarget {
     TabTarget(
       worktree: TabTargetWorktree(
@@ -1516,6 +1646,52 @@ private struct ListPane: Encodable {
 
 private struct ListTask: Encodable {
   let status: String?
+}
+
+private struct AgentsResponseData: Encodable {
+  let count: Int
+  let agents: [AgentsResponseAgent]
+}
+
+private struct AgentsResponseAgent: Encodable {
+  let id: String
+  let type: String
+  let name: String
+  let status: String
+
+  enum CodingKeys: String, CodingKey {
+    case id
+    case type
+    case name
+    case status
+    case rawState = "raw_state"
+    case lastChangedAt = "last_changed_at"
+    case project
+    case worktree
+    case tab
+    case pane
+  }
+
+  let rawState: String
+  let lastChangedAt: String
+  let project: AgentsResponseProject
+  let worktree: ListWorktree
+  let tab: ListTab
+  let pane: AgentsResponsePane
+}
+
+private struct AgentsResponseProject: Encodable {
+  let name: String
+  let branch: String
+  let path: String
+}
+
+private struct AgentsResponsePane: Encodable {
+  let id: String
+  let index: Int
+  let title: String
+  let cwd: String?
+  let focused: Bool
 }
 
 private struct FocusResponseData: Encodable {

--- a/docs/components/active-agents.md
+++ b/docs/components/active-agents.md
@@ -5,7 +5,7 @@
 
 **Keywords:** active agents, agents panel, running agents, status list, working, blocked, done, idle, jump to agent, roster
 
-**Related:** [agent-detection](agent-detection.md) · [notifications](notifications.md) · [command-palette](command-palette.md) · [canvas](canvas.md)
+**Related:** [agent-detection](agent-detection.md) · [cli](cli.md) · [notifications](notifications.md) · [command-palette](command-palette.md) · [canvas](canvas.md)
 
 ## What it is
 
@@ -66,6 +66,10 @@ When nothing is running: "New agents will appear here".
 ## Relationship to other features
 
 - **Agent detection** ([agent-detection](agent-detection.md)) feeds this panel.
+- **CLI** ([cli](cli.md)) exposes the same roster through `prowl agents` and
+  `prowl agents --json`. The command is read-only; use the returned
+  `pane.id` with `prowl focus --pane`, `prowl read --pane`, or
+  `prowl send --pane` for follow-up actions.
 - **Notifications** ([notifications](notifications.md)) are driven by a separate
   signal — terminal bell / OSC desktop notifications and command-finished
   events — which usually coincides with, but is not the same as, a detected finish.
@@ -81,5 +85,6 @@ When nothing is running: "New agents will appear here".
 - "Blocked" is the actionable state — it means an agent is **waiting on a human**
   (a permission/confirmation prompt). Surface these first.
 - This panel reflects **detected** agents; detection is best-effort (see
-  [agent-detection](agent-detection.md)). For programmatic certainty about a
-  pane's task status, use [`prowl list`](cli.md) → `task.status`.
+  [agent-detection](agent-detection.md)). For the same detected roster in
+  automation, use [`prowl agents --json`](cli.md). For an all-pane inventory,
+  including non-agent shells, use [`prowl list --json`](cli.md).

--- a/docs/components/cli.md
+++ b/docs/components/cli.md
@@ -4,9 +4,9 @@
 > an agent) can list panes, read their screens, run commands and capture output,
 > send keystrokes, focus, and open/close tabs and panes programmatically.
 
-**Keywords:** prowl cli, command line, prowl list, prowl read, prowl send, prowl key, prowl focus, prowl tab, prowl pane, prowl open, pane id, automation, json, capture, socket
+**Keywords:** prowl cli, command line, prowl list, prowl agents, prowl read, prowl send, prowl key, prowl focus, prowl tab, prowl pane, prowl open, pane id, automation, json, capture, socket
 
-**Related:** [terminal](terminal.md) · [concepts](../concepts.md) · [agent-detection](agent-detection.md) · the bundled **`prowl-cli` skill** (`skills/prowl-cli/SKILL.md`)
+**Related:** [terminal](terminal.md) · [concepts](../concepts.md) · [active-agents](active-agents.md) · [agent-detection](agent-detection.md) · the bundled **`prowl-cli` skill** (`skills/prowl-cli/SKILL.md`)
 
 > This is the reference for the `prowl` binary. For an opinionated, safety-first
 > *workflow* guide (recipes, pitfalls, quoting), the repository also ships the
@@ -79,6 +79,37 @@ Find your own pane (to avoid operating on yourself):
 ```bash
 self_pane="$(prowl list --json | jq -r '.data.items[] | select(.pane.focused==true) | .pane.id')"
 ```
+
+### `prowl agents`
+Snapshot of detected agent panes, matching the Active Agents roster. No
+selectors.
+
+```bash
+prowl agents --json
+```
+Each agent contains:
+- `id`: the pane/surface UUID, suitable for `--pane`.
+- `type`, `name`: normalized detector type and displayed command name. Aliases
+  such as `omp` are preserved in `name`.
+- `status`, `raw_state`: detected agent state. `status` is one of `blocked`,
+  `working`, `done`, `idle`; `raw_state` is the lower-level detector state.
+- `last_changed_at`: ISO-8601 timestamp for the most recent state change.
+- `project`: display-oriented `name`, `branch`, `path` resolved from the
+  agent's working directory.
+- `worktree`, `tab`, `pane`: the actual terminal owner and pane metadata for
+  automation.
+
+`prowl agents` is read-only. To jump to or operate on an agent, resolve
+`.data.agents[].pane.id`, then use existing commands:
+
+```bash
+pane="$(prowl agents --json | jq -r '.data.agents[] | select(.status=="blocked") | .pane.id' | head -n1)"
+prowl focus --pane "$pane"
+prowl read --pane "$pane" --last 120 --wait-stable
+```
+
+Text output is sorted for triage: `Blocked`, `Working`, `Done`, then `Idle`.
+Empty output prints `No agents found.`.
 
 ### `prowl read [target]`
 Read a pane's content.
@@ -203,7 +234,7 @@ inside-root / new-root), `app_launched`, `brought_to_front`, `created_tab`, and 
 | `UNSUPPORTED_KEY` / `INVALID_REPEAT` | Check `prowl key --help`. |
 | `PATH_NOT_FOUND` / `PATH_NOT_DIRECTORY` / `PATH_NOT_ALLOWED` | Fix the `open`/`tab create` path. |
 | `LAUNCH_FAILED` | App launch or socket wait failed. |
-| `*_FAILED` (`LIST_FAILED`, `FOCUS_FAILED`, `SEND_FAILED`, `READ_FAILED`, `TAB_FAILED`, `PANE_FAILED`, `OPEN_FAILED`) | The action itself failed. |
+| `*_FAILED` (`LIST_FAILED`, `AGENTS_FAILED`, `FOCUS_FAILED`, `SEND_FAILED`, `READ_FAILED`, `TAB_FAILED`, `PANE_FAILED`, `OPEN_FAILED`) | The action itself failed. |
 
 ## Safety & self-targeting
 
@@ -228,6 +259,8 @@ prowl pane close --pane "$pane" --json
 
 - Resolve a `pane.id` before `read`/`send`/`key`/`focus`/close — never trust tab
   titles.
+- Use `prowl agents --json` when you need agent status; use `prowl list --json`
+  when you need all panes, including ordinary shells.
 - `--capture` needs shell integration; otherwise `read --wait-stable` or file
   redirection.
 - `open` is navigation, not a guaranteed new pane — use `tab create`.

--- a/skills/prowl-cli/SKILL.md
+++ b/skills/prowl-cli/SKILL.md
@@ -104,19 +104,21 @@ prowl pane close --pane "$pane" --force --json
 
 Do not guess field names. Every `--json` response is `{ "ok", "command", "schema_version", "data": {...} }`, and the terminal text lives at `.data.text` — not `.content`, `.output`, or `.stdout`. Always parse with `jq` against the fields below; the authoritative, per-command field reference lives in `docs/components/cli.md`.
 
+When JSON is stored in a shell variable, use `printf '%s\n' "$json" | jq ...`. Do not use `echo "$json" | jq`: zsh can interpret JSON escape sequences such as `\u001B` and turn them back into raw control characters.
+
 ```bash
 # read: rendered terminal text is .data.text
 prowl read --pane "$pane" --last 80 --wait-stable --json | jq -r '.data.text'
 
 # send --capture: captured output is .data.capture.text; exit code is .data.wait.exit_code
 out="$(prowl send --pane "$pane" 'git status --short' --capture --timeout 30 --json)"
-echo "$out" | jq -r '.data.capture.text'
-echo "$out" | jq -r '.data.wait.exit_code'
+printf '%s\n' "$out" | jq -r '.data.capture.text'
+printf '%s\n' "$out" | jq -r '.data.wait.exit_code'
 
 # tab create / open: new pane and tab ids
 created="$(prowl tab create --worktree "$worktree" --json)"
-echo "$created" | jq -r '.data.target.pane.id'
-echo "$created" | jq -r '.data.target.tab.id'
+printf '%s\n' "$created" | jq -r '.data.target.pane.id'
+printf '%s\n' "$created" | jq -r '.data.target.tab.id'
 
 # list / agents: ids and status
 prowl list --json   | jq -r '.data.items[].pane.id'

--- a/skills/prowl-cli/SKILL.md
+++ b/skills/prowl-cli/SKILL.md
@@ -100,6 +100,40 @@ prowl tab close --tab "$tab" --json
 prowl pane close --pane "$pane" --force --json
 ```
 
+## Parsing JSON Output
+
+Do not guess field names. Every `--json` response is `{ "ok", "command", "schema_version", "data": {...} }`, and the terminal text lives at `.data.text` — not `.content`, `.output`, or `.stdout`. Always parse with `jq` against the fields below; the authoritative, per-command field reference lives in `docs/components/cli.md`.
+
+```bash
+# read: rendered terminal text is .data.text
+prowl read --pane "$pane" --last 80 --wait-stable --json | jq -r '.data.text'
+
+# send --capture: captured output is .data.capture.text; exit code is .data.wait.exit_code
+out="$(prowl send --pane "$pane" 'git status --short' --capture --timeout 30 --json)"
+echo "$out" | jq -r '.data.capture.text'
+echo "$out" | jq -r '.data.wait.exit_code'
+
+# tab create / open: new pane and tab ids
+created="$(prowl tab create --worktree "$worktree" --json)"
+echo "$created" | jq -r '.data.target.pane.id'
+echo "$created" | jq -r '.data.target.tab.id'
+
+# list / agents: ids and status
+prowl list --json   | jq -r '.data.items[].pane.id'
+prowl list --json   | jq -r '.data.items[] | select(.pane.focused) | .pane.id'
+prowl agents --json | jq -r '.data.agents[] | "\(.status)\t\(.pane.id)"'
+
+# guard before trusting data: bail if ok is not true
+prowl list --json | jq -e '.ok == true' >/dev/null || echo "command failed"
+```
+
+Key fields by command (see `docs/components/cli.md` for the full contract):
+
+- `read` → `.data.text`, `.data.line_count`, `.data.truncated`, `.data.mode` (`snapshot`|`last`), `.data.source` (`screen`|`scrollback`|`mixed`), plus `.data.stabilized` / `.data.waited_ms` / `.data.samples` when `--wait-stable`.
+- `send` → `.data.input` (source/characters/bytes/trailing_enter_sent); `.data.wait.exit_code` and `.data.wait.duration_ms` when waiting; `.data.capture.text` / `.data.capture.line_count` / `.data.capture.truncated` when `--capture`.
+- `list` / `agents` → `.data.items[]` / `.data.agents[]`, each with `.pane.id`, `.tab.id`, `.worktree.{id,name,path}`, `.task.status`.
+- `tab create` / `open` → `.data.target.{pane,tab,worktree}`.
+
 ## Reading Agent Output
 
 `task.status` is useful for coordination but is not enough to prove the screen finished rendering. `idle` can arrive before a TUI has painted its final response.
@@ -218,6 +252,7 @@ Avoid outer double quotes around payloads containing `$PWD`, `$VAR`, backticks, 
 - `read --wait-stable` sees rendered screen only. It cannot recover content folded by a TUI.
 - `read` returning fewer lines than `--last` requested is normally `truncated: false` — the pane simply has less history and you already have it all, so do not retry for more. `truncated: true` flags a possibly-incomplete result (the full scrollback could not be read).
 - `send --capture` captures a screen diff; multiline input may include command echo.
+- Do not guess JSON field names. Terminal text is `.data.text` (read) and `.data.capture.text` (`send --capture`); see "Parsing JSON Output" and `docs/components/cli.md`.
 - `prowl list --json | jq ...` snippets should pass shell values with `--arg`.
 - In zsh, do not name variables `status`; it is readonly.
 - Parser errors are not JSON even if `--json` is present, because parsing happens before command execution.

--- a/skills/prowl-cli/SKILL.md
+++ b/skills/prowl-cli/SKILL.md
@@ -18,6 +18,14 @@ prowl list --json
 
 Pick the target by `pane.id`, `tab.id`, `worktree.id`, `worktree.path`, `pane.cwd`, and `pane.focused`. Do not trust tab titles: they are free-form and can lag or lie.
 
+When you specifically need active agent status, prefer the agent roster:
+
+```bash
+prowl agents --json
+```
+
+`prowl agents` lists detected agent panes only. It is the right starting point for "which agents are blocked/working/done?", while `prowl list` remains the all-pane inventory, including ordinary shells.
+
 If your session was launched from a Prowl pane, the focused pane is often you. Treat focused pane IDs as something to identify and avoid unless you intentionally want to operate on yourself.
 
 ```bash
@@ -150,6 +158,25 @@ Human scan:
 prowl list --no-color
 ```
 
+Find active agents, prioritizing prompts that need attention:
+
+```bash
+prowl agents --no-color
+```
+
+Get the first blocked agent pane and inspect it:
+
+```bash
+pane="$(prowl agents --json | jq -r '
+  .data.agents[]
+  | select(.status == "blocked")
+  | .pane.id
+' | head -n 1)"
+prowl read --pane "$pane" --last 120 --wait-stable --json
+```
+
+When no agent is blocked, use the same pattern with `working`, `done`, or `idle` depending on the task. The JSON payload also includes `.project.name`, `.project.branch`, `.worktree.path`, `.tab.title`, and `.pane.focused`, so automation can filter by human project label while still targeting the concrete pane.
+
 `-t/--target` can auto-resolve pane UUID, tab UUID, or worktree id/name/path, but explicit `--pane <uuid>` is safer for automation.
 
 ## Argument Rules
@@ -184,6 +211,7 @@ Avoid outer double quotes around payloads containing `$PWD`, `$VAR`, backticks, 
 
 - Never target by tab title alone; use `pane.id` plus path/cwd.
 - Never omit `--pane` for `send`, `key`, `read`, or `focus` in automation.
+- Use `prowl agents --json` for detected agent status; use `prowl list --json` for all panes and worktree-level `task.status`.
 - `open /path` is a project/path navigation command. It may refocus an existing pane and is not a deterministic create command.
 - Use `tab create` when automation needs a fresh shell, and capture the returned `pane.id` before sending input.
 - Focused pane is not stable; `open` and `focus` change it.
@@ -193,6 +221,8 @@ Avoid outer double quotes around payloads containing `$PWD`, `$VAR`, backticks, 
 - `prowl list --json | jq ...` snippets should pass shell values with `--arg`.
 - In zsh, do not name variables `status`; it is readonly.
 - Parser errors are not JSON even if `--json` is present, because parsing happens before command execution.
+- The CLI talks to one socket owner by default. If two Prowl app instances are running, the default `prowl` command reaches whichever app owns the standard socket. For a manually launched dev instance, start the app and every CLI command with the same `PROWL_CLI_SOCKET=/tmp/name.sock`.
+- A newer CLI command sent to an older app can fail at transport level. If `prowl agents` returns `TRANSPORT_FAILED`, confirm the running app instance was built with the command.
 - `cmd-w` can close a temporary tab, but double-check the pane first.
 
 ## Error Handling
@@ -206,6 +236,7 @@ In `--json` mode, command-level failures look like:
 Common codes and recovery:
 
 - `APP_NOT_RUNNING`: Prowl is not reachable. Ask before restarting the app.
+- `TRANSPORT_FAILED`: the socket connection broke or the running app could not decode the command. Recheck which Prowl instance owns the socket.
 - `TARGET_NOT_FOUND` / `TARGET_NOT_UNIQUE`: run `prowl list --json` again and choose an explicit pane UUID.
 - `EMPTY_INPUT`: `send` got neither argv text nor stdin.
 - `NO_ACTIVE_PANE`: no pane resolved for positional (focused-pane) targeting; pass an explicit `--pane`.
@@ -219,4 +250,4 @@ Always check the exit code before piping output into `jq`; parser-level errors p
 
 ## Command Set
 
-Current commands: `list`, `read`, `send`, `key`, `focus`, `tab create`, `tab close`, `pane close`, and `open` (default). There is no CLI `quit`; close temporary tabs or panes with explicit `tab close` / `pane close` targets.
+Current commands: `list`, `agents`, `read`, `send`, `key`, `focus`, `tab create`, `tab close`, `pane close`, and `open` (default). There is no CLI `quit`; close temporary tabs or panes with explicit `tab close` / `pane close` targets.

--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -368,6 +368,15 @@ struct SupacodeApp: App {
         terminalManager: terminalManager
       )
     }
+    let agentsHandler = AgentsCommandHandler {
+      AgentsRuntimeSnapshot(
+        repositoriesState: appStore.state.repositories,
+        listSnapshot: ListRuntimeSnapshotBuilder.makeSnapshot(
+          repositoriesState: appStore.state.repositories,
+          terminalManager: terminalManager
+        )
+      )
+    }
     let sendHandler = SendCommandHandler(
       resolveProvider: { selector in
         let resolver = TargetResolver {
@@ -546,6 +555,7 @@ struct SupacodeApp: App {
     return CLICommandRouter(
       openHandler: openHandler,
       listHandler: listHandler,
+      agentsHandler: agentsHandler,
       focusHandler: focusHandler,
       sendHandler: sendHandler,
       keyHandler: keyHandler,

--- a/supacode/CLIService/AgentsCommandHandler.swift
+++ b/supacode/CLIService/AgentsCommandHandler.swift
@@ -1,0 +1,151 @@
+import Foundation
+
+struct AgentsRuntimeSnapshot {
+  let repositoriesState: RepositoriesFeature.State
+  let listSnapshot: ListRuntimeSnapshot
+}
+
+final class AgentsCommandHandler: CommandHandler {
+  typealias SnapshotProvider = @MainActor () throws -> AgentsRuntimeSnapshot
+
+  private struct TerminalAgentContext {
+    let worktree: ListRuntimeSnapshot.Worktree
+    let tab: ListRuntimeSnapshot.Tab
+    let pane: ListRuntimeSnapshot.Pane
+    let focused: Bool
+  }
+
+  private let snapshotProvider: SnapshotProvider
+  private let dateFormatter: ISO8601DateFormatter
+
+  init(snapshotProvider: @escaping SnapshotProvider) {
+    self.snapshotProvider = snapshotProvider
+    self.dateFormatter = ISO8601DateFormatter()
+    self.dateFormatter.formatOptions = [.withInternetDateTime]
+    self.dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
+  }
+
+  // swiftlint:disable:next async_without_await
+  func handle(envelope _: CommandEnvelope) async -> CommandResponse {
+    do {
+      let snapshot = try snapshotProvider()
+      let payload = makePayload(from: snapshot)
+      return try CommandResponse(
+        ok: true,
+        command: "agents",
+        schemaVersion: "prowl.cli.agents.v1",
+        data: RawJSON(encoding: payload)
+      )
+    } catch {
+      return CommandResponse(
+        ok: false,
+        command: "agents",
+        schemaVersion: "prowl.cli.agents.v1",
+        error: CommandError(
+          code: CLIErrorCode.agentsFailed,
+          message: "Failed to list agents."
+        )
+      )
+    }
+  }
+
+  private func makePayload(from snapshot: AgentsRuntimeSnapshot) -> AgentsCommandPayload {
+    let repositoriesState = snapshot.repositoriesState
+    let metadata = SidebarListView.activeAgentWorktreeMetadata(
+      repositories: repositoriesState.repositories,
+      customTitles: repositoriesState.repositoryCustomTitles
+    )
+    let terminalContexts = makeTerminalContexts(from: snapshot.listSnapshot)
+    let worktreeContexts = Dictionary(
+      uniqueKeysWithValues:
+        ListRuntimeSnapshotBuilder
+        .orderedWorktreeContexts(from: repositoriesState)
+        .map { ($0.id, $0) }
+    )
+
+    let agents = repositoriesState.activeAgents.entries.compactMap { entry -> AgentsCommandAgent? in
+      guard let terminalContext = terminalContexts[entry.surfaceID] else {
+        return nil
+      }
+      let display = SidebarListView.activeAgentRowDisplay(
+        for: entry,
+        repositories: repositoriesState.repositories,
+        metadata: metadata
+      )
+      let projectPath = projectPath(
+        for: entry, repositoriesState: repositoriesState, worktreeContexts: worktreeContexts)
+
+      return AgentsCommandAgent(
+        id: entry.surfaceID.uuidString,
+        type: entry.agent.rawValue,
+        name: entry.displayName,
+        status: AgentsCommandStatus(rawValue: entry.displayState.rawValue) ?? .idle,
+        rawState: entry.rawState.rawValue,
+        lastChangedAt: dateFormatter.string(from: entry.lastChangedAt),
+        project: AgentsCommandProject(
+          name: display.repositoryName,
+          branch: display.branchName,
+          path: projectPath
+        ),
+        worktree: AgentsCommandWorktree(
+          id: terminalContext.worktree.id,
+          name: terminalContext.worktree.name,
+          path: terminalContext.worktree.path,
+          rootPath: terminalContext.worktree.rootPath,
+          kind: terminalContext.worktree.kind.rawValue
+        ),
+        tab: AgentsCommandTab(
+          id: terminalContext.tab.id.uuidString,
+          title: terminalContext.tab.title,
+          selected: terminalContext.tab.selected
+        ),
+        pane: AgentsCommandPane(
+          id: terminalContext.pane.id.uuidString,
+          index: entry.paneIndex,
+          title: terminalContext.pane.title,
+          cwd: terminalContext.pane.cwd,
+          focused: terminalContext.focused
+        )
+      )
+    }
+
+    return AgentsCommandPayload(count: agents.count, agents: agents)
+  }
+
+  private func makeTerminalContexts(from snapshot: ListRuntimeSnapshot) -> [UUID: TerminalAgentContext] {
+    var contexts: [UUID: TerminalAgentContext] = [:]
+    for worktree in snapshot.worktrees {
+      for tab in worktree.tabs {
+        for pane in tab.panes {
+          contexts[pane.id] = TerminalAgentContext(
+            worktree: worktree,
+            tab: tab,
+            pane: pane,
+            focused: worktree.id == snapshot.focusedWorktreeID && tab.selected && tab.focusedPaneID == pane.id
+          )
+        }
+      }
+    }
+    return contexts
+  }
+
+  private func projectPath(
+    for entry: ActiveAgentEntry,
+    repositoriesState: RepositoriesFeature.State,
+    worktreeContexts: [Worktree.ID: ListRuntimeSnapshotBuilder.WorktreeContext]
+  ) -> String {
+    if let workingDirectory = entry.workingDirectory,
+      let key = SidebarListView.resolveWorktreeID(
+        forWorkingDirectory: workingDirectory,
+        in: repositoriesState.repositories
+      ),
+      let context = worktreeContexts[key]
+    {
+      return context.path
+    }
+    if let workingDirectory = entry.workingDirectory {
+      return workingDirectory.path(percentEncoded: false)
+    }
+    return worktreeContexts[entry.worktreeID]?.path ?? entry.worktreeName
+  }
+}

--- a/supacode/CLIService/CLICommandRouter.swift
+++ b/supacode/CLIService/CLICommandRouter.swift
@@ -7,6 +7,7 @@ import Foundation
 final class CLICommandRouter {
   private let openHandler: any CommandHandler
   private let listHandler: any CommandHandler
+  private let agentsHandler: any CommandHandler
   private let focusHandler: any CommandHandler
   private let sendHandler: any CommandHandler
   private let keyHandler: any CommandHandler
@@ -17,6 +18,7 @@ final class CLICommandRouter {
   init(
     openHandler: any CommandHandler = StubCommandHandler(command: "open"),
     listHandler: any CommandHandler = StubCommandHandler(command: "list"),
+    agentsHandler: any CommandHandler = StubCommandHandler(command: "agents"),
     focusHandler: any CommandHandler = StubCommandHandler(command: "focus"),
     sendHandler: any CommandHandler = StubCommandHandler(command: "send"),
     keyHandler: any CommandHandler = StubCommandHandler(command: "key"),
@@ -26,6 +28,7 @@ final class CLICommandRouter {
   ) {
     self.openHandler = openHandler
     self.listHandler = listHandler
+    self.agentsHandler = agentsHandler
     self.focusHandler = focusHandler
     self.sendHandler = sendHandler
     self.keyHandler = keyHandler
@@ -39,6 +42,7 @@ final class CLICommandRouter {
     switch envelope.command {
     case .open: handler = openHandler
     case .list: handler = listHandler
+    case .agents: handler = agentsHandler
     case .focus: handler = focusHandler
     case .send: handler = sendHandler
     case .key: handler = keyHandler

--- a/supacode/CLIService/Shared/AgentsCommandPayload.swift
+++ b/supacode/CLIService/Shared/AgentsCommandPayload.swift
@@ -1,0 +1,132 @@
+import Foundation
+
+public struct AgentsCommandPayload: Codable, Equatable {
+  public let count: Int
+  public let agents: [AgentsCommandAgent]
+
+  public init(count: Int, agents: [AgentsCommandAgent]) {
+    self.count = count
+    self.agents = agents
+  }
+}
+
+public struct AgentsCommandAgent: Codable, Equatable {
+  public let id: String
+  public let type: String
+  public let name: String
+  public let status: AgentsCommandStatus
+  public let rawState: String
+  public let lastChangedAt: String
+  public let project: AgentsCommandProject
+  public let worktree: AgentsCommandWorktree
+  public let tab: AgentsCommandTab
+  public let pane: AgentsCommandPane
+
+  enum CodingKeys: String, CodingKey {
+    case id
+    case type
+    case name
+    case status
+    case rawState = "raw_state"
+    case lastChangedAt = "last_changed_at"
+    case project
+    case worktree
+    case tab
+    case pane
+  }
+
+  public init(
+    id: String,
+    type: String,
+    name: String,
+    status: AgentsCommandStatus,
+    rawState: String,
+    lastChangedAt: String,
+    project: AgentsCommandProject,
+    worktree: AgentsCommandWorktree,
+    tab: AgentsCommandTab,
+    pane: AgentsCommandPane
+  ) {
+    self.id = id
+    self.type = type
+    self.name = name
+    self.status = status
+    self.rawState = rawState
+    self.lastChangedAt = lastChangedAt
+    self.project = project
+    self.worktree = worktree
+    self.tab = tab
+    self.pane = pane
+  }
+}
+
+public enum AgentsCommandStatus: String, Codable, Equatable {
+  case blocked
+  case working
+  case done
+  case idle
+}
+
+public struct AgentsCommandProject: Codable, Equatable {
+  public let name: String
+  public let branch: String
+  public let path: String
+
+  public init(name: String, branch: String, path: String) {
+    self.name = name
+    self.branch = branch
+    self.path = path
+  }
+}
+
+public struct AgentsCommandWorktree: Codable, Equatable {
+  public let id: String
+  public let name: String
+  public let path: String
+  public let rootPath: String
+  public let kind: String
+
+  enum CodingKeys: String, CodingKey {
+    case id
+    case name
+    case path
+    case rootPath = "root_path"
+    case kind
+  }
+
+  public init(id: String, name: String, path: String, rootPath: String, kind: String) {
+    self.id = id
+    self.name = name
+    self.path = path
+    self.rootPath = rootPath
+    self.kind = kind
+  }
+}
+
+public struct AgentsCommandTab: Codable, Equatable {
+  public let id: String
+  public let title: String
+  public let selected: Bool
+
+  public init(id: String, title: String, selected: Bool) {
+    self.id = id
+    self.title = title
+    self.selected = selected
+  }
+}
+
+public struct AgentsCommandPane: Codable, Equatable {
+  public let id: String
+  public let index: Int
+  public let title: String
+  public let cwd: String?
+  public let focused: Bool
+
+  public init(id: String, index: Int, title: String, cwd: String?, focused: Bool) {
+    self.id = id
+    self.index = index
+    self.title = title
+    self.cwd = cwd
+    self.focused = focused
+  }
+}

--- a/supacode/CLIService/Shared/CommandEnvelope.swift
+++ b/supacode/CLIService/Shared/CommandEnvelope.swift
@@ -16,6 +16,7 @@ public struct CommandEnvelope: Codable, Sendable {
 public enum Command: Codable, Sendable {
   case open(OpenInput)
   case list(ListInput)
+  case agents(AgentsInput)
   case focus(FocusInput)
   case send(SendInput)
   case key(KeyInput)
@@ -27,6 +28,7 @@ public enum Command: Codable, Sendable {
     switch self {
     case .open: "open"
     case .list: "list"
+    case .agents: "agents"
     case .focus: "focus"
     case .send: "send"
     case .key: "key"

--- a/supacode/CLIService/Shared/ErrorCodes.swift
+++ b/supacode/CLIService/Shared/ErrorCodes.swift
@@ -20,6 +20,9 @@ public enum CLIErrorCode {
   // List
   public static let listFailed = "LIST_FAILED"
 
+  // Agents
+  public static let agentsFailed = "AGENTS_FAILED"
+
   // Focus
   public static let focusFailed = "FOCUS_FAILED"
 

--- a/supacode/CLIService/Shared/InputModels.swift
+++ b/supacode/CLIService/Shared/InputModels.swift
@@ -26,6 +26,10 @@ public struct ListInput: Codable, Sendable {
   public init() {}
 }
 
+public struct AgentsInput: Codable, Sendable {
+  public init() {}
+}
+
 public struct FocusInput: Codable, Sendable {
   public let selector: TargetSelector
 

--- a/supacodeTests/CLIAgentsCommandHandlerTests.swift
+++ b/supacodeTests/CLIAgentsCommandHandlerTests.swift
@@ -1,0 +1,227 @@
+import Foundation
+import IdentifiedCollections
+import Testing
+
+@testable import supacode
+
+@MainActor
+struct CLIAgentsCommandHandlerTests {
+
+  @Test func buildsAgentsPayloadFromActiveEntriesAndTerminalSnapshot() async throws {
+    let fixture = makePayloadFixture()
+    let handler = AgentsCommandHandler {
+      fixture.snapshot
+    }
+
+    let response = await handler.handle(
+      envelope: CommandEnvelope(output: .json, command: .agents(AgentsInput()))
+    )
+
+    #expect(response.ok)
+    #expect(response.command == "agents")
+    #expect(response.schemaVersion == "prowl.cli.agents.v1")
+
+    let payload = try #require(try response.data?.decode(as: AgentsCommandPayload.self))
+    #expect(payload.count == 2)
+    #expect(payload.agents.map(\.id) == [fixture.tabPaneID.uuidString, fixture.otherPaneID.uuidString])
+
+    let agent = payload.agents[0]
+    #expect(agent.type == "pi")
+    #expect(agent.name == "omp")
+    #expect(agent.status == .blocked)
+    #expect(agent.rawState == "blocked")
+    #expect(agent.lastChangedAt == "2026-09-21T14:00:00Z")
+    #expect(agent.project.name == "Prowl")
+    #expect(agent.project.branch == "feature/agents")
+    #expect(agent.project.path == "/tmp/project-repo")
+    #expect(agent.worktree.id == fixture.tabWorktree.id)
+    #expect(agent.worktree.name == "main")
+    #expect(agent.worktree.path == "/tmp/tab-repo")
+    #expect(agent.tab.id == fixture.tabID.uuidString)
+    #expect(agent.tab.title == "issue 330")
+    #expect(agent.tab.selected)
+    #expect(agent.pane.id == fixture.tabPaneID.uuidString)
+    #expect(agent.pane.index == 2)
+    #expect(agent.pane.title == "omp")
+    #expect(agent.pane.cwd == "/tmp/project-repo/Sources")
+    #expect(agent.pane.focused)
+
+    let idleAgent = payload.agents[1]
+    #expect(idleAgent.status == .idle)
+    #expect(idleAgent.project.name == "Tab Repo")
+    #expect(idleAgent.project.branch == "main")
+    #expect(idleAgent.pane.focused == false)
+  }
+
+  @Test func returnsAgentsFailedWhenSnapshotProviderThrows() async {
+    struct DummyError: Error {}
+
+    let handler = AgentsCommandHandler {
+      throw DummyError()
+    }
+
+    let response = await handler.handle(
+      envelope: CommandEnvelope(output: .json, command: .agents(AgentsInput()))
+    )
+
+    #expect(response.ok == false)
+    #expect(response.command == "agents")
+    #expect(response.schemaVersion == "prowl.cli.agents.v1")
+    #expect(response.error?.code == CLIErrorCode.agentsFailed)
+  }
+
+  private func makeWorktree(repoRoot: String, path: String, branch: String) -> Worktree {
+    Worktree(
+      id: path,
+      name: branch,
+      detail: branch,
+      workingDirectory: URL(fileURLWithPath: path),
+      repositoryRootURL: URL(fileURLWithPath: repoRoot)
+    )
+  }
+
+  private func makeRepository(
+    id: String,
+    name: String,
+    kind: Repository.Kind = .git,
+    worktrees: IdentifiedArrayOf<Worktree>
+  ) -> Repository {
+    Repository(
+      id: id,
+      rootURL: URL(fileURLWithPath: id),
+      name: name,
+      kind: kind,
+      worktrees: worktrees
+    )
+  }
+
+  private func makePayloadFixture() -> PayloadFixture {
+    let tabPaneID = UUID(uuidString: "6E1A2A10-D99F-4E3F-920C-D93AA3C05764")!
+    let otherPaneID = UUID(uuidString: "EF65FF31-1B72-40B2-80DA-3AA87B7B6858")!
+    let tabID = UUID(uuidString: "2FC00CF0-3974-4E1B-BEF8-7A08A8E3B7C0")!
+    let tabWorktree = makeWorktree(repoRoot: "/tmp/tab-repo", path: "/tmp/tab-repo", branch: "main")
+    let projectWorktree = makeWorktree(
+      repoRoot: "/tmp/project-repo", path: "/tmp/project-repo", branch: "feature/agents")
+    let tabRepo = makeRepository(id: "/tmp/tab-repo", name: "Tab Repo", worktrees: [tabWorktree])
+    let projectRepo = makeRepository(id: "/tmp/project-repo", name: "Project Repo", worktrees: [projectWorktree])
+    var repositoriesState = RepositoriesFeature.State()
+    repositoriesState.repositories = [tabRepo, projectRepo]
+    repositoriesState.repositoryCustomTitles = [projectRepo.id: "Prowl"]
+    repositoriesState.activeAgents.entries = [
+      makeAgentEntry(
+        AgentEntryInput(
+          paneID: tabPaneID,
+          tabID: tabID,
+          worktree: tabWorktree,
+          workingDirectory: URL(fileURLWithPath: "/tmp/project-repo/Sources"),
+          paneIndex: 2,
+          iconLookupToken: "omp",
+          agent: .pi,
+          rawState: .blocked,
+          displayState: .blocked,
+          lastChangedAt: Date(timeIntervalSince1970: 1_789_999_200)
+        )),
+      makeAgentEntry(
+        AgentEntryInput(
+          paneID: otherPaneID,
+          tabID: tabID,
+          worktree: tabWorktree,
+          workingDirectory: nil,
+          paneIndex: 1,
+          iconLookupToken: DetectedAgent.codex.iconLookupToken,
+          agent: .codex,
+          rawState: .idle,
+          displayState: .idle,
+          lastChangedAt: Date(timeIntervalSince1970: 1_789_999_260)
+        )),
+    ]
+
+    return PayloadFixture(
+      tabPaneID: tabPaneID,
+      otherPaneID: otherPaneID,
+      tabID: tabID,
+      tabWorktree: tabWorktree,
+      snapshot: AgentsRuntimeSnapshot(
+        repositoriesState: repositoriesState,
+        listSnapshot: makeListSnapshot(
+          tabPaneID: tabPaneID,
+          otherPaneID: otherPaneID,
+          tabID: tabID,
+          tabWorktree: tabWorktree
+        )
+      )
+    )
+  }
+
+  private func makeAgentEntry(_ input: AgentEntryInput) -> ActiveAgentEntry {
+    ActiveAgentEntry(
+      id: input.paneID,
+      worktreeID: input.worktree.id,
+      worktreeName: input.worktree.name,
+      workingDirectory: input.workingDirectory,
+      tabID: TerminalTabID(rawValue: input.tabID),
+      tabTitle: "issue 330",
+      surfaceID: input.paneID,
+      paneIndex: input.paneIndex,
+      iconLookupToken: input.iconLookupToken,
+      agent: input.agent,
+      rawState: input.rawState,
+      displayState: input.displayState,
+      lastChangedAt: input.lastChangedAt
+    )
+  }
+
+  private func makeListSnapshot(
+    tabPaneID: UUID,
+    otherPaneID: UUID,
+    tabID: UUID,
+    tabWorktree: Worktree
+  ) -> ListRuntimeSnapshot {
+    ListRuntimeSnapshot(
+      worktrees: [
+        .init(
+          id: tabWorktree.id,
+          name: tabWorktree.name,
+          path: tabWorktree.workingDirectory.path(percentEncoded: false),
+          rootPath: tabWorktree.repositoryRootURL.path(percentEncoded: false),
+          kind: .git,
+          taskStatus: .running,
+          tabs: [
+            .init(
+              id: tabID,
+              title: "issue 330",
+              selected: true,
+              focusedPaneID: tabPaneID,
+              panes: [
+                .init(id: otherPaneID, title: "zsh", cwd: "/tmp/tab-repo"),
+                .init(id: tabPaneID, title: "omp", cwd: "/tmp/project-repo/Sources"),
+              ]
+            )
+          ]
+        )
+      ],
+      focusedWorktreeID: tabWorktree.id
+    )
+  }
+
+  private struct PayloadFixture {
+    let tabPaneID: UUID
+    let otherPaneID: UUID
+    let tabID: UUID
+    let tabWorktree: Worktree
+    let snapshot: AgentsRuntimeSnapshot
+  }
+
+  private struct AgentEntryInput {
+    let paneID: UUID
+    let tabID: UUID
+    let worktree: Worktree
+    let workingDirectory: URL?
+    let paneIndex: Int
+    let iconLookupToken: String
+    let agent: DetectedAgent
+    let rawState: AgentRawState
+    let displayState: AgentDisplayState
+    let lastChangedAt: Date
+  }
+}

--- a/supacodeTests/CLICommandEnvelopeTests.swift
+++ b/supacodeTests/CLICommandEnvelopeTests.swift
@@ -56,6 +56,21 @@ struct CLICommandEnvelopeTests {
     }
   }
 
+  @Test func envelopeAgentsRoundTrips() throws {
+    let envelope = CommandEnvelope(
+      output: .json,
+      command: .agents(AgentsInput())
+    )
+    let data = try JSONEncoder().encode(envelope)
+    let decoded = try JSONDecoder().decode(CommandEnvelope.self, from: data)
+    #expect(decoded.output == .json)
+    if case .agents = decoded.command {
+      // expected
+    } else {
+      Issue.record("Expected .agents command")
+    }
+  }
+
   @Test func envelopeSendWithSelectorRoundTrips() throws {
     let envelope = CommandEnvelope(
       output: .json,
@@ -231,6 +246,7 @@ struct CLICommandEnvelopeTests {
     let commands: [(Command, String)] = [
       (.open(OpenInput(path: nil)), "open"),
       (.list(ListInput()), "list"),
+      (.agents(AgentsInput()), "agents"),
       (.focus(FocusInput()), "focus"),
       (.send(SendInput(text: "x")), "send"),
       (.key(KeyInput(rawToken: "tab", token: "tab")), "key"),
@@ -249,6 +265,7 @@ struct CLICommandEnvelopeTests {
     let commands: [Command] = [
       .open(OpenInput(path: "/tmp")),
       .list(ListInput()),
+      .agents(AgentsInput()),
       .focus(FocusInput()),
       .send(SendInput(text: "test")),
       .key(KeyInput(rawToken: "enter", token: "enter")),

--- a/supacodeTests/CLICommandRouterTests.swift
+++ b/supacodeTests/CLICommandRouterTests.swift
@@ -56,6 +56,18 @@ struct CLICommandRouterTests {
   }
 
   @MainActor
+  @Test func routerDispatchesAgentsToAgentsHandler() async {
+    let router = CLICommandRouter()
+    let envelope = CommandEnvelope(
+      output: .json,
+      command: .agents(AgentsInput())
+    )
+    let response = await router.route(envelope)
+    #expect(response.command == "agents")
+    #expect(response.error?.code == "NOT_IMPLEMENTED")
+  }
+
+  @MainActor
   @Test func routerDispatchesKeyToKeyHandler() async {
     let router = CLICommandRouter()
     let envelope = CommandEnvelope(
@@ -124,6 +136,7 @@ struct CLICommandRouterTests {
     let commands: [Command] = [
       .open(OpenInput()),
       .list(ListInput()),
+      .agents(AgentsInput()),
       .focus(FocusInput()),
       .send(SendInput(text: "x")),
       .key(KeyInput(rawToken: "tab", token: "tab")),

--- a/supacodeTests/SupacodeAppCLITests.swift
+++ b/supacodeTests/SupacodeAppCLITests.swift
@@ -7,13 +7,16 @@ import Testing
 
 @MainActor
 struct SupacodeAppCLITests {
-  @Test func cliRouterWiresKeyAndReadHandlersInsteadOfStubHandlers() async {
+  @Test func cliRouterWiresAgentsKeyAndReadHandlersInsteadOfStubHandlers() async {
     let store = Store(initialState: AppFeature.State()) {
       AppFeature()
     }
     let terminalManager = WorktreeTerminalManager(runtime: GhosttyRuntime())
     let router = SupacodeApp.makeCLICommandRouter(appStore: store, terminalManager: terminalManager)
 
+    let agentsResponse = await router.route(
+      CommandEnvelope(output: .json, command: .agents(AgentsInput()))
+    )
     let keyResponse = await router.route(
       CommandEnvelope(output: .json, command: .key(KeyInput(rawToken: "enter", token: "enter")))
     )
@@ -21,8 +24,10 @@ struct SupacodeAppCLITests {
       CommandEnvelope(output: .json, command: .read(ReadInput()))
     )
 
+    #expect(agentsResponse.command == "agents")
     #expect(keyResponse.command == "key")
     #expect(readResponse.command == "read")
+    #expect(agentsResponse.error?.code != "NOT_IMPLEMENTED")
     #expect(keyResponse.error?.code != "NOT_IMPLEMENTED")
     #expect(readResponse.error?.code != "NOT_IMPLEMENTED")
   }


### PR DESCRIPTION
## Summary
- Add the read-only `prowl agents` / `prowl agents --json` command for the Active Agents roster.
- Return per-pane agent status with project, owning worktree, tab, and pane metadata.
- Add text rendering, CLI parser wiring, app-side handler wiring, tests, docs, and prowl-cli skill guidance.

Fixes #330

## Tests
- xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -only-testing:supacodeTests/CLICommandEnvelopeTests -only-testing:supacodeTests/CLICommandRouterTests -only-testing:supacodeTests/CLIAgentsCommandHandlerTests -only-testing:supacodeTests/SupacodeAppCLITests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation
- make check
- make build-cli
- make test-cli-smoke
- make test-cli-integration
- make build-app

## Manual validation
- Ran a Debug app instance with a custom `PROWL_CLI_SOCKET` and verified `prowl open`, `prowl tab create`, `prowl send`, `prowl agents`, `prowl read`, and `prowl tab close` against that instance.
- Verified `prowl agents --json` reports a live Codex pane as `working`, then retains it as `idle`, and that the returned `pane.id` works with `prowl read --pane`.
- Confirmed default multi-instance behavior: only the app owning the standard socket receives default CLI commands; a manually launched dev instance needs a matching `PROWL_CLI_SOCKET` for app and CLI.
