### PR TITLE
Add prebuilt GhosttyKit artifact downloader

### DIFF
--- a/.github/actions/setup-macos/action.yml
+++ b/.github/actions/setup-macos/action.yml
@@ -22,7 +22,7 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
-        GHOSTTY_SHA="$(git -C ThirdParty/ghostty rev-parse HEAD)"
+        GHOSTTY_SHA="$(git rev-parse HEAD:ThirdParty/ghostty)"
         printf '%s\n' "GHOSTTY_SHA=$GHOSTTY_SHA" >> "$GITHUB_ENV"
     - name: Ghostty cache
       id: ghostty_cache
@@ -35,12 +35,12 @@ runs:
           .ghostty_hash
           .ghostty_build_stamp
         key: ${{ runner.os }}-${{ runner.arch }}-ghostty-v1-${{ env.GHOSTTY_SHA }}
-    - name: Build ghostty
+    - name: Ensure ghostty
       if: steps.ghostty_cache.outputs.cache-hit != 'true'
       shell: bash
       run: |
         set -euo pipefail
-        make build-ghostty-xcframework
+        make ensure-ghostty
     - name: Sync ghostty marker files
       shell: bash
       run: |

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ PROWL_POSTHOG_API_KEY ?=
 PROWL_POSTHOG_HOST ?=
 
 .DEFAULT_GOAL := help
-.PHONY: build-ghostty-xcframework ensure-ghostty sync-ghostty _check-ghostty-hash _record-ghostty-hash build-app build-cli build-cli-release embed-cli-debug embed-cli embed-docs run-app install-dev-build install-release archive export-archive format format-changed format-lint lint check test test-app test-cli-smoke test-cli-integration bump-version bump-and-release log-stream
+.PHONY: build-ghostty-xcframework ensure-ghostty sync-ghostty _record-ghostty-hash build-app build-cli build-cli-release embed-cli-debug embed-cli embed-docs run-app install-dev-build install-release archive export-archive format format-changed format-lint lint check test test-app test-cli-smoke test-cli-integration bump-version bump-and-release log-stream
 
 help:  # Display this help.
 	@-+echo "Run make with one of the following targets:"
@@ -41,6 +41,7 @@ build-ghostty-xcframework: $(GHOSTTY_BUILD_STAMP) # Build ghostty framework
 
 # Internal: actually rebuild ghostty.
 $(GHOSTTY_BUILD_STAMP):
+	git submodule update --init --recursive ThirdParty/ghostty
 	@cd $(CURRENT_MAKEFILE_DIR)/ThirdParty/ghostty && mise exec -- zig build -Doptimize=ReleaseFast -Demit-xcframework=true -Dsentry=false
 	rsync -a ThirdParty/ghostty/macos/GhosttyKit.xcframework Frameworks
 	@src="$(CURRENT_MAKEFILE_DIR)/ThirdParty/ghostty/zig-out/share/ghostty"; \
@@ -53,36 +54,34 @@ $(GHOSTTY_BUILD_STAMP):
 	rsync -a --delete "$$terminfo_src/" "$$terminfo_dst/"
 	touch "$(GHOSTTY_BUILD_STAMP)"
 
-# Public entry point: only rebuilds ghostty if submodule SHA changed (or outputs are missing).
-ensure-ghostty: _check-ghostty-hash # Ensure GhosttyKit is up-to-date (fast path when unchanged)
-
-# Internal: compare current submodule SHA against the recorded one.
-_check-ghostty-hash:
-	@current_sha="$$(git -C $(CURRENT_MAKEFILE_DIR)/ThirdParty/ghostty rev-parse HEAD)"; \
+# Public entry point: downloads pinned prebuilt artifacts when available, then
+# falls back to a local Ghostty source build.
+ensure-ghostty: # Ensure GhosttyKit is up-to-date (fast path when unchanged)
+	@set +e; \
+	"$(CURRENT_MAKEFILE_DIR)/scripts/ensure-ghosttykit-artifacts.sh"; \
+	status="$$?"; \
+	set -e; \
+	if [ "$$status" -eq 0 ]; then \
+		exit 0; \
+	fi; \
+	if [ "$$status" -ne 2 ]; then \
+		exit "$$status"; \
+	fi; \
+	current_sha="$$(git -C "$(CURRENT_MAKEFILE_DIR)" rev-parse HEAD:ThirdParty/ghostty)"; \
 	last_sha=""; \
 	if [ -f "$(GHOSTTY_HASH_FILE)" ]; then \
 		last_sha="$$(cat "$(GHOSTTY_HASH_FILE)")"; \
 	fi; \
