### PR TITLE
Add configurable external diff tools

### DIFF
--- a/docs/components/diff-view.md
+++ b/docs/components/diff-view.md
@@ -30,6 +30,8 @@ General → Diff Tool, you can choose an external tool instead:
   command in the worktree directory. Supported placeholders:
   `{leftPath}`, `{rightPath}`, `{worktreePath}`, `{repoPath}`, and `{branch}`.
 
+Tools that are not installed on the Mac are shown disabled in the Diff Tool menu.
+
 ## What the built-in window shows
 
 - A **file list** sidebar of changed files, each with a colored status badge:

--- a/docs/components/diff-view.md
+++ b/docs/components/diff-view.md
@@ -9,15 +9,28 @@
 
 ## What it is
 
-The Diff window shows all changes in the selected worktree's working directory
-compared against **HEAD** — exactly what an agent has modified. It's a fast way to
-review before committing or merging.
+The default Diff window shows all changes in the selected worktree's working
+directory compared against **HEAD** — exactly what an agent has modified. It's a
+fast way to review before committing or merging.
 
-**Open:** `⌘⇧Y` (`show_diff`), or Command Palette → "Show Diff". The window is a
-persistent singleton (remembers size/position) and auto-refreshes when it regains
-focus. `⌘W` closes it.
+**Open:** click a worktree's diff badge, press `⌘⇧Y` (`show_diff`), or use
+Command Palette → "Show Diff".
 
-## What it shows
+By default Prowl opens its built-in YiTong-based diff window. In Settings →
+General → Diff Tool, you can choose an external tool instead:
+
+- **Built-in** — opens Prowl's diff window. The window is a persistent singleton
+  (remembers size/position) and auto-refreshes when it regains focus. `⌘W`
+  closes it.
+- **Hunk** — opens a new Prowl terminal tab and runs `hunk diff` in the worktree.
+- **FileMerge** — creates HEAD/worktree snapshot folders and runs `opendiff`.
+- **Kaleidoscope** — creates HEAD/worktree snapshot folders and runs
+  `ksdiff --diff`.
+- **Custom Command** — creates HEAD/worktree snapshot folders and runs your
+  command in the worktree directory. Supported placeholders:
+  `{leftPath}`, `{rightPath}`, `{worktreePath}`, `{repoPath}`, and `{branch}`.
+
+## What the built-in window shows
 
 - A **file list** sidebar of changed files, each with a colored status badge:
   - **M** Modified (orange) · **A** Added/untracked (green) · **D** Deleted (red) ·
@@ -47,5 +60,8 @@ Diff is a **git-only** feature — it's unavailable for plain (non-git) folders.
 
 - The diff is **working-tree vs HEAD**, not vs the base branch — it reflects
   uncommitted changes in that worktree.
+- External GUI tools receive snapshot folders so untracked files are included
+  without changing the git index.
+- The Hunk integration runs in a terminal tab because Hunk is terminal-native.
 - For changes already in a pull request (vs the base branch, with CI), see
   [github-pull-requests](github-pull-requests.md).

--- a/docs/components/settings.md
+++ b/docs/components/settings.md
@@ -16,7 +16,7 @@ window is a sidebar of tabs plus a detail pane.
 
 | Tab | Controls |
 |-----|----------|
-| **General** | Appearance (system/light/dark), default app for opening worktrees, confirm-before-quit, default view mode, window chrome tint, toolbar buttons (Run / Open-in-editor), dim unfocused splits, Active Agents panel auto-show & tab titles. |
+| **General** | Appearance (system/light/dark), default app for opening worktrees, diff tool, confirm-before-quit, default view mode, window chrome tint, toolbar buttons (Run / Open-in-editor), dim unfocused splits, Active Agents panel auto-show & tab titles. |
 | **Notifications** | In-app alerts, sound, macOS system notifications, move-notified-to-top, command-finished notification + threshold, Dock badge & bounce. → [notifications](notifications.md) |
 | **Shortcuts** | Remap app keyboard shortcuts; view defaults; resolve conflicts. → [keyboard-shortcuts](../reference/keyboard-shortcuts.md) |
 | **Worktree** | Worktree creation/deletion defaults: prompt on create, fetch before create, base directory, copy ignored/untracked files, delete-branch-on-delete, merged-worktree action, archived auto-delete period. |

--- a/docs/reference/settings-fields.md
+++ b/docs/reference/settings-fields.md
@@ -63,6 +63,8 @@ JSON is pretty-printed with sorted keys. Legacy `~/.supacode` is migrated to
 | `showNotificationDotOnDock` | Bool | `false` | Numeric unread badge on the Dock icon. |
 | `shelfSpineTintFallback` | enum (`neutral`/`systemTint`) | `neutral` | Shelf spine color when a repo has no color. |
 | `shelfSpineTintFollowsRepositoryColor` | Bool | `true` | Tint shelf spines by repo color. |
+| `externalDiffToolID` | String | `built-in` | Tool used by diff badges and Show Diff: `built-in`, `hunk`, `filemerge`, `kaleidoscope`, or `custom`. |
+| `externalDiffCustomCommand` | String | `""` | Command template for `externalDiffToolID = custom`; supports `{leftPath}`, `{rightPath}`, `{worktreePath}`, `{repoPath}`, and `{branch}`. |
 
 ## Per-repository settings (`RepositorySettings`)
 

