### PR TITLE
Fix workspace sidebar click area and collapse/expand all

### DIFF
--- a/supacode/Features/Repositories/Views/SidebarListView.swift
+++ b/supacode/Features/Repositories/Views/SidebarListView.swift
@@ -503,7 +503,7 @@ struct SidebarListView: View {
   ) -> Set<Repository.ID> where Repositories.Element == Repository {
     Set(
       repositories
-        .filter(\.capabilities.supportsWorktrees)
+        .filter { $0.capabilities.supportsWorktrees || $0.isWorkspace }
         .map(\.id)
     )
   }

--- a/supacode/Features/Repositories/Views/WorkspaceChildRowsView.swift
+++ b/supacode/Features/Repositories/Views/WorkspaceChildRowsView.swift
@@ -12,60 +12,47 @@ struct WorkspaceChildRowsView: View {
   var body: some View {
     ForEach(rows) { row in
       let isSelected = row.id == selectedID
-      WorkspaceChildRowButton(row: row, isSelected: isSelected, onSelect: onSelect)
-        .padding(.leading, 14)
-        .padding(.trailing, 8)
-        .background {
-          if isSelected {
-            RoundedRectangle(cornerRadius: 8)
-              .fill(Color.accentColor.opacity(0.18))
-              .padding(.horizontal, 6)
-          }
+      WorktreeRow(
+        name: row.branchName ?? row.repositoryName,
+        worktreeName: row.branchName == nil ? "" : row.repositoryName,
+        info: row.info,
+        iconSystemName: nil,
+        showsPullRequestInfo: true,
+        isHovered: false,
+        isPinned: false,
+        isMainWorktree: false,
+        isLoading: false,
+        taskStatus: nil,
+        isRunScriptRunning: false,
+        showsNotificationIndicator: false,
+        notifications: [],
+        onFocusNotification: { _ in },
+        shortcutHint: nil,
+        showsShortcutHint: false,
+        pinAction: nil,
+        isSelected: isSelected,
+        archiveAction: nil,
+        onDiffTap: nil,
+        onStopRunScript: nil,
+      )
+      .padding(.leading, 14)
+      .padding(.trailing, 8)
+      .background {
+        if isSelected {
+          RoundedRectangle(cornerRadius: 8)
+            .fill(Color.accentColor.opacity(0.18))
+            .padding(.horizontal, 6)
         }
-        .padding(.vertical, 2)
-        .id(row.id)
+      }
+      .padding(.vertical, 2)
+      .contentShape(.interaction, .rect)
+      .contentShape(.rect)
+      .onTapGesture {
+        onSelect(row.id)
+      }
+      .accessibilityAddTraits(.isButton)
+      .help("Focus Terminal in \(row.repositoryName)")
+      .id(row.id)
     }
-  }
-}
-
-private struct WorkspaceChildRowButton: View {
-  let row: WorkspaceChildRowModel
-  let isSelected: Bool
-  let onSelect: (String) -> Void
-
-  var body: some View {
-    Button {
-      onSelect(row.id)
-    } label: {
-      content
-    }
-    .buttonStyle(.plain)
-    .help("Focus Terminal in \(row.repositoryName)")
-  }
-
-  private var content: some View {
-    WorktreeRow(
-      name: row.branchName ?? row.repositoryName,
-      worktreeName: row.branchName == nil ? "" : row.repositoryName,
-      info: row.info,
-      iconSystemName: nil,
-      showsPullRequestInfo: true,
-      isHovered: false,
-      isPinned: false,
-      isMainWorktree: false,
-      isLoading: false,
-      taskStatus: nil,
-      isRunScriptRunning: false,
-      showsNotificationIndicator: false,
-      notifications: [],
-      onFocusNotification: { _ in },
-      shortcutHint: nil,
-      showsShortcutHint: false,
-      pinAction: nil,
-      isSelected: isSelected,
-      archiveAction: nil,
-      onDiffTap: nil,
-      onStopRunScript: nil,
-    )
   }
 }


### PR DESCRIPTION
## Summary
- Workspace child rows in the sidebar only had their label text clickable, not the full row. Replaced `Button(.plain)` with `onTapGesture` + `contentShape(.interaction, .rect)` to match the pattern used by worktree rows.
- "Collapse all" / "Expand all" toggle in the sidebar header didn't affect workspaces because `expandableRepositoryIDs` only checked `supportsWorktrees`. Added `isWorkspace` to the filter.

## Test plan
- [x] Add a workspace with multiple child repos to the sidebar
- [x] Click on empty space in a workspace child row — should select it
- [x] Click "Collapse all" — workspace sections should collapse
- [x] Click "Expand all" — workspace sections should expand