### PR TITLE
Add Canvas card tab context menu

### DIFF
--- a/supacode/Features/Canvas/Views/CanvasCardView.swift
+++ b/supacode/Features/Canvas/Views/CanvasCardView.swift
@@ -22,6 +22,7 @@ struct CanvasCardView: View {
   let isFocused: Bool
   let isSelected: Bool
   let hasUnseenNotification: Bool
+  let tabIcon: String?
   let tabId: TerminalTabID
   let tabs: [TerminalTabItem]
   let tabContextMenuActions: TerminalTabContextMenuActions
@@ -144,10 +145,16 @@ struct CanvasCardView: View {
       Text(repositoryName)
         .font(.caption.bold())
         .lineLimit(1)
-      Text("/ \(worktreeName)")
-        .font(.caption)
-        .foregroundStyle(.secondary)
-        .lineLimit(1)
+      HStack(spacing: 3) {
+        Text("/")
+        if let tabIcon {
+          TabIconImage(rawName: tabIcon, pointSize: 10)
+        }
+        Text(worktreeName)
+      }
+      .font(.caption)
+      .foregroundStyle(.secondary)
+      .lineLimit(1)
       Spacer()
       titleBarActions
     }

--- a/supacode/Features/Canvas/Views/CanvasCardView.swift
+++ b/supacode/Features/Canvas/Views/CanvasCardView.swift
@@ -177,7 +177,8 @@ struct CanvasCardView: View {
     .terminalTabContextMenu(
       tabId: tabId,
       tabs: tabs,
-      actions: tabContextMenuActions
+      actions: tabContextMenuActions,
+      variant: .canvas
     )
   }
 

--- a/supacode/Features/Canvas/Views/CanvasCardView.swift
+++ b/supacode/Features/Canvas/Views/CanvasCardView.swift
@@ -22,6 +22,9 @@ struct CanvasCardView: View {
   let isFocused: Bool
   let isSelected: Bool
   let hasUnseenNotification: Bool
+  let tabId: TerminalTabID
+  let tabs: [TerminalTabItem]
+  let tabContextMenuActions: TerminalTabContextMenuActions
   let cardSize: CGSize
   /// Whether this card is currently expanded in place (near-fullscreen). When
   /// true the title-bar button restores instead of expands, resize handles and
@@ -170,6 +173,11 @@ struct CanvasCardView: View {
             ))
         },
       isEnabled: !isExpanded
+    )
+    .terminalTabContextMenu(
+      tabId: tabId,
+      tabs: tabs,
+      actions: tabContextMenuActions
     )
   }
 

--- a/supacode/Features/Canvas/Views/CanvasView.swift
+++ b/supacode/Features/Canvas/Views/CanvasView.swift
@@ -326,6 +326,7 @@ struct CanvasView: View {
         isFocused: selectionState.primaryTabID == tab.id,
         isSelected: selectionState.selectedTabIDs.contains(tab.id),
         hasUnseenNotification: state.hasUnseenNotification(for: tab.id),
+        tabIcon: tab.icon,
         tabId: tab.id,
         tabs: state.tabManager.tabs,
         tabContextMenuActions: tabContextMenuActions(for: state),

--- a/supacode/Features/Canvas/Views/CanvasView.swift
+++ b/supacode/Features/Canvas/Views/CanvasView.swift
@@ -326,6 +326,9 @@ struct CanvasView: View {
         isFocused: selectionState.primaryTabID == tab.id,
         isSelected: selectionState.selectedTabIDs.contains(tab.id),
         hasUnseenNotification: state.hasUnseenNotification(for: tab.id),
+        tabId: tab.id,
+        tabs: state.tabManager.tabs,
+        tabContextMenuActions: tabContextMenuActions(for: state),
         cardSize: renderSize,
         isExpanded: isCardExpanded,
         expandHelp: expandHelp,
@@ -379,6 +382,9 @@ struct CanvasView: View {
           state.closeTab(tab.id)
         }
       )
+      .sheet(item: iconPickerBinding(for: tab.id, in: state)) { tabId in
+        iconPickerSheet(state: state, tabId: tabId)
+      }
     }
     // Animatable progress is interpolated by binding the animation to this
     // card's expanded state. A plain withAnimation around expandedTabID doesn't