--- a/supacode/Clients/ExternalDiff/ExternalDiffSnapshotClient.swift
+++ b/supacode/Clients/ExternalDiff/ExternalDiffSnapshotClient.swift
@@ -1,0 +1,125 @@
+import ComposableArchitecture
+import Foundation
+
+nonisolated struct ExternalDiffSnapshotPair: Equatable, Sendable {
+  let leftURL: URL
+  let rightURL: URL
+}
+
+nonisolated struct ExternalDiffSnapshotClient: Sendable {
+  var makeSnapshotPair: @Sendable (Worktree) async throws -> ExternalDiffSnapshotPair
+}
+
+extension ExternalDiffSnapshotClient: DependencyKey {
+  static let liveValue = ExternalDiffSnapshotClient { worktree in
+    try await ExternalDiffSnapshotBuilder().makeSnapshotPair(for: worktree)
+  }
+
+  static let testValue = ExternalDiffSnapshotClient { _ in
+    ExternalDiffSnapshotPair(
+      leftURL: URL(fileURLWithPath: "/tmp/prowl-diff-left"),
+      rightURL: URL(fileURLWithPath: "/tmp/prowl-diff-right")
+    )
+  }
+}
+
+extension DependencyValues {
+  var externalDiffSnapshotClient: ExternalDiffSnapshotClient {
+    get { self[ExternalDiffSnapshotClient.self] }
+    set { self[ExternalDiffSnapshotClient.self] = newValue }
+  }
+}
+
+private nonisolated struct ExternalDiffSnapshotBuilder {
+  func makeSnapshotPair(for worktree: Worktree) async throws -> ExternalDiffSnapshotPair {
+    let gitClient = GitClient()
+    async let trackedOutput = gitClient.diffNameStatus(at: worktree.workingDirectory)
+    async let untrackedPaths = gitClient.untrackedFilePaths(at: worktree.workingDirectory)
+    let trackedFiles = DiffChangedFile.parseNameStatus(await trackedOutput)
+    let untrackedFiles = await untrackedPaths.map {
+      DiffChangedFile(status: .added, oldPath: nil, newPath: $0)
+    }
+    let files = trackedFiles + untrackedFiles
+
+    return try await Task.detached {
+      let rootURL = FileManager.default.temporaryDirectory
+        .appending(path: "ProwlDiffSnapshots")
+        .appending(path: UUID().uuidString)
+      let leftURL = rootURL.appending(path: "HEAD")
+      let rightURL = rootURL.appending(path: "Worktree")
+      try FileManager.default.createDirectory(at: leftURL, withIntermediateDirectories: true)
+      try FileManager.default.createDirectory(at: rightURL, withIntermediateDirectories: true)
+
+      for file in files {
+        try copySnapshotFile(file, from: worktree.workingDirectory, leftURL: leftURL, rightURL: rightURL)
+      }
+
+      return ExternalDiffSnapshotPair(leftURL: leftURL, rightURL: rightURL)
+    }.value
+  }
+
+  private func copySnapshotFile(
+    _ file: DiffChangedFile,
+    from worktreeURL: URL,
+    leftURL: URL,
+    rightURL: URL
+  ) throws {
+    if let oldPath = file.oldPath {
+      try writeHeadFile(oldPath, worktreeURL: worktreeURL, destinationRoot: leftURL)
+    }
+    if let newPath = file.newPath {
+      let sourceURL = worktreeURL.appending(path: newPath)
+      guard FileManager.default.fileExists(atPath: sourceURL.path(percentEncoded: false)) else {
+        return
+      }
+      let destinationURL = rightURL.appending(path: newPath)
+      try createParentDirectory(for: destinationURL)
+      if FileManager.default.fileExists(atPath: destinationURL.path(percentEncoded: false)) {
+        try FileManager.default.removeItem(at: destinationURL)
+      }
+      try FileManager.default.copyItem(at: sourceURL, to: destinationURL)
+    }
+  }
+
+  private func writeHeadFile(
+    _ relativePath: String,
+    worktreeURL: URL,
+    destinationRoot: URL
+  ) throws {
+    let destinationURL = destinationRoot.appending(path: relativePath)
+    try createParentDirectory(for: destinationURL)
+    if FileManager.default.fileExists(atPath: destinationURL.path(percentEncoded: false)) {
+      try FileManager.default.removeItem(at: destinationURL)
+    }
+    FileManager.default.createFile(atPath: destinationURL.path(percentEncoded: false), contents: nil)
+    let outputHandle = try FileHandle(forWritingTo: destinationURL)
+    defer { try? outputHandle.close() }
+
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+    process.arguments = [
+      "-C",
+      worktreeURL.path(percentEncoded: false),
+      "show",
+      "HEAD:\(relativePath)",
+    ]
+    process.standardOutput = outputHandle
+    process.standardError = Pipe()
+    try process.run()
+    process.waitUntilExit()
+    if process.terminationStatus != 0 {
+      throw ExternalDiffSnapshotError.gitShowFailed(relativePath)
+    }
+  }
+
+  private func createParentDirectory(for fileURL: URL) throws {
+    try FileManager.default.createDirectory(
+      at: fileURL.deletingLastPathComponent(),
+      withIntermediateDirectories: true
+    )
+  }
+}
+
+private nonisolated enum ExternalDiffSnapshotError: Error {
+  case gitShowFailed(String)
+}

