### PR TITLE
Relax toolbar button spacing and improve hover consistency

### DIFF
--- a/supacode/Features/Repositories/Views/OpenWorktreeActionMenuLabelView.swift
+++ b/supacode/Features/Repositories/Views/OpenWorktreeActionMenuLabelView.swift
@@ -32,5 +32,6 @@ struct OpenWorktreeActionMenuLabelView: View {
           .font(.body)
       }
     }
+    .padding(.horizontal, 4)
   }
 }

--- a/supacode/Features/Repositories/Views/OpenWorktreeActionMenuLabelView.swift
+++ b/supacode/Features/Repositories/Views/OpenWorktreeActionMenuLabelView.swift
@@ -6,7 +6,7 @@ struct OpenWorktreeActionMenuLabelView: View {
   let shortcutHint: String?
 
   var body: some View {
-    HStack(spacing: 6) {
+    HStack(spacing: 8) {
       if let icon = action.menuIcon {
         switch icon {
         case .app(let image):

--- a/supacode/Features/Repositories/Views/WorktreeDetailTitleView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailTitleView.swift
@@ -70,6 +70,7 @@ struct WorktreeDetailTitleView: View {
       Text(title.text)
     }
     .font(.headline)
+    .padding(.horizontal, 8)
   }
 }
 

--- a/supacode/Features/Repositories/Views/WorktreeDetailTitleView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailTitleView.swift
@@ -70,22 +70,6 @@ struct WorktreeDetailTitleView: View {
       Text(title.text)
     }
     .font(.headline)
-<<<<<<< HEAD
-    .padding(.horizontal, horizontalPadding)
-  }
-
-  private var iconWidth: CGFloat {
-    16
-  }
-
-  private var horizontalSpacing: CGFloat {
-    8
-  }
-
-  private var horizontalPadding: CGFloat {
-    title.supportsRename ? 0 : 8
-=======
->>>>>>> origin/main
   }
 }
 

--- a/supacode/Features/Repositories/Views/WorktreeDetailTitleView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailTitleView.swift
@@ -83,11 +83,11 @@ struct WorktreeDetailTitleView: View {
   }
 
   private var horizontalSpacing: CGFloat {
-    6
+    8
   }
 
   private var horizontalPadding: CGFloat {
-    title.supportsRename ? 0 : 6
+    title.supportsRename ? 0 : 8
   }
 }
 

--- a/supacode/Features/Repositories/Views/WorktreeDetailToolbarViews.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailToolbarViews.swift
@@ -92,7 +92,7 @@ struct RunScriptToolbarButton: View {
     Button {
       config.action()
     } label: {
-      HStack(spacing: 6) {
+      HStack(spacing: 8) {
         Image(systemName: config.systemImage)
           .accessibilityHidden(true)
         Text(config.title)
@@ -103,8 +103,9 @@ struct RunScriptToolbarButton: View {
             .foregroundStyle(.secondary)
         }
       }
+      .padding(.horizontal, 6)
     }
-    .font(.caption)
+    .font(.callout)
     .help(config.helpText)
     .disabled(!config.isEnabled)
   }
@@ -131,7 +132,7 @@ struct UserCustomCommandToolbarButton: View {
     Button {
       action()
     } label: {
-      HStack(spacing: 6) {
+      HStack(spacing: 8) {
         Image(systemName: systemImage)
           .accessibilityHidden(true)
         Text(title)
@@ -141,8 +142,9 @@ struct UserCustomCommandToolbarButton: View {
             .foregroundStyle(.secondary)
         }
       }
+      .padding(.horizontal, 6)
     }
-    .font(.caption)
+    .font(.callout)
     .help(helpText)
     .disabled(!isEnabled)
   }

--- a/supacode/Features/Repositories/Views/WorktreeDetailToolbarViews.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailToolbarViews.swift
@@ -103,7 +103,7 @@ struct RunScriptToolbarButton: View {
             .foregroundStyle(.secondary)
         }
       }
-      .padding(.horizontal, 6)
+      .padding(.horizontal, 4)
     }
     .font(.callout)
     .help(config.helpText)
@@ -142,7 +142,7 @@ struct UserCustomCommandToolbarButton: View {
             .foregroundStyle(.secondary)
         }
       }
