### PR TITLE
Show worktree running while an agent is working/blocked or a workflow runs

### DIFF
--- a/docs/components/agent-detection.md
+++ b/docs/components/agent-detection.md
@@ -32,6 +32,10 @@ icon where Prowl shows detected command icons, including terminal tabs.
    loader or braille spinner status line (working), confirmation/permission prompts
    (blocked), idle prompts. Each agent family has its own patterns (including spinner glyphs:
    braille frames, symbol cycles, Cursor's hexagons, Kimi's moon phases, etc.).
+   For Claude, a running **background workflow** keeps a status line *below* the
+   input box (e.g. `3/5 agents done · 7m 29s · ↓ 288.5k tokens`) after the turn has
+   ended; Prowl reads that footer as **Working**, so a churning workflow isn't
+   mistaken for idle.
 
 To avoid flicker, detection **stabilizes**: it tolerates several consecutive
 misses before declaring an agent gone, and a working agent gets a short (~3s)
@@ -74,6 +78,39 @@ In tabs and the Active Agents panel, a **Working** agent shows an animated spinn
 attention color; **Idle/Done** are static. The "working" animation style is also
 configurable in spirit — Prowl uses a bagua/trigram-style spinner in the agents
 list.
+
+## Worktree running indicator
+
+The sidebar worktree row spinner and `prowl list`'s `task.status` report
+**running** whenever any pane in the worktree is busy. A pane is busy when:
+
+- a terminal command reports progress (OSC 9;4 / ConEmu-style, e.g. a long shell
+  command), **or**
+- a detected agent is **Working** or **Blocked** — including Claude running a
+  background **workflow**, detected from its below-prompt `… agents done …` status
+  line even while the input box looks idle.
+
+It's a single coarse running/idle bit (it can't distinguish a background workflow
+from a long command). For the agent's finer state use the
+[Active Agents panel](active-agents.md) or [`prowl agents`](cli.md). Expect up to
+~2 s before it lights on a warm pane, and the ~3 s working-hold before it clears.
+
+### Optional: a lower-latency signal via a Claude Code hook
+
+Footer detection is zero-config but Claude-specific and depends on that footer's
+wording. For a faster, restyle-proof signal, have Claude Code emit an **OSC 9;4**
+progress sequence while background work runs — Prowl already treats OSC 9;4
+progress as *running*, with no extra setup on its side. Add a hook to
+`~/.claude/settings.json` that returns the bytes via the `terminalSequence` output
+field (Claude Code ≥ 2.1.141; hooks have no controlling terminal, so
+`terminalSequence` is the only path to the terminal):
+
+- **start** (e.g. `PreToolUse` on a backgrounded `Bash`, or `SubagentStart`):
+  emit `printf '\e]9;4;3\e\\'` (indeterminate progress)
+- **stop** (e.g. `SubagentStop`): emit `printf '\e]9;4;0\e\\'` (clear)
+
+A plain backgrounded `Bash` has no completion hook, so the clear is best-effort;
+Prowl auto-clears a stale progress bar after ~15 s.
 
 ## Settings
 

--- a/docs/components/cli.md
+++ b/docs/components/cli.md
@@ -71,9 +71,12 @@ Each item contains:
 - `pane`: `id`, `title`, `cwd`, `focused`
 - `task`: `status` (`running` | `idle` | null)
 