-	artifacts_ok=1; \
-	for path in "$(GHOSTTY_XCFRAMEWORK_PATH)" "$(GHOSTTY_RESOURCE_PATH)" "$(GHOSTTY_TERMINFO_PATH)"; do \
-		if [ ! -e "$$path" ]; then \
-			artifacts_ok=0; \
-		fi; \
-	done; \
-	if [ "$$current_sha" != "$$last_sha" ] || [ "$$artifacts_ok" -ne 1 ]; then \
-		echo "Syncing GhosttyKit for submodule $$current_sha"; \
-		$(MAKE) -B build-ghostty-xcframework || exit $$?; \
-		if [ "$$current_sha" != "$$last_sha" ]; then \
-			rm -rf ~/Library/Developer/Xcode/DerivedData/supacode-*; \
-			echo "Cleared Xcode DerivedData for ghostty header/module changes"; \
-		fi; \
-	else \
-		echo "GhosttyKit up-to-date (SHA unchanged)"; \
+	echo "Building GhosttyKit locally for $$current_sha"; \
+	$(MAKE) -B build-ghostty-xcframework; \
+	if [ "$$current_sha" != "$$last_sha" ]; then \
+		rm -rf ~/Library/Developer/Xcode/DerivedData/supacode-*; \
+		echo "Cleared Xcode DerivedData for ghostty header/module changes"; \
 	fi
 
 # Internal: record the current submodule SHA after a successful build.
 _record-ghostty-hash:
-	@git -C $(CURRENT_MAKEFILE_DIR)/ThirdParty/ghostty rev-parse HEAD > "$(GHOSTTY_HASH_FILE)"
+	@git -C "$(CURRENT_MAKEFILE_DIR)" rev-parse HEAD:ThirdParty/ghostty > "$(GHOSTTY_HASH_FILE)"
 
 # Force a clean rebuild of GhosttyKit (ignores cached SHA, useful after submodule updates).
 sync-ghostty: # Force sync GhosttyKit to current submodule HEAD (always rebuilds)