-      .padding(.horizontal, 6)
+      .padding(.horizontal, 4)
     }
     .font(.callout)
     .help(helpText)

--- a/supacode/Features/Repositories/Views/WorktreeDetailToolbarViews.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailToolbarViews.swift
@@ -103,7 +103,7 @@ struct RunScriptToolbarButton: View {
             .foregroundStyle(.secondary)
         }
       }
-      .padding(.horizontal, 4)
+      .padding(.horizontal, 8)
     }
     .font(.callout)
     .help(config.helpText)
@@ -142,7 +142,7 @@ struct UserCustomCommandToolbarButton: View {
             .foregroundStyle(.secondary)
         }
       }
-      .padding(.horizontal, 4)
+      .padding(.horizontal, 8)
     }
     .font(.callout)
     .help(helpText)

--- a/supacode/Features/Repositories/Views/WorktreeDetailView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailView.swift
@@ -916,33 +916,32 @@ struct WorktreeDetailView: View {
         ToolbarSpacer(.fixed)
       }
 
-      if showRunButton {
+      if showRunButton || !inlineEntries.isEmpty {
         ToolbarItem {
-          RunScriptToolbarButton(
-            isRunning: toolbarState.runScriptIsRunning,
-            isEnabled: toolbarState.runScriptEnabled,
-            runHelpText: AppShortcuts.helpText(
-              title: "Run Script",
-              commandID: AppShortcuts.CommandID.runScript,
-              in: resolvedKeybindings
-            ),
-            stopHelpText: AppShortcuts.helpText(
-              title: "Stop Script",
-              commandID: AppShortcuts.CommandID.stopScript,
-              in: resolvedKeybindings
-            ),
-            runShortcut: shortcutDisplay(for: AppShortcuts.CommandID.runScript),
-            stopShortcut: shortcutDisplay(for: AppShortcuts.CommandID.stopScript),
-            runAction: onRunScript,
-            stopAction: onStopRunScript
-          )
-        }
-      }
-
-      if !inlineEntries.isEmpty {
-        ToolbarItemGroup {
-          ForEach(inlineEntries, id: \.command.id) { entry in
-            customCommandButton(entry.command, index: entry.index)
+          HStack(spacing: -16) {
+            if showRunButton {
+              RunScriptToolbarButton(
+                isRunning: toolbarState.runScriptIsRunning,
+                isEnabled: toolbarState.runScriptEnabled,
+                runHelpText: AppShortcuts.helpText(
+                  title: "Run Script",
+                  commandID: AppShortcuts.CommandID.runScript,
+                  in: resolvedKeybindings
+                ),
+                stopHelpText: AppShortcuts.helpText(
+                  title: "Stop Script",
+                  commandID: AppShortcuts.CommandID.stopScript,
+                  in: resolvedKeybindings
+                ),
+                runShortcut: shortcutDisplay(for: AppShortcuts.CommandID.runScript),
+                stopShortcut: shortcutDisplay(for: AppShortcuts.CommandID.stopScript),
+                runAction: onRunScript,
+                stopAction: onStopRunScript
+              )
+            }
+            ForEach(inlineEntries, id: \.command.id) { entry in
+              customCommandButton(entry.command, index: entry.index)
+            }
           }
         }
       }


### PR DESCRIPTION
## Summary

Improves toolbar button spacing and hover behavior for Run, custom commands, Open, and branch name buttons.

## Changes

- **Font**: Bump Run and custom command buttons from `.caption` to `.callout` for better readability
- **Icon-text spacing**: Increase from 6pt to 8pt across all toolbar buttons
- **Label padding**: Add 8pt horizontal padding to Run, custom command, and branch name buttons
- **Button cluster**: Merge Run + custom commands into single `ToolbarItem` with `HStack(spacing: -16)` for tight visual grouping
- **Hover consistency**: Move padding outside Button so hover highlights include margin area, matching Open button behavior
- **Open button**: Add 4pt horizontal padding and 8pt icon-text spacing for consistent feel

## Before/After

Toolbar buttons now have better text-to-edge spacing while maintaining a compact cluster appearance. Hover behavior is consistent with the Open button.