--- a/supacode/Clients/ExternalDiff/ExternalDiffToolClient.swift
+++ b/supacode/Clients/ExternalDiff/ExternalDiffToolClient.swift
@@ -1,0 +1,150 @@
+import ComposableArchitecture
+import Foundation
+
+nonisolated struct ExternalDiffToolClient: Sendable {
+  var open:
+    @MainActor @Sendable (
+      _ settings: ExternalDiffSettings,
+      _ worktree: Worktree,
+      _ resolvedKeybindings: ResolvedKeybindingMap,
+      _ onError: @escaping @MainActor @Sendable (OpenActionError) -> Void
+    ) async -> Void
+}
+
+extension ExternalDiffToolClient: DependencyKey {
+  static let liveValue = ExternalDiffToolClient { settings, worktree, resolvedKeybindings, onError in
+    @Dependency(TerminalClient.self) var terminalClient
+    @Dependency(ShellClient.self) var shellClient
+    @Dependency(ExternalDiffSnapshotClient.self) var snapshotClient
+
+    switch settings.tool {
+    case .builtIn:
+      DiffWindowManager.shared.show(
+        worktreeURL: worktree.workingDirectory,
+        branchName: worktree.name,
+        resolvedKeybindings: resolvedKeybindings
+      )
+
+    case .hunk:
+      await terminalClient.send(
+        .createTabWithInput(
+          worktree,
+          input: "hunk diff",
+          runSetupScriptIfNew: false,
+          autoCloseOnSuccess: false,
+          customCommandName: "Hunk Diff",
+          customCommandIcon: "square.split.2x1"
+        )
+      )
+
+    case .fileMerge:
+      await runGUICommand(
+        ExternalDiffGUICommandRequest(tool: settings.tool, executableName: "opendiff", arguments: []),
+        worktree: worktree,
+        shellClient: shellClient,
+        snapshotClient: snapshotClient,
+        onError: onError
+      )
+
+    case .kaleidoscope:
+      await runGUICommand(
+        ExternalDiffGUICommandRequest(tool: settings.tool, executableName: "ksdiff", arguments: ["--diff"]),
+        worktree: worktree,
+        shellClient: shellClient,
+        snapshotClient: snapshotClient,
+        onError: onError
+      )
+
+    case .custom:
+      await runCustomCommand(
+        settings: settings,
+        worktree: worktree,
+        shellClient: shellClient,
+        snapshotClient: snapshotClient,
+        onError: onError
+      )
+    }
+  }
+
+  static let testValue = ExternalDiffToolClient { _, _, _, _ in }
+}
+
+extension DependencyValues {
+  var externalDiffToolClient: ExternalDiffToolClient {
+    get { self[ExternalDiffToolClient.self] }
+    set { self[ExternalDiffToolClient.self] = newValue }
+  }
+}
+
+private struct ExternalDiffGUICommandRequest {
+  let tool: ExternalDiffTool
+  let executableName: String
+  let arguments: [String]
+}
+
+private func runGUICommand(
+  _ request: ExternalDiffGUICommandRequest,
+  worktree: Worktree,
+  shellClient: ShellClient,
+  snapshotClient: ExternalDiffSnapshotClient,
+  onError: @escaping @MainActor @Sendable (OpenActionError) -> Void
+) async {
+  do {
+    let snapshot = try await snapshotClient.makeSnapshotPair(worktree)
+    let executableURL = URL(fileURLWithPath: "/usr/bin/env")
+    _ = try await shellClient.runLogin(
+      executableURL,
+      [request.executableName] + request.arguments + [
+        snapshot.leftURL.path(percentEncoded: false),
+        snapshot.rightURL.path(percentEncoded: false),
+      ],
+      worktree.workingDirectory
+    )
+  } catch {
+    onError(openError(for: request.tool, error: error))
+  }
+}
+
+private func runCustomCommand(
+  settings: ExternalDiffSettings,
+  worktree: Worktree,
+  shellClient: ShellClient,
+  snapshotClient: ExternalDiffSnapshotClient,
+  onError: @escaping @MainActor @Sendable (OpenActionError) -> Void
+) async {
+  let template = settings.customCommand.trimmingCharacters(in: .whitespacesAndNewlines)
+  guard !template.isEmpty else {
+    onError(
+      OpenActionError(
+        title: "Custom diff command is empty",
+        message: "Add a custom diff command in Settings before opening the diff."
+      )
+    )
+    return
+  }
+  do {
+    let snapshot = try await snapshotClient.makeSnapshotPair(worktree)
+    let context = ExternalDiffCommandContext(
+      worktreePath: worktree.workingDirectory.path(percentEncoded: false),
+      repoPath: worktree.repositoryRootURL.path(percentEncoded: false),
+      branch: worktree.name,
+      leftPath: snapshot.leftURL.path(percentEncoded: false),
+      rightPath: snapshot.rightURL.path(percentEncoded: false)
+    )
+    let command = ExternalDiffCommandTemplate.render(template, context: context)
+    _ = try await shellClient.runLogin(
+      URL(fileURLWithPath: "/bin/zsh"),
+      ["-lc", command],
+      worktree.workingDirectory
+    )
+  } catch {
+    onError(openError(for: settings.tool, error: error))
+  }
+}
+
+private func openError(for tool: ExternalDiffTool, error: Error) -> OpenActionError {
+  OpenActionError(
+    title: "Unable to open diff in \(tool.title)",
+    message: error.localizedDescription
+  )
+}

--- a/supacode/Commands/SidebarCommands.swift
+++ b/supacode/Commands/SidebarCommands.swift
@@ -72,15 +72,7 @@ struct SidebarCommands: Commands {
       .help(helpText(title: "Select Previous Book", commandID: AppShortcuts.CommandID.selectPreviousShelfBook))
       shelfBookMenuButtons
       Button("Show Diff", systemImage: "plusminus.circle") {
-        let repos = store.repositories
-        guard let worktreeID = repos.selectedWorktreeID,
-          let worktree = repos.worktree(for: worktreeID)
-        else { return }
-        DiffWindowManager.shared.show(
-          worktreeURL: worktree.workingDirectory,
-          branchName: worktree.name,
-          resolvedKeybindings: store.resolvedKeybindings
-        )
+        store.send(.showSelectedWorktreeDiff)
       }
       .modifier(KeyboardShortcutModifier(shortcut: keyboardShortcut(for: AppShortcuts.CommandID.showDiff)))
       .help(helpText(title: "Show Diff", commandID: AppShortcuts.CommandID.showDiff))

--- a/supacode/Domain/ExternalDiffTool.swift
+++ b/supacode/Domain/ExternalDiffTool.swift
@@ -1,0 +1,146 @@
+import Foundation
+
+nonisolated enum ExternalDiffLaunchMode: Equatable, Sendable {
+  case builtIn
+  case terminal
+  case gui
+}
+
+nonisolated enum ExternalDiffTool: String, CaseIterable, Identifiable, Codable, Sendable {
+  case builtIn = "built-in"
+  case hunk
+  case fileMerge = "filemerge"
+  case kaleidoscope
+  case custom
+
+  var id: String { settingsID }
+
+  var settingsID: String { rawValue }
+
+  var title: String {
+    switch self {
+    case .builtIn: "Built-in"
+    case .hunk: "Hunk"
+    case .fileMerge: "FileMerge"
+    case .kaleidoscope: "Kaleidoscope"
+    case .custom: "Custom Command"
+    }
+  }
+
+  var launchMode: ExternalDiffLaunchMode {
+    switch self {
+    case .builtIn:
+      .builtIn
+    case .hunk:
+      .terminal
+    case .fileMerge, .kaleidoscope, .custom:
+      .gui
+    }
+  }
+
+  var defaultCommandName: String? {
+    switch self {
+    case .fileMerge:
+      "opendiff"
+    case .kaleidoscope:
+      "ksdiff"
+    case .hunk:
+      "hunk"
+    case .builtIn, .custom:
+      nil
+    }
+  }
+
+  var isInstalled: Bool {
+    switch self {
+    case .builtIn, .custom:
+      true
+    case .fileMerge:
+      ExternalDiffToolPathResolver.executableExists("opendiff")
+    case .kaleidoscope:
+      ExternalDiffToolPathResolver.executableExists("ksdiff")
+    case .hunk:
+      ExternalDiffToolPathResolver.executableExists("hunk")
+    }
+  }
+
+  static var menuOrder: [ExternalDiffTool] {
+    [.builtIn, .hunk, .fileMerge, .kaleidoscope, .custom]
+  }
+
+  static var availableCases: [ExternalDiffTool] {
+    menuOrder.filter(\.isInstalled)
+  }
+
+  static func fromSettingsID(_ settingsID: String?) -> ExternalDiffTool {
+    guard let settingsID,
+      let tool = Self(rawValue: settingsID),
+      tool.isInstalled
+    else {
+      return .builtIn
+    }
+    return tool
+  }
+
+  static func normalizedSettingsID(_ settingsID: String?) -> String {
+    fromSettingsID(settingsID).settingsID
+  }
+}
+
+nonisolated struct ExternalDiffSettings: Equatable, Sendable {
+  var toolID: String
+  var customCommand: String
+
+  var tool: ExternalDiffTool {
+    ExternalDiffTool.fromSettingsID(toolID)
+  }
+}
+
+nonisolated struct ExternalDiffCommandContext: Equatable, Sendable {
+  let worktreePath: String
+  let repoPath: String
+  let branch: String
+  let leftPath: String
+  let rightPath: String
+}
+
+nonisolated enum ExternalDiffCommandTemplate {
+  static func render(_ template: String, context: ExternalDiffCommandContext) -> String {
+    let replacements = [
+      "{worktreePath}": shellQuoted(context.worktreePath),
+      "{repoPath}": shellQuoted(context.repoPath),
+      "{branch}": shellQuoted(context.branch),
+      "{leftPath}": shellQuoted(context.leftPath),
+      "{rightPath}": shellQuoted(context.rightPath),
+    ]
+    return replacements.reduce(template) { partial, replacement in
+      partial.replacing(replacement.key, with: replacement.value)
+    }
+  }
+
+  static func shellQuoted(_ value: String) -> String {
+    "'\(value.replacing("'", with: "'\"'\"'"))'"
+  }
+}
+
+nonisolated enum ExternalDiffToolPathResolver {
+  static func executableExists(_ name: String) -> Bool {
+    executableURL(named: name) != nil
+  }
+
+  static func executableURL(named name: String) -> URL? {
+    for directory in executableSearchPaths {
+      let url = URL(fileURLWithPath: directory).appending(path: name)
+      if FileManager.default.isExecutableFile(atPath: url.path(percentEncoded: false)) {
+        return url
+      }
+    }
+    return nil
+  }
+
+  private static var executableSearchPaths: [String] {
+    let path = ProcessInfo.processInfo.environment["PATH"] ?? ""
+    let environmentPaths = path.split(separator: ":").map(String.init)
+    return environmentPaths + ["/opt/homebrew/bin", "/usr/local/bin", "/usr/bin", "/bin"]
+  }
+}