@@ -387,6 +393,39 @@ struct CanvasView: View {
     // value changes, so the rest stay put.
     .animation(expandAnimation, value: isCardExpanded)
     .zIndex(zIndex(for: tab.id, cardKey: cardKey))
+  }
+
+  func tabContextMenuActions(for state: WorktreeTerminalState) -> TerminalTabContextMenuActions {
+    TerminalTabContextMenuActions(
+      renameTab: { state.promptChangeTabTitle($0) },
+      changeIcon: { state.presentIconPicker(for: $0) },
+      closeTab: { state.closeTab($0) },
+      closeOthers: { state.closeOtherTabs(keeping: $0) },
+      closeToRight: { state.closeTabsToRight(of: $0) },
+      closeAll: { state.closeAllTabs() }
+    )
+  }
+
+  func iconPickerBinding(for tabId: TerminalTabID, in state: WorktreeTerminalState) -> Binding<TerminalTabID?> {
+    Binding(
+      get: { state.iconPickerTabId == tabId ? tabId : nil },
+      set: { state.iconPickerTabId = $0 }
+    )
+  }
+
+  func iconPickerSheet(state: WorktreeTerminalState, tabId: TerminalTabID) -> some View {
+    let currentIcon = state.tabManager.tabs.first(where: { $0.id == tabId })?.icon
+    return TabIconPickerView(
+      initialIcon: currentIcon,
+      defaultIcon: state.defaultIcon(for: tabId),
+      onApply: { newIcon in
+        state.applyIconChange(tabId, icon: newIcon)
+        state.dismissIconPicker()
+      },
+      onCancel: {
+        state.dismissIconPicker()
+      }
+    )
   }
 
   // MARK: - Canvas Gestures

--- a/supacode/Features/Canvas/Views/CanvasView.swift
+++ b/supacode/Features/Canvas/Views/CanvasView.swift
@@ -326,7 +326,7 @@ struct CanvasView: View {
         isFocused: selectionState.primaryTabID == tab.id,
         isSelected: selectionState.selectedTabIDs.contains(tab.id),
         hasUnseenNotification: state.hasUnseenNotification(for: tab.id),
-        tabIcon: tab.icon,
+        tabIcon: tab.iconLock != .auto ? tab.icon : nil,
         tabId: tab.id,
         tabs: state.tabManager.tabs,
         tabContextMenuActions: tabContextMenuActions(for: state),

--- a/supacode/Features/Shelf/Views/ShelfSpineView.swift
+++ b/supacode/Features/Shelf/Views/ShelfSpineView.swift
@@ -332,7 +332,8 @@ struct ShelfSpineView: View {
             closeOthers: { terminalState.closeOtherTabs(keeping: $0) },
             closeToRight: { terminalState.closeTabsToRight(of: $0) },
             closeAll: { terminalState.closeAllTabs() }
-          )
+          ),
+          variant: .shelf
         )
       }
     }

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabContextMenu.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabContextMenu.swift
@@ -1,16 +1,27 @@
 import SwiftUI
 
+enum TerminalTabContextMenuVariant {
+  /// Horizontal tab bar — shows all items; "Close Tabs to the Right".
+  case tabBar
+  /// Vertical shelf spine — shows all items; "Close Tabs Below".
+  case shelf
+  /// 2D canvas cards — worktree-scoped labels; hides "Close Tabs to the Right".
+  case canvas
+}
+
 extension View {
   func terminalTabContextMenu(
     tabId: TerminalTabID,
     tabs: [TerminalTabItem],
-    actions: TerminalTabContextMenuActions
+    actions: TerminalTabContextMenuActions,
+    variant: TerminalTabContextMenuVariant = .tabBar
   ) -> some View {
     modifier(
       TerminalTabContextMenu(
         tabId: tabId,
         tabs: tabs,
-        actions: actions
+        actions: actions,
+        variant: variant
       )
     )
   }
@@ -20,6 +31,7 @@ struct TerminalTabContextMenu: ViewModifier {
   let tabId: TerminalTabID
   let tabs: [TerminalTabItem]
   let actions: TerminalTabContextMenuActions
+  let variant: TerminalTabContextMenuVariant
 
   func body(content: Content) -> some View {
     content.contextMenu {
@@ -39,19 +51,28 @@ struct TerminalTabContextMenu: ViewModifier {
         actions.closeTab(tabId)
       }
 
-      Button("Close Other Tabs") {
+      Button(variant == .canvas ? "Close Other Tabs in This Worktree" : "Close Other Tabs") {
         actions.closeOthers(tabId)
       }
       .disabled(tabs.count <= 1)
 
-      Button("Close Tabs to the Right") {
-        actions.closeToRight(tabId)
+      if variant != .canvas {
+        Button(closeToTrailingLabel) {
+          actions.closeToRight(tabId)
+        }
+        .disabled(isLastTab)
       }
-      .disabled(isLastTab)
 
-      Button("Close All") {
+      Button(variant == .canvas ? "Close All Tabs in This Worktree" : "Close All") {
         actions.closeAll()
       }
+    }
+  }
+
+  private var closeToTrailingLabel: String {
+    switch variant {
+    case .shelf: "Close Tabs Below"
+    case .tabBar, .canvas: "Close Tabs to the Right"
     }
   }
 


### PR DESCRIPTION
## Summary
- Add the shared terminal tab context menu to Canvas card title bars.
- Wire Canvas title-bar menu actions to the owning worktree tab state, including Rename Tab, Change Tab Icon, and tab close variants.
- Add Canvas-local icon picker sheet presentation so the reused menu stays functional outside Default/Shelf views.

## Verification
- `make check`
- `make build-app`

Fixes #453