-`task.status` is the same agent activity signal described in
-[agent-detection](agent-detection.md). It's good for coordination but can flip to
-idle **before** a TUI finishes painting — confirm with `read --wait-stable`.
+`task.status` is **running** when any pane in the worktree is busy — a terminal
+command reporting progress, or a detected agent that is Working/Blocked (including
+Claude running a background **workflow**); otherwise **idle**. See the
+[worktree running indicator](agent-detection.md#worktree-running-indicator). It's
+good for coordination but lags a screen by ~2–3 s and can flip to idle **before** a
+TUI finishes painting — confirm with `read --wait-stable`.
 
 Find your own pane (to avoid operating on yourself):
 ```bash

--- a/docs/components/terminal.md
+++ b/docs/components/terminal.md
@@ -92,8 +92,10 @@ sequences:
   finishes** and its **exit code**. This powers command-finished notifications,
   auto-close-on-success, and the `prowl send --capture` output capture.
 - **OSC 2** (title) — feeds tab titles and agent/icon detection.
-- **Progress reports** — agents/commands report busy/idle, feeding the tab's
-  activity indicator and task status.
+- **Progress reports (OSC 9;4)** — long commands report busy/idle, feeding the
+  tab's activity indicator and task status. Task status *also* folds in detected
+  agent activity (Working/Blocked, incl. background workflows) — see
+  [agent-detection](agent-detection.md#worktree-running-indicator).
 - **Bell / desktop notification** — increments unread indicators.
 
 `--capture` in the CLI **requires OSC 133** on the target pane; without it you get

--- a/supacode/Domain/AgentDetection/PaneAgentState.swift
+++ b/supacode/Domain/AgentDetection/PaneAgentState.swift
@@ -36,6 +36,16 @@ struct PaneAgentState: Equatable, Sendable {
       return .idle
     }
   }
+
+  /// Whether this pane should count toward the worktree running indicator: a
+  /// detected agent that is working or blocked (awaiting permission). Folded
+  /// into `taskStatus` so the sidebar spinner and `prowl list` light up on agent
+  /// activity even when no OSC 9;4 command progress is reported (Claude Code
+  /// does not emit OSC 9;4 while it works).
+  var isBusy: Bool {
+    guard detectedAgent != nil else { return false }
+    return displayState == .working || displayState == .blocked
+  }
 }
 
 struct AgentDetectionPresence: Equatable, Sendable {

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState+AgentDetection.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState+AgentDetection.swift
@@ -150,6 +150,7 @@ extension WorktreeTerminalState {
     }
     guard next != previous else { return true }
     surfaceAgentStates[surfaceID] = next
+    updateTabAgentBusyState(for: tabId)
     emitAgentEntry(surfaceID: surfaceID, tabId: tabId, state: next)
     return true
   }
@@ -168,6 +169,23 @@ extension WorktreeTerminalState {
     surfaceAgentStates[surfaceID] = PaneAgentState(lastChangedAt: Date())
     lastWorkingAtBySurface.removeValue(forKey: surfaceID)
     onAgentEntryRemoved?(surfaceID)
+    if let tabId = tabId(containing: surfaceID) {
+      updateTabAgentBusyState(for: tabId)
+    }
+  }
+
+  /// Recompute `tabAgentBusyById[tabId]` from the stabilized state of every
+  /// surface in the tab, emitting a task-status change only when the aggregate
+  /// flips. Driven by `detectAgentState` (state change), agent release, and
+  /// surface teardown so the sidebar/`prowl list` running indicator tracks agent
+  /// activity. Uses `displayState` (post-stabilization) so the 3 s working-hold
+  /// absorbs raw oscillation; `emitTaskStatusIfChanged` dedupes emissions.
+  func updateTabAgentBusyState(for tabId: TerminalTabID) {
+    let surfaceIDs = trees[tabId]?.leaves().map(\.id) ?? []
+    let isBusy = surfaceIDs.contains { surfaceAgentStates[$0]?.isBusy == true }
+    guard (tabAgentBusyById[tabId] ?? false) != isBusy else { return }
+    tabAgentBusyById[tabId] = isBusy
+    emitTaskStatusIfChanged()
   }
 
   /// Re-emit Active Agents entries for every pane in `tabId` so the panel picks

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState+Surfaces.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState+Surfaces.swift
@@ -320,6 +320,7 @@ extension WorktreeTerminalState {
     focusedSurfaceIdByTab.removeAll()
     cleanupAllAgentDetectionState()
     tabIsRunningById.removeAll()
+    tabAgentBusyById.removeAll()
     boundDirectoryTabIDs.removeAll()
     autoCloseSurfaceIds.removeAll()
     pendingCustomCommands.removeAll()
@@ -611,6 +612,9 @@ extension WorktreeTerminalState {
     pendingCustomCommands.removeValue(forKey: surfaceID)
     cleanupCommandDetectorState(forSurfaceId: surfaceID)
     cleanupAgentDetectionState(forSurfaceId: surfaceID)
+    if let tabId = tabId(containing: surfaceID) {
+      updateTabAgentBusyState(for: tabId)
+    }
     let previousHasUnseen = hasUnseenNotification
     notifications = Self.prunedNotifications(from: notifications, removingSurfaceID: surfaceID)
     emitNotificationIndicatorIfNeeded(previousHasUnseen: previousHasUnseen)
@@ -624,6 +628,7 @@ extension WorktreeTerminalState {
     }
     focusedSurfaceIdByTab.removeValue(forKey: tabId)
     tabIsRunningById.removeValue(forKey: tabId)
+    tabAgentBusyById.removeValue(forKey: tabId)
   }
 
   func tabID(containing surfaceId: UUID) -> TerminalTabID? {

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -76,6 +76,12 @@ final class WorktreeTerminalState {
   var lastWorkingAtBySurface: [UUID: Date] = [:]
   var lastAgentDetectionDiagnosticsBySurface: [UUID: String] = [:]
   var tabIsRunningById: [TerminalTabID: Bool] = [:]
+  /// Per-tab aggregate of agent busy-state: `true` when at least one surface in
+  /// the tab has a detected agent whose stabilized `displayState` is `.working`
+  /// or `.blocked`. OR-ed into `taskStatus` alongside `tabIsRunningById` so the
+  /// sidebar spinner and `prowl list` reflect agent activity, not just OSC 9;4
+  /// command progress (which Claude Code does not emit while it works).
+  var tabAgentBusyById: [TerminalTabID: Bool] = [:]
   var boundDirectoryTabIDs: [String: TerminalTabID] = [:]
   var surfaceRunningStartedAtById: [UUID: Date] = [:]
   var runScriptTabId: TerminalTabID?
@@ -253,7 +259,9 @@ final class WorktreeTerminalState {
   }
 
   var taskStatus: WorktreeTaskStatus {
-    tabIsRunningById.values.contains(true) ? .running : .idle
+    let hasRunningCommand = tabIsRunningById.values.contains(true)
+    let hasBusyAgent = tabAgentBusyById.values.contains(true)
+    return (hasRunningCommand || hasBusyAgent) ? .running : .idle
   }
 
   var isRunScriptRunning: Bool {

--- a/supacode/Infrastructure/AgentDetection/ScreenHeuristics.swift
+++ b/supacode/Infrastructure/AgentDetection/ScreenHeuristics.swift
@@ -101,6 +101,9 @@ nonisolated private func detectClaude(_ content: String) -> AgentRawState {
   if hasSpinnerActivity(above) {
     return .working
   }
+  if hasClaudeBackgroundWork(content) {
+    return .working
+  }
   return .idle
 }
 
@@ -292,6 +295,31 @@ nonisolated private func isBoxBorderLine(_ line: String) -> Bool {
   let trimmed = line.trimmingCharacters(in: .whitespaces)
   guard trimmed.count >= 3 else { return false }
   return trimmed.allSatisfy { $0 == "─" || $0 == "-" }
+}
+
+// Everything rendered AFTER the input prompt line — i.e. the footer area where
+// Claude shows its persistent background-work / workflow status. Mirrors
+// `contentAbovePromptBox` so the background-work check can stay anchored to the
+// footer and never trip on transcript text that merely mentions the marker.
+nonisolated private func contentBelowPromptBox(_ content: String) -> String {
+  let lines = content.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+  guard let promptIndex = lines.lastIndex(where: { $0.contains("❯") }) else {
+    return ""
+  }
+  let startIndex = lines.index(after: promptIndex)
+  guard startIndex < lines.endIndex else { return "" }
+  return lines[startIndex...].joined(separator: "\n")
+}
+
+// While a background workflow runs, Claude's turn has ended (so the spinner and
+// "esc to interrupt" hint above the prompt are gone) but it keeps a persistent
+// status line BELOW the input box, e.g.
+//   "◯ my-workflow  <desc>  3/5 agents done · 7m 29s · ↓ 288.5k tokens"
+// The "<done>/<total> agents done" segment is Claude's stable statusText
+// template, so "agents done" is a distinctive marker. Anchored to the
+// below-prompt footer so it can't be tripped by conversation text.
+nonisolated private func hasClaudeBackgroundWork(_ content: String) -> Bool {
+  contentBelowPromptBox(content).lowercased().contains("agents done")
 }
 
 nonisolated private func claudeCurrentInteractionRegion(_ content: String) -> String {

--- a/supacodeTests/PaneAgentStateTests.swift
+++ b/supacodeTests/PaneAgentStateTests.swift
@@ -126,4 +126,14 @@ struct PaneAgentStateTests {
     #expect(presence.update(detectedAgent: nil) == nil)
     #expect(presence.currentAgent == nil)
   }
+
+  @Test func isBusyReflectsWorkingAndBlockedDetectedAgents() {
+    #expect(PaneAgentState(detectedAgent: .claude, state: .working).isBusy)
+    #expect(PaneAgentState(detectedAgent: .claude, state: .blocked).isBusy)
+    #expect(!PaneAgentState(detectedAgent: .claude, state: .idle).isBusy)
+    // Unseen idle surfaces display as `.done`, which must not count as busy.
+    #expect(!PaneAgentState(detectedAgent: .claude, state: .idle, seen: false).isBusy)
+    // A plain shell (no detected agent) is never busy, even mid-output.
+    #expect(!PaneAgentState(detectedAgent: nil, state: .working).isBusy)
+  }
 }

--- a/supacodeTests/ScreenHeuristicsTests.swift
+++ b/supacodeTests/ScreenHeuristicsTests.swift
@@ -277,6 +277,48 @@ struct ScreenHeuristicsTests {
     )
   }
 
+  @Test func claudeDetectsRunningWorkflowFooterBelowPrompt() {
+    // A running background workflow: the turn has ended (no spinner / "esc to
+    // interrupt" above the prompt), but Claude keeps a status line BELOW the
+    // input box. The "<done>/<total> agents done" segment marks active work.
+    #expect(
+      DetectedAgent.claude.detectState(
+        in: """
+          ⏺ Kicked off the scout workflow in the background.
+          ─────────
+          ❯
+          ─────────
+          ◯ scout-prowl-idle  Map idle detection   3/5 agents done · 7m 29s · ↓ 288.5k tokens
+          """
+      ) == .working
+    )
+    // Idle with an ordinary footer (no workflow line) stays idle.
+    #expect(
+      DetectedAgent.claude.detectState(
+        in: """
+          Task complete.
+          ─────────
+          ❯
+          ─────────
+          ? for shortcuts
+          """
+      ) == .idle
+    )
+    // The marker quoted in conversation (above the prompt) must NOT force
+    // working — the check is anchored to the below-prompt footer.
+    #expect(
+      DetectedAgent.claude.detectState(
+        in: """
+          ⏺ The run showed 3/5 agents done before it wrapped up.
+          ─────────
+          ❯
+          ─────────
+          ? for shortcuts
+          """
+      ) == .idle
+    )
+  }
+
   @Test func codexDetection() {
     #expect(DetectedAgent.codex.detectState(in: "press enter to confirm or esc to cancel") == .blocked)
     #expect(DetectedAgent.codex.detectState(in: "• Working (12s)\nesc to interrupt") == .working)

--- a/supacodeTests/WorktreeTerminalManagerTests.swift
+++ b/supacodeTests/WorktreeTerminalManagerTests.swift
@@ -588,6 +588,55 @@ struct WorktreeTerminalManagerTests {
     )
   }
 
+  @Test func busyAgentFoldsIntoTaskStatusAndEmits() throws {
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    let worktree = makeWorktree()
+    let state = manager.state(for: worktree)
+
+    let tabId = try #require(state.createTab())
+    let surfaceId = try #require(state.focusedSurfaceId(in: tabId))
+
+    #expect(state.taskStatus == .idle)
+
+    var emissions: [WorktreeTaskStatus] = []
+    state.onTaskStatusChanged = { emissions.append($0) }
+
+    // A working agent on the tab makes the worktree run, with one emission.
+    state.surfaceAgentStates[surfaceId] = PaneAgentState(detectedAgent: .claude, state: .working)
+    state.updateTabAgentBusyState(for: tabId)
+    #expect(state.taskStatus == .running)
+    #expect(emissions == [.running])
+
+    // Idempotent while it stays busy — no duplicate emission.
+    state.updateTabAgentBusyState(for: tabId)
+    #expect(emissions == [.running])
+
+    // Returning to idle clears the indicator and emits once more.
+    state.surfaceAgentStates[surfaceId] = PaneAgentState(detectedAgent: .claude, state: .idle)
+    state.updateTabAgentBusyState(for: tabId)
+    #expect(state.taskStatus == .idle)
+    #expect(emissions == [.running, .idle])
+
+    state.cleanupAllAgentDetectionState()
+  }
+
+  @Test func tabTeardownClearsAgentBusyTaskStatus() throws {
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    let worktree = makeWorktree()
+    let state = manager.state(for: worktree)
+
+    let tabId = try #require(state.createTab())
+    let surfaceId = try #require(state.focusedSurfaceId(in: tabId))
+
+    state.surfaceAgentStates[surfaceId] = PaneAgentState(detectedAgent: .claude, state: .working)
+    state.updateTabAgentBusyState(for: tabId)
+    #expect(state.taskStatus == .running)
+
+    state.closeAllSurfaces()
+    #expect(state.tabAgentBusyById.isEmpty)
+    #expect(state.taskStatus == .idle)
+  }
+
   private func nextEvent(
     _ stream: AsyncStream<TerminalClient.Event>,
     matching predicate: (TerminalClient.Event) -> Bool


### PR DESCRIPTION
## Problem

The worktree **running indicator** — the sidebar row spinner and `prowl list`'s `task.status` — was driven *only* by OSC 9;4 command progress (`tabIsRunningById`). Claude Code never emits OSC 9;4 while it works, so a pane that's mid-task — and especially one running a **background workflow** (the turn has ended, the input box is visible, but subagents are churning) — showed up as **idle**.

Agent detection already knew the pane was busy, but that signal only fed the Active Agents panel; it never reached `taskStatus`.

## Fix

**1. Fold agent activity into `taskStatus` (agent-agnostic).**
A new per-tab `tabAgentBusyById` aggregate is `true` when any surface in the tab has a detected agent whose stabilized `displayState` is **Working** or **Blocked**. It's OR-ed into `taskStatus` next to `tabIsRunningById`, recomputed on every detection tick, on agent release (6-miss), and on surface/tab teardown, and emits a task-status change only when it flips. Both consumers (sidebar + `prowl list`) read `taskStatus` live, so there's no extra wiring.

**2. Detect Claude's background-workflow footer (B1).**
While a workflow runs, Claude keeps a persistent status line *below* the input box, e.g.:

> `◯ my-workflow  …  3/5 agents done · 7m 29s · ↓ 288.5k tokens`

The existing heuristic only scanned *above* the prompt, so it missed this. `detectClaude` now also scans the below-prompt footer for the `N/M agents done` marker (Claude's stable `statusText` template) and reports **Working** — anchored to the footer region so conversation text that merely mentions the phrase can't trip it.

**3. Optional low-latency signal (B2, documented only).**
For a faster, restyle-proof alternative, the docs describe a Claude Code hook that emits OSC 9;4 via `terminalSequence` — which Prowl's existing progress pipeline already handles with zero app code.

Per the agreed design, **Working + Blocked + background workflows** all count as busy, merged into the single existing running indicator (no new CLI field or icon).

## Tests

- `ScreenHeuristicsTests`: workflow-footer → Working, idle-footer → idle, and the marker quoted mid-conversation → idle (false-positive guard).
- `PaneAgentStateTests`: `PaneAgentState.isBusy`.
- `WorktreeTerminalManagerTests`: object-level fold (busy → `taskStatus == .running`, single emission, idempotent, return-to-idle) and teardown clearing.

## Verification

- `swift-format --strict` clean on all changed files.
- ⚠️ I could **not** run `make build-app` / `xcodebuild test` in my working checkout: it has no `Frameworks/GhosttyKit.xcframework` and lacks the `ThirdParty/ghostty` submodule + mise/zig toolchain to build one. Relying on **CI** (`test.yml`: `make lint` + `make build-app` + `make test-app`) for the full build/test gate.

## Note on the B1 marker

`agents done` was taken from Claude Code v2.1.181's `statusText` template (``${done}/${total} agents done…``) and confirmed against a real running-workflow footer. It's Claude- and version-specific; a future Claude restyle that changes the wording would need re-confirming (the test fixture pins it), and the documented B2 hook is the restyle-proof fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
