### PR TITLE
Add project workspace support (with review fixes)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,14 @@ xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platf
   CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation
 ```
 
+**Swift Testing vs XCTest `-only-testing` format**: Swift Testing (`@Test`) requires trailing `()` in the test identifier. Without it, `xcodebuild` silently matches nothing and reports `TEST SUCCEEDED` with zero tests run.
+```bash
+# XCTest (func testFoo)
+-only-testing:supacodeTests/FooTests/testBar
+# Swift Testing (@Test func bar)
+-only-testing:"supacodeTests/FooTests/bar()"
+```
+
 Requires [mise](https://mise.jdx.dev/) for zig, swiftlint, and xcsift tooling.
 
 ## Architecture

--- a/README.md
+++ b/README.md
@@ -121,8 +121,9 @@ A personal fork of [Supacode](https://github.com/supabitapp/supacode), built on 
 ```bash
 make build-ghostty-xcframework   # Build GhosttyKit from Zig source
 make build-app                   # Build the macOS app (Debug)
-make run-app                     # Build, launch, and stream logs
-make install-dev-build           # Build Debug and install to /Applications
+make run-app                     # Build, install, and launch Debug from /Applications/Prowl Debug.app
+make install-debug               # Build Debug and install to /Applications/Prowl Debug.app
+make install-dev-build           # Alias-compatible Debug install target
 make install-release             # Build Release, sign locally, install to /Applications
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -43,6 +43,7 @@ its keyboard shortcuts, detailed behavior, settings, and gotchas.
 | File | What it covers |
 |------|----------------|
 | [`components/repositories-and-worktrees.md`](components/repositories-and-worktrees.md) | The sidebar: adding repositories, creating / opening / archiving / deleting git worktrees, plain (non-git) folders, pinning, ordering, repository icons & colors. |
+| [`components/workspaces.md`](components/workspaces.md) | Multi-repo workspaces: one agent terminal rooted at a shared folder, with `.prowl/workspace.json` metadata describing the repositories in scope. |
 | [`components/terminal.md`](components/terminal.md) | Terminal tabs, splits/panes, surfaces, the Ghostty engine, tab titles & icons, shell integration, scrollback, font size. |
 | [`components/canvas.md`](components/canvas.md) | Canvas view — a zoomable board of live terminal cards, multi-select, and **broadcast a command to every agent at once**. |
 | [`components/shelf.md`](components/shelf.md) | Shelf view — worktrees as vertical "book spines" you flip through from the keyboard. |
@@ -70,6 +71,7 @@ its keyboard shortcuts, detailed behavior, settings, and gotchas.
 | I want to… | Read |
 |------------|------|
 | Run many agents side by side and see them all | [`components/canvas.md`](components/canvas.md), [`components/shelf.md`](components/shelf.md) |
+| Give one agent a task that spans several repos | [`components/workspaces.md`](components/workspaces.md) |
 | Send one command to every agent simultaneously | [`components/canvas.md`](components/canvas.md) (broadcast) |
 | Spin up a new branch/worktree for a new agent | [`components/repositories-and-worktrees.md`](components/repositories-and-worktrees.md) |
 | Find / run any action by name | [`components/command-palette.md`](components/command-palette.md) |

--- a/docs/components/cli.md
+++ b/docs/components/cli.md
@@ -66,7 +66,7 @@ Snapshot of all worktrees → tabs → panes. No selectors.
 prowl list --json
 ```
 Each item contains:
-- `worktree`: `id`, `name`, `path`, `root_path`, `kind` (`git`|`plain`)
+- `worktree`: `id`, `name`, `path`, `root_path`, `kind` (`git`|`plain`|`workspace`)
 - `tab`: `id`, `title`, `selected`
 - `pane`: `id`, `title`, `cwd`, `focused`
 - `task`: `status` (`running` | `idle` | null)

--- a/docs/components/repositories-and-worktrees.md
+++ b/docs/components/repositories-and-worktrees.md
@@ -33,8 +33,7 @@ root; "not a git repository" → plain folder).
 
 - **Shortcut:** `⌘⇧O` (`open_repository`)
 - **Toolbar:** the **Add Repository** button (folder-with-plus icon) at the top of
-  the sidebar. Clicking runs Add Repository directly; its attached menu holds
-  **New Workspace**.
+  the sidebar, next to **New Workspace** (person-in-folder icon).
 - **Command Palette:** "Open Repository".
 
 Pick one or more directories. Prowl detects git vs plain, de-duplicates, and

--- a/docs/components/repositories-and-worktrees.md
+++ b/docs/components/repositories-and-worktrees.md
@@ -33,7 +33,8 @@ root; "not a git repository" → plain folder).
 
 - **Shortcut:** `⌘⇧O` (`open_repository`)
 - **Toolbar:** the **Add Repository** button (folder-with-plus icon) at the top of
-  the sidebar.
+  the sidebar. Clicking runs Add Repository directly; its attached menu holds
+  **New Workspace**.
 - **Command Palette:** "Open Repository".
 
 Pick one or more directories. Prowl detects git vs plain, de-duplicates, and

--- a/docs/components/repositories-and-worktrees.md
+++ b/docs/components/repositories-and-worktrees.md
@@ -32,8 +32,8 @@ root; "not a git repository" → plain folder).
 ## Adding a repository
 
 - **Shortcut:** `⌘⇧O` (`open_repository`)
-- **Toolbar:** the **Add Repository** button (folder-with-plus icon) at the top of
-  the sidebar, next to **New Workspace** (person-in-folder icon).
+- **Toolbar:** the **Add...** button (folder-with-plus icon) at the top of the
+  sidebar. Choose **Add Local Repository/Folder**.
 - **Command Palette:** "Open Repository".
 
 Pick one or more directories. Prowl detects git vs plain, de-duplicates, and

--- a/docs/components/workspaces.md
+++ b/docs/components/workspaces.md
@@ -60,8 +60,9 @@ folder is materialized:
   the workspace gets an isolated checkout on a new branch created from the
   selected base ref, without touching the source repository's own checkout. The
   new worktree also appears in the source repository's worktree list.
-- **Use Existing** runs `git worktree add` with the selected ref. Git rejects a
-  local branch that is already checked out elsewhere.
+- **Use Existing** runs `git worktree add` with the selected ref. Choosing a
+  remote-tracking ref creates a local tracking branch instead of a detached
+  worktree. Git rejects a branch that is already checked out elsewhere.
 
 The creation prompt detects base-ref candidates for already opened, local, and
 bare repositories by reading local git refs, preferring the detected default
@@ -78,10 +79,12 @@ Branch behavior is explicit:
   every source kind.
 - **Use Existing** uses the selected ref directly. For remote clones, Prowl
   checks out the selected remote branch after clone; Git creates the normal
-  local tracking branch for refs such as `origin/feature`. For bare
-  repositories, Prowl passes the selected ref to `git worktree add`, so local
-  branch refs produce branch worktrees and remote-tracking refs produce detached
-  worktrees.
+  local tracking branch for refs such as `origin/feature`. For bare and local
+  repositories, a local branch ref produces a branch worktree, and a
+  remote-tracking ref such as `origin/feature` runs
+  `git worktree add --track -B feature`, which creates the local tracking
+  branch — aligning a same-named local branch to the remote when one exists.
+  Git refuses if that branch is already checked out in another worktree.
 
 ## Metadata
 

--- a/docs/components/workspaces.md
+++ b/docs/components/workspaces.md
@@ -18,9 +18,9 @@ When you open a workspace in Prowl:
 
 ## Folder layout
 
-Use **New Workspace** from the sidebar toolbar (the menu attached to the **Add
-Repository** button), the Worktrees menu, or the command palette to create a
-workspace. Prowl creates the shared folder, materializes the
+Use **New Workspace** from the sidebar toolbar (the
+person-in-folder button next to **Add Repository**), the Worktrees menu, or the
+command palette to create a workspace. Prowl creates the shared folder, materializes the
 selected repositories, writes `.prowl/workspace.json`, and opens the workspace
 as a runnable folder. A workspace needs at least two repositories.
 

--- a/docs/components/workspaces.md
+++ b/docs/components/workspaces.md
@@ -34,8 +34,8 @@ my-feature-workspace/
 
 Repository sources can be mixed in one workspace:
 
-- Already opened repositories are added as symlinks with `source_kind:
-  existing_path`.
+- Already opened repositories can be inserted from the **Add Opened** menu. They
+  are added as symlinks with `source_kind: existing_path`.
 - Local repository folders selected from disk are added as symlinks with
   `source_kind: local_repository`.
 - Remote repositories are added through a URL prompt that loads remote heads
@@ -50,7 +50,8 @@ The creation prompt detects base-ref candidates for already opened, local, and
 bare repositories by reading local git refs, preferring the detected default
 branch such as `main` or `master`. Refs are grouped as local branches, remote
 tracking branches, or fetched remote branches, and the picker supports simple
-text search. Base refs are selected from detected refs so workspace creation
+text search. Remote default-branch pointers are shown explicitly, such as
+`origin/HEAD`. Base refs are selected from detected refs so workspace creation
 does not try to checkout an arbitrary, nonexistent branch.
 
 Branch behavior is explicit:
@@ -59,7 +60,11 @@ Branch behavior is explicit:
   new branch or worktree branch. Remote and bare sources require a branch name
   in this mode.
 - **Use Existing** uses the selected ref directly. For remote clones, Prowl
-  checks out the selected remote branch after clone.
+  checks out the selected remote branch after clone; Git creates the normal
+  local tracking branch for refs such as `origin/feature`. For bare
+  repositories, Prowl passes the selected ref to `git worktree add`, so local
+  branch refs produce branch worktrees and remote-tracking refs produce detached
+  worktrees.
 
 ## Metadata
 

--- a/docs/components/workspaces.md
+++ b/docs/components/workspaces.md
@@ -86,6 +86,17 @@ Branch behavior is explicit:
   branch — aligning a same-named local branch to the remote when one exists.
   Git refuses if that branch is already checked out in another worktree.
 
+## Removing a workspace
+
+**Remove Repository** on a workspace opens a dedicated confirmation. By default
+it only removes the entry from Prowl and leaves everything on disk. Tick **Also
+delete the workspace folder and its worktrees** to additionally unregister the
+worktrees that were created for this workspace from their source repositories
+(`git worktree remove --force`) and delete the workspace folder. Linked
+repositories stay untouched — only the symlinks inside the workspace folder are
+removed. Cleanup is best-effort: a broken source repository is logged and
+skipped instead of blocking the deletion.
+
 ## Metadata
 
 Example `.prowl/workspace.json`:

--- a/docs/components/workspaces.md
+++ b/docs/components/workspaces.md
@@ -92,10 +92,13 @@ Branch behavior is explicit:
 it only removes the entry from Prowl and leaves everything on disk. Tick **Also
 delete the workspace folder and its worktrees** to additionally unregister the
 worktrees that were created for this workspace from their source repositories
-(`git worktree remove --force`) and delete the workspace folder. Linked
-repositories stay untouched — only the symlinks inside the workspace folder are
-removed. Cleanup is best-effort: a broken source repository is logged and
-skipped instead of blocking the deletion.
+(`git worktree remove --force`) and delete the workspace folder. Worktree
+entries with a recorded branch additionally offer a per-repository **Delete
+branch** checkbox that removes the branch from the source repository
+(`git branch -D`) after the worktree is gone. Linked repositories stay
+untouched — only the symlinks inside the workspace folder are removed. Cleanup
+is best-effort: a broken source repository is logged and skipped instead of
+blocking the deletion.
 
 ## Metadata
 

--- a/docs/components/workspaces.md
+++ b/docs/components/workspaces.md
@@ -18,11 +18,11 @@ When you open a workspace in Prowl:
 
 ## Folder layout
 
-Use **New Workspace** from the sidebar toolbar (the
-person-in-folder button next to **Add Repository**), the Worktrees menu, or the
-command palette to create a workspace. Prowl creates the shared folder, materializes the
-selected repositories, writes `.prowl/workspace.json`, and opens the workspace
-as a runnable folder. A workspace needs at least two repositories.
+Use **Add...** from the sidebar toolbar and choose **Add Workspace**, or use the
+Worktrees menu or command palette to create a workspace. Prowl creates the
+shared folder, materializes the selected repositories, writes
+`.prowl/workspace.json`, and opens the workspace as a runnable folder. A
+workspace needs at least two repositories.
 
 While a workspace is being created the prompt shows a spinner. **Cancel** stops
 the creation and rolls back everything created so far: cloned folders, created
@@ -44,12 +44,17 @@ Repository sources can be mixed in one workspace:
 - Local repository folders are selected from disk
   (`source_kind: local_repository`).
 - Remote repositories are added through a URL prompt that loads remote heads
-  before inserting the row. They are cloned into the workspace folder with
-  `source_kind: remote`. The inserted row defaults to **Use Existing** on the
-  detected default remote branch.
-- Bare repositories are materialized with `git worktree add` and recorded with
-  `source_kind: bare_repository`. If both branch and base ref are supplied,
-  Prowl creates the worktree branch from that base ref.
+  before inserting the row. Loading can be canceled while the prompt is open.
+  They are cloned into the workspace folder with `source_kind: remote`. The
+  inserted row defaults to **Use Existing** on the detected default remote
+  branch.
+- Bare repositories are supported by the metadata and materialization layer as
+  `source_kind: bare_repository`, but the first workspace UI keeps that
+  advanced source hidden.
+
+Opened and local repository rows show their source as read-only provenance
+rather than a mode selector because both follow the same materialization rules
+after they have been added.
 
 For already opened and local repositories, the branch action decides how the
 folder is materialized:
@@ -64,14 +69,21 @@ folder is materialized:
   remote-tracking ref creates a local tracking branch instead of a detached
   worktree. Git rejects a branch that is already checked out elsewhere.
 
-The creation prompt detects base-ref candidates for already opened, local, and
-bare repositories by reading local git refs, preferring the detected default
+The creation prompt detects base-ref candidates for already opened and local
+repositories by reading local git refs, preferring the detected default
 branch such as `main` or `master`. Refs are grouped as local branches, remote
 tracking branches, or fetched remote branches, and the picker supports simple
 text search. `<remote>/HEAD` symbolic pointers are omitted from the picker
 because they only alias a branch that is already listed. Base refs are selected
 from detected refs so workspace creation does not try to checkout an arbitrary,
 nonexistent branch.
+
+When creation validation fails inside a repository row, the repository list
+scrolls to that row and highlights the invalid field with a red border.
+
+The **Folder** path follows the workspace **Title** while it is still generated
+by Prowl. Once you edit or choose the folder directly, Prowl treats it as a
+manual path and stops changing it when the title changes.
 
 Branch behavior is explicit:
 
@@ -92,6 +104,12 @@ Branch behavior is explicit:
     remote ref (the `-B` behavior, which discards local-only commits on that
     branch). This prevents an unnoticed reset of a local branch that is ahead of
     the remote.
+
+Workspace rows expand to show child repository rows. Each child row displays its
+current branch, uncommitted line counts, and pull request badge when available,
+including immediately after a newly created workspace is opened. Click a child
+row to select it and focus its terminal tab rooted at that repository folder
+inside the workspace, creating that tab the first time it is selected.
 
 ## Removing a workspace
 
@@ -121,6 +139,7 @@ Example `.prowl/workspace.json`:
 
 ```json
 {
+  "schema_version": "prowl.workspace.v1",
   "title": "Checkout Flow",
   "description": "Update app UI, API contract, and shared package together.",
   "task_links": [
@@ -157,6 +176,8 @@ Example `.prowl/workspace.json`:
 
 Top-level fields:
 
+- `schema_version` — metadata format version. Defaults to
+  `prowl.workspace.v1` when omitted.
 - `id` — optional stable identifier. Defaults to the workspace root path.
 - `title` — display title. Defaults to the folder name.
 - `description` — optional task summary shown in the detail view.

--- a/docs/components/workspaces.md
+++ b/docs/components/workspaces.md
@@ -1,0 +1,111 @@
+# Workspaces
+
+**Keywords:** workspace, multi-repo, many repositories, agent cwd, `.prowl/workspace.json`, workspace metadata, `prowl list`
+
+Workspaces let one agent work on a task that spans several repositories. A
+workspace is a folder added to Prowl as a runnable project, with metadata at
+`.prowl/workspace.json` describing the repositories inside it.
+
+When you open a workspace in Prowl:
+
+- The terminal starts in the workspace root.
+- The sidebar/detail view uses the workspace title and repository list from
+  `.prowl/workspace.json`.
+- The `prowl` CLI reports the runnable target's `worktree.kind` as `workspace`.
+- Git worktree, branch, diff, and PR controls remain per-repository features; a
+  workspace is intentionally a multi-repo working directory rather than a single
+  git repository.
+
+## Folder layout
+
+Create or clone the repositories into a shared folder first, then add that
+folder to Prowl.
+
+```text
+my-feature-workspace/
+├─ .prowl/
+│  └─ workspace.json
+├─ app/
+├─ api/
+└─ shared-package/
+```
+
+Prowl currently reads the metadata and opens the workspace root. It does not yet
+clone remote repositories or materialize git worktrees from the metadata by
+itself, so those directories should already exist when the agent starts.
+
+## Metadata
+
+Example `.prowl/workspace.json`:
+
+```json
+{
+  "title": "Checkout Flow",
+  "description": "Update app UI, API contract, and shared package together.",
+  "task_links": [
+    "https://github.com/onevcat/Prowl/issues/123"
+  ],
+  "repositories": [
+    {
+      "name": "App",
+      "role": "macOS app",
+      "path": "app",
+      "source_kind": "local_repository",
+      "source_location": "/Users/mikoto/Documents/Repos/github/Prowl",
+      "branch_name": "codex/checkout-flow"
+    },
+    {
+      "name": "API",
+      "role": "backend",
+      "path": "api",
+      "source_kind": "remote",
+      "source_location": "git@github.com:onevcat/api.git",
+      "base_ref": "main"
+    },
+    {
+      "name": "Shared Package",
+      "role": "library",
+      "path": "shared-package",
+      "source_kind": "bare_repository",
+      "source_location": "/Users/mikoto/Documents/Repos/bare/shared-package.git",
+      "branch_name": "codex/checkout-flow"
+    }
+  ]
+}
+```
+
+Top-level fields:
+
+- `id` — optional stable identifier. Defaults to the workspace root path.
+- `title` — display title. Defaults to the folder name.
+- `description` — optional task summary shown in the detail view.
+- `task_links` — optional links or identifiers for the work item.
+- `repositories` — repo entries that belong to the workspace.
+- `created_at` / `updated_at` — optional ISO-8601 timestamps.
+
+Repository entry fields:
+
+- `id` — optional stable identifier. Defaults to `path`.
+- `name` — display name. Defaults to the last path component.
+- `role` — optional short role such as `app`, `backend`, or `docs`.
+- `path` — relative path under the workspace root, or an absolute path.
+- `source_kind` — `existing_path`, `remote`, `local_repository`, or
+  `bare_repository`.
+- `source_location` — optional remote URL, local repository path, or bare repo
+  path.
+- `branch_name` — optional branch/worktree name expected for the task.
+- `base_ref` — optional base branch or ref.
+
+## Agent usage
+
+Because the terminal cwd is the workspace root, agents can inspect and modify
+all listed repositories in one session:
+
+```bash
+git -C app status
+git -C api status
+git -C shared-package status
+```
+
+Use the metadata as the contract: it tells the agent which repos are in scope,
+where they are on disk, and what role each repo plays in the task.

--- a/docs/components/workspaces.md
+++ b/docs/components/workspaces.md
@@ -38,19 +38,28 @@ Repository sources can be mixed in one workspace:
   existing_path`.
 - Local repository folders selected from disk are added as symlinks with
   `source_kind: local_repository`.
-- Remote repositories are cloned into the workspace folder with `source_kind:
-  remote`. If a branch and base ref are supplied, Prowl checks out the branch
-  from the base after cloning.
+- Remote repositories are added through a URL prompt that loads remote heads
+  before inserting the row. They are cloned into the workspace folder with
+  `source_kind: remote`. The inserted row defaults to **Use Existing** on the
+  detected default remote branch.
 - Bare repositories are materialized with `git worktree add` and recorded with
   `source_kind: bare_repository`. If both branch and base ref are supplied,
   Prowl creates the worktree branch from that base ref.
 
 The creation prompt detects base-ref candidates for already opened, local, and
 bare repositories by reading local git refs, preferring the detected default
-branch such as `main` or `master`. Base refs are selected from detected refs so
-workspace creation does not try to checkout an arbitrary, nonexistent branch.
-Remote clone entries can be created without a base ref; after cloning, a branch
-name without an explicit base is created from the repository's default checkout.
+branch such as `main` or `master`. Refs are grouped as local branches, remote
+tracking branches, or fetched remote branches, and the picker supports simple
+text search. Base refs are selected from detected refs so workspace creation
+does not try to checkout an arbitrary, nonexistent branch.
+
+Branch behavior is explicit:
+
+- **Create Branch** uses `branch_name` plus the selected base ref to create a
+  new branch or worktree branch. Remote and bare sources require a branch name
+  in this mode.
+- **Use Existing** uses the selected ref directly. For remote clones, Prowl
+  checks out the selected remote branch after clone.
 
 ## Metadata
 

--- a/docs/components/workspaces.md
+++ b/docs/components/workspaces.md
@@ -68,9 +68,10 @@ The creation prompt detects base-ref candidates for already opened, local, and
 bare repositories by reading local git refs, preferring the detected default
 branch such as `main` or `master`. Refs are grouped as local branches, remote
 tracking branches, or fetched remote branches, and the picker supports simple
-text search. Remote default-branch pointers are shown explicitly, such as
-`origin/HEAD`. Base refs are selected from detected refs so workspace creation
-does not try to checkout an arbitrary, nonexistent branch.
+text search. `<remote>/HEAD` symbolic pointers are omitted from the picker
+because they only alias a branch that is already listed. Base refs are selected
+from detected refs so workspace creation does not try to checkout an arbitrary,
+nonexistent branch.
 
 Branch behavior is explicit:
 
@@ -85,6 +86,12 @@ Branch behavior is explicit:
   `git worktree add --track -B feature`, which creates the local tracking
   branch — aligning a same-named local branch to the remote when one exists.
   Git refuses if that branch is already checked out in another worktree.
+  - When a remote-tracking ref is selected and a same-named local branch already
+    exists, the repository row shows a choice: **Use local branch** (the
+    default — checks out the existing local branch as-is) or **Reset to** the
+    remote ref (the `-B` behavior, which discards local-only commits on that
+    branch). This prevents an unnoticed reset of a local branch that is ahead of
+    the remote.
 
 ## Removing a workspace
 
@@ -94,11 +101,15 @@ delete the workspace folder and its worktrees** to additionally unregister the
 worktrees that were created for this workspace from their source repositories
 (`git worktree remove --force`) and delete the workspace folder. Worktree
 entries with a recorded branch additionally offer a per-repository **Delete
-branch** checkbox that removes the branch from the source repository
-(`git branch -D`) after the worktree is gone. Linked repositories stay
-untouched — only the symlinks inside the workspace folder are removed. Cleanup
-is best-effort: a broken source repository is logged and skipped instead of
-blocking the deletion.
+branch** checkbox that removes the branch from the source repository after the
+worktree is gone. Branch deletion goes through the same protected-branch guard
+as the rest of Prowl, so `main`, `master`, and the repository's default remote
+branch are never deleted even if they were recorded as a workspace branch.
+Linked repositories stay untouched — only the symlinks inside the workspace
+folder are removed. Cleanup is best-effort: a broken source repository is logged
+and skipped instead of blocking the deletion. If a worktree cannot be
+unregistered, Prowl asks before deleting the workspace folder, since deleting it
+anyway would leave a dangling worktree registration in the source repository.
 
 ## Metadata
 

--- a/docs/components/workspaces.md
+++ b/docs/components/workspaces.md
@@ -18,8 +18,9 @@ When you open a workspace in Prowl:
 
 ## Folder layout
 
-Use **New Workspace** from the sidebar toolbar, Worktrees menu, or command
-palette to create a workspace. Prowl creates the shared folder, materializes the
+Use **New Workspace** from the sidebar toolbar (the menu attached to the **Add
+Repository** button), the Worktrees menu, or the command palette to create a
+workspace. Prowl creates the shared folder, materializes the
 selected repositories, writes `.prowl/workspace.json`, and opens the workspace
 as a runnable folder. A workspace needs at least two repositories.
 

--- a/docs/components/workspaces.md
+++ b/docs/components/workspaces.md
@@ -45,6 +45,12 @@ Repository sources can be mixed in one workspace:
   `source_kind: bare_repository`. If both branch and base ref are supplied,
   Prowl creates the worktree branch from that base ref.
 
+The creation prompt detects base-ref candidates for already opened, local, and
+bare repositories by reading local git refs, preferring the detected default
+branch such as `main` or `master`. Remote clone entries show common base-ref
+candidates (`main`, `master`, `origin/main`, `origin/master`) without probing
+the network; you can choose one from the menu or type any ref manually.
+
 ## Metadata
 
 Example `.prowl/workspace.json`:

--- a/docs/components/workspaces.md
+++ b/docs/components/workspaces.md
@@ -21,7 +21,11 @@ When you open a workspace in Prowl:
 Use **New Workspace** from the sidebar toolbar, Worktrees menu, or command
 palette to create a workspace. Prowl creates the shared folder, materializes the
 selected repositories, writes `.prowl/workspace.json`, and opens the workspace
-as a runnable folder.
+as a runnable folder. A workspace needs at least two repositories.
+
+While a workspace is being created the prompt shows a spinner. **Cancel** stops
+the creation and rolls back everything created so far: cloned folders, created
+worktrees, and the workspace folder itself when Prowl created it.
 
 ```text
 my-feature-workspace/
@@ -34,10 +38,10 @@ my-feature-workspace/
 
 Repository sources can be mixed in one workspace:
 
-- Already opened repositories can be inserted from the **Add Opened** menu. They
-  are added as symlinks with `source_kind: existing_path`.
-- Local repository folders selected from disk are added as symlinks with
-  `source_kind: local_repository`.
+- Already opened repositories can be inserted from the **Add Opened** menu
+  (`source_kind: existing_path`).
+- Local repository folders are selected from disk
+  (`source_kind: local_repository`).
 - Remote repositories are added through a URL prompt that loads remote heads
   before inserting the row. They are cloned into the workspace folder with
   `source_kind: remote`. The inserted row defaults to **Use Existing** on the
@@ -45,6 +49,18 @@ Repository sources can be mixed in one workspace:
 - Bare repositories are materialized with `git worktree add` and recorded with
   `source_kind: bare_repository`. If both branch and base ref are supplied,
   Prowl creates the worktree branch from that base ref.
+
+For already opened and local repositories, the branch action decides how the
+folder is materialized:
+
+- **Link** (the default) adds a symlink to the repository as it is on disk, so
+  the workspace shares the live checkout.
+- **Create Branch** runs `git worktree add -b` against the source repository:
+  the workspace gets an isolated checkout on a new branch created from the
+  selected base ref, without touching the source repository's own checkout. The
+  new worktree also appears in the source repository's worktree list.
+- **Use Existing** runs `git worktree add` with the selected ref. Git rejects a
+  local branch that is already checked out elsewhere.
 
 The creation prompt detects base-ref candidates for already opened, local, and
 bare repositories by reading local git refs, preferring the detected default
@@ -57,8 +73,8 @@ does not try to checkout an arbitrary, nonexistent branch.
 Branch behavior is explicit:
 
 - **Create Branch** uses `branch_name` plus the selected base ref to create a
-  new branch or worktree branch. Remote and bare sources require a branch name
-  in this mode.
+  new branch or worktree branch. A branch name is required in this mode for
+  every source kind.
 - **Use Existing** uses the selected ref directly. For remote clones, Prowl
   checks out the selected remote branch after clone; Git creates the normal
   local tracking branch for refs such as `origin/feature`. For bare

--- a/docs/components/workspaces.md
+++ b/docs/components/workspaces.md
@@ -99,6 +99,10 @@ skipped instead of blocking the deletion.
 
 ## Metadata
 
+The workspace's repository settings page (Settings → the workspace under
+Repositories) shows this metadata read-only; edit `.prowl/workspace.json` to
+change it.
+
 Example `.prowl/workspace.json`:
 
 ```json

--- a/docs/components/workspaces.md
+++ b/docs/components/workspaces.md
@@ -19,9 +19,9 @@ When you open a workspace in Prowl:
 ## Folder layout
 
 Use **New Workspace** from the sidebar toolbar, Worktrees menu, or command
-palette to create a workspace from repositories already opened in Prowl. Prowl
-creates the shared folder, writes `.prowl/workspace.json`, and places symlinks
-to the selected repositories in the workspace root.
+palette to create a workspace. Prowl creates the shared folder, materializes the
+selected repositories, writes `.prowl/workspace.json`, and opens the workspace
+as a runnable folder.
 
 ```text
 my-feature-workspace/
@@ -32,10 +32,18 @@ my-feature-workspace/
 └─ shared-package/
 ```
 
-The current creation flow supports existing local repositories that are already
-loaded in Prowl. Prowl still reads hand-authored metadata, but it does not yet
-clone remote repositories or materialize git worktrees from bare repositories by
-itself.
+Repository sources can be mixed in one workspace:
+
+- Already opened repositories are added as symlinks with `source_kind:
+  existing_path`.
+- Local repository folders selected from disk are added as symlinks with
+  `source_kind: local_repository`.
+- Remote repositories are cloned into the workspace folder with `source_kind:
+  remote`. If a branch and base ref are supplied, Prowl checks out the branch
+  from the base after cloning.
+- Bare repositories are materialized with `git worktree add` and recorded with
+  `source_kind: bare_repository`. If both branch and base ref are supplied,
+  Prowl creates the worktree branch from that base ref.
 
 ## Metadata
 

--- a/docs/components/workspaces.md
+++ b/docs/components/workspaces.md
@@ -47,9 +47,10 @@ Repository sources can be mixed in one workspace:
 
 The creation prompt detects base-ref candidates for already opened, local, and
 bare repositories by reading local git refs, preferring the detected default
-branch such as `main` or `master`. Remote clone entries show common base-ref
-candidates (`main`, `master`, `origin/main`, `origin/master`) without probing
-the network; you can choose one from the menu or type any ref manually.
+branch such as `main` or `master`. Base refs are selected from detected refs so
+workspace creation does not try to checkout an arbitrary, nonexistent branch.
+Remote clone entries can be created without a base ref; after cloning, a branch
+name without an explicit base is created from the repository's default checkout.
 
 ## Metadata
 

--- a/docs/components/workspaces.md
+++ b/docs/components/workspaces.md
@@ -18,8 +18,10 @@ When you open a workspace in Prowl:
 
 ## Folder layout
 
-Create or clone the repositories into a shared folder first, then add that
-folder to Prowl.
+Use **New Workspace** from the sidebar toolbar, Worktrees menu, or command
+palette to create a workspace from repositories already opened in Prowl. Prowl
+creates the shared folder, writes `.prowl/workspace.json`, and places symlinks
+to the selected repositories in the workspace root.
 
 ```text
 my-feature-workspace/
@@ -30,9 +32,10 @@ my-feature-workspace/
 └─ shared-package/
 ```
 
-Prowl currently reads the metadata and opens the workspace root. It does not yet
-clone remote repositories or materialize git worktrees from the metadata by
-itself, so those directories should already exist when the agent starts.
+The current creation flow supports existing local repositories that are already
+loaded in Prowl. Prowl still reads hand-authored metadata, but it does not yet
+clone remote repositories or materialize git worktrees from bare repositories by
+itself.
 
 ## Metadata
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -10,16 +10,21 @@
 Prowl nests four levels. Everything in the app refers back to these.
 
 ```
-Repository            a git repo (or a plain folder) you've added to Prowl
+Repository            a git repo, workspace, or plain folder added to Prowl
 └─ Worktree           a git worktree = one branch checked out in its own directory
    └─ Tab             a terminal tab inside that worktree
       └─ Pane         one terminal surface; a tab can be split into several panes
 ```
 
-- **Repository** — a project you added to the sidebar. Two kinds:
+- **Repository** — a project you added to the sidebar. Two persisted kinds, plus
+  a workspace overlay:
   - **`git`** — a real git repository; supports worktrees, branches, diff, PRs.
   - **`plain`** — a non-git folder; you can open a terminal and run scripts in it,
     but there are no worktrees, branches, diff, or PR features.
+  - **Workspace** — a plain runnable folder with `.prowl/workspace.json`
+    metadata. One agent starts in the workspace root and can work across several
+    repositories listed in that file. The `prowl` CLI reports this runnable
+    target's `worktree.kind` as `workspace`.
 - **Worktree** — a git *worktree*: a branch checked out into its own working
   directory, so several branches are live on disk at once. This is the unit you
   hand to an agent. The repository's root directory is the **main worktree**
@@ -73,6 +78,7 @@ all agents and their statuses is the
 - **Global settings:** `~/.prowl/settings.json`
 - **Per-repository settings:** `~/.prowl/repo/<repo-name>/prowl.json`
 - **Per-repository user custom commands:** `~/.prowl/repo/<repo-name>/prowl.onevcat.json`
+- **Per-workspace metadata:** `<workspace>/.prowl/workspace.json`
 - **CLI socket:** `~/Library/Application Support/com.onevcat.prowl/cli.sock`
   (overridable with `PROWL_CLI_SOCKET`)
 - Legacy `~/.supacode` is migrated to `~/.prowl` on first launch. (Prowl is a fork
@@ -94,6 +100,8 @@ tabs, worktrees, views — are Prowl's. See
 
 - **Worktree** — a git branch checked out in its own directory; the unit you give
   an agent.
+- **Workspace** — a folder whose terminal root contains several repositories for
+  one agent to handle together, described by `.prowl/workspace.json`.
 - **Book / spine** — Shelf-view name for a worktree shown as a vertical strip.
 - **Card** — Canvas-view name for one terminal tab shown as a floating tile.
 - **Broadcast** — typing into one Canvas card and mirroring it to all selected

--- a/supacode/App/ContentView.swift
+++ b/supacode/App/ContentView.swift
@@ -115,6 +115,9 @@ struct ContentView: View {
           onDeleteFilesChanged: {
             repositoriesStore.send(.repositoryManagement(.removeWorkspaceDeleteFilesChanged($0)))
           },
+          onDeleteBranchChanged: {
+            repositoriesStore.send(.repositoryManagement(.removeWorkspaceDeleteBranchChanged($0, $1)))
+          },
           onCancel: {
             repositoriesStore.send(.repositoryManagement(.removeWorkspacePromptDismissed))
           },

--- a/supacode/App/ContentView.swift
+++ b/supacode/App/ContentView.swift
@@ -39,6 +39,14 @@ struct ContentView: View {
         }
       }
     )
+    let removeWorkspaceConfirmationPresented = Binding(
+      get: { repositoriesStore.removeWorkspaceConfirmation != nil },
+      set: { isPresented in
+        if !isPresented {
+          repositoriesStore.send(.repositoryManagement(.removeWorkspacePromptDismissed))
+        }
+      }
+    )
     Group {
       if store.repositories.isInitialLoadComplete {
         mainSplitView
@@ -96,6 +104,22 @@ struct ContentView: View {
           },
           onDelete: {
             repositoriesStore.send(.worktreeLifecycle(.deleteWorktreePromptConfirmed))
+          }
+        )
+      }
+    }
+    .sheet(isPresented: removeWorkspaceConfirmationPresented) {
+      if let confirmation = repositoriesStore.removeWorkspaceConfirmation {
+        RemoveWorkspaceConfirmationView(
+          confirmation: confirmation,
+          onDeleteFilesChanged: {
+            repositoriesStore.send(.repositoryManagement(.removeWorkspaceDeleteFilesChanged($0)))
+          },
+          onCancel: {
+            repositoriesStore.send(.repositoryManagement(.removeWorkspacePromptDismissed))
+          },
+          onRemove: {
+            repositoriesStore.send(.repositoryManagement(.removeWorkspacePromptConfirmed))
           }
         )
       }

--- a/supacode/App/ContentView.swift
+++ b/supacode/App/ContentView.swift
@@ -80,6 +80,10 @@ struct ContentView: View {
       promptStore in
       WorktreeCreationPromptView(store: promptStore)
     }
+    .sheet(item: $repositoriesStore.scope(state: \.workspaceCreationPrompt, action: \.workspaceCreationPrompt)) {
+      promptStore in
+      WorkspaceCreationPromptView(store: promptStore)
+    }
     .sheet(isPresented: deleteWorktreeConfirmationPresented) {
       if let confirmation = repositoriesStore.deleteWorktreeConfirmation {
         DeleteWorktreeConfirmationView(

--- a/supacode/CLIService/ListRuntimeSnapshotBuilder.swift
+++ b/supacode/CLIService/ListRuntimeSnapshotBuilder.swift
@@ -86,7 +86,7 @@ enum ListRuntimeSnapshotBuilder {
               name: worktree.name,
               path: worktree.workingDirectory.path(percentEncoded: false),
               rootPath: worktree.repositoryRootURL.path(percentEncoded: false),
-              kind: repository.kind == .git ? ListCommandWorktree.Kind.git : .plain
+              kind: listCommandKind(for: repository)
             )
           )
         }
@@ -101,7 +101,7 @@ enum ListRuntimeSnapshotBuilder {
             name: repository.name,
             path: rootPath,
             rootPath: rootPath,
-            kind: repository.kind == .git ? ListCommandWorktree.Kind.git : .plain
+            kind: listCommandKind(for: repository)
           )
         )
       }
@@ -113,5 +113,12 @@ enum ListRuntimeSnapshotBuilder {
   private static func normalizeAbsolutePath(_ value: String?) -> String? {
     guard let value else { return nil }
     return value.hasPrefix("/") ? value : nil
+  }
+
+  private static func listCommandKind(for repository: Repository) -> ListCommandWorktree.Kind {
+    if repository.isWorkspace {
+      return .workspace
+    }
+    return repository.kind == .git ? .git : .plain
   }
 }

--- a/supacode/CLIService/Shared/ListCommandPayload.swift
+++ b/supacode/CLIService/Shared/ListCommandPayload.swift
@@ -33,6 +33,7 @@ public struct ListCommandWorktree: Codable, Equatable {
   public enum Kind: String, Codable, Equatable {
     case git
     case plain
+    case workspace
   }
 
   public let id: String

--- a/supacode/Clients/Git/GitClient.swift
+++ b/supacode/Clients/Git/GitClient.swift
@@ -144,7 +144,7 @@ struct GitClient {
         "-C",
         path,
         "for-each-ref",
-        "--format=%(refname:short)",
+        "--format=%(refname)",
         "refs/heads",
       ]
     )
@@ -154,15 +154,14 @@ struct GitClient {
         "-C",
         path,
         "for-each-ref",
-        "--format=%(refname:short)",
+        "--format=%(refname)",
         "refs/remotes",
       ]
     )
-    let localRefs = parseRefLines(localOutput)
+    let localRefs = parseRefLines(localOutput, prefix: "refs/heads/")
       .filter { !$0.hasSuffix("/HEAD") }
       .sorted { $0.localizedStandardCompare($1) == .orderedAscending }
-    let remoteRefs = parseRefLines(remoteOutput)
-      .filter { !$0.hasSuffix("/HEAD") }
+    let remoteRefs = parseRefLines(remoteOutput, prefix: "refs/remotes/")
       .sorted { $0.localizedStandardCompare($1) == .orderedAscending }
     return deduplicatedOptions(
       localRefs.map { GitBranchRefOption(ref: $0, kind: .local) }
@@ -692,12 +691,15 @@ struct GitClient {
       .last { !$0.isEmpty }
   }
 
-  nonisolated private func parseRefLines(_ output: String) -> [String] {
+  nonisolated private func parseRefLines(_ output: String, prefix: String) -> [String] {
     output
       .split(whereSeparator: \.isNewline)
       .compactMap { line -> String? in
         let ref = String(line).trimmingCharacters(in: .whitespacesAndNewlines)
-        return ref.isEmpty ? nil : ref
+        guard !ref.isEmpty else {
+          return nil
+        }
+        return ref.hasPrefix(prefix) ? String(ref.dropFirst(prefix.count)) : ref
       }
   }
 

--- a/supacode/Clients/Git/GitClient.swift
+++ b/supacode/Clients/Git/GitClient.swift
@@ -129,6 +129,14 @@ struct GitClient {
   }
 
   nonisolated func branchRefs(for repoRoot: URL) async throws -> [String] {
+    let options = try await branchRefOptions(for: repoRoot)
+    let refs = options.map(\.ref)
+      .filter { !$0.hasSuffix("/HEAD") }
+      .sorted { $0.localizedStandardCompare($1) == .orderedAscending }
+    return deduplicated(refs)
+  }
+
+  nonisolated func branchRefOptions(for repoRoot: URL) async throws -> [GitBranchRefOption] {
     let path = repoRoot.path(percentEncoded: false)
     let localOutput = try await runGit(
       operation: .branchRefs,
@@ -136,14 +144,45 @@ struct GitClient {
         "-C",
         path,
         "for-each-ref",
-        "--format=%(refname:short)\t%(upstream:short)",
+        "--format=%(refname:short)",
         "refs/heads",
       ]
     )
-    let refs = parseLocalRefsWithUpstream(localOutput)
+    let remoteOutput = try await runGit(
+      operation: .branchRefs,
+      arguments: [
+        "-C",
+        path,
+        "for-each-ref",
+        "--format=%(refname:short)",
+        "refs/remotes",
+      ]
+    )
+    let localRefs = parseRefLines(localOutput)
       .filter { !$0.hasSuffix("/HEAD") }
       .sorted { $0.localizedStandardCompare($1) == .orderedAscending }
-    return deduplicated(refs)
+    let remoteRefs = parseRefLines(remoteOutput)
+      .filter { !$0.hasSuffix("/HEAD") }
+      .sorted { $0.localizedStandardCompare($1) == .orderedAscending }
+    return deduplicatedOptions(
+      localRefs.map { GitBranchRefOption(ref: $0, kind: .local) }
+        + remoteRefs.map { GitBranchRefOption(ref: $0, kind: .remoteTracking) }
+    )
+  }
+
+  nonisolated func remoteBranchRefs(for remoteURL: String) async throws -> GitRemoteBranchRefs {
+    let output = try await runGit(
+      operation: .remoteBranchRefs,
+      arguments: ["ls-remote", "--heads", "--symref", remoteURL]
+    )
+    let parsed = parseRemoteBranchRefs(output)
+    let options = parsed.refs
+      .sorted { $0.localizedStandardCompare($1) == .orderedAscending }
+      .map { GitBranchRefOption(ref: "origin/\($0)", kind: .fetchedRemote) }
+    let defaultBaseRef =
+      parsed.defaultBranch.map { "origin/\($0)" }
+      ?? options.first?.ref
+    return GitRemoteBranchRefs(options: deduplicatedOptions(options), defaultBaseRef: defaultBaseRef)
   }
 
   nonisolated func defaultRemoteBranchRef(for repoRoot: URL) async throws -> String? {
@@ -653,34 +692,62 @@ struct GitClient {
       .last { !$0.isEmpty }
   }
 
-  nonisolated private func parseLocalRefsWithUpstream(_ output: String) -> [String] {
+  nonisolated private func parseRefLines(_ output: String) -> [String] {
     output
       .split(whereSeparator: \.isNewline)
-      .flatMap { line -> [String] in
-        let parts = line.split(separator: "\t", omittingEmptySubsequences: false)
-        guard let local = parts.first else {
-          return []
-        }
-        let localRef = String(local).trimmingCharacters(in: .whitespacesAndNewlines)
-        let upstreamRef =
-          parts.count > 1
-          ? String(parts[1]).trimmingCharacters(in: .whitespacesAndNewlines)
-          : ""
-
-        var refs: [String] = []
-        if !localRef.isEmpty {
-          refs.append(localRef)
-        }
-        if !upstreamRef.isEmpty {
-          refs.append(upstreamRef)
-        }
-        return refs
+      .compactMap { line -> String? in
+        let ref = String(line).trimmingCharacters(in: .whitespacesAndNewlines)
+        return ref.isEmpty ? nil : ref
       }
+  }
+
+  nonisolated private func parseRemoteBranchRefs(_ output: String) -> (refs: [String], defaultBranch: String?) {
+    var refs: [String] = []
+    var defaultBranch: String?
+    for rawLine in output.split(whereSeparator: \.isNewline) {
+      let line = String(rawLine).trimmingCharacters(in: .whitespacesAndNewlines)
+      if line.hasPrefix("ref:") {
+        let parts = line.split(separator: "\t", omittingEmptySubsequences: false)
+        guard parts.count >= 2, parts[1] == "HEAD" else {
+          continue
+        }
+        let target = parts[0]
+          .dropFirst("ref:".count)
+          .trimmingCharacters(in: .whitespacesAndNewlines)
+        if let branch = normalizeHeadRef(target) {
+          defaultBranch = branch
+        }
+        continue
+      }
+      let parts = line.split(separator: "\t", omittingEmptySubsequences: false)
+      guard parts.count >= 2,
+        let branch = normalizeHeadRef(String(parts[1]))
+      else {
+        continue
+      }
+      refs.append(branch)
+    }
+    return (deduplicated(refs), defaultBranch)
+  }
+
+  nonisolated private func normalizeHeadRef(_ value: String) -> String? {
+    let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+    let prefix = "refs/heads/"
+    guard trimmed.hasPrefix(prefix) else {
+      return nil
+    }
+    let branch = String(trimmed.dropFirst(prefix.count))
+    return branch.isEmpty ? nil : branch
   }
 
   nonisolated private func deduplicated(_ values: [String]) -> [String] {
     var seen = Set<String>()
     return values.filter { seen.insert($0).inserted }
+  }
+
+  nonisolated private func deduplicatedOptions(_ options: [GitBranchRefOption]) -> [GitBranchRefOption] {
+    var seen = Set<String>()
+    return options.filter { seen.insert($0.id).inserted }
   }
 
   nonisolated private func normalizeRemoteRef(_ value: String) -> String? {

--- a/supacode/Clients/Git/GitClient.swift
+++ b/supacode/Clients/Git/GitClient.swift
@@ -172,7 +172,7 @@ struct GitClient {
   nonisolated func remoteBranchRefs(for remoteURL: String) async throws -> GitRemoteBranchRefs {
     let output = try await runGit(
       operation: .remoteBranchRefs,
-      arguments: ["ls-remote", "--symref", remoteURL, "HEAD", "refs/heads/*"]
+      arguments: ["ls-remote", "--symref", "--end-of-options", remoteURL, "HEAD", "refs/heads/*"]
     )
     let parsed = parseRemoteBranchRefs(output)
     let options = parsed.refs

--- a/supacode/Clients/Git/GitClient.swift
+++ b/supacode/Clients/Git/GitClient.swift
@@ -162,6 +162,10 @@ struct GitClient {
       .filter { !$0.hasSuffix("/HEAD") }
       .sorted { $0.localizedStandardCompare($1) == .orderedAscending }
     let remoteRefs = parseRefLines(remoteOutput, prefix: "refs/remotes/")
+      // Drop `<remote>/HEAD` symbolic pointers: they resolve to a branch that is
+      // already listed, and selecting one would derive an invalid `HEAD` branch
+      // name in the remote-tracking checkout path.
+      .filter { !$0.hasSuffix("/HEAD") }
       .sorted { $0.localizedStandardCompare($1) == .orderedAscending }
     return deduplicatedOptions(
       localRefs.map { GitBranchRefOption(ref: $0, kind: .local) }

--- a/supacode/Clients/Git/GitClient.swift
+++ b/supacode/Clients/Git/GitClient.swift
@@ -172,7 +172,7 @@ struct GitClient {
   nonisolated func remoteBranchRefs(for remoteURL: String) async throws -> GitRemoteBranchRefs {
     let output = try await runGit(
       operation: .remoteBranchRefs,
-      arguments: ["ls-remote", "--heads", "--symref", remoteURL]
+      arguments: ["ls-remote", "--symref", remoteURL, "HEAD", "refs/heads/*"]
     )
     let parsed = parseRemoteBranchRefs(output)
     let options = parsed.refs

--- a/supacode/Clients/Git/GitClient.swift
+++ b/supacode/Clients/Git/GitClient.swift
@@ -129,11 +129,7 @@ struct GitClient {
   }
 
   nonisolated func branchRefs(for repoRoot: URL) async throws -> [String] {
-    let options = try await branchRefOptions(for: repoRoot)
-    let refs = options.map(\.ref)
-      .filter { !$0.hasSuffix("/HEAD") }
-      .sorted { $0.localizedStandardCompare($1) == .orderedAscending }
-    return deduplicated(refs)
+    try await branchRefOptions(for: repoRoot).map(\.ref)
   }
 
   nonisolated func branchRefOptions(for repoRoot: URL) async throws -> [GitBranchRefOption] {
@@ -159,7 +155,6 @@ struct GitClient {
       ]
     )
     let localRefs = parseRefLines(localOutput, prefix: "refs/heads/")
-      .filter { !$0.hasSuffix("/HEAD") }
       .sorted { $0.localizedStandardCompare($1) == .orderedAscending }
     let remoteRefs = parseRefLines(remoteOutput, prefix: "refs/remotes/")
       // Drop `<remote>/HEAD` symbolic pointers: they resolve to a branch that is

--- a/supacode/Clients/Git/GitClientTypes.swift
+++ b/supacode/Clients/Git/GitClientTypes.swift
@@ -23,6 +23,7 @@ enum GitOperation: String {
   case remoteInfo = "remote_info"
   case remoteList = "remote_list"
   case fetchRemote = "fetch_remote"
+  case remoteBranchRefs = "remote_branch_refs"
 }
 
 enum GitClientError: LocalizedError {
@@ -87,6 +88,42 @@ nonisolated enum GitRemoteMatcher {
       .sorted { $0.count > $1.count }
       .first { ref.hasPrefix("\($0)/") }
   }
+}
+
+nonisolated enum GitBranchRefKind: String, Codable, Equatable, Hashable, Sendable, CaseIterable {
+  case local
+  case remoteTracking = "remote_tracking"
+  case fetchedRemote = "fetched_remote"
+
+  var title: String {
+    switch self {
+    case .local:
+      return "Local Branches"
+    case .remoteTracking:
+      return "Remote Branches"
+    case .fetchedRemote:
+      return "Fetched Remote Branches"
+    }
+  }
+}
+
+nonisolated struct GitBranchRefOption: Codable, Equatable, Hashable, Sendable, Identifiable {
+  var ref: String
+  var kind: GitBranchRefKind
+
+  var id: String {
+    "\(kind.rawValue):\(ref)"
+  }
+
+  init(ref: String, kind: GitBranchRefKind) {
+    self.ref = ref
+    self.kind = kind
+  }
+}
+
+nonisolated struct GitRemoteBranchRefs: Equatable, Sendable {
+  var options: [GitBranchRefOption]
+  var defaultBaseRef: String?
 }
 
 struct GitWtWorktreeEntry: Decodable, Equatable {

--- a/supacode/Clients/Git/GitClientTypes.swift
+++ b/supacode/Clients/Git/GitClientTypes.swift
@@ -126,6 +126,21 @@ nonisolated struct GitRemoteBranchRefs: Equatable, Sendable {
   var defaultBaseRef: String?
 }
 
+nonisolated enum GitRemoteNaming {
+  static func repositoryName(fromRemoteURL remoteURL: String) -> String {
+    let trimmed = remoteURL.trimmingCharacters(in: .whitespacesAndNewlines)
+      .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+    guard !trimmed.isEmpty else {
+      return ""
+    }
+    let separatorIndex = trimmed.lastIndex { $0 == "/" || $0 == ":" }
+    let component =
+      separatorIndex.map { String(trimmed[trimmed.index(after: $0)...]) }
+      ?? trimmed
+    return component.hasSuffix(".git") ? String(component.dropLast(4)) : component
+  }
+}
+
 struct GitWtWorktreeEntry: Decodable, Equatable {
   let branch: String
   let path: String

--- a/supacode/Clients/Repositories/GitClientDependency.swift
+++ b/supacode/Clients/Repositories/GitClientDependency.swift
@@ -8,6 +8,8 @@ struct GitClientDependency: Sendable {
   var localBranchNames: @Sendable (URL) async throws -> Set<String>
   var isValidBranchName: @Sendable (String, URL) async -> Bool
   var branchRefs: @Sendable (URL) async throws -> [String]
+  var branchRefOptions: @Sendable (URL) async throws -> [GitBranchRefOption]
+  var remoteBranchRefs: @Sendable (String) async throws -> GitRemoteBranchRefs
   var defaultRemoteBranchRef: @Sendable (URL) async throws -> String?
   var automaticWorktreeBaseRef: @Sendable (URL) async -> String?
   var ignoredFileCount: @Sendable (URL) async throws -> Int
@@ -47,6 +49,8 @@ extension GitClientDependency: DependencyKey {
       await GitClient().isValidBranchName(branchName, for: repoRoot)
     },
     branchRefs: { try await GitClient().branchRefs(for: $0) },
+    branchRefOptions: { try await GitClient().branchRefOptions(for: $0) },
+    remoteBranchRefs: { try await GitClient().remoteBranchRefs(for: $0) },
     defaultRemoteBranchRef: { try await GitClient().defaultRemoteBranchRef(for: $0) },
     automaticWorktreeBaseRef: { await GitClient().automaticWorktreeBaseRef(for: $0) },
     ignoredFileCount: { try await GitClient().ignoredFileCount(for: $0) },

--- a/supacode/Clients/Repositories/RepositoryPersistenceClient.swift
+++ b/supacode/Clients/Repositories/RepositoryPersistenceClient.swift
@@ -270,12 +270,14 @@ extension RepositorySnapshotCachePayload {
     let name: String
     let kind: Repository.Kind
     let worktrees: [SnapshotWorktree]
+    let workspace: ProjectWorkspace?
 
     init(repository: Repository) {
       rootPath = repository.rootURL.path(percentEncoded: false)
       name = repository.name
       kind = repository.kind
       worktrees = repository.worktrees.map { SnapshotWorktree(worktree: $0) }
+      workspace = repository.workspace
     }
 
     func restore(
@@ -310,7 +312,8 @@ extension RepositorySnapshotCachePayload {
         rootURL: rootURL,
         name: repositoryName.isEmpty ? Repository.name(for: rootURL) : repositoryName,
         kind: kind,
-        worktrees: IdentifiedArray(restoredWorktrees, uniquingIDsWith: { current, _ in current })
+        worktrees: IdentifiedArray(restoredWorktrees, uniquingIDsWith: { current, _ in current }),
+        workspace: workspace?.normalized(relativeTo: rootURL)
       )
     }
   }

--- a/supacode/Clients/Terminal/TerminalClient.swift
+++ b/supacode/Clients/Terminal/TerminalClient.swift
@@ -33,6 +33,7 @@ struct TerminalClient {
       customCommandIcon: String? = nil
     )
     case createTabInDirectory(Worktree, directory: URL)
+    case focusOrCreateTabInDirectory(Worktree, directory: URL, title: String?)
     case ensureInitialTab(Worktree, runSetupScriptIfNew: Bool, focusing: Bool)
     case runScript(Worktree, script: String)
     case insertText(Worktree, text: String)

--- a/supacode/Commands/WorktreeCommands.swift
+++ b/supacode/Commands/WorktreeCommands.swift
@@ -90,7 +90,6 @@ struct WorktreeCommands: Commands {
         store.send(.repositories(.workspaceCreation(.promptRequested)))
       }
       .help("New Workspace")
-      .disabled(!repositories.canCreateWorkspace)
       Button("Open Worktree") {
         openSelectedWorktreeAction?()
       }

--- a/supacode/Commands/WorktreeCommands.swift
+++ b/supacode/Commands/WorktreeCommands.swift
@@ -86,6 +86,11 @@ struct WorktreeCommands: Commands {
       }
       .modifier(KeyboardShortcutModifier(shortcut: keyboardShortcut(for: AppShortcuts.CommandID.openRepository)))
       .help(helpText(title: "Open Repository", commandID: AppShortcuts.CommandID.openRepository))
+      Button("New Workspace...", systemImage: "folder.badge.person.crop") {
+        store.send(.repositories(.workspaceCreation(.promptRequested)))
+      }
+      .help("New Workspace")
+      .disabled(!repositories.canCreateWorkspace)
       Button("Open Worktree") {
         openSelectedWorktreeAction?()
       }

--- a/supacode/Domain/ProjectWorkspace.swift
+++ b/supacode/Domain/ProjectWorkspace.swift
@@ -1,6 +1,8 @@
 import Foundation
 
-nonisolated enum ProjectWorkspaceRepositorySourceKind: String, Codable, Equatable, Hashable, Sendable {
+nonisolated enum ProjectWorkspaceRepositorySourceKind: String, Codable, Equatable, Hashable,
+  Sendable
+{
   case remote
   case localRepository = "local_repository"
   case bareRepository = "bare_repository"
@@ -40,7 +42,9 @@ nonisolated enum ProjectWorkspaceRepositorySourceKind: String, Codable, Equatabl
   }
 }
 
-nonisolated enum ProjectWorkspaceRepositoryCheckoutMode: String, Codable, Equatable, Hashable, Sendable {
+nonisolated enum ProjectWorkspaceRepositoryCheckoutMode: String, Codable, Equatable, Hashable,
+  Sendable
+{
   case link
   case createBranch = "create_branch"
   case useExistingRef = "use_existing_ref"
@@ -84,7 +88,8 @@ nonisolated struct ProjectWorkspaceCreationRepository: Equatable, Hashable, Send
     self.path = path
     sourceKind = .existingPath
     sourceLocation = normalizedURL.path(percentEncoded: false)
-    self.checkoutMode = checkoutMode ?? ProjectWorkspaceRepositorySourceKind.existingPath.defaultCheckoutMode
+    self.checkoutMode =
+      checkoutMode ?? ProjectWorkspaceRepositorySourceKind.existingPath.defaultCheckoutMode
     self.branchName = branchName
     self.baseRef = baseRef
     self.baseRefOptions = Self.normalizedBaseRefOptions(baseRefOptions)
@@ -128,13 +133,25 @@ nonisolated struct ProjectWorkspaceCreationRepository: Equatable, Hashable, Send
     else {
       return nil
     }
-    let localName = selectedRef.split(separator: "/").dropFirst().joined(separator: "/")
-    guard !localName.isEmpty,
+    guard let localName = Self.localBranchName(forRemoteRef: selectedRef),
       baseRefOptions.contains(where: { $0.kind == .local && $0.ref == localName })
     else {
       return nil
     }
     return localName
+  }
+
+  /// Converts refs loaded as `<remote>/<branch>` into the local branch name Git
+  /// would create or reset for a tracking checkout. Branch names can contain
+  /// slashes, so only the first path component is the remote name.
+  nonisolated static func localBranchName(forRemoteRef ref: String) -> String? {
+    let parts = ref.trimmingCharacters(in: .whitespacesAndNewlines).split(
+      separator: "/", maxSplits: 1)
+    guard parts.count == 2 else {
+      return nil
+    }
+    let branchName = String(parts[1])
+    return branchName.isEmpty ? nil : branchName
   }
 
   nonisolated static func baseRefOptions(
@@ -151,7 +168,9 @@ nonisolated struct ProjectWorkspaceCreationRepository: Equatable, Hashable, Send
     return normalizedBaseRefOptions(values)
   }
 
-  nonisolated static func preferredBaseRef(automaticBaseRef: String?, options: [GitBranchRefOption]) -> String? {
+  nonisolated static func preferredBaseRef(automaticBaseRef: String?, options: [GitBranchRefOption])
+    -> String?
+  {
     let refs = Set(options.map(\.ref))
     if let trimmed = automaticBaseRef?.trimmingCharacters(in: .whitespacesAndNewlines),
       !trimmed.isEmpty,
@@ -163,7 +182,9 @@ nonisolated struct ProjectWorkspaceCreationRepository: Equatable, Hashable, Send
       ?? options.first?.ref
   }
 
-  nonisolated static func normalizedBaseRefOptions(_ values: [GitBranchRefOption]) -> [GitBranchRefOption] {
+  nonisolated static func normalizedBaseRefOptions(_ values: [GitBranchRefOption])
+    -> [GitBranchRefOption]
+  {
     var seen = Set<String>()
     var result: [GitBranchRefOption] = []
     for value in values {
@@ -274,7 +295,9 @@ nonisolated enum ProjectWorkspaceCreationError: LocalizedError, Equatable, Senda
   }
 }
 
-nonisolated struct ProjectWorkspaceRepositoryEntry: Codable, Equatable, Hashable, Sendable, Identifiable {
+nonisolated struct ProjectWorkspaceRepositoryEntry: Codable, Equatable, Hashable, Sendable,
+  Identifiable
+{
   var id: String
   var name: String
   var role: String?
@@ -347,8 +370,10 @@ nonisolated struct ProjectWorkspace: Codable, Equatable, Hashable, Sendable {
 
   nonisolated static let metadataDirectoryName = ".prowl"
   nonisolated static let metadataFileName = "workspace.json"
+  nonisolated static let currentSchemaVersion = "prowl.workspace.v1"
   nonisolated private static let log = SupaLogger("workspace")
 
+  var schemaVersion: String
   var id: String
   var title: String
   var description: String
@@ -358,6 +383,7 @@ nonisolated struct ProjectWorkspace: Codable, Equatable, Hashable, Sendable {
   var updatedAt: Date?
 
   enum CodingKeys: String, CodingKey {
+    case schemaVersion = "schema_version"
     case id
     case title
     case description
@@ -368,6 +394,7 @@ nonisolated struct ProjectWorkspace: Codable, Equatable, Hashable, Sendable {
   }
 
   init(
+    schemaVersion: String = currentSchemaVersion,
     id: String = "",
     title: String = "",
     description: String = "",
@@ -376,6 +403,7 @@ nonisolated struct ProjectWorkspace: Codable, Equatable, Hashable, Sendable {
     createdAt: Date? = nil,
     updatedAt: Date? = nil
   ) {
+    self.schemaVersion = schemaVersion
     self.id = id
     self.title = title
     self.description = description
@@ -387,11 +415,15 @@ nonisolated struct ProjectWorkspace: Codable, Equatable, Hashable, Sendable {
 
   init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
+    schemaVersion =
+      try container.decodeIfPresent(String.self, forKey: .schemaVersion)
+      ?? Self.currentSchemaVersion
     id = try container.decodeIfPresent(String.self, forKey: .id) ?? ""
     title = try container.decodeIfPresent(String.self, forKey: .title) ?? ""
     description = try container.decodeIfPresent(String.self, forKey: .description) ?? ""
     taskLinks = try container.decodeIfPresent([String].self, forKey: .taskLinks) ?? []
-    repositories = try container.decodeIfPresent([RepositoryEntry].self, forKey: .repositories) ?? []
+    repositories =
+      try container.decodeIfPresent([RepositoryEntry].self, forKey: .repositories) ?? []
     createdAt = try container.decodeIfPresent(Date.self, forKey: .createdAt)
     updatedAt = try container.decodeIfPresent(Date.self, forKey: .updatedAt)
   }
@@ -423,13 +455,18 @@ nonisolated struct ProjectWorkspace: Codable, Equatable, Hashable, Sendable {
       workspace.id = normalizedRoot
     }
     if workspace.title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-      workspace.title = rootURL.lastPathComponent.isEmpty ? normalizedRoot : rootURL.lastPathComponent
+      workspace.title =
+        rootURL.lastPathComponent.isEmpty ? normalizedRoot : rootURL.lastPathComponent
     }
     return workspace.normalized(relativeTo: rootURL)
   }
 
   func normalized(relativeTo rootURL: URL) -> ProjectWorkspace {
     var copy = self
+    copy.schemaVersion = copy.schemaVersion.trimmingCharacters(in: .whitespacesAndNewlines)
+    if copy.schemaVersion.isEmpty {
+      copy.schemaVersion = Self.currentSchemaVersion
+    }
     let normalizedRoot = rootURL.standardizedFileURL.path(percentEncoded: false)
     if copy.id.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
       copy.id = normalizedRoot
@@ -451,11 +488,14 @@ nonisolated struct ProjectWorkspace: Codable, Equatable, Hashable, Sendable {
       }
       if entry.name.isEmpty {
         let resolvedURL = entry.resolvedURL(relativeTo: rootURL)
-        entry.name = resolvedURL.lastPathComponent.isEmpty ? entry.id : resolvedURL.lastPathComponent
+        entry.name =
+          resolvedURL.lastPathComponent.isEmpty ? entry.id : resolvedURL.lastPathComponent
       }
       entry.role = entry.role?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
-      entry.sourceLocation = entry.sourceLocation?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
-      entry.branchName = entry.branchName?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+      entry.sourceLocation =
+        entry.sourceLocation?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+      entry.branchName =
+        entry.branchName?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
       entry.baseRef = entry.baseRef?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
       return entry
     }
@@ -492,7 +532,8 @@ nonisolated struct ProjectWorkspace: Codable, Equatable, Hashable, Sendable {
         ledger.createdRoot = true
       }
 
-      let metadataDirectoryURL = rootURL.appending(path: metadataDirectoryName, directoryHint: .isDirectory)
+      let metadataDirectoryURL = rootURL.appending(
+        path: metadataDirectoryName, directoryHint: .isDirectory)
       let metadataPath = metadataDirectoryURL.path(percentEncoded: false)
       let metadataURL = metadataURL(for: rootURL)
       if fileManager.fileExists(atPath: metadataURL.path(percentEncoded: false)) {
@@ -570,7 +611,8 @@ nonisolated struct ProjectWorkspace: Codable, Equatable, Hashable, Sendable {
             : [])
       for url in removableURLs {
         let path = url.path(percentEncoded: false)
-        guard fileManager.fileExists(atPath: path) || (try? url.checkResourceIsReachable()) == true else {
+        guard fileManager.fileExists(atPath: path) || (try? url.checkResourceIsReachable()) == true
+        else {
           continue
         }
         do {
@@ -609,7 +651,8 @@ nonisolated struct ProjectWorkspace: Codable, Equatable, Hashable, Sendable {
       }
       let isSymbolicLink =
         (try? entryURL.resourceValues(forKeys: [.isSymbolicLinkKey]).isSymbolicLink) == true
-      guard !isSymbolicLink, entry.sourceKind != .remote, let sourceLocation = entry.sourceLocation else {
+      guard !isSymbolicLink, entry.sourceKind != .remote, let sourceLocation = entry.sourceLocation
+      else {
         continue
       }
       do {
@@ -661,13 +704,15 @@ nonisolated struct ProjectWorkspace: Codable, Equatable, Hashable, Sendable {
     guard !sourceLocation.isEmpty else {
       throw ProjectWorkspaceCreationError.missingRepositorySource(name)
     }
-    let checkout = try validatedCheckout(repository.checkout, sourceKind: repository.sourceKind, name: name)
+    let checkout = try validatedCheckout(
+      repository.checkout, sourceKind: repository.sourceKind, name: name)
     let workspacePath = uniqueRepositoryPath(
       for: repository,
       displayName: name,
       occupiedNames: &ledger.occupiedNames
     )
-    let destinationURL = workspaceRootURL.appending(path: workspacePath, directoryHint: .isDirectory)
+    let destinationURL = workspaceRootURL.appending(
+      path: workspacePath, directoryHint: .isDirectory)
     let destinationPath = normalizedPath(destinationURL, resolvingSymlinks: false)
     guard !fileManager.fileExists(atPath: destinationPath) else {
       throw ProjectWorkspaceCreationError.linkAlreadyExists(destinationPath)
@@ -676,7 +721,8 @@ nonisolated struct ProjectWorkspace: Codable, Equatable, Hashable, Sendable {
     let normalizedSourceLocation: String
     switch repository.sourceKind {
     case .existingPath, .localRepository:
-      let sourcePath = try localRepositoryPath(sourceLocation: sourceLocation, fileManager: fileManager)
+      let sourcePath = try localRepositoryPath(
+        sourceLocation: sourceLocation, fileManager: fileManager)
       switch checkout {
       case .link:
         let sourceURL = URL(fileURLWithPath: sourcePath, isDirectory: true).standardizedFileURL
@@ -707,7 +753,8 @@ nonisolated struct ProjectWorkspace: Codable, Equatable, Hashable, Sendable {
       normalizedSourceLocation = sourceLocation
 
     case .bareRepository:
-      let sourcePath = try localRepositoryPath(sourceLocation: sourceLocation, fileManager: fileManager)
+      let sourcePath = try localRepositoryPath(
+        sourceLocation: sourceLocation, fileManager: fileManager)
       try await gitRunner.run(
         worktreeAddCommand(checkout, sourcePath: sourcePath, destinationPath: destinationPath)
       )
@@ -758,7 +805,9 @@ nonisolated struct ProjectWorkspace: Codable, Equatable, Hashable, Sendable {
       }
       return .link
     case .createBranch(let branchName, let baseRef):
-      guard let trimmedBranch = branchName.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty else {
+      guard
+        let trimmedBranch = branchName.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+      else {
         throw ProjectWorkspaceCreationError.missingBranchName(name)
       }
       return .createBranch(
@@ -771,7 +820,8 @@ nonisolated struct ProjectWorkspace: Codable, Equatable, Hashable, Sendable {
       }
       return .useExistingRef(trimmedRef)
     case .trackRemoteRef(let remoteRef, let branchName):
-      guard let trimmedRemoteRef = remoteRef.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty,
+      guard
+        let trimmedRemoteRef = remoteRef.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty,
         let trimmedBranch = branchName.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
       else {
         throw ProjectWorkspaceCreationError.missingExistingRef(name)
@@ -829,7 +879,10 @@ nonisolated struct ProjectWorkspace: Codable, Equatable, Hashable, Sendable {
       return ProjectWorkspaceGitCommand(arguments: arguments, currentDirectoryURL: nil)
     case .useExistingRef(let ref):
       return ProjectWorkspaceGitCommand(
-        arguments: ["-C", destinationPath, "checkout", "--end-of-options", remoteCloneExistingCheckoutRef(ref)],
+        arguments: [
+          "-C", destinationPath, "checkout", "--end-of-options",
+          remoteCloneExistingCheckoutRef(ref),
+        ],
         currentDirectoryURL: nil
       )
     case .trackRemoteRef(_, let branchName):
@@ -859,7 +912,8 @@ nonisolated struct ProjectWorkspace: Codable, Equatable, Hashable, Sendable {
     sourceLocation: String,
     fileManager: FileManager
   ) throws -> String {
-    let repositoryPath = normalizedPath(URL(fileURLWithPath: sourceLocation), resolvingSymlinks: true)
+    let repositoryPath = normalizedPath(
+      URL(fileURLWithPath: sourceLocation), resolvingSymlinks: true)
     var repositoryIsDirectory = ObjCBool(false)
     guard fileManager.fileExists(atPath: repositoryPath, isDirectory: &repositoryIsDirectory),
       repositoryIsDirectory.boolValue
@@ -933,7 +987,8 @@ nonisolated struct ProjectWorkspace: Codable, Equatable, Hashable, Sendable {
   }
 
   private static func normalizedPath(_ url: URL, resolvingSymlinks: Bool) -> String {
-    var path = PathPolicy.normalizeURL(url, resolvingSymlinks: resolvingSymlinks).path(percentEncoded: false)
+    var path = PathPolicy.normalizeURL(url, resolvingSymlinks: resolvingSymlinks).path(
+      percentEncoded: false)
     while path.count > 1, path.hasSuffix("/") {
       path.removeLast()
     }

--- a/supacode/Domain/ProjectWorkspace.swift
+++ b/supacode/Domain/ProjectWorkspace.swift
@@ -563,6 +563,7 @@ nonisolated struct ProjectWorkspace: Codable, Equatable, Hashable, Sendable {
   static func cleanup(
     _ workspace: ProjectWorkspace,
     rootURL: URL,
+    deleteBranchEntryIDs: Set<String> = [],
     fileManager: FileManager = .default,
     gitRunner: ProjectWorkspaceGitRunner
   ) async {
@@ -587,6 +588,20 @@ nonisolated struct ProjectWorkspace: Codable, Equatable, Hashable, Sendable {
         )
       } catch {
         log.warning("Workspace cleanup could not unregister worktree at \(entryPath): \(error)")
+      }
+      // Branch deletion must follow the worktree removal — git refuses to
+      // delete a branch that still has a checkout.
+      if deleteBranchEntryIDs.contains(entry.id), let branchName = entry.branchName {
+        do {
+          try await gitRunner.run(
+            ProjectWorkspaceGitCommand(
+              arguments: ["-C", sourceLocation, "branch", "-D", branchName],
+              currentDirectoryURL: nil
+            )
+          )
+        } catch {
+          log.warning("Workspace cleanup could not delete branch \(branchName): \(error)")
+        }
       }
     }
     do {

--- a/supacode/Domain/ProjectWorkspace.swift
+++ b/supacode/Domain/ProjectWorkspace.swift
@@ -693,6 +693,25 @@ nonisolated struct ProjectWorkspace: Codable, Equatable, Hashable, Sendable {
     return sanitized.isEmpty ? "workspace" : sanitized
   }
 
+  nonisolated static func workspaceRootPath(folderName: String, suffix: Int?) -> String {
+    let component = suffix.map { "\(folderName)-\($0)" } ?? folderName
+    return SupacodePaths.workspacesDirectory
+      .appending(path: component, directoryHint: .isDirectory)
+      .standardizedFileURL
+      .path(percentEncoded: false)
+  }
+
+  nonisolated static func uniqueWorkspaceRootPath(folderName: String) -> String {
+    var suffix: Int?
+    while true {
+      let candidate = workspaceRootPath(folderName: folderName, suffix: suffix)
+      if !FileManager.default.fileExists(atPath: candidate) {
+        return candidate
+      }
+      suffix = (suffix ?? 1) + 1
+    }
+  }
+
   private static func materialize(
     _ repository: ProjectWorkspaceRepositoryPlan,
     workspaceRootURL: URL,

--- a/supacode/Domain/ProjectWorkspace.swift
+++ b/supacode/Domain/ProjectWorkspace.swift
@@ -434,6 +434,10 @@ nonisolated struct ProjectWorkspace: Codable, Equatable, Hashable, Sendable {
       .appending(path: metadataFileName)
   }
 
+  static func hasMetadata(at rootURL: URL) -> Bool {
+    FileManager.default.fileExists(atPath: metadataURL(for: rootURL).path(percentEncoded: false))
+  }
+
   static func load(from rootURL: URL) -> ProjectWorkspace? {
     let metadataURL = metadataURL(for: rootURL)
     guard let data = try? Data(contentsOf: metadataURL) else {

--- a/supacode/Domain/ProjectWorkspace.swift
+++ b/supacode/Domain/ProjectWorkspace.swift
@@ -1,0 +1,196 @@
+import Foundation
+
+nonisolated enum ProjectWorkspaceRepositorySourceKind: String, Codable, Equatable, Hashable, Sendable {
+  case remote
+  case localRepository = "local_repository"
+  case bareRepository = "bare_repository"
+  case existingPath = "existing_path"
+}
+
+nonisolated struct ProjectWorkspaceRepositoryEntry: Codable, Equatable, Hashable, Sendable, Identifiable {
+  var id: String
+  var name: String
+  var role: String?
+  var path: String
+  var sourceKind: ProjectWorkspaceRepositorySourceKind
+  var sourceLocation: String?
+  var branchName: String?
+  var baseRef: String?
+
+  enum CodingKeys: String, CodingKey {
+    case id
+    case name
+    case role
+    case path
+    case sourceKind = "source_kind"
+    case sourceLocation = "source_location"
+    case branchName = "branch_name"
+    case baseRef = "base_ref"
+  }
+
+  init(
+    id: String = "",
+    name: String = "",
+    role: String? = nil,
+    path: String = "",
+    sourceKind: ProjectWorkspaceRepositorySourceKind = .existingPath,
+    sourceLocation: String? = nil,
+    branchName: String? = nil,
+    baseRef: String? = nil
+  ) {
+    self.id = id
+    self.name = name
+    self.role = role
+    self.path = path
+    self.sourceKind = sourceKind
+    self.sourceLocation = sourceLocation
+    self.branchName = branchName
+    self.baseRef = baseRef
+  }
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    id = try container.decodeIfPresent(String.self, forKey: .id) ?? ""
+    name = try container.decodeIfPresent(String.self, forKey: .name) ?? ""
+    role = try container.decodeIfPresent(String.self, forKey: .role)
+    path =
+      try container.decodeIfPresent(String.self, forKey: .path)
+      ?? name.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+      ?? id.trimmingCharacters(in: .whitespacesAndNewlines)
+    sourceKind =
+      try container.decodeIfPresent(ProjectWorkspaceRepositorySourceKind.self, forKey: .sourceKind)
+      ?? .existingPath
+    sourceLocation = try container.decodeIfPresent(String.self, forKey: .sourceLocation)
+    branchName = try container.decodeIfPresent(String.self, forKey: .branchName)
+    baseRef = try container.decodeIfPresent(String.self, forKey: .baseRef)
+  }
+
+  func resolvedURL(relativeTo workspaceRootURL: URL) -> URL {
+    let trimmedPath = path.trimmingCharacters(in: .whitespacesAndNewlines)
+    if trimmedPath.hasPrefix("/") {
+      return URL(fileURLWithPath: trimmedPath).standardizedFileURL
+    }
+    return workspaceRootURL.appending(path: trimmedPath).standardizedFileURL
+  }
+}
+
+nonisolated struct ProjectWorkspace: Codable, Equatable, Hashable, Sendable {
+  typealias RepositorySourceKind = ProjectWorkspaceRepositorySourceKind
+  typealias RepositoryEntry = ProjectWorkspaceRepositoryEntry
+
+  nonisolated static let metadataDirectoryName = ".prowl"
+  nonisolated static let metadataFileName = "workspace.json"
+
+  var id: String
+  var title: String
+  var description: String
+  var taskLinks: [String]
+  var repositories: [RepositoryEntry]
+  var createdAt: Date?
+  var updatedAt: Date?
+
+  enum CodingKeys: String, CodingKey {
+    case id
+    case title
+    case description
+    case taskLinks = "task_links"
+    case repositories
+    case createdAt = "created_at"
+    case updatedAt = "updated_at"
+  }
+
+  init(
+    id: String = "",
+    title: String = "",
+    description: String = "",
+    taskLinks: [String] = [],
+    repositories: [RepositoryEntry] = [],
+    createdAt: Date? = nil,
+    updatedAt: Date? = nil
+  ) {
+    self.id = id
+    self.title = title
+    self.description = description
+    self.taskLinks = taskLinks
+    self.repositories = repositories
+    self.createdAt = createdAt
+    self.updatedAt = updatedAt
+  }
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    id = try container.decodeIfPresent(String.self, forKey: .id) ?? ""
+    title = try container.decodeIfPresent(String.self, forKey: .title) ?? ""
+    description = try container.decodeIfPresent(String.self, forKey: .description) ?? ""
+    taskLinks = try container.decodeIfPresent([String].self, forKey: .taskLinks) ?? []
+    repositories = try container.decodeIfPresent([RepositoryEntry].self, forKey: .repositories) ?? []
+    createdAt = try container.decodeIfPresent(Date.self, forKey: .createdAt)
+    updatedAt = try container.decodeIfPresent(Date.self, forKey: .updatedAt)
+  }
+
+  static func metadataURL(for rootURL: URL) -> URL {
+    rootURL
+      .appending(path: metadataDirectoryName)
+      .appending(path: metadataFileName)
+  }
+
+  static func load(from rootURL: URL) -> ProjectWorkspace? {
+    let metadataURL = metadataURL(for: rootURL)
+    guard let data = try? Data(contentsOf: metadataURL) else {
+      return nil
+    }
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+    guard var workspace = try? decoder.decode(ProjectWorkspace.self, from: data) else {
+      return nil
+    }
+    let normalizedRoot = rootURL.standardizedFileURL.path(percentEncoded: false)
+    if workspace.id.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+      workspace.id = normalizedRoot
+    }
+    if workspace.title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+      workspace.title = rootURL.lastPathComponent.isEmpty ? normalizedRoot : rootURL.lastPathComponent
+    }
+    return workspace.normalized(relativeTo: rootURL)
+  }
+
+  func normalized(relativeTo rootURL: URL) -> ProjectWorkspace {
+    var copy = self
+    let normalizedRoot = rootURL.standardizedFileURL.path(percentEncoded: false)
+    if copy.id.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+      copy.id = normalizedRoot
+    }
+    copy.title = copy.title.trimmingCharacters(in: .whitespacesAndNewlines)
+    if copy.title.isEmpty {
+      copy.title = rootURL.lastPathComponent.isEmpty ? normalizedRoot : rootURL.lastPathComponent
+    }
+    copy.description = copy.description.trimmingCharacters(in: .whitespacesAndNewlines)
+    copy.taskLinks = copy.taskLinks.map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+      .filter { !$0.isEmpty }
+    copy.repositories = copy.repositories.map { entry in
+      var entry = entry
+      entry.id = entry.id.trimmingCharacters(in: .whitespacesAndNewlines)
+      entry.name = entry.name.trimmingCharacters(in: .whitespacesAndNewlines)
+      entry.path = entry.path.trimmingCharacters(in: .whitespacesAndNewlines)
+      if entry.id.isEmpty {
+        entry.id = entry.path.isEmpty ? entry.name : entry.path
+      }
+      if entry.name.isEmpty {
+        let resolvedURL = entry.resolvedURL(relativeTo: rootURL)
+        entry.name = resolvedURL.lastPathComponent.isEmpty ? entry.id : resolvedURL.lastPathComponent
+      }
+      entry.role = entry.role?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+      entry.sourceLocation = entry.sourceLocation?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+      entry.branchName = entry.branchName?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+      entry.baseRef = entry.baseRef?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+      return entry
+    }
+    return copy
+  }
+}
+
+extension String {
+  nonisolated fileprivate var nilIfEmpty: String? {
+    isEmpty ? nil : self
+  }
+}

--- a/supacode/Domain/ProjectWorkspace.swift
+++ b/supacode/Domain/ProjectWorkspace.swift
@@ -63,6 +63,10 @@ nonisolated struct ProjectWorkspaceCreationRepository: Equatable, Hashable, Send
   var branchName: String?
   var baseRef: String?
   var baseRefOptions: [GitBranchRefOption]
+  // User choice when a Use-Existing checkout on a remote-tracking ref would
+  // reset an existing same-named local branch: false keeps the local branch
+  // (checks it out directly), true resets it to the remote ref.
+  var resetLocalBranchToRemote: Bool = false
 
   init(
     id: String,
@@ -110,6 +114,27 @@ nonisolated struct ProjectWorkspaceCreationRepository: Equatable, Hashable, Send
 
   var localSourceURL: URL? {
     sourceKind.localSourceURL(from: sourceLocation)
+  }
+
+  // Non-nil when a Use-Existing checkout on a remote-tracking ref would reset an
+  // already-existing same-named local branch via `git worktree add -B`, so the
+  // user should choose between keeping the local branch and resetting it.
+  // Derived purely from the already-loaded ref options — no extra git lookup.
+  var resettableLocalBranchName: String? {
+    guard checkoutMode == .useExistingRef,
+      let selectedRef = baseRef?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty,
+      let kind = baseRefOptions.first(where: { $0.ref == selectedRef })?.kind,
+      kind != .local
+    else {
+      return nil
+    }
+    let localName = selectedRef.split(separator: "/").dropFirst().joined(separator: "/")
+    guard !localName.isEmpty,
+      baseRefOptions.contains(where: { $0.kind == .local && $0.ref == localName })
+    else {
+      return nil
+    }
+    return localName
   }
 
   nonisolated static func baseRefOptions(
@@ -558,16 +583,24 @@ nonisolated struct ProjectWorkspace: Codable, Equatable, Hashable, Sendable {
     await task.value
   }
 
-  // Best-effort removal cleanup: every failure is logged and the remaining
-  // entries are still processed so a broken repository cannot block deletion.
-  static func cleanup(
+  // Best-effort worktree removal for a workspace being deleted. Every failure
+  // is logged and the remaining entries are still processed so a broken
+  // repository cannot block deletion. Returns the display names of entries
+  // whose worktree could not be unregistered, so the caller can decide whether
+  // to still delete the workspace folder — deleting it unconditionally would
+  // leave a dangling worktree registration in the source repository.
+  //
+  // Branch deletion is intentionally NOT performed here: the caller routes it
+  // through GitClient's guarded entry point so protected branches
+  // (main/master/default) can never be force-deleted.
+  static func removeWorktrees(
     _ workspace: ProjectWorkspace,
     rootURL: URL,
-    deleteBranchEntryIDs: Set<String> = [],
     fileManager: FileManager = .default,
     gitRunner: ProjectWorkspaceGitRunner
-  ) async {
+  ) async -> [String] {
     let rootPath = normalizedPath(rootURL, resolvingSymlinks: false)
+    var failedRemovals: [String] = []
     for entry in workspace.repositories {
       let entryURL = entry.resolvedURL(relativeTo: rootURL)
       let entryPath = entryURL.path(percentEncoded: false)
@@ -588,22 +621,19 @@ nonisolated struct ProjectWorkspace: Codable, Equatable, Hashable, Sendable {
         )
       } catch {
         log.warning("Workspace cleanup could not unregister worktree at \(entryPath): \(error)")
-      }
-      // Branch deletion must follow the worktree removal — git refuses to
-      // delete a branch that still has a checkout.
-      if deleteBranchEntryIDs.contains(entry.id), let branchName = entry.branchName {
-        do {
-          try await gitRunner.run(
-            ProjectWorkspaceGitCommand(
-              arguments: ["-C", sourceLocation, "branch", "-D", branchName],
-              currentDirectoryURL: nil
-            )
-          )
-        } catch {
-          log.warning("Workspace cleanup could not delete branch \(branchName): \(error)")
-        }
+        failedRemovals.append(entry.name)
       }
     }
+    return failedRemovals
+  }
+
+  // Deletes the workspace folder itself. Separate from `removeWorktrees` so the
+  // caller can gate it on whether every worktree was successfully unregistered.
+  static func removeWorkspaceFolder(
+    at rootURL: URL,
+    fileManager: FileManager = .default
+  ) {
+    let rootPath = normalizedPath(rootURL, resolvingSymlinks: false)
     do {
       try fileManager.removeItem(at: rootURL)
     } catch {

--- a/supacode/Domain/ProjectWorkspace.swift
+++ b/supacode/Domain/ProjectWorkspace.swift
@@ -7,24 +7,31 @@ nonisolated enum ProjectWorkspaceRepositorySourceKind: String, Codable, Equatabl
   case existingPath = "existing_path"
 }
 
+nonisolated enum ProjectWorkspaceRepositoryCheckoutMode: String, Codable, Equatable, Hashable, Sendable {
+  case createBranch = "create_branch"
+  case useExistingRef = "use_existing_ref"
+}
+
 nonisolated struct ProjectWorkspaceCreationRepository: Equatable, Hashable, Sendable, Identifiable {
   var id: String
   var name: String
   var path: String?
   var sourceKind: ProjectWorkspaceRepositorySourceKind
   var sourceLocation: String
+  var checkoutMode: ProjectWorkspaceRepositoryCheckoutMode
   var branchName: String?
   var baseRef: String?
-  var baseRefOptions: [String]
+  var baseRefOptions: [GitBranchRefOption]
 
   init(
     id: String,
     name: String,
     rootURL: URL,
+    checkoutMode: ProjectWorkspaceRepositoryCheckoutMode = .createBranch,
     branchName: String? = nil,
     path: String? = nil,
     baseRef: String? = nil,
-    baseRefOptions: [String] = []
+    baseRefOptions: [GitBranchRefOption] = []
   ) {
     let normalizedURL = rootURL.standardizedFileURL
     self.id = id
@@ -32,6 +39,7 @@ nonisolated struct ProjectWorkspaceCreationRepository: Equatable, Hashable, Send
     self.path = path
     sourceKind = .existingPath
     sourceLocation = normalizedURL.path(percentEncoded: false)
+    self.checkoutMode = checkoutMode
     self.branchName = branchName
     self.baseRef = baseRef
     self.baseRefOptions = Self.normalizedBaseRefOptions(baseRefOptions)
@@ -42,16 +50,18 @@ nonisolated struct ProjectWorkspaceCreationRepository: Equatable, Hashable, Send
     name: String,
     sourceKind: ProjectWorkspaceRepositorySourceKind,
     sourceLocation: String,
+    checkoutMode: ProjectWorkspaceRepositoryCheckoutMode = .createBranch,
     branchName: String? = nil,
     baseRef: String? = nil,
     path: String? = nil,
-    baseRefOptions: [String] = []
+    baseRefOptions: [GitBranchRefOption] = []
   ) {
     self.id = id
     self.name = name
     self.path = path
     self.sourceKind = sourceKind
     self.sourceLocation = sourceLocation
+    self.checkoutMode = checkoutMode
     self.branchName = branchName
     self.baseRef = baseRef
     self.baseRefOptions = Self.normalizedBaseRefOptions(baseRefOptions)
@@ -72,35 +82,39 @@ nonisolated struct ProjectWorkspaceCreationRepository: Equatable, Hashable, Send
 
   nonisolated static func baseRefOptions(
     automaticBaseRef: String?,
-    refs: [String]
-  ) -> [String] {
-    var values: [String] = []
+    options: [GitBranchRefOption]
+  ) -> [GitBranchRefOption] {
+    var values: [GitBranchRefOption] = []
     if let automaticBaseRef {
-      values.append(automaticBaseRef)
+      let trimmed = automaticBaseRef.trimmingCharacters(in: .whitespacesAndNewlines)
+      let kind = options.first { $0.ref == trimmed }?.kind ?? .local
+      values.append(GitBranchRefOption(ref: automaticBaseRef, kind: kind))
     }
-    values += refs
+    values += options
     return normalizedBaseRefOptions(values)
   }
 
-  nonisolated static func preferredBaseRef(automaticBaseRef: String?, options: [String]) -> String? {
+  nonisolated static func preferredBaseRef(automaticBaseRef: String?, options: [GitBranchRefOption]) -> String? {
+    let refs = Set(options.map(\.ref))
     if let automaticBaseRef,
-      !automaticBaseRef.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+      !automaticBaseRef.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+      refs.contains(automaticBaseRef)
     {
       return automaticBaseRef
     }
-    return ["main", "master", "origin/main", "origin/master"].first { options.contains($0) }
-      ?? options.first
+    return ["main", "master", "origin/main", "origin/master"].first { refs.contains($0) }
+      ?? options.first?.ref
   }
 
-  nonisolated static func normalizedBaseRefOptions(_ values: [String]) -> [String] {
+  nonisolated static func normalizedBaseRefOptions(_ values: [GitBranchRefOption]) -> [GitBranchRefOption] {
     var seen = Set<String>()
-    var result: [String] = []
+    var result: [GitBranchRefOption] = []
     for value in values {
-      let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+      let trimmed = value.ref.trimmingCharacters(in: .whitespacesAndNewlines)
       guard !trimmed.isEmpty, seen.insert(trimmed).inserted else {
         continue
       }
-      result.append(trimmed)
+      result.append(GitBranchRefOption(ref: trimmed, kind: value.kind))
     }
     return result
   }
@@ -534,7 +548,9 @@ nonisolated struct ProjectWorkspace: Codable, Equatable, Hashable, Sendable {
         path: workspacePath,
         sourceKind: sourceKind,
         sourceLocation: normalizedSourceLocation,
-        branchName: repository.branchName?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty,
+        branchName: repository.checkoutMode == .createBranch
+          ? repository.branchName?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+          : nil,
         baseRef: repository.baseRef?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
       ),
       createdURL: destinationURL,
@@ -550,6 +566,18 @@ nonisolated struct ProjectWorkspace: Codable, Equatable, Hashable, Sendable {
     let destinationPath = normalizedPath(destinationURL, resolvingSymlinks: false)
     let branchName = repository.branchName?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
     let baseRef = repository.baseRef?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+    if repository.checkoutMode == .useExistingRef {
+      guard let baseRef else {
+        return
+      }
+      try await gitRunner.run(
+        ProjectWorkspaceGitCommand(
+          arguments: ["-C", destinationPath, "checkout", remoteCloneExistingCheckoutRef(baseRef)],
+          currentDirectoryURL: nil
+        )
+      )
+      return
+    }
     switch (branchName, baseRef) {
     case (.some(let branchName), .some(let baseRef)):
       try await gitRunner.run(
@@ -585,7 +613,13 @@ nonisolated struct ProjectWorkspace: Codable, Equatable, Hashable, Sendable {
     let branchName = repository.branchName?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
     let baseRef = repository.baseRef?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
     var arguments = ["-C", sourcePath, "worktree", "add"]
-    if let branchName, let baseRef {
+    if repository.checkoutMode == .useExistingRef {
+      if let baseRef {
+        arguments += [destinationPath, baseRef]
+      } else {
+        arguments += [destinationPath]
+      }
+    } else if let branchName, let baseRef {
       arguments += ["-b", branchName, destinationPath, baseRef]
     } else if let branchName {
       arguments += [destinationPath, branchName]
@@ -595,6 +629,14 @@ nonisolated struct ProjectWorkspace: Codable, Equatable, Hashable, Sendable {
       arguments += [destinationPath]
     }
     return ProjectWorkspaceGitCommand(arguments: arguments, currentDirectoryURL: nil)
+  }
+
+  private static func remoteCloneExistingCheckoutRef(_ baseRef: String) -> String {
+    let prefix = "origin/"
+    guard baseRef.hasPrefix(prefix), baseRef.count > prefix.count else {
+      return baseRef
+    }
+    return String(baseRef.dropFirst(prefix.count))
   }
 
   private static func localRepositoryPath(

--- a/supacode/Domain/ProjectWorkspace.swift
+++ b/supacode/Domain/ProjectWorkspace.swift
@@ -15,13 +15,16 @@ nonisolated struct ProjectWorkspaceCreationRepository: Equatable, Hashable, Send
   var sourceLocation: String
   var branchName: String?
   var baseRef: String?
+  var baseRefOptions: [String]
 
   init(
     id: String,
     name: String,
     rootURL: URL,
     branchName: String? = nil,
-    path: String? = nil
+    path: String? = nil,
+    baseRef: String? = nil,
+    baseRefOptions: [String] = []
   ) {
     let normalizedURL = rootURL.standardizedFileURL
     self.id = id
@@ -30,7 +33,8 @@ nonisolated struct ProjectWorkspaceCreationRepository: Equatable, Hashable, Send
     sourceKind = .existingPath
     sourceLocation = normalizedURL.path(percentEncoded: false)
     self.branchName = branchName
-    baseRef = nil
+    self.baseRef = baseRef
+    self.baseRefOptions = Self.normalizedBaseRefOptions(baseRefOptions)
   }
 
   init(
@@ -40,7 +44,8 @@ nonisolated struct ProjectWorkspaceCreationRepository: Equatable, Hashable, Send
     sourceLocation: String,
     branchName: String? = nil,
     baseRef: String? = nil,
-    path: String? = nil
+    path: String? = nil,
+    baseRefOptions: [String] = []
   ) {
     self.id = id
     self.name = name
@@ -49,6 +54,7 @@ nonisolated struct ProjectWorkspaceCreationRepository: Equatable, Hashable, Send
     self.sourceLocation = sourceLocation
     self.branchName = branchName
     self.baseRef = baseRef
+    self.baseRefOptions = Self.normalizedBaseRefOptions(baseRefOptions)
   }
 
   var localSourceURL: URL? {
@@ -62,6 +68,50 @@ nonisolated struct ProjectWorkspaceCreationRepository: Equatable, Hashable, Send
     case .remote:
       return nil
     }
+  }
+
+  nonisolated static let commonRemoteBaseRefOptions = ["main", "master", "origin/main", "origin/master"]
+
+  nonisolated static func baseRefOptions(
+    automaticBaseRef: String?,
+    refs: [String],
+    sourceKind: ProjectWorkspaceRepositorySourceKind
+  ) -> [String] {
+    var values: [String] = []
+    if let automaticBaseRef {
+      values.append(automaticBaseRef)
+    }
+    switch sourceKind {
+    case .remote:
+      values += commonRemoteBaseRefOptions
+    case .existingPath, .localRepository, .bareRepository:
+      values += ["main", "master", "origin/main", "origin/master"]
+    }
+    values += refs
+    return normalizedBaseRefOptions(values)
+  }
+
+  nonisolated static func preferredBaseRef(automaticBaseRef: String?, options: [String]) -> String? {
+    if let automaticBaseRef,
+      !automaticBaseRef.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    {
+      return automaticBaseRef
+    }
+    return ["main", "master", "origin/main", "origin/master"].first { options.contains($0) }
+      ?? options.first
+  }
+
+  nonisolated static func normalizedBaseRefOptions(_ values: [String]) -> [String] {
+    var seen = Set<String>()
+    var result: [String] = []
+    for value in values {
+      let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+      guard !trimmed.isEmpty, seen.insert(trimmed).inserted else {
+        continue
+      }
+      result.append(trimmed)
+    }
+    return result
   }
 }
 

--- a/supacode/Domain/ProjectWorkspace.swift
+++ b/supacode/Domain/ProjectWorkspace.swift
@@ -558,6 +558,44 @@ nonisolated struct ProjectWorkspace: Codable, Equatable, Hashable, Sendable {
     await task.value
   }
 
+  // Best-effort removal cleanup: every failure is logged and the remaining
+  // entries are still processed so a broken repository cannot block deletion.
+  static func cleanup(
+    _ workspace: ProjectWorkspace,
+    rootURL: URL,
+    fileManager: FileManager = .default,
+    gitRunner: ProjectWorkspaceGitRunner
+  ) async {
+    let rootPath = normalizedPath(rootURL, resolvingSymlinks: false)
+    for entry in workspace.repositories {
+      let entryURL = entry.resolvedURL(relativeTo: rootURL)
+      let entryPath = entryURL.path(percentEncoded: false)
+      guard entryPath.hasPrefix(rootPath + "/") else {
+        continue
+      }
+      let isSymbolicLink =
+        (try? entryURL.resourceValues(forKeys: [.isSymbolicLinkKey]).isSymbolicLink) == true
+      guard !isSymbolicLink, entry.sourceKind != .remote, let sourceLocation = entry.sourceLocation else {
+        continue
+      }
+      do {
+        try await gitRunner.run(
+          ProjectWorkspaceGitCommand(
+            arguments: ["-C", sourceLocation, "worktree", "remove", "--force", entryPath],
+            currentDirectoryURL: nil
+          )
+        )
+      } catch {
+        log.warning("Workspace cleanup could not unregister worktree at \(entryPath): \(error)")
+      }
+    }
+    do {
+      try fileManager.removeItem(at: rootURL)
+    } catch {
+      log.warning("Workspace cleanup could not remove \(rootPath): \(error)")
+    }
+  }
+
   static func defaultWorkspaceFolderName(for title: String) -> String {
     let sanitized = sanitizedWorkspaceComponent(title)
     return sanitized.isEmpty ? "workspace" : sanitized

--- a/supacode/Domain/ProjectWorkspace.swift
+++ b/supacode/Domain/ProjectWorkspace.swift
@@ -5,11 +5,51 @@ nonisolated enum ProjectWorkspaceRepositorySourceKind: String, Codable, Equatabl
   case localRepository = "local_repository"
   case bareRepository = "bare_repository"
   case existingPath = "existing_path"
+
+  var supportsLinkCheckout: Bool {
+    switch self {
+    case .existingPath, .localRepository:
+      return true
+    case .remote, .bareRepository:
+      return false
+    }
+  }
+
+  var defaultCheckoutMode: ProjectWorkspaceRepositoryCheckoutMode {
+    switch self {
+    case .existingPath, .localRepository:
+      return .link
+    case .bareRepository:
+      return .createBranch
+    case .remote:
+      return .useExistingRef
+    }
+  }
+
+  func localSourceURL(from sourceLocation: String) -> URL? {
+    switch self {
+    case .existingPath, .localRepository, .bareRepository:
+      let trimmed = sourceLocation.trimmingCharacters(in: .whitespacesAndNewlines)
+      guard !trimmed.isEmpty else {
+        return nil
+      }
+      return URL(fileURLWithPath: trimmed).standardizedFileURL
+    case .remote:
+      return nil
+    }
+  }
 }
 
 nonisolated enum ProjectWorkspaceRepositoryCheckoutMode: String, Codable, Equatable, Hashable, Sendable {
+  case link
   case createBranch = "create_branch"
   case useExistingRef = "use_existing_ref"
+}
+
+nonisolated enum ProjectWorkspaceRepositoryCheckout: Equatable, Hashable, Sendable {
+  case link
+  case createBranch(branchName: String, baseRef: String?)
+  case useExistingRef(String)
 }
 
 nonisolated struct ProjectWorkspaceCreationRepository: Equatable, Hashable, Sendable, Identifiable {
@@ -27,7 +67,7 @@ nonisolated struct ProjectWorkspaceCreationRepository: Equatable, Hashable, Send
     id: String,
     name: String,
     rootURL: URL,
-    checkoutMode: ProjectWorkspaceRepositoryCheckoutMode = .createBranch,
+    checkoutMode: ProjectWorkspaceRepositoryCheckoutMode? = nil,
     branchName: String? = nil,
     path: String? = nil,
     baseRef: String? = nil,
@@ -39,7 +79,7 @@ nonisolated struct ProjectWorkspaceCreationRepository: Equatable, Hashable, Send
     self.path = path
     sourceKind = .existingPath
     sourceLocation = normalizedURL.path(percentEncoded: false)
-    self.checkoutMode = checkoutMode
+    self.checkoutMode = checkoutMode ?? ProjectWorkspaceRepositorySourceKind.existingPath.defaultCheckoutMode
     self.branchName = branchName
     self.baseRef = baseRef
     self.baseRefOptions = Self.normalizedBaseRefOptions(baseRefOptions)
@@ -50,7 +90,7 @@ nonisolated struct ProjectWorkspaceCreationRepository: Equatable, Hashable, Send
     name: String,
     sourceKind: ProjectWorkspaceRepositorySourceKind,
     sourceLocation: String,
-    checkoutMode: ProjectWorkspaceRepositoryCheckoutMode = .createBranch,
+    checkoutMode: ProjectWorkspaceRepositoryCheckoutMode? = nil,
     branchName: String? = nil,
     baseRef: String? = nil,
     path: String? = nil,
@@ -61,23 +101,14 @@ nonisolated struct ProjectWorkspaceCreationRepository: Equatable, Hashable, Send
     self.path = path
     self.sourceKind = sourceKind
     self.sourceLocation = sourceLocation
-    self.checkoutMode = checkoutMode
+    self.checkoutMode = checkoutMode ?? sourceKind.defaultCheckoutMode
     self.branchName = branchName
     self.baseRef = baseRef
     self.baseRefOptions = Self.normalizedBaseRefOptions(baseRefOptions)
   }
 
   var localSourceURL: URL? {
-    switch sourceKind {
-    case .existingPath, .localRepository, .bareRepository:
-      let trimmed = sourceLocation.trimmingCharacters(in: .whitespacesAndNewlines)
-      guard !trimmed.isEmpty else {
-        return nil
-      }
-      return URL(fileURLWithPath: trimmed).standardizedFileURL
-    case .remote:
-      return nil
-    }
+    sourceKind.localSourceURL(from: sourceLocation)
   }
 
   nonisolated static func baseRefOptions(
@@ -96,11 +127,11 @@ nonisolated struct ProjectWorkspaceCreationRepository: Equatable, Hashable, Send
 
   nonisolated static func preferredBaseRef(automaticBaseRef: String?, options: [GitBranchRefOption]) -> String? {
     let refs = Set(options.map(\.ref))
-    if let automaticBaseRef,
-      !automaticBaseRef.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
-      refs.contains(automaticBaseRef)
+    if let trimmed = automaticBaseRef?.trimmingCharacters(in: .whitespacesAndNewlines),
+      !trimmed.isEmpty,
+      refs.contains(trimmed)
     {
-      return automaticBaseRef
+      return trimmed
     }
     return ["main", "master", "origin/main", "origin/master"].first { refs.contains($0) }
       ?? options.first?.ref
@@ -120,15 +151,28 @@ nonisolated struct ProjectWorkspaceCreationRepository: Equatable, Hashable, Send
   }
 }
 
+nonisolated struct ProjectWorkspaceRepositoryPlan: Equatable, Sendable, Identifiable {
+  var id: String
+  var name: String
+  var path: String?
+  var sourceKind: ProjectWorkspaceRepositorySourceKind
+  var sourceLocation: String
+  var checkout: ProjectWorkspaceRepositoryCheckout
+
+  var localSourceURL: URL? {
+    sourceKind.localSourceURL(from: sourceLocation)
+  }
+}
+
 nonisolated struct ProjectWorkspaceCreationDraft: Equatable, Sendable {
   var title: String
   var rootURL: URL
-  var repositories: [ProjectWorkspaceCreationRepository]
+  var repositories: [ProjectWorkspaceRepositoryPlan]
 
   init(
     title: String,
     rootURL: URL,
-    repositories: [ProjectWorkspaceCreationRepository]
+    repositories: [ProjectWorkspaceRepositoryPlan]
   ) {
     self.title = title
     self.rootURL = rootURL.standardizedFileURL
@@ -160,6 +204,9 @@ nonisolated enum ProjectWorkspaceCreationError: LocalizedError, Equatable, Senda
   case notEnoughRepositories
   case missingRepositoryName
   case missingRepositorySource(String)
+  case missingBranchName(String)
+  case missingExistingRef(String)
+  case linkCheckoutUnsupported(String)
   case destinationIsFile(String)
   case workspaceAlreadyExists(String)
   case repositoryDoesNotExist(String)
@@ -178,6 +225,12 @@ nonisolated enum ProjectWorkspaceCreationError: LocalizedError, Equatable, Senda
       return "Repository name required."
     case .missingRepositorySource(let name):
       return "Source required for \(name)."
+    case .missingBranchName(let name):
+      return "Branch name required for \(name)."
+    case .missingExistingRef(let name):
+      return "Choose an existing branch for \(name)."
+    case .linkCheckoutUnsupported(let name):
+      return "Link is not available for \(name)."
     case .destinationIsFile(let path):
       return "\(path) is a file. Choose a folder path instead."
     case .workspaceAlreadyExists(let path):
@@ -268,6 +321,7 @@ nonisolated struct ProjectWorkspace: Codable, Equatable, Hashable, Sendable {
 
   nonisolated static let metadataDirectoryName = ".prowl"
   nonisolated static let metadataFileName = "workspace.json"
+  nonisolated private static let log = SupaLogger("workspace")
 
   var id: String
   var title: String
@@ -329,7 +383,13 @@ nonisolated struct ProjectWorkspace: Codable, Equatable, Hashable, Sendable {
     }
     let decoder = JSONDecoder()
     decoder.dateDecodingStrategy = .iso8601
-    guard var workspace = try? decoder.decode(ProjectWorkspace.self, from: data) else {
+    var workspace: ProjectWorkspace
+    do {
+      workspace = try decoder.decode(ProjectWorkspace.self, from: data)
+    } catch {
+      log.warning(
+        "Ignoring malformed workspace metadata at \(metadataURL.path(percentEncoded: false)): \(error)"
+      )
       return nil
     }
     let normalizedRoot = rootURL.standardizedFileURL.path(percentEncoded: false)
@@ -394,10 +454,7 @@ nonisolated struct ProjectWorkspace: Codable, Equatable, Hashable, Sendable {
     }
     let rootURL = URL(fileURLWithPath: rootPath, isDirectory: true).standardizedFileURL
 
-    var createdRoot = false
-    var createdMetadataDirectory = false
-    var createdURLs: [URL] = []
-    var cleanupCommands: [ProjectWorkspaceGitCommand] = []
+    var ledger = MaterializationLedger()
     do {
       var isDirectory = ObjCBool(false)
       if fileManager.fileExists(atPath: rootPath, isDirectory: &isDirectory) {
@@ -406,7 +463,7 @@ nonisolated struct ProjectWorkspace: Codable, Equatable, Hashable, Sendable {
         }
       } else {
         try fileManager.createDirectory(at: rootURL, withIntermediateDirectories: true)
-        createdRoot = true
+        ledger.createdRoot = true
       }
 
       let metadataDirectoryURL = rootURL.appending(path: metadataDirectoryName, directoryHint: .isDirectory)
@@ -417,24 +474,19 @@ nonisolated struct ProjectWorkspace: Codable, Equatable, Hashable, Sendable {
       }
       if !fileManager.fileExists(atPath: metadataPath) {
         try fileManager.createDirectory(at: metadataDirectoryURL, withIntermediateDirectories: true)
-        createdMetadataDirectory = true
+        ledger.createdMetadataDirectory = true
       }
 
-      var occupiedNames: Set<String> = []
       var entries: [RepositoryEntry] = []
       for repository in request.draft.repositories {
-        let prepared = try await materialize(
+        let entry = try await materialize(
           repository,
           workspaceRootURL: rootURL,
-          occupiedNames: &occupiedNames,
+          ledger: &ledger,
           fileManager: fileManager,
           gitRunner: gitRunner
         )
-        createdURLs.append(prepared.createdURL)
-        if let cleanupCommand = prepared.cleanupCommand {
-          cleanupCommands.append(cleanupCommand)
-        }
-        entries.append(prepared.entry)
+        entries.append(entry)
       }
 
       let workspace = ProjectWorkspace(
@@ -449,22 +501,60 @@ nonisolated struct ProjectWorkspace: Codable, Equatable, Hashable, Sendable {
       encoder.dateEncodingStrategy = .iso8601
       encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
       try encoder.encode(workspace).write(to: metadataURL, options: .atomic)
-      createdURLs.append(metadataURL)
+      ledger.createdURLs.append(metadataURL)
       return workspace
     } catch {
-      for command in cleanupCommands.reversed() {
-        try? await gitRunner.run(command)
-      }
-      for url in createdURLs.reversed() {
-        try? fileManager.removeItem(at: url)
-      }
-      if createdRoot {
-        try? fileManager.removeItem(at: rootURL)
-      } else if createdMetadataDirectory {
-        try? fileManager.removeItem(at: rootURL.appending(path: metadataDirectoryName, directoryHint: .isDirectory))
-      }
+      await rollback(ledger, rootURL: rootURL, fileManager: fileManager, gitRunner: gitRunner)
       throw error
     }
+  }
+
+  private struct MaterializationLedger: Sendable {
+    var occupiedNames: Set<String> = []
+    var createdURLs: [URL] = []
+    var cleanupCommands: [ProjectWorkspaceGitCommand] = []
+    var createdRoot = false
+    var createdMetadataDirectory = false
+  }
+
+  // Rollback runs in a detached task so it survives cooperative cancellation of
+  // the surrounding effect: a cancelled parent task would otherwise SIGTERM the
+  // cleanup git subprocesses before they finish.
+  private static func rollback(
+    _ ledger: MaterializationLedger,
+    rootURL: URL,
+    fileManager: FileManager,
+    gitRunner: ProjectWorkspaceGitRunner
+  ) async {
+    nonisolated(unsafe) let fileManager = fileManager
+    let task = Task.detached {
+      for command in ledger.cleanupCommands.reversed() {
+        do {
+          try await gitRunner.run(command)
+        } catch {
+          log.warning("Workspace rollback command failed: \(command.displayCommand): \(error)")
+        }
+      }
+      let removableURLs =
+        ledger.createdURLs.reversed()
+        + (ledger.createdRoot
+          ? [rootURL]
+          : ledger.createdMetadataDirectory
+            ? [rootURL.appending(path: metadataDirectoryName, directoryHint: .isDirectory)]
+            : [])
+      for url in removableURLs {
+        let path = url.path(percentEncoded: false)
+        guard fileManager.fileExists(atPath: path) || (try? url.checkResourceIsReachable()) == true else {
+          continue
+        }
+        do {
+          try fileManager.removeItem(at: url)
+        } catch {
+          log.warning("Workspace rollback could not remove \(path): \(error)")
+        }
+      }
+    }
+    await task.value
   }
 
   static func defaultWorkspaceFolderName(for title: String) -> String {
@@ -472,19 +562,13 @@ nonisolated struct ProjectWorkspace: Codable, Equatable, Hashable, Sendable {
     return sanitized.isEmpty ? "workspace" : sanitized
   }
 
-  private struct PreparedRepository {
-    var entry: RepositoryEntry
-    var createdURL: URL
-    var cleanupCommand: ProjectWorkspaceGitCommand?
-  }
-
   private static func materialize(
-    _ repository: ProjectWorkspaceCreationRepository,
+    _ repository: ProjectWorkspaceRepositoryPlan,
     workspaceRootURL: URL,
-    occupiedNames: inout Set<String>,
+    ledger: inout MaterializationLedger,
     fileManager: FileManager,
     gitRunner: ProjectWorkspaceGitRunner
-  ) async throws -> PreparedRepository {
+  ) async throws -> RepositoryEntry {
     let name = repositoryDisplayName(repository)
     guard !name.isEmpty else {
       throw ProjectWorkspaceCreationError.missingRepositoryName
@@ -493,142 +577,164 @@ nonisolated struct ProjectWorkspace: Codable, Equatable, Hashable, Sendable {
     guard !sourceLocation.isEmpty else {
       throw ProjectWorkspaceCreationError.missingRepositorySource(name)
     }
-    let workspacePath = uniqueRepositoryPath(for: repository, displayName: name, occupiedNames: &occupiedNames)
+    let checkout = try validatedCheckout(repository.checkout, sourceKind: repository.sourceKind, name: name)
+    let workspacePath = uniqueRepositoryPath(
+      for: repository,
+      displayName: name,
+      occupiedNames: &ledger.occupiedNames
+    )
     let destinationURL = workspaceRootURL.appending(path: workspacePath, directoryHint: .isDirectory)
     let destinationPath = normalizedPath(destinationURL, resolvingSymlinks: false)
     guard !fileManager.fileExists(atPath: destinationPath) else {
       throw ProjectWorkspaceCreationError.linkAlreadyExists(destinationPath)
     }
 
-    let sourceKind = repository.sourceKind
-    let normalizedSourceLocation: String?
-    let cleanupCommand: ProjectWorkspaceGitCommand?
-    switch sourceKind {
+    let normalizedSourceLocation: String
+    switch repository.sourceKind {
     case .existingPath, .localRepository:
-      let sourcePath = try localRepositoryPath(repository, sourceLocation: sourceLocation, fileManager: fileManager)
-      let sourceURL = URL(fileURLWithPath: sourcePath, isDirectory: true).standardizedFileURL
-      try fileManager.createSymbolicLink(at: destinationURL, withDestinationURL: sourceURL)
+      let sourcePath = try localRepositoryPath(sourceLocation: sourceLocation, fileManager: fileManager)
+      switch checkout {
+      case .link:
+        let sourceURL = URL(fileURLWithPath: sourcePath, isDirectory: true).standardizedFileURL
+        try fileManager.createSymbolicLink(at: destinationURL, withDestinationURL: sourceURL)
+        ledger.createdURLs.append(destinationURL)
+      case .createBranch, .useExistingRef:
+        try await gitRunner.run(
+          worktreeAddCommand(checkout, sourcePath: sourcePath, destinationPath: destinationPath)
+        )
+        ledger.createdURLs.append(destinationURL)
+        ledger.cleanupCommands.append(
+          worktreeRemoveCommand(sourcePath: sourcePath, destinationPath: destinationPath)
+        )
+      }
       normalizedSourceLocation = sourcePath
-      cleanupCommand = nil
 
     case .remote:
       try await gitRunner.run(
         ProjectWorkspaceGitCommand(
-          arguments: ["clone", sourceLocation, destinationPath],
+          arguments: ["clone", "--end-of-options", sourceLocation, destinationPath],
           currentDirectoryURL: workspaceRootURL
         )
       )
-      try await checkoutIfNeeded(
-        repository,
-        destinationURL: destinationURL,
-        gitRunner: gitRunner
-      )
+      ledger.createdURLs.append(destinationURL)
+      if let checkoutCommand = remoteCheckoutCommand(checkout, destinationPath: destinationPath) {
+        try await gitRunner.run(checkoutCommand)
+      }
       normalizedSourceLocation = sourceLocation
-      cleanupCommand = nil
 
     case .bareRepository:
-      let sourcePath = try localRepositoryPath(repository, sourceLocation: sourceLocation, fileManager: fileManager)
-      let command = bareWorktreeCommand(
-        repository,
-        sourcePath: sourcePath,
-        destinationPath: destinationPath
+      let sourcePath = try localRepositoryPath(sourceLocation: sourceLocation, fileManager: fileManager)
+      try await gitRunner.run(
+        worktreeAddCommand(checkout, sourcePath: sourcePath, destinationPath: destinationPath)
       )
-      try await gitRunner.run(command)
+      ledger.createdURLs.append(destinationURL)
+      ledger.cleanupCommands.append(
+        worktreeRemoveCommand(sourcePath: sourcePath, destinationPath: destinationPath)
+      )
       normalizedSourceLocation = sourcePath
-      cleanupCommand = ProjectWorkspaceGitCommand(
-        arguments: ["-C", sourcePath, "worktree", "remove", "--force", destinationPath],
-        currentDirectoryURL: nil
-      )
     }
 
-    return PreparedRepository(
-      entry: RepositoryEntry(
-        id: repository.id.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty ?? workspacePath,
-        name: name,
-        path: workspacePath,
-        sourceKind: sourceKind,
-        sourceLocation: normalizedSourceLocation,
-        branchName: repository.checkoutMode == .createBranch
-          ? repository.branchName?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
-          : nil,
-        baseRef: repository.baseRef?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
-      ),
-      createdURL: destinationURL,
-      cleanupCommand: cleanupCommand
+    let entryBranchName: String?
+    let entryBaseRef: String?
+    switch checkout {
+    case .link:
+      entryBranchName = nil
+      entryBaseRef = nil
+    case .createBranch(let branchName, let baseRef):
+      entryBranchName = branchName
+      entryBaseRef = baseRef
+    case .useExistingRef(let ref):
+      entryBranchName = nil
+      entryBaseRef = ref
+    }
+
+    return RepositoryEntry(
+      id: repository.id.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty ?? workspacePath,
+      name: name,
+      path: workspacePath,
+      sourceKind: repository.sourceKind,
+      sourceLocation: normalizedSourceLocation,
+      branchName: entryBranchName,
+      baseRef: entryBaseRef
     )
   }
 
-  private static func checkoutIfNeeded(
-    _ repository: ProjectWorkspaceCreationRepository,
-    destinationURL: URL,
-    gitRunner: ProjectWorkspaceGitRunner
-  ) async throws {
-    let destinationPath = normalizedPath(destinationURL, resolvingSymlinks: false)
-    let branchName = repository.branchName?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
-    let baseRef = repository.baseRef?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
-    if repository.checkoutMode == .useExistingRef {
-      guard let baseRef else {
-        return
+  private static func validatedCheckout(
+    _ checkout: ProjectWorkspaceRepositoryCheckout,
+    sourceKind: ProjectWorkspaceRepositorySourceKind,
+    name: String
+  ) throws -> ProjectWorkspaceRepositoryCheckout {
+    switch checkout {
+    case .link:
+      guard sourceKind.supportsLinkCheckout else {
+        throw ProjectWorkspaceCreationError.linkCheckoutUnsupported(name)
       }
-      try await gitRunner.run(
-        ProjectWorkspaceGitCommand(
-          arguments: ["-C", destinationPath, "checkout", remoteCloneExistingCheckoutRef(baseRef)],
-          currentDirectoryURL: nil
-        )
+      return .link
+    case .createBranch(let branchName, let baseRef):
+      guard let trimmedBranch = branchName.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty else {
+        throw ProjectWorkspaceCreationError.missingBranchName(name)
+      }
+      return .createBranch(
+        branchName: trimmedBranch,
+        baseRef: baseRef?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
       )
-      return
-    }
-    switch (branchName, baseRef) {
-    case (.some(let branchName), .some(let baseRef)):
-      try await gitRunner.run(
-        ProjectWorkspaceGitCommand(
-          arguments: ["-C", destinationPath, "checkout", "-B", branchName, baseRef],
-          currentDirectoryURL: nil
-        )
-      )
-    case (.some(let branchName), .none):
-      try await gitRunner.run(
-        ProjectWorkspaceGitCommand(
-          arguments: ["-C", destinationPath, "checkout", "-B", branchName],
-          currentDirectoryURL: nil
-        )
-      )
-    case (.none, .some(let baseRef)):
-      try await gitRunner.run(
-        ProjectWorkspaceGitCommand(
-          arguments: ["-C", destinationPath, "checkout", baseRef],
-          currentDirectoryURL: nil
-        )
-      )
-    case (.none, .none):
-      break
+    case .useExistingRef(let ref):
+      guard let trimmedRef = ref.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty else {
+        throw ProjectWorkspaceCreationError.missingExistingRef(name)
+      }
+      return .useExistingRef(trimmedRef)
     }
   }
 
-  private static func bareWorktreeCommand(
-    _ repository: ProjectWorkspaceCreationRepository,
+  private static func worktreeAddCommand(
+    _ checkout: ProjectWorkspaceRepositoryCheckout,
     sourcePath: String,
     destinationPath: String
   ) -> ProjectWorkspaceGitCommand {
-    let branchName = repository.branchName?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
-    let baseRef = repository.baseRef?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
     var arguments = ["-C", sourcePath, "worktree", "add"]
-    if repository.checkoutMode == .useExistingRef {
-      if let baseRef {
-        arguments += [destinationPath, baseRef]
-      } else {
-        arguments += [destinationPath]
-      }
-    } else if let branchName, let baseRef {
-      arguments += ["-b", branchName, destinationPath, baseRef]
-    } else if let branchName {
-      arguments += [destinationPath, branchName]
-    } else if let baseRef {
-      arguments += [destinationPath, baseRef]
-    } else {
+    switch checkout {
+    case .link:
       arguments += [destinationPath]
+    case .createBranch(let branchName, let baseRef):
+      arguments += ["-b", branchName, destinationPath]
+      if let baseRef {
+        arguments += ["--end-of-options", baseRef]
+      }
+    case .useExistingRef(let ref):
+      arguments += [destinationPath, "--end-of-options", ref]
     }
     return ProjectWorkspaceGitCommand(arguments: arguments, currentDirectoryURL: nil)
+  }
+
+  private static func worktreeRemoveCommand(
+    sourcePath: String,
+    destinationPath: String
+  ) -> ProjectWorkspaceGitCommand {
+    ProjectWorkspaceGitCommand(
+      arguments: ["-C", sourcePath, "worktree", "remove", "--force", destinationPath],
+      currentDirectoryURL: nil
+    )
+  }
+
+  private static func remoteCheckoutCommand(
+    _ checkout: ProjectWorkspaceRepositoryCheckout,
+    destinationPath: String
+  ) -> ProjectWorkspaceGitCommand? {
+    switch checkout {
+    case .link:
+      return nil
+    case .createBranch(let branchName, let baseRef):
+      var arguments = ["-C", destinationPath, "checkout", "-B", branchName]
+      if let baseRef {
+        arguments += ["--end-of-options", baseRef]
+      }
+      return ProjectWorkspaceGitCommand(arguments: arguments, currentDirectoryURL: nil)
+    case .useExistingRef(let ref):
+      return ProjectWorkspaceGitCommand(
+        arguments: ["-C", destinationPath, "checkout", "--end-of-options", remoteCloneExistingCheckoutRef(ref)],
+        currentDirectoryURL: nil
+      )
+    }
   }
 
   private static func remoteCloneExistingCheckoutRef(_ baseRef: String) -> String {
@@ -640,7 +746,6 @@ nonisolated struct ProjectWorkspace: Codable, Equatable, Hashable, Sendable {
   }
 
   private static func localRepositoryPath(
-    _ repository: ProjectWorkspaceCreationRepository,
     sourceLocation: String,
     fileManager: FileManager
   ) throws -> String {
@@ -655,7 +760,7 @@ nonisolated struct ProjectWorkspace: Codable, Equatable, Hashable, Sendable {
   }
 
   private static func uniqueRepositoryPath(
-    for repository: ProjectWorkspaceCreationRepository,
+    for repository: ProjectWorkspaceRepositoryPlan,
     displayName: String,
     occupiedNames: inout Set<String>
   ) -> String {
@@ -677,7 +782,7 @@ nonisolated struct ProjectWorkspace: Codable, Equatable, Hashable, Sendable {
     return candidate
   }
 
-  private static func repositoryDisplayName(_ repository: ProjectWorkspaceCreationRepository) -> String {
+  private static func repositoryDisplayName(_ repository: ProjectWorkspaceRepositoryPlan) -> String {
     let trimmedName = repository.name.trimmingCharacters(in: .whitespacesAndNewlines)
     if !trimmedName.isEmpty {
       return trimmedName
@@ -688,15 +793,9 @@ nonisolated struct ProjectWorkspace: Codable, Equatable, Hashable, Sendable {
         return Repository.name(for: localSourceURL)
       }
     case .remote:
-      let source = repository.sourceLocation.trimmingCharacters(in: .whitespacesAndNewlines)
-      let lastPathComponent =
-        source
-        .split(separator: "/")
-        .last
-        .map(String.init)?
-        .replacing(".git", with: "")
-      if let lastPathComponent, !lastPathComponent.isEmpty {
-        return lastPathComponent
+      let name = GitRemoteNaming.repositoryName(fromRemoteURL: repository.sourceLocation)
+      if !name.isEmpty {
+        return name
       }
     }
     return ""

--- a/supacode/Domain/ProjectWorkspace.swift
+++ b/supacode/Domain/ProjectWorkspace.swift
@@ -50,6 +50,7 @@ nonisolated enum ProjectWorkspaceRepositoryCheckout: Equatable, Hashable, Sendab
   case link
   case createBranch(branchName: String, baseRef: String?)
   case useExistingRef(String)
+  case trackRemoteRef(remoteRef: String, branchName: String)
 }
 
 nonisolated struct ProjectWorkspaceCreationRepository: Equatable, Hashable, Sendable, Identifiable {
@@ -598,7 +599,7 @@ nonisolated struct ProjectWorkspace: Codable, Equatable, Hashable, Sendable {
         let sourceURL = URL(fileURLWithPath: sourcePath, isDirectory: true).standardizedFileURL
         try fileManager.createSymbolicLink(at: destinationURL, withDestinationURL: sourceURL)
         ledger.createdURLs.append(destinationURL)
-      case .createBranch, .useExistingRef:
+      case .createBranch, .useExistingRef, .trackRemoteRef:
         try await gitRunner.run(
           worktreeAddCommand(checkout, sourcePath: sourcePath, destinationPath: destinationPath)
         )
@@ -646,6 +647,9 @@ nonisolated struct ProjectWorkspace: Codable, Equatable, Hashable, Sendable {
     case .useExistingRef(let ref):
       entryBranchName = nil
       entryBaseRef = ref
+    case .trackRemoteRef(let remoteRef, let branchName):
+      entryBranchName = branchName
+      entryBaseRef = remoteRef
     }
 
     return RepositoryEntry(
@@ -683,6 +687,13 @@ nonisolated struct ProjectWorkspace: Codable, Equatable, Hashable, Sendable {
         throw ProjectWorkspaceCreationError.missingExistingRef(name)
       }
       return .useExistingRef(trimmedRef)
+    case .trackRemoteRef(let remoteRef, let branchName):
+      guard let trimmedRemoteRef = remoteRef.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty,
+        let trimmedBranch = branchName.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+      else {
+        throw ProjectWorkspaceCreationError.missingExistingRef(name)
+      }
+      return .trackRemoteRef(remoteRef: trimmedRemoteRef, branchName: trimmedBranch)
     }
   }
 
@@ -702,6 +713,10 @@ nonisolated struct ProjectWorkspace: Codable, Equatable, Hashable, Sendable {
       }
     case .useExistingRef(let ref):
       arguments += [destinationPath, "--end-of-options", ref]
+    case .trackRemoteRef(let remoteRef, let branchName):
+      // -B aligns a same-named local branch to the remote ref; git still refuses
+      // when that branch is checked out in another worktree.
+      arguments += ["--track", "-B", branchName, destinationPath, "--end-of-options", remoteRef]
     }
     return ProjectWorkspaceGitCommand(arguments: arguments, currentDirectoryURL: nil)
   }
@@ -734,7 +749,19 @@ nonisolated struct ProjectWorkspace: Codable, Equatable, Hashable, Sendable {
         arguments: ["-C", destinationPath, "checkout", "--end-of-options", remoteCloneExistingCheckoutRef(ref)],
         currentDirectoryURL: nil
       )
+    case .trackRemoteRef(_, let branchName):
+      return ProjectWorkspaceGitCommand(
+        arguments: ["-C", destinationPath, "checkout", "--end-of-options", branchName],
+        currentDirectoryURL: nil
+      )
     }
+  }
+
+  private static func withoutGitSuffix(_ name: String) -> String {
+    guard name.count > 4, name.hasSuffix(".git") else {
+      return name
+    }
+    return String(name.dropLast(4))
   }
 
   private static func remoteCloneExistingCheckoutRef(_ baseRef: String) -> String {
@@ -764,9 +791,9 @@ nonisolated struct ProjectWorkspace: Codable, Equatable, Hashable, Sendable {
     displayName: String,
     occupiedNames: inout Set<String>
   ) -> String {
-    var baseName = sanitizedWorkspaceComponent(repository.path ?? "")
+    var baseName = withoutGitSuffix(sanitizedWorkspaceComponent(repository.path ?? ""))
     if baseName.isEmpty {
-      baseName = sanitizedWorkspaceComponent(displayName)
+      baseName = withoutGitSuffix(sanitizedWorkspaceComponent(displayName))
     }
     if baseName.isEmpty {
       baseName = "repository"

--- a/supacode/Domain/ProjectWorkspace.swift
+++ b/supacode/Domain/ProjectWorkspace.swift
@@ -70,22 +70,13 @@ nonisolated struct ProjectWorkspaceCreationRepository: Equatable, Hashable, Send
     }
   }
 
-  nonisolated static let commonRemoteBaseRefOptions = ["main", "master", "origin/main", "origin/master"]
-
   nonisolated static func baseRefOptions(
     automaticBaseRef: String?,
-    refs: [String],
-    sourceKind: ProjectWorkspaceRepositorySourceKind
+    refs: [String]
   ) -> [String] {
     var values: [String] = []
     if let automaticBaseRef {
       values.append(automaticBaseRef)
-    }
-    switch sourceKind {
-    case .remote:
-      values += commonRemoteBaseRefOptions
-    case .existingPath, .localRepository, .bareRepository:
-      values += ["main", "master", "origin/main", "origin/master"]
     }
     values += refs
     return normalizedBaseRefOptions(values)

--- a/supacode/Domain/ProjectWorkspace.swift
+++ b/supacode/Domain/ProjectWorkspace.swift
@@ -7,6 +7,75 @@ nonisolated enum ProjectWorkspaceRepositorySourceKind: String, Codable, Equatabl
   case existingPath = "existing_path"
 }
 
+nonisolated struct ProjectWorkspaceCreationRepository: Equatable, Hashable, Sendable, Identifiable {
+  var id: String
+  var name: String
+  var rootURL: URL
+  var branchName: String?
+
+  init(
+    id: String,
+    name: String,
+    rootURL: URL,
+    branchName: String? = nil
+  ) {
+    self.id = id
+    self.name = name
+    self.rootURL = rootURL.standardizedFileURL
+    self.branchName = branchName
+  }
+}
+
+nonisolated struct ProjectWorkspaceCreationDraft: Equatable, Sendable {
+  var title: String
+  var rootURL: URL
+  var repositories: [ProjectWorkspaceCreationRepository]
+
+  init(
+    title: String,
+    rootURL: URL,
+    repositories: [ProjectWorkspaceCreationRepository]
+  ) {
+    self.title = title
+    self.rootURL = rootURL.standardizedFileURL
+    self.repositories = repositories
+  }
+}
+
+nonisolated struct ProjectWorkspaceCreationRequest: Equatable, Sendable {
+  var draft: ProjectWorkspaceCreationDraft
+  var createdAt: Date
+}
+
+nonisolated enum ProjectWorkspaceCreationError: LocalizedError, Equatable, Sendable {
+  case missingTitle
+  case missingPath
+  case notEnoughRepositories
+  case destinationIsFile(String)
+  case workspaceAlreadyExists(String)
+  case repositoryDoesNotExist(String)
+  case linkAlreadyExists(String)
+
+  var errorDescription: String? {
+    switch self {
+    case .missingTitle:
+      return "Workspace title required."
+    case .missingPath:
+      return "Workspace folder required."
+    case .notEnoughRepositories:
+      return "Select at least two repositories."
+    case .destinationIsFile(let path):
+      return "\(path) is a file. Choose a folder path instead."
+    case .workspaceAlreadyExists(let path):
+      return "\(path) already contains a Prowl workspace."
+    case .repositoryDoesNotExist(let path):
+      return "\(path) does not exist."
+    case .linkAlreadyExists(let path):
+      return "\(path) already exists."
+    }
+  }
+}
+
 nonisolated struct ProjectWorkspaceRepositoryEntry: Codable, Equatable, Hashable, Sendable, Identifiable {
   var id: String
   var name: String
@@ -186,6 +255,160 @@ nonisolated struct ProjectWorkspace: Codable, Equatable, Hashable, Sendable {
       return entry
     }
     return copy
+  }
+
+  static func create(
+    _ request: ProjectWorkspaceCreationRequest,
+    fileManager: FileManager = .default
+  ) throws -> ProjectWorkspace {
+    let title = request.draft.title.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !title.isEmpty else {
+      throw ProjectWorkspaceCreationError.missingTitle
+    }
+    guard request.draft.repositories.count >= 2 else {
+      throw ProjectWorkspaceCreationError.notEnoughRepositories
+    }
+    let rootPath = normalizedPath(request.draft.rootURL, resolvingSymlinks: false)
+    guard !rootPath.isEmpty else {
+      throw ProjectWorkspaceCreationError.missingPath
+    }
+    let rootURL = URL(fileURLWithPath: rootPath, isDirectory: true).standardizedFileURL
+
+    var createdRoot = false
+    var createdMetadataDirectory = false
+    var createdURLs: [URL] = []
+    do {
+      var isDirectory = ObjCBool(false)
+      if fileManager.fileExists(atPath: rootPath, isDirectory: &isDirectory) {
+        guard isDirectory.boolValue else {
+          throw ProjectWorkspaceCreationError.destinationIsFile(rootPath)
+        }
+      } else {
+        try fileManager.createDirectory(at: rootURL, withIntermediateDirectories: true)
+        createdRoot = true
+      }
+
+      let metadataDirectoryURL = rootURL.appending(path: metadataDirectoryName, directoryHint: .isDirectory)
+      let metadataPath = metadataDirectoryURL.path(percentEncoded: false)
+      let metadataURL = metadataURL(for: rootURL)
+      if fileManager.fileExists(atPath: metadataURL.path(percentEncoded: false)) {
+        throw ProjectWorkspaceCreationError.workspaceAlreadyExists(rootPath)
+      }
+      if !fileManager.fileExists(atPath: metadataPath) {
+        try fileManager.createDirectory(at: metadataDirectoryURL, withIntermediateDirectories: true)
+        createdMetadataDirectory = true
+      }
+
+      var occupiedNames: Set<String> = []
+      let entries = try request.draft.repositories.map { repository in
+        let repositoryPath = normalizedPath(repository.rootURL, resolvingSymlinks: true)
+        let repositoryURL = URL(fileURLWithPath: repositoryPath, isDirectory: true).standardizedFileURL
+        var repositoryIsDirectory = ObjCBool(false)
+        guard fileManager.fileExists(atPath: repositoryPath, isDirectory: &repositoryIsDirectory),
+          repositoryIsDirectory.boolValue
+        else {
+          throw ProjectWorkspaceCreationError.repositoryDoesNotExist(repositoryPath)
+        }
+
+        let linkName = uniqueRepositoryLinkName(for: repository, occupiedNames: &occupiedNames)
+        let linkURL = rootURL.appending(path: linkName, directoryHint: .isDirectory)
+        let linkPath = linkURL.path(percentEncoded: false)
+        guard !fileManager.fileExists(atPath: linkPath) else {
+          throw ProjectWorkspaceCreationError.linkAlreadyExists(linkPath)
+        }
+        try fileManager.createSymbolicLink(at: linkURL, withDestinationURL: repositoryURL)
+        createdURLs.append(linkURL)
+        return RepositoryEntry(
+          id: repository.id,
+          name: repository.name,
+          path: linkName,
+          sourceKind: .existingPath,
+          sourceLocation: repositoryPath,
+          branchName: repository.branchName
+        )
+      }
+
+      let workspace = ProjectWorkspace(
+        id: rootPath,
+        title: title,
+        repositories: entries,
+        createdAt: request.createdAt,
+        updatedAt: request.createdAt
+      )
+      .normalized(relativeTo: rootURL)
+      let encoder = JSONEncoder()
+      encoder.dateEncodingStrategy = .iso8601
+      encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+      try encoder.encode(workspace).write(to: metadataURL, options: .atomic)
+      createdURLs.append(metadataURL)
+      return workspace
+    } catch {
+      for url in createdURLs.reversed() {
+        try? fileManager.removeItem(at: url)
+      }
+      if createdRoot {
+        try? fileManager.removeItem(at: rootURL)
+      } else if createdMetadataDirectory {
+        try? fileManager.removeItem(at: rootURL.appending(path: metadataDirectoryName, directoryHint: .isDirectory))
+      }
+      throw error
+    }
+  }
+
+  static func defaultWorkspaceFolderName(for title: String) -> String {
+    let sanitized = sanitizedWorkspaceComponent(title)
+    return sanitized.isEmpty ? "workspace" : sanitized
+  }
+
+  private static func uniqueRepositoryLinkName(
+    for repository: ProjectWorkspaceCreationRepository,
+    occupiedNames: inout Set<String>
+  ) -> String {
+    var baseName = sanitizedWorkspaceComponent(repository.name)
+    if baseName.isEmpty {
+      baseName = sanitizedWorkspaceComponent(repository.rootURL.lastPathComponent)
+    }
+    if baseName.isEmpty {
+      baseName = "repository"
+    }
+
+    var candidate = baseName
+    var suffix = 2
+    while occupiedNames.contains(candidate.lowercased()) {
+      candidate = "\(baseName)-\(suffix)"
+      suffix += 1
+    }
+    occupiedNames.insert(candidate.lowercased())
+    return candidate
+  }
+
+  private static func sanitizedWorkspaceComponent(_ value: String) -> String {
+    var result = ""
+    for scalar in value.trimmingCharacters(in: .whitespacesAndNewlines).unicodeScalars {
+      if CharacterSet.whitespacesAndNewlines.contains(scalar)
+        || CharacterSet(charactersIn: "/:").contains(scalar)
+      {
+        result.append("-")
+      } else {
+        result.unicodeScalars.append(scalar)
+      }
+    }
+    while result.contains("--") {
+      result = result.replacing("--", with: "-")
+    }
+    result = result.trimmingCharacters(in: CharacterSet(charactersIn: "-"))
+    if result == "." || result == ".." {
+      return ""
+    }
+    return result
+  }
+
+  private static func normalizedPath(_ url: URL, resolvingSymlinks: Bool) -> String {
+    var path = PathPolicy.normalizeURL(url, resolvingSymlinks: resolvingSymlinks).path(percentEncoded: false)
+    while path.count > 1, path.hasSuffix("/") {
+      path.removeLast()
+    }
+    return path
   }
 }
 

--- a/supacode/Domain/ProjectWorkspace.swift
+++ b/supacode/Domain/ProjectWorkspace.swift
@@ -10,19 +10,58 @@ nonisolated enum ProjectWorkspaceRepositorySourceKind: String, Codable, Equatabl
 nonisolated struct ProjectWorkspaceCreationRepository: Equatable, Hashable, Sendable, Identifiable {
   var id: String
   var name: String
-  var rootURL: URL
+  var path: String?
+  var sourceKind: ProjectWorkspaceRepositorySourceKind
+  var sourceLocation: String
   var branchName: String?
+  var baseRef: String?
 
   init(
     id: String,
     name: String,
     rootURL: URL,
-    branchName: String? = nil
+    branchName: String? = nil,
+    path: String? = nil
+  ) {
+    let normalizedURL = rootURL.standardizedFileURL
+    self.id = id
+    self.name = name
+    self.path = path
+    sourceKind = .existingPath
+    sourceLocation = normalizedURL.path(percentEncoded: false)
+    self.branchName = branchName
+    baseRef = nil
+  }
+
+  init(
+    id: String,
+    name: String,
+    sourceKind: ProjectWorkspaceRepositorySourceKind,
+    sourceLocation: String,
+    branchName: String? = nil,
+    baseRef: String? = nil,
+    path: String? = nil
   ) {
     self.id = id
     self.name = name
-    self.rootURL = rootURL.standardizedFileURL
+    self.path = path
+    self.sourceKind = sourceKind
+    self.sourceLocation = sourceLocation
     self.branchName = branchName
+    self.baseRef = baseRef
+  }
+
+  var localSourceURL: URL? {
+    switch sourceKind {
+    case .existingPath, .localRepository, .bareRepository:
+      let trimmed = sourceLocation.trimmingCharacters(in: .whitespacesAndNewlines)
+      guard !trimmed.isEmpty else {
+        return nil
+      }
+      return URL(fileURLWithPath: trimmed).standardizedFileURL
+    case .remote:
+      return nil
+    }
   }
 }
 
@@ -47,14 +86,30 @@ nonisolated struct ProjectWorkspaceCreationRequest: Equatable, Sendable {
   var createdAt: Date
 }
 
+nonisolated struct ProjectWorkspaceGitCommand: Equatable, Sendable {
+  var arguments: [String]
+  var currentDirectoryURL: URL?
+
+  var displayCommand: String {
+    (["git"] + arguments).joined(separator: " ")
+  }
+}
+
+nonisolated struct ProjectWorkspaceGitRunner: Sendable {
+  var run: @Sendable (ProjectWorkspaceGitCommand) async throws -> Void
+}
+
 nonisolated enum ProjectWorkspaceCreationError: LocalizedError, Equatable, Sendable {
   case missingTitle
   case missingPath
   case notEnoughRepositories
+  case missingRepositoryName
+  case missingRepositorySource(String)
   case destinationIsFile(String)
   case workspaceAlreadyExists(String)
   case repositoryDoesNotExist(String)
   case linkAlreadyExists(String)
+  case gitCommandFailed(command: String, message: String)
 
   var errorDescription: String? {
     switch self {
@@ -64,6 +119,10 @@ nonisolated enum ProjectWorkspaceCreationError: LocalizedError, Equatable, Senda
       return "Workspace folder required."
     case .notEnoughRepositories:
       return "Select at least two repositories."
+    case .missingRepositoryName:
+      return "Repository name required."
+    case .missingRepositorySource(let name):
+      return "Source required for \(name)."
     case .destinationIsFile(let path):
       return "\(path) is a file. Choose a folder path instead."
     case .workspaceAlreadyExists(let path):
@@ -72,6 +131,11 @@ nonisolated enum ProjectWorkspaceCreationError: LocalizedError, Equatable, Senda
       return "\(path) does not exist."
     case .linkAlreadyExists(let path):
       return "\(path) already exists."
+    case .gitCommandFailed(let command, let message):
+      if message.isEmpty {
+        return "Git command failed: \(command)"
+      }
+      return "Git command failed: \(command)\n\(message)"
     }
   }
 }
@@ -259,8 +323,9 @@ nonisolated struct ProjectWorkspace: Codable, Equatable, Hashable, Sendable {
 
   static func create(
     _ request: ProjectWorkspaceCreationRequest,
-    fileManager: FileManager = .default
-  ) throws -> ProjectWorkspace {
+    fileManager: FileManager = .default,
+    gitRunner: ProjectWorkspaceGitRunner
+  ) async throws -> ProjectWorkspace {
     let title = request.draft.title.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !title.isEmpty else {
       throw ProjectWorkspaceCreationError.missingTitle
@@ -277,6 +342,7 @@ nonisolated struct ProjectWorkspace: Codable, Equatable, Hashable, Sendable {
     var createdRoot = false
     var createdMetadataDirectory = false
     var createdURLs: [URL] = []
+    var cleanupCommands: [ProjectWorkspaceGitCommand] = []
     do {
       var isDirectory = ObjCBool(false)
       if fileManager.fileExists(atPath: rootPath, isDirectory: &isDirectory) {
@@ -300,32 +366,20 @@ nonisolated struct ProjectWorkspace: Codable, Equatable, Hashable, Sendable {
       }
 
       var occupiedNames: Set<String> = []
-      let entries = try request.draft.repositories.map { repository in
-        let repositoryPath = normalizedPath(repository.rootURL, resolvingSymlinks: true)
-        let repositoryURL = URL(fileURLWithPath: repositoryPath, isDirectory: true).standardizedFileURL
-        var repositoryIsDirectory = ObjCBool(false)
-        guard fileManager.fileExists(atPath: repositoryPath, isDirectory: &repositoryIsDirectory),
-          repositoryIsDirectory.boolValue
-        else {
-          throw ProjectWorkspaceCreationError.repositoryDoesNotExist(repositoryPath)
-        }
-
-        let linkName = uniqueRepositoryLinkName(for: repository, occupiedNames: &occupiedNames)
-        let linkURL = rootURL.appending(path: linkName, directoryHint: .isDirectory)
-        let linkPath = linkURL.path(percentEncoded: false)
-        guard !fileManager.fileExists(atPath: linkPath) else {
-          throw ProjectWorkspaceCreationError.linkAlreadyExists(linkPath)
-        }
-        try fileManager.createSymbolicLink(at: linkURL, withDestinationURL: repositoryURL)
-        createdURLs.append(linkURL)
-        return RepositoryEntry(
-          id: repository.id,
-          name: repository.name,
-          path: linkName,
-          sourceKind: .existingPath,
-          sourceLocation: repositoryPath,
-          branchName: repository.branchName
+      var entries: [RepositoryEntry] = []
+      for repository in request.draft.repositories {
+        let prepared = try await materialize(
+          repository,
+          workspaceRootURL: rootURL,
+          occupiedNames: &occupiedNames,
+          fileManager: fileManager,
+          gitRunner: gitRunner
         )
+        createdURLs.append(prepared.createdURL)
+        if let cleanupCommand = prepared.cleanupCommand {
+          cleanupCommands.append(cleanupCommand)
+        }
+        entries.append(prepared.entry)
       }
 
       let workspace = ProjectWorkspace(
@@ -343,6 +397,9 @@ nonisolated struct ProjectWorkspace: Codable, Equatable, Hashable, Sendable {
       createdURLs.append(metadataURL)
       return workspace
     } catch {
+      for command in cleanupCommands.reversed() {
+        try? await gitRunner.run(command)
+      }
       for url in createdURLs.reversed() {
         try? fileManager.removeItem(at: url)
       }
@@ -360,13 +417,168 @@ nonisolated struct ProjectWorkspace: Codable, Equatable, Hashable, Sendable {
     return sanitized.isEmpty ? "workspace" : sanitized
   }
 
-  private static func uniqueRepositoryLinkName(
+  private struct PreparedRepository {
+    var entry: RepositoryEntry
+    var createdURL: URL
+    var cleanupCommand: ProjectWorkspaceGitCommand?
+  }
+
+  private static func materialize(
+    _ repository: ProjectWorkspaceCreationRepository,
+    workspaceRootURL: URL,
+    occupiedNames: inout Set<String>,
+    fileManager: FileManager,
+    gitRunner: ProjectWorkspaceGitRunner
+  ) async throws -> PreparedRepository {
+    let name = repositoryDisplayName(repository)
+    guard !name.isEmpty else {
+      throw ProjectWorkspaceCreationError.missingRepositoryName
+    }
+    let sourceLocation = repository.sourceLocation.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !sourceLocation.isEmpty else {
+      throw ProjectWorkspaceCreationError.missingRepositorySource(name)
+    }
+    let workspacePath = uniqueRepositoryPath(for: repository, displayName: name, occupiedNames: &occupiedNames)
+    let destinationURL = workspaceRootURL.appending(path: workspacePath, directoryHint: .isDirectory)
+    let destinationPath = normalizedPath(destinationURL, resolvingSymlinks: false)
+    guard !fileManager.fileExists(atPath: destinationPath) else {
+      throw ProjectWorkspaceCreationError.linkAlreadyExists(destinationPath)
+    }
+
+    let sourceKind = repository.sourceKind
+    let normalizedSourceLocation: String?
+    let cleanupCommand: ProjectWorkspaceGitCommand?
+    switch sourceKind {
+    case .existingPath, .localRepository:
+      let sourcePath = try localRepositoryPath(repository, sourceLocation: sourceLocation, fileManager: fileManager)
+      let sourceURL = URL(fileURLWithPath: sourcePath, isDirectory: true).standardizedFileURL
+      try fileManager.createSymbolicLink(at: destinationURL, withDestinationURL: sourceURL)
+      normalizedSourceLocation = sourcePath
+      cleanupCommand = nil
+
+    case .remote:
+      try await gitRunner.run(
+        ProjectWorkspaceGitCommand(
+          arguments: ["clone", sourceLocation, destinationPath],
+          currentDirectoryURL: workspaceRootURL
+        )
+      )
+      try await checkoutIfNeeded(
+        repository,
+        destinationURL: destinationURL,
+        gitRunner: gitRunner
+      )
+      normalizedSourceLocation = sourceLocation
+      cleanupCommand = nil
+
+    case .bareRepository:
+      let sourcePath = try localRepositoryPath(repository, sourceLocation: sourceLocation, fileManager: fileManager)
+      let command = bareWorktreeCommand(
+        repository,
+        sourcePath: sourcePath,
+        destinationPath: destinationPath
+      )
+      try await gitRunner.run(command)
+      normalizedSourceLocation = sourcePath
+      cleanupCommand = ProjectWorkspaceGitCommand(
+        arguments: ["-C", sourcePath, "worktree", "remove", "--force", destinationPath],
+        currentDirectoryURL: nil
+      )
+    }
+
+    return PreparedRepository(
+      entry: RepositoryEntry(
+        id: repository.id.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty ?? workspacePath,
+        name: name,
+        path: workspacePath,
+        sourceKind: sourceKind,
+        sourceLocation: normalizedSourceLocation,
+        branchName: repository.branchName?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty,
+        baseRef: repository.baseRef?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+      ),
+      createdURL: destinationURL,
+      cleanupCommand: cleanupCommand
+    )
+  }
+
+  private static func checkoutIfNeeded(
+    _ repository: ProjectWorkspaceCreationRepository,
+    destinationURL: URL,
+    gitRunner: ProjectWorkspaceGitRunner
+  ) async throws {
+    let destinationPath = normalizedPath(destinationURL, resolvingSymlinks: false)
+    let branchName = repository.branchName?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+    let baseRef = repository.baseRef?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+    switch (branchName, baseRef) {
+    case (.some(let branchName), .some(let baseRef)):
+      try await gitRunner.run(
+        ProjectWorkspaceGitCommand(
+          arguments: ["-C", destinationPath, "checkout", "-B", branchName, baseRef],
+          currentDirectoryURL: nil
+        )
+      )
+    case (.some(let branchName), .none):
+      try await gitRunner.run(
+        ProjectWorkspaceGitCommand(
+          arguments: ["-C", destinationPath, "checkout", "-B", branchName],
+          currentDirectoryURL: nil
+        )
+      )
+    case (.none, .some(let baseRef)):
+      try await gitRunner.run(
+        ProjectWorkspaceGitCommand(
+          arguments: ["-C", destinationPath, "checkout", baseRef],
+          currentDirectoryURL: nil
+        )
+      )
+    case (.none, .none):
+      break
+    }
+  }
+
+  private static func bareWorktreeCommand(
+    _ repository: ProjectWorkspaceCreationRepository,
+    sourcePath: String,
+    destinationPath: String
+  ) -> ProjectWorkspaceGitCommand {
+    let branchName = repository.branchName?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+    let baseRef = repository.baseRef?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+    var arguments = ["-C", sourcePath, "worktree", "add"]
+    if let branchName, let baseRef {
+      arguments += ["-b", branchName, destinationPath, baseRef]
+    } else if let branchName {
+      arguments += [destinationPath, branchName]
+    } else if let baseRef {
+      arguments += [destinationPath, baseRef]
+    } else {
+      arguments += [destinationPath]
+    }
+    return ProjectWorkspaceGitCommand(arguments: arguments, currentDirectoryURL: nil)
+  }
+
+  private static func localRepositoryPath(
+    _ repository: ProjectWorkspaceCreationRepository,
+    sourceLocation: String,
+    fileManager: FileManager
+  ) throws -> String {
+    let repositoryPath = normalizedPath(URL(fileURLWithPath: sourceLocation), resolvingSymlinks: true)
+    var repositoryIsDirectory = ObjCBool(false)
+    guard fileManager.fileExists(atPath: repositoryPath, isDirectory: &repositoryIsDirectory),
+      repositoryIsDirectory.boolValue
+    else {
+      throw ProjectWorkspaceCreationError.repositoryDoesNotExist(repositoryPath)
+    }
+    return repositoryPath
+  }
+
+  private static func uniqueRepositoryPath(
     for repository: ProjectWorkspaceCreationRepository,
+    displayName: String,
     occupiedNames: inout Set<String>
   ) -> String {
-    var baseName = sanitizedWorkspaceComponent(repository.name)
+    var baseName = sanitizedWorkspaceComponent(repository.path ?? "")
     if baseName.isEmpty {
-      baseName = sanitizedWorkspaceComponent(repository.rootURL.lastPathComponent)
+      baseName = sanitizedWorkspaceComponent(displayName)
     }
     if baseName.isEmpty {
       baseName = "repository"
@@ -380,6 +592,31 @@ nonisolated struct ProjectWorkspace: Codable, Equatable, Hashable, Sendable {
     }
     occupiedNames.insert(candidate.lowercased())
     return candidate
+  }
+
+  private static func repositoryDisplayName(_ repository: ProjectWorkspaceCreationRepository) -> String {
+    let trimmedName = repository.name.trimmingCharacters(in: .whitespacesAndNewlines)
+    if !trimmedName.isEmpty {
+      return trimmedName
+    }
+    switch repository.sourceKind {
+    case .existingPath, .localRepository, .bareRepository:
+      if let localSourceURL = repository.localSourceURL {
+        return Repository.name(for: localSourceURL)
+      }
+    case .remote:
+      let source = repository.sourceLocation.trimmingCharacters(in: .whitespacesAndNewlines)
+      let lastPathComponent =
+        source
+        .split(separator: "/")
+        .last
+        .map(String.init)?
+        .replacing(".git", with: "")
+      if let lastPathComponent, !lastPathComponent.isEmpty {
+        return lastPathComponent
+      }
+    }
+    return ""
   }
 
   private static func sanitizedWorkspaceComponent(_ value: String) -> String {

--- a/supacode/Domain/Repository.swift
+++ b/supacode/Domain/Repository.swift
@@ -45,19 +45,22 @@ nonisolated struct Repository: Identifiable, Hashable, Sendable {
   let name: String
   let kind: Kind
   let worktrees: IdentifiedArrayOf<Worktree>
+  let workspace: ProjectWorkspace?
 
   init(
     id: String,
     rootURL: URL,
     name: String,
     kind: Kind = .git,
-    worktrees: IdentifiedArrayOf<Worktree>
+    worktrees: IdentifiedArrayOf<Worktree>,
+    workspace: ProjectWorkspace? = nil
   ) {
     self.id = id
     self.rootURL = rootURL
     self.name = name
     self.kind = kind
     self.worktrees = worktrees
+    self.workspace = workspace
   }
 
   var initials: String {
@@ -71,6 +74,10 @@ nonisolated struct Repository: Identifiable, Hashable, Sendable {
     case .plain:
       .plain
     }
+  }
+
+  var isWorkspace: Bool {
+    workspace != nil
   }
 
   static func name(for rootURL: URL) -> String {

--- a/supacode/Domain/Repository.swift
+++ b/supacode/Domain/Repository.swift
@@ -58,7 +58,8 @@ nonisolated struct Repository: Identifiable, Hashable, Sendable {
     self.id = id
     self.rootURL = rootURL
     self.name = name
-    self.kind = kind
+    // A workspace is always a plain runnable folder; git capabilities stay per-repository.
+    self.kind = workspace == nil ? kind : .plain
     self.worktrees = worktrees
     self.workspace = workspace
   }

--- a/supacode/Features/App/Reducer/AppFeature+CommandPalette.swift
+++ b/supacode/Features/App/Reducer/AppFeature+CommandPalette.swift
@@ -30,6 +30,9 @@ extension AppFeature {
     if let effect = reduceCommandPaletteNavigationDelegate(delegate, state: &state) {
       return effect
     }
+    if let effect = reduceCommandPaletteRepositoryDelegate(delegate) {
+      return effect
+    }
     if let effect = reduceCommandPaletteCanvasDelegate(delegate) {
       return effect
     }
@@ -80,9 +83,6 @@ extension AppFeature {
     case .newWorktree:
       return .send(.repositories(.worktreeCreation(.createRandomWorktree)))
 
-    case .openRepository:
-      return .send(.repositories(.setOpenPanelPresented(true)))
-
     case .deleteWorktree(let worktreeID, let repositoryID):
       return .send(.repositories(.worktreeLifecycle(.requestDeleteWorktree(worktreeID, repositoryID))))
 
@@ -103,6 +103,21 @@ extension AppFeature {
 
     case .toggleActiveAgentsPanel:
       return .send(.repositories(.activeAgents(.togglePanelVisibility)))
+
+    default:
+      return nil
+    }
+  }
+
+  func reduceCommandPaletteRepositoryDelegate(
+    _ delegate: CommandPaletteFeature.Delegate
+  ) -> Effect<Action>? {
+    switch delegate {
+    case .openRepository:
+      return .send(.repositories(.setOpenPanelPresented(true)))
+
+    case .newWorkspace:
+      return .send(.repositories(.workspaceCreation(.promptRequested)))
 
     default:
       return nil

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -373,6 +373,7 @@ struct AppFeature {
             userSettings: userRepositorySettings,
             appearance: repositoryAppearances[repository.id] ?? .empty
           )
+          repoSettingsState.workspace = repository.workspace
           repoSettingsState.globalCopyIgnoredOnWorktreeCreate = state.settings.copyIgnoredOnWorktreeCreate
           repoSettingsState.globalCopyUntrackedOnWorktreeCreate = state.settings.copyUntrackedOnWorktreeCreate
           repoSettingsState.globalPullRequestMergeStrategy = state.settings.pullRequestMergeStrategy

--- a/supacode/Features/CommandPalette/CommandPaletteItem.swift
+++ b/supacode/Features/CommandPalette/CommandPaletteItem.swift
@@ -43,6 +43,7 @@ struct CommandPaletteItem: Identifiable, Equatable {
   enum Kind: Equatable {
     case checkForUpdates
     case openRepository
+    case newWorkspace
     case worktreeSelect(Worktree.ID)
     case openSettings
     case newWorktree
@@ -105,6 +106,8 @@ struct CommandPaletteItem: Identifiable, Equatable {
       return AppShortcuts.CommandID.checkForUpdates
     case .openRepository:
       return AppShortcuts.CommandID.openRepository
+    case .newWorkspace:
+      return nil
     case .openSettings:
       return AppShortcuts.CommandID.openSettings
     case .newWorktree:

--- a/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
+++ b/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
@@ -36,6 +36,7 @@ struct CommandPaletteFeature {
     case openSettings
     case newWorktree
     case openRepository
+    case newWorkspace
     case deleteWorktree(Worktree.ID, Repository.ID)
     case viewArchivedWorktrees
     case refreshWorktrees
@@ -351,6 +352,15 @@ private func globalCommandItems(showsNewWorktreeAction: Bool) -> [CommandPalette
       category: .app,
       kind: .openRepository,
       keywords: ["repo", "add repo"]
+    ),
+    CommandPaletteItem(
+      id: CommandPaletteItemID.globalNewWorkspace,
+      title: "New Workspace",
+      subtitle: nil,
+      kind: .newWorkspace,
+      category: .app,
+      defaultSuggestion: true,
+      keywords: ["workspace", "multi repo", "many repos"]
     ),
   ]
   if showsNewWorktreeAction {

--- a/supacode/Features/CommandPalette/Reducer/CommandPaletteSupport.swift
+++ b/supacode/Features/CommandPalette/Reducer/CommandPaletteSupport.swift
@@ -6,6 +6,7 @@ enum CommandPaletteItemID {
   static let globalCheckForUpdates = "global.check-for-updates"
   static let globalOpenSettings = "global.open-settings"
   static let globalOpenRepository = "global.open-repository"
+  static let globalNewWorkspace = "global.new-workspace"
   static let globalNewWorktree = "global.new-worktree"
   static let globalRefreshWorktrees = "global.refresh-worktrees"
   static let globalJumpToLatestUnread = "global.jump-to-latest-unread"
@@ -42,6 +43,7 @@ enum CommandPaletteItemID {
       globalCheckForUpdates,
       globalOpenSettings,
       globalOpenRepository,
+      globalNewWorkspace,
       globalNewWorktree,
       globalRefreshWorktrees,
       globalJumpToLatestUnread,
@@ -178,6 +180,7 @@ func delegateAction(for kind: CommandPaletteItem.Kind) -> CommandPaletteFeature.
     .openSettings,
     .newWorktree,
     .openRepository,
+    .newWorkspace,
     .viewArchivedWorktrees,
     .refreshWorktrees,
     .jumpToLatestUnread,
@@ -217,6 +220,8 @@ func appDelegateAction(for kind: CommandPaletteItem.Kind) -> CommandPaletteFeatu
     return .newWorktree
   case .openRepository:
     return .openRepository
+  case .newWorkspace:
+    return .newWorkspace
   case .viewArchivedWorktrees:
     return .viewArchivedWorktrees
   case .refreshWorktrees:
@@ -300,6 +305,7 @@ func pullRequestDelegateAction(
     .openSettings,
     .newWorktree,
     .openRepository,
+    .newWorkspace,
     .viewArchivedWorktrees,
     .refreshWorktrees,
     .jumpToLatestUnread,

--- a/supacode/Features/CommandPalette/Views/CommandPaletteOverlayView.swift
+++ b/supacode/Features/CommandPalette/Views/CommandPaletteOverlayView.swift
@@ -515,7 +515,7 @@ private struct CommandPaletteRowView: View {
 
   private var badge: String? {
     switch row.kind {
-    case .checkForUpdates, .openRepository, .openSettings, .newWorktree, .viewArchivedWorktrees,
+    case .checkForUpdates, .openRepository, .newWorkspace, .openSettings, .newWorktree, .viewArchivedWorktrees,
       .refreshWorktrees, .installCLI, .jumpToLatestUnread, .ghosttyCommand,
       .openPullRequest, .openRepositoryOnCodeHost, .markPullRequestReady, .mergePullRequest, .closePullRequest,
       .copyFailingJobURL,
@@ -543,6 +543,8 @@ private struct CommandPaletteRowView: View {
       return "arrow.down.circle"
     case .openRepository:
       return "folder"
+    case .newWorkspace:
+      return "folder.badge.person.crop"
     case .openSettings:
       return "gearshape"
     case .newWorktree:
@@ -628,7 +630,7 @@ private struct CommandPaletteRowView: View {
 
   private var emphasis: Bool {
     switch row.kind {
-    case .checkForUpdates, .openRepository, .openSettings, .newWorktree, .viewArchivedWorktrees,
+    case .checkForUpdates, .openRepository, .newWorkspace, .openSettings, .newWorktree, .viewArchivedWorktrees,
       .refreshWorktrees, .installCLI, .jumpToLatestUnread, .ghosttyCommand,
       .openPullRequest, .openRepositoryOnCodeHost, .markPullRequestReady, .mergePullRequest, .closePullRequest,
       .copyFailingJobURL,
@@ -728,6 +730,8 @@ private struct CommandPaletteRowView: View {
       base = "Check for Updates"
     case .openRepository:
       base = "Open Repository"
+    case .newWorkspace:
+      base = "New Workspace"
     case .openSettings:
       base = "Open Settings"
     case .newWorktree:

--- a/supacode/Features/Repositories/Models/SidebarPresentation.swift
+++ b/supacode/Features/Repositories/Models/SidebarPresentation.swift
@@ -79,7 +79,19 @@ struct SidebarRepositoryContainerModel: Equatable, Identifiable {
   var kind: Repository.Kind
   var isExpanded: Bool
   var isRemoving: Bool
+  var isWorkspace: Bool
   var worktreeSections: WorktreeRowSections
+  var workspaceChildRows: [WorkspaceChildRowModel]
+}
+
+/// A display-only sidebar row for one workspace child repository. `branchName`
+/// is the live current branch (falling back to metadata); `info` carries the
+/// uncommitted diff counts and PR, mirroring a worktree row's badges.
+struct WorkspaceChildRowModel: Equatable, Identifiable {
+  let id: String
+  let repositoryName: String
+  let branchName: String?
+  let info: WorktreeInfoEntry?
 }
 
 struct FailedRepositoryModel: Equatable, Identifiable {
@@ -157,7 +169,11 @@ extension RepositoriesFeature.State {
               kind: repository.kind,
               isExpanded: isExpanded,
               isRemoving: isRemovingRepository(repository),
-              worktreeSections: isExpanded ? worktreeRowSections(in: repository) : .empty
+              isWorkspace: repository.isWorkspace,
+              worktreeSections: isExpanded ? worktreeRowSections(in: repository) : .empty,
+              workspaceChildRows: isExpanded && repository.isWorkspace
+                ? workspaceChildRows(in: repository)
+                : []
             )
           )
         )

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+CoreReducer.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+CoreReducer.swift
@@ -284,6 +284,7 @@ extension RepositoriesFeature {
       {
         allEffects.append(effect)
       }
+      allEffects.append(refreshWorkspaceChildrenEffect(state: state))
       return .merge(allEffects)
 
     case .refreshAllCustomTitles:
@@ -846,6 +847,10 @@ extension RepositoriesFeature {
         removed: removed,
         state: &state
       )
+      return .none
+
+    case .workspaceChildrenInfoLoaded(let updates):
+      applyWorkspaceChildrenInfo(updates, state: &state)
       return .none
 
     case .alert(.dismiss):

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+CoreReducer.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+CoreReducer.swift
@@ -10,7 +10,8 @@ extension RepositoriesFeature {
     action: Action
   ) -> Effect<Action> {
     switch action {
-    case .worktreeCreation, .worktreeLifecycle, .worktreeOrdering, .githubIntegration, .repositoryManagement,
+    case .worktreeCreation, .worktreeLifecycle, .worktreeOrdering, .githubIntegration,
+      .repositoryManagement,
       .workspaceCreation:
       return .none
 
@@ -346,6 +347,7 @@ extension RepositoriesFeature {
       state.isShelfActive = false
       recordWorktreeHistoryTransition(from: state.selectedWorktreeID, to: nil, state: &state)
       state.selection = .archivedWorktrees
+      state.selectedWorkspaceChildID = nil
       state.sidebarSelectedWorktreeIDs = []
       return .send(.delegate(.selectedWorktreeChanged(nil)))
 
@@ -356,6 +358,7 @@ extension RepositoriesFeature {
       state.preCanvasTerminalTargetID = canvasSeedWorktree?.id
       state.isShelfActive = false
       state.selection = .canvas
+      state.selectedWorkspaceChildID = nil
       state.sidebarSelectedWorktreeIDs = []
       // Canvas only renders cards for worktrees that already have a live
       // terminal surface. Normal/Shelf get the previously-focused worktree
@@ -525,7 +528,9 @@ extension RepositoriesFeature {
     case .setSidebarSelectedWorktreeIDs(let worktreeIDs):
       let validWorktreeIDs = Set(state.orderedWorktreeRows().map(\.id))
       var nextWorktreeIDs = worktreeIDs.intersection(validWorktreeIDs)
-      if let selectedWorktreeID = state.selectedWorktreeID, validWorktreeIDs.contains(selectedWorktreeID) {
+      if let selectedWorktreeID = state.selectedWorktreeID,
+        validWorktreeIDs.contains(selectedWorktreeID)
+      {
         nextWorktreeIDs.insert(selectedWorktreeID)
       }
       state.sidebarSelectedWorktreeIDs = nextWorktreeIDs
@@ -539,12 +544,44 @@ extension RepositoriesFeature {
       guard let repositoryID, state.repositories[id: repositoryID] != nil else { return .none }
       recordWorktreeHistoryTransition(from: state.selectedWorktreeID, to: nil, state: &state)
       state.selection = .repository(repositoryID)
+      state.selectedWorkspaceChildID = nil
       state.sidebarSelectedWorktreeIDs = []
       if state.repositories[id: repositoryID]?.kind == .plain {
         // Plain folder selection opens the folder as a Shelf book.
         state.openedWorktreeIDs.insert(repositoryID)
       }
       return .send(.delegate(.selectedWorktreeChanged(state.selectedTerminalWorktree)))
+
+    case .openWorkspaceChild(let childID):
+      guard let child = state.allResolvedWorkspaceChildren().first(where: { $0.id == childID }),
+        let workspaceRepository = state.repositories[id: child.workspaceID]
+      else {
+        return .none
+      }
+      recordWorktreeHistoryTransition(from: state.selectedWorktreeID, to: nil, state: &state)
+      state.selection = .repository(child.workspaceID)
+      state.selectedWorkspaceChildID = child.id
+      state.sidebarSelectedWorktreeIDs = []
+      state.openedWorktreeIDs.insert(child.workspaceID)
+      state.pendingTerminalFocusWorktreeIDs.insert(child.workspaceID)
+      let workspaceWorktree = Worktree(
+        id: workspaceRepository.id,
+        name: workspaceRepository.name,
+        detail: workspaceRepository.rootURL.path(percentEncoded: false),
+        workingDirectory: workspaceRepository.rootURL,
+        repositoryRootURL: workspaceRepository.rootURL
+      )
+      return .merge(
+        .send(.delegate(.selectedWorktreeChanged(workspaceWorktree))),
+        .run { _ in
+          await terminalClient.send(
+            .focusOrCreateTabInDirectory(
+              workspaceWorktree,
+              directory: child.workingDirectory,
+              title: child.repositoryName
+            ))
+        }
+      )
 
     case .selectWorktree(let worktreeID, let focusTerminal, let recordHistory):
       let selectWtToken = repositoriesLogger.beginInterval("reducer.selectWorktree")
@@ -567,7 +604,8 @@ extension RepositoriesFeature {
       }
       requestCanvasFocus(.worktree(worktree.id), openedWorktreeID: worktree.id, state: &state)
       return .run { _ in
-        await terminalClient.send(.ensureInitialTab(worktree, runSetupScriptIfNew: false, focusing: false))
+        await terminalClient.send(
+          .ensureInitialTab(worktree, runSetupScriptIfNew: false, focusing: false))
       }
 
     case .focusCanvasWorktree(let worktreeID):
@@ -578,7 +616,8 @@ extension RepositoriesFeature {
       }
       requestCanvasFocus(.worktree(worktree.id), openedWorktreeID: worktree.id, state: &state)
       return .run { _ in
-        await terminalClient.send(.ensureInitialTab(worktree, runSetupScriptIfNew: false, focusing: false))
+        await terminalClient.send(
+          .ensureInitialTab(worktree, runSetupScriptIfNew: false, focusing: false))
       }
 
     case .selectNextWorktree:
@@ -740,7 +779,8 @@ extension RepositoriesFeature {
     case .alert(.presented(.confirmArchiveWorktrees(let targets))):
       return .merge(
         targets.map { target in
-          .send(.worktreeLifecycle(.archiveWorktreeConfirmed(target.worktreeID, target.repositoryID)))
+          .send(
+            .worktreeLifecycle(.archiveWorktreeConfirmed(target.worktreeID, target.repositoryID)))
         }
       )
 
@@ -761,21 +801,28 @@ extension RepositoriesFeature {
           repository.worktrees.contains(where: { $0.id == id })
         } ?? false
       return .send(
-        .repositoryManagement(.repositoryRemoved(repository.id, selectionWasRemoved: selectionWasRemoved)))
+        .repositoryManagement(
+          .repositoryRemoved(repository.id, selectionWasRemoved: selectionWasRemoved)))
 
-    case .alert(.presented(.confirmWorkspaceRootDeletion(let repositoryID, let rootPath, let selectionWasRemoved))):
+    case .alert(
+      .presented(
+        .confirmWorkspaceRootDeletion(let repositoryID, let rootPath, let selectionWasRemoved))):
       state.alert = nil
       let rootURL = URL(fileURLWithPath: rootPath)
       return .run { send in
         ProjectWorkspace.removeWorkspaceFolder(at: rootURL)
         await send(
-          .repositoryManagement(.repositoryRemoved(repositoryID, selectionWasRemoved: selectionWasRemoved)))
+          .repositoryManagement(
+            .repositoryRemoved(repositoryID, selectionWasRemoved: selectionWasRemoved)))
       }
 
-    case .alert(.presented(.keepWorkspaceFolderAfterCleanupFailure(let repositoryID, let selectionWasRemoved))):
+    case .alert(
+      .presented(.keepWorkspaceFolderAfterCleanupFailure(let repositoryID, let selectionWasRemoved))
+    ):
       state.alert = nil
       return .send(
-        .repositoryManagement(.repositoryRemoved(repositoryID, selectionWasRemoved: selectionWasRemoved)))
+        .repositoryManagement(
+          .repositoryRemoved(repositoryID, selectionWasRemoved: selectionWasRemoved)))
 
     case .presentAlert(let title, let message):
       state.alert = messageAlert(title: title, message: message)
@@ -824,7 +871,8 @@ extension RepositoriesFeature {
         let previousLineChanges = normalizedLineChanges(state.worktreeInfoByID[worktreeID])
         return .run { send in
           if let changes = await gitClient.lineChanges(worktreeURL) {
-            let nextLineChanges = normalizedLineChanges(added: changes.added, removed: changes.removed)
+            let nextLineChanges = normalizedLineChanges(
+              added: changes.added, removed: changes.removed)
             guard !lineChangesEqual(nextLineChanges, previousLineChanges) else {
               return
             }

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+CoreReducer.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+CoreReducer.swift
@@ -721,6 +721,9 @@ extension RepositoriesFeature {
     case .workspaceCreationPrompt(.presented(.delegate(.cancel))):
       return .send(.workspaceCreation(.promptCanceled))
 
+    case .workspaceCreationPrompt(.presented(.delegate(.baseRefSourceChanged(let repositoryID)))):
+      return .send(.workspaceCreation(.refreshBaseRefs(repositoryID)))
+
     case .workspaceCreationPrompt(.presented(.delegate(.submit(let draft)))):
       return .send(.workspaceCreation(.createWorkspace(draft)))
 

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+CoreReducer.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+CoreReducer.swift
@@ -763,6 +763,20 @@ extension RepositoriesFeature {
       return .send(
         .repositoryManagement(.repositoryRemoved(repository.id, selectionWasRemoved: selectionWasRemoved)))
 
+    case .alert(.presented(.confirmWorkspaceRootDeletion(let repositoryID, let rootPath, let selectionWasRemoved))):
+      state.alert = nil
+      let rootURL = URL(fileURLWithPath: rootPath)
+      return .run { send in
+        ProjectWorkspace.removeWorkspaceFolder(at: rootURL)
+        await send(
+          .repositoryManagement(.repositoryRemoved(repositoryID, selectionWasRemoved: selectionWasRemoved)))
+      }
+
+    case .alert(.presented(.keepWorkspaceFolderAfterCleanupFailure(let repositoryID, let selectionWasRemoved))):
+      state.alert = nil
+      return .send(
+        .repositoryManagement(.repositoryRemoved(repositoryID, selectionWasRemoved: selectionWasRemoved)))
+
     case .presentAlert(let title, let message):
       state.alert = messageAlert(title: title, message: message)
       return .none

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+CoreReducer.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+CoreReducer.swift
@@ -10,7 +10,8 @@ extension RepositoriesFeature {
     action: Action
   ) -> Effect<Action> {
     switch action {
-    case .worktreeCreation, .worktreeLifecycle, .worktreeOrdering, .githubIntegration, .repositoryManagement:
+    case .worktreeCreation, .worktreeLifecycle, .worktreeOrdering, .githubIntegration, .repositoryManagement,
+      .workspaceCreation:
       return .none
 
     case .activeAgents(.entryTapped(let id)):
@@ -715,6 +716,18 @@ extension RepositoriesFeature {
       return .send(.worktreeCreation(.promptDismissed))
 
     case .worktreeCreationPrompt:
+      return .none
+
+    case .workspaceCreationPrompt(.presented(.delegate(.cancel))):
+      return .send(.workspaceCreation(.promptCanceled))
+
+    case .workspaceCreationPrompt(.presented(.delegate(.submit(let draft)))):
+      return .send(.workspaceCreation(.createWorkspace(draft)))
+
+    case .workspaceCreationPrompt(.dismiss):
+      return .send(.workspaceCreation(.promptDismissed))
+
+    case .workspaceCreationPrompt:
       return .none
 
     case .alert(.presented(.confirmArchiveWorktree(let worktreeID, let repositoryID))):

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+RepositoryLoading.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+RepositoryLoading.swift
@@ -64,6 +64,9 @@ extension RepositoriesFeature {
           let normalizedPath = URL(fileURLWithPath: entry.path)
             .standardizedFileURL
             .path(percentEncoded: false)
+          if ProjectWorkspace.load(from: URL(fileURLWithPath: normalizedPath)) != nil {
+            return (index, PersistedRepositoryEntry(path: normalizedPath, kind: .plain))
+          }
           do {
             let repoRoot = try await gitClient.repoRoot(URL(fileURLWithPath: normalizedPath))
             let normalizedRepoRoot = repoRoot.standardizedFileURL.path(percentEncoded: false)
@@ -183,14 +186,16 @@ extension RepositoriesFeature {
               )
             }
           case .plain:
+            let workspace = ProjectWorkspace.load(from: rootURL)
             return WorktreesFetchResult(
               entry: entry,
               repository: Repository(
                 id: rootURL.path(percentEncoded: false),
                 rootURL: rootURL,
-                name: Repository.name(for: rootURL),
+                name: workspace?.title ?? Repository.name(for: rootURL),
                 kind: .plain,
-                worktrees: IdentifiedArray()
+                worktrees: IdentifiedArray(),
+                workspace: workspace
               ),
               errorMessage: nil
             )

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+RepositoryLoading.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+RepositoryLoading.swift
@@ -324,6 +324,7 @@ extension RepositoriesFeature {
         .map(SidebarSelection.worktree)
       state.shouldSelectFirstAfterReload = false
     }
+    pruneWorkspaceChildInfo(state: &state)
     return ApplyRepositoriesResult(
       didPrunePinned: didPrunePinned,
       didPruneRepositoryOrder: didPruneRepositoryOrder,

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+RepositoryLoading.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+RepositoryLoading.swift
@@ -310,6 +310,7 @@ extension RepositoriesFeature {
       !isSidebarSelectionValid(state.selection, state: state)
     {
       state.selection = nil
+      state.selectedWorkspaceChildID = nil
     }
     if state.shouldRestoreLastFocusedWorktree {
       state.shouldRestoreLastFocusedWorktree = false
@@ -317,11 +318,13 @@ extension RepositoriesFeature {
         isSelectionValid(state.lastFocusedWorktreeID, state: state)
       {
         state.selection = state.lastFocusedWorktreeID.map(SidebarSelection.worktree)
+        state.selectedWorkspaceChildID = nil
       }
     }
     if state.selection == nil, state.shouldSelectFirstAfterReload {
       state.selection = firstAvailableWorktreeID(from: repositories, state: state)
         .map(SidebarSelection.worktree)
+      state.selectedWorkspaceChildID = nil
       state.shouldSelectFirstAfterReload = false
     }
     pruneWorkspaceChildInfo(state: &state)

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+RepositoryManagement.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+RepositoryManagement.swift
@@ -160,6 +160,7 @@ extension RepositoriesFeature {
       if let effect = detectCodeHostsEffect(for: state.repositories) {
         allEffects.append(effect)
       }
+      allEffects.append(refreshWorkspaceChildrenEffect(state: state))
       return .merge(allEffects)
 
     case .requestRemoveRepository(let repositoryID):
@@ -333,6 +334,7 @@ extension RepositoriesFeature {
       state.removingRepositoryIDs.remove(repositoryID)
       if selectionWasRemoved {
         state.selection = nil
+        state.selectedWorkspaceChildID = nil
         state.shouldSelectFirstAfterReload = true
       }
       let selectedWorktree = state.worktree(for: state.selectedWorktreeID)

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+RepositoryManagement.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+RepositoryManagement.swift
@@ -163,8 +163,57 @@ extension RepositoriesFeature {
       return .merge(allEffects)
 
     case .requestRemoveRepository(let repositoryID):
+      if let repository = state.repositories[id: repositoryID], repository.isWorkspace {
+        state.removeWorkspaceConfirmation = RemoveWorkspaceConfirmation(
+          repositoryID: repositoryID,
+          workspaceTitle: repository.name,
+          rootPath: repository.rootURL.path(percentEncoded: false)
+        )
+        return .none
+      }
       state.alert = confirmationAlertForRepositoryRemoval(repositoryID: repositoryID, state: state)
       return .none
+
+    case .removeWorkspaceDeleteFilesChanged(let deleteFiles):
+      state.removeWorkspaceConfirmation?.deleteFiles = deleteFiles
+      return .none
+
+    case .removeWorkspacePromptDismissed:
+      state.removeWorkspaceConfirmation = nil
+      return .none
+
+    case .removeWorkspacePromptConfirmed:
+      guard let confirmation = state.removeWorkspaceConfirmation else {
+        return .none
+      }
+      state.removeWorkspaceConfirmation = nil
+      guard let repository = state.repositories[id: confirmation.repositoryID],
+        !state.removingRepositoryIDs.contains(repository.id)
+      else {
+        return .none
+      }
+      state.removingRepositoryIDs.insert(repository.id)
+      let selectionWasRemoved =
+        state.selectedWorktreeID.map { id in
+          repository.worktrees.contains(where: { $0.id == id })
+        } ?? false
+      guard confirmation.deleteFiles, let workspace = repository.workspace else {
+        return .send(
+          .repositoryManagement(
+            .repositoryRemoved(repository.id, selectionWasRemoved: selectionWasRemoved)
+          )
+        )
+      }
+      let rootURL = repository.rootURL
+      let gitRunner = Self.workspaceGitRunner(shellClient: shellClient)
+      return .run { send in
+        await ProjectWorkspace.cleanup(workspace, rootURL: rootURL, gitRunner: gitRunner)
+        await send(
+          .repositoryManagement(
+            .repositoryRemoved(repository.id, selectionWasRemoved: selectionWasRemoved)
+          )
+        )
+      }
 
     case .removeFailedRepository(let repositoryID):
       state.alert = nil

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+RepositoryManagement.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+RepositoryManagement.swift
@@ -219,12 +219,12 @@ extension RepositoriesFeature {
       state.alert = nil
       state.loadFailuresByID.removeValue(forKey: repositoryID)
       state.repositoryRoots.removeAll {
-        $0.standardizedFileURL.path(percentEncoded: false) == repositoryID
+        isSameRepositoryPath($0.standardizedFileURL.path(percentEncoded: false), repositoryID)
       }
       let remainingRoots = state.repositoryRoots
       return .run { send in
         let loadedEntries = await loadPersistedRepositoryEntries(fallbackRoots: remainingRoots)
-        let remainingEntries = loadedEntries.filter { $0.path != repositoryID }
+        let remainingEntries = loadedEntries.filter { !isSameRepositoryPath($0.path, repositoryID) }
         await repositoryPersistence.saveRepositoryEntries(remainingEntries)
         let roots = remainingEntries.map { URL(fileURLWithPath: $0.path) }
         let (repositories, failures) = await loadRepositoriesData(remainingEntries)
@@ -252,7 +252,7 @@ extension RepositoriesFeature {
         .send(.delegate(.selectedWorktreeChanged(selectedWorktree))),
         .run { send in
           let loadedEntries = await loadPersistedRepositoryEntries(fallbackRoots: remainingRoots)
-          let remainingEntries = loadedEntries.filter { $0.path != repositoryID }
+          let remainingEntries = loadedEntries.filter { !isSameRepositoryPath($0.path, repositoryID) }
           await repositoryPersistence.saveRepositoryEntries(remainingEntries)
           let roots = remainingEntries.map { URL(fileURLWithPath: $0.path) }
           let (repositories, failures) = await loadRepositoriesData(remainingEntries)
@@ -281,4 +281,19 @@ extension RepositoriesFeature {
       return reduceRepositoryManagement(state: &state, action: action)
     }
   }
+}
+
+// Path-based URL APIs append a trailing slash only while the directory exists
+// on disk, so an ID captured before a deletion may not equal the re-normalized
+// entry path afterwards.
+nonisolated private func isSameRepositoryPath(_ lhs: String, _ rhs: String) -> Bool {
+  comparableRepositoryPath(lhs) == comparableRepositoryPath(rhs)
+}
+
+nonisolated private func comparableRepositoryPath(_ path: String) -> String {
+  var path = path
+  while path.count > 1, path.hasSuffix("/") {
+    path.removeLast()
+  }
+  return path
 }

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+RepositoryManagement.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+RepositoryManagement.swift
@@ -17,6 +17,16 @@ extension RepositoriesFeature {
         var invalidRoots: [String] = []
         var openFailures: [String] = []
         for url in urls {
+          let normalizedURL = url.standardizedFileURL
+          if ProjectWorkspace.load(from: normalizedURL) != nil {
+            resolvedEntries.append(
+              PersistedRepositoryEntry(
+                path: normalizedURL.path(percentEncoded: false),
+                kind: .plain
+              )
+            )
+            continue
+          }
           do {
             let root = try await gitClient.repoRoot(url)
             resolvedEntries.append(

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+RepositoryManagement.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+RepositoryManagement.swift
@@ -229,22 +229,80 @@ extension RepositoriesFeature {
           )
         )
       }
+      let repositoryID = repository.id
       let rootURL = repository.rootURL
-      let deleteBranchEntryIDs = Set(confirmation.branchOptions.filter(\.isSelected).map(\.id))
+      // Resolve the (source repo, branch) pairs the user opted to delete. The
+      // deletion itself is routed through GitClient's guarded entry point so a
+      // protected branch (main/master/default) can never be force-deleted.
+      let branchDeletions: [WorkspaceBranchDeletion] =
+        confirmation.branchOptions
+        .filter(\.isSelected)
+        .compactMap { option in
+          guard let entry = workspace.repositories.first(where: { $0.id == option.id }),
+            let sourceLocation = entry.sourceLocation,
+            let branchName = entry.branchName
+          else {
+            return nil
+          }
+          return WorkspaceBranchDeletion(sourceLocation: sourceLocation, branchName: branchName)
+        }
       let gitRunner = Self.workspaceGitRunner(shellClient: shellClient)
+      let gitClient = self.gitClient
       return .run { send in
-        await ProjectWorkspace.cleanup(
+        let failedRepositoryNames = await ProjectWorkspace.removeWorktrees(
           workspace,
           rootURL: rootURL,
-          deleteBranchEntryIDs: deleteBranchEntryIDs,
           gitRunner: gitRunner
         )
-        await send(
-          .repositoryManagement(
-            .repositoryRemoved(repository.id, selectionWasRemoved: selectionWasRemoved)
+        for deletion in branchDeletions {
+          let outcome = try? await gitClient.deleteLocalBranch(
+            deletion.branchName,
+            URL(fileURLWithPath: deletion.sourceLocation),
+            true
           )
-        )
+          if case .protected? = outcome {
+            workspaceRemovalLog.warning(
+              "Skipped deleting protected branch \(deletion.branchName) in \(deletion.sourceLocation)"
+            )
+          }
+        }
+        // Only delete the workspace folder when every worktree was unregistered;
+        // otherwise ask the user, since deleting it would orphan a live worktree
+        // registration in the source repository.
+        if failedRepositoryNames.isEmpty {
+          ProjectWorkspace.removeWorkspaceFolder(at: rootURL)
+          await send(
+            .repositoryManagement(
+              .repositoryRemoved(repositoryID, selectionWasRemoved: selectionWasRemoved)
+            )
+          )
+        } else {
+          await send(
+            .repositoryManagement(
+              .workspaceCleanupReportedFailures(
+                repositoryID: repositoryID,
+                rootPath: rootURL.path(percentEncoded: false),
+                failedRepositoryNames: failedRepositoryNames,
+                selectionWasRemoved: selectionWasRemoved
+              )
+            )
+          )
+        }
       }
+
+    case .workspaceCleanupReportedFailures(
+      let repositoryID,
+      let rootPath,
+      let failedRepositoryNames,
+      let selectionWasRemoved
+    ):
+      state.alert = workspaceCleanupFailureAlert(
+        repositoryID: repositoryID,
+        rootPath: rootPath,
+        failedRepositoryNames: failedRepositoryNames,
+        selectionWasRemoved: selectionWasRemoved
+      )
+      return .none
 
     case .removeFailedRepository(let repositoryID):
       state.alert = nil
@@ -312,6 +370,50 @@ extension RepositoriesFeature {
       return reduceRepositoryManagement(state: &state, action: action)
     }
   }
+
+  func workspaceCleanupFailureAlert(
+    repositoryID: Repository.ID,
+    rootPath: String,
+    failedRepositoryNames: [String],
+    selectionWasRemoved: Bool
+  ) -> AlertState<Alert> {
+    AlertState {
+      TextState("Some worktrees couldn't be removed")
+    } actions: {
+      ButtonState(
+        role: .destructive,
+        action: .confirmWorkspaceRootDeletion(
+          repositoryID: repositoryID,
+          rootPath: rootPath,
+          selectionWasRemoved: selectionWasRemoved
+        )
+      ) {
+        TextState("Delete Folder Anyway")
+      }
+      ButtonState(
+        role: .cancel,
+        action: .keepWorkspaceFolderAfterCleanupFailure(
+          repositoryID: repositoryID,
+          selectionWasRemoved: selectionWasRemoved
+        )
+      ) {
+        TextState("Keep Folder")
+      }
+    } message: {
+      TextState(
+        "Couldn't unregister worktrees for \(failedRepositoryNames.joined(separator: ", ")). "
+          + "Deleting the workspace folder now would leave those worktrees registered in their "
+          + "source repositories. Delete it anyway?"
+      )
+    }
+  }
+}
+
+nonisolated private let workspaceRemovalLog = SupaLogger("workspace")
+
+nonisolated struct WorkspaceBranchDeletion: Sendable, Equatable {
+  let sourceLocation: String
+  let branchName: String
 }
 
 // Path-based URL APIs append a trailing slash only while the directory exists

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+RepositoryManagement.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+RepositoryManagement.swift
@@ -164,10 +164,25 @@ extension RepositoriesFeature {
 
     case .requestRemoveRepository(let repositoryID):
       if let repository = state.repositories[id: repositoryID], repository.isWorkspace {
+        let branchOptions = (repository.workspace?.repositories ?? []).compactMap {
+          entry -> RemoveWorkspaceConfirmation.BranchOption? in
+          guard entry.sourceKind != .remote,
+            let branchName = entry.branchName,
+            entry.sourceLocation != nil
+          else {
+            return nil
+          }
+          return RemoveWorkspaceConfirmation.BranchOption(
+            id: entry.id,
+            repositoryName: entry.name,
+            branchName: branchName
+          )
+        }
         state.removeWorkspaceConfirmation = RemoveWorkspaceConfirmation(
           repositoryID: repositoryID,
           workspaceTitle: repository.name,
-          rootPath: repository.rootURL.path(percentEncoded: false)
+          rootPath: repository.rootURL.path(percentEncoded: false),
+          branchOptions: branchOptions
         )
         return .none
       }
@@ -176,6 +191,16 @@ extension RepositoriesFeature {
 
     case .removeWorkspaceDeleteFilesChanged(let deleteFiles):
       state.removeWorkspaceConfirmation?.deleteFiles = deleteFiles
+      return .none
+
+    case .removeWorkspaceDeleteBranchChanged(let entryID, let isSelected):
+      guard var confirmation = state.removeWorkspaceConfirmation,
+        let index = confirmation.branchOptions.firstIndex(where: { $0.id == entryID })
+      else {
+        return .none
+      }
+      confirmation.branchOptions[index].isSelected = isSelected
+      state.removeWorkspaceConfirmation = confirmation
       return .none
 
     case .removeWorkspacePromptDismissed:
@@ -205,9 +230,15 @@ extension RepositoriesFeature {
         )
       }
       let rootURL = repository.rootURL
+      let deleteBranchEntryIDs = Set(confirmation.branchOptions.filter(\.isSelected).map(\.id))
       let gitRunner = Self.workspaceGitRunner(shellClient: shellClient)
       return .run { send in
-        await ProjectWorkspace.cleanup(workspace, rootURL: rootURL, gitRunner: gitRunner)
+        await ProjectWorkspace.cleanup(
+          workspace,
+          rootURL: rootURL,
+          deleteBranchEntryIDs: deleteBranchEntryIDs,
+          gitRunner: gitRunner
+        )
         await send(
           .repositoryManagement(
             .repositoryRemoved(repository.id, selectionWasRemoved: selectionWasRemoved)

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+RepositoryManagement.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+RepositoryManagement.swift
@@ -220,9 +220,10 @@ extension RepositoriesFeature {
       }
       state.removingRepositoryIDs.insert(repository.id)
       let selectionWasRemoved =
-        state.selectedWorktreeID.map { id in
+        state.selection == .repository(repository.id)
+        || (state.selectedWorktreeID.map { id in
           repository.worktrees.contains(where: { $0.id == id })
-        } ?? false
+        } ?? false)
       guard confirmation.deleteFiles, let workspace = repository.workspace else {
         return .send(
           .repositoryManagement(

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+Selection.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+Selection.swift
@@ -141,6 +141,7 @@ func setSingleWorktreeSelection(
     recordWorktreeHistoryTransition(from: state.selectedWorktreeID, to: worktreeID, state: &state)
   }
   state.selection = worktreeID.map(SidebarSelection.worktree)
+  state.selectedWorkspaceChildID = nil
   if let worktreeID {
     state.sidebarSelectedWorktreeIDs = [worktreeID]
   } else {

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+StateQueries.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+StateQueries.swift
@@ -148,6 +148,43 @@ extension RepositoriesFeature.State {
     return worktrees.filter { !archivedSet.contains($0.id) }
   }
 
+  /// Child repositories materialized inside every workspace, resolved to their
+  /// on-disk working directory. Used both to refresh their live status and to
+  /// render their sidebar rows. Child id is the working-directory path string.
+  func resolvedWorkspaceChildren(in repository: Repository) -> [ResolvedWorkspaceChild] {
+    guard let workspace = repository.workspace else {
+      return []
+    }
+    return workspace.repositories.map { entry in
+      let url = entry.resolvedURL(relativeTo: repository.rootURL)
+      return ResolvedWorkspaceChild(
+        id: url.path(percentEncoded: false),
+        workspaceID: repository.id,
+        repositoryName: entry.name,
+        metadataBranch: entry.branchName,
+        workingDirectory: url
+      )
+    }
+  }
+
+  func allResolvedWorkspaceChildren() -> [ResolvedWorkspaceChild] {
+    repositories.filter(\.isWorkspace).flatMap { resolvedWorkspaceChildren(in: $0) }
+  }
+
+  /// Sidebar display rows for one workspace's children, merging the resolved
+  /// metadata with live branch (`workspaceChildBranchByID`) and diff/PR info
+  /// (`workspaceChildInfoByID`). Live branch falls back to the metadata branch.
+  func workspaceChildRows(in repository: Repository) -> [WorkspaceChildRowModel] {
+    resolvedWorkspaceChildren(in: repository).map { child in
+      WorkspaceChildRowModel(
+        id: child.id,
+        repositoryName: child.repositoryName,
+        branchName: workspaceChildBranchByID[child.id] ?? child.metadataBranch,
+        info: workspaceChildInfoByID[child.id]
+      )
+    }
+  }
+
   struct ArchivedWorktreeGroup: Equatable {
     var repository: Repository
     var worktrees: [Worktree]

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+WorkspaceChildren.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+WorkspaceChildren.swift
@@ -128,4 +128,9 @@ func pruneWorkspaceChildInfo(state: inout RepositoriesFeature.State) {
   let validIDs = Set(state.allResolvedWorkspaceChildren().map(\.id))
   state.workspaceChildInfoByID = state.workspaceChildInfoByID.filter { validIDs.contains($0.key) }
   state.workspaceChildBranchByID = state.workspaceChildBranchByID.filter { validIDs.contains($0.key) }
+  if let selectedWorkspaceChildID = state.selectedWorkspaceChildID,
+    !validIDs.contains(selectedWorkspaceChildID)
+  {
+    state.selectedWorkspaceChildID = nil
+  }
 }

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+WorkspaceChildren.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+WorkspaceChildren.swift
@@ -86,7 +86,8 @@ extension RepositoriesFeature {
       remote.host,
       remote.owner,
       remote.repo,
-      [branch]
+      [branch],
+      nil
     )
     return pullRequestsByBranch?[branch]
   }

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+WorkspaceChildren.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+WorkspaceChildren.swift
@@ -1,0 +1,130 @@
+import ComposableArchitecture
+import Foundation
+
+/// A workspace child repository resolved to its on-disk working directory.
+/// `id` is the working-directory path string (the key for all child maps).
+struct ResolvedWorkspaceChild: Equatable, Sendable, Identifiable {
+  let id: String
+  let workspaceID: Repository.ID
+  let repositoryName: String
+  let metadataBranch: String?
+  let workingDirectory: URL
+}
+
+extension RepositoriesFeature {
+  /// Refresh live status (current branch + uncommitted diff) for every
+  /// workspace child. Driven from `repositoriesLoaded`, which fires on initial
+  /// load, explicit reloads, and the periodic scene-active refresh — so child
+  /// rows update on the same cadence without watching their files directly.
+  ///
+  /// Workspace children are deliberately NOT fed through the worktree info
+  /// watcher: that pipeline bails on any worktree not tracked in
+  /// `repository.worktrees`, and children are metadata entries, not tracked
+  /// worktrees.
+  func refreshWorkspaceChildrenEffect(state: State) -> Effect<Action> {
+    let children = state.allResolvedWorkspaceChildren()
+    guard !children.isEmpty else {
+      return .none
+    }
+    let gitClient = self.gitClient
+    let githubCLI = self.githubCLI
+    // PR fetch only when GitHub integration is globally available; each child is
+    // its own repo, so its remote is resolved from the child's own git root.
+    let fetchesPullRequests = state.githubIntegrationAvailability == .available
+    return .run { send in
+      let updates = await withTaskGroup(of: WorkspaceChildInfoUpdate.self) { group in
+        for child in children {
+          group.addTask {
+            async let branchTask = gitClient.branchName(child.workingDirectory)
+            async let changesTask = gitClient.lineChanges(child.workingDirectory)
+            let changes = await changesTask
+            let branch = await branchTask
+            let pullRequest = await Self.fetchWorkspaceChildPullRequest(
+              workingDirectory: child.workingDirectory,
+              branch: branch,
+              enabled: fetchesPullRequests,
+              gitClient: gitClient,
+              githubCLI: githubCLI
+            )
+            return WorkspaceChildInfoUpdate(
+              id: child.id,
+              branch: branch,
+              added: changes?.added,
+              removed: changes?.removed,
+              pullRequest: pullRequest
+            )
+          }
+        }
+        var results: [WorkspaceChildInfoUpdate] = []
+        for await update in group {
+          results.append(update)
+        }
+        return results
+      }
+      await send(.workspaceChildrenInfoLoaded(updates))
+    }
+    .cancellable(id: CancelID.workspaceChildrenRefresh, cancelInFlight: true)
+  }
+
+  /// Resolve the child repo's GitHub remote (local-only, cheap) and fetch the
+  /// PR for the current branch. Returns nil on any failure — children are
+  /// best-effort status, never blocking.
+  nonisolated private static func fetchWorkspaceChildPullRequest(
+    workingDirectory: URL,
+    branch: String?,
+    enabled: Bool,
+    gitClient: GitClientDependency,
+    githubCLI: GithubCLIClient
+  ) async -> GithubPullRequest? {
+    guard enabled,
+      let branch = branch?.trimmingCharacters(in: .whitespacesAndNewlines), !branch.isEmpty,
+      let remote = await gitClient.remoteInfo(workingDirectory)
+    else {
+      return nil
+    }
+    let pullRequestsByBranch = try? await githubCLI.batchPullRequests(
+      remote.host,
+      remote.owner,
+      remote.repo,
+      [branch]
+    )
+    return pullRequestsByBranch?[branch]
+  }
+}
+
+/// Merge a batch of child refresh results into the child maps.
+func applyWorkspaceChildrenInfo(
+  _ updates: [WorkspaceChildInfoUpdate],
+  state: inout RepositoriesFeature.State
+) {
+  for update in updates {
+    if let branch = update.branch?.trimmingCharacters(in: .whitespacesAndNewlines), !branch.isEmpty {
+      state.workspaceChildBranchByID[update.id] = branch
+    } else {
+      state.workspaceChildBranchByID.removeValue(forKey: update.id)
+    }
+
+    var entry = state.workspaceChildInfoByID[update.id] ?? WorktreeInfoEntry()
+    if let added = update.added, let removed = update.removed, !(added == 0 && removed == 0) {
+      entry.addedLines = added
+      entry.removedLines = removed
+    } else {
+      entry.addedLines = nil
+      entry.removedLines = nil
+    }
+    entry.pullRequest = update.pullRequest
+    if entry.isEmpty {
+      state.workspaceChildInfoByID.removeValue(forKey: update.id)
+    } else {
+      state.workspaceChildInfoByID[update.id] = entry
+    }
+  }
+}
+
+/// Drop child map entries that no longer belong to any current workspace.
+/// Called from `applyRepositories` on every reload.
+func pruneWorkspaceChildInfo(state: inout RepositoriesFeature.State) {
+  let validIDs = Set(state.allResolvedWorkspaceChildren().map(\.id))
+  state.workspaceChildInfoByID = state.workspaceChildInfoByID.filter { validIDs.contains($0.key) }
+  state.workspaceChildBranchByID = state.workspaceChildBranchByID.filter { validIDs.contains($0.key) }
+}

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+WorkspaceCreation.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+WorkspaceCreation.swift
@@ -30,14 +30,15 @@ extension RepositoriesFeature {
     switch action {
     case .promptRequested:
       let candidates = state.workspaceCreationCandidates
-      let title = workspaceCreationDefaultTitle(candidates: candidates)
+      let title = "Workspace"
       state.workspaceCreationPrompt = WorkspaceCreationPromptFeature.State(
-        repositories: candidates,
+        repositories: [],
         title: title,
         rootPath: defaultWorkspaceRootURL(title: title).path(percentEncoded: false),
-        selectedRepositoryIDs: Set(candidates.map(\.id))
+        selectedRepositoryIDs: [],
+        openedRepositoryCandidates: candidates
       )
-      return workspaceBaseRefsEffect(for: candidates)
+      return .none
 
     case .promptCanceled, .promptDismissed:
       state.workspaceCreationPrompt = nil
@@ -124,20 +125,6 @@ extension RepositoriesFeature {
       }
       return reduceWorkspaceCreation(state: &state, action: action)
     }
-  }
-
-  private func workspaceCreationDefaultTitle(candidates: [ProjectWorkspaceCreationRepository]) -> String {
-    let names = candidates.map(\.name).filter { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
-    if names.isEmpty {
-      return "Workspace"
-    }
-    if names.count <= 3 {
-      return names.joined(separator: " + ")
-    }
-    guard let first = names.first else {
-      return "Workspace"
-    }
-    return "\(first) + \(names.count - 1) repos"
   }
 
   private func defaultWorkspaceRootURL(title: String) -> URL {

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+WorkspaceCreation.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+WorkspaceCreation.swift
@@ -37,11 +37,36 @@ extension RepositoriesFeature {
         rootPath: defaultWorkspaceRootURL(title: title).path(percentEncoded: false),
         selectedRepositoryIDs: Set(candidates.map(\.id))
       )
-      return .none
+      return workspaceBaseRefsEffect(for: candidates)
 
     case .promptCanceled, .promptDismissed:
       state.workspaceCreationPrompt = nil
       return .cancel(id: CancelID.workspaceCreation)
+
+    case .refreshBaseRefs(let repositoryID):
+      guard let repository = state.workspaceCreationPrompt?.repositories[id: repositoryID] else {
+        return .none
+      }
+      return workspaceBaseRefsEffect(for: [repository])
+
+    case .baseRefsLoaded(let repositoryID, let sourceKind, let sourceLocation, let options, let defaultBaseRef):
+      guard var repository = state.workspaceCreationPrompt?.repositories[id: repositoryID],
+        repository.sourceKind == sourceKind,
+        repository.sourceLocation == sourceLocation
+      else {
+        return .none
+      }
+      var baseRefOptions = options
+      let baseRef = Self.trimmedNonEmpty(repository.baseRef)
+      if let baseRef {
+        baseRefOptions = ProjectWorkspaceCreationRepository.normalizedBaseRefOptions([baseRef] + baseRefOptions)
+      }
+      repository.baseRefOptions = baseRefOptions
+      if baseRef == nil {
+        repository.baseRef = defaultBaseRef
+      }
+      state.workspaceCreationPrompt?.repositories[id: repositoryID] = repository
+      return .none
 
     case .createWorkspace(let draft):
       state.workspaceCreationPrompt?.isCreating = true
@@ -126,5 +151,79 @@ extension RepositoriesFeature {
       suffix += 1
     }
     return candidateURL.standardizedFileURL
+  }
+
+  private static func trimmedNonEmpty(_ value: String?) -> String? {
+    guard let value else {
+      return nil
+    }
+    let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+    return trimmed.isEmpty ? nil : trimmed
+  }
+
+  private func workspaceBaseRefsEffect(for repositories: [ProjectWorkspaceCreationRepository]) -> Effect<Action> {
+    guard !repositories.isEmpty else {
+      return .none
+    }
+    let gitClient = gitClient
+    return .run { send in
+      for repository in repositories {
+        let result = await Self.workspaceBaseRefs(for: repository, gitClient: gitClient)
+        await send(
+          .workspaceCreation(
+            .baseRefsLoaded(
+              repositoryID: repository.id,
+              sourceKind: repository.sourceKind,
+              sourceLocation: repository.sourceLocation,
+              options: result.options,
+              defaultBaseRef: result.defaultBaseRef
+            )
+          )
+        )
+      }
+    }
+  }
+
+  private static func workspaceBaseRefs(
+    for repository: ProjectWorkspaceCreationRepository,
+    gitClient: GitClientDependency
+  ) async -> (options: [String], defaultBaseRef: String?) {
+    switch repository.sourceKind {
+    case .remote:
+      return (ProjectWorkspaceCreationRepository.commonRemoteBaseRefOptions, nil)
+
+    case .existingPath, .localRepository, .bareRepository:
+      guard let sourceURL = repository.localSourceURL else {
+        let options = ProjectWorkspaceCreationRepository.baseRefOptions(
+          automaticBaseRef: nil,
+          refs: [],
+          sourceKind: repository.sourceKind
+        )
+        return (options, nil)
+      }
+
+      let repositoryURL: URL
+      if repository.sourceKind == .bareRepository {
+        repositoryURL = sourceURL
+      } else {
+        repositoryURL = (try? await gitClient.repoRoot(sourceURL)) ?? sourceURL
+      }
+
+      let automaticBaseRef = await gitClient.automaticWorktreeBaseRef(repositoryURL)
+      let refs = (try? await gitClient.branchRefs(repositoryURL)) ?? []
+      let options = ProjectWorkspaceCreationRepository.baseRefOptions(
+        automaticBaseRef: automaticBaseRef,
+        refs: refs,
+        sourceKind: repository.sourceKind
+      )
+      let defaultBaseRef =
+        automaticBaseRef != nil || !refs.isEmpty
+        ? ProjectWorkspaceCreationRepository.preferredBaseRef(
+          automaticBaseRef: automaticBaseRef,
+          options: options
+        )
+        : nil
+      return (options, defaultBaseRef)
+    }
   }
 }

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+WorkspaceCreation.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+WorkspaceCreation.swift
@@ -170,7 +170,7 @@ extension RepositoriesFeature {
     state.workspaceCreationPrompt?.repositories[id: repositoryID] = repository
   }
 
-  private static func workspaceGitRunner(shellClient: ShellClient) -> ProjectWorkspaceGitRunner {
+  static func workspaceGitRunner(shellClient: ShellClient) -> ProjectWorkspaceGitRunner {
     ProjectWorkspaceGitRunner { command in
       do {
         _ = try await shellClient.run(

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+WorkspaceCreation.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+WorkspaceCreation.swift
@@ -38,7 +38,7 @@ extension RepositoriesFeature {
       // then resolve a unique, non-colliding folder name off the main actor so
       // the reducer body performs no filesystem I/O.
       let folderName = ProjectWorkspace.defaultWorkspaceFolderName(for: title)
-      let requestedRootPath = Self.workspaceRootPath(folderName: folderName, suffix: nil)
+      let requestedRootPath = ProjectWorkspace.workspaceRootPath(folderName: folderName, suffix: nil)
       state.workspaceCreationPrompt = WorkspaceCreationPromptFeature.State(
         repositories: [],
         title: title,
@@ -46,7 +46,7 @@ extension RepositoriesFeature {
         openedRepositoryCandidates: candidates
       )
       return .run { send in
-        let resolved = Self.uniqueWorkspaceRootPath(folderName: folderName)
+        let resolved = ProjectWorkspace.uniqueWorkspaceRootPath(folderName: folderName)
         await send(.workspaceCreation(.defaultRootPathResolved(path: resolved, requestedRootPath: requestedRootPath)))
       }
 
@@ -137,28 +137,6 @@ extension RepositoriesFeature {
         return .none
       }
       return reduceWorkspaceCreation(state: &state, action: action)
-    }
-  }
-
-  nonisolated private static func workspaceRootPath(folderName: String, suffix: Int?) -> String {
-    let component = suffix.map { "\(folderName)-\($0)" } ?? folderName
-    return SupacodePaths.workspacesDirectory
-      .appending(path: component, directoryHint: .isDirectory)
-      .standardizedFileURL
-      .path(percentEncoded: false)
-  }
-
-  // Resolves a workspace folder path that does not collide with an existing
-  // directory. Touches the filesystem, so it must run inside an effect rather
-  // than the reducer body.
-  nonisolated static func uniqueWorkspaceRootPath(folderName: String) -> String {
-    var suffix: Int?
-    while true {
-      let candidate = workspaceRootPath(folderName: folderName, suffix: suffix)
-      if !FileManager.default.fileExists(atPath: candidate) {
-        return candidate
-      }
-      suffix = (suffix ?? 1) + 1
     }
   }
 

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+WorkspaceCreation.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+WorkspaceCreation.swift
@@ -260,11 +260,13 @@ extension RepositoriesFeature {
         repositoryURL = (try? await gitClient.repoRoot(sourceURL)) ?? sourceURL
       }
 
-      let automaticBaseRef = await gitClient.automaticWorktreeBaseRef(repositoryURL)
+      async let automaticBaseRefTask = gitClient.automaticWorktreeBaseRef(repositoryURL)
+      async let refsTask = gitClient.branchRefOptions(repositoryURL)
+      let automaticBaseRef = await automaticBaseRefTask
       let refs: [GitBranchRefOption]
       var errorMessage: String?
       do {
-        refs = try await gitClient.branchRefOptions(repositoryURL)
+        refs = try await refsTask
       } catch {
         refs = []
         let name = repository.name.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+WorkspaceCreation.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+WorkspaceCreation.swift
@@ -2,10 +2,6 @@ import ComposableArchitecture
 import Foundation
 
 extension RepositoriesFeature.State {
-  var canCreateWorkspace: Bool {
-    true
-  }
-
   var workspaceCreationCandidates: [ProjectWorkspaceCreationRepository] {
     repositories.compactMap { repository in
       guard !repository.isWorkspace, !removingRepositoryIDs.contains(repository.id) else {
@@ -15,11 +11,18 @@ extension RepositoriesFeature.State {
       return ProjectWorkspaceCreationRepository(
         id: repository.id,
         name: name,
-        rootURL: repository.rootURL,
-        branchName: repository.worktrees.first(where: \.isMain)?.name
+        rootURL: repository.rootURL
       )
     }
   }
+}
+
+nonisolated private let workspaceLog = SupaLogger("workspace")
+
+nonisolated private struct WorkspaceBaseRefsResult: Sendable {
+  var options: [GitBranchRefOption] = []
+  var defaultBaseRef: String?
+  var errorMessage: String?
 }
 
 extension RepositoriesFeature {
@@ -35,14 +38,20 @@ extension RepositoriesFeature {
         repositories: [],
         title: title,
         rootPath: defaultWorkspaceRootURL(title: title).path(percentEncoded: false),
-        selectedRepositoryIDs: [],
         openedRepositoryCandidates: candidates
       )
       return .none
 
     case .promptCanceled, .promptDismissed:
+      let wasCreating = state.workspaceCreationPrompt?.isCreating == true
       state.workspaceCreationPrompt = nil
-      return .cancel(id: CancelID.workspaceCreation)
+      guard wasCreating else {
+        return .cancel(id: CancelID.workspaceCreation)
+      }
+      return .merge(
+        .cancel(id: CancelID.workspaceCreation),
+        .send(.showToast(.warning("Workspace creation canceled")))
+      )
 
     case .refreshBaseRefs(let repositoryID):
       guard let repository = state.workspaceCreationPrompt?.repositories[id: repositoryID] else {
@@ -50,50 +59,37 @@ extension RepositoriesFeature {
       }
       return workspaceBaseRefsEffect(for: [repository])
 
-    case .baseRefsLoaded(let repositoryID, let sourceKind, let sourceLocation, let options, let defaultBaseRef):
-      guard var repository = state.workspaceCreationPrompt?.repositories[id: repositoryID],
-        repository.sourceKind == sourceKind,
-        repository.sourceLocation == sourceLocation
-      else {
-        return .none
-      }
-      let baseRef = Self.trimmedNonEmpty(repository.baseRef)
-      let baseRefOptions = ProjectWorkspaceCreationRepository.normalizedBaseRefOptions(options)
-      repository.baseRefOptions = baseRefOptions
-      if let baseRef, baseRefOptions.contains(where: { $0.ref == baseRef }) {
-        repository.baseRef = baseRef
-      } else {
-        repository.baseRef = defaultBaseRef
-      }
-      state.workspaceCreationPrompt?.repositories[id: repositoryID] = repository
+    case .baseRefsLoaded(
+      let repositoryID, let sourceKind, let sourceLocation, let options, let defaultBaseRef, let errorMessage
+    ):
+      Self.applyLoadedBaseRefs(
+        into: &state,
+        repositoryID: repositoryID,
+        sourceKind: sourceKind,
+        sourceLocation: sourceLocation,
+        result: WorkspaceBaseRefsResult(
+          options: options,
+          defaultBaseRef: defaultBaseRef,
+          errorMessage: errorMessage
+        )
+      )
       return .none
 
     case .createWorkspace(let draft):
       state.workspaceCreationPrompt?.isCreating = true
       state.workspaceCreationPrompt?.validationMessage = nil
       let request = ProjectWorkspaceCreationRequest(draft: draft, createdAt: now)
-      let shellClient = shellClient
-      let gitRunner = ProjectWorkspaceGitRunner { command in
-        do {
-          _ = try await shellClient.run(
-            URL(fileURLWithPath: "/usr/bin/env"),
-            ["git"] + command.arguments,
-            command.currentDirectoryURL
-          )
-        } catch let error as ShellClientError {
-          throw ProjectWorkspaceCreationError.gitCommandFailed(
-            command: command.displayCommand,
-            message: error.stderr.isEmpty ? error.stdout : error.stderr
-          )
-        } catch {
-          throw error
-        }
-      }
+      let gitRunner = Self.workspaceGitRunner(shellClient: shellClient)
       return .run { send in
         do {
           _ = try await ProjectWorkspace.create(request, gitRunner: gitRunner)
           await send(.workspaceCreation(.workspaceCreated(request.draft.rootURL)))
         } catch {
+          guard !Task.isCancelled else {
+            workspaceLog.warning("Workspace creation canceled, rollback finished")
+            return
+          }
+          workspaceLog.warning("Workspace creation failed: \(error.localizedDescription)")
           await send(.workspaceCreation(.workspaceCreationFailed(error.localizedDescription)))
         }
       }
@@ -147,6 +143,52 @@ extension RepositoriesFeature {
     return trimmed.isEmpty ? nil : trimmed
   }
 
+  private static func applyLoadedBaseRefs(
+    into state: inout State,
+    repositoryID: Repository.ID,
+    sourceKind: ProjectWorkspaceRepositorySourceKind,
+    sourceLocation: String,
+    result: WorkspaceBaseRefsResult
+  ) {
+    guard var repository = state.workspaceCreationPrompt?.repositories[id: repositoryID],
+      repository.sourceKind == sourceKind,
+      repository.sourceLocation == sourceLocation
+    else {
+      return
+    }
+    if let errorMessage = result.errorMessage {
+      state.workspaceCreationPrompt?.validationMessage = errorMessage
+    }
+    let baseRef = trimmedNonEmpty(repository.baseRef)
+    let baseRefOptions = ProjectWorkspaceCreationRepository.normalizedBaseRefOptions(result.options)
+    repository.baseRefOptions = baseRefOptions
+    if let baseRef, baseRefOptions.contains(where: { $0.ref == baseRef }) {
+      repository.baseRef = baseRef
+    } else {
+      repository.baseRef = result.defaultBaseRef
+    }
+    state.workspaceCreationPrompt?.repositories[id: repositoryID] = repository
+  }
+
+  private static func workspaceGitRunner(shellClient: ShellClient) -> ProjectWorkspaceGitRunner {
+    ProjectWorkspaceGitRunner { command in
+      do {
+        _ = try await shellClient.run(
+          URL(fileURLWithPath: "/usr/bin/env"),
+          ["git"] + command.arguments,
+          command.currentDirectoryURL
+        )
+      } catch let error as ShellClientError {
+        throw ProjectWorkspaceCreationError.gitCommandFailed(
+          command: command.displayCommand,
+          message: error.stderr.isEmpty ? error.stdout : error.stderr
+        )
+      } catch {
+        throw error
+      }
+    }
+  }
+
   private func workspaceBaseRefsEffect(for repositories: [ProjectWorkspaceCreationRepository]) -> Effect<Action> {
     guard !repositories.isEmpty else {
       return .none
@@ -162,7 +204,8 @@ extension RepositoriesFeature {
               sourceKind: repository.sourceKind,
               sourceLocation: repository.sourceLocation,
               options: result.options,
-              defaultBaseRef: result.defaultBaseRef
+              defaultBaseRef: result.defaultBaseRef,
+              errorMessage: result.errorMessage
             )
           )
         )
@@ -173,18 +216,14 @@ extension RepositoriesFeature {
   private static func workspaceBaseRefs(
     for repository: ProjectWorkspaceCreationRepository,
     gitClient: GitClientDependency
-  ) async -> (options: [GitBranchRefOption], defaultBaseRef: String?) {
+  ) async -> WorkspaceBaseRefsResult {
     switch repository.sourceKind {
     case .remote:
-      return ([], nil)
+      return WorkspaceBaseRefsResult()
 
     case .existingPath, .localRepository, .bareRepository:
       guard let sourceURL = repository.localSourceURL else {
-        let options = ProjectWorkspaceCreationRepository.baseRefOptions(
-          automaticBaseRef: nil,
-          options: []
-        )
-        return (options, nil)
+        return WorkspaceBaseRefsResult()
       }
 
       let repositoryURL: URL
@@ -195,7 +234,19 @@ extension RepositoriesFeature {
       }
 
       let automaticBaseRef = await gitClient.automaticWorktreeBaseRef(repositoryURL)
-      let refs = (try? await gitClient.branchRefOptions(repositoryURL)) ?? []
+      let refs: [GitBranchRefOption]
+      var errorMessage: String?
+      do {
+        refs = try await gitClient.branchRefOptions(repositoryURL)
+      } catch {
+        refs = []
+        let name = repository.name.trimmingCharacters(in: .whitespacesAndNewlines)
+        let displayName = name.isEmpty ? repositoryURL.lastPathComponent : name
+        errorMessage = "Could not read branches for \(displayName): \(error.localizedDescription)"
+        workspaceLog.warning(
+          "Branch detection failed for \(repositoryURL.path(percentEncoded: false)): \(error)"
+        )
+      }
       let options = ProjectWorkspaceCreationRepository.baseRefOptions(
         automaticBaseRef: automaticBaseRef,
         options: refs
@@ -207,7 +258,11 @@ extension RepositoriesFeature {
           options: options
         )
         : nil
-      return (options, defaultBaseRef)
+      return WorkspaceBaseRefsResult(
+        options: options,
+        defaultBaseRef: defaultBaseRef,
+        errorMessage: errorMessage
+      )
     }
   }
 }

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+WorkspaceCreation.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+WorkspaceCreation.swift
@@ -59,7 +59,7 @@ extension RepositoriesFeature {
       let baseRef = Self.trimmedNonEmpty(repository.baseRef)
       let baseRefOptions = ProjectWorkspaceCreationRepository.normalizedBaseRefOptions(options)
       repository.baseRefOptions = baseRefOptions
-      if let baseRef, baseRefOptions.contains(baseRef) {
+      if let baseRef, baseRefOptions.contains(where: { $0.ref == baseRef }) {
         repository.baseRef = baseRef
       } else {
         repository.baseRef = defaultBaseRef
@@ -186,7 +186,7 @@ extension RepositoriesFeature {
   private static func workspaceBaseRefs(
     for repository: ProjectWorkspaceCreationRepository,
     gitClient: GitClientDependency
-  ) async -> (options: [String], defaultBaseRef: String?) {
+  ) async -> (options: [GitBranchRefOption], defaultBaseRef: String?) {
     switch repository.sourceKind {
     case .remote:
       return ([], nil)
@@ -195,7 +195,7 @@ extension RepositoriesFeature {
       guard let sourceURL = repository.localSourceURL else {
         let options = ProjectWorkspaceCreationRepository.baseRefOptions(
           automaticBaseRef: nil,
-          refs: []
+          options: []
         )
         return (options, nil)
       }
@@ -208,10 +208,10 @@ extension RepositoriesFeature {
       }
 
       let automaticBaseRef = await gitClient.automaticWorktreeBaseRef(repositoryURL)
-      let refs = (try? await gitClient.branchRefs(repositoryURL)) ?? []
+      let refs = (try? await gitClient.branchRefOptions(repositoryURL)) ?? []
       let options = ProjectWorkspaceCreationRepository.baseRefOptions(
         automaticBaseRef: automaticBaseRef,
-        refs: refs
+        options: refs
       )
       let defaultBaseRef =
         automaticBaseRef != nil || !refs.isEmpty

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+WorkspaceCreation.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+WorkspaceCreation.swift
@@ -34,12 +34,29 @@ extension RepositoriesFeature {
     case .promptRequested:
       let candidates = state.workspaceCreationCandidates
       let title = "Workspace"
+      // Seed with the collision-free base path synchronously (pure path math),
+      // then resolve a unique, non-colliding folder name off the main actor so
+      // the reducer body performs no filesystem I/O.
+      let folderName = ProjectWorkspace.defaultWorkspaceFolderName(for: title)
+      let requestedRootPath = Self.workspaceRootPath(folderName: folderName, suffix: nil)
       state.workspaceCreationPrompt = WorkspaceCreationPromptFeature.State(
         repositories: [],
         title: title,
-        rootPath: defaultWorkspaceRootURL(title: title).path(percentEncoded: false),
+        rootPath: requestedRootPath,
         openedRepositoryCandidates: candidates
       )
+      return .run { send in
+        let resolved = Self.uniqueWorkspaceRootPath(folderName: folderName)
+        await send(.workspaceCreation(.defaultRootPathResolved(path: resolved, requestedRootPath: requestedRootPath)))
+      }
+
+    case .defaultRootPathResolved(let path, let requestedRootPath):
+      // Only adopt the de-duplicated path if the user has not edited the field
+      // since the prompt opened.
+      guard state.workspaceCreationPrompt?.rootPath == requestedRootPath else {
+        return .none
+      }
+      state.workspaceCreationPrompt?.rootPath = path
       return .none
 
     case .promptCanceled, .promptDismissed:
@@ -123,16 +140,26 @@ extension RepositoriesFeature {
     }
   }
 
-  private func defaultWorkspaceRootURL(title: String) -> URL {
-    let folderName = ProjectWorkspace.defaultWorkspaceFolderName(for: title)
-    let baseURL = SupacodePaths.workspacesDirectory
-    var candidateURL = baseURL.appending(path: folderName, directoryHint: .isDirectory)
-    var suffix = 2
-    while FileManager.default.fileExists(atPath: candidateURL.path(percentEncoded: false)) {
-      candidateURL = baseURL.appending(path: "\(folderName)-\(suffix)", directoryHint: .isDirectory)
-      suffix += 1
+  nonisolated private static func workspaceRootPath(folderName: String, suffix: Int?) -> String {
+    let component = suffix.map { "\(folderName)-\($0)" } ?? folderName
+    return SupacodePaths.workspacesDirectory
+      .appending(path: component, directoryHint: .isDirectory)
+      .standardizedFileURL
+      .path(percentEncoded: false)
+  }
+
+  // Resolves a workspace folder path that does not collide with an existing
+  // directory. Touches the filesystem, so it must run inside an effect rather
+  // than the reducer body.
+  nonisolated static func uniqueWorkspaceRootPath(folderName: String) -> String {
+    var suffix: Int?
+    while true {
+      let candidate = workspaceRootPath(folderName: folderName, suffix: suffix)
+      if !FileManager.default.fileExists(atPath: candidate) {
+        return candidate
+      }
+      suffix = (suffix ?? 1) + 1
     }
-    return candidateURL.standardizedFileURL
   }
 
   private static func trimmedNonEmpty(_ value: String?) -> String? {

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+WorkspaceCreation.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+WorkspaceCreation.swift
@@ -200,7 +200,7 @@ extension RepositoriesFeature {
   static func workspaceGitRunner(shellClient: ShellClient) -> ProjectWorkspaceGitRunner {
     ProjectWorkspaceGitRunner { command in
       do {
-        _ = try await shellClient.run(
+        _ = try await shellClient.runLogin(
           URL(fileURLWithPath: "/usr/bin/env"),
           ["git"] + command.arguments,
           command.currentDirectoryURL

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+WorkspaceCreation.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+WorkspaceCreation.swift
@@ -56,13 +56,12 @@ extension RepositoriesFeature {
       else {
         return .none
       }
-      var baseRefOptions = options
       let baseRef = Self.trimmedNonEmpty(repository.baseRef)
-      if let baseRef {
-        baseRefOptions = ProjectWorkspaceCreationRepository.normalizedBaseRefOptions([baseRef] + baseRefOptions)
-      }
+      let baseRefOptions = ProjectWorkspaceCreationRepository.normalizedBaseRefOptions(options)
       repository.baseRefOptions = baseRefOptions
-      if baseRef == nil {
+      if let baseRef, baseRefOptions.contains(baseRef) {
+        repository.baseRef = baseRef
+      } else {
         repository.baseRef = defaultBaseRef
       }
       state.workspaceCreationPrompt?.repositories[id: repositoryID] = repository
@@ -190,14 +189,13 @@ extension RepositoriesFeature {
   ) async -> (options: [String], defaultBaseRef: String?) {
     switch repository.sourceKind {
     case .remote:
-      return (ProjectWorkspaceCreationRepository.commonRemoteBaseRefOptions, nil)
+      return ([], nil)
 
     case .existingPath, .localRepository, .bareRepository:
       guard let sourceURL = repository.localSourceURL else {
         let options = ProjectWorkspaceCreationRepository.baseRefOptions(
           automaticBaseRef: nil,
-          refs: [],
-          sourceKind: repository.sourceKind
+          refs: []
         )
         return (options, nil)
       }
@@ -213,8 +211,7 @@ extension RepositoriesFeature {
       let refs = (try? await gitClient.branchRefs(repositoryURL)) ?? []
       let options = ProjectWorkspaceCreationRepository.baseRefOptions(
         automaticBaseRef: automaticBaseRef,
-        refs: refs,
-        sourceKind: repository.sourceKind
+        refs: refs
       )
       let defaultBaseRef =
         automaticBaseRef != nil || !refs.isEmpty

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+WorkspaceCreation.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+WorkspaceCreation.swift
@@ -3,7 +3,7 @@ import Foundation
 
 extension RepositoriesFeature.State {
   var canCreateWorkspace: Bool {
-    workspaceCreationCandidates.count >= 2
+    true
   }
 
   var workspaceCreationCandidates: [ProjectWorkspaceCreationRepository] {
@@ -30,16 +30,9 @@ extension RepositoriesFeature {
     switch action {
     case .promptRequested:
       let candidates = state.workspaceCreationCandidates
-      guard candidates.count >= 2 else {
-        state.alert = messageAlert(
-          title: "Unable to create workspace",
-          message: "Open at least two repositories to create a workspace."
-        )
-        return .none
-      }
       let title = workspaceCreationDefaultTitle(candidates: candidates)
       state.workspaceCreationPrompt = WorkspaceCreationPromptFeature.State(
-        candidates: candidates,
+        repositories: candidates,
         title: title,
         rootPath: defaultWorkspaceRootURL(title: title).path(percentEncoded: false),
         selectedRepositoryIDs: Set(candidates.map(\.id))
@@ -54,9 +47,26 @@ extension RepositoriesFeature {
       state.workspaceCreationPrompt?.isCreating = true
       state.workspaceCreationPrompt?.validationMessage = nil
       let request = ProjectWorkspaceCreationRequest(draft: draft, createdAt: now)
+      let shellClient = shellClient
+      let gitRunner = ProjectWorkspaceGitRunner { command in
+        do {
+          _ = try await shellClient.run(
+            URL(fileURLWithPath: "/usr/bin/env"),
+            ["git"] + command.arguments,
+            command.currentDirectoryURL
+          )
+        } catch let error as ShellClientError {
+          throw ProjectWorkspaceCreationError.gitCommandFailed(
+            command: command.displayCommand,
+            message: error.stderr.isEmpty ? error.stdout : error.stderr
+          )
+        } catch {
+          throw error
+        }
+      }
       return .run { send in
         do {
-          _ = try ProjectWorkspace.create(request)
+          _ = try await ProjectWorkspace.create(request, gitRunner: gitRunner)
           await send(.workspaceCreation(.workspaceCreated(request.draft.rootURL)))
         } catch {
           await send(.workspaceCreation(.workspaceCreationFailed(error.localizedDescription)))
@@ -94,6 +104,9 @@ extension RepositoriesFeature {
 
   private func workspaceCreationDefaultTitle(candidates: [ProjectWorkspaceCreationRepository]) -> String {
     let names = candidates.map(\.name).filter { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+    if names.isEmpty {
+      return "Workspace"
+    }
     if names.count <= 3 {
       return names.joined(separator: " + ")
     }

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+WorkspaceCreation.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+WorkspaceCreation.swift
@@ -1,0 +1,117 @@
+import ComposableArchitecture
+import Foundation
+
+extension RepositoriesFeature.State {
+  var canCreateWorkspace: Bool {
+    workspaceCreationCandidates.count >= 2
+  }
+
+  var workspaceCreationCandidates: [ProjectWorkspaceCreationRepository] {
+    repositories.compactMap { repository in
+      guard !repository.isWorkspace, !removingRepositoryIDs.contains(repository.id) else {
+        return nil
+      }
+      let name = repositoryCustomTitles[repository.id] ?? repository.name
+      return ProjectWorkspaceCreationRepository(
+        id: repository.id,
+        name: name,
+        rootURL: repository.rootURL,
+        branchName: repository.worktrees.first(where: \.isMain)?.name
+      )
+    }
+  }
+}
+
+extension RepositoriesFeature {
+  func reduceWorkspaceCreation(
+    state: inout State,
+    action: WorkspaceCreationAction
+  ) -> Effect<Action> {
+    switch action {
+    case .promptRequested:
+      let candidates = state.workspaceCreationCandidates
+      guard candidates.count >= 2 else {
+        state.alert = messageAlert(
+          title: "Unable to create workspace",
+          message: "Open at least two repositories to create a workspace."
+        )
+        return .none
+      }
+      let title = workspaceCreationDefaultTitle(candidates: candidates)
+      state.workspaceCreationPrompt = WorkspaceCreationPromptFeature.State(
+        candidates: candidates,
+        title: title,
+        rootPath: defaultWorkspaceRootURL(title: title).path(percentEncoded: false),
+        selectedRepositoryIDs: Set(candidates.map(\.id))
+      )
+      return .none
+
+    case .promptCanceled, .promptDismissed:
+      state.workspaceCreationPrompt = nil
+      return .cancel(id: CancelID.workspaceCreation)
+
+    case .createWorkspace(let draft):
+      state.workspaceCreationPrompt?.isCreating = true
+      state.workspaceCreationPrompt?.validationMessage = nil
+      let request = ProjectWorkspaceCreationRequest(draft: draft, createdAt: now)
+      return .run { send in
+        do {
+          _ = try ProjectWorkspace.create(request)
+          await send(.workspaceCreation(.workspaceCreated(request.draft.rootURL)))
+        } catch {
+          await send(.workspaceCreation(.workspaceCreationFailed(error.localizedDescription)))
+        }
+      }
+      .cancellable(id: CancelID.workspaceCreation, cancelInFlight: true)
+
+    case .workspaceCreated(let rootURL):
+      analyticsClient.capture("workspace_created", [String: Any]?.none)
+      state.workspaceCreationPrompt = nil
+      return .merge(
+        .send(.showToast(.success("Workspace created"))),
+        .send(.repositoryManagement(.openRepositories([rootURL])))
+      )
+
+    case .workspaceCreationFailed(let message):
+      if state.workspaceCreationPrompt != nil {
+        state.workspaceCreationPrompt?.isCreating = false
+        state.workspaceCreationPrompt?.validationMessage = message
+      } else {
+        state.alert = messageAlert(title: "Unable to create workspace", message: message)
+      }
+      return .none
+    }
+  }
+
+  var workspaceCreationReducer: some ReducerOf<Self> {
+    Reduce { state, action in
+      guard case .workspaceCreation(let action) = action else {
+        return .none
+      }
+      return reduceWorkspaceCreation(state: &state, action: action)
+    }
+  }
+
+  private func workspaceCreationDefaultTitle(candidates: [ProjectWorkspaceCreationRepository]) -> String {
+    let names = candidates.map(\.name).filter { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+    if names.count <= 3 {
+      return names.joined(separator: " + ")
+    }
+    guard let first = names.first else {
+      return "Workspace"
+    }
+    return "\(first) + \(names.count - 1) repos"
+  }
+
+  private func defaultWorkspaceRootURL(title: String) -> URL {
+    let folderName = ProjectWorkspace.defaultWorkspaceFolderName(for: title)
+    let baseURL = SupacodePaths.workspacesDirectory
+    var candidateURL = baseURL.appending(path: folderName, directoryHint: .isDirectory)
+    var suffix = 2
+    while FileManager.default.fileExists(atPath: candidateURL.path(percentEncoded: false)) {
+      candidateURL = baseURL.appending(path: "\(folderName)-\(suffix)", directoryHint: .isDirectory)
+      suffix += 1
+    }
+    return candidateURL.standardizedFileURL
+  }
+}

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+WorktreeLifecycle.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+WorktreeLifecycle.swift
@@ -219,6 +219,7 @@ extension RepositoriesFeature {
         if selectionWasRemoved {
           let nextWorktreeID = nextSelection ?? firstAvailableWorktreeID(in: repositoryID, state: state)
           state.selection = nextWorktreeID.map(SidebarSelection.worktree)
+          state.selectedWorkspaceChildID = nil
         }
       }
       let archivedWorktrees = state.archivedWorktrees
@@ -457,6 +458,7 @@ extension RepositoriesFeature {
         if selectionNeedsUpdate {
           let nextWorktreeID = nextSelection ?? firstAvailableWorktreeID(in: repositoryID, state: state)
           state.selection = nextWorktreeID.map(SidebarSelection.worktree)
+          state.selectedWorkspaceChildID = nil
         }
       }
       let roots = state.repositories.map(\.rootURL)

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -224,7 +224,8 @@ struct RepositoriesFeature {
       sourceKind: ProjectWorkspaceRepositorySourceKind,
       sourceLocation: String,
       options: [GitBranchRefOption],
-      defaultBaseRef: String?
+      defaultBaseRef: String?,
+      errorMessage: String?
     )
     case createWorkspace(ProjectWorkspaceCreationDraft)
     case workspaceCreated(URL)

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -223,7 +223,7 @@ struct RepositoriesFeature {
       repositoryID: Repository.ID,
       sourceKind: ProjectWorkspaceRepositorySourceKind,
       sourceLocation: String,
-      options: [String],
+      options: [GitBranchRefOption],
       defaultBaseRef: String?
     )
     case createWorkspace(ProjectWorkspaceCreationDraft)

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -69,6 +69,13 @@ struct ForceDeleteBranchRequest: Equatable {
   let errorMessage: String
 }
 
+struct RemoveWorkspaceConfirmation: Equatable {
+  let repositoryID: Repository.ID
+  let workspaceTitle: String
+  let rootPath: String
+  var deleteFiles = false
+}
+
 @Reducer
 struct RepositoriesFeature {
   enum CancelID {
@@ -209,6 +216,9 @@ struct RepositoriesFeature {
     )
     case requestRemoveRepository(Repository.ID)
     case removeFailedRepository(Repository.ID)
+    case removeWorkspaceDeleteFilesChanged(Bool)
+    case removeWorkspacePromptDismissed
+    case removeWorkspacePromptConfirmed
     case repositoryRemoved(Repository.ID, selectionWasRemoved: Bool)
     case openRepositorySettings(Repository.ID)
   }
@@ -290,6 +300,7 @@ struct RepositoriesFeature {
     @Shared(.appStorage("prowlCreatedWorktreeIDs")) var prowlCreatedWorktreeIDs: [Worktree.ID] = []
     var nextDeleteWorktreeConfirmationID = 0
     var deleteWorktreeConfirmation: DeleteWorktreeConfirmation?
+    var removeWorkspaceConfirmation: RemoveWorkspaceConfirmation?
     var pendingForceDeleteBranchRequests: [ForceDeleteBranchRequest] = []
     var nextPendingSidebarRevealID = 0
     var pendingSidebarReveal: PendingSidebarReveal?

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -292,6 +292,7 @@ struct RepositoriesFeature {
     // folder. Refreshed by `refreshWorkspaceChildrenEffect` on each repo reload.
     var workspaceChildInfoByID: [String: WorktreeInfoEntry] = [:]
     var workspaceChildBranchByID: [String: String] = [:]
+    var selectedWorkspaceChildID: String?
     var worktreeOrderByRepository: [Repository.ID: [Worktree.ID]] = [:]
     var isOpenPanelPresented = false
     var isInitialLoadComplete = false
@@ -419,6 +420,7 @@ struct RepositoriesFeature {
     case markWorktreeClosed(Worktree.ID)
     case setSidebarSelectedWorktreeIDs(Set<Worktree.ID>)
     case selectRepository(Repository.ID?)
+    case openWorkspaceChild(String)
     case selectWorktree(Worktree.ID?, focusTerminal: Bool = false, recordHistory: Bool = true)
     case focusCanvasRepository(Repository.ID)
     case focusCanvasWorktree(Worktree.ID)
@@ -486,8 +488,10 @@ struct RepositoriesFeature {
     case confirmArchiveWorktrees([ArchiveWorktreeTarget])
     case confirmForceDeleteBranch(ForceDeleteBranchRequest)
     case confirmRemoveRepository(Repository.ID)
-    case confirmWorkspaceRootDeletion(repositoryID: Repository.ID, rootPath: String, selectionWasRemoved: Bool)
-    case keepWorkspaceFolderAfterCleanupFailure(repositoryID: Repository.ID, selectionWasRemoved: Bool)
+    case confirmWorkspaceRootDeletion(
+      repositoryID: Repository.ID, rootPath: String, selectionWasRemoved: Bool)
+    case keepWorkspaceFolderAfterCleanupFailure(
+      repositoryID: Repository.ID, selectionWasRemoved: Bool)
   }
 
   enum PullRequestAction: Equatable {

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -218,6 +218,14 @@ struct RepositoriesFeature {
     case promptRequested
     case promptCanceled
     case promptDismissed
+    case refreshBaseRefs(Repository.ID)
+    case baseRefsLoaded(
+      repositoryID: Repository.ID,
+      sourceKind: ProjectWorkspaceRepositorySourceKind,
+      sourceLocation: String,
+      options: [String],
+      defaultBaseRef: String?
+    )
     case createWorkspace(ProjectWorkspaceCreationDraft)
     case workspaceCreated(URL)
     case workspaceCreationFailed(String)

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -70,10 +70,18 @@ struct ForceDeleteBranchRequest: Equatable {
 }
 
 struct RemoveWorkspaceConfirmation: Equatable {
+  struct BranchOption: Equatable, Identifiable {
+    let id: String
+    let repositoryName: String
+    let branchName: String
+    var isSelected = false
+  }
+
   let repositoryID: Repository.ID
   let workspaceTitle: String
   let rootPath: String
   var deleteFiles = false
+  var branchOptions: [BranchOption] = []
 }
 
 @Reducer
@@ -217,6 +225,7 @@ struct RepositoriesFeature {
     case requestRemoveRepository(Repository.ID)
     case removeFailedRepository(Repository.ID)
     case removeWorkspaceDeleteFilesChanged(Bool)
+    case removeWorkspaceDeleteBranchChanged(String, Bool)
     case removeWorkspacePromptDismissed
     case removeWorkspacePromptConfirmed
     case repositoryRemoved(Repository.ID, selectionWasRemoved: Bool)

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -240,6 +240,12 @@ struct RepositoriesFeature {
     case removeWorkspaceDeleteBranchChanged(String, Bool)
     case removeWorkspacePromptDismissed
     case removeWorkspacePromptConfirmed
+    case workspaceCleanupReportedFailures(
+      repositoryID: Repository.ID,
+      rootPath: String,
+      failedRepositoryNames: [String],
+      selectionWasRemoved: Bool
+    )
     case repositoryRemoved(Repository.ID, selectionWasRemoved: Bool)
     case openRepositorySettings(Repository.ID)
   }
@@ -247,6 +253,7 @@ struct RepositoriesFeature {
   @CasePathable
   enum WorkspaceCreationAction: Equatable {
     case promptRequested
+    case defaultRootPathResolved(path: String, requestedRootPath: String)
     case promptCanceled
     case promptDismissed
     case refreshBaseRefs(Repository.ID)
@@ -479,6 +486,8 @@ struct RepositoriesFeature {
     case confirmArchiveWorktrees([ArchiveWorktreeTarget])
     case confirmForceDeleteBranch(ForceDeleteBranchRequest)
     case confirmRemoveRepository(Repository.ID)
+    case confirmWorkspaceRootDeletion(repositoryID: Repository.ID, rootPath: String, selectionWasRemoved: Bool)
+    case keepWorkspaceFolderAfterCleanupFailure(repositoryID: Repository.ID, selectionWasRemoved: Bool)
   }
 
   enum PullRequestAction: Equatable {

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -69,6 +69,17 @@ struct ForceDeleteBranchRequest: Equatable {
   let errorMessage: String
 }
 
+// Result of refreshing one workspace child repository's live status: current
+// branch, uncommitted diff counts, and (when GitHub integration is available)
+// the PR for that branch.
+struct WorkspaceChildInfoUpdate: Equatable, Sendable {
+  let id: String
+  let branch: String?
+  let added: Int?
+  let removed: Int?
+  let pullRequest: GithubPullRequest?
+}
+
 struct RemoveWorkspaceConfirmation: Equatable {
   struct BranchOption: Equatable, Identifiable {
     let id: String
@@ -94,6 +105,7 @@ struct RepositoriesFeature {
     static let worktreePromptLoad = "repositories.worktreePromptLoad"
     static let worktreePromptValidation = "repositories.worktreePromptValidation"
     static let workspaceCreation = "repositories.workspaceCreation"
+    static let workspaceChildrenRefresh = "repositories.workspaceChildrenRefresh"
     static func archiveScript(_ worktreeID: Worktree.ID) -> String {
       "repositories.archiveScript.\(worktreeID)"
     }
@@ -266,6 +278,13 @@ struct RepositoriesFeature {
     var repositoryCustomTitles: [Repository.ID: String] = [:]
     var selection: SidebarSelection?
     var worktreeInfoByID: [Worktree.ID: WorktreeInfoEntry] = [:]
+    // Live status for workspace child repositories, keyed by the child's
+    // working-directory path. Kept separate from `worktreeInfoByID` (which is
+    // pruned to tracked worktrees) because workspace children are not tracked
+    // worktrees — they are metadata entries materialized inside the workspace
+    // folder. Refreshed by `refreshWorkspaceChildrenEffect` on each repo reload.
+    var workspaceChildInfoByID: [String: WorktreeInfoEntry] = [:]
+    var workspaceChildBranchByID: [String: String] = [:]
     var worktreeOrderByRepository: [Repository.ID: [Worktree.ID]] = [:]
     var isOpenPanelPresented = false
     var isInitialLoadComplete = false
@@ -412,6 +431,7 @@ struct RepositoriesFeature {
     case worktreeInfoEvent(WorktreeInfoWatcherClient.Event)
     case worktreeBranchNameLoaded(worktreeID: Worktree.ID, name: String)
     case worktreeLineChangesLoaded(worktreeID: Worktree.ID, added: Int, removed: Int)
+    case workspaceChildrenInfoLoaded([WorkspaceChildInfoUpdate])
     case showToast(StatusToast)
     case dismissToast
     case worktreeCreationPrompt(PresentationAction<WorktreeCreationPromptFeature.Action>)

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -78,6 +78,7 @@ struct RepositoriesFeature {
     static let githubIntegrationRecovery = "repositories.githubIntegrationRecovery"
     static let worktreePromptLoad = "repositories.worktreePromptLoad"
     static let worktreePromptValidation = "repositories.worktreePromptValidation"
+    static let workspaceCreation = "repositories.workspaceCreation"
     static func archiveScript(_ worktreeID: Worktree.ID) -> String {
       "repositories.archiveScript.\(worktreeID)"
     }
@@ -212,6 +213,16 @@ struct RepositoriesFeature {
     case openRepositorySettings(Repository.ID)
   }
 
+  @CasePathable
+  enum WorkspaceCreationAction: Equatable {
+    case promptRequested
+    case promptCanceled
+    case promptDismissed
+    case createWorkspace(ProjectWorkspaceCreationDraft)
+    case workspaceCreated(URL)
+    case workspaceCreationFailed(String)
+  }
+
   @ObservableState
   struct State: Equatable {
     var repositories: IdentifiedArrayOf<Repository> = []
@@ -285,6 +296,7 @@ struct RepositoriesFeature {
     var activeAgents = ActiveAgentsFeature.State()
     @Shared(.appStorage("sidebarCollapsedRepositoryIDs")) var collapsedRepositoryIDs: [Repository.ID] = []
     @Presents var worktreeCreationPrompt: WorktreeCreationPromptFeature.State?
+    @Presents var workspaceCreationPrompt: WorkspaceCreationPromptFeature.State?
     @Presents var alert: AlertState<Alert>?
   }
 
@@ -317,6 +329,7 @@ struct RepositoriesFeature {
     case worktreeOrdering(WorktreeOrderingAction)
     case githubIntegration(GithubIntegrationAction)
     case repositoryManagement(RepositoryManagementAction)
+    case workspaceCreation(WorkspaceCreationAction)
     case activeAgents(ActiveAgentsFeature.Action)
     case task
     case repositorySnapshotLoaded([Repository]?)
@@ -373,6 +386,7 @@ struct RepositoriesFeature {
     case showToast(StatusToast)
     case dismissToast
     case worktreeCreationPrompt(PresentationAction<WorktreeCreationPromptFeature.Action>)
+    case workspaceCreationPrompt(PresentationAction<WorkspaceCreationPromptFeature.Action>)
     case alert(PresentationAction<Alert>)
     case delegate(Delegate)
   }
@@ -461,12 +475,16 @@ struct RepositoriesFeature {
       worktreeOrderingReducer
       githubIntegrationReducer
       repositoryManagementReducer
+      workspaceCreationReducer
       Scope(state: \.activeAgents, action: \.activeAgents) {
         ActiveAgentsFeature()
       }
     }
     .ifLet(\.$worktreeCreationPrompt, action: \.worktreeCreationPrompt) {
       WorktreeCreationPromptFeature()
+    }
+    .ifLet(\.$workspaceCreationPrompt, action: \.workspaceCreationPrompt) {
+      WorkspaceCreationPromptFeature()
     }
   }
 
@@ -478,3 +496,4 @@ struct RepositoriesFeature {
 // - RepositoriesFeature+WorktreeOrdering.swift
 // - RepositoriesFeature+GithubIntegration.swift
 // - RepositoriesFeature+RepositoryManagement.swift
+// - RepositoriesFeature+WorkspaceCreation.swift

--- a/supacode/Features/Repositories/Reducer/WorkspaceCreationPromptFeature.swift
+++ b/supacode/Features/Repositories/Reducer/WorkspaceCreationPromptFeature.swift
@@ -74,6 +74,7 @@ struct WorkspaceCreationPromptFeature {
     case repositorySourceLocationChanged(Repository.ID, String)
     case repositoryBranchNameChanged(Repository.ID, String)
     case repositoryBaseRefChanged(Repository.ID, String)
+    case repositoryResetLocalBranchChanged(Repository.ID, Bool)
     case rootPathChosen(String)
     case cancelButtonTapped
     case createButtonTapped
@@ -326,7 +327,14 @@ struct WorkspaceCreationPromptFeature {
           return .none
         }
         repository.baseRef = trimmed.isEmpty ? nil : trimmed
+        // A new ref selection invalidates any previous keep/reset choice.
+        repository.resetLocalBranchToRemote = false
         state.repositories[id: repositoryID] = repository
+        state.validationMessage = nil
+        return .none
+
+      case .repositoryResetLocalBranchChanged(let repositoryID, let resetToRemote):
+        state.repositories[id: repositoryID]?.resetLocalBranchToRemote = resetToRemote
         state.validationMessage = nil
         return .none
 
@@ -432,7 +440,14 @@ struct WorkspaceCreationPromptFeature {
         guard !branchName.isEmpty else {
           return .failure(.missingExistingRef(displayName))
         }
-        checkout = .trackRemoteRef(remoteRef: baseRef, branchName: branchName)
+        if let localBranchName = repository.resettableLocalBranchName, !repository.resetLocalBranchToRemote {
+          // A same-named local branch already exists and the user chose to keep
+          // it: check out the local branch directly rather than resetting it to
+          // the remote ref with `-B`, which would discard local-only commits.
+          checkout = .useExistingRef(localBranchName)
+        } else {
+          checkout = .trackRemoteRef(remoteRef: baseRef, branchName: branchName)
+        }
       }
     }
     return .success(

--- a/supacode/Features/Repositories/Reducer/WorkspaceCreationPromptFeature.swift
+++ b/supacode/Features/Repositories/Reducer/WorkspaceCreationPromptFeature.swift
@@ -7,6 +7,7 @@ struct WorkspaceCreationPromptFeature {
   @ObservableState
   struct State: Equatable {
     var repositories: IdentifiedArrayOf<ProjectWorkspaceCreationRepository>
+    var openedRepositoryCandidates: IdentifiedArrayOf<ProjectWorkspaceCreationRepository>
     var title: String
     var rootPath: String
     var selectedRepositoryIDs: Set<Repository.ID>
@@ -15,11 +16,15 @@ struct WorkspaceCreationPromptFeature {
     var remoteRepositoryPrompt: RemoteRepositoryPromptState?
 
     var selectedRepositoryCount: Int {
-      repositories.count { selectedRepositoryIDs.contains($0.id) }
+      repositories.count
     }
 
     var selectedRepositories: [ProjectWorkspaceCreationRepository] {
-      repositories.filter { selectedRepositoryIDs.contains($0.id) }
+      Array(repositories)
+    }
+
+    var availableOpenedRepositories: [ProjectWorkspaceCreationRepository] {
+      openedRepositoryCandidates.filter { repositories[id: $0.id] == nil }
     }
 
     var rootPathPreview: String {
@@ -30,9 +35,14 @@ struct WorkspaceCreationPromptFeature {
       repositories: [ProjectWorkspaceCreationRepository],
       title: String,
       rootPath: String,
-      selectedRepositoryIDs: Set<Repository.ID>
+      selectedRepositoryIDs: Set<Repository.ID>,
+      openedRepositoryCandidates: [ProjectWorkspaceCreationRepository] = []
     ) {
       self.repositories = IdentifiedArray(repositories, uniquingIDsWith: { current, _ in current })
+      self.openedRepositoryCandidates = IdentifiedArray(
+        openedRepositoryCandidates,
+        uniquingIDsWith: { current, _ in current }
+      )
       self.title = title
       self.rootPath = rootPath
       self.selectedRepositoryIDs = selectedRepositoryIDs
@@ -57,6 +67,7 @@ struct WorkspaceCreationPromptFeature {
   enum Action: BindableAction, Equatable {
     case binding(BindingAction<State>)
     case addBlankRepository(ProjectWorkspaceRepositorySourceKind)
+    case addOpenedRepository(Repository.ID)
     case addRepositoryFromURL(ProjectWorkspaceRepositorySourceKind, String)
     case addRemoteButtonTapped
     case remoteRepositoryPromptURLChanged(String)
@@ -115,6 +126,17 @@ struct WorkspaceCreationPromptFeature {
         state.selectedRepositoryIDs.insert(id)
         state.validationMessage = nil
         return .none
+
+      case .addOpenedRepository(let repositoryID):
+        guard let repository = state.openedRepositoryCandidates[id: repositoryID],
+          state.repositories[id: repositoryID] == nil
+        else {
+          return .none
+        }
+        state.repositories.append(repository)
+        state.selectedRepositoryIDs.insert(repositoryID)
+        state.validationMessage = nil
+        return .send(.delegate(.baseRefSourceChanged(repositoryID)))
 
       case .addRemoteButtonTapped:
         state.remoteRepositoryPrompt = RemoteRepositoryPromptState()

--- a/supacode/Features/Repositories/Reducer/WorkspaceCreationPromptFeature.swift
+++ b/supacode/Features/Repositories/Reducer/WorkspaceCreationPromptFeature.swift
@@ -12,6 +12,7 @@ struct WorkspaceCreationPromptFeature {
     var selectedRepositoryIDs: Set<Repository.ID>
     var validationMessage: String?
     var isCreating = false
+    var remoteRepositoryPrompt: RemoteRepositoryPromptState?
 
     var selectedRepositoryCount: Int {
       repositories.count { selectedRepositoryIDs.contains($0.id) }
@@ -38,13 +39,37 @@ struct WorkspaceCreationPromptFeature {
     }
   }
 
+  @ObservableState
+  struct RemoteRepositoryPromptState: Equatable {
+    var url = ""
+    var name = ""
+    var branchOptions: [GitBranchRefOption] = []
+    var defaultBaseRef: String?
+    var validationMessage: String?
+    var isLoading = false
+
+    var displayName: String {
+      let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+      return trimmed.isEmpty ? "Remote Repository" : trimmed
+    }
+  }
+
   enum Action: BindableAction, Equatable {
     case binding(BindingAction<State>)
     case addBlankRepository(ProjectWorkspaceRepositorySourceKind)
     case addRepositoryFromURL(ProjectWorkspaceRepositorySourceKind, String)
+    case addRemoteButtonTapped
+    case remoteRepositoryPromptURLChanged(String)
+    case remoteRepositoryPromptNameChanged(String)
+    case remoteRepositoryPromptLoadButtonTapped
+    case remoteRepositoryPromptLoaded(String, GitRemoteBranchRefs)
+    case remoteRepositoryPromptFailed(String)
+    case remoteRepositoryPromptAddButtonTapped
+    case remoteRepositoryPromptDismissed
     case removeRepository(Repository.ID)
     case repositorySelectionChanged(Repository.ID, Bool)
     case repositorySourceKindChanged(Repository.ID, ProjectWorkspaceRepositorySourceKind)
+    case repositoryCheckoutModeChanged(Repository.ID, ProjectWorkspaceRepositoryCheckoutMode)
     case repositoryNameChanged(Repository.ID, String)
     case repositoryPathChanged(Repository.ID, String)
     case repositorySourceChosen(Repository.ID, String)
@@ -67,6 +92,7 @@ struct WorkspaceCreationPromptFeature {
   }
 
   @Dependency(\.uuid) var uuid
+  @Dependency(GitClientDependency.self) var gitClient
 
   var body: some Reducer<State, Action> {
     BindingReducer()
@@ -88,6 +114,109 @@ struct WorkspaceCreationPromptFeature {
         )
         state.selectedRepositoryIDs.insert(id)
         state.validationMessage = nil
+        return .none
+
+      case .addRemoteButtonTapped:
+        state.remoteRepositoryPrompt = RemoteRepositoryPromptState()
+        state.validationMessage = nil
+        return .none
+
+      case .remoteRepositoryPromptURLChanged(let url):
+        state.remoteRepositoryPrompt?.url = url
+        state.remoteRepositoryPrompt?.validationMessage = nil
+        state.remoteRepositoryPrompt?.branchOptions = []
+        state.remoteRepositoryPrompt?.defaultBaseRef = nil
+        if state.remoteRepositoryPrompt?.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == true {
+          state.remoteRepositoryPrompt?.name = Self.remoteRepositoryName(for: url)
+        }
+        return .none
+
+      case .remoteRepositoryPromptNameChanged(let name):
+        state.remoteRepositoryPrompt?.name = name
+        state.remoteRepositoryPrompt?.validationMessage = nil
+        return .none
+
+      case .remoteRepositoryPromptLoadButtonTapped:
+        guard var prompt = state.remoteRepositoryPrompt else {
+          return .none
+        }
+        let url = prompt.url.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !url.isEmpty else {
+          prompt.validationMessage = "Remote URL required."
+          state.remoteRepositoryPrompt = prompt
+          return .none
+        }
+        prompt.url = url
+        if prompt.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+          prompt.name = Self.remoteRepositoryName(for: url)
+        }
+        prompt.isLoading = true
+        prompt.validationMessage = nil
+        state.remoteRepositoryPrompt = prompt
+        let gitClient = gitClient
+        return .run { send in
+          do {
+            let refs = try await gitClient.remoteBranchRefs(url)
+            await send(.remoteRepositoryPromptLoaded(url, refs))
+          } catch {
+            await send(.remoteRepositoryPromptFailed(error.localizedDescription))
+          }
+        }
+
+      case .remoteRepositoryPromptLoaded(let url, let refs):
+        guard var prompt = state.remoteRepositoryPrompt,
+          prompt.url.trimmingCharacters(in: .whitespacesAndNewlines) == url
+        else {
+          return .none
+        }
+        let options = ProjectWorkspaceCreationRepository.normalizedBaseRefOptions(refs.options)
+        prompt.isLoading = false
+        prompt.branchOptions = options
+        prompt.defaultBaseRef = ProjectWorkspaceCreationRepository.preferredBaseRef(
+          automaticBaseRef: refs.defaultBaseRef,
+          options: options
+        )
+        prompt.validationMessage = options.isEmpty ? "No remote branches found." : nil
+        state.remoteRepositoryPrompt = prompt
+        return .none
+
+      case .remoteRepositoryPromptFailed(let message):
+        state.remoteRepositoryPrompt?.isLoading = false
+        state.remoteRepositoryPrompt?.validationMessage = message
+        return .none
+
+      case .remoteRepositoryPromptAddButtonTapped:
+        guard let prompt = state.remoteRepositoryPrompt else {
+          return .none
+        }
+        let url = prompt.url.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !url.isEmpty else {
+          state.remoteRepositoryPrompt?.validationMessage = "Remote URL required."
+          return .none
+        }
+        guard !prompt.branchOptions.isEmpty else {
+          state.remoteRepositoryPrompt?.validationMessage = "Load remote branches before adding."
+          return .none
+        }
+        let id = uuid().uuidString
+        state.repositories.append(
+          ProjectWorkspaceCreationRepository(
+            id: id,
+            name: prompt.displayName,
+            sourceKind: .remote,
+            sourceLocation: url,
+            checkoutMode: .useExistingRef,
+            baseRef: prompt.defaultBaseRef,
+            baseRefOptions: prompt.branchOptions
+          )
+        )
+        state.selectedRepositoryIDs.insert(id)
+        state.remoteRepositoryPrompt = nil
+        state.validationMessage = nil
+        return .none
+
+      case .remoteRepositoryPromptDismissed:
+        state.remoteRepositoryPrompt = nil
         return .none
 
       case .addRepositoryFromURL(let sourceKind, let path):
@@ -125,16 +254,24 @@ struct WorkspaceCreationPromptFeature {
         state.validationMessage = nil
         return .none
 
+      case .repositoryCheckoutModeChanged(let repositoryID, let checkoutMode):
+        guard var repository = state.repositories[id: repositoryID] else {
+          return .none
+        }
+        repository.checkoutMode = checkoutMode
+        state.repositories[id: repositoryID] = repository
+        state.validationMessage = nil
+        return .none
+
       case .repositorySourceKindChanged(let repositoryID, let sourceKind):
         guard var repository = state.repositories[id: repositoryID] else {
           return .none
         }
         repository.sourceKind = sourceKind
         repository.baseRef = nil
+        repository.baseRefOptions = []
         if sourceKind == .remote {
           repository.sourceLocation = ""
-        } else {
-          repository.baseRefOptions = []
         }
         state.repositories[id: repositoryID] = repository
         state.validationMessage = nil
@@ -187,7 +324,7 @@ struct WorkspaceCreationPromptFeature {
           return .none
         }
         let trimmed = baseRef.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard trimmed.isEmpty || repository.baseRefOptions.contains(trimmed) else {
+        guard trimmed.isEmpty || repository.baseRefOptions.contains(where: { $0.ref == trimmed }) else {
           return .none
         }
         repository.baseRef = trimmed.isEmpty ? nil : trimmed
@@ -227,6 +364,21 @@ struct WorkspaceCreationPromptFeature {
               ProjectWorkspaceCreationError.missingRepositorySource(displayName).localizedDescription
             return .none
           }
+          if repository.checkoutMode == .createBranch,
+            repository.sourceKind == .remote || repository.sourceKind == .bareRepository,
+            repository.branchName?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty != false
+          {
+            let displayName = name.isEmpty ? "repository" : name
+            state.validationMessage = "Branch name required for \(displayName)."
+            return .none
+          }
+          if repository.checkoutMode == .useExistingRef,
+            repository.baseRef?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty != false
+          {
+            let displayName = name.isEmpty ? "repository" : name
+            state.validationMessage = "Choose an existing branch for \(displayName)."
+            return .none
+          }
         }
         state.validationMessage = nil
         return .send(
@@ -253,5 +405,18 @@ struct WorkspaceCreationPromptFeature {
         return .none
       }
     }
+  }
+
+  private static func remoteRepositoryName(for remoteURL: String) -> String {
+    let trimmed = remoteURL.trimmingCharacters(in: .whitespacesAndNewlines)
+      .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+    guard !trimmed.isEmpty else {
+      return ""
+    }
+    let separatorIndex = trimmed.lastIndex { $0 == "/" || $0 == ":" }
+    let component =
+      separatorIndex.map { String(trimmed[trimmed.index(after: $0)...]) }
+      ?? trimmed
+    return component.hasSuffix(".git") ? String(component.dropLast(4)) : component
   }
 }

--- a/supacode/Features/Repositories/Reducer/WorkspaceCreationPromptFeature.swift
+++ b/supacode/Features/Repositories/Reducer/WorkspaceCreationPromptFeature.swift
@@ -140,10 +140,10 @@ struct WorkspaceCreationPromptFeature {
           return .none
         }
         let folderName = ProjectWorkspace.defaultWorkspaceFolderName(for: title)
-        let requestedRootPath = Self.workspaceRootPath(folderName: folderName, suffix: nil)
+        let requestedRootPath = ProjectWorkspace.workspaceRootPath(folderName: folderName, suffix: nil)
         state.rootPath = requestedRootPath
         return .run { send in
-          let resolved = Self.uniqueWorkspaceRootPath(folderName: folderName)
+          let resolved = ProjectWorkspace.uniqueWorkspaceRootPath(folderName: folderName)
           await send(
             .automaticRootPathResolved(path: resolved, requestedRootPath: requestedRootPath))
         }
@@ -481,25 +481,6 @@ struct WorkspaceCreationPromptFeature {
       return name
     }
     return String(name.dropLast(4))
-  }
-
-  nonisolated private static func workspaceRootPath(folderName: String, suffix: Int?) -> String {
-    let component = suffix.map { "\(folderName)-\($0)" } ?? folderName
-    return SupacodePaths.workspacesDirectory
-      .appending(path: component, directoryHint: .isDirectory)
-      .standardizedFileURL
-      .path(percentEncoded: false)
-  }
-
-  nonisolated static func uniqueWorkspaceRootPath(folderName: String) -> String {
-    var suffix: Int?
-    while true {
-      let candidate = workspaceRootPath(folderName: folderName, suffix: suffix)
-      if !FileManager.default.fileExists(atPath: candidate) {
-        return candidate
-      }
-      suffix = (suffix ?? 1) + 1
-    }
   }
 
   nonisolated private static func loadRemoteBranchRefs(

--- a/supacode/Features/Repositories/Reducer/WorkspaceCreationPromptFeature.swift
+++ b/supacode/Features/Repositories/Reducer/WorkspaceCreationPromptFeature.swift
@@ -332,9 +332,21 @@ struct WorkspaceCreationPromptFeature {
         return .send(.delegate(.baseRefSourceChanged(repositoryID)))
 
       case .repositorySourceLocationChanged(let repositoryID, let sourceLocation):
-        state.repositories[id: repositoryID]?.sourceLocation = sourceLocation
+        guard var repository = state.repositories[id: repositoryID] else {
+          return .none
+        }
+        let sourceLocationChanged = repository.sourceLocation != sourceLocation
+        repository.sourceLocation = sourceLocation
+        if sourceLocationChanged {
+          repository.baseRef = nil
+          repository.baseRefOptions = []
+        }
+        state.repositories[id: repositoryID] = repository
         state.validationMessage = nil
-        return .none
+        guard sourceLocationChanged, repository.sourceKind != .remote, repository.localSourceURL != nil else {
+          return .none
+        }
+        return .send(.delegate(.baseRefSourceChanged(repositoryID)))
 
       case .repositoryBranchNameChanged(let repositoryID, let branchName):
         state.repositories[id: repositoryID]?.branchName = branchName

--- a/supacode/Features/Repositories/Reducer/WorkspaceCreationPromptFeature.swift
+++ b/supacode/Features/Repositories/Reducer/WorkspaceCreationPromptFeature.swift
@@ -10,18 +10,9 @@ struct WorkspaceCreationPromptFeature {
     var openedRepositoryCandidates: IdentifiedArrayOf<ProjectWorkspaceCreationRepository>
     var title: String
     var rootPath: String
-    var selectedRepositoryIDs: Set<Repository.ID>
     var validationMessage: String?
     var isCreating = false
     var remoteRepositoryPrompt: RemoteRepositoryPromptState?
-
-    var selectedRepositoryCount: Int {
-      repositories.count
-    }
-
-    var selectedRepositories: [ProjectWorkspaceCreationRepository] {
-      Array(repositories)
-    }
 
     var availableOpenedRepositories: [ProjectWorkspaceCreationRepository] {
       openedRepositoryCandidates.filter { repositories[id: $0.id] == nil }
@@ -35,7 +26,6 @@ struct WorkspaceCreationPromptFeature {
       repositories: [ProjectWorkspaceCreationRepository],
       title: String,
       rootPath: String,
-      selectedRepositoryIDs: Set<Repository.ID>,
       openedRepositoryCandidates: [ProjectWorkspaceCreationRepository] = []
     ) {
       self.repositories = IdentifiedArray(repositories, uniquingIDsWith: { current, _ in current })
@@ -45,7 +35,6 @@ struct WorkspaceCreationPromptFeature {
       )
       self.title = title
       self.rootPath = rootPath
-      self.selectedRepositoryIDs = selectedRepositoryIDs
     }
   }
 
@@ -66,7 +55,6 @@ struct WorkspaceCreationPromptFeature {
 
   enum Action: BindableAction, Equatable {
     case binding(BindingAction<State>)
-    case addBlankRepository(ProjectWorkspaceRepositorySourceKind)
     case addOpenedRepository(Repository.ID)
     case addRepositoryFromURL(ProjectWorkspaceRepositorySourceKind, String)
     case addRemoteButtonTapped
@@ -78,7 +66,6 @@ struct WorkspaceCreationPromptFeature {
     case remoteRepositoryPromptAddButtonTapped
     case remoteRepositoryPromptDismissed
     case removeRepository(Repository.ID)
-    case repositorySelectionChanged(Repository.ID, Bool)
     case repositorySourceKindChanged(Repository.ID, ProjectWorkspaceRepositorySourceKind)
     case repositoryCheckoutModeChanged(Repository.ID, ProjectWorkspaceRepositoryCheckoutMode)
     case repositoryNameChanged(Repository.ID, String)
@@ -90,8 +77,6 @@ struct WorkspaceCreationPromptFeature {
     case rootPathChosen(String)
     case cancelButtonTapped
     case createButtonTapped
-    case setCreating(Bool)
-    case setValidationMessage(String?)
     case delegate(Delegate)
   }
 
@@ -113,20 +98,6 @@ struct WorkspaceCreationPromptFeature {
         state.validationMessage = nil
         return .none
 
-      case .addBlankRepository(let sourceKind):
-        let id = uuid().uuidString
-        state.repositories.append(
-          ProjectWorkspaceCreationRepository(
-            id: id,
-            name: "",
-            sourceKind: sourceKind,
-            sourceLocation: ""
-          )
-        )
-        state.selectedRepositoryIDs.insert(id)
-        state.validationMessage = nil
-        return .none
-
       case .addOpenedRepository(let repositoryID):
         guard let repository = state.openedRepositoryCandidates[id: repositoryID],
           state.repositories[id: repositoryID] == nil
@@ -134,7 +105,6 @@ struct WorkspaceCreationPromptFeature {
           return .none
         }
         state.repositories.append(repository)
-        state.selectedRepositoryIDs.insert(repositoryID)
         state.validationMessage = nil
         return .send(.delegate(.baseRefSourceChanged(repositoryID)))
 
@@ -149,7 +119,7 @@ struct WorkspaceCreationPromptFeature {
         state.remoteRepositoryPrompt?.branchOptions = []
         state.remoteRepositoryPrompt?.defaultBaseRef = nil
         if state.remoteRepositoryPrompt?.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == true {
-          state.remoteRepositoryPrompt?.name = Self.remoteRepositoryName(for: url)
+          state.remoteRepositoryPrompt?.name = GitRemoteNaming.repositoryName(fromRemoteURL: url)
         }
         return .none
 
@@ -170,7 +140,7 @@ struct WorkspaceCreationPromptFeature {
         }
         prompt.url = url
         if prompt.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-          prompt.name = Self.remoteRepositoryName(for: url)
+          prompt.name = GitRemoteNaming.repositoryName(fromRemoteURL: url)
         }
         prompt.isLoading = true
         prompt.validationMessage = nil
@@ -232,7 +202,6 @@ struct WorkspaceCreationPromptFeature {
             baseRefOptions: prompt.branchOptions
           )
         )
-        state.selectedRepositoryIDs.insert(id)
         state.remoteRepositoryPrompt = nil
         state.validationMessage = nil
         return .none
@@ -257,27 +226,19 @@ struct WorkspaceCreationPromptFeature {
             sourceLocation: rootPath
           )
         )
-        state.selectedRepositoryIDs.insert(id)
         state.validationMessage = nil
         return .send(.delegate(.baseRefSourceChanged(id)))
 
       case .removeRepository(let repositoryID):
         state.repositories.remove(id: repositoryID)
-        state.selectedRepositoryIDs.remove(repositoryID)
-        state.validationMessage = nil
-        return .none
-
-      case .repositorySelectionChanged(let repositoryID, let isSelected):
-        if isSelected {
-          state.selectedRepositoryIDs.insert(repositoryID)
-        } else {
-          state.selectedRepositoryIDs.remove(repositoryID)
-        }
         state.validationMessage = nil
         return .none
 
       case .repositoryCheckoutModeChanged(let repositoryID, let checkoutMode):
         guard var repository = state.repositories[id: repositoryID] else {
+          return .none
+        }
+        guard checkoutMode != .link || repository.sourceKind.supportsLinkCheckout else {
           return .none
         }
         repository.checkoutMode = checkoutMode
@@ -292,6 +253,9 @@ struct WorkspaceCreationPromptFeature {
         repository.sourceKind = sourceKind
         repository.baseRef = nil
         repository.baseRefOptions = []
+        if repository.checkoutMode == .link, !sourceKind.supportsLinkCheckout {
+          repository.checkoutMode = sourceKind.defaultCheckoutMode
+        }
         if sourceKind == .remote {
           repository.sourceLocation = ""
         }
@@ -384,33 +348,17 @@ struct WorkspaceCreationPromptFeature {
           state.validationMessage = ProjectWorkspaceCreationError.missingPath.localizedDescription
           return .none
         }
-        let repositories = state.selectedRepositories
-        guard repositories.count >= 2 else {
+        guard state.repositories.count >= 2 else {
           state.validationMessage = ProjectWorkspaceCreationError.notEnoughRepositories.localizedDescription
           return .none
         }
-        for repository in repositories {
-          let name = repository.name.trimmingCharacters(in: .whitespacesAndNewlines)
-          let sourceLocation = repository.sourceLocation.trimmingCharacters(in: .whitespacesAndNewlines)
-          guard !sourceLocation.isEmpty else {
-            let displayName = name.isEmpty ? "repository" : name
-            state.validationMessage =
-              ProjectWorkspaceCreationError.missingRepositorySource(displayName).localizedDescription
-            return .none
-          }
-          if repository.checkoutMode == .createBranch,
-            repository.sourceKind == .remote || repository.sourceKind == .bareRepository,
-            repository.branchName?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty != false
-          {
-            let displayName = name.isEmpty ? "repository" : name
-            state.validationMessage = "Branch name required for \(displayName)."
-            return .none
-          }
-          if repository.checkoutMode == .useExistingRef,
-            repository.baseRef?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty != false
-          {
-            let displayName = name.isEmpty ? "repository" : name
-            state.validationMessage = "Choose an existing branch for \(displayName)."
+        var plans: [ProjectWorkspaceRepositoryPlan] = []
+        for repository in state.repositories {
+          switch Self.plan(for: repository) {
+          case .success(let plan):
+            plans.append(plan)
+          case .failure(let error):
+            state.validationMessage = error.localizedDescription
             return .none
           }
         }
@@ -421,19 +369,11 @@ struct WorkspaceCreationPromptFeature {
               ProjectWorkspaceCreationDraft(
                 title: title,
                 rootURL: URL(filePath: rootPath, directoryHint: .isDirectory),
-                repositories: repositories
+                repositories: plans
               )
             )
           )
         )
-
-      case .setCreating(let isCreating):
-        state.isCreating = isCreating
-        return .none
-
-      case .setValidationMessage(let message):
-        state.validationMessage = message
-        return .none
 
       case .delegate:
         return .none
@@ -441,16 +381,50 @@ struct WorkspaceCreationPromptFeature {
     }
   }
 
-  private static func remoteRepositoryName(for remoteURL: String) -> String {
-    let trimmed = remoteURL.trimmingCharacters(in: .whitespacesAndNewlines)
-      .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
-    guard !trimmed.isEmpty else {
-      return ""
+  static func plan(
+    for repository: ProjectWorkspaceCreationRepository
+  ) -> Result<ProjectWorkspaceRepositoryPlan, ProjectWorkspaceCreationError> {
+    let name = repository.name.trimmingCharacters(in: .whitespacesAndNewlines)
+    let displayName = name.isEmpty ? "repository" : name
+    let sourceLocation = repository.sourceLocation.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !sourceLocation.isEmpty else {
+      return .failure(.missingRepositorySource(displayName))
     }
-    let separatorIndex = trimmed.lastIndex { $0 == "/" || $0 == ":" }
-    let component =
-      separatorIndex.map { String(trimmed[trimmed.index(after: $0)...]) }
-      ?? trimmed
-    return component.hasSuffix(".git") ? String(component.dropLast(4)) : component
+    let checkout: ProjectWorkspaceRepositoryCheckout
+    switch repository.checkoutMode {
+    case .link:
+      guard repository.sourceKind.supportsLinkCheckout else {
+        return .failure(.linkCheckoutUnsupported(displayName))
+      }
+      checkout = .link
+    case .createBranch:
+      guard let branchName = repository.branchName?.trimmingCharacters(in: .whitespacesAndNewlines),
+        !branchName.isEmpty
+      else {
+        return .failure(.missingBranchName(displayName))
+      }
+      let trimmedBase = repository.baseRef?.trimmingCharacters(in: .whitespacesAndNewlines)
+      checkout = .createBranch(
+        branchName: branchName,
+        baseRef: trimmedBase?.isEmpty == false ? trimmedBase : nil
+      )
+    case .useExistingRef:
+      guard let baseRef = repository.baseRef?.trimmingCharacters(in: .whitespacesAndNewlines),
+        !baseRef.isEmpty
+      else {
+        return .failure(.missingExistingRef(displayName))
+      }
+      checkout = .useExistingRef(baseRef)
+    }
+    return .success(
+      ProjectWorkspaceRepositoryPlan(
+        id: repository.id,
+        name: repository.name,
+        path: repository.path,
+        sourceKind: repository.sourceKind,
+        sourceLocation: sourceLocation,
+        checkout: checkout
+      )
+    )
   }
 }

--- a/supacode/Features/Repositories/Reducer/WorkspaceCreationPromptFeature.swift
+++ b/supacode/Features/Repositories/Reducer/WorkspaceCreationPromptFeature.swift
@@ -47,6 +47,7 @@ struct WorkspaceCreationPromptFeature {
     case repositorySourceKindChanged(Repository.ID, ProjectWorkspaceRepositorySourceKind)
     case repositoryNameChanged(Repository.ID, String)
     case repositoryPathChanged(Repository.ID, String)
+    case repositorySourceChosen(Repository.ID, String)
     case repositorySourceLocationChanged(Repository.ID, String)
     case repositoryBranchNameChanged(Repository.ID, String)
     case repositoryBaseRefChanged(Repository.ID, String)
@@ -60,6 +61,7 @@ struct WorkspaceCreationPromptFeature {
 
   @CasePathable
   enum Delegate: Equatable {
+    case baseRefSourceChanged(Repository.ID)
     case cancel
     case submit(ProjectWorkspaceCreationDraft)
   }
@@ -81,7 +83,10 @@ struct WorkspaceCreationPromptFeature {
             id: id,
             name: "",
             sourceKind: sourceKind,
-            sourceLocation: ""
+            sourceLocation: "",
+            baseRefOptions: sourceKind == .remote
+              ? ProjectWorkspaceCreationRepository.commonRemoteBaseRefOptions
+              : []
           )
         )
         state.selectedRepositoryIDs.insert(id)
@@ -106,7 +111,7 @@ struct WorkspaceCreationPromptFeature {
         )
         state.selectedRepositoryIDs.insert(id)
         state.validationMessage = nil
-        return .none
+        return .send(.delegate(.baseRefSourceChanged(id)))
 
       case .removeRepository(let repositoryID):
         state.repositories.remove(id: repositoryID)
@@ -130,10 +135,17 @@ struct WorkspaceCreationPromptFeature {
         repository.sourceKind = sourceKind
         if sourceKind == .remote {
           repository.sourceLocation = ""
+          repository.baseRef = nil
+          repository.baseRefOptions = ProjectWorkspaceCreationRepository.commonRemoteBaseRefOptions
+        } else {
+          repository.baseRefOptions = []
         }
         state.repositories[id: repositoryID] = repository
         state.validationMessage = nil
-        return .none
+        guard sourceKind != .remote, repository.localSourceURL != nil else {
+          return .none
+        }
+        return .send(.delegate(.baseRefSourceChanged(repositoryID)))
 
       case .repositoryNameChanged(let repositoryID, let name):
         state.repositories[id: repositoryID]?.name = name
@@ -144,6 +156,24 @@ struct WorkspaceCreationPromptFeature {
         state.repositories[id: repositoryID]?.path = path
         state.validationMessage = nil
         return .none
+
+      case .repositorySourceChosen(let repositoryID, let sourceLocation):
+        guard let rootPath = PathPolicy.normalizePath(sourceLocation) else {
+          state.validationMessage =
+            ProjectWorkspaceCreationError.missingRepositorySource("repository").localizedDescription
+          return .none
+        }
+        guard var repository = state.repositories[id: repositoryID] else {
+          return .none
+        }
+        repository.sourceLocation = rootPath
+        if repository.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+          repository.name = Repository.name(for: URL(fileURLWithPath: rootPath))
+        }
+        repository.baseRefOptions = []
+        state.repositories[id: repositoryID] = repository
+        state.validationMessage = nil
+        return .send(.delegate(.baseRefSourceChanged(repositoryID)))
 
       case .repositorySourceLocationChanged(let repositoryID, let sourceLocation):
         state.repositories[id: repositoryID]?.sourceLocation = sourceLocation

--- a/supacode/Features/Repositories/Reducer/WorkspaceCreationPromptFeature.swift
+++ b/supacode/Features/Repositories/Reducer/WorkspaceCreationPromptFeature.swift
@@ -221,7 +221,7 @@ struct WorkspaceCreationPromptFeature {
         state.repositories.append(
           ProjectWorkspaceCreationRepository(
             id: id,
-            name: Repository.name(for: url),
+            name: Self.defaultRepositoryName(for: url),
             sourceKind: sourceKind,
             sourceLocation: rootPath
           )
@@ -287,7 +287,7 @@ struct WorkspaceCreationPromptFeature {
         }
         repository.sourceLocation = rootPath
         if repository.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-          repository.name = Repository.name(for: URL(fileURLWithPath: rootPath))
+          repository.name = Self.defaultRepositoryName(for: URL(fileURLWithPath: rootPath))
         }
         repository.baseRef = nil
         repository.baseRefOptions = []
@@ -381,6 +381,14 @@ struct WorkspaceCreationPromptFeature {
     }
   }
 
+  static func defaultRepositoryName(for url: URL) -> String {
+    let name = Repository.name(for: url)
+    guard name.count > 4, name.hasSuffix(".git") else {
+      return name
+    }
+    return String(name.dropLast(4))
+  }
+
   static func plan(
     for repository: ProjectWorkspaceCreationRepository
   ) -> Result<ProjectWorkspaceRepositoryPlan, ProjectWorkspaceCreationError> {
@@ -414,7 +422,18 @@ struct WorkspaceCreationPromptFeature {
       else {
         return .failure(.missingExistingRef(displayName))
       }
-      checkout = .useExistingRef(baseRef)
+      let kind = repository.baseRefOptions.first { $0.ref == baseRef }?.kind ?? .local
+      if kind == .local {
+        checkout = .useExistingRef(baseRef)
+      } else {
+        // Remote refs are named <remote>/<branch>; materialize them as a local
+        // tracking branch instead of a detached worktree.
+        let branchName = baseRef.split(separator: "/").dropFirst().joined(separator: "/")
+        guard !branchName.isEmpty else {
+          return .failure(.missingExistingRef(displayName))
+        }
+        checkout = .trackRemoteRef(remoteRef: baseRef, branchName: branchName)
+      }
     }
     return .success(
       ProjectWorkspaceRepositoryPlan(

--- a/supacode/Features/Repositories/Reducer/WorkspaceCreationPromptFeature.swift
+++ b/supacode/Features/Repositories/Reducer/WorkspaceCreationPromptFeature.swift
@@ -4,13 +4,20 @@ import IdentifiedCollections
 
 @Reducer
 struct WorkspaceCreationPromptFeature {
+  private enum CancelID {
+    static let remoteRepositoryPromptLoad = "workspaceCreationPrompt.remoteRepositoryPromptLoad"
+  }
+
   @ObservableState
   struct State: Equatable {
     var repositories: IdentifiedArrayOf<ProjectWorkspaceCreationRepository>
     var openedRepositoryCandidates: IdentifiedArrayOf<ProjectWorkspaceCreationRepository>
     var title: String
     var rootPath: String
+    var isRootPathDirty = false
     var validationMessage: String?
+    var validationTarget: ValidationTarget?
+    var validationRequestID = 0
     var isCreating = false
     var remoteRepositoryPrompt: RemoteRepositoryPromptState?
 
@@ -36,6 +43,30 @@ struct WorkspaceCreationPromptFeature {
       self.title = title
       self.rootPath = rootPath
     }
+
+    mutating func clearValidation() {
+      validationMessage = nil
+      validationTarget = nil
+    }
+
+    mutating func setValidation(_ message: String, target: ValidationTarget?) {
+      validationMessage = message
+      validationTarget = target
+      validationRequestID += 1
+    }
+  }
+
+  enum ValidationTarget: Equatable, Sendable {
+    case title
+    case rootPath
+    case repository(Repository.ID, RepositoryField)
+  }
+
+  enum RepositoryField: Equatable, Sendable {
+    case name
+    case source
+    case branchName
+    case baseRef
   }
 
   @ObservableState
@@ -55,6 +86,9 @@ struct WorkspaceCreationPromptFeature {
 
   enum Action: BindableAction, Equatable {
     case binding(BindingAction<State>)
+    case titleChanged(String)
+    case rootPathChanged(String)
+    case automaticRootPathResolved(path: String, requestedRootPath: String)
     case addOpenedRepository(Repository.ID)
     case addRepositoryFromURL(ProjectWorkspaceRepositorySourceKind, String)
     case addRemoteButtonTapped
@@ -96,7 +130,35 @@ struct WorkspaceCreationPromptFeature {
     Reduce { state, action in
       switch action {
       case .binding:
-        state.validationMessage = nil
+        state.clearValidation()
+        return .none
+
+      case .titleChanged(let title):
+        state.title = title
+        state.clearValidation()
+        guard !state.isRootPathDirty else {
+          return .none
+        }
+        let folderName = ProjectWorkspace.defaultWorkspaceFolderName(for: title)
+        let requestedRootPath = Self.workspaceRootPath(folderName: folderName, suffix: nil)
+        state.rootPath = requestedRootPath
+        return .run { send in
+          let resolved = Self.uniqueWorkspaceRootPath(folderName: folderName)
+          await send(
+            .automaticRootPathResolved(path: resolved, requestedRootPath: requestedRootPath))
+        }
+
+      case .rootPathChanged(let rootPath):
+        state.rootPath = rootPath
+        state.isRootPathDirty = true
+        state.clearValidation()
+        return .none
+
+      case .automaticRootPathResolved(let path, let requestedRootPath):
+        guard !state.isRootPathDirty, state.rootPath == requestedRootPath else {
+          return .none
+        }
+        state.rootPath = path
         return .none
 
       case .addOpenedRepository(let repositoryID):
@@ -106,12 +168,12 @@ struct WorkspaceCreationPromptFeature {
           return .none
         }
         state.repositories.append(repository)
-        state.validationMessage = nil
+        state.clearValidation()
         return .send(.delegate(.baseRefSourceChanged(repositoryID)))
 
       case .addRemoteButtonTapped:
         state.remoteRepositoryPrompt = RemoteRepositoryPromptState()
-        state.validationMessage = nil
+        state.clearValidation()
         return .none
 
       case .remoteRepositoryPromptURLChanged(let url):
@@ -119,7 +181,9 @@ struct WorkspaceCreationPromptFeature {
         state.remoteRepositoryPrompt?.validationMessage = nil
         state.remoteRepositoryPrompt?.branchOptions = []
         state.remoteRepositoryPrompt?.defaultBaseRef = nil
-        if state.remoteRepositoryPrompt?.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == true {
+        if state.remoteRepositoryPrompt?.name.trimmingCharacters(in: .whitespacesAndNewlines)
+          .isEmpty == true
+        {
           state.remoteRepositoryPrompt?.name = GitRemoteNaming.repositoryName(fromRemoteURL: url)
         }
         return .none
@@ -149,12 +213,13 @@ struct WorkspaceCreationPromptFeature {
         let gitClient = gitClient
         return .run { send in
           do {
-            let refs = try await gitClient.remoteBranchRefs(url)
+            let refs = try await Self.loadRemoteBranchRefs(url, gitClient: gitClient)
             await send(.remoteRepositoryPromptLoaded(url, refs))
           } catch {
             await send(.remoteRepositoryPromptFailed(error.localizedDescription))
           }
         }
+        .cancellable(id: CancelID.remoteRepositoryPromptLoad, cancelInFlight: true)
 
       case .remoteRepositoryPromptLoaded(let url, let refs):
         guard var prompt = state.remoteRepositoryPrompt,
@@ -204,17 +269,19 @@ struct WorkspaceCreationPromptFeature {
           )
         )
         state.remoteRepositoryPrompt = nil
-        state.validationMessage = nil
+        state.clearValidation()
         return .none
 
       case .remoteRepositoryPromptDismissed:
         state.remoteRepositoryPrompt = nil
-        return .none
+        return .cancel(id: CancelID.remoteRepositoryPromptLoad)
 
       case .addRepositoryFromURL(let sourceKind, let path):
         guard let rootPath = PathPolicy.normalizePath(path) else {
-          state.validationMessage =
-            ProjectWorkspaceCreationError.missingRepositorySource("repository").localizedDescription
+          state.setValidation(
+            ProjectWorkspaceCreationError.missingRepositorySource("repository").localizedDescription,
+            target: nil
+          )
           return .none
         }
         let url = URL(fileURLWithPath: rootPath).standardizedFileURL
@@ -227,12 +294,12 @@ struct WorkspaceCreationPromptFeature {
             sourceLocation: rootPath
           )
         )
-        state.validationMessage = nil
+        state.clearValidation()
         return .send(.delegate(.baseRefSourceChanged(id)))
 
       case .removeRepository(let repositoryID):
         state.repositories.remove(id: repositoryID)
-        state.validationMessage = nil
+        state.clearValidation()
         return .none
 
       case .repositoryCheckoutModeChanged(let repositoryID, let checkoutMode):
@@ -244,7 +311,7 @@ struct WorkspaceCreationPromptFeature {
         }
         repository.checkoutMode = checkoutMode
         state.repositories[id: repositoryID] = repository
-        state.validationMessage = nil
+        state.clearValidation()
         return .none
 
       case .repositorySourceKindChanged(let repositoryID, let sourceKind):
@@ -261,7 +328,7 @@ struct WorkspaceCreationPromptFeature {
           repository.sourceLocation = ""
         }
         state.repositories[id: repositoryID] = repository
-        state.validationMessage = nil
+        state.clearValidation()
         guard sourceKind != .remote, repository.localSourceURL != nil else {
           return .none
         }
@@ -269,18 +336,20 @@ struct WorkspaceCreationPromptFeature {
 
       case .repositoryNameChanged(let repositoryID, let name):
         state.repositories[id: repositoryID]?.name = name
-        state.validationMessage = nil
+        state.clearValidation()
         return .none
 
       case .repositoryPathChanged(let repositoryID, let path):
         state.repositories[id: repositoryID]?.path = path
-        state.validationMessage = nil
+        state.clearValidation()
         return .none
 
       case .repositorySourceChosen(let repositoryID, let sourceLocation):
         guard let rootPath = PathPolicy.normalizePath(sourceLocation) else {
-          state.validationMessage =
-            ProjectWorkspaceCreationError.missingRepositorySource("repository").localizedDescription
+          state.setValidation(
+            ProjectWorkspaceCreationError.missingRepositorySource("repository").localizedDescription,
+            target: .repository(repositoryID, .source)
+          )
           return .none
         }
         guard var repository = state.repositories[id: repositoryID] else {
@@ -293,7 +362,7 @@ struct WorkspaceCreationPromptFeature {
         repository.baseRef = nil
         repository.baseRefOptions = []
         state.repositories[id: repositoryID] = repository
-        state.validationMessage = nil
+        state.clearValidation()
         return .send(.delegate(.baseRefSourceChanged(repositoryID)))
 
       case .repositorySourceLocationChanged(let repositoryID, let sourceLocation):
@@ -307,15 +376,17 @@ struct WorkspaceCreationPromptFeature {
           repository.baseRefOptions = []
         }
         state.repositories[id: repositoryID] = repository
-        state.validationMessage = nil
-        guard sourceLocationChanged, repository.sourceKind != .remote, repository.localSourceURL != nil else {
+        state.clearValidation()
+        guard sourceLocationChanged, repository.sourceKind != .remote,
+          repository.localSourceURL != nil
+        else {
           return .none
         }
         return .send(.delegate(.baseRefSourceChanged(repositoryID)))
 
       case .repositoryBranchNameChanged(let repositoryID, let branchName):
         state.repositories[id: repositoryID]?.branchName = branchName
-        state.validationMessage = nil
+        state.clearValidation()
         return .none
 
       case .repositoryBaseRefChanged(let repositoryID, let baseRef):
@@ -323,24 +394,26 @@ struct WorkspaceCreationPromptFeature {
           return .none
         }
         let trimmed = baseRef.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard trimmed.isEmpty || repository.baseRefOptions.contains(where: { $0.ref == trimmed }) else {
+        guard trimmed.isEmpty || repository.baseRefOptions.contains(where: { $0.ref == trimmed })
+        else {
           return .none
         }
         repository.baseRef = trimmed.isEmpty ? nil : trimmed
         // A new ref selection invalidates any previous keep/reset choice.
         repository.resetLocalBranchToRemote = false
         state.repositories[id: repositoryID] = repository
-        state.validationMessage = nil
+        state.clearValidation()
         return .none
 
       case .repositoryResetLocalBranchChanged(let repositoryID, let resetToRemote):
         state.repositories[id: repositoryID]?.resetLocalBranchToRemote = resetToRemote
-        state.validationMessage = nil
+        state.clearValidation()
         return .none
 
       case .rootPathChosen(let path):
         state.rootPath = path
-        state.validationMessage = nil
+        state.isRootPathDirty = true
+        state.clearValidation()
         return .none
 
       case .cancelButtonTapped:
@@ -349,15 +422,25 @@ struct WorkspaceCreationPromptFeature {
       case .createButtonTapped:
         let title = state.title.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !title.isEmpty else {
-          state.validationMessage = ProjectWorkspaceCreationError.missingTitle.localizedDescription
+          state.setValidation(
+            ProjectWorkspaceCreationError.missingTitle.localizedDescription,
+            target: .title
+          )
           return .none
         }
-        guard let rootPath = PathPolicy.normalizePath(state.rootPath, resolvingSymlinks: false) else {
-          state.validationMessage = ProjectWorkspaceCreationError.missingPath.localizedDescription
+        guard let rootPath = PathPolicy.normalizePath(state.rootPath, resolvingSymlinks: false)
+        else {
+          state.setValidation(
+            ProjectWorkspaceCreationError.missingPath.localizedDescription,
+            target: .rootPath
+          )
           return .none
         }
         guard state.repositories.count >= 2 else {
-          state.validationMessage = ProjectWorkspaceCreationError.notEnoughRepositories.localizedDescription
+          state.setValidation(
+            ProjectWorkspaceCreationError.notEnoughRepositories.localizedDescription,
+            target: nil
+          )
           return .none
         }
         var plans: [ProjectWorkspaceRepositoryPlan] = []
@@ -366,11 +449,14 @@ struct WorkspaceCreationPromptFeature {
           case .success(let plan):
             plans.append(plan)
           case .failure(let error):
-            state.validationMessage = error.localizedDescription
+            state.setValidation(
+              error.localizedDescription,
+              target: Self.validationTarget(for: error, repositoryID: repository.id)
+            )
             return .none
           }
         }
-        state.validationMessage = nil
+        state.clearValidation()
         return .send(
           .delegate(
             .submit(
@@ -395,6 +481,68 @@ struct WorkspaceCreationPromptFeature {
       return name
     }
     return String(name.dropLast(4))
+  }
+
+  nonisolated private static func workspaceRootPath(folderName: String, suffix: Int?) -> String {
+    let component = suffix.map { "\(folderName)-\($0)" } ?? folderName
+    return SupacodePaths.workspacesDirectory
+      .appending(path: component, directoryHint: .isDirectory)
+      .standardizedFileURL
+      .path(percentEncoded: false)
+  }
+
+  nonisolated static func uniqueWorkspaceRootPath(folderName: String) -> String {
+    var suffix: Int?
+    while true {
+      let candidate = workspaceRootPath(folderName: folderName, suffix: suffix)
+      if !FileManager.default.fileExists(atPath: candidate) {
+        return candidate
+      }
+      suffix = (suffix ?? 1) + 1
+    }
+  }
+
+  nonisolated private static func loadRemoteBranchRefs(
+    _ url: String,
+    gitClient: GitClientDependency
+  ) async throws -> GitRemoteBranchRefs {
+    try await withThrowingTaskGroup(of: GitRemoteBranchRefs.self) { group in
+      group.addTask {
+        try await gitClient.remoteBranchRefs(url)
+      }
+      group.addTask {
+        try await Task.sleep(for: .seconds(30))
+        throw RemoteBranchLoadTimeoutError()
+      }
+      guard let refs = try await group.next() else {
+        throw CancellationError()
+      }
+      group.cancelAll()
+      return refs
+    }
+  }
+
+  nonisolated static func validationTarget(
+    for error: ProjectWorkspaceCreationError,
+    repositoryID: Repository.ID
+  ) -> ValidationTarget? {
+    switch error {
+    case .missingRepositoryName:
+      return .repository(repositoryID, .name)
+    case .missingRepositorySource:
+      return .repository(repositoryID, .source)
+    case .missingBranchName:
+      return .repository(repositoryID, .branchName)
+    case .missingExistingRef:
+      return .repository(repositoryID, .baseRef)
+    case .missingTitle:
+      return .title
+    case .missingPath:
+      return .rootPath
+    case .notEnoughRepositories, .linkCheckoutUnsupported, .destinationIsFile,
+      .workspaceAlreadyExists, .repositoryDoesNotExist, .linkAlreadyExists, .gitCommandFailed:
+      return nil
+    }
   }
 
   static func plan(
@@ -434,13 +582,14 @@ struct WorkspaceCreationPromptFeature {
       if kind == .local {
         checkout = .useExistingRef(baseRef)
       } else {
-        // Remote refs are named <remote>/<branch>; materialize them as a local
-        // tracking branch instead of a detached worktree.
-        let branchName = baseRef.split(separator: "/").dropFirst().joined(separator: "/")
-        guard !branchName.isEmpty else {
+        guard
+          let branchName = ProjectWorkspaceCreationRepository.localBranchName(forRemoteRef: baseRef)
+        else {
           return .failure(.missingExistingRef(displayName))
         }
-        if let localBranchName = repository.resettableLocalBranchName, !repository.resetLocalBranchToRemote {
+        if let localBranchName = repository.resettableLocalBranchName,
+          !repository.resetLocalBranchToRemote
+        {
           // A same-named local branch already exists and the user chose to keep
           // it: check out the local branch directly rather than resetting it to
           // the remote ref with `-B`, which would discard local-only commits.
@@ -460,5 +609,11 @@ struct WorkspaceCreationPromptFeature {
         checkout: checkout
       )
     )
+  }
+}
+
+private struct RemoteBranchLoadTimeoutError: LocalizedError {
+  var errorDescription: String? {
+    "Remote branch loading timed out."
   }
 }

--- a/supacode/Features/Repositories/Reducer/WorkspaceCreationPromptFeature.swift
+++ b/supacode/Features/Repositories/Reducer/WorkspaceCreationPromptFeature.swift
@@ -83,10 +83,7 @@ struct WorkspaceCreationPromptFeature {
             id: id,
             name: "",
             sourceKind: sourceKind,
-            sourceLocation: "",
-            baseRefOptions: sourceKind == .remote
-              ? ProjectWorkspaceCreationRepository.commonRemoteBaseRefOptions
-              : []
+            sourceLocation: ""
           )
         )
         state.selectedRepositoryIDs.insert(id)
@@ -133,10 +130,9 @@ struct WorkspaceCreationPromptFeature {
           return .none
         }
         repository.sourceKind = sourceKind
+        repository.baseRef = nil
         if sourceKind == .remote {
           repository.sourceLocation = ""
-          repository.baseRef = nil
-          repository.baseRefOptions = ProjectWorkspaceCreationRepository.commonRemoteBaseRefOptions
         } else {
           repository.baseRefOptions = []
         }
@@ -170,6 +166,7 @@ struct WorkspaceCreationPromptFeature {
         if repository.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
           repository.name = Repository.name(for: URL(fileURLWithPath: rootPath))
         }
+        repository.baseRef = nil
         repository.baseRefOptions = []
         state.repositories[id: repositoryID] = repository
         state.validationMessage = nil
@@ -186,7 +183,15 @@ struct WorkspaceCreationPromptFeature {
         return .none
 
       case .repositoryBaseRefChanged(let repositoryID, let baseRef):
-        state.repositories[id: repositoryID]?.baseRef = baseRef
+        guard var repository = state.repositories[id: repositoryID] else {
+          return .none
+        }
+        let trimmed = baseRef.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.isEmpty || repository.baseRefOptions.contains(trimmed) else {
+          return .none
+        }
+        repository.baseRef = trimmed.isEmpty ? nil : trimmed
+        state.repositories[id: repositoryID] = repository
         state.validationMessage = nil
         return .none
 

--- a/supacode/Features/Repositories/Reducer/WorkspaceCreationPromptFeature.swift
+++ b/supacode/Features/Repositories/Reducer/WorkspaceCreationPromptFeature.swift
@@ -1,0 +1,111 @@
+import ComposableArchitecture
+import Foundation
+
+@Reducer
+struct WorkspaceCreationPromptFeature {
+  @ObservableState
+  struct State: Equatable {
+    let candidates: [ProjectWorkspaceCreationRepository]
+    var title: String
+    var rootPath: String
+    var selectedRepositoryIDs: Set<Repository.ID>
+    var validationMessage: String?
+    var isCreating = false
+
+    var selectedRepositoryCount: Int {
+      candidates.count { selectedRepositoryIDs.contains($0.id) }
+    }
+
+    var selectedRepositories: [ProjectWorkspaceCreationRepository] {
+      candidates.filter { selectedRepositoryIDs.contains($0.id) }
+    }
+
+    var rootPathPreview: String {
+      PathPolicy.normalizePath(rootPath, resolvingSymlinks: false) ?? rootPath
+    }
+  }
+
+  enum Action: BindableAction, Equatable {
+    case binding(BindingAction<State>)
+    case repositorySelectionChanged(Repository.ID, Bool)
+    case rootPathChosen(String)
+    case cancelButtonTapped
+    case createButtonTapped
+    case setCreating(Bool)
+    case setValidationMessage(String?)
+    case delegate(Delegate)
+  }
+
+  @CasePathable
+  enum Delegate: Equatable {
+    case cancel
+    case submit(ProjectWorkspaceCreationDraft)
+  }
+
+  var body: some Reducer<State, Action> {
+    BindingReducer()
+    Reduce { state, action in
+      switch action {
+      case .binding:
+        state.validationMessage = nil
+        return .none
+
+      case .repositorySelectionChanged(let repositoryID, let isSelected):
+        if isSelected {
+          state.selectedRepositoryIDs.insert(repositoryID)
+        } else {
+          state.selectedRepositoryIDs.remove(repositoryID)
+        }
+        state.validationMessage = nil
+        return .none
+
+      case .rootPathChosen(let path):
+        state.rootPath = path
+        state.validationMessage = nil
+        return .none
+
+      case .cancelButtonTapped:
+        return .send(.delegate(.cancel))
+
+      case .createButtonTapped:
+        let title = state.title.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !title.isEmpty else {
+          state.validationMessage = ProjectWorkspaceCreationError.missingTitle.localizedDescription
+          return .none
+        }
+        guard let rootPath = PathPolicy.normalizePath(state.rootPath, resolvingSymlinks: false) else {
+          state.validationMessage = ProjectWorkspaceCreationError.missingPath.localizedDescription
+          return .none
+        }
+        let repositories = state.selectedRepositories
+        guard repositories.count >= 2 else {
+          state.validationMessage = ProjectWorkspaceCreationError.notEnoughRepositories.localizedDescription
+          return .none
+        }
+        state.validationMessage = nil
+        return .send(
+          .delegate(
+            .submit(
+              ProjectWorkspaceCreationDraft(
+                title: title,
+                rootURL: URL(filePath: rootPath, directoryHint: .isDirectory),
+                repositories: repositories
+              )
+            )
+          )
+        )
+
+      case .setCreating(let isCreating):
+        state.isCreating = isCreating
+        return .none
+
+      case .setValidationMessage(let message):
+        state.validationMessage = message
+        return .none
+
+      case .delegate:
+        return .none
+      }
+    }
+  }
+}

--- a/supacode/Features/Repositories/Reducer/WorkspaceCreationPromptFeature.swift
+++ b/supacode/Features/Repositories/Reducer/WorkspaceCreationPromptFeature.swift
@@ -1,11 +1,12 @@
 import ComposableArchitecture
 import Foundation
+import IdentifiedCollections
 
 @Reducer
 struct WorkspaceCreationPromptFeature {
   @ObservableState
   struct State: Equatable {
-    let candidates: [ProjectWorkspaceCreationRepository]
+    var repositories: IdentifiedArrayOf<ProjectWorkspaceCreationRepository>
     var title: String
     var rootPath: String
     var selectedRepositoryIDs: Set<Repository.ID>
@@ -13,21 +14,42 @@ struct WorkspaceCreationPromptFeature {
     var isCreating = false
 
     var selectedRepositoryCount: Int {
-      candidates.count { selectedRepositoryIDs.contains($0.id) }
+      repositories.count { selectedRepositoryIDs.contains($0.id) }
     }
 
     var selectedRepositories: [ProjectWorkspaceCreationRepository] {
-      candidates.filter { selectedRepositoryIDs.contains($0.id) }
+      repositories.filter { selectedRepositoryIDs.contains($0.id) }
     }
 
     var rootPathPreview: String {
       PathPolicy.normalizePath(rootPath, resolvingSymlinks: false) ?? rootPath
     }
+
+    init(
+      repositories: [ProjectWorkspaceCreationRepository],
+      title: String,
+      rootPath: String,
+      selectedRepositoryIDs: Set<Repository.ID>
+    ) {
+      self.repositories = IdentifiedArray(repositories, uniquingIDsWith: { current, _ in current })
+      self.title = title
+      self.rootPath = rootPath
+      self.selectedRepositoryIDs = selectedRepositoryIDs
+    }
   }
 
   enum Action: BindableAction, Equatable {
     case binding(BindingAction<State>)
+    case addBlankRepository(ProjectWorkspaceRepositorySourceKind)
+    case addRepositoryFromURL(ProjectWorkspaceRepositorySourceKind, String)
+    case removeRepository(Repository.ID)
     case repositorySelectionChanged(Repository.ID, Bool)
+    case repositorySourceKindChanged(Repository.ID, ProjectWorkspaceRepositorySourceKind)
+    case repositoryNameChanged(Repository.ID, String)
+    case repositoryPathChanged(Repository.ID, String)
+    case repositorySourceLocationChanged(Repository.ID, String)
+    case repositoryBranchNameChanged(Repository.ID, String)
+    case repositoryBaseRefChanged(Repository.ID, String)
     case rootPathChosen(String)
     case cancelButtonTapped
     case createButtonTapped
@@ -42,11 +64,53 @@ struct WorkspaceCreationPromptFeature {
     case submit(ProjectWorkspaceCreationDraft)
   }
 
+  @Dependency(\.uuid) var uuid
+
   var body: some Reducer<State, Action> {
     BindingReducer()
     Reduce { state, action in
       switch action {
       case .binding:
+        state.validationMessage = nil
+        return .none
+
+      case .addBlankRepository(let sourceKind):
+        let id = uuid().uuidString
+        state.repositories.append(
+          ProjectWorkspaceCreationRepository(
+            id: id,
+            name: "",
+            sourceKind: sourceKind,
+            sourceLocation: ""
+          )
+        )
+        state.selectedRepositoryIDs.insert(id)
+        state.validationMessage = nil
+        return .none
+
+      case .addRepositoryFromURL(let sourceKind, let path):
+        guard let rootPath = PathPolicy.normalizePath(path) else {
+          state.validationMessage =
+            ProjectWorkspaceCreationError.missingRepositorySource("repository").localizedDescription
+          return .none
+        }
+        let url = URL(fileURLWithPath: rootPath).standardizedFileURL
+        let id = uuid().uuidString
+        state.repositories.append(
+          ProjectWorkspaceCreationRepository(
+            id: id,
+            name: Repository.name(for: url),
+            sourceKind: sourceKind,
+            sourceLocation: rootPath
+          )
+        )
+        state.selectedRepositoryIDs.insert(id)
+        state.validationMessage = nil
+        return .none
+
+      case .removeRepository(let repositoryID):
+        state.repositories.remove(id: repositoryID)
+        state.selectedRepositoryIDs.remove(repositoryID)
         state.validationMessage = nil
         return .none
 
@@ -56,6 +120,43 @@ struct WorkspaceCreationPromptFeature {
         } else {
           state.selectedRepositoryIDs.remove(repositoryID)
         }
+        state.validationMessage = nil
+        return .none
+
+      case .repositorySourceKindChanged(let repositoryID, let sourceKind):
+        guard var repository = state.repositories[id: repositoryID] else {
+          return .none
+        }
+        repository.sourceKind = sourceKind
+        if sourceKind == .remote {
+          repository.sourceLocation = ""
+        }
+        state.repositories[id: repositoryID] = repository
+        state.validationMessage = nil
+        return .none
+
+      case .repositoryNameChanged(let repositoryID, let name):
+        state.repositories[id: repositoryID]?.name = name
+        state.validationMessage = nil
+        return .none
+
+      case .repositoryPathChanged(let repositoryID, let path):
+        state.repositories[id: repositoryID]?.path = path
+        state.validationMessage = nil
+        return .none
+
+      case .repositorySourceLocationChanged(let repositoryID, let sourceLocation):
+        state.repositories[id: repositoryID]?.sourceLocation = sourceLocation
+        state.validationMessage = nil
+        return .none
+
+      case .repositoryBranchNameChanged(let repositoryID, let branchName):
+        state.repositories[id: repositoryID]?.branchName = branchName
+        state.validationMessage = nil
+        return .none
+
+      case .repositoryBaseRefChanged(let repositoryID, let baseRef):
+        state.repositories[id: repositoryID]?.baseRef = baseRef
         state.validationMessage = nil
         return .none
 
@@ -81,6 +182,16 @@ struct WorkspaceCreationPromptFeature {
         guard repositories.count >= 2 else {
           state.validationMessage = ProjectWorkspaceCreationError.notEnoughRepositories.localizedDescription
           return .none
+        }
+        for repository in repositories {
+          let name = repository.name.trimmingCharacters(in: .whitespacesAndNewlines)
+          let sourceLocation = repository.sourceLocation.trimmingCharacters(in: .whitespacesAndNewlines)
+          guard !sourceLocation.isEmpty else {
+            let displayName = name.isEmpty ? "repository" : name
+            state.validationMessage =
+              ProjectWorkspaceCreationError.missingRepositorySource(displayName).localizedDescription
+            return .none
+          }
         }
         state.validationMessage = nil
         return .send(

--- a/supacode/Features/Repositories/Views/DetailToolbarTitle.swift
+++ b/supacode/Features/Repositories/Views/DetailToolbarTitle.swift
@@ -4,13 +4,14 @@ struct DetailToolbarTitle: Equatable {
   enum Kind: Equatable {
     case branch(name: String)
     case folder(name: String)
+    case workspace(name: String)
   }
 
   let kind: Kind
 
   var text: String {
     switch kind {
-    case .branch(let name), .folder(let name):
+    case .branch(let name), .folder(let name), .workspace(let name):
       return name
     }
   }
@@ -19,6 +20,8 @@ struct DetailToolbarTitle: Equatable {
     switch kind {
     case .branch:
       return "arrow.trianglehead.branch"
+    case .workspace:
+      return "folder.badge.person.crop"
     case .folder:
       return "folder"
     }
@@ -40,6 +43,9 @@ struct DetailToolbarTitle: Equatable {
     }
     guard let repository, repository.kind == .plain else {
       return nil
+    }
+    if repository.isWorkspace {
+      return DetailToolbarTitle(kind: .workspace(name: repository.name))
     }
     return DetailToolbarTitle(kind: .folder(name: repository.name))
   }

--- a/supacode/Features/Repositories/Views/EmptyStateView.swift
+++ b/supacode/Features/Repositories/Views/EmptyStateView.swift
@@ -4,16 +4,18 @@ import SwiftUI
 struct EmptyStateView: View {
   let store: StoreOf<RepositoriesFeature>
   @Environment(\.resolvedKeybindings) private var resolvedKeybindings
+  @State private var isAddChoicePresented = false
 
   var body: some View {
-    let shortcutDisplay = AppShortcuts.display(for: AppShortcuts.CommandID.openRepository, in: resolvedKeybindings)
+    let shortcutDisplay = AppShortcuts.display(
+      for: AppShortcuts.CommandID.openRepository, in: resolvedKeybindings)
     ContentUnavailableView {
       Label("Open a repository or folder", systemImage: "folder.badge.plus")
     } description: {
       Text(promptText(shortcutDisplay: shortcutDisplay))
     } actions: {
-      Button("Add Repository...") {
-        store.send(.setOpenPanelPresented(true))
+      Button("Add...") {
+        isAddChoicePresented = true
       }
       .modifier(
         KeyboardShortcutModifier(
@@ -27,14 +29,33 @@ struct EmptyStateView: View {
           in: resolvedKeybindings
         ))
     }
+    .confirmationDialog(
+      "Add to Prowl",
+      isPresented: $isAddChoicePresented,
+      titleVisibility: .visible
+    ) {
+      Button("Add Local Repository/Folder") {
+        store.send(.setOpenPanelPresented(true))
+      }
+      Button("Add Workspace") {
+        store.send(.workspaceCreation(.promptRequested))
+      }
+      Button("Cancel", role: .cancel) {}
+    } message: {
+      Text(
+        "A local repository or folder opens one project root. "
+          + "A workspace creates one shared task folder "
+          + "containing multiple repositories for one agent to work across."
+      )
+    }
     .frame(maxWidth: .infinity, maxHeight: .infinity)
     .background(Color(nsColor: .windowBackgroundColor))
   }
 
   private func promptText(shortcutDisplay: String?) -> String {
     if let shortcutDisplay {
-      return "Press \(shortcutDisplay) or click Add Repository to add one."
+      return "Press \(shortcutDisplay) or click Add to add one."
     }
-    return "Click Add Repository to add one."
+    return "Click Add to add one."
   }
 }

--- a/supacode/Features/Repositories/Views/RemoveWorkspaceConfirmationView.swift
+++ b/supacode/Features/Repositories/Views/RemoveWorkspaceConfirmationView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct RemoveWorkspaceConfirmationView: View {
   let confirmation: RemoveWorkspaceConfirmation
   let onDeleteFilesChanged: (Bool) -> Void
+  let onDeleteBranchChanged: (String, Bool) -> Void
   let onCancel: () -> Void
   let onRemove: () -> Void
 
@@ -33,6 +34,29 @@ struct RemoveWorkspaceConfirmationView: View {
         "Unregister worktrees created for this workspace from their source repositories, "
           + "then delete the workspace folder."
       )
+
+      if !confirmation.branchOptions.isEmpty {
+        VStack(alignment: .leading, spacing: 6) {
+          ForEach(confirmation.branchOptions) { option in
+            Toggle(
+              isOn: Binding(
+                get: { option.isSelected },
+                set: { onDeleteBranchChanged(option.id, $0) }
+              )
+            ) {
+              HStack(spacing: 4) {
+                Text("Delete branch")
+                Text(option.branchName)
+                  .font(.body.monospaced())
+                Text("in \(option.repositoryName)")
+              }
+            }
+            .help("Delete the branch from the source repository with git branch -D after removing the worktree.")
+          }
+        }
+        .padding(.leading, 20)
+        .disabled(!confirmation.deleteFiles)
+      }
 
       Text("Linked repositories stay untouched; only the symlinks inside the workspace folder are removed.")
         .font(.footnote)

--- a/supacode/Features/Repositories/Views/RemoveWorkspaceConfirmationView.swift
+++ b/supacode/Features/Repositories/Views/RemoveWorkspaceConfirmationView.swift
@@ -1,0 +1,60 @@
+import SwiftUI
+
+struct RemoveWorkspaceConfirmationView: View {
+  let confirmation: RemoveWorkspaceConfirmation
+  let onDeleteFilesChanged: (Bool) -> Void
+  let onCancel: () -> Void
+  let onRemove: () -> Void
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 16) {
+      VStack(alignment: .leading, spacing: 6) {
+        Text("Remove workspace?")
+          .font(.headline)
+        Text("This removes \(confirmation.workspaceTitle) from Prowl.")
+          .foregroundStyle(.secondary)
+          .fixedSize(horizontal: false, vertical: true)
+        Text(confirmation.rootPath)
+          .font(.footnote.monospaced())
+          .foregroundStyle(.secondary)
+          .lineLimit(1)
+          .truncationMode(.middle)
+          .textSelection(.enabled)
+      }
+
+      Toggle(
+        "Also delete the workspace folder and its worktrees",
+        isOn: Binding(
+          get: { confirmation.deleteFiles },
+          set: { onDeleteFilesChanged($0) }
+        )
+      )
+      .help(
+        "Unregister worktrees created for this workspace from their source repositories, "
+          + "then delete the workspace folder."
+      )
+
+      Text("Linked repositories stay untouched; only the symlinks inside the workspace folder are removed.")
+        .font(.footnote)
+        .foregroundStyle(.secondary)
+        .fixedSize(horizontal: false, vertical: true)
+
+      HStack {
+        Spacer()
+        Button("Cancel", role: .cancel) {
+          onCancel()
+        }
+        .keyboardShortcut(.cancelAction)
+        .help("Cancel (Esc)")
+
+        Button("Remove", role: .destructive) {
+          onRemove()
+        }
+        .keyboardShortcut(.defaultAction)
+        .help("Remove workspace (↩)")
+      }
+    }
+    .padding(24)
+    .frame(width: 440)
+  }
+}

--- a/supacode/Features/Repositories/Views/RepositoryDetailView.swift
+++ b/supacode/Features/Repositories/Views/RepositoryDetailView.swift
@@ -7,6 +7,14 @@ struct RepositoryDetailView: View {
   var customTitle: String?
 
   var body: some View {
+    if let workspace = repository.workspace {
+      WorkspaceDetailView(repository: repository, workspace: workspace)
+    } else {
+      repositoryDetail
+    }
+  }
+
+  private var repositoryDetail: some View {
     VStack(spacing: 12) {
       Image(systemName: repository.kind == .git ? "folder.badge.gearshape" : "folder")
         .font(.largeTitle)

--- a/supacode/Features/Repositories/Views/RepositorySectionView.swift
+++ b/supacode/Features/Repositories/Views/RepositorySectionView.swift
@@ -22,6 +22,11 @@ struct RepositorySectionView: View {
   var body: some View {
     let state = store.state
     let isExpanded = expandedRepoIDs.contains(repository.id)
+    // Workspaces are `.plain` (no git worktrees) but still expand to reveal
+    // their child repository rows, so they get the chevron even though
+    // `supportsWorktrees` is false. Worktree-creation affordances stay gated on
+    // `supportsWorktrees` so a workspace never offers "New Worktree".
+    let isExpandable = repository.capabilities.supportsWorktrees || repository.isWorkspace
     let isRemovingRepository = state.isRemovingRepository(repository)
     let isSelected = state.selection == .repository(repository.id)
     let openRepoSettings = {
@@ -147,7 +152,7 @@ struct RepositorySectionView: View {
           )
           .disabled(isRemovingRepository)
         }
-        if repository.capabilities.supportsWorktrees {
+        if isExpandable {
           Button {
             toggleExpanded()
           } label: {
@@ -186,7 +191,7 @@ struct RepositorySectionView: View {
     .frame(maxWidth: .infinity, minHeight: headerCellHeight, maxHeight: .infinity, alignment: .center)
     .padding(.horizontal, 12)
     .padding(.top, hasTopSpacing ? 4 : 0)
-    .padding(.bottom, hasTopSpacing && !repository.capabilities.supportsWorktrees ? 4 : 0)
+    .padding(.bottom, hasTopSpacing && !isExpandable ? 4 : 0)
     .contentShape(.interaction, .rect)
     .background {
       if isSelected {
@@ -236,14 +241,18 @@ struct RepositorySectionView: View {
       header
         .tag(SidebarSelection.repository(repository.id))
       if isExpanded {
-        WorktreeRowsView(
-          repository: repository,
-          isExpanded: isExpanded,
-          hotkeyRows: hotkeyRows,
-          selectedWorktreeIDs: selectedWorktreeIDs,
-          store: store,
-          terminalManager: terminalManager
-        )
+        if repository.isWorkspace {
+          WorkspaceChildRowsView(rows: state.workspaceChildRows(in: repository))
+        } else {
+          WorktreeRowsView(
+            repository: repository,
+            isExpanded: isExpanded,
+            hotkeyRows: hotkeyRows,
+            selectedWorktreeIDs: selectedWorktreeIDs,
+            store: store,
+            terminalManager: terminalManager
+          )
+        }
       }
     }
     .id(SidebarScrollID.repository(repository.id))

--- a/supacode/Features/Repositories/Views/RepositorySectionView.swift
+++ b/supacode/Features/Repositories/Views/RepositorySectionView.swift
@@ -54,7 +54,7 @@ struct RepositorySectionView: View {
           repositoryRootURL: repository.rootURL,
           nameTooltip: repository.capabilities.supportsWorktrees
             ? (isExpanded ? "Collapse" : "Expand")
-            : "Open terminal in folder"
+            : (repository.isWorkspace ? "Open terminal in workspace" : "Open terminal in folder")
         )
         RepoHeaderTabCountBadge(
           repository: repository,

--- a/supacode/Features/Repositories/Views/RepositorySectionView.swift
+++ b/supacode/Features/Repositories/Views/RepositorySectionView.swift
@@ -28,7 +28,7 @@ struct RepositorySectionView: View {
     // `supportsWorktrees` so a workspace never offers "New Worktree".
     let isExpandable = repository.capabilities.supportsWorktrees || repository.isWorkspace
     let isRemovingRepository = state.isRemovingRepository(repository)
-    let isSelected = state.selection == .repository(repository.id)
+    let isSelected = state.selection == .repository(repository.id) && state.selectedWorkspaceChildID == nil
     let openRepoSettings = {
       _ = store.send(.repositoryManagement(.openRepositorySettings(repository.id)))
     }
@@ -188,7 +188,9 @@ struct RepositorySectionView: View {
           .accessibilityLabel(Text("Repo color: \(color.displayName)"))
       }
     }
-    .frame(maxWidth: .infinity, minHeight: headerCellHeight, maxHeight: .infinity, alignment: .center)
+    .frame(
+      maxWidth: .infinity, minHeight: headerCellHeight, maxHeight: .infinity, alignment: .center
+    )
     .padding(.horizontal, 12)
     .padding(.top, hasTopSpacing ? 4 : 0)
     .padding(.bottom, hasTopSpacing && !isExpandable ? 4 : 0)
@@ -242,7 +244,14 @@ struct RepositorySectionView: View {
         .tag(SidebarSelection.repository(repository.id))
       if isExpanded {
         if repository.isWorkspace {
-          WorkspaceChildRowsView(rows: state.workspaceChildRows(in: repository))
+          WorkspaceChildRowsView(
+            rows: state.workspaceChildRows(in: repository),
+            selectedID: state.selection == .repository(repository.id)
+              ? state.selectedWorkspaceChildID : nil,
+            onSelect: { childID in
+              store.send(.openWorkspaceChild(childID))
+            }
+          )
         } else {
           WorktreeRowsView(
             repository: repository,

--- a/supacode/Features/Repositories/Views/RepositorySectionView.swift
+++ b/supacode/Features/Repositories/Views/RepositorySectionView.swift
@@ -54,7 +54,7 @@ struct RepositorySectionView: View {
           name: repository.name,
           customTitle: store.repositoryCustomTitles[repository.id],
           isRemoving: isRemovingRepository,
-          icon: appearance.icon,
+          icon: appearance.icon ?? (repository.isWorkspace ? .sfSymbol("folder") : nil),
           iconTint: appearance.color?.color ?? .accentColor,
           repositoryRootURL: repository.rootURL,
           nameTooltip: repository.capabilities.supportsWorktrees

--- a/supacode/Features/Repositories/Views/SidebarListView.swift
+++ b/supacode/Features/Repositories/Views/SidebarListView.swift
@@ -194,19 +194,21 @@ struct SidebarListView: View {
         await revealPendingSidebarWorktree(pendingSidebarReveal, with: scrollProxy)
       }
       .toolbar {
-        ToolbarItemGroup(placement: .automatic) {
-          Button {
-            store.send(.workspaceCreation(.promptRequested))
-          } label: {
-            Label("New Workspace", systemImage: "folder.badge.person.crop")
-          }
-          .help("New Workspace")
-          Button {
-            store.send(.setOpenPanelPresented(true))
+        ToolbarItem(placement: .automatic) {
+          // Single toolbar slot: two separate buttons overflow into the
+          // window-trailing ">>" menu when the sidebar gets narrow.
+          Menu {
+            Button {
+              store.send(.workspaceCreation(.promptRequested))
+            } label: {
+              Label("New Workspace", systemImage: "folder.badge.person.crop")
+            }
           } label: {
             Label("Add Repository", systemImage: "folder.badge.plus")
+          } primaryAction: {
+            store.send(.setOpenPanelPresented(true))
           }
-          .help("Add Repository")
+          .help("Add Repository — open the menu for New Workspace")
         }
       }
     }  // ScrollViewReader

--- a/supacode/Features/Repositories/Views/SidebarListView.swift
+++ b/supacode/Features/Repositories/Views/SidebarListView.swift
@@ -201,7 +201,6 @@ struct SidebarListView: View {
             Label("New Workspace", systemImage: "folder.badge.person.crop")
           }
           .help("New Workspace")
-          .disabled(!state.canCreateWorkspace)
           Button {
             store.send(.setOpenPanelPresented(true))
           } label: {

--- a/supacode/Features/Repositories/Views/SidebarListView.swift
+++ b/supacode/Features/Repositories/Views/SidebarListView.swift
@@ -42,6 +42,7 @@ struct SidebarListView: View {
   @State private var sidebarHeight = 0.0
   @State private var sidebarFooterHeight = 0.0
   @State private var resizingPanelHeight: Double?
+  @State private var isAddChoicePresented = false
   @Namespace private var topSegmentNamespace
   @Environment(\.resolvedKeybindings) private var resolvedKeybindings
   @Environment(CommandKeyObserver.self) private var commandKeyObserver
@@ -86,7 +87,8 @@ struct SidebarListView: View {
     let panelHeight = min(resizingPanelHeight ?? state.activeAgents.panelHeight, maximumPanelHeight)
     let panelOffset = state.activeAgents.isPanelHidden ? panelHeight : 0
     let activeAgentsPanelTopGap = 4.0
-    let listBottomPadding = state.activeAgents.isPanelHidden ? 0 : panelHeight + activeAgentsPanelTopGap
+    let listBottomPadding =
+      state.activeAgents.isPanelHidden ? 0 : panelHeight + activeAgentsPanelTopGap
 
     ScrollViewReader { scrollProxy in
       ScrollView {
@@ -95,7 +97,7 @@ struct SidebarListView: View {
         VStack(spacing: 0) {
           // When there are no repositories the sidebar stays empty — the
           // detail pane's `EmptyStateView` ("Open a repository or folder")
-          // carries the prompt and the Add Repository button instead.
+          // carries the prompt and the Add button instead.
           if !repositoryItems.isEmpty {
             repositoryListHeader(
               action: repositoryListHeaderAction,
@@ -194,20 +196,33 @@ struct SidebarListView: View {
         await revealPendingSidebarWorktree(pendingSidebarReveal, with: scrollProxy)
       }
       .toolbar {
-        ToolbarItemGroup(placement: .automatic) {
+        ToolbarItem(placement: .automatic) {
           Button {
-            store.send(.workspaceCreation(.promptRequested))
+            isAddChoicePresented = true
           } label: {
-            Label("New Workspace", systemImage: "folder.badge.person.crop")
+            Label("Add...", systemImage: "folder.badge.plus")
           }
-          .help("New Workspace")
-          Button {
-            store.send(.setOpenPanelPresented(true))
-          } label: {
-            Label("Add Repository", systemImage: "folder.badge.plus")
-          }
-          .help("Add Repository")
+          .help("Add Repository or Workspace")
         }
+      }
+      .confirmationDialog(
+        "Add to Prowl",
+        isPresented: $isAddChoicePresented,
+        titleVisibility: .visible
+      ) {
+        Button("Add Local Repository/Folder") {
+          store.send(.setOpenPanelPresented(true))
+        }
+        Button("Add Workspace") {
+          store.send(.workspaceCreation(.promptRequested))
+        }
+        Button("Cancel", role: .cancel) {}
+      } message: {
+        Text(
+          "A local repository or folder opens one project root. "
+            + "A workspace creates one shared task folder "
+            + "containing multiple repositories for one agent to work across."
+        )
       }
     }  // ScrollViewReader
   }
@@ -477,7 +492,8 @@ struct SidebarListView: View {
     await Task.yield()
     await Task.yield()
     withAnimation(.easeOut(duration: 0.2)) {
-      scrollProxy.scrollTo(SidebarScrollID.worktree(pendingSidebarReveal.worktreeID), anchor: .center)
+      scrollProxy.scrollTo(
+        SidebarScrollID.worktree(pendingSidebarReveal.worktreeID), anchor: .center)
     }
     store.send(.consumePendingSidebarReveal(pendingSidebarReveal.id))
   }
@@ -510,7 +526,8 @@ struct SidebarListView: View {
   }
 
   static func repositoryHeaderOpensCanvasTarget(_ repository: Repository) -> Bool {
-    repository.capabilities.supportsRunnableFolderActions && !repository.capabilities.supportsWorktrees
+    repository.capabilities.supportsRunnableFolderActions
+      && !repository.capabilities.supportsWorktrees
   }
 
   static func activeAgentWorktreeMetadata(
@@ -525,7 +542,9 @@ struct SidebarListView: View {
     for repository in repositories {
       let repositoryName = customTitles[repository.id] ?? repository.name
       let repositoryColor = repositoryAppearances[repository.id]?.color
-      if repository.capabilities.supportsRunnableFolderActions && !repository.capabilities.supportsWorktrees {
+      if repository.capabilities.supportsRunnableFolderActions
+        && !repository.capabilities.supportsWorktrees
+      {
         repositoryNamesByWorktreeID[repository.id] = repositoryName
         branchNamesByWorktreeID[repository.id] = repository.name
         if let repositoryColor {
@@ -612,7 +631,9 @@ struct SidebarListView: View {
       best = (id, depth)
     }
     for repository in repositories {
-      if repository.capabilities.supportsRunnableFolderActions, !repository.capabilities.supportsWorktrees {
+      if repository.capabilities.supportsRunnableFolderActions,
+        !repository.capabilities.supportsWorktrees
+      {
         consider(id: repository.id, directory: repository.rootURL)
       }
       for worktree in repository.worktrees {

--- a/supacode/Features/Repositories/Views/SidebarListView.swift
+++ b/supacode/Features/Repositories/Views/SidebarListView.swift
@@ -194,21 +194,19 @@ struct SidebarListView: View {
         await revealPendingSidebarWorktree(pendingSidebarReveal, with: scrollProxy)
       }
       .toolbar {
-        ToolbarItem(placement: .automatic) {
-          // Single toolbar slot: two separate buttons overflow into the
-          // window-trailing ">>" menu when the sidebar gets narrow.
-          Menu {
-            Button {
-              store.send(.workspaceCreation(.promptRequested))
-            } label: {
-              Label("New Workspace", systemImage: "folder.badge.person.crop")
-            }
+        ToolbarItemGroup(placement: .automatic) {
+          Button {
+            store.send(.workspaceCreation(.promptRequested))
+          } label: {
+            Label("New Workspace", systemImage: "folder.badge.person.crop")
+          }
+          .help("New Workspace")
+          Button {
+            store.send(.setOpenPanelPresented(true))
           } label: {
             Label("Add Repository", systemImage: "folder.badge.plus")
-          } primaryAction: {
-            store.send(.setOpenPanelPresented(true))
           }
-          .help("Add Repository — open the menu for New Workspace")
+          .help("Add Repository")
         }
       }
     }  // ScrollViewReader

--- a/supacode/Features/Repositories/Views/SidebarListView.swift
+++ b/supacode/Features/Repositories/Views/SidebarListView.swift
@@ -194,7 +194,14 @@ struct SidebarListView: View {
         await revealPendingSidebarWorktree(pendingSidebarReveal, with: scrollProxy)
       }
       .toolbar {
-        ToolbarItem(placement: .automatic) {
+        ToolbarItemGroup(placement: .automatic) {
+          Button {
+            store.send(.workspaceCreation(.promptRequested))
+          } label: {
+            Label("New Workspace", systemImage: "folder.badge.person.crop")
+          }
+          .help("New Workspace")
+          .disabled(!state.canCreateWorkspace)
           Button {
             store.send(.setOpenPanelPresented(true))
           } label: {

--- a/supacode/Features/Repositories/Views/WorkspaceChildRowsView.swift
+++ b/supacode/Features/Repositories/Views/WorkspaceChildRowsView.swift
@@ -1,40 +1,71 @@
 import SwiftUI
 
-/// Display-only rows for the child repositories of an expanded workspace.
-/// Reuses `WorktreeRow` for visual parity with git worktree rows (branch icon,
-/// `+N/-M` diff badge, PR tag), but deliberately omits selection, drag, context
-/// menu, and tap handling — a workspace has a single root terminal and its
-/// children are not independently runnable targets.
+/// Rows for the child repositories of an expanded workspace.
+/// Reuses `WorktreeRow` for visual parity with git worktree rows (`+N/-M` diff
+/// badge, PR tag), while clicking a child focuses its bound terminal tab,
+/// creating one rooted at that repository's folder when needed.
 struct WorkspaceChildRowsView: View {
   let rows: [WorkspaceChildRowModel]
+  let selectedID: String?
+  let onSelect: (String) -> Void
 
   var body: some View {
     ForEach(rows) { row in
-      WorktreeRow(
-        name: row.branchName ?? row.repositoryName,
-        worktreeName: row.branchName == nil ? "" : row.repositoryName,
-        info: row.info,
-        showsPullRequestInfo: true,
-        isHovered: false,
-        isPinned: false,
-        isMainWorktree: false,
-        isLoading: false,
-        taskStatus: nil,
-        isRunScriptRunning: false,
-        showsNotificationIndicator: false,
-        notifications: [],
-        onFocusNotification: { _ in },
-        shortcutHint: nil,
-        showsShortcutHint: false,
-        pinAction: nil,
-        isSelected: false,
-        archiveAction: nil,
-        onDiffTap: nil,
-        onStopRunScript: nil,
-      )
-      .padding(.leading, 14)
-      .padding(.trailing, 8)
-      .id(row.id)
+      let isSelected = row.id == selectedID
+      WorkspaceChildRowButton(row: row, isSelected: isSelected, onSelect: onSelect)
+        .padding(.leading, 14)
+        .padding(.trailing, 8)
+        .background {
+          if isSelected {
+            RoundedRectangle(cornerRadius: 8)
+              .fill(Color.accentColor.opacity(0.18))
+              .padding(.horizontal, 6)
+          }
+        }
+        .padding(.vertical, 2)
+        .id(row.id)
     }
+  }
+}
+
+private struct WorkspaceChildRowButton: View {
+  let row: WorkspaceChildRowModel
+  let isSelected: Bool
+  let onSelect: (String) -> Void
+
+  var body: some View {
+    Button {
+      onSelect(row.id)
+    } label: {
+      content
+    }
+    .buttonStyle(.plain)
+    .help("Focus Terminal in \(row.repositoryName)")
+  }
+
+  private var content: some View {
+    WorktreeRow(
+      name: row.branchName ?? row.repositoryName,
+      worktreeName: row.branchName == nil ? "" : row.repositoryName,
+      info: row.info,
+      iconSystemName: "folder",
+      showsPullRequestInfo: true,
+      isHovered: false,
+      isPinned: false,
+      isMainWorktree: false,
+      isLoading: false,
+      taskStatus: nil,
+      isRunScriptRunning: false,
+      showsNotificationIndicator: false,
+      notifications: [],
+      onFocusNotification: { _ in },
+      shortcutHint: nil,
+      showsShortcutHint: false,
+      pinAction: nil,
+      isSelected: isSelected,
+      archiveAction: nil,
+      onDiffTap: nil,
+      onStopRunScript: nil,
+    )
   }
 }

--- a/supacode/Features/Repositories/Views/WorkspaceChildRowsView.swift
+++ b/supacode/Features/Repositories/Views/WorkspaceChildRowsView.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+
+/// Display-only rows for the child repositories of an expanded workspace.
+/// Reuses `WorktreeRow` for visual parity with git worktree rows (branch icon,
+/// `+N/-M` diff badge, PR tag), but deliberately omits selection, drag, context
+/// menu, and tap handling — a workspace has a single root terminal and its
+/// children are not independently runnable targets.
+struct WorkspaceChildRowsView: View {
+  let rows: [WorkspaceChildRowModel]
+
+  var body: some View {
+    ForEach(rows) { row in
+      WorktreeRow(
+        name: row.branchName ?? row.repositoryName,
+        worktreeName: row.branchName == nil ? "" : row.repositoryName,
+        info: row.info,
+        showsPullRequestInfo: true,
+        isHovered: false,
+        isPinned: false,
+        isMainWorktree: false,
+        isLoading: false,
+        taskStatus: nil,
+        isRunScriptRunning: false,
+        showsNotificationIndicator: false,
+        notifications: [],
+        onFocusNotification: { _ in },
+        shortcutHint: nil,
+        showsShortcutHint: false,
+        pinAction: nil,
+        isSelected: false,
+        archiveAction: nil,
+        onDiffTap: nil,
+        onStopRunScript: nil,
+      )
+      .padding(.leading, 14)
+      .padding(.trailing, 8)
+      .id(row.id)
+    }
+  }
+}

--- a/supacode/Features/Repositories/Views/WorkspaceChildRowsView.swift
+++ b/supacode/Features/Repositories/Views/WorkspaceChildRowsView.swift
@@ -48,7 +48,7 @@ private struct WorkspaceChildRowButton: View {
       name: row.branchName ?? row.repositoryName,
       worktreeName: row.branchName == nil ? "" : row.repositoryName,
       info: row.info,
-      iconSystemName: "folder",
+      iconSystemName: nil,
       showsPullRequestInfo: true,
       isHovered: false,
       isPinned: false,

--- a/supacode/Features/Repositories/Views/WorkspaceCreationPromptView.swift
+++ b/supacode/Features/Repositories/Views/WorkspaceCreationPromptView.swift
@@ -17,7 +17,7 @@ struct WorkspaceCreationPromptView: View {
       VStack(alignment: .leading, spacing: 4) {
         Text("New Workspace")
           .font(.title3)
-        Text("\(store.selectedRepositoryCount) of \(store.repositories.count) repositories selected")
+        Text(repositoryCountText)
           .foregroundStyle(.secondary)
       }
 
@@ -61,6 +61,20 @@ struct WorkspaceCreationPromptView: View {
         Text("Repositories")
           .foregroundStyle(.secondary)
         HStack(spacing: 8) {
+          Menu {
+            ForEach(store.availableOpenedRepositories) { repository in
+              Button {
+                store.send(.addOpenedRepository(repository.id))
+              } label: {
+                Text(repository.name.isEmpty ? repository.sourceLocation : repository.name)
+              }
+            }
+          } label: {
+            Label("Add Opened", systemImage: "folder.badge.plus")
+          }
+          .help("Add Opened Path")
+          .disabled(store.isCreating || store.availableOpenedRepositories.isEmpty)
+
           Button {
             store.send(.addRemoteButtonTapped)
           } label: {
@@ -148,6 +162,10 @@ struct WorkspaceCreationPromptView: View {
     }
   }
 
+  private var repositoryCountText: String {
+    store.repositories.count == 1 ? "1 repository" : "\(store.repositories.count) repositories"
+  }
+
   private func repositoryEditor(_ repository: ProjectWorkspaceCreationRepository) -> some View {
     VStack(alignment: .leading, spacing: 10) {
       repositoryHeader(repository)
@@ -161,16 +179,9 @@ struct WorkspaceCreationPromptView: View {
 
   private func repositoryHeader(_ repository: ProjectWorkspaceCreationRepository) -> some View {
     HStack(spacing: 10) {
-      Toggle(
-        isOn: Binding(
-          get: { store.selectedRepositoryIDs.contains(repository.id) },
-          set: { store.send(.repositorySelectionChanged(repository.id, $0)) }
-        )
-      ) {
-        Text(repository.name.isEmpty ? "Repository" : repository.name)
-          .fontWeight(.medium)
-      }
-      .toggleStyle(.checkbox)
+      Text(repository.name.isEmpty ? "Repository" : repository.name)
+        .fontWeight(.medium)
+        .lineLimit(1)
 
       Picker(
         "Source",

--- a/supacode/Features/Repositories/Views/WorkspaceCreationPromptView.swift
+++ b/supacode/Features/Repositories/Views/WorkspaceCreationPromptView.swift
@@ -62,7 +62,7 @@ struct WorkspaceCreationPromptView: View {
           .foregroundStyle(.secondary)
         HStack(spacing: 8) {
           Button {
-            store.send(.addBlankRepository(.remote))
+            store.send(.addRemoteButtonTapped)
           } label: {
             Label("Add Remote", systemImage: "network")
           }
@@ -133,6 +133,18 @@ struct WorkspaceCreationPromptView: View {
     .frame(minWidth: 680)
     .task {
       isTitleFieldFocused = true
+    }
+    .sheet(
+      isPresented: Binding(
+        get: { store.remoteRepositoryPrompt != nil },
+        set: { isPresented in
+          if !isPresented {
+            store.send(.remoteRepositoryPromptDismissed)
+          }
+        }
+      )
+    ) {
+      remoteRepositoryPromptView()
     }
   }
 
@@ -242,33 +254,123 @@ struct WorkspaceCreationPromptView: View {
 
   private func repositoryBranchFields(_ repository: ProjectWorkspaceCreationRepository) -> some View {
     HStack(spacing: 8) {
-      TextField(
-        "Branch",
-        text: Binding(
-          get: { repository.branchName ?? "" },
-          set: { store.send(.repositoryBranchNameChanged(repository.id, $0)) }
-        )
-      )
-      .textFieldStyle(.roundedBorder)
-      .disabled(store.isCreating)
-
       Picker(
-        "Base ref",
+        "Branch action",
         selection: Binding(
-          get: { repository.baseRef ?? "" },
-          set: { store.send(.repositoryBaseRefChanged(repository.id, $0)) }
+          get: { repository.checkoutMode },
+          set: { store.send(.repositoryCheckoutModeChanged(repository.id, $0)) }
         )
       ) {
-        Text("Base ref").tag("")
-        ForEach(repository.baseRefOptions, id: \.self) { option in
-          Text(option).tag(option)
-        }
+        Text("Create Branch").tag(ProjectWorkspaceRepositoryCheckoutMode.createBranch)
+        Text("Use Existing").tag(ProjectWorkspaceRepositoryCheckoutMode.useExistingRef)
       }
       .pickerStyle(.menu)
       .labelsHidden()
-      .frame(maxWidth: .infinity, alignment: .leading)
-      .help("Choose Base Ref")
+      .frame(width: 150)
+      .help("Choose Branch Action")
+      .disabled(store.isCreating)
+
+      if repository.checkoutMode == .createBranch {
+        TextField(
+          "Branch",
+          text: Binding(
+            get: { repository.branchName ?? "" },
+            set: { store.send(.repositoryBranchNameChanged(repository.id, $0)) }
+          )
+        )
+        .textFieldStyle(.roundedBorder)
+        .disabled(store.isCreating)
+      }
+
+      WorkspaceBranchRefPickerView(
+        title: repository.checkoutMode == .createBranch ? "Base ref" : "Existing branch",
+        selection: repository.baseRef,
+        options: repository.baseRefOptions,
+        isDisabled: store.isCreating || repository.baseRefOptions.isEmpty
+      ) { ref in
+        store.send(.repositoryBaseRefChanged(repository.id, ref))
+      }
       .disabled(store.isCreating || repository.baseRefOptions.isEmpty)
+    }
+  }
+
+  @ViewBuilder
+  private func remoteRepositoryPromptView() -> some View {
+    if let prompt = store.remoteRepositoryPrompt {
+      VStack(alignment: .leading, spacing: 16) {
+        Text("Add Remote Repository")
+          .font(.title3)
+
+        VStack(alignment: .leading, spacing: 8) {
+          Text("Remote URL")
+            .foregroundStyle(.secondary)
+          TextField(
+            "git@github.com:owner/repo.git",
+            text: Binding(
+              get: { prompt.url },
+              set: { store.send(.remoteRepositoryPromptURLChanged($0)) }
+            )
+          )
+          .textFieldStyle(.roundedBorder)
+          .font(.body.monospaced())
+          .disabled(prompt.isLoading)
+        }
+
+        VStack(alignment: .leading, spacing: 8) {
+          Text("Name")
+            .foregroundStyle(.secondary)
+          TextField(
+            "Repository name",
+            text: Binding(
+              get: { prompt.name },
+              set: { store.send(.remoteRepositoryPromptNameChanged($0)) }
+            )
+          )
+          .textFieldStyle(.roundedBorder)
+          .disabled(prompt.isLoading)
+        }
+
+        if !prompt.branchOptions.isEmpty {
+          Text("\(prompt.branchOptions.count) remote branches loaded")
+            .font(.footnote)
+            .foregroundStyle(.secondary)
+        }
+
+        if let message = prompt.validationMessage, !message.isEmpty {
+          Text(message)
+            .font(.footnote)
+            .foregroundStyle(.red)
+        }
+
+        HStack {
+          if prompt.isLoading {
+            ProgressView()
+              .controlSize(.small)
+          }
+          Spacer()
+          Button("Cancel") {
+            store.send(.remoteRepositoryPromptDismissed)
+          }
+          .keyboardShortcut(.cancelAction)
+          .help("Cancel (Esc)")
+          .disabled(prompt.isLoading)
+
+          Button("Load") {
+            store.send(.remoteRepositoryPromptLoadButtonTapped)
+          }
+          .help("Load Remote Branches")
+          .disabled(prompt.isLoading || prompt.url.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+
+          Button("Add") {
+            store.send(.remoteRepositoryPromptAddButtonTapped)
+          }
+          .keyboardShortcut(.defaultAction)
+          .help("Add Remote Repository")
+          .disabled(prompt.isLoading || prompt.branchOptions.isEmpty)
+        }
+      }
+      .padding(20)
+      .frame(width: 520)
     }
   }
 
@@ -346,6 +448,105 @@ struct WorkspaceCreationPromptView: View {
       return "Remote URL"
     case .bareRepository:
       return "Bare repository folder"
+    }
+  }
+}
+
+private struct WorkspaceBranchRefPickerView: View {
+  let title: String
+  let selection: String?
+  let options: [GitBranchRefOption]
+  let isDisabled: Bool
+  let onSelect: (String) -> Void
+
+  @State private var isPresented = false
+  @State private var searchText = ""
+
+  var body: some View {
+    Button {
+      isPresented = true
+    } label: {
+      HStack {
+        Text(displayTitle)
+          .lineLimit(1)
+          .truncationMode(.middle)
+        Spacer(minLength: 8)
+        Image(systemName: "chevron.down")
+          .imageScale(.small)
+          .accessibilityHidden(true)
+      }
+      .frame(maxWidth: .infinity, alignment: .leading)
+    }
+    .buttonStyle(.bordered)
+    .help("Choose \(title)")
+    .disabled(isDisabled)
+    .popover(isPresented: $isPresented, arrowEdge: .bottom) {
+      VStack(alignment: .leading, spacing: 10) {
+        TextField("Search branches", text: $searchText)
+          .textFieldStyle(.roundedBorder)
+
+        ScrollView {
+          VStack(alignment: .leading, spacing: 10) {
+            ForEach(groupedOptions, id: \.kind) { group in
+              VStack(alignment: .leading, spacing: 4) {
+                Text(group.kind.title)
+                  .font(.caption)
+                  .foregroundStyle(.secondary)
+                ForEach(group.options) { option in
+                  Button {
+                    onSelect(option.ref)
+                    isPresented = false
+                    searchText = ""
+                  } label: {
+                    HStack {
+                      if option.ref == selection {
+                        Image(systemName: "checkmark")
+                          .frame(width: 14)
+                          .accessibilityHidden(true)
+                      } else {
+                        Color.clear
+                          .frame(width: 14, height: 1)
+                      }
+                      Text(option.ref)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                      Spacer()
+                    }
+                  }
+                  .buttonStyle(.plain)
+                  .padding(.vertical, 3)
+                }
+              }
+            }
+            if groupedOptions.isEmpty {
+              Text("No matching branches")
+                .foregroundStyle(.secondary)
+            }
+          }
+        }
+        .frame(maxHeight: 260)
+      }
+      .padding(14)
+      .frame(width: 420)
+    }
+  }
+
+  private var displayTitle: String {
+    guard let selection, !selection.isEmpty else {
+      return title
+    }
+    return selection
+  }
+
+  private var groupedOptions: [(kind: GitBranchRefKind, options: [GitBranchRefOption])] {
+    let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+    let filtered =
+      query.isEmpty
+      ? options
+      : options.filter { $0.ref.localizedCaseInsensitiveContains(query) }
+    return GitBranchRefKind.allCases.compactMap { kind in
+      let group = filtered.filter { $0.kind == kind }
+      return group.isEmpty ? nil : (kind, group)
     }
   }
 }

--- a/supacode/Features/Repositories/Views/WorkspaceCreationPromptView.swift
+++ b/supacode/Features/Repositories/Views/WorkspaceCreationPromptView.swift
@@ -309,6 +309,28 @@ struct WorkspaceCreationPromptView: View {
           store.send(.repositoryBaseRefChanged(repository.id, ref))
         }
         .disabled(store.isCreating || repository.baseRefOptions.isEmpty)
+
+        if let localBranchName = repository.resettableLocalBranchName {
+          VStack(alignment: .leading, spacing: 4) {
+            Text("Local branch “\(localBranchName)” already exists and would be reset to this ref.")
+              .font(.footnote)
+              .foregroundStyle(.secondary)
+              .fixedSize(horizontal: false, vertical: true)
+            Picker(
+              "Local branch “\(localBranchName)”",
+              selection: Binding(
+                get: { repository.resetLocalBranchToRemote },
+                set: { store.send(.repositoryResetLocalBranchChanged(repository.id, $0)) }
+              )
+            ) {
+              Text("Use local branch").tag(false)
+              Text("Reset to \(repository.baseRef ?? "remote")").tag(true)
+            }
+            .pickerStyle(.radioGroup)
+            .labelsHidden()
+            .disabled(store.isCreating)
+          }
+        }
       }
     }
   }

--- a/supacode/Features/Repositories/Views/WorkspaceCreationPromptView.swift
+++ b/supacode/Features/Repositories/Views/WorkspaceCreationPromptView.swift
@@ -261,6 +261,20 @@ struct WorkspaceCreationPromptView: View {
       )
       .textFieldStyle(.roundedBorder)
       .disabled(store.isCreating)
+
+      Menu {
+        ForEach(repository.baseRefOptions, id: \.self) { option in
+          Button(option) {
+            store.send(.repositoryBaseRefChanged(repository.id, option))
+          }
+        }
+      } label: {
+        Image(systemName: "chevron.down")
+          .accessibilityLabel("Choose Base Ref")
+      }
+      .buttonStyle(.borderless)
+      .help("Choose Base Ref")
+      .disabled(store.isCreating || repository.baseRefOptions.isEmpty)
     }
   }
 
@@ -296,7 +310,7 @@ struct WorkspaceCreationPromptView: View {
       guard response == .OK, let url = panel.url else {
         return
       }
-      store.send(.repositorySourceLocationChanged(repository.id, url.path(percentEncoded: false)))
+      store.send(.repositorySourceChosen(repository.id, url.path(percentEncoded: false)))
     }
   }
 

--- a/supacode/Features/Repositories/Views/WorkspaceCreationPromptView.swift
+++ b/supacode/Features/Repositories/Views/WorkspaceCreationPromptView.swift
@@ -133,8 +133,7 @@ struct WorkspaceCreationPromptView: View {
           store.send(.cancelButtonTapped)
         }
         .keyboardShortcut(.cancelAction)
-        .help("Cancel (Esc)")
-        .disabled(store.isCreating)
+        .help(store.isCreating ? "Cancel creation and roll back (Esc)" : "Cancel (Esc)")
         Button("Create") {
           store.send(.createButtonTapped)
         }
@@ -190,7 +189,7 @@ struct WorkspaceCreationPromptView: View {
           set: { store.send(.repositorySourceKindChanged(repository.id, $0)) }
         )
       ) {
-        ForEach(sourceKinds, id: \.self) { kind in
+        ForEach(sourceKinds(for: repository), id: \.self) { kind in
           Text(sourceKindTitle(kind)).tag(kind)
         }
       }
@@ -272,6 +271,9 @@ struct WorkspaceCreationPromptView: View {
           set: { store.send(.repositoryCheckoutModeChanged(repository.id, $0)) }
         )
       ) {
+        if repository.sourceKind.supportsLinkCheckout {
+          Text("Link").tag(ProjectWorkspaceRepositoryCheckoutMode.link)
+        }
         Text("Create Branch").tag(ProjectWorkspaceRepositoryCheckoutMode.createBranch)
         Text("Use Existing").tag(ProjectWorkspaceRepositoryCheckoutMode.useExistingRef)
       }
@@ -293,16 +295,30 @@ struct WorkspaceCreationPromptView: View {
         .disabled(store.isCreating)
       }
 
-      WorkspaceBranchRefPickerView(
-        title: repository.checkoutMode == .createBranch ? "Base ref" : "Existing branch",
-        selection: repository.baseRef,
-        options: repository.baseRefOptions,
-        isDisabled: store.isCreating || repository.baseRefOptions.isEmpty
-      ) { ref in
-        store.send(.repositoryBaseRefChanged(repository.id, ref))
+      if repository.checkoutMode == .link {
+        Text("Symlink to the repository as it is on disk")
+          .font(.footnote)
+          .foregroundStyle(.secondary)
+      } else {
+        WorkspaceBranchRefPickerView(
+          title: repository.checkoutMode == .createBranch ? "Base ref" : "Existing branch",
+          selection: repository.baseRef,
+          options: repository.baseRefOptions,
+          isDisabled: store.isCreating || repository.baseRefOptions.isEmpty
+        ) { ref in
+          store.send(.repositoryBaseRefChanged(repository.id, ref))
+        }
+        .disabled(store.isCreating || repository.baseRefOptions.isEmpty)
       }
-      .disabled(store.isCreating || repository.baseRefOptions.isEmpty)
     }
+  }
+
+  private func sourceKinds(
+    for repository: ProjectWorkspaceCreationRepository
+  ) -> [ProjectWorkspaceRepositorySourceKind] {
+    repository.sourceKind == .remote
+      ? sourceKinds
+      : sourceKinds.filter { $0 != .remote }
   }
 
   @ViewBuilder

--- a/supacode/Features/Repositories/Views/WorkspaceCreationPromptView.swift
+++ b/supacode/Features/Repositories/Views/WorkspaceCreationPromptView.swift
@@ -5,12 +5,6 @@ import SwiftUI
 struct WorkspaceCreationPromptView: View {
   @Bindable var store: StoreOf<WorkspaceCreationPromptFeature>
   @FocusState private var isTitleFieldFocused: Bool
-  private let sourceKinds: [ProjectWorkspaceRepositorySourceKind] = [
-    .existingPath,
-    .localRepository,
-    .remote,
-    .bareRepository,
-  ]
 
   var body: some View {
     VStack(alignment: .leading, spacing: 16) {
@@ -24,23 +18,43 @@ struct WorkspaceCreationPromptView: View {
       VStack(alignment: .leading, spacing: 8) {
         Text("Title")
           .foregroundStyle(.secondary)
-        TextField("Workspace title", text: $store.title)
-          .textFieldStyle(.roundedBorder)
-          .focused($isTitleFieldFocused)
-          .disabled(store.isCreating)
-          .onSubmit {
-            store.send(.createButtonTapped)
-          }
+        TextField(
+          "Workspace title",
+          text: Binding(
+            get: { store.title },
+            set: { store.send(.titleChanged($0)) }
+          )
+        )
+        .textFieldStyle(.roundedBorder)
+        .focused($isTitleFieldFocused)
+        .disabled(store.isCreating)
+        .overlay {
+          invalidFieldBorder(store.validationTarget == .title)
+        }
+        .onSubmit {
+          store.send(.createButtonTapped)
+        }
+        helpText(
+          "A short name for the shared task folder shown in the sidebar and workspace metadata.")
       }
 
       VStack(alignment: .leading, spacing: 8) {
         Text("Folder")
           .foregroundStyle(.secondary)
         HStack(spacing: 8) {
-          TextField("Workspace folder", text: $store.rootPath)
-            .textFieldStyle(.roundedBorder)
-            .font(.body.monospaced())
-            .disabled(store.isCreating)
+          TextField(
+            "Workspace folder",
+            text: Binding(
+              get: { store.rootPath },
+              set: { store.send(.rootPathChanged($0)) }
+            )
+          )
+          .textFieldStyle(.roundedBorder)
+          .font(.body.monospaced())
+          .disabled(store.isCreating)
+          .overlay {
+            invalidFieldBorder(store.validationTarget == .rootPath)
+          }
           Button {
             chooseFolder()
           } label: {
@@ -55,6 +69,9 @@ struct WorkspaceCreationPromptView: View {
           .lineLimit(1)
           .truncationMode(.middle)
           .textSelection(.enabled)
+        helpText(
+          "Where Prowl creates the workspace root. Until you edit it, this path follows the workspace title."
+        )
       }
 
       VStack(alignment: .leading, spacing: 8) {
@@ -90,22 +107,28 @@ struct WorkspaceCreationPromptView: View {
           }
           .help("Add Local Repository")
           .disabled(store.isCreating)
-
-          Button {
-            chooseRepositorySource(kind: .bareRepository)
-          } label: {
-            Label("Add Bare", systemImage: "externaldrive")
-          }
-          .help("Add Bare Repository")
-          .disabled(store.isCreating)
         }
-        ScrollView {
-          VStack(spacing: 0) {
-            ForEach(store.repositories) { repository in
-              repositoryEditor(repository)
-              if repository.id != store.repositories.last?.id {
-                Divider()
+        helpText(
+          "Add at least two repositories. Opened and local repositories can be linked or materialized as worktrees."
+        )
+        ScrollViewReader { proxy in
+          ScrollView {
+            VStack(spacing: 0) {
+              ForEach(store.repositories) { repository in
+                repositoryEditor(repository)
+                  .id(repository.id)
+                if repository.id != store.repositories.last?.id {
+                  Divider()
+                }
               }
+            }
+          }
+          .onChange(of: store.validationRequestID) { _, _ in
+            guard let repositoryID = validationRepositoryID else {
+              return
+            }
+            withAnimation(.easeInOut(duration: 0.2)) {
+              proxy.scrollTo(repositoryID, anchor: .center)
             }
           }
         }
@@ -182,21 +205,7 @@ struct WorkspaceCreationPromptView: View {
         .fontWeight(.medium)
         .lineLimit(1)
 
-      Picker(
-        "Source",
-        selection: Binding(
-          get: { repository.sourceKind },
-          set: { store.send(.repositorySourceKindChanged(repository.id, $0)) }
-        )
-      ) {
-        ForEach(sourceKinds(for: repository), id: \.self) { kind in
-          Text(sourceKindTitle(kind)).tag(kind)
-        }
-      }
-      .pickerStyle(.menu)
-      .labelsHidden()
-      .frame(width: 150)
-      .disabled(store.isCreating)
+      sourceKindBadge(repository.sourceKind)
 
       Spacer()
 
@@ -212,104 +221,133 @@ struct WorkspaceCreationPromptView: View {
     }
   }
 
-  private func repositoryNameAndPathFields(_ repository: ProjectWorkspaceCreationRepository) -> some View {
+  private func repositoryNameAndPathFields(_ repository: ProjectWorkspaceCreationRepository)
+    -> some View
+  {
     HStack(spacing: 8) {
-      TextField(
-        "Name",
-        text: Binding(
-          get: { repository.name },
-          set: { store.send(.repositoryNameChanged(repository.id, $0)) }
-        )
-      )
-      .textFieldStyle(.roundedBorder)
-      .disabled(store.isCreating)
-
-      TextField(
-        "Workspace path",
-        text: Binding(
-          get: { repository.path ?? "" },
-          set: { store.send(.repositoryPathChanged(repository.id, $0)) }
-        )
-      )
-      .textFieldStyle(.roundedBorder)
-      .disabled(store.isCreating)
-    }
-  }
-
-  private func repositorySourceField(_ repository: ProjectWorkspaceCreationRepository) -> some View {
-    HStack(spacing: 8) {
-      TextField(
-        sourceLocationPlaceholder(repository.sourceKind),
-        text: Binding(
-          get: { repository.sourceLocation },
-          set: { store.send(.repositorySourceLocationChanged(repository.id, $0)) }
-        )
-      )
-      .textFieldStyle(.roundedBorder)
-      .font(.body.monospaced())
-      .disabled(store.isCreating)
-
-      if repository.sourceKind != .remote {
-        Button {
-          chooseSource(for: repository)
-        } label: {
-          Image(systemName: "folder")
-            .accessibilityLabel("Choose Repository Source")
-        }
-        .help("Choose Repository Source")
-        .disabled(store.isCreating)
-      }
-    }
-  }
-
-  private func repositoryBranchFields(_ repository: ProjectWorkspaceCreationRepository) -> some View {
-    HStack(spacing: 8) {
-      Picker(
-        "Branch action",
-        selection: Binding(
-          get: { repository.checkoutMode },
-          set: { store.send(.repositoryCheckoutModeChanged(repository.id, $0)) }
-        )
-      ) {
-        if repository.sourceKind.supportsLinkCheckout {
-          Text("Link").tag(ProjectWorkspaceRepositoryCheckoutMode.link)
-        }
-        Text("Create Branch").tag(ProjectWorkspaceRepositoryCheckoutMode.createBranch)
-        Text("Use Existing").tag(ProjectWorkspaceRepositoryCheckoutMode.useExistingRef)
-      }
-      .pickerStyle(.menu)
-      .labelsHidden()
-      .frame(width: 150)
-      .help("Choose Branch Action")
-      .disabled(store.isCreating)
-
-      if repository.checkoutMode == .createBranch {
+      VStack(alignment: .leading, spacing: 4) {
+        Text("Name")
+          .foregroundStyle(.secondary)
         TextField(
-          "Branch",
+          "Repository name",
           text: Binding(
-            get: { repository.branchName ?? "" },
-            set: { store.send(.repositoryBranchNameChanged(repository.id, $0)) }
+            get: { repository.name },
+            set: { store.send(.repositoryNameChanged(repository.id, $0)) }
           )
         )
         .textFieldStyle(.roundedBorder)
         .disabled(store.isCreating)
+        .overlay {
+          invalidFieldBorder(repositoryFieldIsInvalid(repository, .name))
+        }
+        helpText("Display name for this repository in the workspace metadata.")
       }
 
-      if repository.checkoutMode == .link {
-        Text("Symlink to the repository as it is on disk")
-          .font(.footnote)
+      VStack(alignment: .leading, spacing: 4) {
+        Text("Folder inside workspace")
           .foregroundStyle(.secondary)
-      } else {
-        WorkspaceBranchRefPickerView(
-          title: repository.checkoutMode == .createBranch ? "Base ref" : "Existing branch",
-          selection: repository.baseRef,
-          options: repository.baseRefOptions,
-          isDisabled: store.isCreating || repository.baseRefOptions.isEmpty
-        ) { ref in
-          store.send(.repositoryBaseRefChanged(repository.id, ref))
-        }
-        .disabled(store.isCreating || repository.baseRefOptions.isEmpty)
+        TextField(
+          "Folder name",
+          text: Binding(
+            get: { repository.path ?? "" },
+            set: { store.send(.repositoryPathChanged(repository.id, $0)) }
+          )
+        )
+        .textFieldStyle(.roundedBorder)
+        .disabled(store.isCreating)
+        helpText(
+          "Destination folder under the workspace root. It does not change the original source path."
+        )
+      }
+    }
+  }
 
+  private func repositorySourceField(_ repository: ProjectWorkspaceCreationRepository) -> some View {
+    VStack(alignment: .leading, spacing: 4) {
+      HStack(spacing: 8) {
+        TextField(
+          sourceLocationPlaceholder(repository.sourceKind),
+          text: Binding(
+            get: { repository.sourceLocation },
+            set: { store.send(.repositorySourceLocationChanged(repository.id, $0)) }
+          )
+        )
+        .textFieldStyle(.roundedBorder)
+        .font(.body.monospaced())
+        .disabled(store.isCreating)
+        .overlay {
+          invalidFieldBorder(repositoryFieldIsInvalid(repository, .source))
+        }
+
+        if repository.sourceKind != .remote {
+          Button {
+            chooseSource(for: repository)
+          } label: {
+            Image(systemName: "folder")
+              .accessibilityLabel("Choose Repository Source")
+          }
+          .help("Choose Repository Source")
+          .disabled(store.isCreating)
+        }
+      }
+      helpText(sourceLocationHelpText(repository.sourceKind))
+    }
+  }
+
+  private func repositoryBranchFields(_ repository: ProjectWorkspaceCreationRepository) -> some View {
+    VStack(alignment: .leading, spacing: 4) {
+      HStack(spacing: 8) {
+        Picker(
+          "Branch action",
+          selection: Binding(
+            get: { repository.checkoutMode },
+            set: { store.send(.repositoryCheckoutModeChanged(repository.id, $0)) }
+          )
+        ) {
+          if repository.sourceKind.supportsLinkCheckout {
+            Text("Link").tag(ProjectWorkspaceRepositoryCheckoutMode.link)
+          }
+          Text("Create Branch").tag(ProjectWorkspaceRepositoryCheckoutMode.createBranch)
+          Text("Use Existing").tag(ProjectWorkspaceRepositoryCheckoutMode.useExistingRef)
+        }
+        .pickerStyle(.menu)
+        .labelsHidden()
+        .frame(width: 150)
+        .help("Choose Branch Action")
+        .disabled(store.isCreating)
+
+        if repository.checkoutMode == .createBranch {
+          TextField(
+            "Branch",
+            text: Binding(
+              get: { repository.branchName ?? "" },
+              set: { store.send(.repositoryBranchNameChanged(repository.id, $0)) }
+            )
+          )
+          .textFieldStyle(.roundedBorder)
+          .disabled(store.isCreating)
+          .overlay {
+            invalidFieldBorder(repositoryFieldIsInvalid(repository, .branchName))
+          }
+        }
+
+        if repository.checkoutMode != .link {
+          WorkspaceBranchRefPickerView(
+            title: repository.checkoutMode == .createBranch ? "Base ref" : "Existing branch",
+            selection: repository.baseRef,
+            options: repository.baseRefOptions,
+            isDisabled: store.isCreating || repository.baseRefOptions.isEmpty,
+            isInvalid: repositoryFieldIsInvalid(repository, .baseRef)
+          ) { ref in
+            store.send(.repositoryBaseRefChanged(repository.id, ref))
+          }
+          .disabled(store.isCreating || repository.baseRefOptions.isEmpty)
+        }
+      }
+
+      helpText(branchActionHelpText(repository))
+
+      if repository.checkoutMode != .link {
         if let localBranchName = repository.resettableLocalBranchName {
           VStack(alignment: .leading, spacing: 4) {
             Text("Local branch “\(localBranchName)” already exists and would be reset to this ref.")
@@ -335,14 +373,6 @@ struct WorkspaceCreationPromptView: View {
     }
   }
 
-  private func sourceKinds(
-    for repository: ProjectWorkspaceCreationRepository
-  ) -> [ProjectWorkspaceRepositorySourceKind] {
-    repository.sourceKind == .remote
-      ? sourceKinds
-      : sourceKinds.filter { $0 != .remote }
-  }
-
   @ViewBuilder
   private func remoteRepositoryPromptView() -> some View {
     if let prompt = store.remoteRepositoryPrompt {
@@ -363,6 +393,7 @@ struct WorkspaceCreationPromptView: View {
           .textFieldStyle(.roundedBorder)
           .font(.body.monospaced())
           .disabled(prompt.isLoading)
+          helpText("Remote git URL to clone into the workspace, such as SSH or HTTPS.")
         }
 
         VStack(alignment: .leading, spacing: 8) {
@@ -377,12 +408,15 @@ struct WorkspaceCreationPromptView: View {
           )
           .textFieldStyle(.roundedBorder)
           .disabled(prompt.isLoading)
+          helpText("Display name and default folder name for this remote repository.")
         }
 
         if !prompt.branchOptions.isEmpty {
           Text("\(prompt.branchOptions.count) remote branches loaded")
             .font(.footnote)
             .foregroundStyle(.secondary)
+        } else {
+          helpText("Load branches before adding so Prowl can choose an existing branch safely.")
         }
 
         if let message = prompt.validationMessage, !message.isEmpty {
@@ -402,13 +436,13 @@ struct WorkspaceCreationPromptView: View {
           }
           .keyboardShortcut(.cancelAction)
           .help("Cancel (Esc)")
-          .disabled(prompt.isLoading)
 
           Button("Load") {
             store.send(.remoteRepositoryPromptLoadButtonTapped)
           }
           .help("Load Remote Branches")
-          .disabled(prompt.isLoading || prompt.url.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+          .disabled(
+            prompt.isLoading || prompt.url.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
 
           Button("Add") {
             store.send(.remoteRepositoryPromptAddButtonTapped)
@@ -450,7 +484,8 @@ struct WorkspaceCreationPromptView: View {
   }
 
   private func chooseSource(for repository: ProjectWorkspaceCreationRepository) {
-    let panel = repositorySourcePanel(kind: repository.sourceKind, currentPath: repository.sourceLocation)
+    let panel = repositorySourcePanel(
+      kind: repository.sourceKind, currentPath: repository.sourceLocation)
     panel.begin { response in
       guard response == .OK, let url = panel.url else {
         return
@@ -472,21 +507,57 @@ struct WorkspaceCreationPromptView: View {
     if let currentPath, !currentPath.isEmpty {
       panel.directoryURL = URL(filePath: currentPath).deletingLastPathComponent()
     }
-    panel.message = kind == .bareRepository ? "Choose a bare repository folder" : "Choose a repository folder"
+    panel.message =
+      kind == .bareRepository ? "Choose a bare repository folder" : "Choose a repository folder"
     return panel
   }
 
   private func sourceKindTitle(_ kind: ProjectWorkspaceRepositorySourceKind) -> String {
     switch kind {
     case .existingPath:
-      return "Opened Path"
+      return "Opened in Prowl"
     case .localRepository:
-      return "Local Repo"
+      return "Picked from Disk"
     case .remote:
       return "Remote Clone"
     case .bareRepository:
       return "Bare Worktree"
     }
+  }
+
+  private func sourceKindIcon(_ kind: ProjectWorkspaceRepositorySourceKind) -> String {
+    switch kind {
+    case .existingPath:
+      return "folder.badge.plus"
+    case .localRepository:
+      return "folder"
+    case .remote:
+      return "network"
+    case .bareRepository:
+      return "externaldrive"
+    }
+  }
+
+  private func sourceKindBadgeHelp(_ kind: ProjectWorkspaceRepositorySourceKind) -> String {
+    switch kind {
+    case .existingPath:
+      return "Added from repositories already opened in Prowl."
+    case .localRepository:
+      return "Added by choosing a repository folder from disk."
+    case .remote:
+      return "Added from a remote URL and cloned into the workspace."
+    case .bareRepository:
+      return "Added from a local bare repository."
+    }
+  }
+
+  private func sourceKindBadge(_ kind: ProjectWorkspaceRepositorySourceKind) -> some View {
+    Label(sourceKindTitle(kind), systemImage: sourceKindIcon(kind))
+      .font(.caption)
+      .foregroundStyle(.secondary)
+      .labelStyle(.titleAndIcon)
+      .lineLimit(1)
+      .help(sourceKindBadgeHelp(kind))
   }
 
   private func sourceLocationPlaceholder(_ kind: ProjectWorkspaceRepositorySourceKind) -> String {
@@ -499,6 +570,68 @@ struct WorkspaceCreationPromptView: View {
       return "Bare repository folder"
     }
   }
+
+  private func sourceLocationHelpText(_ kind: ProjectWorkspaceRepositorySourceKind) -> String {
+    switch kind {
+    case .existingPath:
+      return
+        "Existing opened repository path. Link keeps using this checkout; "
+        + "branch actions create workspace worktrees from it."
+    case .localRepository:
+      return
+        "Local repository folder on disk. It can be linked as-is or used as the source for a workspace worktree."
+    case .remote:
+      return "Remote URL cloned into the workspace folder after branches are loaded."
+    case .bareRepository:
+      return "Advanced source: a local bare repository used only for git worktree materialization."
+    }
+  }
+
+  private func branchActionHelpText(_ repository: ProjectWorkspaceCreationRepository) -> String {
+    switch repository.checkoutMode {
+    case .link:
+      return
+        "Link adds a symlink to the source checkout, so workspace edits affect the original folder directly."
+    case .createBranch:
+      return
+        "Create Branch materializes an isolated checkout on a new branch from the selected base ref."
+    case .useExistingRef:
+      if repository.resettableLocalBranchName != nil {
+        return
+          "Use Existing checks out the selected branch. "
+          + "If a matching local branch already exists, choose whether to keep or reset it."
+      }
+      return
+        "Use Existing checks out the selected local branch or creates a local tracking branch from a remote ref."
+    }
+  }
+
+  private func helpText(_ text: String) -> some View {
+    Text(text)
+      .font(.footnote)
+      .foregroundStyle(.secondary)
+      .fixedSize(horizontal: false, vertical: true)
+  }
+
+  private var validationRepositoryID: Repository.ID? {
+    guard case .repository(let repositoryID, _) = store.validationTarget else {
+      return nil
+    }
+    return repositoryID
+  }
+
+  private func repositoryFieldIsInvalid(
+    _ repository: ProjectWorkspaceCreationRepository,
+    _ field: WorkspaceCreationPromptFeature.RepositoryField
+  ) -> Bool {
+    store.validationTarget == .repository(repository.id, field)
+  }
+
+  private func invalidFieldBorder(_ isInvalid: Bool) -> some View {
+    RoundedRectangle(cornerRadius: 5)
+      .stroke(isInvalid ? Color.red : Color.clear, lineWidth: isInvalid ? 1.5 : 0)
+      .allowsHitTesting(false)
+  }
 }
 
 private struct WorkspaceBranchRefPickerView: View {
@@ -506,6 +639,7 @@ private struct WorkspaceBranchRefPickerView: View {
   let selection: String?
   let options: [GitBranchRefOption]
   let isDisabled: Bool
+  let isInvalid: Bool
   let onSelect: (String) -> Void
 
   @State private var isPresented = false
@@ -527,6 +661,9 @@ private struct WorkspaceBranchRefPickerView: View {
       .frame(maxWidth: .infinity, alignment: .leading)
     }
     .buttonStyle(.bordered)
+    .overlay {
+      invalidFieldBorder
+    }
     .help("Choose \(title)")
     .disabled(isDisabled)
     .popover(isPresented: $isPresented, arrowEdge: .bottom) {
@@ -585,6 +722,12 @@ private struct WorkspaceBranchRefPickerView: View {
       return title
     }
     return selection
+  }
+
+  private var invalidFieldBorder: some View {
+    RoundedRectangle(cornerRadius: 5)
+      .stroke(isInvalid ? Color.red : Color.clear, lineWidth: isInvalid ? 1.5 : 0)
+      .allowsHitTesting(false)
   }
 
   private var groupedOptions: [(kind: GitBranchRefKind, options: [GitBranchRefOption])] {

--- a/supacode/Features/Repositories/Views/WorkspaceCreationPromptView.swift
+++ b/supacode/Features/Repositories/Views/WorkspaceCreationPromptView.swift
@@ -1,0 +1,153 @@
+import AppKit
+import ComposableArchitecture
+import SwiftUI
+
+struct WorkspaceCreationPromptView: View {
+  @Bindable var store: StoreOf<WorkspaceCreationPromptFeature>
+  @FocusState private var isTitleFieldFocused: Bool
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 16) {
+      VStack(alignment: .leading, spacing: 4) {
+        Text("New Workspace")
+          .font(.title3)
+        Text("\(store.selectedRepositoryCount) of \(store.candidates.count) repositories selected")
+          .foregroundStyle(.secondary)
+      }
+
+      VStack(alignment: .leading, spacing: 8) {
+        Text("Title")
+          .foregroundStyle(.secondary)
+        TextField("Workspace title", text: $store.title)
+          .textFieldStyle(.roundedBorder)
+          .focused($isTitleFieldFocused)
+          .disabled(store.isCreating)
+          .onSubmit {
+            store.send(.createButtonTapped)
+          }
+      }
+
+      VStack(alignment: .leading, spacing: 8) {
+        Text("Folder")
+          .foregroundStyle(.secondary)
+        HStack(spacing: 8) {
+          TextField("Workspace folder", text: $store.rootPath)
+            .textFieldStyle(.roundedBorder)
+            .font(.body.monospaced())
+            .disabled(store.isCreating)
+          Button {
+            chooseFolder()
+          } label: {
+            Label("Choose Folder", systemImage: "folder")
+          }
+          .help("Choose Workspace Folder")
+          .disabled(store.isCreating)
+        }
+        Text(store.rootPathPreview)
+          .font(.footnote.monospaced())
+          .foregroundStyle(.secondary)
+          .lineLimit(1)
+          .truncationMode(.middle)
+          .textSelection(.enabled)
+      }
+
+      VStack(alignment: .leading, spacing: 8) {
+        Text("Repositories")
+          .foregroundStyle(.secondary)
+        ScrollView {
+          VStack(spacing: 0) {
+            ForEach(store.candidates) { repository in
+              repositoryToggle(repository)
+              if repository.id != store.candidates.last?.id {
+                Divider()
+              }
+            }
+          }
+        }
+        .frame(maxHeight: 220)
+        .clipShape(.rect(cornerRadius: 8))
+        .overlay {
+          RoundedRectangle(cornerRadius: 8)
+            .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
+        }
+      }
+
+      if let message = store.validationMessage, !message.isEmpty {
+        Text(message)
+          .font(.footnote)
+          .foregroundStyle(.red)
+      }
+
+      HStack {
+        if store.isCreating {
+          ProgressView()
+            .controlSize(.small)
+        }
+        Spacer()
+        Button("Cancel") {
+          store.send(.cancelButtonTapped)
+        }
+        .keyboardShortcut(.cancelAction)
+        .help("Cancel (Esc)")
+        .disabled(store.isCreating)
+        Button("Create") {
+          store.send(.createButtonTapped)
+        }
+        .keyboardShortcut(.defaultAction)
+        .help("Create Workspace (↩)")
+        .disabled(store.isCreating)
+      }
+    }
+    .padding(20)
+    .frame(minWidth: 520)
+    .task {
+      isTitleFieldFocused = true
+    }
+  }
+
+  private func repositoryToggle(_ repository: ProjectWorkspaceCreationRepository) -> some View {
+    Toggle(
+      isOn: Binding(
+        get: { store.selectedRepositoryIDs.contains(repository.id) },
+        set: { store.send(.repositorySelectionChanged(repository.id, $0)) }
+      )
+    ) {
+      VStack(alignment: .leading, spacing: 3) {
+        HStack(spacing: 6) {
+          Text(repository.name)
+            .fontWeight(.medium)
+          if let branchName = repository.branchName {
+            Text(branchName)
+              .font(.caption.monospaced())
+              .foregroundStyle(.secondary)
+          }
+        }
+        Text(repository.rootURL.path(percentEncoded: false))
+          .font(.caption.monospaced())
+          .foregroundStyle(.secondary)
+          .lineLimit(1)
+          .truncationMode(.middle)
+      }
+      .frame(maxWidth: .infinity, alignment: .leading)
+    }
+    .toggleStyle(.checkbox)
+    .padding(.horizontal, 10)
+    .padding(.vertical, 8)
+  }
+
+  private func chooseFolder() {
+    let panel = NSOpenPanel()
+    panel.canChooseFiles = false
+    panel.canChooseDirectories = true
+    panel.canCreateDirectories = true
+    panel.allowsMultipleSelection = false
+    panel.prompt = "Choose"
+    panel.directoryURL = URL(filePath: store.rootPath).deletingLastPathComponent()
+    panel.begin { response in
+      guard response == .OK, let url = panel.url else {
+        return
+      }
+      store.send(.rootPathChosen(url.path(percentEncoded: false)))
+    }
+  }
+}

--- a/supacode/Features/Repositories/Views/WorkspaceCreationPromptView.swift
+++ b/supacode/Features/Repositories/Views/WorkspaceCreationPromptView.swift
@@ -5,13 +5,19 @@ import SwiftUI
 struct WorkspaceCreationPromptView: View {
   @Bindable var store: StoreOf<WorkspaceCreationPromptFeature>
   @FocusState private var isTitleFieldFocused: Bool
+  private let sourceKinds: [ProjectWorkspaceRepositorySourceKind] = [
+    .existingPath,
+    .localRepository,
+    .remote,
+    .bareRepository,
+  ]
 
   var body: some View {
     VStack(alignment: .leading, spacing: 16) {
       VStack(alignment: .leading, spacing: 4) {
         Text("New Workspace")
           .font(.title3)
-        Text("\(store.selectedRepositoryCount) of \(store.candidates.count) repositories selected")
+        Text("\(store.selectedRepositoryCount) of \(store.repositories.count) repositories selected")
           .foregroundStyle(.secondary)
       }
 
@@ -54,17 +60,42 @@ struct WorkspaceCreationPromptView: View {
       VStack(alignment: .leading, spacing: 8) {
         Text("Repositories")
           .foregroundStyle(.secondary)
+        HStack(spacing: 8) {
+          Button {
+            store.send(.addBlankRepository(.remote))
+          } label: {
+            Label("Add Remote", systemImage: "network")
+          }
+          .help("Add Remote Repository")
+          .disabled(store.isCreating)
+
+          Button {
+            chooseRepositorySource(kind: .localRepository)
+          } label: {
+            Label("Add Local", systemImage: "folder")
+          }
+          .help("Add Local Repository")
+          .disabled(store.isCreating)
+
+          Button {
+            chooseRepositorySource(kind: .bareRepository)
+          } label: {
+            Label("Add Bare", systemImage: "externaldrive")
+          }
+          .help("Add Bare Repository")
+          .disabled(store.isCreating)
+        }
         ScrollView {
           VStack(spacing: 0) {
-            ForEach(store.candidates) { repository in
-              repositoryToggle(repository)
-              if repository.id != store.candidates.last?.id {
+            ForEach(store.repositories) { repository in
+              repositoryEditor(repository)
+              if repository.id != store.repositories.last?.id {
                 Divider()
               }
             }
           }
         }
-        .frame(maxHeight: 220)
+        .frame(maxHeight: 340)
         .clipShape(.rect(cornerRadius: 8))
         .overlay {
           RoundedRectangle(cornerRadius: 8)
@@ -99,40 +130,138 @@ struct WorkspaceCreationPromptView: View {
       }
     }
     .padding(20)
-    .frame(minWidth: 520)
+    .frame(minWidth: 680)
     .task {
       isTitleFieldFocused = true
     }
   }
 
-  private func repositoryToggle(_ repository: ProjectWorkspaceCreationRepository) -> some View {
-    Toggle(
-      isOn: Binding(
-        get: { store.selectedRepositoryIDs.contains(repository.id) },
-        set: { store.send(.repositorySelectionChanged(repository.id, $0)) }
-      )
-    ) {
-      VStack(alignment: .leading, spacing: 3) {
-        HStack(spacing: 6) {
-          Text(repository.name)
-            .fontWeight(.medium)
-          if let branchName = repository.branchName {
-            Text(branchName)
-              .font(.caption.monospaced())
-              .foregroundStyle(.secondary)
-          }
-        }
-        Text(repository.rootURL.path(percentEncoded: false))
-          .font(.caption.monospaced())
-          .foregroundStyle(.secondary)
-          .lineLimit(1)
-          .truncationMode(.middle)
-      }
-      .frame(maxWidth: .infinity, alignment: .leading)
+  private func repositoryEditor(_ repository: ProjectWorkspaceCreationRepository) -> some View {
+    VStack(alignment: .leading, spacing: 10) {
+      repositoryHeader(repository)
+      repositoryNameAndPathFields(repository)
+      repositorySourceField(repository)
+      repositoryBranchFields(repository)
     }
-    .toggleStyle(.checkbox)
     .padding(.horizontal, 10)
-    .padding(.vertical, 8)
+    .padding(.vertical, 10)
+  }
+
+  private func repositoryHeader(_ repository: ProjectWorkspaceCreationRepository) -> some View {
+    HStack(spacing: 10) {
+      Toggle(
+        isOn: Binding(
+          get: { store.selectedRepositoryIDs.contains(repository.id) },
+          set: { store.send(.repositorySelectionChanged(repository.id, $0)) }
+        )
+      ) {
+        Text(repository.name.isEmpty ? "Repository" : repository.name)
+          .fontWeight(.medium)
+      }
+      .toggleStyle(.checkbox)
+
+      Picker(
+        "Source",
+        selection: Binding(
+          get: { repository.sourceKind },
+          set: { store.send(.repositorySourceKindChanged(repository.id, $0)) }
+        )
+      ) {
+        ForEach(sourceKinds, id: \.self) { kind in
+          Text(sourceKindTitle(kind)).tag(kind)
+        }
+      }
+      .pickerStyle(.menu)
+      .labelsHidden()
+      .frame(width: 150)
+      .disabled(store.isCreating)
+
+      Spacer()
+
+      Button {
+        store.send(.removeRepository(repository.id))
+      } label: {
+        Image(systemName: "trash")
+          .accessibilityLabel("Remove Repository")
+      }
+      .buttonStyle(.borderless)
+      .help("Remove Repository")
+      .disabled(store.isCreating)
+    }
+  }
+
+  private func repositoryNameAndPathFields(_ repository: ProjectWorkspaceCreationRepository) -> some View {
+    HStack(spacing: 8) {
+      TextField(
+        "Name",
+        text: Binding(
+          get: { repository.name },
+          set: { store.send(.repositoryNameChanged(repository.id, $0)) }
+        )
+      )
+      .textFieldStyle(.roundedBorder)
+      .disabled(store.isCreating)
+
+      TextField(
+        "Workspace path",
+        text: Binding(
+          get: { repository.path ?? "" },
+          set: { store.send(.repositoryPathChanged(repository.id, $0)) }
+        )
+      )
+      .textFieldStyle(.roundedBorder)
+      .disabled(store.isCreating)
+    }
+  }
+
+  private func repositorySourceField(_ repository: ProjectWorkspaceCreationRepository) -> some View {
+    HStack(spacing: 8) {
+      TextField(
+        sourceLocationPlaceholder(repository.sourceKind),
+        text: Binding(
+          get: { repository.sourceLocation },
+          set: { store.send(.repositorySourceLocationChanged(repository.id, $0)) }
+        )
+      )
+      .textFieldStyle(.roundedBorder)
+      .font(.body.monospaced())
+      .disabled(store.isCreating)
+
+      if repository.sourceKind != .remote {
+        Button {
+          chooseSource(for: repository)
+        } label: {
+          Image(systemName: "folder")
+            .accessibilityLabel("Choose Repository Source")
+        }
+        .help("Choose Repository Source")
+        .disabled(store.isCreating)
+      }
+    }
+  }
+
+  private func repositoryBranchFields(_ repository: ProjectWorkspaceCreationRepository) -> some View {
+    HStack(spacing: 8) {
+      TextField(
+        "Branch",
+        text: Binding(
+          get: { repository.branchName ?? "" },
+          set: { store.send(.repositoryBranchNameChanged(repository.id, $0)) }
+        )
+      )
+      .textFieldStyle(.roundedBorder)
+      .disabled(store.isCreating)
+
+      TextField(
+        "Base ref",
+        text: Binding(
+          get: { repository.baseRef ?? "" },
+          set: { store.send(.repositoryBaseRefChanged(repository.id, $0)) }
+        )
+      )
+      .textFieldStyle(.roundedBorder)
+      .disabled(store.isCreating)
+    }
   }
 
   private func chooseFolder() {
@@ -148,6 +277,67 @@ struct WorkspaceCreationPromptView: View {
         return
       }
       store.send(.rootPathChosen(url.path(percentEncoded: false)))
+    }
+  }
+
+  private func chooseRepositorySource(kind: ProjectWorkspaceRepositorySourceKind) {
+    let panel = repositorySourcePanel(kind: kind, currentPath: nil)
+    panel.begin { response in
+      guard response == .OK, let url = panel.url else {
+        return
+      }
+      store.send(.addRepositoryFromURL(kind, url.path(percentEncoded: false)))
+    }
+  }
+
+  private func chooseSource(for repository: ProjectWorkspaceCreationRepository) {
+    let panel = repositorySourcePanel(kind: repository.sourceKind, currentPath: repository.sourceLocation)
+    panel.begin { response in
+      guard response == .OK, let url = panel.url else {
+        return
+      }
+      store.send(.repositorySourceLocationChanged(repository.id, url.path(percentEncoded: false)))
+    }
+  }
+
+  private func repositorySourcePanel(
+    kind: ProjectWorkspaceRepositorySourceKind,
+    currentPath: String?
+  ) -> NSOpenPanel {
+    let panel = NSOpenPanel()
+    panel.canChooseFiles = false
+    panel.canChooseDirectories = true
+    panel.canCreateDirectories = false
+    panel.allowsMultipleSelection = false
+    panel.prompt = "Choose"
+    if let currentPath, !currentPath.isEmpty {
+      panel.directoryURL = URL(filePath: currentPath).deletingLastPathComponent()
+    }
+    panel.message = kind == .bareRepository ? "Choose a bare repository folder" : "Choose a repository folder"
+    return panel
+  }
+
+  private func sourceKindTitle(_ kind: ProjectWorkspaceRepositorySourceKind) -> String {
+    switch kind {
+    case .existingPath:
+      return "Opened Path"
+    case .localRepository:
+      return "Local Repo"
+    case .remote:
+      return "Remote Clone"
+    case .bareRepository:
+      return "Bare Worktree"
+    }
+  }
+
+  private func sourceLocationPlaceholder(_ kind: ProjectWorkspaceRepositorySourceKind) -> String {
+    switch kind {
+    case .existingPath, .localRepository:
+      return "Repository folder"
+    case .remote:
+      return "Remote URL"
+    case .bareRepository:
+      return "Bare repository folder"
     }
   }
 }

--- a/supacode/Features/Repositories/Views/WorkspaceCreationPromptView.swift
+++ b/supacode/Features/Repositories/Views/WorkspaceCreationPromptView.swift
@@ -252,27 +252,21 @@ struct WorkspaceCreationPromptView: View {
       .textFieldStyle(.roundedBorder)
       .disabled(store.isCreating)
 
-      TextField(
+      Picker(
         "Base ref",
-        text: Binding(
+        selection: Binding(
           get: { repository.baseRef ?? "" },
           set: { store.send(.repositoryBaseRefChanged(repository.id, $0)) }
         )
-      )
-      .textFieldStyle(.roundedBorder)
-      .disabled(store.isCreating)
-
-      Menu {
+      ) {
+        Text("Base ref").tag("")
         ForEach(repository.baseRefOptions, id: \.self) { option in
-          Button(option) {
-            store.send(.repositoryBaseRefChanged(repository.id, option))
-          }
+          Text(option).tag(option)
         }
-      } label: {
-        Image(systemName: "chevron.down")
-          .accessibilityLabel("Choose Base Ref")
       }
-      .buttonStyle(.borderless)
+      .pickerStyle(.menu)
+      .labelsHidden()
+      .frame(maxWidth: .infinity, alignment: .leading)
       .help("Choose Base Ref")
       .disabled(store.isCreating || repository.baseRefOptions.isEmpty)
     }

--- a/supacode/Features/Repositories/Views/WorkspaceDetailView.swift
+++ b/supacode/Features/Repositories/Views/WorkspaceDetailView.swift
@@ -1,0 +1,107 @@
+import SwiftUI
+
+struct WorkspaceDetailView: View {
+  let repository: Repository
+  let workspace: ProjectWorkspace
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 18) {
+      header
+      if !workspace.description.isEmpty {
+        Text(workspace.description)
+          .font(.callout)
+          .foregroundStyle(.secondary)
+          .textSelection(.enabled)
+      }
+      if !workspace.taskLinks.isEmpty {
+        taskLinks
+      }
+      repositoriesTable
+      Spacer(minLength: 0)
+    }
+    .padding(24)
+    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    .background(Color(nsColor: .windowBackgroundColor))
+  }
+
+  private var header: some View {
+    HStack(alignment: .top, spacing: 12) {
+      Image(systemName: "folder.badge.person.crop")
+        .font(.largeTitle)
+        .foregroundStyle(.secondary)
+        .accessibilityHidden(true)
+      VStack(alignment: .leading, spacing: 4) {
+        Text(workspace.title)
+          .font(.title3.weight(.semibold))
+          .textSelection(.enabled)
+        Text(repository.rootURL.path(percentEncoded: false))
+          .font(.subheadline.monospaced())
+          .foregroundStyle(.secondary)
+          .textSelection(.enabled)
+        Text("\(workspace.repositories.count) repositories")
+          .font(.subheadline)
+          .foregroundStyle(.tertiary)
+      }
+    }
+  }
+
+  private var taskLinks: some View {
+    VStack(alignment: .leading, spacing: 6) {
+      Text("Task Links")
+        .font(.headline)
+      ForEach(workspace.taskLinks, id: \.self) { link in
+        Text(link)
+          .font(.subheadline.monospaced())
+          .foregroundStyle(.secondary)
+          .textSelection(.enabled)
+      }
+    }
+  }
+
+  private var repositoriesTable: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      Text("Repositories")
+        .font(.headline)
+      if workspace.repositories.isEmpty {
+        Text("No repositories are declared in this workspace metadata.")
+          .font(.callout)
+          .foregroundStyle(.secondary)
+      } else {
+        Grid(alignment: .leading, horizontalSpacing: 16, verticalSpacing: 8) {
+          GridRow {
+            tableHeader("Name")
+            tableHeader("Role")
+            tableHeader("Branch")
+            tableHeader("Path")
+          }
+          Divider()
+            .gridCellUnsizedAxes(.horizontal)
+          ForEach(workspace.repositories) { entry in
+            GridRow(alignment: .firstTextBaseline) {
+              Text(entry.name)
+                .font(.subheadline.weight(.medium))
+              Text(entry.role ?? " ")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+              Text(entry.branchName ?? entry.baseRef ?? " ")
+                .font(.subheadline.monospaced())
+                .foregroundStyle(.secondary)
+              Text(entry.resolvedURL(relativeTo: repository.rootURL).path(percentEncoded: false))
+                .font(.subheadline.monospaced())
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .truncationMode(.middle)
+                .textSelection(.enabled)
+            }
+          }
+        }
+      }
+    }
+  }
+
+  private func tableHeader(_ title: String) -> some View {
+    Text(title)
+      .font(.caption.weight(.semibold))
+      .foregroundStyle(.tertiary)
+  }
+}

--- a/supacode/Features/Repositories/Views/WorkspaceDetailView.swift
+++ b/supacode/Features/Repositories/Views/WorkspaceDetailView.swift
@@ -38,11 +38,16 @@ struct WorkspaceDetailView: View {
           .font(.subheadline.monospaced())
           .foregroundStyle(.secondary)
           .textSelection(.enabled)
-        Text("\(workspace.repositories.count) repositories")
+        Text(repositoryCountText)
           .font(.subheadline)
           .foregroundStyle(.tertiary)
       }
     }
+  }
+
+  private var repositoryCountText: String {
+    workspace.repositories.count == 1
+      ? "1 repository" : "\(workspace.repositories.count) repositories"
   }
 
   private var taskLinks: some View {

--- a/supacode/Features/Repositories/Views/WorkspaceDetailView.swift
+++ b/supacode/Features/Repositories/Views/WorkspaceDetailView.swift
@@ -62,46 +62,7 @@ struct WorkspaceDetailView: View {
     VStack(alignment: .leading, spacing: 8) {
       Text("Repositories")
         .font(.headline)
-      if workspace.repositories.isEmpty {
-        Text("No repositories are declared in this workspace metadata.")
-          .font(.callout)
-          .foregroundStyle(.secondary)
-      } else {
-        Grid(alignment: .leading, horizontalSpacing: 16, verticalSpacing: 8) {
-          GridRow {
-            tableHeader("Name")
-            tableHeader("Role")
-            tableHeader("Branch")
-            tableHeader("Path")
-          }
-          Divider()
-            .gridCellUnsizedAxes(.horizontal)
-          ForEach(workspace.repositories) { entry in
-            GridRow(alignment: .firstTextBaseline) {
-              Text(entry.name)
-                .font(.subheadline.weight(.medium))
-              Text(entry.role ?? " ")
-                .font(.subheadline)
-                .foregroundStyle(.secondary)
-              Text(entry.branchName ?? entry.baseRef ?? " ")
-                .font(.subheadline.monospaced())
-                .foregroundStyle(.secondary)
-              Text(entry.resolvedURL(relativeTo: repository.rootURL).path(percentEncoded: false))
-                .font(.subheadline.monospaced())
-                .foregroundStyle(.secondary)
-                .lineLimit(1)
-                .truncationMode(.middle)
-                .textSelection(.enabled)
-            }
-          }
-        }
-      }
+      WorkspaceRepositoriesGridView(workspace: workspace, rootURL: repository.rootURL)
     }
-  }
-
-  private func tableHeader(_ title: String) -> some View {
-    Text(title)
-      .font(.caption.weight(.semibold))
-      .foregroundStyle(.tertiary)
   }
 }

--- a/supacode/Features/Repositories/Views/WorkspaceRepositoriesGridView.swift
+++ b/supacode/Features/Repositories/Views/WorkspaceRepositoriesGridView.swift
@@ -15,6 +15,7 @@ struct WorkspaceRepositoriesGridView: View {
           header("Name")
           header("Role")
           header("Source")
+          header("Mode")
           header("Branch")
           header("Path")
         }
@@ -31,6 +32,9 @@ struct WorkspaceRepositoriesGridView: View {
               .font(.subheadline)
               .foregroundStyle(.secondary)
               .help(entry.sourceLocation ?? "")
+            Text(materializationTitle(entry))
+              .font(.subheadline)
+              .foregroundStyle(.secondary)
             Text(entry.branchName ?? entry.baseRef ?? " ")
               .font(.subheadline.monospaced())
               .foregroundStyle(.secondary)
@@ -55,13 +59,26 @@ struct WorkspaceRepositoriesGridView: View {
   private func sourceKindTitle(_ kind: ProjectWorkspaceRepositorySourceKind) -> String {
     switch kind {
     case .existingPath:
-      return "Linked"
+      return "Opened"
     case .localRepository:
       return "Local"
     case .remote:
       return "Remote"
     case .bareRepository:
       return "Bare"
+    }
+  }
+
+  // The metadata does not record the checkout mode, but it is implied: only
+  // Link materialization leaves both branch fields empty for git sources.
+  private func materializationTitle(_ entry: ProjectWorkspaceRepositoryEntry) -> String {
+    switch entry.sourceKind {
+    case .remote:
+      return "Clone"
+    case .bareRepository:
+      return "Worktree"
+    case .existingPath, .localRepository:
+      return entry.branchName == nil && entry.baseRef == nil ? "Link" : "Worktree"
     }
   }
 }

--- a/supacode/Features/Repositories/Views/WorkspaceRepositoriesGridView.swift
+++ b/supacode/Features/Repositories/Views/WorkspaceRepositoriesGridView.swift
@@ -1,0 +1,67 @@
+import SwiftUI
+
+struct WorkspaceRepositoriesGridView: View {
+  let workspace: ProjectWorkspace
+  let rootURL: URL
+
+  var body: some View {
+    if workspace.repositories.isEmpty {
+      Text("No repositories are declared in this workspace metadata.")
+        .font(.callout)
+        .foregroundStyle(.secondary)
+    } else {
+      Grid(alignment: .leading, horizontalSpacing: 16, verticalSpacing: 8) {
+        GridRow {
+          header("Name")
+          header("Role")
+          header("Source")
+          header("Branch")
+          header("Path")
+        }
+        Divider()
+          .gridCellUnsizedAxes(.horizontal)
+        ForEach(workspace.repositories) { entry in
+          GridRow(alignment: .firstTextBaseline) {
+            Text(entry.name)
+              .font(.subheadline.weight(.medium))
+            Text(entry.role ?? " ")
+              .font(.subheadline)
+              .foregroundStyle(.secondary)
+            Text(sourceKindTitle(entry.sourceKind))
+              .font(.subheadline)
+              .foregroundStyle(.secondary)
+              .help(entry.sourceLocation ?? "")
+            Text(entry.branchName ?? entry.baseRef ?? " ")
+              .font(.subheadline.monospaced())
+              .foregroundStyle(.secondary)
+            Text(entry.resolvedURL(relativeTo: rootURL).path(percentEncoded: false))
+              .font(.subheadline.monospaced())
+              .foregroundStyle(.secondary)
+              .lineLimit(1)
+              .truncationMode(.middle)
+              .textSelection(.enabled)
+          }
+        }
+      }
+    }
+  }
+
+  private func header(_ title: String) -> some View {
+    Text(title)
+      .font(.caption.weight(.semibold))
+      .foregroundStyle(.tertiary)
+  }
+
+  private func sourceKindTitle(_ kind: ProjectWorkspaceRepositorySourceKind) -> String {
+    switch kind {
+    case .existingPath:
+      return "Linked"
+    case .localRepository:
+      return "Local"
+    case .remote:
+      return "Remote"
+    case .bareRepository:
+      return "Bare"
+    }
+  }
+}

--- a/supacode/Features/Repositories/Views/WorktreeRow.swift
+++ b/supacode/Features/Repositories/Views/WorktreeRow.swift
@@ -5,6 +5,7 @@ struct WorktreeRow: View {
   let name: String
   let worktreeName: String
   let info: WorktreeInfoEntry?
+  let iconSystemName: String?
   let showsPullRequestInfo: Bool
   let isHovered: Bool
   let isPinned: Bool
@@ -25,9 +26,57 @@ struct WorktreeRow: View {
   @Environment(\.colorScheme) private var colorScheme
   @Environment(\.resolvedKeybindings) private var resolvedKeybindings
 
+  init(
+    name: String,
+    worktreeName: String,
+    info: WorktreeInfoEntry?,
+    iconSystemName: String? = nil,
+    showsPullRequestInfo: Bool,
+    isHovered: Bool,
+    isPinned: Bool,
+    isMainWorktree: Bool,
+    isLoading: Bool,
+    taskStatus: WorktreeTaskStatus?,
+    isRunScriptRunning: Bool,
+    showsNotificationIndicator: Bool,
+    notifications: [WorktreeTerminalNotification],
+    onFocusNotification: @escaping (WorktreeTerminalNotification) -> Void,
+    shortcutHint: String?,
+    showsShortcutHint: Bool,
+    pinAction: (() -> Void)?,
+    isSelected: Bool,
+    archiveAction: (() -> Void)?,
+    onDiffTap: (() -> Void)?,
+    onStopRunScript: (() -> Void)?
+  ) {
+    self.name = name
+    self.worktreeName = worktreeName
+    self.info = info
+    self.iconSystemName = iconSystemName
+    self.showsPullRequestInfo = showsPullRequestInfo
+    self.isHovered = isHovered
+    self.isPinned = isPinned
+    self.isMainWorktree = isMainWorktree
+    self.isLoading = isLoading
+    self.taskStatus = taskStatus
+    self.isRunScriptRunning = isRunScriptRunning
+    self.showsNotificationIndicator = showsNotificationIndicator
+    self.notifications = notifications
+    self.onFocusNotification = onFocusNotification
+    self.shortcutHint = shortcutHint
+    self.showsShortcutHint = showsShortcutHint
+    self.pinAction = pinAction
+    self.isSelected = isSelected
+    self.archiveAction = archiveAction
+    self.onDiffTap = onDiffTap
+    self.onStopRunScript = onStopRunScript
+  }
+
   var body: some View {
     let showsSpinner = isLoading || taskStatus == .running
-    let branchIconName = isMainWorktree ? "star.fill" : (isPinned ? "pin.fill" : "arrow.triangle.branch")
+    let branchIconName =
+      iconSystemName
+      ?? (isMainWorktree ? "star.fill" : (isPinned ? "pin.fill" : "arrow.triangle.branch"))
     let display = WorktreePullRequestDisplay(
       worktreeName: name,
       pullRequest: showsPullRequestInfo ? info?.pullRequest : nil
@@ -35,7 +84,8 @@ struct WorktreeRow: View {
     let displayAddedLines = info?.addedLines
     let displayRemovedLines = info?.removedLines
     let mergeReadiness = pullRequestMergeReadiness(for: display.pullRequest)
-    let isQueued = display.pullRequest.flatMap(PullRequestMergeQueueStatus.init(pullRequest:)) != nil
+    let isQueued =
+      display.pullRequest.flatMap(PullRequestMergeQueueStatus.init(pullRequest:)) != nil
     let hasChangeCounts = displayAddedLines != nil && displayRemovedLines != nil
     let showsPullRequestTag = display.pullRequest != nil && display.pullRequestBadgeStyle != nil
     let nameColor = colorScheme == .dark ? Color.white : Color.primary
@@ -265,11 +315,16 @@ private struct WorktreeRowPreview: View {
         addedLines: 632,
         removedLines: 344
       )
-      row(id: "pinned", name: "feature/pinned-branch", worktreeName: "pinned-branch", isPinned: true)
+      row(
+        id: "pinned", name: "feature/pinned-branch", worktreeName: "pinned-branch", isPinned: true)
       row(id: "running", name: "feature/auth-flow", worktreeName: "auth-flow", taskStatus: .running)
       row(id: "loading", name: "creating-worktree...", worktreeName: "Setting up", isLoading: true)
-      row(id: "notif", name: "feature/notifications", worktreeName: "notifications", showsNotificationIndicator: true)
-      row(id: "script", name: "feature/run-script", worktreeName: "run-script", isRunScriptRunning: true)
+      row(
+        id: "notif", name: "feature/notifications", worktreeName: "notifications",
+        showsNotificationIndicator: true)
+      row(
+        id: "script", name: "feature/run-script", worktreeName: "run-script",
+        isRunScriptRunning: true)
       row(id: "hint", name: "feature/shortcuts", worktreeName: "shortcuts", shortcutHint: "⌘1")
       row(id: "selected", name: "feature/selected", worktreeName: "selected", isSelected: true)
     }
@@ -356,7 +411,9 @@ private struct WorktreeRowChangeCountView: View {
     .fixedSize(horizontal: true, vertical: false)
     .overlay {
       Capsule()
-        .stroke(isSelected ? AnyShapeStyle(.secondary.opacity(0.3)) : AnyShapeStyle(.tertiary), lineWidth: 1)
+        .stroke(
+          isSelected ? AnyShapeStyle(.secondary.opacity(0.3)) : AnyShapeStyle(.tertiary),
+          lineWidth: 1)
     }
     .monospacedDigit()
   }

--- a/supacode/Features/RepositorySettings/Reducer/RepositorySettingsFeature.swift
+++ b/supacode/Features/RepositorySettings/Reducer/RepositorySettingsFeature.swift
@@ -12,6 +12,7 @@ struct RepositorySettingsFeature {
     /// callers (AppFeature) always pass the canonical `repository.id`.
     var repositoryID: Repository.ID = ""
     var repositoryKind: Repository.Kind
+    var workspace: ProjectWorkspace?
     var settings: RepositorySettings
     var userSettings: UserRepositorySettings
     var appearance: RepositoryAppearance = .empty

--- a/supacode/Features/Settings/BusinessLogic/RepositoryPersistenceKeys.swift
+++ b/supacode/Features/Settings/BusinessLogic/RepositoryPersistenceKeys.swift
@@ -205,6 +205,9 @@ nonisolated enum RepositoryEntryNormalizer {
 
     return order.compactMap { path in
       guard let kind = kindByPath[path] else { return nil }
+      if ProjectWorkspace.load(from: URL(fileURLWithPath: path)) != nil {
+        return PersistedRepositoryEntry(path: path, kind: .plain)
+      }
       return PersistedRepositoryEntry(path: path, kind: kind)
     }
   }

--- a/supacode/Features/Settings/BusinessLogic/RepositoryPersistenceKeys.swift
+++ b/supacode/Features/Settings/BusinessLogic/RepositoryPersistenceKeys.swift
@@ -205,7 +205,7 @@ nonisolated enum RepositoryEntryNormalizer {
 
     return order.compactMap { path in
       guard let kind = kindByPath[path] else { return nil }
-      if ProjectWorkspace.load(from: URL(fileURLWithPath: path)) != nil {
+      if ProjectWorkspace.hasMetadata(at: URL(fileURLWithPath: path)) {
         return PersistedRepositoryEntry(path: path, kind: .plain)
       }
       return PersistedRepositoryEntry(path: path, kind: kind)

--- a/supacode/Features/Settings/Views/RepositorySettingsView.swift
+++ b/supacode/Features/Settings/Views/RepositorySettingsView.swift
@@ -140,8 +140,10 @@ struct RepositorySettingsView: View {
               isBranchPickerPresented = true
             } label: {
               HStack {
-                Text(store.settings.worktreeBaseRef ?? "Automatic (\(store.defaultWorktreeBaseRef))")
-                  .foregroundStyle(.primary)
+                Text(
+                  store.settings.worktreeBaseRef ?? "Automatic (\(store.defaultWorktreeBaseRef))"
+                )
+                .foregroundStyle(.primary)
                 Spacer()
                 Image(systemName: "chevron.up.chevron.down")
                   .foregroundStyle(.secondary)
@@ -169,7 +171,7 @@ struct RepositorySettingsView: View {
           }
         } header: {
           VStack(alignment: .leading, spacing: 4) {
-            Text("Branch new workspaces from")
+            Text("Branch new worktrees from")
             Text("Each workspace is an isolated copy of your codebase.")
               .foregroundStyle(.secondary)
           }
@@ -183,8 +185,10 @@ struct RepositorySettingsView: View {
             )
             .textFieldStyle(.roundedBorder)
 
-            Text("Set a repository-specific worktree base directory. Leave empty to inherit the global setting.")
-              .foregroundStyle(.secondary)
+            Text(
+              "Set a repository-specific worktree base directory. Leave empty to inherit the global setting."
+            )
+            .foregroundStyle(.secondary)
             Text("Example new worktree path: \(exampleWorktreePath)")
               .foregroundStyle(.secondary)
               .monospaced()
@@ -370,8 +374,10 @@ struct RepositorySettingsView: View {
         } header: {
           VStack(alignment: .leading, spacing: 4) {
             Text("Custom Commands")
-            Text("Repository-local terminal actions. Custom command shortcuts take precedence in this repository.")
-              .foregroundStyle(.secondary)
+            Text(
+              "Repository-local terminal actions. Custom command shortcuts take precedence in this repository."
+            )
+            .foregroundStyle(.secondary)
           }
         }
       }

--- a/supacode/Features/Settings/Views/RepositorySettingsView.swift
+++ b/supacode/Features/Settings/Views/RepositorySettingsView.swift
@@ -96,6 +96,42 @@ struct RepositorySettingsView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
       }
 
+      if let workspace = store.workspace {
+        Section {
+          VStack(alignment: .leading, spacing: 12) {
+            if !workspace.description.isEmpty {
+              Text(workspace.description)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+                .textSelection(.enabled)
+            }
+            if !workspace.taskLinks.isEmpty {
+              VStack(alignment: .leading, spacing: 4) {
+                ForEach(workspace.taskLinks, id: \.self) { link in
+                  Text(link)
+                    .font(.subheadline.monospaced())
+                    .foregroundStyle(.secondary)
+                    .textSelection(.enabled)
+                }
+              }
+            }
+            WorkspaceRepositoriesGridView(workspace: workspace, rootURL: store.rootURL)
+          }
+          .frame(maxWidth: .infinity, alignment: .leading)
+        } header: {
+          Text("Workspace")
+        } footer: {
+          Text(
+            "Read-only. Defined in "
+              + "\(ProjectWorkspace.metadataURL(for: store.rootURL).path(percentEncoded: false)) "
+              + "— edit that file to change it."
+          )
+          .font(.footnote)
+          .foregroundStyle(.secondary)
+          .textSelection(.enabled)
+        }
+      }
+
       if store.showsWorktreeSettings {
         Section {
           if store.isBranchDataLoaded {

--- a/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
+++ b/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
@@ -87,6 +87,8 @@ final class WorktreeTerminalManager {
       Task {
         createTabAsync(in: worktree, runSetupScriptIfNew: false, workingDirectory: directory)
       }
+    case .focusOrCreateTabInDirectory(let worktree, let directory, let title):
+      state(for: worktree).focusOrCreateTab(boundToDirectory: directory, title: title)
     case .ensureInitialTab(let worktree, let runSetupScriptIfNew, let focusing):
       let state = state(for: worktree) { runSetupScriptIfNew }
       state.ensureInitialTab(focusing: focusing)

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState+Surfaces.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState+Surfaces.swift
@@ -320,6 +320,7 @@ extension WorktreeTerminalState {
     focusedSurfaceIdByTab.removeAll()
     cleanupAllAgentDetectionState()
     tabIsRunningById.removeAll()
+    boundDirectoryTabIDs.removeAll()
     autoCloseSurfaceIds.removeAll()
     pendingCustomCommands.removeAll()
     setRunScriptTabId(nil)
@@ -805,6 +806,7 @@ extension WorktreeTerminalState {
     if newTree.isEmpty {
       trees.removeValue(forKey: tabId)
       focusedSurfaceIdByTab.removeValue(forKey: tabId)
+      removeBoundDirectoryTab(tabId)
       tabManager.closeTab(tabId)
       if tabId == runScriptTabId {
         setRunScriptTabId(nil)

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -76,6 +76,7 @@ final class WorktreeTerminalState {
   var lastWorkingAtBySurface: [UUID: Date] = [:]
   var lastAgentDetectionDiagnosticsBySurface: [UUID: String] = [:]
   var tabIsRunningById: [TerminalTabID: Bool] = [:]
+  var boundDirectoryTabIDs: [String: TerminalTabID] = [:]
   var surfaceRunningStartedAtById: [UUID: Date] = [:]
   var runScriptTabId: TerminalTabID?
   var pendingSetupScript: Bool
@@ -291,6 +292,7 @@ final class WorktreeTerminalState {
   @discardableResult
   func createTab(
     focusing: Bool = true,
+    title: String? = nil,
     setupScript: String? = nil,
     initialInput: String? = nil,
     inheritingFromSurfaceId: UUID? = nil,
@@ -298,7 +300,7 @@ final class WorktreeTerminalState {
   ) -> TerminalTabID? {
     let context = GHOSTTY_SURFACE_CONTEXT_TAB
     let resolvedInheritanceSurfaceId = inheritingFromSurfaceId ?? currentFocusedSurfaceId()
-    let title = "\(worktree.name) \(nextTabIndex())"
+    let title = title ?? "\(worktree.name) \(nextTabIndex())"
     let setupInput = setupScriptInput(setupScript: setupScript)
     let commandInput = initialInput.flatMap { runScriptInput($0) }
     let resolvedInput: String?
@@ -330,6 +332,36 @@ final class WorktreeTerminalState {
     )
     if shouldConsumeSetupScript, tabId != nil {
       onSetupScriptConsumed?()
+    }
+    return tabId
+  }
+
+  @discardableResult
+  func focusOrCreateTab(
+    boundToDirectory directory: URL,
+    title: String?
+  ) -> TerminalTabID? {
+    let directoryKey = boundDirectoryKey(for: directory)
+    if let tabId = boundDirectoryTabIDs[directoryKey],
+      tabManager.tabs.contains(where: { $0.id == tabId })
+    {
+      selectTab(tabId)
+      return tabId
+    }
+    boundDirectoryTabIDs.removeValue(forKey: directoryKey)
+
+    if let tabId = tabID(withWorkingDirectoryKey: directoryKey) {
+      boundDirectoryTabIDs[directoryKey] = tabId
+      selectTab(tabId)
+      return tabId
+    }
+
+    let tabId = createTab(
+      title: title,
+      workingDirectoryOverride: directory
+    )
+    if let tabId {
+      boundDirectoryTabIDs[directoryKey] = tabId
     }
     return tabId
   }
@@ -564,6 +596,7 @@ final class WorktreeTerminalState {
     guard confirmCloseIfNeeded(tabIds: [tabId], mode: confirmation) else { return false }
     let wasRunScriptTab = tabId == runScriptTabId
     removeTree(for: tabId)
+    removeBoundDirectoryTab(tabId)
     tabManager.closeTab(tabId)
     if let selected = tabManager.selectedTabId {
       focusSurface(in: selected)
@@ -619,6 +652,35 @@ final class WorktreeTerminalState {
   private func setupScriptInput(setupScript: String?) -> String? {
     guard pendingSetupScript, let script = setupScript else { return nil }
     return formatCommandInput(script)
+  }
+
+  func removeBoundDirectoryTab(_ tabId: TerminalTabID) {
+    boundDirectoryTabIDs = boundDirectoryTabIDs.filter { $0.value != tabId }
+  }
+
+  private func tabID(withWorkingDirectoryKey directoryKey: String) -> TerminalTabID? {
+    for tab in tabManager.tabs {
+      let paneIDs = trees[tab.id]?.leaves().map(\.id) ?? []
+      let hasMatchingPane = paneIDs.contains { paneID in
+        guard
+          let workingDirectory = inheritedSurfaceConfig(
+            fromSurfaceId: paneID,
+            context: GHOSTTY_SURFACE_CONTEXT_TAB
+          ).workingDirectory
+        else {
+          return false
+        }
+        return boundDirectoryKey(for: workingDirectory) == directoryKey
+      }
+      if hasMatchingPane {
+        return tab.id
+      }
+    }
+    return nil
+  }
+
+  private func boundDirectoryKey(for url: URL) -> String {
+    url.standardizedFileURL.path(percentEncoded: false)
   }
 
   // Env vars are injected into the surface's shell process via

--- a/supacode/Support/SupacodePaths.swift
+++ b/supacode/Support/SupacodePaths.swift
@@ -57,6 +57,10 @@ nonisolated enum SupacodePaths {
     baseDirectory.appending(path: "repos", directoryHint: .isDirectory)
   }
 
+  static var workspacesDirectory: URL {
+    baseDirectory.appending(path: "workspaces", directoryHint: .isDirectory)
+  }
+
   static func repositoryDirectory(for rootURL: URL) -> URL {
     let name = repositoryDirectoryName(for: rootURL)
     return reposDirectory.appending(path: name, directoryHint: .isDirectory)

--- a/supacodeTests/AppFeatureCommandPaletteTests.swift
+++ b/supacodeTests/AppFeatureCommandPaletteTests.swift
@@ -375,16 +375,22 @@ struct AppFeatureCommandPaletteTests {
     }
 
     let title = "Workspace"
+    let requestedRootPath = defaultWorkspaceBaseRootPath(for: title)
+    let resolvedRootPath = expectedDefaultWorkspaceRootPath(for: title)
     await store.send(.commandPalette(.delegate(.newWorkspace)))
     await store.receive(\.repositories.workspaceCreation.promptRequested) {
       $0.repositories.workspaceCreationPrompt = WorkspaceCreationPromptFeature.State(
         repositories: [],
         title: title,
-        rootPath: defaultWorkspaceBaseRootPath(for: title)
+        rootPath: requestedRootPath
       )
     }
-    await store.receive(\.repositories.workspaceCreation.defaultRootPathResolved) {
-      $0.repositories.workspaceCreationPrompt?.rootPath = expectedDefaultWorkspaceRootPath(for: title)
+    if resolvedRootPath == requestedRootPath {
+      await store.receive(\.repositories.workspaceCreation.defaultRootPathResolved)
+    } else {
+      await store.receive(\.repositories.workspaceCreation.defaultRootPathResolved) {
+        $0.repositories.workspaceCreationPrompt?.rootPath = resolvedRootPath
+      }
     }
   }
 

--- a/supacodeTests/AppFeatureCommandPaletteTests.swift
+++ b/supacodeTests/AppFeatureCommandPaletteTests.swift
@@ -374,15 +374,17 @@ struct AppFeatureCommandPaletteTests {
       AppFeature()
     }
 
+    let title = "Workspace"
     await store.send(.commandPalette(.delegate(.newWorkspace)))
     await store.receive(\.repositories.workspaceCreation.promptRequested) {
-      let title = "Workspace"
-      let expectedRootPath = expectedDefaultWorkspaceRootPath(for: title)
       $0.repositories.workspaceCreationPrompt = WorkspaceCreationPromptFeature.State(
         repositories: [],
         title: title,
-        rootPath: expectedRootPath
+        rootPath: defaultWorkspaceBaseRootPath(for: title)
       )
+    }
+    await store.receive(\.repositories.workspaceCreation.defaultRootPathResolved) {
+      $0.repositories.workspaceCreationPrompt?.rootPath = expectedDefaultWorkspaceRootPath(for: title)
     }
   }
 

--- a/supacodeTests/AppFeatureCommandPaletteTests.swift
+++ b/supacodeTests/AppFeatureCommandPaletteTests.swift
@@ -377,10 +377,7 @@ struct AppFeatureCommandPaletteTests {
     await store.send(.commandPalette(.delegate(.newWorkspace)))
     await store.receive(\.repositories.workspaceCreation.promptRequested) {
       let title = "Workspace"
-      let expectedRootPath = SupacodePaths.workspacesDirectory
-        .appending(path: ProjectWorkspace.defaultWorkspaceFolderName(for: title), directoryHint: .isDirectory)
-        .standardizedFileURL
-        .path(percentEncoded: false)
+      let expectedRootPath = expectedDefaultWorkspaceRootPath(for: title)
       $0.repositories.workspaceCreationPrompt = WorkspaceCreationPromptFeature.State(
         repositories: [],
         title: title,

--- a/supacodeTests/AppFeatureCommandPaletteTests.swift
+++ b/supacodeTests/AppFeatureCommandPaletteTests.swift
@@ -384,8 +384,7 @@ struct AppFeatureCommandPaletteTests {
       $0.repositories.workspaceCreationPrompt = WorkspaceCreationPromptFeature.State(
         repositories: [],
         title: title,
-        rootPath: expectedRootPath,
-        selectedRepositoryIDs: []
+        rootPath: expectedRootPath
       )
     }
   }

--- a/supacodeTests/AppFeatureCommandPaletteTests.swift
+++ b/supacodeTests/AppFeatureCommandPaletteTests.swift
@@ -369,6 +369,26 @@ struct AppFeatureCommandPaletteTests {
     }
   }
 
+  @Test(.dependencies) func newWorkspaceDispatchesPromptRequest() async {
+    let store = TestStore(initialState: AppFeature.State()) {
+      AppFeature()
+    }
+    let expectedAlert = AlertState<RepositoriesFeature.Alert> {
+      TextState("Unable to create workspace")
+    } actions: {
+      ButtonState(role: .cancel) {
+        TextState("OK")
+      }
+    } message: {
+      TextState("Open at least two repositories to create a workspace.")
+    }
+
+    await store.send(.commandPalette(.delegate(.newWorkspace)))
+    await store.receive(\.repositories.workspaceCreation.promptRequested) {
+      $0.repositories.alert = expectedAlert
+    }
+  }
+
   @Test(.dependencies) func refreshWorktreesDispatchesRefresh() async {
     let store = TestStore(initialState: AppFeature.State()) {
       AppFeature()

--- a/supacodeTests/AppFeatureCommandPaletteTests.swift
+++ b/supacodeTests/AppFeatureCommandPaletteTests.swift
@@ -373,19 +373,20 @@ struct AppFeatureCommandPaletteTests {
     let store = TestStore(initialState: AppFeature.State()) {
       AppFeature()
     }
-    let expectedAlert = AlertState<RepositoriesFeature.Alert> {
-      TextState("Unable to create workspace")
-    } actions: {
-      ButtonState(role: .cancel) {
-        TextState("OK")
-      }
-    } message: {
-      TextState("Open at least two repositories to create a workspace.")
-    }
 
     await store.send(.commandPalette(.delegate(.newWorkspace)))
     await store.receive(\.repositories.workspaceCreation.promptRequested) {
-      $0.repositories.alert = expectedAlert
+      let title = "Workspace"
+      let expectedRootPath = SupacodePaths.workspacesDirectory
+        .appending(path: ProjectWorkspace.defaultWorkspaceFolderName(for: title), directoryHint: .isDirectory)
+        .standardizedFileURL
+        .path(percentEncoded: false)
+      $0.repositories.workspaceCreationPrompt = WorkspaceCreationPromptFeature.State(
+        repositories: [],
+        title: title,
+        rootPath: expectedRootPath,
+        selectedRepositoryIDs: []
+      )
     }
   }
 

--- a/supacodeTests/CommandPaletteFeatureTests.swift
+++ b/supacodeTests/CommandPaletteFeatureTests.swift
@@ -14,6 +14,7 @@ struct CommandPaletteFeatureTests {
       "global.check-for-updates",
       "global.open-settings",
       "global.open-repository",
+      "global.new-workspace",
       "global.new-worktree",
       "global.refresh-worktrees",
       "global.jump-to-latest-unread",
@@ -1704,7 +1705,7 @@ private func makeItem(
 
 private func testCategory(for kind: CommandPaletteItem.Kind) -> CommandPaletteItem.Category {
   switch kind {
-  case .checkForUpdates, .openSettings, .openRepository, .installCLI,
+  case .checkForUpdates, .openSettings, .openRepository, .newWorkspace, .installCLI,
     .openRepositorySettings:
     return .app
   case .newWorktree, .refreshWorktrees, .viewArchivedWorktrees,
@@ -1733,7 +1734,7 @@ private func testCategory(for kind: CommandPaletteItem.Kind) -> CommandPaletteIt
 
 private func testDefaultSuggestion(for kind: CommandPaletteItem.Kind) -> Bool {
   switch kind {
-  case .checkForUpdates, .openSettings, .openRepository, .installCLI,
+  case .checkForUpdates, .openSettings, .openRepository, .newWorkspace, .installCLI,
     .newWorktree, .refreshWorktrees, .viewArchivedWorktrees, .jumpToLatestUnread,
     .openPullRequest, .markPullRequestReady, .mergePullRequest, .closePullRequest,
     .copyFailingJobURL, .copyCiFailureLogs, .rerunFailedJobs, .openFailingCheckDetails,

--- a/supacodeTests/DetailToolbarTitleTests.swift
+++ b/supacodeTests/DetailToolbarTitleTests.swift
@@ -42,4 +42,24 @@ struct DetailToolbarTitleTests {
     #expect(title?.systemImage == "folder")
     #expect(title?.supportsRename == false)
   }
+
+  @Test func workspaceSelectionUsesWorkspaceTitle() {
+    let repository = Repository(
+      id: "/tmp/workspace",
+      rootURL: URL(fileURLWithPath: "/tmp/workspace"),
+      name: "workspace",
+      kind: .plain,
+      worktrees: [],
+      workspace: ProjectWorkspace(title: "workspace")
+    )
+
+    let title = DetailToolbarTitle.forSelection(
+      worktree: nil,
+      repository: repository
+    )
+
+    #expect(title?.kind == .workspace(name: "workspace"))
+    #expect(title?.systemImage == "folder.badge.person.crop")
+    #expect(title?.supportsRename == false)
+  }
 }

--- a/supacodeTests/GitClientBranchRefsTests.swift
+++ b/supacodeTests/GitClientBranchRefsTests.swift
@@ -109,12 +109,20 @@ struct GitClientBranchRefsTests {
     let output = """
       ref: refs/heads/main\tHEAD
       abc123\tHEAD
+      def456\trefs/heads/develop
       abc123\trefs/heads/main
-      def456\trefs/heads/feature/login
       """
     let shell = ShellClient(
       run: { _, arguments, _ in
-        #expect(arguments.contains("ls-remote"))
+        #expect(
+          arguments == [
+            "git",
+            "ls-remote",
+            "--symref",
+            "git@github.com:onevcat/app.git",
+            "HEAD",
+            "refs/heads/*",
+          ])
         return ShellOutput(stdout: output, stderr: "", exitCode: 0)
       },
       runLoginImpl: { _, _, _, _ in ShellOutput(stdout: "", stderr: "", exitCode: 0) }
@@ -126,7 +134,7 @@ struct GitClientBranchRefsTests {
     #expect(refs.defaultBaseRef == "origin/main")
     #expect(
       refs.options == [
-        GitBranchRefOption(ref: "origin/feature/login", kind: .fetchedRemote),
+        GitBranchRefOption(ref: "origin/develop", kind: .fetchedRemote),
         GitBranchRefOption(ref: "origin/main", kind: .fetchedRemote),
       ])
   }

--- a/supacodeTests/GitClientBranchRefsTests.swift
+++ b/supacodeTests/GitClientBranchRefsTests.swift
@@ -119,6 +119,7 @@ struct GitClientBranchRefsTests {
             "git",
             "ls-remote",
             "--symref",
+            "--end-of-options",
             "git@github.com:onevcat/app.git",
             "HEAD",
             "refs/heads/*",

--- a/supacodeTests/GitClientBranchRefsTests.swift
+++ b/supacodeTests/GitClientBranchRefsTests.swift
@@ -80,7 +80,7 @@ struct GitClientBranchRefsTests {
     #expect(calls[1].contains("refs/remotes"))
   }
 
-  @Test func branchRefOptionsSpellRemoteHeadExplicitly() async throws {
+  @Test func branchRefOptionsOmitsRemoteHeadPointer() async throws {
     let shell = ShellClient(
       run: { _, arguments, _ in
         if arguments.contains("refs/heads") {
@@ -101,8 +101,10 @@ struct GitClientBranchRefsTests {
     let options = try await client.branchRefOptions(for: repoRoot)
 
     #expect(refs == ["main", "origin/main"])
-    #expect(options.contains(GitBranchRefOption(ref: "origin/HEAD", kind: .remoteTracking)))
-    #expect(!options.contains(GitBranchRefOption(ref: "origin", kind: .remoteTracking)))
+    // `<remote>/HEAD` pointers must be filtered so the remote-tracking checkout
+    // path never derives an invalid `HEAD` branch name.
+    #expect(!options.contains(GitBranchRefOption(ref: "origin/HEAD", kind: .remoteTracking)))
+    #expect(options.contains(GitBranchRefOption(ref: "origin/main", kind: .remoteTracking)))
   }
 
   @Test func remoteBranchRefsParsesDefaultHeadAndBranches() async throws {

--- a/supacodeTests/GitClientBranchRefsTests.swift
+++ b/supacodeTests/GitClientBranchRefsTests.swift
@@ -107,6 +107,39 @@ struct GitClientBranchRefsTests {
     #expect(options.contains(GitBranchRefOption(ref: "origin/main", kind: .remoteTracking)))
   }
 
+  @Test func branchRefOptionsPreservesLocalBranchNamedHEAD() async throws {
+    let shell = ShellClient(
+      run: { _, arguments, _ in
+        if arguments.contains("refs/heads") {
+          return ShellOutput(
+            stdout: "refs/heads/main\nrefs/heads/fix/HEAD\n",
+            stderr: "",
+            exitCode: 0
+          )
+        }
+        return ShellOutput(
+          stdout: "refs/remotes/origin/HEAD\nrefs/remotes/origin/main\n",
+          stderr: "",
+          exitCode: 0
+        )
+      },
+      runLoginImpl: { _, _, _, _ in ShellOutput(stdout: "", stderr: "", exitCode: 0) }
+    )
+    let client = GitClient(shell: shell)
+    let repoRoot = URL(fileURLWithPath: "/tmp/repo")
+
+    let options = try await client.branchRefOptions(for: repoRoot)
+
+    #expect(
+      options.contains(GitBranchRefOption(ref: "fix/HEAD", kind: .local)),
+      "Local branch fix/HEAD must not be filtered out"
+    )
+    #expect(
+      !options.contains(GitBranchRefOption(ref: "origin/HEAD", kind: .remoteTracking)),
+      "Remote HEAD pointer should still be filtered"
+    )
+  }
+
   @Test func remoteBranchRefsParsesDefaultHeadAndBranches() async throws {
     let output = """
       ref: refs/heads/main\tHEAD

--- a/supacodeTests/GitClientBranchRefsTests.swift
+++ b/supacodeTests/GitClientBranchRefsTests.swift
@@ -39,17 +39,15 @@ struct GitClientBranchRefsTests {
     #expect(remote == nil)
   }
 
-  @Test func branchRefsIncludesLocalAndUpstreamRefs() async throws {
+  @Test func branchRefsIncludesLocalAndRemoteTrackingRefs() async throws {
     let store = ShellCallStore()
-    let output = """
-      feature\torigin/feature
-      main\t
-      bugfix\torigin/bugfix
-      """
     let shell = ShellClient(
       run: { _, arguments, _ in
         await store.record(arguments)
-        return ShellOutput(stdout: output, stderr: "", exitCode: 0)
+        if arguments.contains("refs/heads") {
+          return ShellOutput(stdout: "feature\nmain\nbugfix\n", stderr: "", exitCode: 0)
+        }
+        return ShellOutput(stdout: "origin/feature\norigin/bugfix\n", stderr: "", exitCode: 0)
       },
       runLoginImpl: { _, _, _, _ in ShellOutput(stdout: "", stderr: "", exitCode: 0) }
     )
@@ -61,22 +59,27 @@ struct GitClientBranchRefsTests {
     let expected = ["bugfix", "feature", "main", "origin/bugfix", "origin/feature"]
       .sorted { $0.localizedStandardCompare($1) == .orderedAscending }
     #expect(refs == expected)
+    let options = try await client.branchRefOptions(for: repoRoot)
+    #expect(options.contains(GitBranchRefOption(ref: "main", kind: .local)))
+    #expect(options.contains(GitBranchRefOption(ref: "origin/feature", kind: .remoteTracking)))
     let calls = await store.calls
-    #expect(calls.count == 1)
+    #expect(calls.count == 4)
     let args = calls[0]
     #expect(args.first == "git")
     #expect(args.contains("for-each-ref"))
     #expect(args.contains("refs/heads"))
-    #expect(args.contains("--format=%(refname:short)\t%(upstream:short)"))
+    #expect(args.contains("--format=%(refname:short)"))
+    #expect(calls[1].contains("refs/remotes"))
   }
 
   @Test func branchRefsDropsOriginHead() async throws {
-    let output = """
-      head\torigin/HEAD
-      main\torigin/main
-      """
     let shell = ShellClient(
-      run: { _, _, _ in ShellOutput(stdout: output, stderr: "", exitCode: 0) },
+      run: { _, arguments, _ in
+        if arguments.contains("refs/heads") {
+          return ShellOutput(stdout: "head\nmain\n", stderr: "", exitCode: 0)
+        }
+        return ShellOutput(stdout: "origin/HEAD\norigin/main\n", stderr: "", exitCode: 0)
+      },
       runLoginImpl: { _, _, _, _ in ShellOutput(stdout: "", stderr: "", exitCode: 0) }
     )
     let client = GitClient(shell: shell)
@@ -85,6 +88,32 @@ struct GitClientBranchRefsTests {
     let refs = try await client.branchRefs(for: repoRoot)
 
     #expect(refs == ["head", "main", "origin/main"])
+  }
+
+  @Test func remoteBranchRefsParsesDefaultHeadAndBranches() async throws {
+    let output = """
+      ref: refs/heads/main\tHEAD
+      abc123\tHEAD
+      abc123\trefs/heads/main
+      def456\trefs/heads/feature/login
+      """
+    let shell = ShellClient(
+      run: { _, arguments, _ in
+        #expect(arguments.contains("ls-remote"))
+        return ShellOutput(stdout: output, stderr: "", exitCode: 0)
+      },
+      runLoginImpl: { _, _, _, _ in ShellOutput(stdout: "", stderr: "", exitCode: 0) }
+    )
+    let client = GitClient(shell: shell)
+
+    let refs = try await client.remoteBranchRefs(for: "git@github.com:onevcat/app.git")
+
+    #expect(refs.defaultBaseRef == "origin/main")
+    #expect(
+      refs.options == [
+        GitBranchRefOption(ref: "origin/feature/login", kind: .fetchedRemote),
+        GitBranchRefOption(ref: "origin/main", kind: .fetchedRemote),
+      ])
   }
 
   @Test func defaultRemoteBranchRefStripsPrefix() async throws {

--- a/supacodeTests/GitClientBranchRefsTests.swift
+++ b/supacodeTests/GitClientBranchRefsTests.swift
@@ -45,9 +45,17 @@ struct GitClientBranchRefsTests {
       run: { _, arguments, _ in
         await store.record(arguments)
         if arguments.contains("refs/heads") {
-          return ShellOutput(stdout: "feature\nmain\nbugfix\n", stderr: "", exitCode: 0)
+          return ShellOutput(
+            stdout: "refs/heads/feature\nrefs/heads/main\nrefs/heads/bugfix\n",
+            stderr: "",
+            exitCode: 0
+          )
         }
-        return ShellOutput(stdout: "origin/feature\norigin/bugfix\n", stderr: "", exitCode: 0)
+        return ShellOutput(
+          stdout: "refs/remotes/origin/feature\nrefs/remotes/origin/bugfix\n",
+          stderr: "",
+          exitCode: 0
+        )
       },
       runLoginImpl: { _, _, _, _ in ShellOutput(stdout: "", stderr: "", exitCode: 0) }
     )
@@ -68,17 +76,21 @@ struct GitClientBranchRefsTests {
     #expect(args.first == "git")
     #expect(args.contains("for-each-ref"))
     #expect(args.contains("refs/heads"))
-    #expect(args.contains("--format=%(refname:short)"))
+    #expect(args.contains("--format=%(refname)"))
     #expect(calls[1].contains("refs/remotes"))
   }
 
-  @Test func branchRefsDropsOriginHead() async throws {
+  @Test func branchRefOptionsSpellRemoteHeadExplicitly() async throws {
     let shell = ShellClient(
       run: { _, arguments, _ in
         if arguments.contains("refs/heads") {
-          return ShellOutput(stdout: "head\nmain\n", stderr: "", exitCode: 0)
+          return ShellOutput(stdout: "refs/heads/main\n", stderr: "", exitCode: 0)
         }
-        return ShellOutput(stdout: "origin/HEAD\norigin/main\n", stderr: "", exitCode: 0)
+        return ShellOutput(
+          stdout: "refs/remotes/origin/HEAD\nrefs/remotes/origin/main\n",
+          stderr: "",
+          exitCode: 0
+        )
       },
       runLoginImpl: { _, _, _, _ in ShellOutput(stdout: "", stderr: "", exitCode: 0) }
     )
@@ -86,8 +98,11 @@ struct GitClientBranchRefsTests {
     let repoRoot = URL(fileURLWithPath: "/tmp/repo")
 
     let refs = try await client.branchRefs(for: repoRoot)
+    let options = try await client.branchRefOptions(for: repoRoot)
 
-    #expect(refs == ["head", "main", "origin/main"])
+    #expect(refs == ["main", "origin/main"])
+    #expect(options.contains(GitBranchRefOption(ref: "origin/HEAD", kind: .remoteTracking)))
+    #expect(!options.contains(GitBranchRefOption(ref: "origin", kind: .remoteTracking)))
   }
 
   @Test func remoteBranchRefsParsesDefaultHeadAndBranches() async throws {

--- a/supacodeTests/ProjectWorkspaceTests.swift
+++ b/supacodeTests/ProjectWorkspaceTests.swift
@@ -23,6 +23,24 @@ struct ProjectWorkspaceTests {
       ])
   }
 
+  @Test func preferredBaseRefMatchesTrimmedAutomaticBaseRef() {
+    let preferred = ProjectWorkspaceCreationRepository.preferredBaseRef(
+      automaticBaseRef: " develop \n",
+      options: [
+        GitBranchRefOption(ref: "develop", kind: .local),
+        GitBranchRefOption(ref: "main", kind: .local),
+      ]
+    )
+
+    #expect(preferred == "develop")
+  }
+
+  @Test func remoteNamingStripsOnlyTrailingGitSuffix() {
+    #expect(GitRemoteNaming.repositoryName(fromRemoteURL: "git@github.com:onevcat/x.github.io.git") == "x.github.io")
+    #expect(GitRemoteNaming.repositoryName(fromRemoteURL: "https://github.com/onevcat/app.git") == "app")
+    #expect(GitRemoteNaming.repositoryName(fromRemoteURL: "https://github.com/onevcat/app") == "app")
+  }
+
   @Test func loadsWorkspaceMetadataWithDefaultsAndSnakeCaseSources() throws {
     let rootURL = try makeTemporaryWorkspaceRoot()
     defer { try? FileManager.default.removeItem(at: rootURL) }
@@ -90,6 +108,14 @@ struct ProjectWorkspaceTests {
     #expect(shared.id == "shared")
     #expect(shared.name == "Shared")
     #expect(shared.sourceKind == .existingPath)
+  }
+
+  @Test func loadReturnsNilForMalformedWorkspaceMetadata() throws {
+    let rootURL = try makeTemporaryWorkspaceRoot()
+    defer { try? FileManager.default.removeItem(at: rootURL) }
+    try writeWorkspaceJSON("{ not json", to: rootURL)
+
+    #expect(ProjectWorkspace.load(from: rootURL) == nil)
   }
 
   @Test func normalizesEmptyWorkspaceAndRepositoryFields() throws {
@@ -161,17 +187,21 @@ struct ProjectWorkspaceTests {
           title: "Checkout Flow",
           rootURL: rootURL,
           repositories: [
-            ProjectWorkspaceCreationRepository(
+            ProjectWorkspaceRepositoryPlan(
               id: "app",
               name: "App Repo",
-              rootURL: appURL,
-              branchName: "main"
+              path: nil,
+              sourceKind: .existingPath,
+              sourceLocation: appURL.path(percentEncoded: false),
+              checkout: .link
             ),
-            ProjectWorkspaceCreationRepository(
+            ProjectWorkspaceRepositoryPlan(
               id: "api",
               name: "App Repo",
-              rootURL: apiURL,
-              branchName: "feature/api"
+              path: nil,
+              sourceKind: .existingPath,
+              sourceLocation: apiURL.path(percentEncoded: false),
+              checkout: .link
             ),
           ]
         ),
@@ -194,7 +224,7 @@ struct ProjectWorkspaceTests {
         appPath,
         apiPath,
       ])
-    #expect(loaded.repositories.map(\.branchName) == ["main", "feature/api"])
+    #expect(loaded.repositories.map(\.branchName) == [nil, nil])
 
     let appLinkPath = rootURL.appending(path: "App-Repo").path(percentEncoded: false)
     let apiLinkPath = rootURL.appending(path: "App-Repo-2").path(percentEncoded: false)
@@ -218,23 +248,21 @@ struct ProjectWorkspaceTests {
           title: "Materialized",
           rootURL: rootURL,
           repositories: [
-            ProjectWorkspaceCreationRepository(
+            ProjectWorkspaceRepositoryPlan(
               id: "app",
               name: "App",
+              path: "app",
               sourceKind: .remote,
               sourceLocation: "git@github.com:onevcat/app.git",
-              branchName: "codex/app",
-              baseRef: "origin/main",
-              path: "app"
+              checkout: .createBranch(branchName: "codex/app", baseRef: "origin/main")
             ),
-            ProjectWorkspaceCreationRepository(
+            ProjectWorkspaceRepositoryPlan(
               id: "api",
               name: "API",
+              path: "api",
               sourceKind: .bareRepository,
               sourceLocation: bareURL.path(percentEncoded: false),
-              branchName: "codex/api",
-              baseRef: "main",
-              path: "api"
+              checkout: .createBranch(branchName: "codex/api", baseRef: "main")
             ),
           ]
         ),
@@ -251,9 +279,9 @@ struct ProjectWorkspaceTests {
     let barePath = normalizedTestPath(bareURL)
     #expect(
       commands.value.map(\.arguments) == [
-        ["clone", "git@github.com:onevcat/app.git", "\(rootPath)/app"],
-        ["-C", "\(rootPath)/app", "checkout", "-B", "codex/app", "origin/main"],
-        ["-C", barePath, "worktree", "add", "-b", "codex/api", "\(rootPath)/api", "main"],
+        ["clone", "--end-of-options", "git@github.com:onevcat/app.git", "\(rootPath)/app"],
+        ["-C", "\(rootPath)/app", "checkout", "-B", "codex/app", "--end-of-options", "origin/main"],
+        ["-C", barePath, "worktree", "add", "-b", "codex/api", "\(rootPath)/api", "--end-of-options", "main"],
       ])
 
     let loaded = try #require(ProjectWorkspace.load(from: rootURL))
@@ -278,25 +306,21 @@ struct ProjectWorkspaceTests {
           title: "Existing Refs",
           rootURL: rootURL,
           repositories: [
-            ProjectWorkspaceCreationRepository(
+            ProjectWorkspaceRepositoryPlan(
               id: "app",
               name: "App",
+              path: "app",
               sourceKind: .remote,
               sourceLocation: "git@github.com:onevcat/app.git",
-              checkoutMode: .useExistingRef,
-              branchName: "codex/app",
-              baseRef: "origin/feature/login",
-              path: "app"
+              checkout: .useExistingRef("origin/feature/login")
             ),
-            ProjectWorkspaceCreationRepository(
+            ProjectWorkspaceRepositoryPlan(
               id: "api",
               name: "API",
+              path: "api",
               sourceKind: .bareRepository,
               sourceLocation: bareURL.path(percentEncoded: false),
-              checkoutMode: .useExistingRef,
-              branchName: "codex/api",
-              baseRef: "main",
-              path: "api"
+              checkout: .useExistingRef("main")
             ),
           ]
         ),
@@ -311,14 +335,257 @@ struct ProjectWorkspaceTests {
     let barePath = normalizedTestPath(bareURL)
     #expect(
       commands.value.map(\.arguments) == [
-        ["clone", "git@github.com:onevcat/app.git", "\(rootPath)/app"],
-        ["-C", "\(rootPath)/app", "checkout", "feature/login"],
-        ["-C", barePath, "worktree", "add", "\(rootPath)/api", "main"],
+        ["clone", "--end-of-options", "git@github.com:onevcat/app.git", "\(rootPath)/app"],
+        ["-C", "\(rootPath)/app", "checkout", "--end-of-options", "feature/login"],
+        ["-C", barePath, "worktree", "add", "\(rootPath)/api", "--end-of-options", "main"],
       ])
 
     let loaded = try #require(ProjectWorkspace.load(from: rootURL))
     #expect(loaded.repositories.map(\.branchName) == [nil, nil])
     #expect(loaded.repositories.map(\.baseRef) == ["origin/feature/login", "main"])
+  }
+
+  @Test func createWorkspaceMaterializesLocalRepositoriesAsWorktrees() async throws {
+    let rootURL = FileManager.default.temporaryDirectory
+      .appending(path: "prowl-local-worktree-workspace-\(UUID().uuidString)")
+      .standardizedFileURL
+    let appURL = try makeTemporaryWorkspaceRoot()
+    let apiURL = try makeTemporaryWorkspaceRoot()
+    defer {
+      try? FileManager.default.removeItem(at: rootURL)
+      try? FileManager.default.removeItem(at: appURL)
+      try? FileManager.default.removeItem(at: apiURL)
+    }
+    let commands = LockIsolated<[ProjectWorkspaceGitCommand]>([])
+    let workspace = try await ProjectWorkspace.create(
+      ProjectWorkspaceCreationRequest(
+        draft: ProjectWorkspaceCreationDraft(
+          title: "Local Worktrees",
+          rootURL: rootURL,
+          repositories: [
+            ProjectWorkspaceRepositoryPlan(
+              id: "app",
+              name: "App",
+              path: "app",
+              sourceKind: .localRepository,
+              sourceLocation: appURL.path(percentEncoded: false),
+              checkout: .createBranch(branchName: "codex/app", baseRef: "main")
+            ),
+            ProjectWorkspaceRepositoryPlan(
+              id: "api",
+              name: "API",
+              path: "api",
+              sourceKind: .existingPath,
+              sourceLocation: apiURL.path(percentEncoded: false),
+              checkout: .useExistingRef("origin/main")
+            ),
+          ]
+        ),
+        createdAt: Date(timeIntervalSince1970: 4_567_890)
+      ),
+      gitRunner: ProjectWorkspaceGitRunner { command in
+        commands.withValue { $0.append(command) }
+      }
+    )
+
+    let rootPath = rootURL.path(percentEncoded: false)
+    let appPath = normalizedTestPath(appURL)
+    let apiPath = normalizedTestPath(apiURL)
+    #expect(
+      commands.value.map(\.arguments) == [
+        ["-C", appPath, "worktree", "add", "-b", "codex/app", "\(rootPath)/app", "--end-of-options", "main"],
+        ["-C", apiPath, "worktree", "add", "\(rootPath)/api", "--end-of-options", "origin/main"],
+      ])
+    #expect(workspace.repositories.map(\.branchName) == ["codex/app", nil])
+    #expect(workspace.repositories.map(\.baseRef) == ["main", "origin/main"])
+  }
+
+  @Test func createWorkspaceRollsBackCloneWhenCheckoutFails() async throws {
+    let rootURL = try makeTemporaryWorkspaceRoot()
+    let bareURL = try makeTemporaryWorkspaceRoot()
+    defer {
+      try? FileManager.default.removeItem(at: rootURL)
+      try? FileManager.default.removeItem(at: bareURL)
+    }
+    let commands = LockIsolated<[ProjectWorkspaceGitCommand]>([])
+    let cloneDestination = rootURL.appending(path: "app", directoryHint: .isDirectory)
+    await #expect(throws: ProjectWorkspaceCreationError.self) {
+      try await ProjectWorkspace.create(
+        ProjectWorkspaceCreationRequest(
+          draft: ProjectWorkspaceCreationDraft(
+            title: "Half Done",
+            rootURL: rootURL,
+            repositories: [
+              ProjectWorkspaceRepositoryPlan(
+                id: "api",
+                name: "API",
+                path: "api",
+                sourceKind: .bareRepository,
+                sourceLocation: bareURL.path(percentEncoded: false),
+                checkout: .createBranch(branchName: "codex/api", baseRef: "main")
+              ),
+              ProjectWorkspaceRepositoryPlan(
+                id: "app",
+                name: "App",
+                path: "app",
+                sourceKind: .remote,
+                sourceLocation: "git@github.com:onevcat/app.git",
+                checkout: .createBranch(branchName: "codex/app", baseRef: "origin/main")
+              ),
+            ]
+          ),
+          createdAt: Date(timeIntervalSince1970: 5_678_901)
+        ),
+        gitRunner: ProjectWorkspaceGitRunner { command in
+          commands.withValue { $0.append(command) }
+          if command.arguments.first == "clone" {
+            try FileManager.default.createDirectory(at: cloneDestination, withIntermediateDirectories: true)
+          }
+          if command.arguments.contains("checkout") {
+            throw ProjectWorkspaceCreationError.gitCommandFailed(
+              command: command.displayCommand,
+              message: "boom"
+            )
+          }
+        }
+      )
+    }
+
+    let rootPath = rootURL.path(percentEncoded: false)
+    let barePath = normalizedTestPath(bareURL)
+    #expect(
+      commands.value.map(\.arguments).contains(
+        ["-C", barePath, "worktree", "remove", "--force", "\(rootPath)/api"]
+      )
+    )
+    #expect(!FileManager.default.fileExists(atPath: cloneDestination.path(percentEncoded: false)))
+    #expect(
+      !FileManager.default.fileExists(
+        atPath: ProjectWorkspace.metadataURL(for: rootURL).path(percentEncoded: false)
+      )
+    )
+    #expect(FileManager.default.fileExists(atPath: rootPath))
+  }
+
+  @Test func createWorkspaceRejectsCreateBranchWithoutName() async throws {
+    let rootURL = FileManager.default.temporaryDirectory
+      .appending(path: "prowl-invalid-workspace-\(UUID().uuidString)")
+    let appURL = try makeTemporaryWorkspaceRoot()
+    defer {
+      try? FileManager.default.removeItem(at: rootURL)
+      try? FileManager.default.removeItem(at: appURL)
+    }
+    await #expect(throws: ProjectWorkspaceCreationError.missingBranchName("App")) {
+      try await ProjectWorkspace.create(
+        ProjectWorkspaceCreationRequest(
+          draft: ProjectWorkspaceCreationDraft(
+            title: "Invalid",
+            rootURL: rootURL,
+            repositories: [
+              ProjectWorkspaceRepositoryPlan(
+                id: "app",
+                name: "App",
+                path: "app",
+                sourceKind: .localRepository,
+                sourceLocation: appURL.path(percentEncoded: false),
+                checkout: .createBranch(branchName: " ", baseRef: nil)
+              ),
+              ProjectWorkspaceRepositoryPlan(
+                id: "api",
+                name: "API",
+                path: "api",
+                sourceKind: .existingPath,
+                sourceLocation: appURL.path(percentEncoded: false),
+                checkout: .link
+              ),
+            ]
+          ),
+          createdAt: Date(timeIntervalSince1970: 6_789_012)
+        ),
+        gitRunner: ProjectWorkspaceGitRunner { _ in }
+      )
+    }
+    #expect(!FileManager.default.fileExists(atPath: rootURL.path(percentEncoded: false)))
+  }
+
+  @Test func createWorkspaceRejectsLinkForBareRepository() async throws {
+    let rootURL = FileManager.default.temporaryDirectory
+      .appending(path: "prowl-invalid-link-workspace-\(UUID().uuidString)")
+    let bareURL = try makeTemporaryWorkspaceRoot()
+    defer {
+      try? FileManager.default.removeItem(at: rootURL)
+      try? FileManager.default.removeItem(at: bareURL)
+    }
+    await #expect(throws: ProjectWorkspaceCreationError.linkCheckoutUnsupported("API")) {
+      try await ProjectWorkspace.create(
+        ProjectWorkspaceCreationRequest(
+          draft: ProjectWorkspaceCreationDraft(
+            title: "Invalid Link",
+            rootURL: rootURL,
+            repositories: [
+              ProjectWorkspaceRepositoryPlan(
+                id: "api",
+                name: "API",
+                path: "api",
+                sourceKind: .bareRepository,
+                sourceLocation: bareURL.path(percentEncoded: false),
+                checkout: .link
+              ),
+              ProjectWorkspaceRepositoryPlan(
+                id: "app",
+                name: "App",
+                path: "app",
+                sourceKind: .existingPath,
+                sourceLocation: bareURL.path(percentEncoded: false),
+                checkout: .link
+              ),
+            ]
+          ),
+          createdAt: Date(timeIntervalSince1970: 7_890_123)
+        ),
+        gitRunner: ProjectWorkspaceGitRunner { _ in }
+      )
+    }
+  }
+
+  @Test func planRequiresBranchNameForCreateBranchOnLocalSources() {
+    let repository = ProjectWorkspaceCreationRepository(
+      id: "app",
+      name: "App",
+      rootURL: URL(fileURLWithPath: "/tmp/app"),
+      checkoutMode: .createBranch
+    )
+
+    #expect(
+      WorkspaceCreationPromptFeature.plan(for: repository)
+        == .failure(.missingBranchName("App"))
+    )
+  }
+
+  @Test func planMapsLinkAndExistingRefModes() throws {
+    let linked = ProjectWorkspaceCreationRepository(
+      id: "app",
+      name: "App",
+      rootURL: URL(fileURLWithPath: "/tmp/app")
+    )
+    #expect(WorkspaceCreationPromptFeature.plan(for: linked).map(\.checkout) == .success(.link))
+
+    var existing = ProjectWorkspaceCreationRepository(
+      id: "api",
+      name: "API",
+      sourceKind: .bareRepository,
+      sourceLocation: "/tmp/api.git",
+      checkoutMode: .useExistingRef
+    )
+    #expect(
+      WorkspaceCreationPromptFeature.plan(for: existing)
+        == .failure(.missingExistingRef("API"))
+    )
+    existing.baseRef = "main"
+    #expect(
+      WorkspaceCreationPromptFeature.plan(for: existing).map(\.checkout)
+        == .success(.useExistingRef("main"))
+    )
   }
 
   @Test func listRuntimeContextsReportWorkspaceKind() {
@@ -339,6 +606,21 @@ struct ProjectWorkspaceTests {
 
     #expect(contexts.map(\.kind) == [.workspace])
     #expect(contexts.first?.id == repository.id)
+  }
+
+  @Test func repositoryWithWorkspaceIsAlwaysPlain() {
+    let rootURL = URL(fileURLWithPath: "/tmp/workspace")
+    let repository = Repository(
+      id: rootURL.path(percentEncoded: false),
+      rootURL: rootURL,
+      name: "Workspace",
+      kind: .git,
+      worktrees: [],
+      workspace: ProjectWorkspace(title: "Workspace")
+    )
+
+    #expect(repository.kind == .plain)
+    #expect(repository.isWorkspace)
   }
 
   private func makeTemporaryWorkspaceRoot() throws -> URL {

--- a/supacodeTests/ProjectWorkspaceTests.swift
+++ b/supacodeTests/ProjectWorkspaceTests.swift
@@ -7,6 +7,22 @@ import Testing
 
 @MainActor
 struct ProjectWorkspaceTests {
+  @Test func baseRefOptionsKeepsDetectedKindForAutomaticSlashBranch() {
+    let options = ProjectWorkspaceCreationRepository.baseRefOptions(
+      automaticBaseRef: "feature/login",
+      options: [
+        GitBranchRefOption(ref: "feature/login", kind: .local),
+        GitBranchRefOption(ref: "origin/main", kind: .remoteTracking),
+      ]
+    )
+
+    #expect(
+      options == [
+        GitBranchRefOption(ref: "feature/login", kind: .local),
+        GitBranchRefOption(ref: "origin/main", kind: .remoteTracking),
+      ])
+  }
+
   @Test func loadsWorkspaceMetadataWithDefaultsAndSnakeCaseSources() throws {
     let rootURL = try makeTemporaryWorkspaceRoot()
     defer { try? FileManager.default.removeItem(at: rootURL) }
@@ -244,6 +260,65 @@ struct ProjectWorkspaceTests {
     #expect(loaded.repositories.map(\.sourceLocation) == ["git@github.com:onevcat/app.git", barePath])
     #expect(loaded.repositories.map(\.branchName) == ["codex/app", "codex/api"])
     #expect(loaded.repositories.map(\.baseRef) == ["origin/main", "main"])
+  }
+
+  @Test func createWorkspaceUsesExistingRefsWithoutCreatingBranches() async throws {
+    let rootURL = FileManager.default.temporaryDirectory
+      .appending(path: "prowl-existing-ref-workspace-\(UUID().uuidString)")
+      .standardizedFileURL
+    let bareURL = try makeTemporaryWorkspaceRoot()
+    defer {
+      try? FileManager.default.removeItem(at: rootURL)
+      try? FileManager.default.removeItem(at: bareURL)
+    }
+    let commands = LockIsolated<[ProjectWorkspaceGitCommand]>([])
+    _ = try await ProjectWorkspace.create(
+      ProjectWorkspaceCreationRequest(
+        draft: ProjectWorkspaceCreationDraft(
+          title: "Existing Refs",
+          rootURL: rootURL,
+          repositories: [
+            ProjectWorkspaceCreationRepository(
+              id: "app",
+              name: "App",
+              sourceKind: .remote,
+              sourceLocation: "git@github.com:onevcat/app.git",
+              checkoutMode: .useExistingRef,
+              branchName: "codex/app",
+              baseRef: "origin/feature/login",
+              path: "app"
+            ),
+            ProjectWorkspaceCreationRepository(
+              id: "api",
+              name: "API",
+              sourceKind: .bareRepository,
+              sourceLocation: bareURL.path(percentEncoded: false),
+              checkoutMode: .useExistingRef,
+              branchName: "codex/api",
+              baseRef: "main",
+              path: "api"
+            ),
+          ]
+        ),
+        createdAt: Date(timeIntervalSince1970: 3_456_789)
+      ),
+      gitRunner: ProjectWorkspaceGitRunner { command in
+        commands.withValue { $0.append(command) }
+      }
+    )
+
+    let rootPath = rootURL.path(percentEncoded: false)
+    let barePath = normalizedTestPath(bareURL)
+    #expect(
+      commands.value.map(\.arguments) == [
+        ["clone", "git@github.com:onevcat/app.git", "\(rootPath)/app"],
+        ["-C", "\(rootPath)/app", "checkout", "feature/login"],
+        ["-C", barePath, "worktree", "add", "\(rootPath)/api", "main"],
+      ])
+
+    let loaded = try #require(ProjectWorkspace.load(from: rootURL))
+    #expect(loaded.repositories.map(\.branchName) == [nil, nil])
+    #expect(loaded.repositories.map(\.baseRef) == ["origin/feature/login", "main"])
   }
 
   @Test func listRuntimeContextsReportWorkspaceKind() {

--- a/supacodeTests/ProjectWorkspaceTests.swift
+++ b/supacodeTests/ProjectWorkspaceTests.swift
@@ -36,9 +36,13 @@ struct ProjectWorkspaceTests {
   }
 
   @Test func remoteNamingStripsOnlyTrailingGitSuffix() {
-    #expect(GitRemoteNaming.repositoryName(fromRemoteURL: "git@github.com:onevcat/x.github.io.git") == "x.github.io")
-    #expect(GitRemoteNaming.repositoryName(fromRemoteURL: "https://github.com/onevcat/app.git") == "app")
-    #expect(GitRemoteNaming.repositoryName(fromRemoteURL: "https://github.com/onevcat/app") == "app")
+    #expect(
+      GitRemoteNaming.repositoryName(fromRemoteURL: "git@github.com:onevcat/x.github.io.git")
+        == "x.github.io")
+    #expect(
+      GitRemoteNaming.repositoryName(fromRemoteURL: "https://github.com/onevcat/app.git") == "app")
+    #expect(
+      GitRemoteNaming.repositoryName(fromRemoteURL: "https://github.com/onevcat/app") == "app")
   }
 
   @Test func loadsWorkspaceMetadataWithDefaultsAndSnakeCaseSources() throws {
@@ -78,6 +82,7 @@ struct ProjectWorkspaceTests {
     let rootPath = rootURL.standardizedFileURL.path(percentEncoded: false)
 
     #expect(workspace.id == rootPath)
+    #expect(workspace.schemaVersion == ProjectWorkspace.currentSchemaVersion)
     #expect(workspace.title == "Multi Repo Task")
     #expect(workspace.description == "")
     #expect(workspace.taskLinks == [])
@@ -208,13 +213,16 @@ struct ProjectWorkspaceTests {
         createdAt: createdAt
       ),
       gitRunner: ProjectWorkspaceGitRunner { command in
-        throw ProjectWorkspaceCreationError.gitCommandFailed(command: command.displayCommand, message: "unexpected")
+        throw ProjectWorkspaceCreationError.gitCommandFailed(
+          command: command.displayCommand, message: "unexpected")
       }
     )
 
     #expect(workspace.title == "Checkout Flow")
+    #expect(workspace.schemaVersion == ProjectWorkspace.currentSchemaVersion)
     #expect(workspace.createdAt == createdAt)
     let loaded = try #require(ProjectWorkspace.load(from: rootURL))
+    #expect(loaded.schemaVersion == ProjectWorkspace.currentSchemaVersion)
     #expect(loaded.repositories.map(\.path) == ["App-Repo", "App-Repo-2"])
     #expect(loaded.repositories.map(\.sourceKind) == [.existingPath, .existingPath])
     let appPath = normalizedTestPath(appURL)
@@ -228,8 +236,12 @@ struct ProjectWorkspaceTests {
 
     let appLinkPath = rootURL.appending(path: "App-Repo").path(percentEncoded: false)
     let apiLinkPath = rootURL.appending(path: "App-Repo-2").path(percentEncoded: false)
-    #expect(URL(fileURLWithPath: appLinkPath).resolvingSymlinksInPath().path(percentEncoded: false) == appPath)
-    #expect(URL(fileURLWithPath: apiLinkPath).resolvingSymlinksInPath().path(percentEncoded: false) == apiPath)
+    #expect(
+      URL(fileURLWithPath: appLinkPath).resolvingSymlinksInPath().path(percentEncoded: false)
+        == appPath)
+    #expect(
+      URL(fileURLWithPath: apiLinkPath).resolvingSymlinksInPath().path(percentEncoded: false)
+        == apiPath)
   }
 
   @Test func createWorkspaceMaterializesRemoteCloneAndBareWorktree() async throws {
@@ -280,12 +292,18 @@ struct ProjectWorkspaceTests {
     #expect(
       commands.value.map(\.arguments) == [
         ["clone", "--end-of-options", "git@github.com:onevcat/app.git", "\(rootPath)/app"],
-        ["-C", "\(rootPath)/app", "checkout", "-B", "codex/app", "--end-of-options", "origin/main"],
-        ["-C", barePath, "worktree", "add", "-b", "codex/api", "\(rootPath)/api", "--end-of-options", "main"],
+        [
+          "-C", "\(rootPath)/app", "checkout", "-B", "codex/app", "--end-of-options", "origin/main",
+        ],
+        [
+          "-C", barePath, "worktree", "add", "-b", "codex/api", "\(rootPath)/api",
+          "--end-of-options", "main",
+        ],
       ])
 
     let loaded = try #require(ProjectWorkspace.load(from: rootURL))
-    #expect(loaded.repositories.map(\.sourceLocation) == ["git@github.com:onevcat/app.git", barePath])
+    #expect(
+      loaded.repositories.map(\.sourceLocation) == ["git@github.com:onevcat/app.git", barePath])
     #expect(loaded.repositories.map(\.branchName) == ["codex/app", "codex/api"])
     #expect(loaded.repositories.map(\.baseRef) == ["origin/main", "main"])
   }
@@ -367,7 +385,8 @@ struct ProjectWorkspaceTests {
               path: "app",
               sourceKind: .remote,
               sourceLocation: "git@github.com:onevcat/app.git",
-              checkout: .trackRemoteRef(remoteRef: "origin/chore/disable-spine", branchName: "chore/disable-spine")
+              checkout: .trackRemoteRef(
+                remoteRef: "origin/chore/disable-spine", branchName: "chore/disable-spine")
             ),
             ProjectWorkspaceRepositoryPlan(
               id: "maker",
@@ -375,7 +394,8 @@ struct ProjectWorkspaceTests {
               path: nil,
               sourceKind: .bareRepository,
               sourceLocation: bareURL.path(percentEncoded: false),
-              checkout: .trackRemoteRef(remoteRef: "origin/chore/disable-spine", branchName: "chore/disable-spine")
+              checkout: .trackRemoteRef(
+                remoteRef: "origin/chore/disable-spine", branchName: "chore/disable-spine")
             ),
           ]
         ),
@@ -398,7 +418,8 @@ struct ProjectWorkspaceTests {
         ],
       ])
     #expect(workspace.repositories.map(\.path) == ["app", "maker"])
-    #expect(workspace.repositories.map(\.branchName) == ["chore/disable-spine", "chore/disable-spine"])
+    #expect(
+      workspace.repositories.map(\.branchName) == ["chore/disable-spine", "chore/disable-spine"])
     #expect(
       workspace.repositories.map(\.baseRef)
         == ["origin/chore/disable-spine", "origin/chore/disable-spine"]
@@ -445,6 +466,15 @@ struct ProjectWorkspaceTests {
     )
   }
 
+  @Test func localBranchNameForRemoteRefKeepsSlashedBranchName() {
+    #expect(
+      ProjectWorkspaceCreationRepository.localBranchName(forRemoteRef: "origin/chore/x")
+        == "chore/x")
+    #expect(
+      ProjectWorkspaceCreationRepository.localBranchName(forRemoteRef: "upstream/main") == "main")
+    #expect(ProjectWorkspaceCreationRepository.localBranchName(forRemoteRef: "main") == nil)
+  }
+
   @Test func planResetsLocalBranchToRemoteWhenChosen() {
     var repository = ProjectWorkspaceCreationRepository(
       id: "maker",
@@ -468,7 +498,8 @@ struct ProjectWorkspaceTests {
 
   @Test func defaultRepositoryNameStripsGitSuffix() {
     #expect(
-      WorkspaceCreationPromptFeature.defaultRepositoryName(for: URL(fileURLWithPath: "/tmp/maker.git"))
+      WorkspaceCreationPromptFeature.defaultRepositoryName(
+        for: URL(fileURLWithPath: "/tmp/maker.git"))
         == "maker"
     )
     #expect(
@@ -525,7 +556,10 @@ struct ProjectWorkspaceTests {
     let apiPath = normalizedTestPath(apiURL)
     #expect(
       commands.value.map(\.arguments) == [
-        ["-C", appPath, "worktree", "add", "-b", "codex/app", "\(rootPath)/app", "--end-of-options", "main"],
+        [
+          "-C", appPath, "worktree", "add", "-b", "codex/app", "\(rootPath)/app",
+          "--end-of-options", "main",
+        ],
         ["-C", apiPath, "worktree", "add", "\(rootPath)/api", "--end-of-options", "origin/main"],
       ])
     #expect(workspace.repositories.map(\.branchName) == ["codex/app", nil])
@@ -571,7 +605,8 @@ struct ProjectWorkspaceTests {
         gitRunner: ProjectWorkspaceGitRunner { command in
           commands.withValue { $0.append(command) }
           if command.arguments.first == "clone" {
-            try FileManager.default.createDirectory(at: cloneDestination, withIntermediateDirectories: true)
+            try FileManager.default.createDirectory(
+              at: cloneDestination, withIntermediateDirectories: true)
           }
           if command.arguments.contains("checkout") {
             throw ProjectWorkspaceCreationError.gitCommandFailed(
@@ -851,7 +886,8 @@ struct ProjectWorkspaceTests {
       workspace,
       rootURL: rootURL,
       gitRunner: ProjectWorkspaceGitRunner { _ in
-        throw ProjectWorkspaceCreationError.gitCommandFailed(command: "git worktree remove", message: "broken")
+        throw ProjectWorkspaceCreationError.gitCommandFailed(
+          command: "git worktree remove", message: "broken")
       }
     )
 
@@ -904,7 +940,8 @@ struct ProjectWorkspaceTests {
 
   private func writeWorkspaceJSON(_ json: String, to rootURL: URL) throws {
     let metadataDirectoryURL = rootURL.appending(path: ProjectWorkspace.metadataDirectoryName)
-    try FileManager.default.createDirectory(at: metadataDirectoryURL, withIntermediateDirectories: true)
+    try FileManager.default.createDirectory(
+      at: metadataDirectoryURL, withIntermediateDirectories: true)
     try Data(json.utf8).write(to: ProjectWorkspace.metadataURL(for: rootURL))
   }
 

--- a/supacodeTests/ProjectWorkspaceTests.swift
+++ b/supacodeTests/ProjectWorkspaceTests.swift
@@ -731,6 +731,50 @@ struct ProjectWorkspaceTests {
     #expect(FileManager.default.fileExists(atPath: linkedSourceURL.path(percentEncoded: false)))
   }
 
+  @Test func cleanupDeletesSelectedBranchesAfterWorktreeRemoval() async throws {
+    let rootURL = try makeTemporaryWorkspaceRoot()
+    let bareURL = try makeTemporaryWorkspaceRoot()
+    defer {
+      try? FileManager.default.removeItem(at: rootURL)
+      try? FileManager.default.removeItem(at: bareURL)
+    }
+    try FileManager.default.createDirectory(
+      at: rootURL.appending(path: "api"),
+      withIntermediateDirectories: true
+    )
+
+    let workspace = ProjectWorkspace(
+      repositories: [
+        ProjectWorkspace.RepositoryEntry(
+          id: "api",
+          name: "API",
+          path: "api",
+          sourceKind: .bareRepository,
+          sourceLocation: bareURL.path(percentEncoded: false),
+          branchName: "chore/x"
+        )
+      ]
+    )
+    let commands = LockIsolated<[ProjectWorkspaceGitCommand]>([])
+    let apiPath = rootURL.appending(path: "api").standardizedFileURL.path(percentEncoded: false)
+    await ProjectWorkspace.cleanup(
+      workspace,
+      rootURL: rootURL,
+      deleteBranchEntryIDs: ["api"],
+      gitRunner: ProjectWorkspaceGitRunner { command in
+        commands.withValue { $0.append(command) }
+      }
+    )
+
+    let barePath = bareURL.path(percentEncoded: false)
+    #expect(
+      commands.value.map(\.arguments) == [
+        ["-C", barePath, "worktree", "remove", "--force", apiPath],
+        ["-C", barePath, "branch", "-D", "chore/x"],
+      ])
+    #expect(!FileManager.default.fileExists(atPath: rootURL.path(percentEncoded: false)))
+  }
+
   @Test func listRuntimeContextsReportWorkspaceKind() {
     let rootURL = URL(fileURLWithPath: "/tmp/workspace")
     let repository = Repository(

--- a/supacodeTests/ProjectWorkspaceTests.swift
+++ b/supacodeTests/ProjectWorkspaceTests.swift
@@ -422,6 +422,50 @@ struct ProjectWorkspaceTests {
     )
   }
 
+  @Test func planKeepsExistingLocalBranchWhenNotResetting() {
+    let repository = ProjectWorkspaceCreationRepository(
+      id: "maker",
+      name: "maker.git",
+      sourceKind: .bareRepository,
+      sourceLocation: "/tmp/maker.git",
+      checkoutMode: .useExistingRef,
+      baseRef: "origin/chore/x",
+      baseRefOptions: [
+        GitBranchRefOption(ref: "origin/chore/x", kind: .remoteTracking),
+        GitBranchRefOption(ref: "chore/x", kind: .local),
+      ]
+    )
+
+    // A same-named local branch exists and the user keeps it (default): check
+    // out the local branch directly instead of resetting it to the remote.
+    #expect(repository.resettableLocalBranchName == "chore/x")
+    #expect(
+      WorkspaceCreationPromptFeature.plan(for: repository).map(\.checkout)
+        == .success(.useExistingRef("chore/x"))
+    )
+  }
+
+  @Test func planResetsLocalBranchToRemoteWhenChosen() {
+    var repository = ProjectWorkspaceCreationRepository(
+      id: "maker",
+      name: "maker.git",
+      sourceKind: .bareRepository,
+      sourceLocation: "/tmp/maker.git",
+      checkoutMode: .useExistingRef,
+      baseRef: "origin/chore/x",
+      baseRefOptions: [
+        GitBranchRefOption(ref: "origin/chore/x", kind: .remoteTracking),
+        GitBranchRefOption(ref: "chore/x", kind: .local),
+      ]
+    )
+    repository.resetLocalBranchToRemote = true
+
+    #expect(
+      WorkspaceCreationPromptFeature.plan(for: repository).map(\.checkout)
+        == .success(.trackRemoteRef(remoteRef: "origin/chore/x", branchName: "chore/x"))
+    )
+  }
+
   @Test func defaultRepositoryNameStripsGitSuffix() {
     #expect(
       WorkspaceCreationPromptFeature.defaultRepositoryName(for: URL(fileURLWithPath: "/tmp/maker.git"))
@@ -715,7 +759,7 @@ struct ProjectWorkspaceTests {
     )
     let commands = LockIsolated<[ProjectWorkspaceGitCommand]>([])
     let apiPath = rootURL.appending(path: "api").standardizedFileURL.path(percentEncoded: false)
-    await ProjectWorkspace.cleanup(
+    let failures = await ProjectWorkspace.removeWorktrees(
       workspace,
       rootURL: rootURL,
       gitRunner: ProjectWorkspaceGitRunner { command in
@@ -723,15 +767,19 @@ struct ProjectWorkspaceTests {
       }
     )
 
+    #expect(failures.isEmpty)
     #expect(
       commands.value.map(\.arguments) == [
         ["-C", bareURL.path(percentEncoded: false), "worktree", "remove", "--force", apiPath]
       ])
+    // removeWorktrees must leave the folder and the linked source intact.
+    #expect(FileManager.default.fileExists(atPath: rootURL.path(percentEncoded: false)))
+    ProjectWorkspace.removeWorkspaceFolder(at: rootURL)
     #expect(!FileManager.default.fileExists(atPath: rootURL.path(percentEncoded: false)))
     #expect(FileManager.default.fileExists(atPath: linkedSourceURL.path(percentEncoded: false)))
   }
 
-  @Test func cleanupDeletesSelectedBranchesAfterWorktreeRemoval() async throws {
+  @Test func removeWorktreesDoesNotDeleteBranches() async throws {
     let rootURL = try makeTemporaryWorkspaceRoot()
     let bareURL = try makeTemporaryWorkspaceRoot()
     defer {
@@ -757,22 +805,59 @@ struct ProjectWorkspaceTests {
     )
     let commands = LockIsolated<[ProjectWorkspaceGitCommand]>([])
     let apiPath = rootURL.appending(path: "api").standardizedFileURL.path(percentEncoded: false)
-    await ProjectWorkspace.cleanup(
+    let failures = await ProjectWorkspace.removeWorktrees(
       workspace,
       rootURL: rootURL,
-      deleteBranchEntryIDs: ["api"],
       gitRunner: ProjectWorkspaceGitRunner { command in
         commands.withValue { $0.append(command) }
       }
     )
 
     let barePath = bareURL.path(percentEncoded: false)
+    #expect(failures.isEmpty)
+    // Branch deletion is routed through GitClient's guarded entry point, never
+    // the workspace git runner — so no `branch -D` is issued here.
     #expect(
       commands.value.map(\.arguments) == [
-        ["-C", barePath, "worktree", "remove", "--force", apiPath],
-        ["-C", barePath, "branch", "-D", "chore/x"],
+        ["-C", barePath, "worktree", "remove", "--force", apiPath]
       ])
-    #expect(!FileManager.default.fileExists(atPath: rootURL.path(percentEncoded: false)))
+  }
+
+  @Test func removeWorktreesReportsFailedRemovals() async throws {
+    let rootURL = try makeTemporaryWorkspaceRoot()
+    let bareURL = try makeTemporaryWorkspaceRoot()
+    defer {
+      try? FileManager.default.removeItem(at: rootURL)
+      try? FileManager.default.removeItem(at: bareURL)
+    }
+    try FileManager.default.createDirectory(
+      at: rootURL.appending(path: "api"),
+      withIntermediateDirectories: true
+    )
+
+    let workspace = ProjectWorkspace(
+      repositories: [
+        ProjectWorkspace.RepositoryEntry(
+          id: "api",
+          name: "API",
+          path: "api",
+          sourceKind: .bareRepository,
+          sourceLocation: bareURL.path(percentEncoded: false),
+          branchName: "chore/x"
+        )
+      ]
+    )
+    let failures = await ProjectWorkspace.removeWorktrees(
+      workspace,
+      rootURL: rootURL,
+      gitRunner: ProjectWorkspaceGitRunner { _ in
+        throw ProjectWorkspaceCreationError.gitCommandFailed(command: "git worktree remove", message: "broken")
+      }
+    )
+
+    #expect(failures == ["API"])
+    // A failed worktree removal must not delete the folder.
+    #expect(FileManager.default.fileExists(atPath: rootURL.path(percentEncoded: false)))
   }
 
   @Test func listRuntimeContextsReportWorkspaceKind() {

--- a/supacodeTests/ProjectWorkspaceTests.swift
+++ b/supacodeTests/ProjectWorkspaceTests.swift
@@ -676,6 +676,61 @@ struct ProjectWorkspaceTests {
     )
   }
 
+  @Test func cleanupUnregistersWorktreesAndRemovesFolder() async throws {
+    let rootURL = try makeTemporaryWorkspaceRoot()
+    let linkedSourceURL = try makeTemporaryWorkspaceRoot()
+    let bareURL = try makeTemporaryWorkspaceRoot()
+    defer {
+      try? FileManager.default.removeItem(at: rootURL)
+      try? FileManager.default.removeItem(at: linkedSourceURL)
+      try? FileManager.default.removeItem(at: bareURL)
+    }
+    try FileManager.default.createSymbolicLink(
+      at: rootURL.appending(path: "app"),
+      withDestinationURL: linkedSourceURL
+    )
+    try FileManager.default.createDirectory(
+      at: rootURL.appending(path: "api"),
+      withIntermediateDirectories: true
+    )
+
+    let workspace = ProjectWorkspace(
+      repositories: [
+        ProjectWorkspace.RepositoryEntry(
+          id: "app",
+          name: "App",
+          path: "app",
+          sourceKind: .existingPath,
+          sourceLocation: linkedSourceURL.path(percentEncoded: false)
+        ),
+        ProjectWorkspace.RepositoryEntry(
+          id: "api",
+          name: "API",
+          path: "api",
+          sourceKind: .bareRepository,
+          sourceLocation: bareURL.path(percentEncoded: false),
+          branchName: "chore/x"
+        ),
+      ]
+    )
+    let commands = LockIsolated<[ProjectWorkspaceGitCommand]>([])
+    let apiPath = rootURL.appending(path: "api").standardizedFileURL.path(percentEncoded: false)
+    await ProjectWorkspace.cleanup(
+      workspace,
+      rootURL: rootURL,
+      gitRunner: ProjectWorkspaceGitRunner { command in
+        commands.withValue { $0.append(command) }
+      }
+    )
+
+    #expect(
+      commands.value.map(\.arguments) == [
+        ["-C", bareURL.path(percentEncoded: false), "worktree", "remove", "--force", apiPath]
+      ])
+    #expect(!FileManager.default.fileExists(atPath: rootURL.path(percentEncoded: false)))
+    #expect(FileManager.default.fileExists(atPath: linkedSourceURL.path(percentEncoded: false)))
+  }
+
   @Test func listRuntimeContextsReportWorkspaceKind() {
     let rootURL = URL(fileURLWithPath: "/tmp/workspace")
     let repository = Repository(

--- a/supacodeTests/ProjectWorkspaceTests.swift
+++ b/supacodeTests/ProjectWorkspaceTests.swift
@@ -1,0 +1,161 @@
+import Foundation
+import IdentifiedCollections
+import Testing
+
+@testable import supacode
+
+@MainActor
+struct ProjectWorkspaceTests {
+  @Test func loadsWorkspaceMetadataWithDefaultsAndSnakeCaseSources() throws {
+    let rootURL = try makeTemporaryWorkspaceRoot()
+    defer { try? FileManager.default.removeItem(at: rootURL) }
+
+    try writeWorkspaceJSON(
+      """
+      {
+        "title": "Multi Repo Task",
+        "repositories": [
+          {
+            "role": "backend",
+            "path": "api",
+            "source_kind": "bare_repository",
+            "source_location": "/Users/mikoto/Repos/api.git",
+            "branch_name": "feature/workspace"
+          },
+          {
+            "id": "web",
+            "name": "Web",
+            "path": "/tmp/web",
+            "source_kind": "remote",
+            "source_location": "git@github.com:onevcat/web.git"
+          },
+          {
+            "name": "Shared",
+            "path": "shared"
+          }
+        ]
+      }
+      """,
+      to: rootURL
+    )
+
+    let workspace = try #require(ProjectWorkspace.load(from: rootURL))
+    let rootPath = rootURL.standardizedFileURL.path(percentEncoded: false)
+
+    #expect(workspace.id == rootPath)
+    #expect(workspace.title == "Multi Repo Task")
+    #expect(workspace.description == "")
+    #expect(workspace.taskLinks == [])
+    try #require(workspace.repositories.count == 3)
+
+    let api = workspace.repositories[0]
+    #expect(api.id == "api")
+    #expect(api.name == "api")
+    #expect(api.role == "backend")
+    #expect(api.sourceKind == .bareRepository)
+    #expect(api.sourceLocation == "/Users/mikoto/Repos/api.git")
+    #expect(api.branchName == "feature/workspace")
+    #expect(
+      api.resolvedURL(relativeTo: rootURL).path(percentEncoded: false)
+        == rootURL.appending(path: "api").standardizedFileURL.path(percentEncoded: false)
+    )
+
+    let web = workspace.repositories[1]
+    #expect(web.id == "web")
+    #expect(web.name == "Web")
+    #expect(web.sourceKind == .remote)
+    #expect(
+      web.resolvedURL(relativeTo: rootURL).path(percentEncoded: false)
+        == URL(fileURLWithPath: "/tmp/web").standardizedFileURL.path(percentEncoded: false)
+    )
+
+    let shared = workspace.repositories[2]
+    #expect(shared.id == "shared")
+    #expect(shared.name == "Shared")
+    #expect(shared.sourceKind == .existingPath)
+  }
+
+  @Test func normalizesEmptyWorkspaceAndRepositoryFields() throws {
+    let rootURL = URL(fileURLWithPath: "/tmp/prowl-workspace")
+
+    let workspace = ProjectWorkspace(
+      id: " ",
+      title: " ",
+      description: "  Touch app and API together  ",
+      taskLinks: [" https://github.com/onevcat/Prowl/issues/1 ", " "],
+      repositories: [
+        ProjectWorkspace.RepositoryEntry(
+          id: " ",
+          name: " ",
+          role: " ",
+          path: " app ",
+          sourceKind: .localRepository,
+          sourceLocation: " ",
+          branchName: " feature/workspace ",
+          baseRef: " "
+        )
+      ]
+    )
+    .normalized(relativeTo: rootURL)
+
+    #expect(workspace.id == "/tmp/prowl-workspace")
+    #expect(workspace.title == "prowl-workspace")
+    #expect(workspace.description == "Touch app and API together")
+    #expect(workspace.taskLinks == ["https://github.com/onevcat/Prowl/issues/1"])
+
+    let entry = try #require(workspace.repositories.first)
+    #expect(entry.id == "app")
+    #expect(entry.name == "app")
+    #expect(entry.role == nil)
+    #expect(entry.sourceKind == .localRepository)
+    #expect(entry.sourceLocation == nil)
+    #expect(entry.branchName == "feature/workspace")
+    #expect(entry.baseRef == nil)
+  }
+
+  @Test func repositoryEntryNormalizerKeepsWorkspacePathPlain() throws {
+    let rootURL = try makeTemporaryWorkspaceRoot()
+    defer { try? FileManager.default.removeItem(at: rootURL) }
+    try writeWorkspaceJSON("{}", to: rootURL)
+
+    let rootPath = rootURL.standardizedFileURL.path(percentEncoded: false)
+    let normalized = RepositoryEntryNormalizer.normalize([
+      PersistedRepositoryEntry(path: rootPath, kind: .git)
+    ])
+
+    #expect(normalized == [PersistedRepositoryEntry(path: rootPath, kind: .plain)])
+  }
+
+  @Test func listRuntimeContextsReportWorkspaceKind() {
+    let rootURL = URL(fileURLWithPath: "/tmp/workspace")
+    let repository = Repository(
+      id: rootURL.path(percentEncoded: false),
+      rootURL: rootURL,
+      name: "Workspace",
+      kind: .plain,
+      worktrees: [],
+      workspace: ProjectWorkspace(title: "Workspace")
+    )
+    var state = RepositoriesFeature.State()
+    state.repositories = [repository]
+    state.repositoryRoots = [rootURL]
+
+    let contexts = ListRuntimeSnapshotBuilder.orderedWorktreeContexts(from: state)
+
+    #expect(contexts.map(\.kind) == [.workspace])
+    #expect(contexts.first?.id == repository.id)
+  }
+
+  private func makeTemporaryWorkspaceRoot() throws -> URL {
+    let rootURL = FileManager.default.temporaryDirectory
+      .appending(path: "prowl-workspace-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+    return rootURL
+  }
+
+  private func writeWorkspaceJSON(_ json: String, to rootURL: URL) throws {
+    let metadataDirectoryURL = rootURL.appending(path: ProjectWorkspace.metadataDirectoryName)
+    try FileManager.default.createDirectory(at: metadataDirectoryURL, withIntermediateDirectories: true)
+    try Data(json.utf8).write(to: ProjectWorkspace.metadataURL(for: rootURL))
+  }
+}

--- a/supacodeTests/ProjectWorkspaceTests.swift
+++ b/supacodeTests/ProjectWorkspaceTests.swift
@@ -345,6 +345,94 @@ struct ProjectWorkspaceTests {
     #expect(loaded.repositories.map(\.baseRef) == ["origin/feature/login", "main"])
   }
 
+  @Test func createWorkspaceTracksRemoteRefsAsLocalBranches() async throws {
+    let rootURL = FileManager.default.temporaryDirectory
+      .appending(path: "prowl-tracked-ref-workspace-\(UUID().uuidString)")
+      .standardizedFileURL
+    let bareURL = try makeTemporaryWorkspaceRoot()
+    defer {
+      try? FileManager.default.removeItem(at: rootURL)
+      try? FileManager.default.removeItem(at: bareURL)
+    }
+    let commands = LockIsolated<[ProjectWorkspaceGitCommand]>([])
+    let workspace = try await ProjectWorkspace.create(
+      ProjectWorkspaceCreationRequest(
+        draft: ProjectWorkspaceCreationDraft(
+          title: "Tracked Refs",
+          rootURL: rootURL,
+          repositories: [
+            ProjectWorkspaceRepositoryPlan(
+              id: "app",
+              name: "App",
+              path: "app",
+              sourceKind: .remote,
+              sourceLocation: "git@github.com:onevcat/app.git",
+              checkout: .trackRemoteRef(remoteRef: "origin/chore/disable-spine", branchName: "chore/disable-spine")
+            ),
+            ProjectWorkspaceRepositoryPlan(
+              id: "maker",
+              name: "maker.git",
+              path: nil,
+              sourceKind: .bareRepository,
+              sourceLocation: bareURL.path(percentEncoded: false),
+              checkout: .trackRemoteRef(remoteRef: "origin/chore/disable-spine", branchName: "chore/disable-spine")
+            ),
+          ]
+        ),
+        createdAt: Date(timeIntervalSince1970: 8_901_234)
+      ),
+      gitRunner: ProjectWorkspaceGitRunner { command in
+        commands.withValue { $0.append(command) }
+      }
+    )
+
+    let rootPath = rootURL.path(percentEncoded: false)
+    let barePath = normalizedTestPath(bareURL)
+    #expect(
+      commands.value.map(\.arguments) == [
+        ["clone", "--end-of-options", "git@github.com:onevcat/app.git", "\(rootPath)/app"],
+        ["-C", "\(rootPath)/app", "checkout", "--end-of-options", "chore/disable-spine"],
+        [
+          "-C", barePath, "worktree", "add", "--track", "-B", "chore/disable-spine",
+          "\(rootPath)/maker", "--end-of-options", "origin/chore/disable-spine",
+        ],
+      ])
+    #expect(workspace.repositories.map(\.path) == ["app", "maker"])
+    #expect(workspace.repositories.map(\.branchName) == ["chore/disable-spine", "chore/disable-spine"])
+    #expect(
+      workspace.repositories.map(\.baseRef)
+        == ["origin/chore/disable-spine", "origin/chore/disable-spine"]
+    )
+  }
+
+  @Test func planMapsRemoteTrackingRefToTrackingBranch() {
+    let repository = ProjectWorkspaceCreationRepository(
+      id: "maker",
+      name: "maker.git",
+      sourceKind: .bareRepository,
+      sourceLocation: "/tmp/maker.git",
+      checkoutMode: .useExistingRef,
+      baseRef: "origin/chore/x",
+      baseRefOptions: [GitBranchRefOption(ref: "origin/chore/x", kind: .remoteTracking)]
+    )
+
+    #expect(
+      WorkspaceCreationPromptFeature.plan(for: repository).map(\.checkout)
+        == .success(.trackRemoteRef(remoteRef: "origin/chore/x", branchName: "chore/x"))
+    )
+  }
+
+  @Test func defaultRepositoryNameStripsGitSuffix() {
+    #expect(
+      WorkspaceCreationPromptFeature.defaultRepositoryName(for: URL(fileURLWithPath: "/tmp/maker.git"))
+        == "maker"
+    )
+    #expect(
+      WorkspaceCreationPromptFeature.defaultRepositoryName(for: URL(fileURLWithPath: "/tmp/maker"))
+        == "maker"
+    )
+  }
+
   @Test func createWorkspaceMaterializesLocalRepositoriesAsWorktrees() async throws {
     let rootURL = FileManager.default.temporaryDirectory
       .appending(path: "prowl-local-worktree-workspace-\(UUID().uuidString)")

--- a/supacodeTests/ProjectWorkspaceTests.swift
+++ b/supacodeTests/ProjectWorkspaceTests.swift
@@ -126,6 +126,62 @@ struct ProjectWorkspaceTests {
     #expect(normalized == [PersistedRepositoryEntry(path: rootPath, kind: .plain)])
   }
 
+  @Test func createWorkspaceWritesMetadataAndRepositoryLinks() throws {
+    let rootURL = FileManager.default.temporaryDirectory
+      .appending(path: "prowl-created-workspace-\(UUID().uuidString)")
+      .standardizedFileURL
+    let appURL = try makeTemporaryWorkspaceRoot()
+    let apiURL = try makeTemporaryWorkspaceRoot()
+    defer {
+      try? FileManager.default.removeItem(at: rootURL)
+      try? FileManager.default.removeItem(at: appURL)
+      try? FileManager.default.removeItem(at: apiURL)
+    }
+    let createdAt = Date(timeIntervalSince1970: 1_234_567)
+    let workspace = try ProjectWorkspace.create(
+      ProjectWorkspaceCreationRequest(
+        draft: ProjectWorkspaceCreationDraft(
+          title: "Checkout Flow",
+          rootURL: rootURL,
+          repositories: [
+            ProjectWorkspaceCreationRepository(
+              id: "app",
+              name: "App Repo",
+              rootURL: appURL,
+              branchName: "main"
+            ),
+            ProjectWorkspaceCreationRepository(
+              id: "api",
+              name: "App Repo",
+              rootURL: apiURL,
+              branchName: "feature/api"
+            ),
+          ]
+        ),
+        createdAt: createdAt
+      )
+    )
+
+    #expect(workspace.title == "Checkout Flow")
+    #expect(workspace.createdAt == createdAt)
+    let loaded = try #require(ProjectWorkspace.load(from: rootURL))
+    #expect(loaded.repositories.map(\.path) == ["App-Repo", "App-Repo-2"])
+    #expect(loaded.repositories.map(\.sourceKind) == [.existingPath, .existingPath])
+    let appPath = normalizedTestPath(appURL)
+    let apiPath = normalizedTestPath(apiURL)
+    #expect(
+      loaded.repositories.map(\.sourceLocation) == [
+        appPath,
+        apiPath,
+      ])
+    #expect(loaded.repositories.map(\.branchName) == ["main", "feature/api"])
+
+    let appLinkPath = rootURL.appending(path: "App-Repo").path(percentEncoded: false)
+    let apiLinkPath = rootURL.appending(path: "App-Repo-2").path(percentEncoded: false)
+    #expect(URL(fileURLWithPath: appLinkPath).resolvingSymlinksInPath().path(percentEncoded: false) == appPath)
+    #expect(URL(fileURLWithPath: apiLinkPath).resolvingSymlinksInPath().path(percentEncoded: false) == apiPath)
+  }
+
   @Test func listRuntimeContextsReportWorkspaceKind() {
     let rootURL = URL(fileURLWithPath: "/tmp/workspace")
     let repository = Repository(
@@ -157,5 +213,13 @@ struct ProjectWorkspaceTests {
     let metadataDirectoryURL = rootURL.appending(path: ProjectWorkspace.metadataDirectoryName)
     try FileManager.default.createDirectory(at: metadataDirectoryURL, withIntermediateDirectories: true)
     try Data(json.utf8).write(to: ProjectWorkspace.metadataURL(for: rootURL))
+  }
+
+  private func normalizedTestPath(_ url: URL) -> String {
+    var path = PathPolicy.normalizeURL(url).path(percentEncoded: false)
+    while path.count > 1, path.hasSuffix("/") {
+      path.removeLast()
+    }
+    return path
   }
 }

--- a/supacodeTests/ProjectWorkspaceTests.swift
+++ b/supacodeTests/ProjectWorkspaceTests.swift
@@ -1,3 +1,4 @@
+import ComposableArchitecture
 import Foundation
 import IdentifiedCollections
 import Testing
@@ -126,7 +127,7 @@ struct ProjectWorkspaceTests {
     #expect(normalized == [PersistedRepositoryEntry(path: rootPath, kind: .plain)])
   }
 
-  @Test func createWorkspaceWritesMetadataAndRepositoryLinks() throws {
+  @Test func createWorkspaceWritesMetadataAndRepositoryLinks() async throws {
     let rootURL = FileManager.default.temporaryDirectory
       .appending(path: "prowl-created-workspace-\(UUID().uuidString)")
       .standardizedFileURL
@@ -138,7 +139,7 @@ struct ProjectWorkspaceTests {
       try? FileManager.default.removeItem(at: apiURL)
     }
     let createdAt = Date(timeIntervalSince1970: 1_234_567)
-    let workspace = try ProjectWorkspace.create(
+    let workspace = try await ProjectWorkspace.create(
       ProjectWorkspaceCreationRequest(
         draft: ProjectWorkspaceCreationDraft(
           title: "Checkout Flow",
@@ -159,7 +160,10 @@ struct ProjectWorkspaceTests {
           ]
         ),
         createdAt: createdAt
-      )
+      ),
+      gitRunner: ProjectWorkspaceGitRunner { command in
+        throw ProjectWorkspaceCreationError.gitCommandFailed(command: command.displayCommand, message: "unexpected")
+      }
     )
 
     #expect(workspace.title == "Checkout Flow")
@@ -180,6 +184,66 @@ struct ProjectWorkspaceTests {
     let apiLinkPath = rootURL.appending(path: "App-Repo-2").path(percentEncoded: false)
     #expect(URL(fileURLWithPath: appLinkPath).resolvingSymlinksInPath().path(percentEncoded: false) == appPath)
     #expect(URL(fileURLWithPath: apiLinkPath).resolvingSymlinksInPath().path(percentEncoded: false) == apiPath)
+  }
+
+  @Test func createWorkspaceMaterializesRemoteCloneAndBareWorktree() async throws {
+    let rootURL = FileManager.default.temporaryDirectory
+      .appending(path: "prowl-materialized-workspace-\(UUID().uuidString)")
+      .standardizedFileURL
+    let bareURL = try makeTemporaryWorkspaceRoot()
+    defer {
+      try? FileManager.default.removeItem(at: rootURL)
+      try? FileManager.default.removeItem(at: bareURL)
+    }
+    let commands = LockIsolated<[ProjectWorkspaceGitCommand]>([])
+    let workspace = try await ProjectWorkspace.create(
+      ProjectWorkspaceCreationRequest(
+        draft: ProjectWorkspaceCreationDraft(
+          title: "Materialized",
+          rootURL: rootURL,
+          repositories: [
+            ProjectWorkspaceCreationRepository(
+              id: "app",
+              name: "App",
+              sourceKind: .remote,
+              sourceLocation: "git@github.com:onevcat/app.git",
+              branchName: "codex/app",
+              baseRef: "origin/main",
+              path: "app"
+            ),
+            ProjectWorkspaceCreationRepository(
+              id: "api",
+              name: "API",
+              sourceKind: .bareRepository,
+              sourceLocation: bareURL.path(percentEncoded: false),
+              branchName: "codex/api",
+              baseRef: "main",
+              path: "api"
+            ),
+          ]
+        ),
+        createdAt: Date(timeIntervalSince1970: 2_345_678)
+      ),
+      gitRunner: ProjectWorkspaceGitRunner { command in
+        commands.withValue { $0.append(command) }
+      }
+    )
+
+    #expect(workspace.repositories.map(\.path) == ["app", "api"])
+    #expect(workspace.repositories.map(\.sourceKind) == [.remote, .bareRepository])
+    let rootPath = rootURL.path(percentEncoded: false)
+    let barePath = normalizedTestPath(bareURL)
+    #expect(
+      commands.value.map(\.arguments) == [
+        ["clone", "git@github.com:onevcat/app.git", "\(rootPath)/app"],
+        ["-C", "\(rootPath)/app", "checkout", "-B", "codex/app", "origin/main"],
+        ["-C", barePath, "worktree", "add", "-b", "codex/api", "\(rootPath)/api", "main"],
+      ])
+
+    let loaded = try #require(ProjectWorkspace.load(from: rootURL))
+    #expect(loaded.repositories.map(\.sourceLocation) == ["git@github.com:onevcat/app.git", barePath])
+    #expect(loaded.repositories.map(\.branchName) == ["codex/app", "codex/api"])
+    #expect(loaded.repositories.map(\.baseRef) == ["origin/main", "main"])
   }
 
   @Test func listRuntimeContextsReportWorkspaceKind() {

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -589,11 +589,13 @@ struct RepositoriesFeatureTests {
     }
 
     let title = "Workspace"
+    let requestedRootPath = defaultWorkspaceBaseRootPath(for: title)
+    let resolvedRootPath = expectedDefaultWorkspaceRootPath(for: title)
     await store.send(.workspaceCreation(.promptRequested)) {
       $0.workspaceCreationPrompt = WorkspaceCreationPromptFeature.State(
         repositories: [],
         title: title,
-        rootPath: defaultWorkspaceBaseRootPath(for: title),
+        rootPath: requestedRootPath,
         openedRepositoryCandidates: [
           ProjectWorkspaceCreationRepository(
             id: "/tmp/repo-a",
@@ -603,8 +605,12 @@ struct RepositoriesFeatureTests {
         ]
       )
     }
-    await store.receive(\.workspaceCreation.defaultRootPathResolved) {
-      $0.workspaceCreationPrompt?.rootPath = expectedDefaultWorkspaceRootPath(for: title)
+    if resolvedRootPath == requestedRootPath {
+      await store.receive(\.workspaceCreation.defaultRootPathResolved)
+    } else {
+      await store.receive(\.workspaceCreation.defaultRootPathResolved) {
+        $0.workspaceCreationPrompt?.rootPath = resolvedRootPath
+      }
     }
   }
 
@@ -701,11 +707,13 @@ struct RepositoriesFeatureTests {
     }
 
     let title = "Workspace"
+    let requestedRootPath = defaultWorkspaceBaseRootPath(for: title)
+    let resolvedRootPath = expectedDefaultWorkspaceRootPath(for: title)
     await store.send(.workspaceCreation(.promptRequested)) {
       $0.workspaceCreationPrompt = WorkspaceCreationPromptFeature.State(
         repositories: [],
         title: title,
-        rootPath: defaultWorkspaceBaseRootPath(for: title),
+        rootPath: requestedRootPath,
         openedRepositoryCandidates: [
           ProjectWorkspaceCreationRepository(
             id: repoRootA,
@@ -720,8 +728,12 @@ struct RepositoriesFeatureTests {
         ]
       )
     }
-    await store.receive(\.workspaceCreation.defaultRootPathResolved) {
-      $0.workspaceCreationPrompt?.rootPath = expectedDefaultWorkspaceRootPath(for: title)
+    if resolvedRootPath == requestedRootPath {
+      await store.receive(\.workspaceCreation.defaultRootPathResolved)
+    } else {
+      await store.receive(\.workspaceCreation.defaultRootPathResolved) {
+        $0.workspaceCreationPrompt?.rootPath = resolvedRootPath
+      }
     }
   }
 
@@ -755,11 +767,13 @@ struct RepositoriesFeatureTests {
     }
 
     let title = "Workspace"
+    let requestedRootPath = defaultWorkspaceBaseRootPath(for: title)
+    let resolvedRootPath = expectedDefaultWorkspaceRootPath(for: title)
     await store.send(.workspaceCreation(.promptRequested)) {
       $0.workspaceCreationPrompt = WorkspaceCreationPromptFeature.State(
         repositories: [],
         title: title,
-        rootPath: defaultWorkspaceBaseRootPath(for: title),
+        rootPath: requestedRootPath,
         openedRepositoryCandidates: [
           ProjectWorkspaceCreationRepository(
             id: repoRootA,
@@ -774,8 +788,12 @@ struct RepositoriesFeatureTests {
         ]
       )
     }
-    await store.receive(\.workspaceCreation.defaultRootPathResolved) {
-      $0.workspaceCreationPrompt?.rootPath = expectedDefaultWorkspaceRootPath(for: title)
+    if resolvedRootPath == requestedRootPath {
+      await store.receive(\.workspaceCreation.defaultRootPathResolved)
+    } else {
+      await store.receive(\.workspaceCreation.defaultRootPathResolved) {
+        $0.workspaceCreationPrompt?.rootPath = resolvedRootPath
+      }
     }
     await store.send(.workspaceCreationPrompt(.presented(.addOpenedRepository(repoRootA)))) {
       $0.workspaceCreationPrompt?.repositories.append(

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -545,6 +545,7 @@ struct RepositoriesFeatureTests {
       workspace: workspace
     )
 
+    let childID = repository.rootURL.appending(path: "app").standardizedFileURL.path(percentEncoded: false)
     let store = TestStore(initialState: RepositoriesFeature.State()) {
       RepositoriesFeature()
     } withDependencies: {
@@ -560,6 +561,11 @@ struct RepositoriesFeatureTests {
         Issue.record("workspace should not load git worktrees: \(url.path(percentEncoded: false))")
         return []
       }
+      // The workspace's child repository is refreshed via the child pipeline
+      // (live branch + diff), distinct from the worktree probing above.
+      $0.gitClient.branchName = { _ in "main" }
+      $0.gitClient.lineChanges = { _ in nil }
+      $0.gitClient.remoteInfo = { _ in nil }
     }
 
     await store.send(.loadPersistedRepositories)
@@ -570,6 +576,9 @@ struct RepositoriesFeatureTests {
       $0.snapshotPersistencePhase = .active
     }
     await store.receive(\.delegate.repositoriesChanged)
+    await store.receive(\.workspaceChildrenInfoLoaded) {
+      $0.workspaceChildBranchByID = [childID: "main"]
+    }
     await store.finish()
   }
 
@@ -6054,6 +6063,118 @@ struct RepositoriesFeatureTests {
 
     #expect(!store.state.canNavigateWorktreeHistoryForward)
     #expect(store.state.canNavigateWorktreeHistoryBackward)
+  }
+
+  // MARK: - Workspace child rows
+
+  private func makeWorkspaceRepository(
+    id: String,
+    children: [ProjectWorkspace.RepositoryEntry]
+  ) -> Repository {
+    makeRepository(
+      id: id,
+      name: "Workspace",
+      kind: .plain,
+      worktrees: [],
+      workspace: ProjectWorkspace(title: "Workspace", repositories: children)
+    )
+  }
+
+  @Test func applyWorkspaceChildrenInfoWritesBranchDiffAndPR() {
+    var state = RepositoriesFeature.State()
+    let pullRequest = makePullRequest(state: "OPEN", headRefName: "feature")
+    applyWorkspaceChildrenInfo(
+      [
+        WorkspaceChildInfoUpdate(id: "/ws/app", branch: "feature", added: 7, removed: 2, pullRequest: pullRequest),
+        WorkspaceChildInfoUpdate(id: "/ws/api", branch: "  ", added: 0, removed: 0, pullRequest: nil),
+      ],
+      state: &state
+    )
+
+    #expect(state.workspaceChildBranchByID["/ws/app"] == "feature")
+    #expect(state.workspaceChildInfoByID["/ws/app"]?.addedLines == 7)
+    #expect(state.workspaceChildInfoByID["/ws/app"]?.removedLines == 2)
+    #expect(state.workspaceChildInfoByID["/ws/app"]?.pullRequest == pullRequest)
+    // Blank branch + empty diff + no PR → no entries.
+    #expect(state.workspaceChildBranchByID["/ws/api"] == nil)
+    #expect(state.workspaceChildInfoByID["/ws/api"] == nil)
+  }
+
+  @Test func workspaceChildRowsMergesLiveBranchAndInfo() {
+    let entry = ProjectWorkspace.RepositoryEntry(
+      id: "app",
+      name: "App",
+      path: "app",
+      sourceKind: .existingPath,
+      branchName: "metadata-branch"
+    )
+    let repository = makeWorkspaceRepository(id: "/tmp/ws", children: [entry])
+    var state = makeState(repositories: [repository])
+    let childID = entry.resolvedURL(relativeTo: repository.rootURL).path(percentEncoded: false)
+    state.workspaceChildBranchByID[childID] = "live-branch"
+    state.workspaceChildInfoByID[childID] = WorktreeInfoEntry(addedLines: 3, removedLines: 1, pullRequest: nil)
+
+    let rows = state.workspaceChildRows(in: repository)
+
+    #expect(rows.count == 1)
+    #expect(rows.first?.repositoryName == "App")
+    // Live branch wins over the metadata branch.
+    #expect(rows.first?.branchName == "live-branch")
+    #expect(rows.first?.info?.addedLines == 3)
+  }
+
+  @Test func workspaceChildRowsFallsBackToMetadataBranch() {
+    let entry = ProjectWorkspace.RepositoryEntry(
+      id: "app",
+      name: "App",
+      path: "app",
+      sourceKind: .bareRepository,
+      branchName: "metadata-branch"
+    )
+    let repository = makeWorkspaceRepository(id: "/tmp/ws2", children: [entry])
+    let state = makeState(repositories: [repository])
+
+    let rows = state.workspaceChildRows(in: repository)
+    #expect(rows.first?.branchName == "metadata-branch")
+    #expect(rows.first?.info == nil)
+  }
+
+  @Test func repositoriesLoadedRefreshesAndPrunesWorkspaceChildren() async {
+    let entry = ProjectWorkspace.RepositoryEntry(
+      id: "app",
+      name: "App",
+      path: "app",
+      sourceKind: .existingPath,
+      branchName: "metadata"
+    )
+    let repository = makeWorkspaceRepository(id: "/tmp/ws-refresh", children: [entry])
+    let childID = entry.resolvedURL(relativeTo: repository.rootURL).path(percentEncoded: false)
+    var initialState = makeState(repositories: [repository])
+    // A stale child entry from a workspace that no longer exists must be pruned.
+    initialState.workspaceChildInfoByID["/tmp/gone/app"] = WorktreeInfoEntry(
+      addedLines: 1,
+      removedLines: 1,
+      pullRequest: nil
+    )
+    let store = TestStore(initialState: initialState) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.gitClient.branchName = { _ in "feature/live" }
+      $0.gitClient.lineChanges = { _ in (7, 2) }
+      $0.repositoryPersistence.saveRepositorySnapshot = { _ in }
+    }
+    store.exhaustivity = .off
+
+    await store.send(
+      .repositoriesLoaded([repository], failures: [], roots: [repository.rootURL], animated: false)
+    )
+    await store.receive(\.workspaceChildrenInfoLoaded)
+    await store.finish()
+
+    #expect(store.state.workspaceChildInfoByID["/tmp/gone/app"] == nil)
+    #expect(store.state.workspaceChildBranchByID[childID] == "feature/live")
+    #expect(store.state.workspaceChildInfoByID[childID]?.addedLines == 7)
+    #expect(store.state.workspaceChildInfoByID[childID]?.removedLines == 2)
   }
 
   private func makeWorktree(

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -579,7 +579,7 @@ struct RepositoriesFeatureTests {
     } withDependencies: {
       $0.gitClient.repoRoot = { url in url }
       $0.gitClient.automaticWorktreeBaseRef = { _ in "master" }
-      $0.gitClient.branchRefs = { _ in ["master"] }
+      $0.gitClient.branchRefOptions = { _ in [GitBranchRefOption(ref: "master", kind: .local)] }
     }
 
     await store.send(.workspaceCreation(.promptRequested)) {
@@ -604,7 +604,7 @@ struct RepositoriesFeatureTests {
     await store.receive(\.workspaceCreation.baseRefsLoaded) {
       $0.workspaceCreationPrompt?.repositories[id: "/tmp/repo-a"]?.baseRef = "master"
       $0.workspaceCreationPrompt?.repositories[id: "/tmp/repo-a"]?.baseRefOptions = [
-        "master"
+        GitBranchRefOption(ref: "master", kind: .local)
       ]
     }
   }
@@ -630,8 +630,16 @@ struct RepositoriesFeatureTests {
       $0.gitClient.automaticWorktreeBaseRef = { url in
         url.path(percentEncoded: false) == repoRootA ? "main" : "master"
       }
-      $0.gitClient.branchRefs = { url in
-        url.path(percentEncoded: false) == repoRootA ? ["main", "origin/main"] : ["master", "origin/master"]
+      $0.gitClient.branchRefOptions = { url in
+        url.path(percentEncoded: false) == repoRootA
+          ? [
+            GitBranchRefOption(ref: "main", kind: .local),
+            GitBranchRefOption(ref: "origin/main", kind: .remoteTracking),
+          ]
+          : [
+            GitBranchRefOption(ref: "master", kind: .local),
+            GitBranchRefOption(ref: "origin/master", kind: .remoteTracking),
+          ]
       }
     }
 
@@ -658,15 +666,15 @@ struct RepositoriesFeatureTests {
     await store.receive(\.workspaceCreation.baseRefsLoaded) {
       $0.workspaceCreationPrompt?.repositories[id: repoRootA]?.baseRef = "main"
       $0.workspaceCreationPrompt?.repositories[id: repoRootA]?.baseRefOptions = [
-        "main",
-        "origin/main",
+        GitBranchRefOption(ref: "main", kind: .local),
+        GitBranchRefOption(ref: "origin/main", kind: .remoteTracking),
       ]
     }
     await store.receive(\.workspaceCreation.baseRefsLoaded) {
       $0.workspaceCreationPrompt?.repositories[id: repoRootB]?.baseRef = "master"
       $0.workspaceCreationPrompt?.repositories[id: repoRootB]?.baseRefOptions = [
-        "master",
-        "origin/master",
+        GitBranchRefOption(ref: "master", kind: .local),
+        GitBranchRefOption(ref: "origin/master", kind: .remoteTracking),
       ]
     }
   }
@@ -713,7 +721,99 @@ struct RepositoriesFeatureTests {
     )
   }
 
-  @Test func workspaceCreationPromptAddsRemoteAndLocalRepositories() async {
+  @Test func workspaceCreationPromptAddsRemoteRepositoryAfterLoadingRefs() async {
+    let options = [
+      GitBranchRefOption(ref: "origin/feature/login", kind: .fetchedRemote),
+      GitBranchRefOption(ref: "origin/main", kind: .fetchedRemote),
+    ]
+    let store = TestStore(
+      initialState: WorkspaceCreationPromptFeature.State(
+        repositories: [],
+        title: "Workspace",
+        rootPath: "/tmp/workspace",
+        selectedRepositoryIDs: []
+      )
+    ) {
+      WorkspaceCreationPromptFeature()
+    } withDependencies: {
+      $0.uuid = .incrementing
+      $0.gitClient.remoteBranchRefs = { remoteURL in
+        #expect(remoteURL == "git@github.com:onevcat/app.git")
+        return GitRemoteBranchRefs(options: options, defaultBaseRef: "origin/main")
+      }
+    }
+
+    await store.send(.addRemoteButtonTapped) {
+      $0.remoteRepositoryPrompt = WorkspaceCreationPromptFeature.RemoteRepositoryPromptState()
+    }
+    await store.send(.remoteRepositoryPromptURLChanged(" git@github.com:onevcat/app.git ")) {
+      $0.remoteRepositoryPrompt?.url = " git@github.com:onevcat/app.git "
+      $0.remoteRepositoryPrompt?.name = "app"
+    }
+    await store.send(.remoteRepositoryPromptLoadButtonTapped) {
+      $0.remoteRepositoryPrompt?.url = "git@github.com:onevcat/app.git"
+      $0.remoteRepositoryPrompt?.isLoading = true
+    }
+    await store.receive(
+      .remoteRepositoryPromptLoaded(
+        "git@github.com:onevcat/app.git", GitRemoteBranchRefs(options: options, defaultBaseRef: "origin/main"))
+    ) {
+      $0.remoteRepositoryPrompt?.isLoading = false
+      $0.remoteRepositoryPrompt?.branchOptions = options
+      $0.remoteRepositoryPrompt?.defaultBaseRef = "origin/main"
+    }
+    await store.send(.remoteRepositoryPromptAddButtonTapped) {
+      $0.repositories.append(
+        ProjectWorkspaceCreationRepository(
+          id: UUID(0).uuidString,
+          name: "app",
+          sourceKind: .remote,
+          sourceLocation: "git@github.com:onevcat/app.git",
+          checkoutMode: .useExistingRef,
+          baseRef: "origin/main",
+          baseRefOptions: options
+        )
+      )
+      $0.selectedRepositoryIDs = [UUID(0).uuidString]
+      $0.remoteRepositoryPrompt = nil
+    }
+  }
+
+  @Test func workspaceCreationPromptRemoteLoadUsesDetectedDefaultFromOptions() async {
+    let store = TestStore(
+      initialState: WorkspaceCreationPromptFeature.State(
+        repositories: [],
+        title: "Workspace",
+        rootPath: "/tmp/workspace",
+        selectedRepositoryIDs: []
+      )
+    ) {
+      WorkspaceCreationPromptFeature()
+    }
+
+    await store.send(.addRemoteButtonTapped) {
+      $0.remoteRepositoryPrompt = WorkspaceCreationPromptFeature.RemoteRepositoryPromptState()
+    }
+    await store.send(
+      .remoteRepositoryPromptLoaded(
+        "",
+        GitRemoteBranchRefs(
+          options: [
+            GitBranchRefOption(ref: " origin/main ", kind: .fetchedRemote),
+            GitBranchRefOption(ref: "origin/main", kind: .fetchedRemote),
+          ],
+          defaultBaseRef: "origin/missing"
+        )
+      )
+    ) {
+      $0.remoteRepositoryPrompt?.branchOptions = [
+        GitBranchRefOption(ref: "origin/main", kind: .fetchedRemote)
+      ]
+      $0.remoteRepositoryPrompt?.defaultBaseRef = "origin/main"
+    }
+  }
+
+  @Test func workspaceCreationPromptAddsLocalRepository() async {
     let store = TestStore(
       initialState: WorkspaceCreationPromptFeature.State(
         repositories: [],
@@ -727,40 +827,18 @@ struct RepositoriesFeatureTests {
       $0.uuid = .incrementing
     }
 
-    await store.send(.addBlankRepository(.remote)) {
-      $0.repositories = [
-        ProjectWorkspaceCreationRepository(
-          id: UUID(0).uuidString,
-          name: "",
-          sourceKind: .remote,
-          sourceLocation: ""
-        )
-      ]
-      $0.selectedRepositoryIDs = [UUID(0).uuidString]
-    }
-
-    await store.send(.repositoryNameChanged(UUID(0).uuidString, "App")) {
-      $0.repositories[id: UUID(0).uuidString]?.name = "App"
-    }
-    await store.send(.repositorySourceLocationChanged(UUID(0).uuidString, "git@github.com:onevcat/app.git")) {
-      $0.repositories[id: UUID(0).uuidString]?.sourceLocation = "git@github.com:onevcat/app.git"
-    }
-    await store.send(.repositoryBranchNameChanged(UUID(0).uuidString, "codex/app")) {
-      $0.repositories[id: UUID(0).uuidString]?.branchName = "codex/app"
-    }
-
     await store.send(.addRepositoryFromURL(.localRepository, "/tmp/local-api")) {
       $0.repositories.append(
         ProjectWorkspaceCreationRepository(
-          id: UUID(1).uuidString,
+          id: UUID(0).uuidString,
           name: "local-api",
           sourceKind: .localRepository,
           sourceLocation: "/tmp/local-api"
         )
       )
-      $0.selectedRepositoryIDs = [UUID(0).uuidString, UUID(1).uuidString]
+      $0.selectedRepositoryIDs = [UUID(0).uuidString]
     }
-    await store.receive(.delegate(.baseRefSourceChanged(UUID(1).uuidString)))
+    await store.receive(.delegate(.baseRefSourceChanged(UUID(0).uuidString)))
   }
 
   @Test func workspaceCreationPromptRejectsUnknownBaseRef() async {
@@ -773,13 +851,13 @@ struct RepositoriesFeatureTests {
             id: repoRootA,
             name: "Repo A",
             rootURL: URL(fileURLWithPath: repoRootA),
-            baseRefOptions: ["main"]
+            baseRefOptions: [GitBranchRefOption(ref: "main", kind: .local)]
           ),
           ProjectWorkspaceCreationRepository(
             id: repoRootB,
             name: "Repo B",
             rootURL: URL(fileURLWithPath: repoRootB),
-            baseRefOptions: ["master"]
+            baseRefOptions: [GitBranchRefOption(ref: "master", kind: .local)]
           ),
         ],
         title: "Workspace",
@@ -793,6 +871,78 @@ struct RepositoriesFeatureTests {
     await store.send(.repositoryBaseRefChanged(repoRootA, "missing-branch"))
     await store.send(.repositoryBaseRefChanged(repoRootA, "main")) {
       $0.repositories[id: repoRootA]?.baseRef = "main"
+    }
+  }
+
+  @Test func workspaceCreationPromptRequiresExistingRefForUseExistingMode() async {
+    let repoRootA = "/tmp/repo-a"
+    let repoRootB = "/tmp/repo-b"
+    let store = TestStore(
+      initialState: WorkspaceCreationPromptFeature.State(
+        repositories: [
+          ProjectWorkspaceCreationRepository(
+            id: repoRootA,
+            name: "Repo A",
+            rootURL: URL(fileURLWithPath: repoRootA),
+            checkoutMode: .useExistingRef,
+            baseRefOptions: [GitBranchRefOption(ref: "main", kind: .local)]
+          ),
+          ProjectWorkspaceCreationRepository(
+            id: repoRootB,
+            name: "Repo B",
+            rootURL: URL(fileURLWithPath: repoRootB)
+          ),
+        ],
+        title: "Workspace",
+        rootPath: "/tmp/workspace",
+        selectedRepositoryIDs: [repoRootA, repoRootB]
+      )
+    ) {
+      WorkspaceCreationPromptFeature()
+    }
+
+    await store.send(.createButtonTapped) {
+      $0.validationMessage = "Choose an existing branch for Repo A."
+    }
+    await store.send(.repositoryBaseRefChanged(repoRootA, "main")) {
+      $0.repositories[id: repoRootA]?.baseRef = "main"
+      $0.validationMessage = nil
+    }
+  }
+
+  @Test func workspaceCreationPromptRequiresBranchNameForCreateBranchMode() async {
+    let repoRootB = "/tmp/repo-b"
+    let store = TestStore(
+      initialState: WorkspaceCreationPromptFeature.State(
+        repositories: [
+          ProjectWorkspaceCreationRepository(
+            id: "remote",
+            name: "Remote",
+            sourceKind: .remote,
+            sourceLocation: "git@github.com:onevcat/app.git",
+            baseRef: "origin/main",
+            baseRefOptions: [GitBranchRefOption(ref: "origin/main", kind: .fetchedRemote)]
+          ),
+          ProjectWorkspaceCreationRepository(
+            id: repoRootB,
+            name: "Repo B",
+            rootURL: URL(fileURLWithPath: repoRootB)
+          ),
+        ],
+        title: "Workspace",
+        rootPath: "/tmp/workspace",
+        selectedRepositoryIDs: ["remote", repoRootB]
+      )
+    ) {
+      WorkspaceCreationPromptFeature()
+    }
+
+    await store.send(.createButtonTapped) {
+      $0.validationMessage = "Branch name required for Remote."
+    }
+    await store.send(.repositoryBranchNameChanged("remote", "codex/app")) {
+      $0.repositories[id: "remote"]?.branchName = "codex/app"
+      $0.validationMessage = nil
     }
   }
 

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -1337,6 +1337,49 @@ struct RepositoriesFeatureTests {
     await store.finish()
   }
 
+  @Test func removeSelectedWorkspaceSelectsNextRepository() async {
+    let workspaceID = "/tmp/ws"
+    let otherWorktree = makeWorktree(id: "/tmp/other/main", name: "main", repoRoot: "/tmp/other")
+    let otherRepo = makeRepository(id: "/tmp/other", name: "other", worktrees: [otherWorktree])
+    let wsRepo = makeRepository(
+      id: workspaceID,
+      name: "WS",
+      kind: .plain,
+      worktrees: [],
+      workspace: ProjectWorkspace(title: "WS")
+    )
+    var state = makeState(repositories: [wsRepo, otherRepo])
+    state.selection = .repository(workspaceID)
+    state.selectedWorkspaceChildID = "child-1"
+    let otherEntry = PersistedRepositoryEntry(path: "/tmp/other", kind: .git)
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.repositoryPersistence.loadRepositoryEntries = { [otherEntry] }
+      $0.repositoryPersistence.saveRepositoryEntries = { _ in }
+      $0.repositoryPersistence.saveRepositorySnapshot = { _ in }
+      $0.gitClient.repoRoot = { @Sendable url in url }
+      $0.gitClient.worktrees = { @Sendable _ in [otherWorktree] }
+      $0.gitClient.isBareRepository = { @Sendable _ in false }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.repositoryManagement(.requestRemoveRepository(workspaceID)))
+    await store.send(.repositoryManagement(.removeWorkspacePromptConfirmed))
+    await store.receive(\.repositoryManagement.repositoryRemoved)
+    await store.receive(\.repositoriesLoaded)
+    await store.finish()
+
+    #expect(store.state.selectedWorkspaceChildID == nil)
+    #expect(store.state.selectedWorkspaceChildID == nil)
+    // After removing the currently-selected workspace with another repo available,
+    // the sidebar should auto-select the next item — not leave an empty selection.
+    #expect(
+      store.state.selection == .worktree(otherWorktree.id),
+      "Expected auto-selection of next worktree, got \(String(describing: store.state.selection))"
+    )
+  }
+
   @Test func removeWorkspaceRoutesBranchDeletionThroughGuardedClient() async throws {
     let rootURL = FileManager.default.temporaryDirectory
       .appending(path: "prowl-ws-\(UUID().uuidString)")

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -576,6 +576,10 @@ struct RepositoriesFeatureTests {
     let repository = makeRepository(id: "/tmp/repo-a", name: "Repo A", worktrees: [])
     let store = TestStore(initialState: makeState(repositories: [repository])) {
       RepositoriesFeature()
+    } withDependencies: {
+      $0.gitClient.repoRoot = { url in url }
+      $0.gitClient.automaticWorktreeBaseRef = { _ in "master" }
+      $0.gitClient.branchRefs = { _ in ["master"] }
     }
 
     await store.send(.workspaceCreation(.promptRequested)) {
@@ -597,6 +601,15 @@ struct RepositoriesFeatureTests {
         selectedRepositoryIDs: ["/tmp/repo-a"]
       )
     }
+    await store.receive(\.workspaceCreation.baseRefsLoaded) {
+      $0.workspaceCreationPrompt?.repositories[id: "/tmp/repo-a"]?.baseRef = "master"
+      $0.workspaceCreationPrompt?.repositories[id: "/tmp/repo-a"]?.baseRefOptions = [
+        "master",
+        "main",
+        "origin/main",
+        "origin/master",
+      ]
+    }
   }
 
   @Test func workspaceCreationPromptUsesLoadedRepositories() async {
@@ -615,6 +628,14 @@ struct RepositoriesFeatureTests {
       .path(percentEncoded: false)
     let store = TestStore(initialState: state) {
       RepositoriesFeature()
+    } withDependencies: {
+      $0.gitClient.repoRoot = { url in url }
+      $0.gitClient.automaticWorktreeBaseRef = { url in
+        url.path(percentEncoded: false) == repoRootA ? "main" : "master"
+      }
+      $0.gitClient.branchRefs = { url in
+        url.path(percentEncoded: false) == repoRootA ? ["main", "origin/main"] : ["master", "origin/master"]
+      }
     }
 
     await store.send(.workspaceCreation(.promptRequested)) {
@@ -636,6 +657,24 @@ struct RepositoriesFeatureTests {
         rootPath: expectedRootPath,
         selectedRepositoryIDs: [repoRootA, repoRootB]
       )
+    }
+    await store.receive(\.workspaceCreation.baseRefsLoaded) {
+      $0.workspaceCreationPrompt?.repositories[id: repoRootA]?.baseRef = "main"
+      $0.workspaceCreationPrompt?.repositories[id: repoRootA]?.baseRefOptions = [
+        "main",
+        "master",
+        "origin/main",
+        "origin/master",
+      ]
+    }
+    await store.receive(\.workspaceCreation.baseRefsLoaded) {
+      $0.workspaceCreationPrompt?.repositories[id: repoRootB]?.baseRef = "master"
+      $0.workspaceCreationPrompt?.repositories[id: repoRootB]?.baseRefOptions = [
+        "master",
+        "main",
+        "origin/main",
+        "origin/master",
+      ]
     }
   }
 
@@ -701,7 +740,8 @@ struct RepositoriesFeatureTests {
           id: UUID(0).uuidString,
           name: "",
           sourceKind: .remote,
-          sourceLocation: ""
+          sourceLocation: "",
+          baseRefOptions: ProjectWorkspaceCreationRepository.commonRemoteBaseRefOptions
         )
       ]
       $0.selectedRepositoryIDs = [UUID(0).uuidString]
@@ -728,6 +768,7 @@ struct RepositoriesFeatureTests {
       )
       $0.selectedRepositoryIDs = [UUID(0).uuidString, UUID(1).uuidString]
     }
+    await store.receive(.delegate(.baseRefSourceChanged(UUID(1).uuidString)))
   }
 
   @Test func loadPersistedRepositoriesAutoUpgradesPlainFolderWhenItBecomesGitRoot() async {

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -927,6 +927,67 @@ struct RepositoriesFeatureTests {
     await store.receive(.delegate(.baseRefSourceChanged(UUID(0).uuidString)))
   }
 
+  @Test func workspaceCreationPromptClearsAndReloadsBaseRefsWhenSourceLocationChanges() async {
+    let repositoryID = "repo"
+    let store = TestStore(
+      initialState: WorkspaceCreationPromptFeature.State(
+        repositories: [
+          ProjectWorkspaceCreationRepository(
+            id: repositoryID,
+            name: "Repo",
+            sourceKind: .bareRepository,
+            sourceLocation: "/tmp/repo-a.git",
+            checkoutMode: .useExistingRef,
+            baseRef: "origin/main",
+            baseRefOptions: [GitBranchRefOption(ref: "origin/main", kind: .remoteTracking)]
+          )
+        ],
+        title: "Workspace",
+        rootPath: "/tmp/workspace",
+        selectedRepositoryIDs: [repositoryID]
+      )
+    ) {
+      WorkspaceCreationPromptFeature()
+    }
+
+    await store.send(.repositorySourceLocationChanged(repositoryID, "/tmp/repo-b.git")) {
+      $0.repositories[id: repositoryID]?.sourceLocation = "/tmp/repo-b.git"
+      $0.repositories[id: repositoryID]?.baseRef = nil
+      $0.repositories[id: repositoryID]?.baseRefOptions = []
+    }
+    await store.receive(.delegate(.baseRefSourceChanged(repositoryID)))
+  }
+
+  @Test func workspaceCreationPromptClearsBaseRefsWhenRemoteSourceLocationChanges() async {
+    let repositoryID = "remote"
+    let store = TestStore(
+      initialState: WorkspaceCreationPromptFeature.State(
+        repositories: [
+          ProjectWorkspaceCreationRepository(
+            id: repositoryID,
+            name: "Remote",
+            sourceKind: .remote,
+            sourceLocation: "git@github.com:onevcat/app.git",
+            checkoutMode: .useExistingRef,
+            baseRef: "origin/main",
+            baseRefOptions: [GitBranchRefOption(ref: "origin/main", kind: .fetchedRemote)]
+          )
+        ],
+        title: "Workspace",
+        rootPath: "/tmp/workspace",
+        selectedRepositoryIDs: [repositoryID]
+      )
+    ) {
+      WorkspaceCreationPromptFeature()
+    }
+
+    await store.send(.repositorySourceLocationChanged(repositoryID, "git@github.com:onevcat/other.git")) {
+      $0.repositories[id: repositoryID]?.sourceLocation = "git@github.com:onevcat/other.git"
+      $0.repositories[id: repositoryID]?.baseRef = nil
+      $0.repositories[id: repositoryID]?.baseRefOptions = []
+    }
+  }
+
   @Test func workspaceCreationPromptRejectsUnknownBaseRef() async {
     let repoRootA = "/tmp/repo-a"
     let repoRootB = "/tmp/repo-b"

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -507,6 +507,71 @@ struct RepositoriesFeatureTests {
     await store.finish()
   }
 
+  @Test func loadPersistedRepositoriesLoadsWorkspaceMetadataAsPlainRepository() async throws {
+    let rootURL = FileManager.default.temporaryDirectory
+      .appending(path: "prowl-workspace-\(UUID().uuidString)")
+      .standardizedFileURL
+    defer { try? FileManager.default.removeItem(at: rootURL) }
+
+    try FileManager.default.createDirectory(
+      at: rootURL.appending(path: ProjectWorkspace.metadataDirectoryName),
+      withIntermediateDirectories: true
+    )
+    try Data(
+      """
+      {
+        "title": "Multi Repo Workspace",
+        "repositories": [
+          {
+            "name": "App",
+            "role": "client",
+            "path": "app",
+            "source_kind": "existing_path"
+          }
+        ]
+      }
+      """.utf8
+    )
+    .write(to: ProjectWorkspace.metadataURL(for: rootURL))
+
+    let rootPath = rootURL.path(percentEncoded: false)
+    let workspace = try #require(ProjectWorkspace.load(from: rootURL))
+    let repository = makeRepository(
+      id: rootPath,
+      name: "Multi Repo Workspace",
+      kind: .plain,
+      worktrees: [],
+      workspace: workspace
+    )
+
+    let store = TestStore(initialState: RepositoriesFeature.State()) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.repositoryPersistence.loadRepositoryEntries = {
+        [PersistedRepositoryEntry(path: rootPath, kind: .plain)]
+      }
+      $0.repositoryPersistence.saveRepositorySnapshot = { _ in }
+      $0.gitClient.repoRoot = { url in
+        Issue.record("workspace should load as plain without git probing: \(url.path(percentEncoded: false))")
+        return url
+      }
+      $0.gitClient.worktrees = { url in
+        Issue.record("workspace should not load git worktrees: \(url.path(percentEncoded: false))")
+        return []
+      }
+    }
+
+    await store.send(.loadPersistedRepositories)
+    await store.receive(\.repositoriesLoaded) {
+      $0.repositories = [repository]
+      $0.repositoryRoots = [rootURL]
+      $0.isInitialLoadComplete = true
+      $0.snapshotPersistencePhase = .active
+    }
+    await store.receive(\.delegate.repositoriesChanged)
+    await store.finish()
+  }
+
   @Test func loadPersistedRepositoriesAutoUpgradesPlainFolderWhenItBecomesGitRoot() async {
     let root = "/tmp/folder"
     let worktree = makeWorktree(id: root, name: "folder", repoRoot: root)
@@ -5304,14 +5369,16 @@ struct RepositoriesFeatureTests {
     id: String,
     name: String = "repo",
     kind: Repository.Kind = .git,
-    worktrees: [Worktree]
+    worktrees: [Worktree],
+    workspace: ProjectWorkspace? = nil
   ) -> Repository {
     Repository(
       id: id,
       rootURL: URL(fileURLWithPath: id),
       name: name,
       kind: kind,
-      worktrees: IdentifiedArray(uniqueElements: worktrees)
+      worktrees: IdentifiedArray(uniqueElements: worktrees),
+      workspace: workspace
     )
   }
 

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -588,13 +588,12 @@ struct RepositoriesFeatureTests {
       RepositoriesFeature()
     }
 
+    let title = "Workspace"
     await store.send(.workspaceCreation(.promptRequested)) {
-      let title = "Workspace"
-      let expectedRootPath = expectedDefaultWorkspaceRootPath(for: title)
       $0.workspaceCreationPrompt = WorkspaceCreationPromptFeature.State(
         repositories: [],
         title: title,
-        rootPath: expectedRootPath,
+        rootPath: defaultWorkspaceBaseRootPath(for: title),
         openedRepositoryCandidates: [
           ProjectWorkspaceCreationRepository(
             id: "/tmp/repo-a",
@@ -603,6 +602,9 @@ struct RepositoriesFeatureTests {
           )
         ]
       )
+    }
+    await store.receive(\.workspaceCreation.defaultRootPathResolved) {
+      $0.workspaceCreationPrompt?.rootPath = expectedDefaultWorkspaceRootPath(for: title)
     }
   }
 
@@ -628,6 +630,40 @@ struct RepositoriesFeatureTests {
       $0.repositories = [candidate]
     }
     await store.receive(.delegate(.baseRefSourceChanged(repoRootA)))
+  }
+
+  @Test func resetLocalBranchChoiceTogglesAndClearsOnRefChange() async {
+    let repoID = "/tmp/repo-a"
+    let repo = ProjectWorkspaceCreationRepository(
+      id: repoID,
+      name: "Repo A",
+      sourceKind: .bareRepository,
+      sourceLocation: "/tmp/repo-a.git",
+      checkoutMode: .useExistingRef,
+      baseRef: "origin/feature",
+      baseRefOptions: [
+        GitBranchRefOption(ref: "origin/feature", kind: .remoteTracking),
+        GitBranchRefOption(ref: "feature", kind: .local),
+      ]
+    )
+    let store = TestStore(
+      initialState: WorkspaceCreationPromptFeature.State(
+        repositories: [repo],
+        title: "Workspace",
+        rootPath: "/tmp/workspace"
+      )
+    ) {
+      WorkspaceCreationPromptFeature()
+    }
+
+    await store.send(.repositoryResetLocalBranchChanged(repoID, true)) {
+      $0.repositories[id: repoID]?.resetLocalBranchToRemote = true
+    }
+    // Selecting a different ref invalidates the keep/reset choice.
+    await store.send(.repositoryBaseRefChanged(repoID, "feature")) {
+      $0.repositories[id: repoID]?.baseRef = "feature"
+      $0.repositories[id: repoID]?.resetLocalBranchToRemote = false
+    }
   }
 
   @Test func workspaceCreationPromptIgnoresDuplicateOpenedRepository() async {
@@ -664,13 +700,12 @@ struct RepositoriesFeatureTests {
       RepositoriesFeature()
     }
 
+    let title = "Workspace"
     await store.send(.workspaceCreation(.promptRequested)) {
-      let title = "Workspace"
-      let expectedRootPath = expectedDefaultWorkspaceRootPath(for: title)
       $0.workspaceCreationPrompt = WorkspaceCreationPromptFeature.State(
         repositories: [],
         title: title,
-        rootPath: expectedRootPath,
+        rootPath: defaultWorkspaceBaseRootPath(for: title),
         openedRepositoryCandidates: [
           ProjectWorkspaceCreationRepository(
             id: repoRootA,
@@ -684,6 +719,9 @@ struct RepositoriesFeatureTests {
           ),
         ]
       )
+    }
+    await store.receive(\.workspaceCreation.defaultRootPathResolved) {
+      $0.workspaceCreationPrompt?.rootPath = expectedDefaultWorkspaceRootPath(for: title)
     }
   }
 
@@ -716,13 +754,12 @@ struct RepositoriesFeatureTests {
       }
     }
 
+    let title = "Workspace"
     await store.send(.workspaceCreation(.promptRequested)) {
-      let title = "Workspace"
-      let expectedRootPath = expectedDefaultWorkspaceRootPath(for: title)
       $0.workspaceCreationPrompt = WorkspaceCreationPromptFeature.State(
         repositories: [],
         title: title,
-        rootPath: expectedRootPath,
+        rootPath: defaultWorkspaceBaseRootPath(for: title),
         openedRepositoryCandidates: [
           ProjectWorkspaceCreationRepository(
             id: repoRootA,
@@ -736,6 +773,9 @@ struct RepositoriesFeatureTests {
           ),
         ]
       )
+    }
+    await store.receive(\.workspaceCreation.defaultRootPathResolved) {
+      $0.workspaceCreationPrompt?.rootPath = expectedDefaultWorkspaceRootPath(for: title)
     }
     await store.send(.workspaceCreationPrompt(.presented(.addOpenedRepository(repoRootA)))) {
       $0.workspaceCreationPrompt?.repositories.append(
@@ -1228,6 +1268,181 @@ struct RepositoriesFeatureTests {
     }
     await store.receive(\.repositoryManagement.repositoryRemoved)
     await store.finish()
+  }
+
+  @Test func removeWorkspaceRoutesBranchDeletionThroughGuardedClient() async throws {
+    let rootURL = FileManager.default.temporaryDirectory
+      .appending(path: "prowl-ws-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(
+      at: rootURL.appending(path: "api"),
+      withIntermediateDirectories: true
+    )
+    defer { try? FileManager.default.removeItem(at: rootURL) }
+    let workspaceID = rootURL.path(percentEncoded: false)
+    let workspace = ProjectWorkspace(
+      repositories: [
+        ProjectWorkspace.RepositoryEntry(
+          id: "api",
+          name: "API",
+          path: "api",
+          sourceKind: .bareRepository,
+          sourceLocation: "/tmp/api.git",
+          branchName: "chore/x"
+        )
+      ]
+    )
+    let repository = makeRepository(
+      id: workspaceID, name: "WS", kind: .plain, worktrees: [], workspace: workspace
+    )
+    struct DeleteBranchCall: Sendable, Equatable {
+      let name: String
+      let root: String
+      let force: Bool
+    }
+    let deleteCalls = LockIsolated<[DeleteBranchCall]>([])
+    let store = TestStore(initialState: makeState(repositories: [repository])) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.repositoryPersistence.loadRepositoryEntries = { [] }
+      $0.repositoryPersistence.saveRepositoryEntries = { _ in }
+      $0.repositoryPersistence.saveRepositorySnapshot = { _ in }
+      $0.shellClient.run = { _, _, _ in ShellOutput(stdout: "", stderr: "", exitCode: 0) }
+      $0.gitClient.deleteLocalBranch = { name, url, force in
+        deleteCalls.withValue {
+          $0.append(DeleteBranchCall(name: name, root: url.path(percentEncoded: false), force: force))
+        }
+        return .deleted
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.repositoryManagement(.requestRemoveRepository(workspaceID)))
+    await store.send(.repositoryManagement(.removeWorkspaceDeleteFilesChanged(true)))
+    await store.send(.repositoryManagement(.removeWorkspaceDeleteBranchChanged("api", true)))
+    await store.send(.repositoryManagement(.removeWorkspacePromptConfirmed))
+    await store.receive(\.repositoryManagement.repositoryRemoved)
+    await store.finish()
+
+    // Branch deletion must go through the guarded GitClient entry point with
+    // force = true, never a raw `git branch -D`.
+    #expect(deleteCalls.value.count == 1)
+    #expect(deleteCalls.value.first?.name == "chore/x")
+    #expect(deleteCalls.value.first?.root == "/tmp/api.git")
+    #expect(deleteCalls.value.first?.force == true)
+    // All worktrees unregistered, so the folder is deleted without prompting.
+    #expect(!FileManager.default.fileExists(atPath: workspaceID))
+  }
+
+  @Test func removeWorkspaceAsksBeforeDeletingFolderWhenWorktreeRemovalFails() async throws {
+    let rootURL = FileManager.default.temporaryDirectory
+      .appending(path: "prowl-ws-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(
+      at: rootURL.appending(path: "api"),
+      withIntermediateDirectories: true
+    )
+    defer { try? FileManager.default.removeItem(at: rootURL) }
+    let workspaceID = rootURL.path(percentEncoded: false)
+    let workspace = ProjectWorkspace(
+      repositories: [
+        ProjectWorkspace.RepositoryEntry(
+          id: "api",
+          name: "API",
+          path: "api",
+          sourceKind: .bareRepository,
+          sourceLocation: "/tmp/api.git"
+        )
+      ]
+    )
+    let repository = makeRepository(
+      id: workspaceID, name: "WS", kind: .plain, worktrees: [], workspace: workspace
+    )
+    let store = TestStore(initialState: makeState(repositories: [repository])) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.repositoryPersistence.loadRepositoryEntries = { [] }
+      $0.repositoryPersistence.saveRepositoryEntries = { _ in }
+      $0.repositoryPersistence.saveRepositorySnapshot = { _ in }
+      $0.shellClient.run = { _, _, _ in
+        throw ShellClientError(command: "git", stdout: "", stderr: "broken", exitCode: 1)
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.repositoryManagement(.requestRemoveRepository(workspaceID)))
+    await store.send(.repositoryManagement(.removeWorkspaceDeleteFilesChanged(true)))
+    await store.send(.repositoryManagement(.removeWorkspacePromptConfirmed))
+    await store.receive(\.repositoryManagement.workspaceCleanupReportedFailures)
+
+    // The folder must NOT be deleted yet — the user is asked first.
+    #expect(store.state.alert != nil)
+    #expect(FileManager.default.fileExists(atPath: workspaceID))
+
+    await store.send(
+      .alert(
+        .presented(
+          .confirmWorkspaceRootDeletion(
+            repositoryID: workspaceID,
+            rootPath: workspaceID,
+            selectionWasRemoved: false
+          ))))
+    await store.receive(\.repositoryManagement.repositoryRemoved)
+    await store.finish()
+
+    #expect(!FileManager.default.fileExists(atPath: workspaceID))
+  }
+
+  @Test func keepWorkspaceFolderAfterCleanupFailureRemovesEntryButKeepsFolder() async throws {
+    let rootURL = FileManager.default.temporaryDirectory
+      .appending(path: "prowl-ws-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(
+      at: rootURL.appending(path: "api"),
+      withIntermediateDirectories: true
+    )
+    defer { try? FileManager.default.removeItem(at: rootURL) }
+    let workspaceID = rootURL.path(percentEncoded: false)
+    let workspace = ProjectWorkspace(
+      repositories: [
+        ProjectWorkspace.RepositoryEntry(
+          id: "api",
+          name: "API",
+          path: "api",
+          sourceKind: .bareRepository,
+          sourceLocation: "/tmp/api.git"
+        )
+      ]
+    )
+    let repository = makeRepository(
+      id: workspaceID, name: "WS", kind: .plain, worktrees: [], workspace: workspace
+    )
+    let store = TestStore(initialState: makeState(repositories: [repository])) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.repositoryPersistence.loadRepositoryEntries = { [] }
+      $0.repositoryPersistence.saveRepositoryEntries = { _ in }
+      $0.repositoryPersistence.saveRepositorySnapshot = { _ in }
+      $0.shellClient.run = { _, _, _ in
+        throw ShellClientError(command: "git", stdout: "", stderr: "broken", exitCode: 1)
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.repositoryManagement(.requestRemoveRepository(workspaceID)))
+    await store.send(.repositoryManagement(.removeWorkspaceDeleteFilesChanged(true)))
+    await store.send(.repositoryManagement(.removeWorkspacePromptConfirmed))
+    await store.receive(\.repositoryManagement.workspaceCleanupReportedFailures)
+
+    await store.send(
+      .alert(
+        .presented(
+          .keepWorkspaceFolderAfterCleanupFailure(
+            repositoryID: workspaceID,
+            selectionWasRemoved: false
+          ))))
+    await store.receive(\.repositoryManagement.repositoryRemoved)
+    await store.finish()
+
+    // Entry removed from Prowl, but the on-disk folder is preserved.
+    #expect(FileManager.default.fileExists(atPath: workspaceID))
   }
 
   @Test func repositoryRemovedDropsEntryDespiteTrailingSlashMismatch() async {
@@ -6446,7 +6661,17 @@ struct RepositoriesFeatureTests {
   }
 }
 
-// Mirrors RepositoriesFeature.defaultWorkspaceRootURL: the default folder name
+// The collision-free base path seeded synchronously by `.promptRequested`
+// before the unique-path effect resolves (no filesystem lookup).
+func defaultWorkspaceBaseRootPath(for title: String) -> String {
+  let folderName = ProjectWorkspace.defaultWorkspaceFolderName(for: title)
+  return SupacodePaths.workspacesDirectory
+    .appending(path: folderName, directoryHint: .isDirectory)
+    .standardizedFileURL
+    .path(percentEncoded: false)
+}
+
+// Mirrors RepositoriesFeature.uniqueWorkspaceRootPath: the default folder name
 // is uniqued against directories that already exist on the test machine.
 func expectedDefaultWorkspaceRootPath(for title: String) -> String {
   let folderName = ProjectWorkspace.defaultWorkspaceFolderName(for: title)

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -535,9 +535,10 @@ struct RepositoriesFeatureTests {
     .write(to: ProjectWorkspace.metadataURL(for: rootURL))
 
     let rootPath = rootURL.path(percentEncoded: false)
-    let workspace = try #require(ProjectWorkspace.load(from: rootURL))
+    let loadedRootURL = URL(fileURLWithPath: rootPath).standardizedFileURL
+    let workspace = try #require(ProjectWorkspace.load(from: loadedRootURL))
     let repository = makeRepository(
-      id: rootPath,
+      id: loadedRootURL.path(percentEncoded: false),
       name: "Multi Repo Workspace",
       kind: .plain,
       worktrees: [],
@@ -564,7 +565,7 @@ struct RepositoriesFeatureTests {
     await store.send(.loadPersistedRepositories)
     await store.receive(\.repositoriesLoaded) {
       $0.repositories = [repository]
-      $0.repositoryRoots = [rootURL]
+      $0.repositoryRoots = [URL(fileURLWithPath: rootPath)]
       $0.isInitialLoadComplete = true
       $0.snapshotPersistencePhase = .active
     }
@@ -588,7 +589,6 @@ struct RepositoriesFeatureTests {
         repositories: [],
         title: title,
         rootPath: expectedRootPath,
-        selectedRepositoryIDs: [],
         openedRepositoryCandidates: [
           ProjectWorkspaceCreationRepository(
             id: "/tmp/repo-a",
@@ -612,7 +612,6 @@ struct RepositoriesFeatureTests {
         repositories: [],
         title: "Workspace",
         rootPath: "/tmp/workspace",
-        selectedRepositoryIDs: [],
         openedRepositoryCandidates: [candidate]
       )
     ) {
@@ -621,7 +620,6 @@ struct RepositoriesFeatureTests {
 
     await store.send(.addOpenedRepository(repoRootA)) {
       $0.repositories = [candidate]
-      $0.selectedRepositoryIDs = [repoRootA]
     }
     await store.receive(.delegate(.baseRefSourceChanged(repoRootA)))
   }
@@ -638,7 +636,6 @@ struct RepositoriesFeatureTests {
         repositories: [candidate],
         title: "Workspace",
         rootPath: "/tmp/workspace",
-        selectedRepositoryIDs: [repoRootA],
         openedRepositoryCandidates: [candidate]
       )
     ) {
@@ -671,13 +668,11 @@ struct RepositoriesFeatureTests {
         repositories: [],
         title: title,
         rootPath: expectedRootPath,
-        selectedRepositoryIDs: [],
         openedRepositoryCandidates: [
           ProjectWorkspaceCreationRepository(
             id: repoRootA,
             name: "Repo A",
-            rootURL: URL(fileURLWithPath: repoRootA),
-            branchName: "main"
+            rootURL: URL(fileURLWithPath: repoRootA)
           ),
           ProjectWorkspaceCreationRepository(
             id: repoRootB,
@@ -728,13 +723,11 @@ struct RepositoriesFeatureTests {
         repositories: [],
         title: title,
         rootPath: expectedRootPath,
-        selectedRepositoryIDs: [],
         openedRepositoryCandidates: [
           ProjectWorkspaceCreationRepository(
             id: repoRootA,
             name: "Repo A",
-            rootURL: URL(fileURLWithPath: repoRootA),
-            branchName: "main"
+            rootURL: URL(fileURLWithPath: repoRootA)
           ),
           ProjectWorkspaceCreationRepository(
             id: repoRootB,
@@ -749,12 +742,11 @@ struct RepositoriesFeatureTests {
         ProjectWorkspaceCreationRepository(
           id: repoRootA,
           name: "Repo A",
-          rootURL: URL(fileURLWithPath: repoRootA),
-          branchName: "main"
+          rootURL: URL(fileURLWithPath: repoRootA)
         )
       )
-      $0.workspaceCreationPrompt?.selectedRepositoryIDs = [repoRootA]
     }
+    await store.receive(\.workspaceCreationPrompt.presented.delegate.baseRefSourceChanged)
     await store.receive(\.workspaceCreation.refreshBaseRefs)
     await store.receive(\.workspaceCreation.baseRefsLoaded) {
       $0.workspaceCreationPrompt?.repositories[id: repoRootA]?.baseRef = "main"
@@ -772,8 +764,7 @@ struct RepositoriesFeatureTests {
       ProjectWorkspaceCreationRepository(
         id: repoRootA,
         name: "Repo A",
-        rootURL: URL(fileURLWithPath: repoRootA),
-        branchName: "main"
+        rootURL: URL(fileURLWithPath: repoRootA)
       ),
       ProjectWorkspaceCreationRepository(
         id: repoRootB,
@@ -781,13 +772,11 @@ struct RepositoriesFeatureTests {
         rootURL: URL(fileURLWithPath: repoRootB)
       ),
     ]
-    let rootURL = URL(fileURLWithPath: "/tmp/multi-repo-workspace")
     let store = TestStore(
       initialState: WorkspaceCreationPromptFeature.State(
         repositories: repositories,
         title: " Multi Repo ",
-        rootPath: " /tmp/multi-repo-workspace ",
-        selectedRepositoryIDs: [repoRootA, repoRootB]
+        rootPath: " /tmp/multi-repo-workspace "
       )
     ) {
       WorkspaceCreationPromptFeature()
@@ -799,8 +788,25 @@ struct RepositoriesFeatureTests {
         .submit(
           ProjectWorkspaceCreationDraft(
             title: "Multi Repo",
-            rootURL: rootURL,
-            repositories: repositories
+            rootURL: URL(filePath: "/tmp/multi-repo-workspace", directoryHint: .isDirectory),
+            repositories: [
+              ProjectWorkspaceRepositoryPlan(
+                id: repoRootA,
+                name: "Repo A",
+                path: nil,
+                sourceKind: .existingPath,
+                sourceLocation: repoRootA,
+                checkout: .link
+              ),
+              ProjectWorkspaceRepositoryPlan(
+                id: repoRootB,
+                name: "Repo B",
+                path: nil,
+                sourceKind: .existingPath,
+                sourceLocation: repoRootB,
+                checkout: .link
+              ),
+            ]
           )
         )
       )
@@ -816,8 +822,7 @@ struct RepositoriesFeatureTests {
       initialState: WorkspaceCreationPromptFeature.State(
         repositories: [],
         title: "Workspace",
-        rootPath: "/tmp/workspace",
-        selectedRepositoryIDs: []
+        rootPath: "/tmp/workspace"
       )
     ) {
       WorkspaceCreationPromptFeature()
@@ -860,7 +865,6 @@ struct RepositoriesFeatureTests {
           baseRefOptions: options
         )
       )
-      $0.selectedRepositoryIDs = [UUID(0).uuidString]
       $0.remoteRepositoryPrompt = nil
     }
   }
@@ -870,8 +874,7 @@ struct RepositoriesFeatureTests {
       initialState: WorkspaceCreationPromptFeature.State(
         repositories: [],
         title: "Workspace",
-        rootPath: "/tmp/workspace",
-        selectedRepositoryIDs: []
+        rootPath: "/tmp/workspace"
       )
     ) {
       WorkspaceCreationPromptFeature()
@@ -904,8 +907,7 @@ struct RepositoriesFeatureTests {
       initialState: WorkspaceCreationPromptFeature.State(
         repositories: [],
         title: "Workspace",
-        rootPath: "/tmp/workspace",
-        selectedRepositoryIDs: []
+        rootPath: "/tmp/workspace"
       )
     ) {
       WorkspaceCreationPromptFeature()
@@ -922,7 +924,6 @@ struct RepositoriesFeatureTests {
           sourceLocation: "/tmp/local-api"
         )
       )
-      $0.selectedRepositoryIDs = [UUID(0).uuidString]
     }
     await store.receive(.delegate(.baseRefSourceChanged(UUID(0).uuidString)))
   }
@@ -943,8 +944,7 @@ struct RepositoriesFeatureTests {
           )
         ],
         title: "Workspace",
-        rootPath: "/tmp/workspace",
-        selectedRepositoryIDs: [repositoryID]
+        rootPath: "/tmp/workspace"
       )
     ) {
       WorkspaceCreationPromptFeature()
@@ -974,8 +974,7 @@ struct RepositoriesFeatureTests {
           )
         ],
         title: "Workspace",
-        rootPath: "/tmp/workspace",
-        selectedRepositoryIDs: [repositoryID]
+        rootPath: "/tmp/workspace"
       )
     ) {
       WorkspaceCreationPromptFeature()
@@ -1008,8 +1007,7 @@ struct RepositoriesFeatureTests {
           ),
         ],
         title: "Workspace",
-        rootPath: "/tmp/workspace",
-        selectedRepositoryIDs: [repoRootA, repoRootB]
+        rootPath: "/tmp/workspace"
       )
     ) {
       WorkspaceCreationPromptFeature()
@@ -1041,8 +1039,7 @@ struct RepositoriesFeatureTests {
           ),
         ],
         title: "Workspace",
-        rootPath: "/tmp/workspace",
-        selectedRepositoryIDs: [repoRootA, repoRootB]
+        rootPath: "/tmp/workspace"
       )
     ) {
       WorkspaceCreationPromptFeature()
@@ -1067,6 +1064,7 @@ struct RepositoriesFeatureTests {
             name: "Remote",
             sourceKind: .remote,
             sourceLocation: "git@github.com:onevcat/app.git",
+            checkoutMode: .createBranch,
             baseRef: "origin/main",
             baseRefOptions: [GitBranchRefOption(ref: "origin/main", kind: .fetchedRemote)]
           ),
@@ -1077,8 +1075,7 @@ struct RepositoriesFeatureTests {
           ),
         ],
         title: "Workspace",
-        rootPath: "/tmp/workspace",
-        selectedRepositoryIDs: ["remote", repoRootB]
+        rootPath: "/tmp/workspace"
       )
     ) {
       WorkspaceCreationPromptFeature()
@@ -1090,6 +1087,84 @@ struct RepositoriesFeatureTests {
     await store.send(.repositoryBranchNameChanged("remote", "codex/app")) {
       $0.repositories[id: "remote"]?.branchName = "codex/app"
       $0.validationMessage = nil
+    }
+  }
+
+  @Test func workspaceCreationPromptResetsLinkModeWhenSwitchingToBare() async {
+    let repositoryID = "repo"
+    let store = TestStore(
+      initialState: WorkspaceCreationPromptFeature.State(
+        repositories: [
+          ProjectWorkspaceCreationRepository(
+            id: repositoryID,
+            name: "Repo",
+            rootURL: URL(fileURLWithPath: "/tmp/repo")
+          )
+        ],
+        title: "Workspace",
+        rootPath: "/tmp/workspace"
+      )
+    ) {
+      WorkspaceCreationPromptFeature()
+    }
+
+    await store.send(.repositorySourceKindChanged(repositoryID, .bareRepository)) {
+      $0.repositories[id: repositoryID]?.sourceKind = .bareRepository
+      $0.repositories[id: repositoryID]?.checkoutMode = .createBranch
+    }
+    await store.receive(.delegate(.baseRefSourceChanged(repositoryID)))
+  }
+
+  @Test func workspaceCreationCancelWhileCreatingShowsToast() async {
+    var initialState = RepositoriesFeature.State()
+    initialState.workspaceCreationPrompt = WorkspaceCreationPromptFeature.State(
+      repositories: [],
+      title: "Workspace",
+      rootPath: "/tmp/workspace"
+    )
+    initialState.workspaceCreationPrompt?.isCreating = true
+    let store = TestStore(initialState: initialState) {
+      RepositoriesFeature()
+    }
+    store.exhaustivity = .off
+
+    await store.send(.workspaceCreation(.promptCanceled)) {
+      $0.workspaceCreationPrompt = nil
+    }
+    await store.receive(\.showToast, .warning("Workspace creation canceled"))
+  }
+
+  @Test func workspaceBaseRefsLoadErrorSurfacesValidationMessage() async {
+    let repositoryID = "/tmp/repo"
+    var initialState = RepositoriesFeature.State()
+    initialState.workspaceCreationPrompt = WorkspaceCreationPromptFeature.State(
+      repositories: [
+        ProjectWorkspaceCreationRepository(
+          id: repositoryID,
+          name: "Repo",
+          rootURL: URL(fileURLWithPath: repositoryID)
+        )
+      ],
+      title: "Workspace",
+      rootPath: "/tmp/workspace"
+    )
+    let store = TestStore(initialState: initialState) {
+      RepositoriesFeature()
+    }
+
+    await store.send(
+      .workspaceCreation(
+        .baseRefsLoaded(
+          repositoryID: repositoryID,
+          sourceKind: .existingPath,
+          sourceLocation: repositoryID,
+          options: [],
+          defaultBaseRef: nil,
+          errorMessage: "Could not read branches for Repo: boom"
+        )
+      )
+    ) {
+      $0.workspaceCreationPrompt?.validationMessage = "Could not read branches for Repo: boom"
     }
   }
 

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -7104,16 +7104,7 @@ func defaultWorkspaceBaseRootPath(for title: String) -> String {
     .path(percentEncoded: false)
 }
 
-// Mirrors RepositoriesFeature.uniqueWorkspaceRootPath: the default folder name
-// is uniqued against directories that already exist on the test machine.
 func expectedDefaultWorkspaceRootPath(for title: String) -> String {
   let folderName = ProjectWorkspace.defaultWorkspaceFolderName(for: title)
-  let baseURL = SupacodePaths.workspacesDirectory
-  var candidateURL = baseURL.appending(path: folderName, directoryHint: .isDirectory)
-  var suffix = 2
-  while FileManager.default.fileExists(atPath: candidateURL.path(percentEncoded: false)) {
-    candidateURL = baseURL.appending(path: "\(folderName)-\(suffix)", directoryHint: .isDirectory)
-    suffix += 1
-  }
-  return candidateURL.standardizedFileURL.path(percentEncoded: false)
+  return ProjectWorkspace.uniqueWorkspaceRootPath(folderName: folderName)
 }

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -572,44 +572,83 @@ struct RepositoriesFeatureTests {
     await store.finish()
   }
 
-  @Test func workspaceCreationPromptOpensWithoutTwoRepositories() async {
+  @Test func workspaceCreationPromptOffersOpenedRepositoriesWithoutAddingThem() async {
     let repository = makeRepository(id: "/tmp/repo-a", name: "Repo A", worktrees: [])
     let store = TestStore(initialState: makeState(repositories: [repository])) {
       RepositoriesFeature()
-    } withDependencies: {
-      $0.gitClient.repoRoot = { url in url }
-      $0.gitClient.automaticWorktreeBaseRef = { _ in "master" }
-      $0.gitClient.branchRefOptions = { _ in [GitBranchRefOption(ref: "master", kind: .local)] }
     }
 
     await store.send(.workspaceCreation(.promptRequested)) {
-      let title = "Repo A"
+      let title = "Workspace"
       let expectedRootPath = SupacodePaths.workspacesDirectory
         .appending(path: ProjectWorkspace.defaultWorkspaceFolderName(for: title), directoryHint: .isDirectory)
         .standardizedFileURL
         .path(percentEncoded: false)
       $0.workspaceCreationPrompt = WorkspaceCreationPromptFeature.State(
-        repositories: [
+        repositories: [],
+        title: title,
+        rootPath: expectedRootPath,
+        selectedRepositoryIDs: [],
+        openedRepositoryCandidates: [
           ProjectWorkspaceCreationRepository(
             id: "/tmp/repo-a",
             name: "Repo A",
             rootURL: URL(fileURLWithPath: "/tmp/repo-a")
           )
-        ],
-        title: title,
-        rootPath: expectedRootPath,
-        selectedRepositoryIDs: ["/tmp/repo-a"]
+        ]
       )
-    }
-    await store.receive(\.workspaceCreation.baseRefsLoaded) {
-      $0.workspaceCreationPrompt?.repositories[id: "/tmp/repo-a"]?.baseRef = "master"
-      $0.workspaceCreationPrompt?.repositories[id: "/tmp/repo-a"]?.baseRefOptions = [
-        GitBranchRefOption(ref: "master", kind: .local)
-      ]
     }
   }
 
-  @Test func workspaceCreationPromptUsesLoadedRepositories() async {
+  @Test func workspaceCreationPromptAddsOpenedRepositoryOnRequest() async {
+    let repoRootA = "/tmp/repo-a"
+    let candidate = ProjectWorkspaceCreationRepository(
+      id: repoRootA,
+      name: "Repo A",
+      rootURL: URL(fileURLWithPath: repoRootA)
+    )
+    let store = TestStore(
+      initialState: WorkspaceCreationPromptFeature.State(
+        repositories: [],
+        title: "Workspace",
+        rootPath: "/tmp/workspace",
+        selectedRepositoryIDs: [],
+        openedRepositoryCandidates: [candidate]
+      )
+    ) {
+      WorkspaceCreationPromptFeature()
+    }
+
+    await store.send(.addOpenedRepository(repoRootA)) {
+      $0.repositories = [candidate]
+      $0.selectedRepositoryIDs = [repoRootA]
+    }
+    await store.receive(.delegate(.baseRefSourceChanged(repoRootA)))
+  }
+
+  @Test func workspaceCreationPromptIgnoresDuplicateOpenedRepository() async {
+    let repoRootA = "/tmp/repo-a"
+    let candidate = ProjectWorkspaceCreationRepository(
+      id: repoRootA,
+      name: "Repo A",
+      rootURL: URL(fileURLWithPath: repoRootA)
+    )
+    let store = TestStore(
+      initialState: WorkspaceCreationPromptFeature.State(
+        repositories: [candidate],
+        title: "Workspace",
+        rootPath: "/tmp/workspace",
+        selectedRepositoryIDs: [repoRootA],
+        openedRepositoryCandidates: [candidate]
+      )
+    ) {
+      WorkspaceCreationPromptFeature()
+    }
+
+    await store.send(.addOpenedRepository(repoRootA))
+  }
+
+  @Test func workspaceCreationPromptOffersLoadedRepositories() async {
     let testID = UUID().uuidString
     let repoRootA = "/tmp/\(testID)-repo-a"
     let repoRootB = "/tmp/\(testID)-repo-b"
@@ -618,11 +657,47 @@ struct RepositoriesFeatureTests {
     let repoB = makeRepository(id: repoRootB, name: "Repo B", worktrees: [])
     var state = makeState(repositories: [repoA, repoB])
     state.repositoryCustomTitles[repoB.id] = "API"
-    let title = "Repo A + API"
-    let expectedRootPath = SupacodePaths.workspacesDirectory
-      .appending(path: ProjectWorkspace.defaultWorkspaceFolderName(for: title), directoryHint: .isDirectory)
-      .standardizedFileURL
-      .path(percentEncoded: false)
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    }
+
+    await store.send(.workspaceCreation(.promptRequested)) {
+      let title = "Workspace"
+      let expectedRootPath = SupacodePaths.workspacesDirectory
+        .appending(path: ProjectWorkspace.defaultWorkspaceFolderName(for: title), directoryHint: .isDirectory)
+        .standardizedFileURL
+        .path(percentEncoded: false)
+      $0.workspaceCreationPrompt = WorkspaceCreationPromptFeature.State(
+        repositories: [],
+        title: title,
+        rootPath: expectedRootPath,
+        selectedRepositoryIDs: [],
+        openedRepositoryCandidates: [
+          ProjectWorkspaceCreationRepository(
+            id: repoRootA,
+            name: "Repo A",
+            rootURL: URL(fileURLWithPath: repoRootA),
+            branchName: "main"
+          ),
+          ProjectWorkspaceCreationRepository(
+            id: repoRootB,
+            name: "API",
+            rootURL: URL(fileURLWithPath: repoRootB)
+          ),
+        ]
+      )
+    }
+  }
+
+  @Test func workspaceCreationPromptLoadsBaseRefsForAddedOpenedRepository() async {
+    let testID = UUID().uuidString
+    let repoRootA = "/tmp/\(testID)-repo-a"
+    let repoRootB = "/tmp/\(testID)-repo-b"
+    let worktreeA = makeWorktree(id: repoRootA, name: "main", repoRoot: repoRootA)
+    let repoA = makeRepository(id: repoRootA, name: "Repo A", worktrees: [worktreeA])
+    let repoB = makeRepository(id: repoRootB, name: "Repo B", worktrees: [])
+    var state = makeState(repositories: [repoA, repoB])
+    state.repositoryCustomTitles[repoB.id] = "API"
     let store = TestStore(initialState: state) {
       RepositoriesFeature()
     } withDependencies: {
@@ -644,8 +719,17 @@ struct RepositoriesFeatureTests {
     }
 
     await store.send(.workspaceCreation(.promptRequested)) {
+      let title = "Workspace"
+      let expectedRootPath = SupacodePaths.workspacesDirectory
+        .appending(path: ProjectWorkspace.defaultWorkspaceFolderName(for: title), directoryHint: .isDirectory)
+        .standardizedFileURL
+        .path(percentEncoded: false)
       $0.workspaceCreationPrompt = WorkspaceCreationPromptFeature.State(
-        repositories: [
+        repositories: [],
+        title: title,
+        rootPath: expectedRootPath,
+        selectedRepositoryIDs: [],
+        openedRepositoryCandidates: [
           ProjectWorkspaceCreationRepository(
             id: repoRootA,
             name: "Repo A",
@@ -657,24 +741,26 @@ struct RepositoriesFeatureTests {
             name: "API",
             rootURL: URL(fileURLWithPath: repoRootB)
           ),
-        ],
-        title: title,
-        rootPath: expectedRootPath,
-        selectedRepositoryIDs: [repoRootA, repoRootB]
+        ]
       )
     }
+    await store.send(.workspaceCreationPrompt(.presented(.addOpenedRepository(repoRootA)))) {
+      $0.workspaceCreationPrompt?.repositories.append(
+        ProjectWorkspaceCreationRepository(
+          id: repoRootA,
+          name: "Repo A",
+          rootURL: URL(fileURLWithPath: repoRootA),
+          branchName: "main"
+        )
+      )
+      $0.workspaceCreationPrompt?.selectedRepositoryIDs = [repoRootA]
+    }
+    await store.receive(\.workspaceCreation.refreshBaseRefs)
     await store.receive(\.workspaceCreation.baseRefsLoaded) {
       $0.workspaceCreationPrompt?.repositories[id: repoRootA]?.baseRef = "main"
       $0.workspaceCreationPrompt?.repositories[id: repoRootA]?.baseRefOptions = [
         GitBranchRefOption(ref: "main", kind: .local),
         GitBranchRefOption(ref: "origin/main", kind: .remoteTracking),
-      ]
-    }
-    await store.receive(\.workspaceCreation.baseRefsLoaded) {
-      $0.workspaceCreationPrompt?.repositories[id: repoRootB]?.baseRef = "master"
-      $0.workspaceCreationPrompt?.repositories[id: repoRootB]?.baseRefOptions = [
-        GitBranchRefOption(ref: "master", kind: .local),
-        GitBranchRefOption(ref: "origin/master", kind: .remoteTracking),
       ]
     }
   }

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -581,10 +581,7 @@ struct RepositoriesFeatureTests {
 
     await store.send(.workspaceCreation(.promptRequested)) {
       let title = "Workspace"
-      let expectedRootPath = SupacodePaths.workspacesDirectory
-        .appending(path: ProjectWorkspace.defaultWorkspaceFolderName(for: title), directoryHint: .isDirectory)
-        .standardizedFileURL
-        .path(percentEncoded: false)
+      let expectedRootPath = expectedDefaultWorkspaceRootPath(for: title)
       $0.workspaceCreationPrompt = WorkspaceCreationPromptFeature.State(
         repositories: [],
         title: title,
@@ -660,10 +657,7 @@ struct RepositoriesFeatureTests {
 
     await store.send(.workspaceCreation(.promptRequested)) {
       let title = "Workspace"
-      let expectedRootPath = SupacodePaths.workspacesDirectory
-        .appending(path: ProjectWorkspace.defaultWorkspaceFolderName(for: title), directoryHint: .isDirectory)
-        .standardizedFileURL
-        .path(percentEncoded: false)
+      let expectedRootPath = expectedDefaultWorkspaceRootPath(for: title)
       $0.workspaceCreationPrompt = WorkspaceCreationPromptFeature.State(
         repositories: [],
         title: title,
@@ -715,10 +709,7 @@ struct RepositoriesFeatureTests {
 
     await store.send(.workspaceCreation(.promptRequested)) {
       let title = "Workspace"
-      let expectedRootPath = SupacodePaths.workspacesDirectory
-        .appending(path: ProjectWorkspace.defaultWorkspaceFolderName(for: title), directoryHint: .isDirectory)
-        .standardizedFileURL
-        .path(percentEncoded: false)
+      let expectedRootPath = expectedDefaultWorkspaceRootPath(for: title)
       $0.workspaceCreationPrompt = WorkspaceCreationPromptFeature.State(
         repositories: [],
         title: title,
@@ -6186,4 +6177,18 @@ struct RepositoriesFeatureTests {
       }
     }
   }
+}
+
+// Mirrors RepositoriesFeature.defaultWorkspaceRootURL: the default folder name
+// is uniqued against directories that already exist on the test machine.
+func expectedDefaultWorkspaceRootPath(for title: String) -> String {
+  let folderName = ProjectWorkspace.defaultWorkspaceFolderName(for: title)
+  let baseURL = SupacodePaths.workspacesDirectory
+  var candidateURL = baseURL.appending(path: folderName, directoryHint: .isDirectory)
+  var suffix = 2
+  while FileManager.default.fileExists(atPath: candidateURL.path(percentEncoded: false)) {
+    candidateURL = baseURL.appending(path: "\(folderName)-\(suffix)", directoryHint: .isDirectory)
+    suffix += 1
+  }
+  return candidateURL.standardizedFileURL.path(percentEncoded: false)
 }

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -1161,6 +1161,37 @@ struct RepositoriesFeatureTests {
     await store.finish()
   }
 
+  @Test func repositoryRemovedDropsEntryDespiteTrailingSlashMismatch() async {
+    let repository = makeRepository(
+      id: "/tmp/ws/",
+      name: "WS",
+      kind: .plain,
+      worktrees: [],
+      workspace: ProjectWorkspace(title: "WS")
+    )
+    let savedEntries = LockIsolated<[[PersistedRepositoryEntry]]>([])
+    let store = TestStore(initialState: makeState(repositories: [repository])) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.repositoryPersistence.loadRepositoryEntries = {
+        [PersistedRepositoryEntry(path: "/tmp/ws", kind: .plain)]
+      }
+      $0.repositoryPersistence.saveRepositoryEntries = { entries in
+        savedEntries.withValue { $0.append(entries) }
+      }
+      $0.repositoryPersistence.saveRepositorySnapshot = { _ in }
+      $0.gitClient.repoRoot = { _ in
+        throw GitClientError.commandFailed(command: "git", message: "not a git repository")
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.repositoryManagement(.repositoryRemoved("/tmp/ws/", selectionWasRemoved: false)))
+    await store.finish()
+
+    #expect(savedEntries.value.last == [])
+  }
+
   @Test func workspaceCreationCancelWhileCreatingShowsToast() async {
     var initialState = RepositoriesFeature.State()
     initialState.workspaceCreationPrompt = WorkspaceCreationPromptFeature.State(

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -333,7 +333,8 @@ struct RepositoriesFeatureTests {
       $0.gitClient.worktrees = { _ in [existingWorktree, discoveredWorktree] }
     }
 
-    await store.send(.worktreeInfoEvent(.repositoryWorktreesChanged(repositoryRootURL: repository.rootURL)))
+    await store.send(
+      .worktreeInfoEvent(.repositoryWorktreesChanged(repositoryRootURL: repository.rootURL)))
     await store.receive(\.reloadRepositories)
     await store.receive(\.repositoriesLoaded) {
       $0.repositories[id: repository.id] = makeRepository(
@@ -545,7 +546,8 @@ struct RepositoriesFeatureTests {
       workspace: workspace
     )
 
-    let childID = repository.rootURL.appending(path: "app").standardizedFileURL.path(percentEncoded: false)
+    let childID = repository.rootURL.appending(path: "app").standardizedFileURL.path(
+      percentEncoded: false)
     let store = TestStore(initialState: RepositoriesFeature.State()) {
       RepositoriesFeature()
     } withDependencies: {
@@ -554,7 +556,8 @@ struct RepositoriesFeatureTests {
       }
       $0.repositoryPersistence.saveRepositorySnapshot = { _ in }
       $0.gitClient.repoRoot = { url in
-        Issue.record("workspace should load as plain without git probing: \(url.path(percentEncoded: false))")
+        Issue.record(
+          "workspace should load as plain without git probing: \(url.path(percentEncoded: false))")
         return url
       }
       $0.gitClient.worktrees = { url in
@@ -905,7 +908,8 @@ struct RepositoriesFeatureTests {
     }
     await store.receive(
       .remoteRepositoryPromptLoaded(
-        "git@github.com:onevcat/app.git", GitRemoteBranchRefs(options: options, defaultBaseRef: "origin/main"))
+        "git@github.com:onevcat/app.git",
+        GitRemoteBranchRefs(options: options, defaultBaseRef: "origin/main"))
     ) {
       $0.remoteRepositoryPrompt?.isLoading = false
       $0.remoteRepositoryPrompt?.branchOptions = options
@@ -924,6 +928,43 @@ struct RepositoriesFeatureTests {
         )
       )
       $0.remoteRepositoryPrompt = nil
+    }
+  }
+
+  @Test func workspaceCreationPromptFolderFollowsTitleUntilEdited() async {
+    let store = TestStore(
+      initialState: WorkspaceCreationPromptFeature.State(
+        repositories: [],
+        title: "Workspace",
+        rootPath: "/tmp/workspace"
+      )
+    ) {
+      WorkspaceCreationPromptFeature()
+    }
+
+    let requestedRootPath = defaultWorkspaceBaseRootPath(for: "Client App")
+    let resolvedRootPath = expectedDefaultWorkspaceRootPath(for: "Client App")
+    await store.send(.titleChanged("Client App")) {
+      $0.title = "Client App"
+      $0.rootPath = requestedRootPath
+    }
+    if resolvedRootPath == requestedRootPath {
+      await store.receive(
+        .automaticRootPathResolved(path: resolvedRootPath, requestedRootPath: requestedRootPath)
+      )
+    } else {
+      await store.receive(
+        .automaticRootPathResolved(path: resolvedRootPath, requestedRootPath: requestedRootPath)
+      ) {
+        $0.rootPath = resolvedRootPath
+      }
+    }
+    await store.send(.rootPathChanged("/tmp/manual-workspace")) {
+      $0.rootPath = "/tmp/manual-workspace"
+      $0.isRootPathDirty = true
+    }
+    await store.send(.titleChanged("Other Title")) {
+      $0.title = "Other Title"
     }
   }
 
@@ -1038,7 +1079,9 @@ struct RepositoriesFeatureTests {
       WorkspaceCreationPromptFeature()
     }
 
-    await store.send(.repositorySourceLocationChanged(repositoryID, "git@github.com:onevcat/other.git")) {
+    await store.send(
+      .repositorySourceLocationChanged(repositoryID, "git@github.com:onevcat/other.git")
+    ) {
       $0.repositories[id: repositoryID]?.sourceLocation = "git@github.com:onevcat/other.git"
       $0.repositories[id: repositoryID]?.baseRef = nil
       $0.repositories[id: repositoryID]?.baseRefOptions = []
@@ -1105,10 +1148,13 @@ struct RepositoriesFeatureTests {
 
     await store.send(.createButtonTapped) {
       $0.validationMessage = "Choose an existing branch for Repo A."
+      $0.validationTarget = .repository(repoRootA, .baseRef)
+      $0.validationRequestID = 1
     }
     await store.send(.repositoryBaseRefChanged(repoRootA, "main")) {
       $0.repositories[id: repoRootA]?.baseRef = "main"
       $0.validationMessage = nil
+      $0.validationTarget = nil
     }
   }
 
@@ -1141,10 +1187,13 @@ struct RepositoriesFeatureTests {
 
     await store.send(.createButtonTapped) {
       $0.validationMessage = "Branch name required for Remote."
+      $0.validationTarget = .repository("remote", .branchName)
+      $0.validationRequestID = 1
     }
     await store.send(.repositoryBranchNameChanged("remote", "codex/app")) {
       $0.repositories[id: "remote"]?.branchName = "codex/app"
       $0.validationMessage = nil
+      $0.validationTarget = nil
     }
   }
 
@@ -1327,7 +1376,8 @@ struct RepositoriesFeatureTests {
       $0.shellClient.run = { _, _, _ in ShellOutput(stdout: "", stderr: "", exitCode: 0) }
       $0.gitClient.deleteLocalBranch = { name, url, force in
         deleteCalls.withValue {
-          $0.append(DeleteBranchCall(name: name, root: url.path(percentEncoded: false), force: force))
+          $0.append(
+            DeleteBranchCall(name: name, root: url.path(percentEncoded: false), force: force))
         }
         return .deleted
       }
@@ -1488,7 +1538,8 @@ struct RepositoriesFeatureTests {
     }
     store.exhaustivity = .off
 
-    await store.send(.repositoryManagement(.repositoryRemoved("/tmp/ws/", selectionWasRemoved: false)))
+    await store.send(
+      .repositoryManagement(.repositoryRemoved("/tmp/ws/", selectionWasRemoved: false)))
     await store.finish()
 
     #expect(savedEntries.value.last == [])
@@ -1511,6 +1562,66 @@ struct RepositoriesFeatureTests {
       $0.workspaceCreationPrompt = nil
     }
     await store.receive(\.showToast, .warning("Workspace creation canceled"))
+  }
+
+  @Test func workspaceCreationSuccessOpensWorkspaceAndShowsToast() async throws {
+    let rootURL = FileManager.default.temporaryDirectory
+      .appending(path: "prowl-feature-success-\(UUID().uuidString)", directoryHint: .isDirectory)
+      .standardizedFileURL
+    defer { try? FileManager.default.removeItem(at: rootURL) }
+    var initialState = RepositoriesFeature.State()
+    initialState.workspaceCreationPrompt = WorkspaceCreationPromptFeature.State(
+      repositories: [],
+      title: "Feature",
+      rootPath: rootURL.path(percentEncoded: false)
+    )
+    let store = TestStore(initialState: initialState) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.date.now = Date(timeIntervalSince1970: 1_700_000_000)
+      $0.shellClient.run = { _, _, _ in ShellOutput(stdout: "", stderr: "", exitCode: 0) }
+      $0.repositoryPersistence.loadRepositoryEntries = { [] }
+      $0.repositoryPersistence.saveRepositoryEntries = { _ in }
+      $0.repositoryPersistence.saveRepositorySnapshot = { _ in }
+    }
+    store.exhaustivity = .off
+
+    let draft = ProjectWorkspaceCreationDraft(
+      title: "Feature",
+      rootURL: rootURL,
+      repositories: [
+        ProjectWorkspaceRepositoryPlan(
+          id: "app",
+          name: "App",
+          path: "app",
+          sourceKind: .remote,
+          sourceLocation: "git@github.com:onevcat/app.git",
+          checkout: .useExistingRef("origin/main")
+        ),
+        ProjectWorkspaceRepositoryPlan(
+          id: "api",
+          name: "API",
+          path: "api",
+          sourceKind: .remote,
+          sourceLocation: "git@github.com:onevcat/api.git",
+          checkout: .useExistingRef("origin/main")
+        ),
+      ]
+    )
+
+    await store.send(.workspaceCreation(.createWorkspace(draft))) {
+      $0.workspaceCreationPrompt?.isCreating = true
+    }
+    await store.receive(\.workspaceCreation.workspaceCreated) {
+      $0.workspaceCreationPrompt = nil
+    }
+    await store.receive(\.showToast, .success("Workspace created")) {
+      $0.statusToast = .success("Workspace created")
+    }
+    await store.receive(\.repositoryManagement.openRepositories)
+    await store.finish()
+
+    #expect(ProjectWorkspace.load(from: rootURL)?.title == "Feature")
   }
 
   @Test func workspaceBaseRefsLoadErrorSurfacesValidationMessage() async {
@@ -1664,7 +1775,8 @@ struct RepositoriesFeatureTests {
         return URL(fileURLWithPath: ancestorRoot)
       }
       $0.gitClient.worktrees = { url in
-        Issue.record("downgraded git entry should not load worktrees: \(url.path(percentEncoded: false))")
+        Issue.record(
+          "downgraded git entry should not load worktrees: \(url.path(percentEncoded: false))")
         return []
       }
     }
@@ -2962,7 +3074,8 @@ struct RepositoriesFeatureTests {
       $0.gitClient.createWorktreeStream = { _ in
         AsyncThrowingStream { continuation in
           continuation.yield(.outputLine(ShellStreamLine(source: .stderr, text: "[1/2] copy .env")))
-          continuation.yield(.outputLine(ShellStreamLine(source: .stderr, text: "[2/2] copy .cache")))
+          continuation.yield(
+            .outputLine(ShellStreamLine(source: .stderr, text: "[2/2] copy .cache")))
           continuation.yield(.finished(createdWorktree))
           continuation.finish()
         }
@@ -3099,7 +3212,8 @@ struct RepositoriesFeatureTests {
       $0.gitClient.automaticWorktreeBaseRef = { _ in "origin/main" }
       $0.gitClient.remoteNames = { _ in ["origin"] }
       $0.gitClient.fetchRemote = { _, _ in
-        throw NSError(domain: "git", code: 128, userInfo: [NSLocalizedDescriptionKey: "network unreachable"])
+        throw NSError(
+          domain: "git", code: 128, userInfo: [NSLocalizedDescriptionKey: "network unreachable"])
       }
       $0.gitClient.ignoredFileCount = { _ in 0 }
       $0.gitClient.untrackedFileCount = { _ in 0 }
@@ -3223,7 +3337,8 @@ struct RepositoriesFeatureTests {
     #expect(observedBaseDirectory.value == expectedBaseDirectory)
   }
 
-  @Test(.dependencies) func createRandomWorktreeUsesGlobalWorktreeBaseDirectoryWhenRepositoryOverrideMissing() async {
+  @Test(.dependencies)
+  func createRandomWorktreeUsesGlobalWorktreeBaseDirectoryWhenRepositoryOverrideMissing() async {
     let repoRoot = "/tmp/repo"
     let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
     let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree])
@@ -3275,7 +3390,9 @@ struct RepositoriesFeatureTests {
     #expect(observedBaseDirectory.value == expectedBaseDirectory)
   }
 
-  @Test(.dependencies) func createRandomWorktreeUsesGlobalCopyFlagsWhenRepositoryOverridesMissing() async {
+  @Test(.dependencies) func createRandomWorktreeUsesGlobalCopyFlagsWhenRepositoryOverridesMissing()
+    async
+  {
     let repoRoot = "/tmp/repo"
     let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
     let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree])
@@ -3306,7 +3423,9 @@ struct RepositoriesFeatureTests {
       $0.gitClient.ignoredFileCount = { _ in 0 }
       $0.gitClient.untrackedFileCount = { _ in 0 }
       $0.gitClient.createWorktreeStream = { request in
-        observedCopyFlags.withValue { $0 = (request.copyFiles.ignored, request.copyFiles.untracked) }
+        observedCopyFlags.withValue {
+          $0 = (request.copyFiles.ignored, request.copyFiles.untracked)
+        }
         return AsyncThrowingStream { continuation in
           continuation.yield(.finished(createdWorktree))
           continuation.finish()
@@ -3355,7 +3474,9 @@ struct RepositoriesFeatureTests {
       $0.gitClient.ignoredFileCount = { _ in 0 }
       $0.gitClient.untrackedFileCount = { _ in 0 }
       $0.gitClient.createWorktreeStream = { request in
-        observedCopyFlags.withValue { $0 = (request.copyFiles.ignored, request.copyFiles.untracked) }
+        observedCopyFlags.withValue {
+          $0 = (request.copyFiles.ignored, request.copyFiles.untracked)
+        }
         return AsyncThrowingStream { continuation in
           continuation.yield(.finished(createdWorktree))
           continuation.finish()
@@ -3373,7 +3494,9 @@ struct RepositoriesFeatureTests {
     #expect(observedCopyFlags.value?.1 == false)
   }
 
-  @Test(.dependencies) func createRandomWorktreeInRepositoryStreamFailureRemovesPendingWorktree() async {
+  @Test(.dependencies) func createRandomWorktreeInRepositoryStreamFailureRemovesPendingWorktree()
+    async
+  {
     let repoRoot = "/tmp/repo"
     let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
     let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree])
@@ -3394,7 +3517,8 @@ struct RepositoriesFeatureTests {
       $0.gitClient.createWorktreeStream = { _ in
         AsyncThrowingStream { continuation in
           continuation.yield(.outputLine(ShellStreamLine(source: .stderr, text: "[1/2] copy .env")))
-          continuation.finish(throwing: GitClientError.commandFailed(command: "wt sw", message: "boom"))
+          continuation.finish(
+            throwing: GitClientError.commandFailed(command: "wt sw", message: "boom"))
         }
       }
     }
@@ -3536,7 +3660,8 @@ struct RepositoriesFeatureTests {
 
   @Test func pendingProgressUpdateIsIgnoredAfterCreateFailureRemovesPendingWorktree() async {
     let repoRoot = "/tmp/repo"
-    let repository = makeRepository(id: repoRoot, worktrees: [makeWorktree(id: repoRoot, name: "main")])
+    let repository = makeRepository(
+      id: repoRoot, worktrees: [makeWorktree(id: repoRoot, name: "main")])
     let pendingID = "pending:test"
     var state = makeState(repositories: [repository])
     state.selection = .worktree(pendingID)
@@ -3603,7 +3728,10 @@ struct RepositoriesFeatureTests {
         id: 0,
         title: "Delete worktree?",
         message: "Delete \(worktree.name)? The worktree directory will be removed.",
-        targets: [RepositoriesFeature.DeleteWorktreeTarget(worktreeID: worktree.id, repositoryID: repository.id)],
+        targets: [
+          RepositoriesFeature.DeleteWorktreeTarget(
+            worktreeID: worktree.id, repositoryID: repository.id)
+        ],
         deleteBranch: false
       )
       $0.nextDeleteWorktreeConfirmationID = 1
@@ -3630,7 +3758,10 @@ struct RepositoriesFeatureTests {
         id: 0,
         title: "Delete worktree?",
         message: "Delete \(worktree.name)? The worktree directory will be removed.",
-        targets: [RepositoriesFeature.DeleteWorktreeTarget(worktreeID: worktree.id, repositoryID: repository.id)],
+        targets: [
+          RepositoriesFeature.DeleteWorktreeTarget(
+            worktreeID: worktree.id, repositoryID: repository.id)
+        ],
         deleteBranch: true
       )
       $0.nextDeleteWorktreeConfirmationID = 1
@@ -3647,7 +3778,10 @@ struct RepositoriesFeatureTests {
       id: 0,
       title: "Delete worktree?",
       message: "Delete feature? The worktree directory will be removed.",
-      targets: [RepositoriesFeature.DeleteWorktreeTarget(worktreeID: worktree.id, repositoryID: repository.id)],
+      targets: [
+        RepositoriesFeature.DeleteWorktreeTarget(
+          worktreeID: worktree.id, repositoryID: repository.id)
+      ],
       deleteBranch: true
     )
     let forceDeleteAttempts = LockIsolated<[Bool]>([])
@@ -3663,7 +3797,8 @@ struct RepositoriesFeatureTests {
         if force {
           return .deleted
         }
-        throw GitClientError.commandFailed(command: "git branch -d feature", message: "not fully merged")
+        throw GitClientError.commandFailed(
+          command: "git branch -d feature", message: "not fully merged")
       }
       $0.gitClient.worktrees = { _ in [mainWorktree] }
     }
@@ -3776,8 +3911,10 @@ struct RepositoriesFeatureTests {
     let worktree2 = makeWorktree(id: "/tmp/repo/wt2", name: "hawk", repoRoot: "/tmp/repo")
     let repository = makeRepository(id: "/tmp/repo", worktrees: [worktree1, worktree2])
     let targets = [
-      RepositoriesFeature.DeleteWorktreeTarget(worktreeID: worktree1.id, repositoryID: repository.id),
-      RepositoriesFeature.DeleteWorktreeTarget(worktreeID: worktree2.id, repositoryID: repository.id),
+      RepositoriesFeature.DeleteWorktreeTarget(
+        worktreeID: worktree1.id, repositoryID: repository.id),
+      RepositoriesFeature.DeleteWorktreeTarget(
+        worktreeID: worktree2.id, repositoryID: repository.id),
     ]
     let store = TestStore(initialState: makeState(repositories: [repository])) {
       RepositoriesFeature()
@@ -3813,7 +3950,9 @@ struct RepositoriesFeatureTests {
         TextState("Cancel")
       }
     } message: {
-      TextState("Find \(worktree.name) later in Menu Bar > Worktrees > Archived Worktrees (\(archivedDisplay)).")
+      TextState(
+        "Find \(worktree.name) later in Menu Bar > Worktrees > Archived Worktrees (\(archivedDisplay))."
+      )
     }
 
     await store.send(.worktreeLifecycle(.requestArchiveWorktree(worktree.id, repository.id))) {
@@ -3826,8 +3965,10 @@ struct RepositoriesFeatureTests {
     let worktree2 = makeWorktree(id: "/tmp/repo/wt2", name: "hawk", repoRoot: "/tmp/repo")
     let repository = makeRepository(id: "/tmp/repo", worktrees: [worktree1, worktree2])
     let targets = [
-      RepositoriesFeature.ArchiveWorktreeTarget(worktreeID: worktree1.id, repositoryID: repository.id),
-      RepositoriesFeature.ArchiveWorktreeTarget(worktreeID: worktree2.id, repositoryID: repository.id),
+      RepositoriesFeature.ArchiveWorktreeTarget(
+        worktreeID: worktree1.id, repositoryID: repository.id),
+      RepositoriesFeature.ArchiveWorktreeTarget(
+        worktreeID: worktree2.id, repositoryID: repository.id),
     ]
     let store = TestStore(initialState: makeState(repositories: [repository])) {
       RepositoriesFeature()
@@ -3844,7 +3985,8 @@ struct RepositoriesFeatureTests {
         TextState("Cancel")
       }
     } message: {
-      TextState("Find them later in Menu Bar > Worktrees > Archived Worktrees (\(archivedDisplay)).")
+      TextState(
+        "Find them later in Menu Bar > Worktrees > Archived Worktrees (\(archivedDisplay)).")
     }
 
     await store.send(.worktreeLifecycle(.requestArchiveWorktrees(targets))) {
@@ -3915,13 +4057,16 @@ struct RepositoriesFeatureTests {
         AsyncThrowingStream { continuation in
           continuation.yield(.line(ShellStreamLine(source: .stdout, text: "syncing")))
           continuation.yield(.line(ShellStreamLine(source: .stdout, text: "done")))
-          continuation.yield(.finished(ShellOutput(stdout: "syncing\ndone", stderr: "", exitCode: 0)))
+          continuation.yield(
+            .finished(ShellOutput(stdout: "syncing\ndone", stderr: "", exitCode: 0)))
           continuation.finish()
         }
       }
     }
 
-    await store.send(.worktreeLifecycle(.archiveWorktreeConfirmed(featureWorktree.id, repository.id))) {
+    await store.send(
+      .worktreeLifecycle(.archiveWorktreeConfirmed(featureWorktree.id, repository.id))
+    ) {
       $0.archivingWorktreeIDs = [featureWorktree.id]
       $0.archiveScriptProgressByWorktreeID[featureWorktree.id] = ArchiveScriptProgress(
         titleText: "Running archive script",
@@ -3995,7 +4140,9 @@ struct RepositoriesFeatureTests {
       TextState("Command failed: bash -lc exit 7\nstderr:\nfail")
     }
 
-    await store.send(.worktreeLifecycle(.archiveWorktreeConfirmed(featureWorktree.id, repository.id))) {
+    await store.send(
+      .worktreeLifecycle(.archiveWorktreeConfirmed(featureWorktree.id, repository.id))
+    ) {
       $0.archivingWorktreeIDs = [featureWorktree.id]
       $0.archiveScriptProgressByWorktreeID[featureWorktree.id] = ArchiveScriptProgress(
         titleText: "Running archive script",
@@ -4025,7 +4172,8 @@ struct RepositoriesFeatureTests {
     }
 
     await store.send(
-      .worktreeLifecycle(.archiveScriptSucceeded(worktreeID: featureWorktree.id, repositoryID: repository.id))
+      .worktreeLifecycle(
+        .archiveScriptSucceeded(worktreeID: featureWorktree.id, repositoryID: repository.id))
     )
     #expect(store.state.archivedWorktrees.isEmpty)
   }
@@ -4043,7 +4191,9 @@ struct RepositoriesFeatureTests {
       RepositoriesFeature()
     }
 
-    await store.send(.worktreeLifecycle(.archiveScriptFailed(worktreeID: featureWorktree.id, message: "late failure")))
+    await store.send(
+      .worktreeLifecycle(
+        .archiveScriptFailed(worktreeID: featureWorktree.id, message: "late failure")))
     #expect(store.state.alert == nil)
     #expect(store.state.archivedWorktrees.isEmpty)
   }
@@ -4081,7 +4231,8 @@ struct RepositoriesFeatureTests {
     #expect(store.state.archiveScriptProgressByWorktreeID[featureWorktree.id] != nil)
 
     await store.send(
-      .worktreeLifecycle(.archiveScriptSucceeded(worktreeID: featureWorktree.id, repositoryID: repository.id))
+      .worktreeLifecycle(
+        .archiveScriptSucceeded(worktreeID: featureWorktree.id, repositoryID: repository.id))
     )
     #expect(store.state.archivingWorktreeIDs.isEmpty)
     #expect(store.state.archiveScriptProgressByWorktreeID.isEmpty)
@@ -4119,7 +4270,9 @@ struct RepositoriesFeatureTests {
     #expect(store.state.archivingWorktreeIDs.contains(featureWorktree.id))
     #expect(store.state.archiveScriptProgressByWorktreeID[featureWorktree.id] != nil)
 
-    await store.send(.worktreeLifecycle(.archiveScriptFailed(worktreeID: featureWorktree.id, message: "script failed")))
+    await store.send(
+      .worktreeLifecycle(
+        .archiveScriptFailed(worktreeID: featureWorktree.id, message: "script failed")))
     #expect(store.state.archivingWorktreeIDs.isEmpty)
     #expect(store.state.archiveScriptProgressByWorktreeID.isEmpty)
     #expect(store.state.alert != nil)
@@ -4247,7 +4400,8 @@ struct RepositoriesFeatureTests {
     let featureA = makeWorktree(id: "/tmp/repo/a", name: "a", repoRoot: repoRoot)
     let featureB = makeWorktree(id: "/tmp/repo/b", name: "b", repoRoot: repoRoot)
     let featureC = makeWorktree(id: "/tmp/repo/c", name: "c", repoRoot: repoRoot)
-    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree, featureA, featureB, featureC])
+    let repository = makeRepository(
+      id: repoRoot, worktrees: [mainWorktree, featureA, featureB, featureC])
     var state = makeState(repositories: [repository])
     state.isSidebarDragActive = true
     state.pendingSidebarNotifyReorderIDs = [featureA.id, featureC.id, featureB.id]
@@ -4362,8 +4516,11 @@ struct RepositoriesFeatureTests {
       )
       $0.repositories[id: repository.id] = repository
     }
-    #expect(store.state.repositories[id: repository.id]?.worktrees[id: worktree.id]?.name == "falcon")
-    #expect(store.state.repositories[id: repository.id]?.worktrees[id: worktree.id]?.createdAt == createdAt)
+    #expect(
+      store.state.repositories[id: repository.id]?.worktrees[id: worktree.id]?.name == "falcon")
+    #expect(
+      store.state.repositories[id: repository.id]?.worktrees[id: worktree.id]?.createdAt
+        == createdAt)
   }
 
   @Test func orderedWorktreeRowsAreGlobal() {
@@ -4493,7 +4650,9 @@ struct RepositoriesFeatureTests {
       RepositoriesFeature()
     }
 
-    await store.send(.worktreeOrdering(.unpinnedWorktreesMoved(repositoryID: repoRoot, IndexSet(integer: 0), 3))) {
+    await store.send(
+      .worktreeOrdering(.unpinnedWorktreesMoved(repositoryID: repoRoot, IndexSet(integer: 0), 3))
+    ) {
       $0.worktreeOrderByRepository[repoRoot] = [worktree2.id, worktree3.id, worktree1.id]
     }
   }
@@ -4512,7 +4671,9 @@ struct RepositoriesFeatureTests {
       RepositoriesFeature()
     }
 
-    await store.send(.worktreeOrdering(.pinnedWorktreesMoved(repositoryID: repoA, IndexSet(integer: 1), 0))) {
+    await store.send(
+      .worktreeOrdering(.pinnedWorktreesMoved(repositoryID: repoA, IndexSet(integer: 1), 0))
+    ) {
       $0.pinnedWorktreeIDs = [worktreeA2.id, worktreeB1.id, worktreeA1.id]
     }
   }
@@ -4597,14 +4758,16 @@ struct RepositoriesFeatureTests {
     }
 
     await store.receive(\.delegate.repositoriesChanged)
-    #expect(store.state.archivedWorktrees == [ArchivedWorktree(id: worktree.id, archivedAt: fixedDate)])
+    #expect(
+      store.state.archivedWorktrees == [ArchivedWorktree(id: worktree.id, archivedAt: fixedDate)])
   }
 
   @Test func repositoriesLoadedSkipsSelectionChangeWhenOnlyDisplayDataChanges() async {
     let repoRoot = "/tmp/repo"
     let worktree = makeWorktree(id: "/tmp/repo/main", name: "main", repoRoot: repoRoot)
     let repository = makeRepository(id: repoRoot, worktrees: [worktree])
-    let updatedWorktree = makeWorktree(id: "/tmp/repo/main", name: "main-updated", repoRoot: repoRoot)
+    let updatedWorktree = makeWorktree(
+      id: "/tmp/repo/main", name: "main-updated", repoRoot: repoRoot)
     let updatedRepository = makeRepository(id: repoRoot, worktrees: [updatedWorktree])
     var initialState = makeState(repositories: [repository])
     initialState.selection = .worktree(worktree.id)
@@ -4754,7 +4917,8 @@ struct RepositoriesFeatureTests {
     let existingWorktree = makeWorktree(id: "/tmp/repo/wt-main", name: "main", repoRoot: repoRoot)
     let repository = makeRepository(id: repoRoot, worktrees: [existingWorktree])
     let newWorktree = makeWorktree(id: "/tmp/repo/wt-new", name: "new", repoRoot: repoRoot)
-    let updatedRepository = makeRepository(id: repoRoot, worktrees: [newWorktree, existingWorktree])
+    let updatedRepository = makeRepository(
+      id: repoRoot, worktrees: [newWorktree, existingWorktree])
     let pendingID = "pending:\(UUID().uuidString)"
     var initialState = makeState(repositories: [repository])
     initialState.pendingWorktrees = [
@@ -4898,7 +5062,9 @@ struct RepositoriesFeatureTests {
     }
   }
 
-  @Test(.dependencies) func repositoryPullRequestsLoadedAutoDeleteOnlyDeletesProwlCreatedBranches() async {
+  @Test(.dependencies) func repositoryPullRequestsLoadedAutoDeleteOnlyDeletesProwlCreatedBranches()
+    async
+  {
     let repoRoot = "/tmp/repo"
     let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
     let externalWorktree = makeWorktree(
@@ -4968,7 +5134,8 @@ struct RepositoriesFeatureTests {
       repoRoot: repoRoot
     )
     let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree, featureWorktree])
-    let openPullRequest = makePullRequest(state: "OPEN", headRefName: featureWorktree.name, number: 12)
+    let openPullRequest = makePullRequest(
+      state: "OPEN", headRefName: featureWorktree.name, number: 12)
     var state = makeState(repositories: [repository])
     state.githubIntegrationAvailability = .disabled
     state.mergedWorktreeAction = .archive
@@ -4977,7 +5144,8 @@ struct RepositoriesFeatureTests {
       removedLines: nil,
       pullRequest: openPullRequest
     )
-    let upstreamRemoteInfo = GithubRemoteInfo(host: "github.com", owner: "supabitapp", repo: "supacode")
+    let upstreamRemoteInfo = GithubRemoteInfo(
+      host: "github.com", owner: "supabitapp", repo: "supacode")
     let mergedNumbers = LockIsolated<[Int]>([])
     let store = TestStore(initialState: state) {
       RepositoriesFeature()
@@ -5013,7 +5181,8 @@ struct RepositoriesFeatureTests {
       repoRoot: repoRoot
     )
     let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree, featureWorktree])
-    let openPullRequest = makePullRequest(state: "OPEN", headRefName: featureWorktree.name, number: 12)
+    let openPullRequest = makePullRequest(
+      state: "OPEN", headRefName: featureWorktree.name, number: 12)
     var state = makeState(repositories: [repository])
     state.githubIntegrationAvailability = .disabled
     state.worktreeInfoByID[featureWorktree.id] = WorktreeInfoEntry(
@@ -5021,7 +5190,8 @@ struct RepositoriesFeatureTests {
       removedLines: nil,
       pullRequest: openPullRequest
     )
-    let upstreamRemoteInfo = GithubRemoteInfo(host: "github.com", owner: "supabitapp", repo: "supacode")
+    let upstreamRemoteInfo = GithubRemoteInfo(
+      host: "github.com", owner: "supabitapp", repo: "supacode")
     let mergedStrategies = LockIsolated<[PullRequestMergeStrategy]>([])
     @Shared(.settingsFile) var settingsFile
     $settingsFile.withLock {
@@ -5063,8 +5233,10 @@ struct RepositoriesFeatureTests {
       repoRoot: repoRoot
     )
     let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree, featureWorktree])
-    let openPullRequest = makePullRequest(state: "OPEN", headRefName: featureWorktree.name, number: 12)
-    let upstreamRemoteInfo = GithubRemoteInfo(host: "github.com", owner: "supabitapp", repo: "supacode")
+    let openPullRequest = makePullRequest(
+      state: "OPEN", headRefName: featureWorktree.name, number: 12)
+    let upstreamRemoteInfo = GithubRemoteInfo(
+      host: "github.com", owner: "supabitapp", repo: "supacode")
     var state = makeState(repositories: [repository])
     state.githubIntegrationAvailability = .disabled
     state.worktreeInfoByID[featureWorktree.id] = WorktreeInfoEntry(
@@ -5114,7 +5286,8 @@ struct RepositoriesFeatureTests {
       repoRoot: repoRoot
     )
     let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree, featureWorktree])
-    let openPullRequest = makePullRequest(state: "OPEN", headRefName: featureWorktree.name, number: 12)
+    let openPullRequest = makePullRequest(
+      state: "OPEN", headRefName: featureWorktree.name, number: 12)
     var state = makeState(repositories: [repository])
     state.githubIntegrationAvailability = .disabled
     state.worktreeInfoByID[featureWorktree.id] = WorktreeInfoEntry(
@@ -5169,7 +5342,8 @@ struct RepositoriesFeatureTests {
       repoRoot: repoRoot
     )
     let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree, featureWorktree])
-    let openPullRequest = makePullRequest(state: "OPEN", headRefName: featureWorktree.name, number: 12)
+    let openPullRequest = makePullRequest(
+      state: "OPEN", headRefName: featureWorktree.name, number: 12)
     var state = makeState(repositories: [repository])
     state.githubIntegrationAvailability = .disabled
     state.worktreeInfoByID[featureWorktree.id] = WorktreeInfoEntry(
@@ -5177,7 +5351,8 @@ struct RepositoriesFeatureTests {
       removedLines: nil,
       pullRequest: openPullRequest
     )
-    let upstreamRemoteInfo = GithubRemoteInfo(host: "github.com", owner: "supabitapp", repo: "supacode")
+    let upstreamRemoteInfo = GithubRemoteInfo(
+      host: "github.com", owner: "supabitapp", repo: "supacode")
     let closedNumbers = LockIsolated<[Int]>([])
     let store = TestStore(initialState: state) {
       RepositoriesFeature()
@@ -5409,10 +5584,11 @@ struct RepositoriesFeatureTests {
       )
     )
     await store.receive(\.githubIntegration.repositoryPullRequestRefreshRequested) {
-      $0.pendingPullRequestRefreshByRepositoryID[repository.id] = RepositoriesFeature.PendingPullRequestRefresh(
-        repositoryRootURL: URL(fileURLWithPath: repoRoot),
-        worktreeIDs: [mainWorktree.id, featureWorktree.id]
-      )
+      $0.pendingPullRequestRefreshByRepositoryID[repository.id] =
+        RepositoriesFeature.PendingPullRequestRefresh(
+          repositoryRootURL: URL(fileURLWithPath: repoRoot),
+          worktreeIDs: [mainWorktree.id, featureWorktree.id]
+        )
     }
     await store.receive(\.githubIntegration.refreshGithubIntegrationAvailability) {
       $0.githubIntegrationAvailability = .checking
@@ -5455,10 +5631,11 @@ struct RepositoriesFeatureTests {
       )
     )
     await store.receive(\.githubIntegration.repositoryPullRequestRefreshRequested) {
-      $0.pendingPullRequestRefreshByRepositoryID[repository.id] = RepositoriesFeature.PendingPullRequestRefresh(
-        repositoryRootURL: URL(fileURLWithPath: repoRoot),
-        worktreeIDs: [mainWorktree.id, featureWorktree.id]
-      )
+      $0.pendingPullRequestRefreshByRepositoryID[repository.id] =
+        RepositoriesFeature.PendingPullRequestRefresh(
+          repositoryRootURL: URL(fileURLWithPath: repoRoot),
+          worktreeIDs: [mainWorktree.id, featureWorktree.id]
+        )
     }
     await store.finish()
   }
@@ -5474,10 +5651,11 @@ struct RepositoriesFeatureTests {
     let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree, featureWorktree])
     var initialState = makeState(repositories: [repository])
     initialState.githubIntegrationAvailability = .unavailable
-    initialState.pendingPullRequestRefreshByRepositoryID[repository.id] = RepositoriesFeature.PendingPullRequestRefresh(
-      repositoryRootURL: URL(fileURLWithPath: repoRoot),
-      worktreeIDs: [mainWorktree.id, featureWorktree.id]
-    )
+    initialState.pendingPullRequestRefreshByRepositoryID[repository.id] =
+      RepositoriesFeature.PendingPullRequestRefresh(
+        repositoryRootURL: URL(fileURLWithPath: repoRoot),
+        worktreeIDs: [mainWorktree.id, featureWorktree.id]
+      )
     let store = TestStore(initialState: initialState) {
       RepositoriesFeature()
     } withDependencies: {
@@ -5514,20 +5692,22 @@ struct RepositoriesFeatureTests {
     var initialState = makeState(repositories: [repository])
     initialState.githubIntegrationAvailability = .available
     initialState.inFlightPullRequestRefreshRepositoryIDs = [repository.id]
-    initialState.queuedPullRequestRefreshByRepositoryID[repository.id] = RepositoriesFeature.PendingPullRequestRefresh(
-      repositoryRootURL: URL(fileURLWithPath: repoRoot),
-      worktreeIDs: [mainWorktree.id, featureWorktree.id]
-    )
+    initialState.queuedPullRequestRefreshByRepositoryID[repository.id] =
+      RepositoriesFeature.PendingPullRequestRefresh(
+        repositoryRootURL: URL(fileURLWithPath: repoRoot),
+        worktreeIDs: [mainWorktree.id, featureWorktree.id]
+      )
     let store = TestStore(initialState: initialState) {
       RepositoriesFeature()
     }
 
     await store.send(.githubIntegration(.githubIntegrationAvailabilityUpdated(false))) {
       $0.githubIntegrationAvailability = .unavailable
-      $0.pendingPullRequestRefreshByRepositoryID[repository.id] = RepositoriesFeature.PendingPullRequestRefresh(
-        repositoryRootURL: URL(fileURLWithPath: repoRoot),
-        worktreeIDs: [mainWorktree.id, featureWorktree.id]
-      )
+      $0.pendingPullRequestRefreshByRepositoryID[repository.id] =
+        RepositoriesFeature.PendingPullRequestRefresh(
+          repositoryRootURL: URL(fileURLWithPath: repoRoot),
+          worktreeIDs: [mainWorktree.id, featureWorktree.id]
+        )
       $0.queuedPullRequestRefreshByRepositoryID = [:]
       $0.inFlightPullRequestRefreshRepositoryIDs = []
     }
@@ -5543,10 +5723,11 @@ struct RepositoriesFeatureTests {
   @Test func githubIntegrationAvailabilityUpdatedWhileDisabledIsIgnored() async {
     var state = makeState(repositories: [])
     state.githubIntegrationAvailability = .disabled
-    state.pendingPullRequestRefreshByRepositoryID["repo"] = RepositoriesFeature.PendingPullRequestRefresh(
-      repositoryRootURL: URL(fileURLWithPath: "/tmp/repo"),
-      worktreeIDs: []
-    )
+    state.pendingPullRequestRefreshByRepositoryID["repo"] =
+      RepositoriesFeature.PendingPullRequestRefresh(
+        repositoryRootURL: URL(fileURLWithPath: "/tmp/repo"),
+        worktreeIDs: []
+      )
     let expectedState = state
     let store = TestStore(initialState: state) {
       RepositoriesFeature()
@@ -5727,7 +5908,9 @@ struct RepositoriesFeatureTests {
     await store.receive(\.worktreeLifecycle.worktreeDeleted)
   }
 
-  @Test(.dependencies) func autoDeleteExpiredArchivedWorktreesOnlyDeletesProwlCreatedBranches() async {
+  @Test(.dependencies) func autoDeleteExpiredArchivedWorktreesOnlyDeletesProwlCreatedBranches()
+    async
+  {
     let repoRoot = "/tmp/repo"
     let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
     let expiredWorktree = makeWorktree(id: "/tmp/repo/expired", name: "expired", repoRoot: repoRoot)
@@ -6318,8 +6501,10 @@ struct RepositoriesFeatureTests {
     let pullRequest = makePullRequest(state: "OPEN", headRefName: "feature")
     applyWorkspaceChildrenInfo(
       [
-        WorkspaceChildInfoUpdate(id: "/ws/app", branch: "feature", added: 7, removed: 2, pullRequest: pullRequest),
-        WorkspaceChildInfoUpdate(id: "/ws/api", branch: "  ", added: 0, removed: 0, pullRequest: nil),
+        WorkspaceChildInfoUpdate(
+          id: "/ws/app", branch: "feature", added: 7, removed: 2, pullRequest: pullRequest),
+        WorkspaceChildInfoUpdate(
+          id: "/ws/api", branch: "  ", added: 0, removed: 0, pullRequest: nil),
       ],
       state: &state
     )
@@ -6345,7 +6530,8 @@ struct RepositoriesFeatureTests {
     var state = makeState(repositories: [repository])
     let childID = entry.resolvedURL(relativeTo: repository.rootURL).path(percentEncoded: false)
     state.workspaceChildBranchByID[childID] = "live-branch"
-    state.workspaceChildInfoByID[childID] = WorktreeInfoEntry(addedLines: 3, removedLines: 1, pullRequest: nil)
+    state.workspaceChildInfoByID[childID] = WorktreeInfoEntry(
+      addedLines: 3, removedLines: 1, pullRequest: nil)
 
     let rows = state.workspaceChildRows(in: repository)
 
@@ -6370,6 +6556,50 @@ struct RepositoriesFeatureTests {
     let rows = state.workspaceChildRows(in: repository)
     #expect(rows.first?.branchName == "metadata-branch")
     #expect(rows.first?.info == nil)
+  }
+
+  @Test func openWorkspaceChildFocusesOrCreatesBoundTerminalTabInChildDirectory() async {
+    let entry = ProjectWorkspace.RepositoryEntry(
+      id: "app",
+      name: "App",
+      path: "app",
+      sourceKind: .existingPath
+    )
+    let repository = makeWorkspaceRepository(id: "/tmp/ws-open-child", children: [entry])
+    let childID = entry.resolvedURL(relativeTo: repository.rootURL).path(percentEncoded: false)
+    let sentCommands = LockIsolated<[TerminalClient.Command]>([])
+    let store = TestStore(initialState: makeState(repositories: [repository])) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in
+        sentCommands.withValue { $0.append(command) }
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.openWorkspaceChild(childID)) {
+      $0.selection = .repository(repository.id)
+      $0.selectedWorkspaceChildID = childID
+      $0.openedWorktreeIDs = [repository.id]
+      $0.pendingTerminalFocusWorktreeIDs = [repository.id]
+    }
+    await store.finish()
+
+    let workspaceWorktree = Worktree(
+      id: repository.id,
+      name: repository.name,
+      detail: repository.rootURL.path(percentEncoded: false),
+      workingDirectory: repository.rootURL,
+      repositoryRootURL: repository.rootURL
+    )
+    #expect(
+      sentCommands.value == [
+        .focusOrCreateTabInDirectory(
+          workspaceWorktree,
+          directory: URL(fileURLWithPath: childID),
+          title: "App"
+        )
+      ])
   }
 
   @Test func repositoriesLoadedRefreshesAndPrunesWorkspaceChildren() async {
@@ -6408,6 +6638,103 @@ struct RepositoriesFeatureTests {
     #expect(store.state.workspaceChildBranchByID[childID] == "feature/live")
     #expect(store.state.workspaceChildInfoByID[childID]?.addedLines == 7)
     #expect(store.state.workspaceChildInfoByID[childID]?.removedLines == 2)
+  }
+
+  @Test func openRepositoriesFinishedRefreshesWorkspaceChildren() async {
+    let entry = ProjectWorkspace.RepositoryEntry(
+      id: "app",
+      name: "App",
+      path: "app",
+      sourceKind: .existingPath,
+      branchName: "metadata"
+    )
+    let repository = makeWorkspaceRepository(id: "/tmp/ws-open-refresh", children: [entry])
+    let childID = entry.resolvedURL(relativeTo: repository.rootURL).path(percentEncoded: false)
+    let store = TestStore(initialState: RepositoriesFeature.State()) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.gitClient.branchName = { _ in "feature/live" }
+      $0.gitClient.lineChanges = { _ in nil }
+      $0.gitClient.remoteInfo = { _ in nil }
+      $0.repositoryPersistence.saveRepositorySnapshot = { _ in }
+    }
+    store.exhaustivity = .off
+
+    await store.send(
+      .repositoryManagement(
+        .openRepositoriesFinished(
+          [repository],
+          failures: [],
+          invalidRoots: [],
+          openFailures: [],
+          roots: [repository.rootURL]
+        ))
+    ) {
+      $0.repositories = [repository]
+      $0.repositoryRoots = [repository.rootURL]
+      $0.isInitialLoadComplete = true
+      $0.snapshotPersistencePhase = .active
+    }
+    await store.receive(\.delegate.repositoriesChanged)
+    await store.receive(\.workspaceChildrenInfoLoaded) {
+      $0.workspaceChildBranchByID = [childID: "feature/live"]
+    }
+    await store.finish()
+  }
+
+  @Test func workspaceChildRefreshLoadsPullRequestWhenGithubIntegrationAvailable() async {
+    let entry = ProjectWorkspace.RepositoryEntry(
+      id: "app",
+      name: "App",
+      path: "app",
+      sourceKind: .existingPath,
+      branchName: "metadata"
+    )
+    let repository = makeWorkspaceRepository(id: "/tmp/ws-pr", children: [entry])
+    let childID = entry.resolvedURL(relativeTo: repository.rootURL).path(percentEncoded: false)
+    let pullRequest = makePullRequest(state: "OPEN", headRefName: "feature/live", number: 42)
+    var initialState = makeState(repositories: [repository])
+    initialState.githubIntegrationAvailability = .available
+    struct PullRequestBatchCall: Equatable, Sendable {
+      let host: String
+      let owner: String
+      let repo: String
+      let branches: [String]
+    }
+    let calls = LockIsolated<[PullRequestBatchCall]>([])
+    let store = TestStore(initialState: initialState) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.gitClient.branchName = { _ in "feature/live" }
+      $0.gitClient.lineChanges = { _ in nil }
+      $0.gitClient.remoteInfo = { url in
+        #expect(url.path(percentEncoded: false) == childID)
+        return GithubRemoteInfo(host: "github.com", owner: "onevcat", repo: "app")
+      }
+      $0.githubCLI.batchPullRequests = { host, owner, repo, branches, accountOverride in
+        #expect(accountOverride == nil)
+        calls.withValue {
+          $0.append(
+            PullRequestBatchCall(host: host, owner: owner, repo: repo, branches: branches))
+        }
+        return ["feature/live": pullRequest]
+      }
+      $0.repositoryPersistence.saveRepositorySnapshot = { _ in }
+    }
+    store.exhaustivity = .off
+
+    await store.send(
+      .repositoriesLoaded([repository], failures: [], roots: [repository.rootURL], animated: false)
+    )
+    await store.receive(\.workspaceChildrenInfoLoaded)
+    await store.finish()
+
+    #expect(calls.value.count == 1)
+    #expect(calls.value.first?.host == "github.com")
+    #expect(calls.value.first?.owner == "onevcat")
+    #expect(calls.value.first?.repo == "app")
+    #expect(calls.value.first?.branches == ["feature/live"])
+    #expect(store.state.workspaceChildInfoByID[childID]?.pullRequest == pullRequest)
   }
 
   private func makeWorktree(

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -1134,6 +1134,66 @@ struct RepositoriesFeatureTests {
     }
   }
 
+  @Test func requestRemoveWorkspaceBuildsBranchOptions() async {
+    let workspaceID = "/tmp/ws"
+    let workspace = ProjectWorkspace(
+      title: "WS",
+      repositories: [
+        ProjectWorkspace.RepositoryEntry(
+          id: "api",
+          name: "API",
+          path: "api",
+          sourceKind: .bareRepository,
+          sourceLocation: "/tmp/api.git",
+          branchName: "chore/x"
+        ),
+        ProjectWorkspace.RepositoryEntry(
+          id: "app",
+          name: "App",
+          path: "app",
+          sourceKind: .existingPath,
+          sourceLocation: "/tmp/app"
+        ),
+        ProjectWorkspace.RepositoryEntry(
+          id: "web",
+          name: "Web",
+          path: "web",
+          sourceKind: .remote,
+          sourceLocation: "git@github.com:onevcat/web.git",
+          branchName: "feature/web"
+        ),
+      ]
+    )
+    let repository = makeRepository(
+      id: workspaceID,
+      name: "WS",
+      kind: .plain,
+      worktrees: [],
+      workspace: workspace
+    )
+    let store = TestStore(initialState: makeState(repositories: [repository])) {
+      RepositoriesFeature()
+    }
+
+    await store.send(.repositoryManagement(.requestRemoveRepository(workspaceID))) {
+      $0.removeWorkspaceConfirmation = RemoveWorkspaceConfirmation(
+        repositoryID: workspaceID,
+        workspaceTitle: "WS",
+        rootPath: workspaceID,
+        branchOptions: [
+          RemoveWorkspaceConfirmation.BranchOption(
+            id: "api",
+            repositoryName: "API",
+            branchName: "chore/x"
+          )
+        ]
+      )
+    }
+    await store.send(.repositoryManagement(.removeWorkspaceDeleteBranchChanged("api", true))) {
+      $0.removeWorkspaceConfirmation?.branchOptions[0].isSelected = true
+    }
+  }
+
   @Test func removeWorkspaceConfirmedRemovesEntry() async {
     let workspaceID = "/tmp/ws"
     let repository = makeRepository(

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -1106,6 +1106,61 @@ struct RepositoriesFeatureTests {
     await store.receive(.delegate(.baseRefSourceChanged(repositoryID)))
   }
 
+  @Test func requestRemoveWorkspaceShowsConfirmationSheet() async {
+    let workspaceID = "/tmp/ws"
+    let repository = makeRepository(
+      id: workspaceID,
+      name: "WS",
+      kind: .plain,
+      worktrees: [],
+      workspace: ProjectWorkspace(title: "WS")
+    )
+    let store = TestStore(initialState: makeState(repositories: [repository])) {
+      RepositoriesFeature()
+    }
+
+    await store.send(.repositoryManagement(.requestRemoveRepository(workspaceID))) {
+      $0.removeWorkspaceConfirmation = RemoveWorkspaceConfirmation(
+        repositoryID: workspaceID,
+        workspaceTitle: "WS",
+        rootPath: workspaceID
+      )
+    }
+    await store.send(.repositoryManagement(.removeWorkspaceDeleteFilesChanged(true))) {
+      $0.removeWorkspaceConfirmation?.deleteFiles = true
+    }
+    await store.send(.repositoryManagement(.removeWorkspacePromptDismissed)) {
+      $0.removeWorkspaceConfirmation = nil
+    }
+  }
+
+  @Test func removeWorkspaceConfirmedRemovesEntry() async {
+    let workspaceID = "/tmp/ws"
+    let repository = makeRepository(
+      id: workspaceID,
+      name: "WS",
+      kind: .plain,
+      worktrees: [],
+      workspace: ProjectWorkspace(title: "WS")
+    )
+    let store = TestStore(initialState: makeState(repositories: [repository])) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.repositoryPersistence.loadRepositoryEntries = { [] }
+      $0.repositoryPersistence.saveRepositoryEntries = { _ in }
+      $0.repositoryPersistence.saveRepositorySnapshot = { _ in }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.repositoryManagement(.requestRemoveRepository(workspaceID)))
+    await store.send(.repositoryManagement(.removeWorkspacePromptConfirmed)) {
+      $0.removeWorkspaceConfirmation = nil
+      $0.removingRepositoryIDs = [workspaceID]
+    }
+    await store.receive(\.repositoryManagement.repositoryRemoved)
+    await store.finish()
+  }
+
   @Test func workspaceCreationCancelWhileCreatingShowsToast() async {
     var initialState = RepositoriesFeature.State()
     initialState.workspaceCreationPrompt = WorkspaceCreationPromptFeature.State(

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -604,10 +604,7 @@ struct RepositoriesFeatureTests {
     await store.receive(\.workspaceCreation.baseRefsLoaded) {
       $0.workspaceCreationPrompt?.repositories[id: "/tmp/repo-a"]?.baseRef = "master"
       $0.workspaceCreationPrompt?.repositories[id: "/tmp/repo-a"]?.baseRefOptions = [
-        "master",
-        "main",
-        "origin/main",
-        "origin/master",
+        "master"
       ]
     }
   }
@@ -662,17 +659,13 @@ struct RepositoriesFeatureTests {
       $0.workspaceCreationPrompt?.repositories[id: repoRootA]?.baseRef = "main"
       $0.workspaceCreationPrompt?.repositories[id: repoRootA]?.baseRefOptions = [
         "main",
-        "master",
         "origin/main",
-        "origin/master",
       ]
     }
     await store.receive(\.workspaceCreation.baseRefsLoaded) {
       $0.workspaceCreationPrompt?.repositories[id: repoRootB]?.baseRef = "master"
       $0.workspaceCreationPrompt?.repositories[id: repoRootB]?.baseRefOptions = [
         "master",
-        "main",
-        "origin/main",
         "origin/master",
       ]
     }
@@ -740,8 +733,7 @@ struct RepositoriesFeatureTests {
           id: UUID(0).uuidString,
           name: "",
           sourceKind: .remote,
-          sourceLocation: "",
-          baseRefOptions: ProjectWorkspaceCreationRepository.commonRemoteBaseRefOptions
+          sourceLocation: ""
         )
       ]
       $0.selectedRepositoryIDs = [UUID(0).uuidString]
@@ -769,6 +761,39 @@ struct RepositoriesFeatureTests {
       $0.selectedRepositoryIDs = [UUID(0).uuidString, UUID(1).uuidString]
     }
     await store.receive(.delegate(.baseRefSourceChanged(UUID(1).uuidString)))
+  }
+
+  @Test func workspaceCreationPromptRejectsUnknownBaseRef() async {
+    let repoRootA = "/tmp/repo-a"
+    let repoRootB = "/tmp/repo-b"
+    let store = TestStore(
+      initialState: WorkspaceCreationPromptFeature.State(
+        repositories: [
+          ProjectWorkspaceCreationRepository(
+            id: repoRootA,
+            name: "Repo A",
+            rootURL: URL(fileURLWithPath: repoRootA),
+            baseRefOptions: ["main"]
+          ),
+          ProjectWorkspaceCreationRepository(
+            id: repoRootB,
+            name: "Repo B",
+            rootURL: URL(fileURLWithPath: repoRootB),
+            baseRefOptions: ["master"]
+          ),
+        ],
+        title: "Workspace",
+        rootPath: "/tmp/workspace",
+        selectedRepositoryIDs: [repoRootA, repoRootB]
+      )
+    ) {
+      WorkspaceCreationPromptFeature()
+    }
+
+    await store.send(.repositoryBaseRefChanged(repoRootA, "missing-branch"))
+    await store.send(.repositoryBaseRefChanged(repoRootA, "main")) {
+      $0.repositories[id: repoRootA]?.baseRef = "main"
+    }
   }
 
   @Test func loadPersistedRepositoriesAutoUpgradesPlainFolderWhenItBecomesGitRoot() async {

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -572,6 +572,108 @@ struct RepositoriesFeatureTests {
     await store.finish()
   }
 
+  @Test func workspaceCreationPromptRequiresAtLeastTwoRepositories() async {
+    let repository = makeRepository(id: "/tmp/repo-a", name: "Repo A", worktrees: [])
+    let expectedAlert = AlertState<RepositoriesFeature.Alert> {
+      TextState("Unable to create workspace")
+    } actions: {
+      ButtonState(role: .cancel) {
+        TextState("OK")
+      }
+    } message: {
+      TextState("Open at least two repositories to create a workspace.")
+    }
+    let store = TestStore(initialState: makeState(repositories: [repository])) {
+      RepositoriesFeature()
+    }
+
+    await store.send(.workspaceCreation(.promptRequested)) {
+      $0.alert = expectedAlert
+    }
+  }
+
+  @Test func workspaceCreationPromptUsesLoadedRepositories() async {
+    let testID = UUID().uuidString
+    let repoRootA = "/tmp/\(testID)-repo-a"
+    let repoRootB = "/tmp/\(testID)-repo-b"
+    let worktreeA = makeWorktree(id: repoRootA, name: "main", repoRoot: repoRootA)
+    let repoA = makeRepository(id: repoRootA, name: "Repo A", worktrees: [worktreeA])
+    let repoB = makeRepository(id: repoRootB, name: "Repo B", worktrees: [])
+    var state = makeState(repositories: [repoA, repoB])
+    state.repositoryCustomTitles[repoB.id] = "API"
+    let title = "Repo A + API"
+    let expectedRootPath = SupacodePaths.workspacesDirectory
+      .appending(path: ProjectWorkspace.defaultWorkspaceFolderName(for: title), directoryHint: .isDirectory)
+      .standardizedFileURL
+      .path(percentEncoded: false)
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    }
+
+    await store.send(.workspaceCreation(.promptRequested)) {
+      $0.workspaceCreationPrompt = WorkspaceCreationPromptFeature.State(
+        candidates: [
+          ProjectWorkspaceCreationRepository(
+            id: repoRootA,
+            name: "Repo A",
+            rootURL: URL(fileURLWithPath: repoRootA),
+            branchName: "main"
+          ),
+          ProjectWorkspaceCreationRepository(
+            id: repoRootB,
+            name: "API",
+            rootURL: URL(fileURLWithPath: repoRootB)
+          ),
+        ],
+        title: title,
+        rootPath: expectedRootPath,
+        selectedRepositoryIDs: [repoRootA, repoRootB]
+      )
+    }
+  }
+
+  @Test func workspaceCreationPromptSubmitBuildsDraft() async {
+    let repoRootA = "/tmp/repo-a"
+    let repoRootB = "/tmp/repo-b"
+    let repositories = [
+      ProjectWorkspaceCreationRepository(
+        id: repoRootA,
+        name: "Repo A",
+        rootURL: URL(fileURLWithPath: repoRootA),
+        branchName: "main"
+      ),
+      ProjectWorkspaceCreationRepository(
+        id: repoRootB,
+        name: "Repo B",
+        rootURL: URL(fileURLWithPath: repoRootB)
+      ),
+    ]
+    let rootURL = URL(fileURLWithPath: "/tmp/multi-repo-workspace")
+    let store = TestStore(
+      initialState: WorkspaceCreationPromptFeature.State(
+        candidates: repositories,
+        title: " Multi Repo ",
+        rootPath: " /tmp/multi-repo-workspace ",
+        selectedRepositoryIDs: [repoRootA, repoRootB]
+      )
+    ) {
+      WorkspaceCreationPromptFeature()
+    }
+
+    await store.send(.createButtonTapped)
+    await store.receive(
+      .delegate(
+        .submit(
+          ProjectWorkspaceCreationDraft(
+            title: "Multi Repo",
+            rootURL: rootURL,
+            repositories: repositories
+          )
+        )
+      )
+    )
+  }
+
   @Test func loadPersistedRepositoriesAutoUpgradesPlainFolderWhenItBecomesGitRoot() async {
     let root = "/tmp/folder"
     let worktree = makeWorktree(id: root, name: "folder", repoRoot: root)

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -572,23 +572,30 @@ struct RepositoriesFeatureTests {
     await store.finish()
   }
 
-  @Test func workspaceCreationPromptRequiresAtLeastTwoRepositories() async {
+  @Test func workspaceCreationPromptOpensWithoutTwoRepositories() async {
     let repository = makeRepository(id: "/tmp/repo-a", name: "Repo A", worktrees: [])
-    let expectedAlert = AlertState<RepositoriesFeature.Alert> {
-      TextState("Unable to create workspace")
-    } actions: {
-      ButtonState(role: .cancel) {
-        TextState("OK")
-      }
-    } message: {
-      TextState("Open at least two repositories to create a workspace.")
-    }
     let store = TestStore(initialState: makeState(repositories: [repository])) {
       RepositoriesFeature()
     }
 
     await store.send(.workspaceCreation(.promptRequested)) {
-      $0.alert = expectedAlert
+      let title = "Repo A"
+      let expectedRootPath = SupacodePaths.workspacesDirectory
+        .appending(path: ProjectWorkspace.defaultWorkspaceFolderName(for: title), directoryHint: .isDirectory)
+        .standardizedFileURL
+        .path(percentEncoded: false)
+      $0.workspaceCreationPrompt = WorkspaceCreationPromptFeature.State(
+        repositories: [
+          ProjectWorkspaceCreationRepository(
+            id: "/tmp/repo-a",
+            name: "Repo A",
+            rootURL: URL(fileURLWithPath: "/tmp/repo-a")
+          )
+        ],
+        title: title,
+        rootPath: expectedRootPath,
+        selectedRepositoryIDs: ["/tmp/repo-a"]
+      )
     }
   }
 
@@ -612,7 +619,7 @@ struct RepositoriesFeatureTests {
 
     await store.send(.workspaceCreation(.promptRequested)) {
       $0.workspaceCreationPrompt = WorkspaceCreationPromptFeature.State(
-        candidates: [
+        repositories: [
           ProjectWorkspaceCreationRepository(
             id: repoRootA,
             name: "Repo A",
@@ -651,7 +658,7 @@ struct RepositoriesFeatureTests {
     let rootURL = URL(fileURLWithPath: "/tmp/multi-repo-workspace")
     let store = TestStore(
       initialState: WorkspaceCreationPromptFeature.State(
-        candidates: repositories,
+        repositories: repositories,
         title: " Multi Repo ",
         rootPath: " /tmp/multi-repo-workspace ",
         selectedRepositoryIDs: [repoRootA, repoRootB]
@@ -672,6 +679,55 @@ struct RepositoriesFeatureTests {
         )
       )
     )
+  }
+
+  @Test func workspaceCreationPromptAddsRemoteAndLocalRepositories() async {
+    let store = TestStore(
+      initialState: WorkspaceCreationPromptFeature.State(
+        repositories: [],
+        title: "Workspace",
+        rootPath: "/tmp/workspace",
+        selectedRepositoryIDs: []
+      )
+    ) {
+      WorkspaceCreationPromptFeature()
+    } withDependencies: {
+      $0.uuid = .incrementing
+    }
+
+    await store.send(.addBlankRepository(.remote)) {
+      $0.repositories = [
+        ProjectWorkspaceCreationRepository(
+          id: UUID(0).uuidString,
+          name: "",
+          sourceKind: .remote,
+          sourceLocation: ""
+        )
+      ]
+      $0.selectedRepositoryIDs = [UUID(0).uuidString]
+    }
+
+    await store.send(.repositoryNameChanged(UUID(0).uuidString, "App")) {
+      $0.repositories[id: UUID(0).uuidString]?.name = "App"
+    }
+    await store.send(.repositorySourceLocationChanged(UUID(0).uuidString, "git@github.com:onevcat/app.git")) {
+      $0.repositories[id: UUID(0).uuidString]?.sourceLocation = "git@github.com:onevcat/app.git"
+    }
+    await store.send(.repositoryBranchNameChanged(UUID(0).uuidString, "codex/app")) {
+      $0.repositories[id: UUID(0).uuidString]?.branchName = "codex/app"
+    }
+
+    await store.send(.addRepositoryFromURL(.localRepository, "/tmp/local-api")) {
+      $0.repositories.append(
+        ProjectWorkspaceCreationRepository(
+          id: UUID(1).uuidString,
+          name: "local-api",
+          sourceKind: .localRepository,
+          sourceLocation: "/tmp/local-api"
+        )
+      )
+      $0.selectedRepositoryIDs = [UUID(0).uuidString, UUID(1).uuidString]
+    }
   }
 
   @Test func loadPersistedRepositoriesAutoUpgradesPlainFolderWhenItBecomesGitRoot() async {

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -1373,7 +1373,7 @@ struct RepositoriesFeatureTests {
       $0.repositoryPersistence.loadRepositoryEntries = { [] }
       $0.repositoryPersistence.saveRepositoryEntries = { _ in }
       $0.repositoryPersistence.saveRepositorySnapshot = { _ in }
-      $0.shellClient.run = { _, _, _ in ShellOutput(stdout: "", stderr: "", exitCode: 0) }
+      $0.shellClient.runLoginImpl = { _, _, _, _ in ShellOutput(stdout: "", stderr: "", exitCode: 0) }
       $0.gitClient.deleteLocalBranch = { name, url, force in
         deleteCalls.withValue {
           $0.append(
@@ -1430,7 +1430,7 @@ struct RepositoriesFeatureTests {
       $0.repositoryPersistence.loadRepositoryEntries = { [] }
       $0.repositoryPersistence.saveRepositoryEntries = { _ in }
       $0.repositoryPersistence.saveRepositorySnapshot = { _ in }
-      $0.shellClient.run = { _, _, _ in
+      $0.shellClient.runLoginImpl = { _, _, _, _ in
         throw ShellClientError(command: "git", stdout: "", stderr: "broken", exitCode: 1)
       }
     }
@@ -1488,7 +1488,7 @@ struct RepositoriesFeatureTests {
       $0.repositoryPersistence.loadRepositoryEntries = { [] }
       $0.repositoryPersistence.saveRepositoryEntries = { _ in }
       $0.repositoryPersistence.saveRepositorySnapshot = { _ in }
-      $0.shellClient.run = { _, _, _ in
+      $0.shellClient.runLoginImpl = { _, _, _, _ in
         throw ShellClientError(command: "git", stdout: "", stderr: "broken", exitCode: 1)
       }
     }
@@ -1564,6 +1564,51 @@ struct RepositoriesFeatureTests {
     await store.receive(\.showToast, .warning("Workspace creation canceled"))
   }
 
+  @Test func workspaceGitRunnerUsesLoginShellForGitCommands() async throws {
+    struct LoginCall: Equatable, Sendable {
+      let executablePath: String
+      let arguments: [String]
+      let currentDirectoryPath: String?
+    }
+    let directRunCalls = LockIsolated(0)
+    let loginCalls = LockIsolated<[LoginCall]>([])
+    let runner = RepositoriesFeature.workspaceGitRunner(
+      shellClient: ShellClient(
+        run: { _, _, _ in
+          directRunCalls.withValue { $0 += 1 }
+          throw ShellClientError(command: "git", stdout: "", stderr: "direct run used", exitCode: 1)
+        },
+        runLoginImpl: { executableURL, arguments, currentDirectoryURL, _ in
+          loginCalls.withValue {
+            $0.append(
+              LoginCall(
+                executablePath: executableURL.path(percentEncoded: false),
+                arguments: arguments,
+                currentDirectoryPath: currentDirectoryURL?.path(percentEncoded: false)
+              ))
+          }
+          return ShellOutput(stdout: "", stderr: "", exitCode: 0)
+        }
+      )
+    )
+
+    try await runner.run(
+      ProjectWorkspaceGitCommand(
+        arguments: ["-C", "/tmp/repo", "worktree", "add", "/tmp/workspace/repo"],
+        currentDirectoryURL: URL(fileURLWithPath: "/tmp/repo")
+      ))
+
+    #expect(directRunCalls.value == 0)
+    #expect(
+      loginCalls.value == [
+        LoginCall(
+          executablePath: "/usr/bin/env",
+          arguments: ["git", "-C", "/tmp/repo", "worktree", "add", "/tmp/workspace/repo"],
+          currentDirectoryPath: "/tmp/repo"
+        )
+      ])
+  }
+
   @Test func workspaceCreationSuccessOpensWorkspaceAndShowsToast() async throws {
     let rootURL = FileManager.default.temporaryDirectory
       .appending(path: "prowl-feature-success-\(UUID().uuidString)", directoryHint: .isDirectory)
@@ -1579,7 +1624,7 @@ struct RepositoriesFeatureTests {
       RepositoriesFeature()
     } withDependencies: {
       $0.date.now = Date(timeIntervalSince1970: 1_700_000_000)
-      $0.shellClient.run = { _, _, _ in ShellOutput(stdout: "", stderr: "", exitCode: 0) }
+      $0.shellClient.runLoginImpl = { _, _, _, _ in ShellOutput(stdout: "", stderr: "", exitCode: 0) }
       $0.repositoryPersistence.loadRepositoryEntries = { [] }
       $0.repositoryPersistence.saveRepositoryEntries = { _ in }
       $0.repositoryPersistence.saveRepositorySnapshot = { _ in }


### PR DESCRIPTION
## Summary

This PR incorporates MikotoZero's workspace feature from #455, with review fixes applied on top.

**Original feature (MikotoZero — 22 commits):**
- `ProjectWorkspace` domain model with `.prowl/workspace.json` metadata
- Workspace creation flow (from opened repos, local repos, bare repos, remote URLs)
- Three checkout modes: Link / Create Branch / Use Existing
- Creation rollback on failure/cancel
- Sidebar workspace + child repo display (read-only rows with branch/diff/PR)
- Workspace removal with confirmation, optional cleanup, per-repo branch deletion
- CLI `prowl list` workspace kind support
- Docs, settings page, comprehensive reducer/domain tests

**Review fixes (onevcat — 5 commits):**
- **Fix workspace removal not auto-selecting next repository** — `selectionWasRemoved` was always false for workspaces (empty worktrees + `.repository(id)` selection); now includes `.repository(id)` match
- **Fix local branches named `*/HEAD` being silently filtered** — `branchRefOptions` incorrectly applied the remote HEAD pointer filter to local refs; also simplifies `branchRefs` to eliminate redundant filter/sort/dedup
- **Avoid full workspace JSON decode in persistence normalizer** — replaced `ProjectWorkspace.load` (sync file read + JSON decode per entry) with lightweight `hasMetadata` file-exists check
- **Parallelize independent git lookups in workspace base ref fetch** — `automaticWorktreeBaseRef` and `branchRefOptions` now run concurrently via `async let`
- **Deduplicate workspace root path logic** — moved `workspaceRootPath`/`uniqueWorkspaceRootPath` from two reducer files into `ProjectWorkspace`

## Test plan

- [x] All existing tests pass (`make build-app` + full test suite)
- [x] New test: `removeSelectedWorkspaceSelectsNextRepository` — verifies auto-selection after workspace removal
- [x] New test: `branchRefOptionsPreservesLocalBranchNamedHEAD` — verifies `fix/HEAD` branch not filtered
- [ ] Manual: create workspace, open children, remove workspace — verify selection transitions
- [ ] Manual: verify workspace creation speed with multiple repos