--- a/doc-onevcat/fork-sync-ghostty.md
+++ b/doc-onevcat/fork-sync-ghostty.md
@@ -57,6 +57,42 @@ make sync-ghostty
 make build-app
 ```
 
+## Prebuilt Artifact Publishing
+
+Prowl's default `make ensure-ghostty` path downloads pinned prebuilt artifacts
+from `onevcat/ghostty` before falling back to a local source build.
+
+Release tag format:
+
+```text
+xcframework-<ghostty_commit_sha>-prowl-v1
+```
+
+Assets:
+
+```text
+GhosttyKit.xcframework.tar.gz
+GhosttyKit-resources.tar.gz
+```
+
+After a local `make sync-ghostty`, package the current artifacts with:
+
+```bash
+scripts/package-ghosttykit-artifacts.sh
+```
+
+Upload both generated assets to the matching `onevcat/ghostty` release, then add
+the emitted manifest line to `scripts/ghosttykit-checksums.txt` in Prowl. The
+manifest is reviewed source of truth for downloaded artifact integrity.
+
+Verify the prebuilt path from a clean artifact state:
+
+```bash
+rm -rf Frameworks/GhosttyKit.xcframework Resources/ghostty Resources/terminfo .ghostty_hash .ghostty_build_stamp
+make ensure-ghostty
+make build-app
+```
+
 ## Force Push Policy
 
 Do not force-push `release/v*-patched` branches. If a cherry-pick needs repair, use a temporary fix branch, validate it, then fast-forward the patched branch.

--- a/doc-onevcat/plans/2026-06-14-ghosttykit-prebuilt-artifacts-plan.md
+++ b/doc-onevcat/plans/2026-06-14-ghosttykit-prebuilt-artifacts-plan.md
@@ -1,0 +1,175 @@
+# GhosttyKit Prebuilt Artifact Plan
+
+## Goal
+
+Make prebuilt GhosttyKit artifacts the default acquisition path for Prowl, while
+keeping local Ghostty source builds available for fork maintenance and emergency
+fallbacks.
+
+This is a long-term integration decision for Prowl:
+
+- Prowl pins `ThirdParty/ghostty` to the `onevcat/ghostty` fork.
+- Each pinned Ghostty commit may have a matching GitHub Release artifact.
+- Normal Prowl builds download and verify that artifact instead of compiling
+  Ghostty from Zig source.
+- Ghostty source builds remain explicit maintenance operations.
+
+We are intentionally not moving GhosttyKit to a SwiftPM binary target for now.
+Prowl's app target currently links `Frameworks/GhosttyKit.xcframework` directly
+from the Xcode project and separately bundles `Resources/ghostty` and
+`Resources/terminfo`. A Makefile downloader matches that shape with less churn.
+
+## Current State
+
+Prowl currently:
+
+1. Pins `ThirdParty/ghostty` as a submodule to `onevcat/ghostty`.
+2. Runs `zig build -Doptimize=ReleaseFast -Demit-xcframework=true -Dsentry=false`
+   from the Ghostty submodule.
+3. Copies `ThirdParty/ghostty/macos/GhosttyKit.xcframework` to `Frameworks/`.
+4. Copies Ghostty runtime resources from `zig-out/share/ghostty` and
+   `zig-out/share/terminfo` to `Resources/`.
+5. Tracks `.ghostty_hash` and `.ghostty_build_stamp` locally to skip unchanged
+   rebuilds.
+
+The expensive part is step 2. Cold worktrees also frequently lack the generated
+framework/resources, so `make build-app` currently triggers a full Ghostty build.
+
+## Artifact Model
+
+Publish artifacts from `onevcat/ghostty` GitHub Releases.
+
+Release tag format:
+
+```text
+xcframework-<ghostty_commit_sha>-prowl-v1
+```
+
+Assets:
+
+```text
+GhosttyKit.xcframework.tar.gz
+GhosttyKit-resources.tar.gz
+```
+
+`GhosttyKit-resources.tar.gz` contains exactly:
+
+```text
+ghostty/
+terminfo/
+```
+
+The Prowl repository stores a reviewed checksum manifest:
+
+```text
+scripts/ghosttykit-checksums.txt
+```
+
+Each non-comment line uses:
+
+```text
+<ghostty_commit_sha> <xcframework_sha256> <resources_sha256>
+```
+
+The commit SHA is the gitlink recorded in Prowl, not "whatever the submodule
+working tree currently reports". This allows cold worktrees to download
+artifacts before the heavy Ghostty submodule is initialized.
+
+## Build Flow
+
+`make ensure-ghostty`:
+
+1. Read the pinned Ghostty gitlink with:
+
+   ```bash
+   git rev-parse HEAD:ThirdParty/ghostty
+   ```
+
+2. If `Frameworks/GhosttyKit.xcframework`, `Resources/ghostty`, and
+   `Resources/terminfo` already exist and `.ghostty_hash` matches, do nothing.
+3. If a checksum entry exists, download both release assets for the pinned SHA.
+4. Verify SHA256 for both assets.
+5. Validate archive shape before extraction.
+6. Extract into `Frameworks/` and `Resources/`.
+7. Refresh `libghostty.a`'s archive index with `xcrun ranlib`.
+8. Write `.ghostty_hash` and `.ghostty_build_stamp`.
+9. If no pinned artifact exists or the download is unavailable, fall back to the
+   existing local Ghostty build.
+
+Checksum mismatch or unsafe archive shape is a hard failure. That indicates a
+broken or suspicious artifact and should not silently fall back.
+
+`make sync-ghostty`:
+
+- Remains the explicit "force local rebuild from source" command.
+- Requires the Ghostty submodule to be initialized.
+- Continues to clear Xcode DerivedData after rebuilding.
+
+## Publishing Flow
+
+For a new Ghostty commit:
+
+1. Build from source on a machine with the required Xcode:
+
+   ```bash
+   DEVELOPER_DIR=/Applications/Xcode-26.3.0.app/Contents/Developer make sync-ghostty
+   ```
+
+2. Package artifacts:
+
+   ```bash
+   scripts/package-ghosttykit-artifacts.sh
+   ```
+
+3. Create the matching `onevcat/ghostty` release and upload both assets.
+4. Add the emitted checksums to `scripts/ghosttykit-checksums.txt`.
+5. Verify a clean acquisition path:
+
+   ```bash
+   rm -rf Frameworks/GhosttyKit.xcframework Resources/ghostty Resources/terminfo .ghostty_hash .ghostty_build_stamp
+   make ensure-ghostty
+   make build-app
+   ```
+
+## CI Flow
+
+The macOS setup action should:
+
+1. Use the pinned gitlink SHA for its cache key.
+2. Restore the existing GitHub Actions cache when available.
+3. Run `make ensure-ghostty` on cache miss.
+4. Continue caching generated framework/resources and marker files.
+
+This keeps CI deterministic while making cache misses much faster.
+
+## Risks
+
+- **Artifact drift:** mitigated by pinned tag names and checked-in SHA256 values.
+- **Unsafe archive extraction:** mitigated by validating tar entries and archive
+  roots before extraction.
+- **Missing artifact for a new Ghostty commit:** local source build remains the
+  fallback, so development is not blocked.
+- **Stale module caches after header changes:** `ensure-ghostty` clears
+  DerivedData when the pinned Ghostty SHA changes, preserving the current
+  behavior.
+
+## Non-Goals
+
+- No SwiftPM binary target migration in this phase.
+- No dependency on upstream Ghostty release assets.
+- No "latest release" behavior.
+- No committed generated `GhosttyKit.xcframework` or runtime resources.
+
+## Implementation Checklist
+
+- Add artifact checksum manifest.
+- Add archive validator.
+- Add artifact packaging script.
+- Add artifact ensure/download script.
+- Wire `make ensure-ghostty` to the downloader with local build fallback.
+- Update CI setup action to use the downloader.
+- Update Ghostty fork sync documentation.
+- Build/package/upload current `48365577c1ae8e422c0dd90489921f07b9f79171`
+  artifact.
+- Verify `make ensure-ghostty` from missing local artifacts.
+- Verify `make build-app`.

--- a/scripts/ensure-ghosttykit-artifacts.sh
+++ b/scripts/ensure-ghosttykit-artifacts.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+cd "$PROJECT_DIR"
+
+GHOSTTY_REPOSITORY="${PROWL_GHOSTTY_ARTIFACT_REPOSITORY:-onevcat/ghostty}"
+GHOSTTY_ARTIFACT_FLAVOR="${PROWL_GHOSTTY_ARTIFACT_FLAVOR:-prowl-v1}"
+CHECKSUMS_FILE="${PROWL_GHOSTTY_CHECKSUMS_FILE:-$SCRIPT_DIR/ghosttykit-checksums.txt}"
+VALIDATOR="${PROWL_GHOSTTY_ARTIFACT_VALIDATOR:-$SCRIPT_DIR/validate-ghosttykit-artifacts.py}"
+
+XCFRAMEWORK_PATH="$PROJECT_DIR/Frameworks/GhosttyKit.xcframework"
+GHOSTTY_RESOURCE_PATH="$PROJECT_DIR/Resources/ghostty"
+TERMINFO_RESOURCE_PATH="$PROJECT_DIR/Resources/terminfo"
+GHOSTTY_HASH_FILE="$PROJECT_DIR/.ghostty_hash"
+GHOSTTY_BUILD_STAMP="$PROJECT_DIR/.ghostty_build_stamp"
+
+hash_file() {
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | awk '{print $1}'
+  else
+    sha256sum "$1" | awk '{print $1}'
+  fi
+}
+
+lookup_checksums() {
+  local ghostty_sha="$1"
+  awk -v sha="$ghostty_sha" '
+    $1 == sha {
+      print $2 " " $3
+      found = 1
+      exit
+    }
+    END {
+      if (!found) {
+        exit 1
+      }
+    }
+  ' "$CHECKSUMS_FILE"
+}
+
+pinned_ghostty_sha() {
+  git rev-parse HEAD:ThirdParty/ghostty
+}
+
+artifacts_exist() {
+  [[ -d "$XCFRAMEWORK_PATH" && -d "$GHOSTTY_RESOURCE_PATH" && -d "$TERMINFO_RESOURCE_PATH" ]]
+}
+
+stamp_matches() {
+  [[ -f "$GHOSTTY_HASH_FILE" ]] && [[ "$(cat "$GHOSTTY_HASH_FILE")" == "$GHOSTTY_SHA" ]]
+}
+
+refresh_archive_index() {
+  local archive="$XCFRAMEWORK_PATH/macos-arm64_x86_64/libghostty.a"
+  if [[ ! -f "$archive" ]]; then
+    return 0
+  fi
+
+  if ! command -v xcrun >/dev/null 2>&1; then
+    echo "error: xcrun is required to refresh libghostty archive index." >&2
+    exit 1
+  fi
+
+  local ranlib
+  ranlib="$(xcrun --find ranlib)"
+  "$ranlib" "$archive"
+}
+
+install_artifacts() {
+  local xcframework_archive="$1"
+  local resources_archive="$2"
+  local tmp_extract="$3"
+
+  mkdir -p "$tmp_extract/xcframework" "$tmp_extract/resources" "$PROJECT_DIR/Frameworks" "$PROJECT_DIR/Resources"
+
+  tar -xzf "$xcframework_archive" -C "$tmp_extract/xcframework"
+  tar -xzf "$resources_archive" -C "$tmp_extract/resources"
+
+  if [[ ! -d "$tmp_extract/xcframework/GhosttyKit.xcframework" ]]; then
+    echo "error: xcframework archive did not contain GhosttyKit.xcframework" >&2
+    exit 1
+  fi
+  if [[ ! -d "$tmp_extract/resources/ghostty" || ! -d "$tmp_extract/resources/terminfo" ]]; then
+    echo "error: resources archive did not contain ghostty and terminfo directories" >&2
+    exit 1
+  fi
+
+  rm -rf "$XCFRAMEWORK_PATH" "$GHOSTTY_RESOURCE_PATH" "$TERMINFO_RESOURCE_PATH"
+  mv "$tmp_extract/xcframework/GhosttyKit.xcframework" "$XCFRAMEWORK_PATH"
+  mv "$tmp_extract/resources/ghostty" "$GHOSTTY_RESOURCE_PATH"
+  mv "$tmp_extract/resources/terminfo" "$TERMINFO_RESOURCE_PATH"
+
+  refresh_archive_index
+  printf '%s\n' "$GHOSTTY_SHA" > "$GHOSTTY_HASH_FILE"
+  touch "$GHOSTTY_BUILD_STAMP"
+}
+
+try_fetch_prebuilt() {
+  if [[ "${PROWL_GHOSTTY_NO_PREBUILT:-0}" == "1" ]]; then
+    echo "GhosttyKit prebuilt download disabled; falling back to local build."
+    return 2
+  fi
+
+  if [[ ! -f "$CHECKSUMS_FILE" ]]; then
+    echo "Missing GhosttyKit checksum manifest; falling back to local build." >&2
+    return 2
+  fi
+
+  local checksums expected_xcframework_sha expected_resources_sha
+  if ! checksums="$(lookup_checksums "$GHOSTTY_SHA" 2>/dev/null)"; then
+    echo "No pinned GhosttyKit artifact for ${GHOSTTY_SHA:0:12}; falling back to local build."
+    return 2
+  fi
+  read -r expected_xcframework_sha expected_resources_sha <<< "$checksums"
+
+  local tag="xcframework-$GHOSTTY_SHA-$GHOSTTY_ARTIFACT_FLAVOR"
+  local base_url="https://github.com/$GHOSTTY_REPOSITORY/releases/download/$tag"
+  local tmp_dir="$PROJECT_DIR/.ghostty-download.$$"
+  local xcframework_archive="$tmp_dir/GhosttyKit.xcframework.tar.gz"
+  local resources_archive="$tmp_dir/GhosttyKit-resources.tar.gz"
+
+  rm -rf "$tmp_dir"
+  mkdir -p "$tmp_dir"
+  trap 'rm -rf "$tmp_dir"' RETURN
+
+  echo "Fetching prebuilt GhosttyKit artifacts for ${GHOSTTY_SHA:0:12}..."
+  if ! curl -fsSL --connect-timeout 10 --max-time 300 --retry 3 --retry-delay 2 --retry-all-errors \
+    -o "$xcframework_archive" "$base_url/GhosttyKit.xcframework.tar.gz"; then
+    echo "Prebuilt GhosttyKit.xcframework unavailable; falling back to local build."
+    return 2
+  fi
+  if ! curl -fsSL --connect-timeout 10 --max-time 300 --retry 3 --retry-delay 2 --retry-all-errors \
+    -o "$resources_archive" "$base_url/GhosttyKit-resources.tar.gz"; then
+    echo "Prebuilt GhosttyKit resources unavailable; falling back to local build."
+    return 2
+  fi
+
+  local actual_xcframework_sha actual_resources_sha
+  actual_xcframework_sha="$(hash_file "$xcframework_archive")"
+  actual_resources_sha="$(hash_file "$resources_archive")"
+
+  if [[ "$actual_xcframework_sha" != "$expected_xcframework_sha" ]]; then
+    echo "error: GhosttyKit.xcframework checksum mismatch." >&2
+    echo "  expected: $expected_xcframework_sha" >&2
+    echo "  actual:   $actual_xcframework_sha" >&2
+    exit 1
+  fi
+  if [[ "$actual_resources_sha" != "$expected_resources_sha" ]]; then
+    echo "error: GhosttyKit resources checksum mismatch." >&2
+    echo "  expected: $expected_resources_sha" >&2
+    echo "  actual:   $actual_resources_sha" >&2
+    exit 1
+  fi
+
+  python3 "$VALIDATOR" xcframework "$xcframework_archive"
+  python3 "$VALIDATOR" resources "$resources_archive"
+
+  install_artifacts "$xcframework_archive" "$resources_archive" "$tmp_dir/extract"
+  echo "Installed prebuilt GhosttyKit artifacts for ${GHOSTTY_SHA:0:12}."
+}
+
+GHOSTTY_SHA="$(pinned_ghostty_sha)"
+
+if artifacts_exist && stamp_matches; then
+  echo "GhosttyKit up-to-date (SHA unchanged)"
+  exit 0
+fi
+
+echo "Syncing GhosttyKit for submodule $GHOSTTY_SHA"
+
+previous_sha=""
+if [[ -f "$GHOSTTY_HASH_FILE" ]]; then
+  previous_sha="$(cat "$GHOSTTY_HASH_FILE")"
+fi
+
+if try_fetch_prebuilt; then
+  if [[ "$previous_sha" != "$GHOSTTY_SHA" ]]; then
+    rm -rf ~/Library/Developer/Xcode/DerivedData/supacode-*
+    echo "Cleared Xcode DerivedData for ghostty header/module changes"
+  fi
+  exit 0
+fi
+
+exit 2

--- a/scripts/ghosttykit-checksums.txt
+++ b/scripts/ghosttykit-checksums.txt
@@ -1,0 +1,4 @@
+# Pinned GhosttyKit artifact checksums keyed by the Ghostty submodule gitlink.
+# Release tags use: xcframework-<ghostty_sha>-prowl-v1
+# Format: <ghostty_sha> <GhosttyKit.xcframework.tar.gz sha256> <GhosttyKit-resources.tar.gz sha256>
+48365577c1ae8e422c0dd90489921f07b9f79171 69c2c06ed0f90c1e1fd86c607641f31239b374ea57d6cb59c61f543ac4528cd5 bfd2645d742670aa42e6bfab97f62d99f73a51fb8d922a091e51ba38ef5bd4d2

--- a/scripts/package-ghosttykit-artifacts.sh
+++ b/scripts/package-ghosttykit-artifacts.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+DIST_DIR="${PROWL_GHOSTTY_ARTIFACT_DIST_DIR:-$PROJECT_DIR/dist/ghosttykit}"
+
+XCFRAMEWORK_PATH="$PROJECT_DIR/Frameworks/GhosttyKit.xcframework"
+GHOSTTY_RESOURCE_PATH="$PROJECT_DIR/Resources/ghostty"
+TERMINFO_RESOURCE_PATH="$PROJECT_DIR/Resources/terminfo"
+
+hash_file() {
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | awk '{print $1}'
+  else
+    sha256sum "$1" | awk '{print $1}'
+  fi
+}
+
+require_dir() {
+  local path="$1"
+  if [[ ! -d "$path" ]]; then
+    echo "error: missing required directory: $path" >&2
+    exit 1
+  fi
+}
+
+require_dir "$XCFRAMEWORK_PATH"
+require_dir "$GHOSTTY_RESOURCE_PATH"
+require_dir "$TERMINFO_RESOURCE_PATH"
+
+rm -rf "$DIST_DIR"
+mkdir -p "$DIST_DIR"
+
+XCFRAMEWORK_ARCHIVE="$DIST_DIR/GhosttyKit.xcframework.tar.gz"
+RESOURCES_ARCHIVE="$DIST_DIR/GhosttyKit-resources.tar.gz"
+
+(
+  cd "$PROJECT_DIR/Frameworks"
+  COPYFILE_DISABLE=1 tar czf "$XCFRAMEWORK_ARCHIVE" GhosttyKit.xcframework
+)
+
+(
+  cd "$PROJECT_DIR/Resources"
+  COPYFILE_DISABLE=1 tar czf "$RESOURCES_ARCHIVE" ghostty terminfo
+)
+
+python3 "$SCRIPT_DIR/validate-ghosttykit-artifacts.py" xcframework "$XCFRAMEWORK_ARCHIVE"
+python3 "$SCRIPT_DIR/validate-ghosttykit-artifacts.py" resources "$RESOURCES_ARCHIVE"
+
+GHOSTTY_SHA="$(git -C "$PROJECT_DIR" rev-parse HEAD:ThirdParty/ghostty)"
+XCFRAMEWORK_SHA="$(hash_file "$XCFRAMEWORK_ARCHIVE")"
+RESOURCES_SHA="$(hash_file "$RESOURCES_ARCHIVE")"
+
+cat <<EOF
+Artifact directory:
+$DIST_DIR
+
+Release tag:
+xcframework-$GHOSTTY_SHA-prowl-v1
+
+Assets:
+$XCFRAMEWORK_ARCHIVE
+$RESOURCES_ARCHIVE
+
+Checksum manifest entry:
+$GHOSTTY_SHA $XCFRAMEWORK_SHA $RESOURCES_SHA
+EOF

--- a/scripts/validate-ghosttykit-artifacts.py
+++ b/scripts/validate-ghosttykit-artifacts.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+from pathlib import PurePosixPath
+import sys
+import tarfile
+
+
+ARCHIVES = {
+  "xcframework": ("GhosttyKit.xcframework",),
+  "resources": ("ghostty", "terminfo"),
+}
+
+
+def normalize(name: str) -> str:
+  while name.startswith("./"):
+    name = name[2:]
+  return name.rstrip("/")
+
+
+def is_safe_member(name: str) -> bool:
+  path = PurePosixPath(name)
+  return not path.is_absolute() and ".." not in path.parts
+
+
+def is_allowed(name: str, roots: tuple[str, ...]) -> bool:
+  return any(name == root or name.startswith(root + "/") for root in roots)
+
+
+def validate(archive_kind: str, archive_path: str) -> None:
+  roots = ARCHIVES[archive_kind]
+  seen_roots: set[str] = set()
+
+  with tarfile.open(archive_path, "r:gz") as tar:
+    for member in tar.getmembers():
+      name = normalize(member.name)
+      if not name:
+        continue
+      if not is_safe_member(name):
+        raise SystemExit(f"unsafe archive entry: {member.name}")
+      if not is_allowed(name, roots):
+        raise SystemExit(f"unexpected archive entry: {member.name}")
+
+      for root in roots:
+        if name == root or name.startswith(root + "/"):
+          seen_roots.add(root)
+
+      if member.islnk() or member.issym():
+        target = normalize(member.linkname)
+        if not target or not is_safe_member(target):
+          raise SystemExit(f"unsafe archive link target: {member.linkname}")
+      elif not (member.isfile() or member.isdir()):
+        raise SystemExit(f"unsupported archive member: {member.name}")
+
+  missing = set(roots) - seen_roots
+  if missing:
+    raise SystemExit(f"archive missing roots: {', '.join(sorted(missing))}")
+
+
+def main() -> None:
+  if len(sys.argv) != 3 or sys.argv[1] not in ARCHIVES:
+    kinds = "|".join(sorted(ARCHIVES))
+    raise SystemExit(f"usage: validate-ghosttykit-artifacts.py <{kinds}> <archive.tar.gz>")
+
+  validate(sys.argv[1], sys.argv[2])
+
+
+if __name__ == "__main__":
+  main()


### PR DESCRIPTION
## Summary

- Add a long-term plan for prebuilt GhosttyKit artifacts under `doc-onevcat/plans`.
- Add scripts to package, validate, download, checksum, and install pinned GhosttyKit artifacts.
- Update `make ensure-ghostty` and CI setup to prefer verified `onevcat/ghostty` release assets before falling back to a local source build.
- Publish and pin the first artifact set for Ghostty commit `48365577c1ae8e422c0dd90489921f07b9f79171`.

## Verification

- `scripts/ensure-ghosttykit-artifacts.sh` returns fallback code when no prebuilt artifact is pinned.
- `scripts/validate-ghosttykit-artifacts.py` accepts valid fixture archives and rejects unexpected archive roots.
- `DEVELOPER_DIR=/Applications/Xcode-26.3.0.app/Contents/Developer make sync-ghostty`
- `scripts/package-ghosttykit-artifacts.sh`
- Created release: https://github.com/onevcat/ghostty/releases/tag/xcframework-48365577c1ae8e422c0dd90489921f07b9f79171-prowl-v1
- `rm -rf Frameworks/GhosttyKit.xcframework Resources/ghostty Resources/terminfo .ghostty_hash .ghostty_build_stamp && make ensure-ghostty`
- Negative download test with missing release repository returns fallback code `2`.
- `make check`
- `make build-app`