--- a/supacode/Domain/ExternalDiffTool.swift
+++ b/supacode/Domain/ExternalDiffTool.swift
@@ -72,6 +72,10 @@ nonisolated enum ExternalDiffTool: String, CaseIterable, Identifiable, Codable, 
     menuOrder.filter(\.isInstalled)
   }
 
+  static var settingsMenuCases: [ExternalDiffTool] {
+    menuOrder
+  }
+
   static func fromSettingsID(_ settingsID: String?) -> ExternalDiffTool {
     guard let settingsID,
       let tool = Self(rawValue: settingsID),

--- a/supacode/Domain/ExternalDiffTool.swift
+++ b/supacode/Domain/ExternalDiffTool.swift
@@ -92,7 +92,7 @@ nonisolated struct ExternalDiffSettings: Equatable, Sendable {
   var customCommand: String
 
   var tool: ExternalDiffTool {
-    ExternalDiffTool.fromSettingsID(toolID)
+    ExternalDiffTool(rawValue: toolID) ?? .builtIn
   }
 }
 

--- a/supacode/Features/App/Reducer/AppFeature+CommandPalette.swift
+++ b/supacode/Features/App/Reducer/AppFeature+CommandPalette.swift
@@ -142,12 +142,7 @@ extension AppFeature {
   ) -> Effect<Action>? {
     switch delegate {
     case .showDiff:
-      guard let worktreeID = state.repositories.selectedWorktreeID,
-        let worktree = state.repositories.worktree(for: worktreeID)
-      else {
-        return .none
-      }
-      return openDiffEffect(worktree: worktree, resolvedKeybindings: state.resolvedKeybindings)
+      return openSelectedWorktreeDiffEffect(state: state)
 
     case .revealInFinder:
       return .send(.openWorktree(.finder))
@@ -190,6 +185,15 @@ extension AppFeature {
         send(.openWorktreeFailed(error))
       }
     }
+  }
+
+  func openSelectedWorktreeDiffEffect(state: State) -> Effect<Action> {
+    guard let worktreeID = state.repositories.selectedWorktreeID,
+      let worktree = state.repositories.worktree(for: worktreeID)
+    else {
+      return .none
+    }
+    return openDiffEffect(worktree: worktree, resolvedKeybindings: state.resolvedKeybindings)
   }
 
   func reduceCommandPaletteWorktreeActionDelegate(

--- a/supacode/Features/App/Reducer/AppFeature+CommandPalette.swift
+++ b/supacode/Features/App/Reducer/AppFeature+CommandPalette.swift
@@ -147,16 +147,7 @@ extension AppFeature {
       else {
         return .none
       }
-      let keybindings = state.resolvedKeybindings
-      return .run { _ in
-        await MainActor.run {
-          DiffWindowManager.shared.show(
-            worktreeURL: worktree.workingDirectory,
-            branchName: worktree.name,
-            resolvedKeybindings: keybindings
-          )
-        }
-      }
+      return openDiffEffect(worktree: worktree, resolvedKeybindings: state.resolvedKeybindings)
 
     case .revealInFinder:
       return .send(.openWorktree(.finder))
@@ -182,6 +173,22 @@ extension AppFeature {
 
     default:
       return nil
+    }
+  }
+
+  func openDiffEffect(
+    worktree: Worktree,
+    resolvedKeybindings: ResolvedKeybindingMap
+  ) -> Effect<Action> {
+    @Shared(.settingsFile) var settingsFile
+    let settings = ExternalDiffSettings(
+      toolID: settingsFile.global.externalDiffToolID,
+      customCommand: settingsFile.global.externalDiffCustomCommand
+    )
+    return .run { send in
+      await externalDiffToolClient.open(settings, worktree, resolvedKeybindings) { error in
+        send(.openWorktreeFailed(error))
+      }
     }
   }
 

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -102,6 +102,7 @@ struct AppFeature {
   @Dependency(TerminalClient.self) var terminalClient
   @Dependency(WorktreeInfoWatcherClient.self) var worktreeInfoWatcher
   @Dependency(CustomShortcutRegistryClient.self) var customShortcutRegistryClient
+  @Dependency(ExternalDiffToolClient.self) var externalDiffToolClient
 
   var body: some Reducer<State, Action> {
     let core = Reduce<State, Action> { state, action in
@@ -345,6 +346,12 @@ struct AppFeature {
             await settingsWindowClient.show()
           }
         )
+
+      case .repositories(.delegate(.showDiff(let worktreeID))):
+        guard let worktree = state.repositories.worktree(for: worktreeID) else {
+          return .none
+        }
+        return openDiffEffect(worktree: worktree, resolvedKeybindings: state.resolvedKeybindings)
 
       case .settings(.setSelection(let selection)):
         let resolvedSelection = selection ?? .general

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -57,6 +57,7 @@ struct AppFeature {
     case worktreeSettingsLoaded(RepositorySettings, worktreeID: Worktree.ID)
     case worktreeUserSettingsLoaded(UserRepositorySettings, worktreeID: Worktree.ID)
     case openSelectedWorktree
+    case showSelectedWorktreeDiff
     case openWorktree(OpenWorktreeAction)
     case openWorktreeFailed(OpenActionError)
     case requestQuit
@@ -538,6 +539,9 @@ struct AppFeature {
 
       case .openSelectedWorktree:
         return .send(.openWorktree(OpenWorktreeAction.availableSelection(state.openActionSelection)))
+
+      case .showSelectedWorktreeDiff:
+        return openSelectedWorktreeDiffEffect(state: state)
 
       case .openWorktree(let action):
         guard let worktree = state.repositories.selectedTerminalWorktree else {

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -434,6 +434,7 @@ struct RepositoriesFeature {
     case selectedWorktreeChanged(Worktree?)
     case repositoriesChanged(IdentifiedArrayOf<Repository>)
     case openRepositorySettings(Repository.ID)
+    case showDiff(Worktree.ID)
     case worktreeCreated(Worktree)
   }
 

--- a/supacode/Features/Repositories/Views/WorktreeRowsView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeRowsView.swift
@@ -240,12 +240,7 @@ struct WorktreeRowsView: View {
 
   private func diffTapHandler(for worktreeID: Worktree.ID) -> (() -> Void)? {
     {
-      guard let worktree = store.state.worktree(for: worktreeID) else { return }
-      DiffWindowManager.shared.show(
-        worktreeURL: worktree.workingDirectory,
-        branchName: worktree.name,
-        resolvedKeybindings: resolvedKeybindings
-      )
+      store.send(.delegate(.showDiff(worktreeID)))
     }
   }
 

--- a/supacode/Features/Settings/Models/GlobalSettings.swift
+++ b/supacode/Features/Settings/Models/GlobalSettings.swift
@@ -39,6 +39,8 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
   var showNotificationDotOnDock: Bool
   var shelfSpineTintFallback: ShelfSpineTintFallback
   var shelfSpineTintFollowsRepositoryColor: Bool
+  var externalDiffToolID: String = ExternalDiffTool.builtIn.settingsID
+  var externalDiffCustomCommand: String = ""
 
   static let `default` = GlobalSettings(
     appearanceMode: .dark,
@@ -209,6 +211,8 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     try container.encode(showNotificationDotOnDock, forKey: .showNotificationDotOnDock)
     try container.encode(shelfSpineTintFallback, forKey: .shelfSpineTintFallback)
     try container.encode(shelfSpineTintFollowsRepositoryColor, forKey: .shelfSpineTintFollowsRepositoryColor)
+    try container.encode(externalDiffToolID, forKey: .externalDiffToolID)
+    try container.encode(externalDiffCustomCommand, forKey: .externalDiffCustomCommand)
   }
 
   private enum CodingKeys: String, CodingKey {
@@ -252,6 +256,8 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     case showNotificationDotOnDock
     case shelfSpineTintFallback
     case shelfSpineTintFollowsRepositoryColor
+    case externalDiffToolID
+    case externalDiffCustomCommand
     // Legacy key for migration
     case automaticallyArchiveMergedWorktrees
   }
@@ -350,6 +356,7 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
       ?? Self.default.showActiveAgentStatusInShelf
     (windowTintMode, windowTintCustomColor) = try Self.decodeWindowTint(from: container)
     (shelfSpineTintFallback, shelfSpineTintFollowsRepositoryColor) = try Self.decodeShelfSpineTint(from: container)
+    (externalDiffToolID, externalDiffCustomCommand) = try Self.decodeExternalDiffSettings(from: container)
     let toolbarAndDock = try Self.decodeToolbarAndDockSettings(from: container)
     showRunButtonInToolbar = toolbarAndDock.showRunButtonInToolbar
     showDefaultEditorInToolbar = toolbarAndDock.showDefaultEditorInToolbar
@@ -379,6 +386,17 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
       try container.decodeIfPresent(Bool.self, forKey: .shelfSpineTintFollowsRepositoryColor)
       ?? Self.default.shelfSpineTintFollowsRepositoryColor
     return (fallback, followsRepositoryColor)
+  }
+
+  private static func decodeExternalDiffSettings(
+    from container: KeyedDecodingContainer<CodingKeys>
+  ) throws -> (String, String) {
+    let toolID =
+      ExternalDiffTool.normalizedSettingsID(try container.decodeIfPresent(String.self, forKey: .externalDiffToolID))
+    let customCommand =
+      try container.decodeIfPresent(String.self, forKey: .externalDiffCustomCommand)
+      ?? Self.default.externalDiffCustomCommand
+    return (toolID, customCommand)
   }
 
   private static func decodeMergedWorktreeAction(

--- a/supacode/Features/Settings/Reducer/SettingsFeature.swift
+++ b/supacode/Features/Settings/Reducer/SettingsFeature.swift
@@ -49,6 +49,8 @@ struct SettingsFeature {
     var showDefaultEditorInToolbar: Bool
     var dockBounceMode: DockBounceMode
     var showNotificationDotOnDock: Bool
+    var externalDiffToolID: String
+    var externalDiffCustomCommand: String
     var cliInstallStatus: CLIInstallStatus = .notInstalled
     var cliInstallShowAlert: Bool = true
     /// Whether macOS will render the Dock notification badge (notification
@@ -102,10 +104,12 @@ struct SettingsFeature {
       showDefaultEditorInToolbar = settings.showDefaultEditorInToolbar
       dockBounceMode = settings.dockBounceMode
       showNotificationDotOnDock = settings.showNotificationDotOnDock
+      externalDiffToolID = settings.externalDiffToolID
+      externalDiffCustomCommand = settings.externalDiffCustomCommand
     }
 
     var globalSettings: GlobalSettings {
-      GlobalSettings(
+      var settings = GlobalSettings(
         appearanceMode: appearanceMode,
         defaultEditorID: defaultEditorID,
         confirmBeforeQuit: confirmBeforeQuit,
@@ -149,6 +153,9 @@ struct SettingsFeature {
         shelfSpineTintFallback: shelfSpineTintFallback,
         shelfSpineTintFollowsRepositoryColor: shelfSpineTintFollowsRepositoryColor
       )
+      settings.externalDiffToolID = externalDiffToolID
+      settings.externalDiffCustomCommand = externalDiffCustomCommand
+      return settings
     }
   }
 
@@ -262,6 +269,8 @@ struct SettingsFeature {
         state.showDefaultEditorInToolbar = normalizedSettings.showDefaultEditorInToolbar
         state.dockBounceMode = normalizedSettings.dockBounceMode
         state.showNotificationDotOnDock = normalizedSettings.showNotificationDotOnDock
+        state.externalDiffToolID = normalizedSettings.externalDiffToolID
+        state.externalDiffCustomCommand = normalizedSettings.externalDiffCustomCommand
         state.syncGlobalDefaults(from: normalizedSettings)
         return .send(.delegate(.settingsChanged(normalizedSettings)))
 

--- a/supacode/Features/Settings/Views/AppearanceSettingsView.swift
+++ b/supacode/Features/Settings/Views/AppearanceSettingsView.swift
@@ -6,7 +6,7 @@ struct AppearanceSettingsView: View {
 
   var body: some View {
     let openActionOptions = OpenWorktreeAction.availableCases
-    let externalDiffToolOptions = ExternalDiffTool.availableCases
+    let externalDiffToolOptions = ExternalDiffTool.settingsMenuCases
     VStack(alignment: .leading) {
       Form {
         Section("Appearance") {
@@ -146,9 +146,13 @@ struct AppearanceSettingsView: View {
             ForEach(externalDiffToolOptions) { tool in
               Text(tool.title)
                 .tag(tool.settingsID)
+                .disabled(!tool.isInstalled)
             }
           }
           .help("Choose what opens when you click a diff badge or run Show Diff.")
+          Text("Tools not installed on this Mac appear disabled.")
+            .font(.callout)
+            .foregroundStyle(.secondary)
           if store.externalDiffToolID == ExternalDiffTool.custom.settingsID {
             TextField(
               "Command",

--- a/supacode/Features/Settings/Views/AppearanceSettingsView.swift
+++ b/supacode/Features/Settings/Views/AppearanceSettingsView.swift
@@ -6,6 +6,7 @@ struct AppearanceSettingsView: View {
 
   var body: some View {
     let openActionOptions = OpenWorktreeAction.availableCases
+    let externalDiffToolOptions = ExternalDiffTool.availableCases
     VStack(alignment: .leading) {
       Form {
         Section("Appearance") {
@@ -136,6 +137,30 @@ struct AppearanceSettingsView: View {
             "Applies to worktrees without repository overrides. "
               + "Automatic prefers an app matching the project type, e.g. Xcode for Swift projects."
           )
+        }
+        Section("Diff Tool") {
+          Picker(
+            "Open diff with",
+            selection: $store.externalDiffToolID
+          ) {
+            ForEach(externalDiffToolOptions) { tool in
+              Text(tool.title)
+                .tag(tool.settingsID)
+            }
+          }
+          .help("Choose what opens when you click a diff badge or run Show Diff.")
+          if store.externalDiffToolID == ExternalDiffTool.custom.settingsID {
+            TextField(
+              "Command",
+              text: $store.externalDiffCustomCommand,
+              prompt: Text("my-diff {leftPath} {rightPath}")
+            )
+            .textFieldStyle(.roundedBorder)
+            .help(
+              "Runs in the worktree directory. Supports {leftPath}, {rightPath}, "
+                + "{worktreePath}, {repoPath}, and {branch}."
+            )
+          }
         }
         Section("Run") {
           Toggle(

--- a/supacodeTests/AppFeatureCommandPaletteTests.swift
+++ b/supacodeTests/AppFeatureCommandPaletteTests.swift
@@ -808,7 +808,8 @@ struct AppFeatureCommandPaletteTests {
     repositoriesState.repositories = [repository]
     repositoriesState.selection = .worktree(worktree.id)
     var settings = GlobalSettings.default
-    settings.externalDiffToolID = ExternalDiffTool.hunk.settingsID
+    settings.externalDiffToolID = ExternalDiffTool.custom.settingsID
+    settings.externalDiffCustomCommand = "my-diff {leftPath} {rightPath}"
     let storage = SettingsTestStorage()
     let settingsFileURL = URL(
       fileURLWithPath: "/tmp/supacode-settings-\(UUID().uuidString).json"
@@ -838,7 +839,13 @@ struct AppFeatureCommandPaletteTests {
     await store.finish()
 
     #expect(
-      launched.value.map(\.0) == [ExternalDiffSettings(toolID: ExternalDiffTool.hunk.settingsID, customCommand: "")])
+      launched.value.map(\.0) == [
+        ExternalDiffSettings(
+          toolID: ExternalDiffTool.custom.settingsID,
+          customCommand: "my-diff {leftPath} {rightPath}"
+        )
+      ]
+    )
     #expect(launched.value.map(\.1) == [worktree])
   }
 

--- a/supacodeTests/AppFeatureCommandPaletteTests.swift
+++ b/supacodeTests/AppFeatureCommandPaletteTests.swift
@@ -849,6 +849,58 @@ struct AppFeatureCommandPaletteTests {
     #expect(launched.value.map(\.1) == [worktree])
   }
 
+  @Test(.dependencies) func showSelectedWorktreeDiffUsesConfiguredExternalDiffTool() async {
+    let worktree = makeWorktree(
+      id: "/tmp/repo-shortcut-diff/wt-1",
+      name: "wt-1",
+      repoRoot: "/tmp/repo-shortcut-diff"
+    )
+    let repository = makeRepository(id: "/tmp/repo-shortcut-diff", worktrees: [worktree])
+    var repositoriesState = RepositoriesFeature.State()
+    repositoriesState.repositories = [repository]
+    repositoriesState.selection = .worktree(worktree.id)
+    var settings = GlobalSettings.default
+    settings.externalDiffToolID = ExternalDiffTool.custom.settingsID
+    settings.externalDiffCustomCommand = "my-diff {leftPath} {rightPath}"
+    let storage = SettingsTestStorage()
+    let settingsFileURL = URL(
+      fileURLWithPath: "/tmp/supacode-settings-\(UUID().uuidString).json"
+    )
+    let launched = LockIsolated<[(ExternalDiffSettings, Worktree)]>([])
+    let store = withDependencies {
+      $0.settingsFileStorage = storage.storage
+      $0.settingsFileURL = settingsFileURL
+      $0.terminalClient.send = { _ in }
+      $0.externalDiffToolClient.open = { settings, worktree, _, _ in
+        launched.withValue { $0.append((settings, worktree)) }
+      }
+    } operation: {
+      @Shared(.settingsFile) var settingsFile
+      $settingsFile.withLock { $0.global = settings }
+      return TestStore(
+        initialState: AppFeature.State(
+          repositories: repositoriesState,
+          settings: SettingsFeature.State(settings: settings)
+        )
+      ) {
+        AppFeature()
+      }
+    }
+
+    await store.send(.showSelectedWorktreeDiff)
+    await store.finish()
+
+    #expect(
+      launched.value.map(\.0) == [
+        ExternalDiffSettings(
+          toolID: ExternalDiffTool.custom.settingsID,
+          customCommand: "my-diff {leftPath} {rightPath}"
+        )
+      ]
+    )
+    #expect(launched.value.map(\.1) == [worktree])
+  }
+
   @Test(.dependencies) func closePullRequestDispatchesAction() async {
     let store = TestStore(initialState: AppFeature.State()) {
       AppFeature()

--- a/supacodeTests/AppFeatureCommandPaletteTests.swift
+++ b/supacodeTests/AppFeatureCommandPaletteTests.swift
@@ -797,6 +797,51 @@ struct AppFeatureCommandPaletteTests {
     await store.receive(\.runCustomCommand)
   }
 
+  @Test(.dependencies) func showDiffDelegateUsesConfiguredExternalDiffTool() async {
+    let worktree = makeWorktree(
+      id: "/tmp/repo-diff/wt-1",
+      name: "wt-1",
+      repoRoot: "/tmp/repo-diff"
+    )
+    let repository = makeRepository(id: "/tmp/repo-diff", worktrees: [worktree])
+    var repositoriesState = RepositoriesFeature.State()
+    repositoriesState.repositories = [repository]
+    repositoriesState.selection = .worktree(worktree.id)
+    var settings = GlobalSettings.default
+    settings.externalDiffToolID = ExternalDiffTool.hunk.settingsID
+    let storage = SettingsTestStorage()
+    let settingsFileURL = URL(
+      fileURLWithPath: "/tmp/supacode-settings-\(UUID().uuidString).json"
+    )
+    let launched = LockIsolated<[(ExternalDiffSettings, Worktree)]>([])
+    let store = withDependencies {
+      $0.settingsFileStorage = storage.storage
+      $0.settingsFileURL = settingsFileURL
+      $0.terminalClient.send = { _ in }
+      $0.externalDiffToolClient.open = { settings, worktree, _, _ in
+        launched.withValue { $0.append((settings, worktree)) }
+      }
+    } operation: {
+      @Shared(.settingsFile) var settingsFile
+      $settingsFile.withLock { $0.global = settings }
+      return TestStore(
+        initialState: AppFeature.State(
+          repositories: repositoriesState,
+          settings: SettingsFeature.State(settings: settings)
+        )
+      ) {
+        AppFeature()
+      }
+    }
+
+    await store.send(.commandPalette(.delegate(.showDiff)))
+    await store.finish()
+
+    #expect(
+      launched.value.map(\.0) == [ExternalDiffSettings(toolID: ExternalDiffTool.hunk.settingsID, customCommand: "")])
+    #expect(launched.value.map(\.1) == [worktree])
+  }
+
   @Test(.dependencies) func closePullRequestDispatchesAction() async {
     let store = TestStore(initialState: AppFeature.State()) {
       AppFeature()

--- a/supacodeTests/ExternalDiffToolTests.swift
+++ b/supacodeTests/ExternalDiffToolTests.swift
@@ -19,6 +19,18 @@ struct ExternalDiffToolTests {
     #expect(ExternalDiffTool.custom.launchMode == .gui)
   }
 
+  @Test func settingsMenuListsAllSupportedTools() {
+    #expect(
+      ExternalDiffTool.settingsMenuCases == [
+        .builtIn,
+        .hunk,
+        .fileMerge,
+        .kaleidoscope,
+        .custom,
+      ]
+    )
+  }
+
   @Test func explicitSettingsResolveWithoutCheckingInstallation() {
     #expect(ExternalDiffSettings(toolID: ExternalDiffTool.hunk.settingsID, customCommand: "").tool == .hunk)
   }

--- a/supacodeTests/ExternalDiffToolTests.swift
+++ b/supacodeTests/ExternalDiffToolTests.swift
@@ -1,0 +1,164 @@
+import Dependencies
+import Foundation
+import Testing
+
+@testable import supacode
+
+@MainActor
+struct ExternalDiffToolTests {
+  @Test func defaultSettingsUseBuiltInDiffTool() {
+    #expect(GlobalSettings.default.externalDiffToolID == ExternalDiffTool.builtIn.settingsID)
+    #expect(GlobalSettings.default.externalDiffCustomCommand == "")
+  }
+
+  @Test func launchModesMatchSupportedTools() {
+    #expect(ExternalDiffTool.builtIn.launchMode == .builtIn)
+    #expect(ExternalDiffTool.hunk.launchMode == .terminal)
+    #expect(ExternalDiffTool.fileMerge.launchMode == .gui)
+    #expect(ExternalDiffTool.kaleidoscope.launchMode == .gui)
+    #expect(ExternalDiffTool.custom.launchMode == .gui)
+  }
+
+  @Test func commandTemplateReplacesPlaceholdersWithShellQuotedValues() {
+    let context = ExternalDiffCommandContext(
+      worktreePath: "/tmp/My Repo/work tree",
+      repoPath: "/tmp/My Repo",
+      branch: "feature/quote's",
+      leftPath: "/tmp/left snapshot",
+      rightPath: "/tmp/right snapshot"
+    )
+
+    let rendered = ExternalDiffCommandTemplate.render(
+      "tool {leftPath} {rightPath} --repo {repoPath} --branch {branch} --worktree {worktreePath}",
+      context: context
+    )
+
+    let expected =
+      "tool '/tmp/left snapshot' '/tmp/right snapshot' --repo '/tmp/My Repo' "
+      + "--branch 'feature/quote'\"'\"'s' --worktree '/tmp/My Repo/work tree'"
+    #expect(rendered == expected)
+  }
+
+  @Test func hunkLaunchesInTerminalTab() async {
+    let sentCommands = LockIsolated<[TerminalClient.Command]>([])
+    let worktree = Worktree(
+      id: "/tmp/repo",
+      name: "feature",
+      detail: "feature",
+      workingDirectory: URL(fileURLWithPath: "/tmp/repo"),
+      repositoryRootURL: URL(fileURLWithPath: "/tmp/repo")
+    )
+
+    await withDependencies {
+      $0.terminalClient.send = { command in
+        sentCommands.withValue { $0.append(command) }
+      }
+    } operation: {
+      await ExternalDiffToolClient.liveValue.open(
+        ExternalDiffSettings(toolID: ExternalDiffTool.hunk.settingsID, customCommand: ""),
+        worktree,
+        .appDefaults
+      ) { _ in }
+    }
+
+    #expect(
+      sentCommands.value == [
+        .createTabWithInput(
+          worktree,
+          input: "hunk diff",
+          runSetupScriptIfNew: false,
+          autoCloseOnSuccess: false,
+          customCommandName: "Hunk Diff",
+          customCommandIcon: "square.split.2x1"
+        )
+      ]
+    )
+  }
+
+  @Test func customCommandRunsRenderedShellCommandInWorktree() async throws {
+    let runs = LockIsolated<[ShellRun]>([])
+    let worktree = Worktree(
+      id: "/tmp/repo",
+      name: "feature",
+      detail: "feature",
+      workingDirectory: URL(fileURLWithPath: "/tmp/repo"),
+      repositoryRootURL: URL(fileURLWithPath: "/tmp/root")
+    )
+    let snapshot = ExternalDiffSnapshotPair(
+      leftURL: URL(fileURLWithPath: "/tmp/left"),
+      rightURL: URL(fileURLWithPath: "/tmp/right")
+    )
+
+    await withDependencies {
+      $0.externalDiffSnapshotClient.makeSnapshotPair = { _ in snapshot }
+      $0.shellClient.runLoginImpl = { executable, arguments, cwd, _ in
+        runs.withValue {
+          $0.append(ShellRun(executable: executable, arguments: arguments, currentDirectoryURL: cwd))
+        }
+        return ShellOutput(stdout: "", stderr: "", exitCode: 0)
+      }
+    } operation: {
+      await ExternalDiffToolClient.liveValue.open(
+        ExternalDiffSettings(
+          toolID: ExternalDiffTool.custom.settingsID,
+          customCommand: "my-diff {leftPath} {rightPath} --repo {repoPath}"
+        ),
+        worktree,
+        .appDefaults
+      ) { _ in }
+    }
+
+    let run = try #require(runs.value.first)
+    #expect(run.executable.path(percentEncoded: false) == "/bin/zsh")
+    #expect(run.arguments == ["-lc", "my-diff '/tmp/left' '/tmp/right' --repo '/tmp/root'"])
+    #expect(run.currentDirectoryURL == worktree.workingDirectory)
+  }
+
+  @Test func snapshotPairIncludesModifiedAndUntrackedFiles() async throws {
+    let repoURL = FileManager.default.temporaryDirectory
+      .appending(path: "prowl-external-diff-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: repoURL, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: repoURL) }
+    try runGit(["init"], in: repoURL)
+    try runGit(["config", "user.email", "test@example.com"], in: repoURL)
+    try runGit(["config", "user.name", "Test User"], in: repoURL)
+    try "one\n".write(to: repoURL.appending(path: "tracked.txt"), atomically: true, encoding: .utf8)
+    try runGit(["add", "tracked.txt"], in: repoURL)
+    try runGit(["commit", "-m", "Initial"], in: repoURL)
+    try "two\n".write(to: repoURL.appending(path: "tracked.txt"), atomically: true, encoding: .utf8)
+    try "new\n".write(to: repoURL.appending(path: "untracked.txt"), atomically: true, encoding: .utf8)
+
+    let worktree = Worktree(
+      id: repoURL.path(percentEncoded: false),
+      name: "main",
+      detail: "main",
+      workingDirectory: repoURL,
+      repositoryRootURL: repoURL
+    )
+
+    let snapshot = try await ExternalDiffSnapshotClient.liveValue.makeSnapshotPair(worktree)
+
+    #expect(try String(contentsOf: snapshot.leftURL.appending(path: "tracked.txt"), encoding: .utf8) == "one\n")
+    #expect(try String(contentsOf: snapshot.rightURL.appending(path: "tracked.txt"), encoding: .utf8) == "two\n")
+    #expect(!FileManager.default.fileExists(atPath: snapshot.leftURL.appending(path: "untracked.txt").path()))
+    #expect(try String(contentsOf: snapshot.rightURL.appending(path: "untracked.txt"), encoding: .utf8) == "new\n")
+  }
+}
+
+private struct ShellRun: Equatable {
+  let executable: URL
+  let arguments: [String]
+  let currentDirectoryURL: URL?
+}
+
+private func runGit(_ arguments: [String], in directory: URL) throws {
+  let process = Process()
+  process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+  process.arguments = arguments
+  process.currentDirectoryURL = directory
+  process.standardOutput = Pipe()
+  process.standardError = Pipe()
+  try process.run()
+  process.waitUntilExit()
+  #expect(process.terminationStatus == 0)
+}

--- a/supacodeTests/ExternalDiffToolTests.swift
+++ b/supacodeTests/ExternalDiffToolTests.swift
@@ -19,6 +19,10 @@ struct ExternalDiffToolTests {
     #expect(ExternalDiffTool.custom.launchMode == .gui)
   }
 
+  @Test func explicitSettingsResolveWithoutCheckingInstallation() {
+    #expect(ExternalDiffSettings(toolID: ExternalDiffTool.hunk.settingsID, customCommand: "").tool == .hunk)
+  }
+
   @Test func commandTemplateReplacesPlaceholdersWithShellQuotedValues() {
     let context = ExternalDiffCommandContext(
       worktreePath: "/tmp/My Repo/work tree",


### PR DESCRIPTION
## Summary
- add a global Diff Tool setting with Built-in, Hunk, FileMerge, Kaleidoscope, and Custom Command options
- route diff badge and Show Diff through one launcher, with Hunk opening a Prowl terminal tab and GUI/custom tools receiving HEAD/worktree snapshot folders
- document the new settings and external diff behavior

Refs #322

## Tests
- `xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -only-testing:supacodeTests/ExternalDiffToolTests -only-testing:supacodeTests/AppFeatureCommandPaletteTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation 2>&1 | xcsift -w --format toon`
- `make check`
- `make build-app`
