### PR TITLE
Fix toolbar title too narrow for folder and workspace

### DIFF
--- a/supacode/Features/Repositories/Views/WorktreeDetailTitleView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailTitleView.swift
@@ -12,47 +12,53 @@ struct WorktreeDetailTitleView: View {
   @State private var draftName = ""
 
   var body: some View {
-    Group {
-      if title.supportsRename {
-        Button {
-          openRenamePopover()
-        } label: {
-          labelContent
-        }
-        .help(
-          AppShortcuts.helpText(
-            title: "Rename branch",
-            commandID: AppShortcuts.CommandID.renameBranch,
-            in: resolvedKeybindings
-          )
+    titleButton
+      .onHover { hovering in
+        isHovered = hovering
+      }
+      .popover(isPresented: $isPresented) {
+        RenameBranchPopover(
+          draftName: $draftName,
+          onCancel: { isPresented = false },
+          onSubmit: { newName in
+            isPresented = false
+            if newName != title.text {
+              onSubmit?(newName)
+            }
+          }
         )
-        .modifier(
-          KeyboardShortcutModifier(
-            shortcut: resolvedKeybindings.keyboardShortcut(for: AppShortcuts.CommandID.renameBranch)
-          ))
-      } else {
+      }
+      .task(id: externalRenamePrompt?.id) {
+        guard let prompt = externalRenamePrompt, title.supportsRename else { return }
+        openRenamePopover()
+        onConsumeExternalRenamePrompt(prompt.id)
+      }
+  }
+
+  @ViewBuilder
+  private var titleButton: some View {
+    if title.supportsRename {
+      Button {
+        openRenamePopover()
+      } label: {
         labelContent
       }
-    }
-    .onHover { hovering in
-      isHovered = hovering
-    }
-    .popover(isPresented: $isPresented) {
-      RenameBranchPopover(
-        draftName: $draftName,
-        onCancel: { isPresented = false },
-        onSubmit: { newName in
-          isPresented = false
-          if newName != title.text {
-            onSubmit?(newName)
-          }
-        }
+      .help(
+        AppShortcuts.helpText(
+          title: "Rename branch",
+          commandID: AppShortcuts.CommandID.renameBranch,
+          in: resolvedKeybindings
+        )
       )
-    }
-    .task(id: externalRenamePrompt?.id) {
-      guard let prompt = externalRenamePrompt, title.supportsRename else { return }
-      openRenamePopover()
-      onConsumeExternalRenamePrompt(prompt.id)
+      .modifier(
+        KeyboardShortcutModifier(
+          shortcut: resolvedKeybindings.keyboardShortcut(for: AppShortcuts.CommandID.renameBranch)
+        ))
+    } else {
+      // Button wrapper gives folder/workspace the same toolbar padding as the branch button.
+      Button {} label: {
+        labelContent
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- Folder and workspace names in the toolbar navigation area appeared too narrow compared to branch names
- Root cause: branch titles were wrapped in a `Button` (for rename), giving them toolbar button padding, while folder/workspace titles were rendered as bare labels
- Fix: wrap folder/workspace titles in a no-op `Button` so they get the same toolbar styling

## Test plan
- [x] Open a plain folder in Prowl, verify the toolbar title has consistent width/padding
- [x] Open a workspace, verify same
- [x] Open a git repo, verify branch name still renders correctly with rename support