### PR TITLE
Fix layout restore race where scenePhase save clears snapshot on launch

### DIFF
--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -152,7 +152,10 @@ struct AppFeature {
           )
         case .inactive, .background:
           var effects: [Effect<Action>] = [.cancel(id: CancelID.periodicRefresh)]
-          if state.settings.restoreTerminalLayoutOnLaunch, !state.suppressLayoutSaveUntilRelaunch {
+          if state.settings.restoreTerminalLayoutOnLaunch,
+            !state.suppressLayoutSaveUntilRelaunch,
+            state.launchRestoreMode != .restoreLayout
+          {
             appLogger.info("[LayoutRestore] scenePhase=\(String(describing: phase)), saving layout snapshot")
             effects.append(.run { _ in await terminalClient.send(.saveLayoutSnapshot) })
           }

--- a/supacodeTests/AppFeatureTerminalLayoutRestoreTests.swift
+++ b/supacodeTests/AppFeatureTerminalLayoutRestoreTests.swift
@@ -372,7 +372,43 @@ struct AppFeatureTerminalLayoutRestoreTests {
     await store.finish()
   }
 
-  @Test(.dependencies) func scenePhaseInactiveSavesLayoutSnapshot() async {
+  @Test(.dependencies) func scenePhaseInactiveSavesLayoutSnapshotAfterRestoreConsumed() async {
+    let worktree = makeWorktree()
+    let repository = makeRepository(worktrees: [worktree])
+    var repositoriesState = RepositoriesFeature.State(repositories: [repository])
+    repositoriesState.snapshotPersistencePhase = .active
+    var settings = SettingsFeature.State()
+    settings.restoreTerminalLayoutOnLaunch = true
+    let sentCommands = LockIsolated<[TerminalClient.Command]>([])
+
+    let store = TestStore(
+      initialState: AppFeature.State(repositories: repositoriesState, settings: settings)
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in
+        sentCommands.withValue { $0.append(command) }
+      }
+      $0.worktreeInfoWatcher.send = { _ in }
+    }
+    store.exhaustivity = .off
+
+    // Consume the restore mode via repositoriesChanged
+    await store.send(.repositories(.delegate(.repositoriesChanged([repository])))) {
+      $0.launchRestoreMode = .lastFocusedWorktree
+      $0.repositories.selection = nil
+    }
+    await store.finish()
+    sentCommands.withValue { $0.removeAll() }
+
+    // Now scenePhase inactive should trigger save
+    await store.send(.scenePhaseChanged(.inactive))
+    await store.finish()
+
+    #expect(sentCommands.value == [.saveLayoutSnapshot])
+  }
+
+  @Test(.dependencies) func scenePhaseInactiveSkipsSaveDuringPendingRestore() async {
     let sentCommands = LockIsolated<[TerminalClient.Command]>([])
     var settings = SettingsFeature.State()
     settings.restoreTerminalLayoutOnLaunch = true
@@ -385,10 +421,12 @@ struct AppFeatureTerminalLayoutRestoreTests {
     }
     store.exhaustivity = .off
 
+    // launchRestoreMode is .restoreLayout — save must be skipped
+    // to prevent clearing a snapshot before restore has a chance to load it
     await store.send(.scenePhaseChanged(.inactive))
     await store.finish()
 
-    #expect(sentCommands.value == [.saveLayoutSnapshot])
+    #expect(!sentCommands.value.contains(.saveLayoutSnapshot))
   }
 
   @Test(.dependencies) func scenePhaseInactiveSkipsSaveWhenRestoreDisabled() async {


### PR DESCRIPTION
## Summary

- Skip the `scenePhaseChanged`-triggered layout save while `launchRestoreMode == .restoreLayout` to prevent clearing the saved snapshot before restore can read it
- The `.task { scenePhaseChanged(scenePhase) }` added in 73d1b07a sends `.background` on launch before terminal states are populated — the async save finds no active states, clears the snapshot, and the later restore finds nothing on disk

## Root Cause

`ContentView.task` fires `scenePhaseChanged(.background)` → async `persistLayoutSnapshot()` → `makeLayoutSnapshotPayload()` returns nil (0 states) → `clearSnapshot()` deletes the file → `restoreLayoutSnapshot` finds no snapshot.

## Test plan

- [x] Existing `AppFeatureTerminalLayoutRestoreTests` pass (17/17)
- [x] New test: `scenePhaseInactiveSkipsSaveDuringPendingRestore` — verifies save is skipped while in `.restoreLayout` mode
- [x] Updated test: `scenePhaseInactiveSavesLayoutSnapshotAfterRestoreConsumed` — verifies save works normally after restore mode is consumed
- [x] Manual: Build & Run → open repos → Cmd+Q → Build & Run again → tabs should restore
