### PR TITLE
Fix git repos shown as plain folders when Xcode CLI tools are unusable

### DIFF
--- a/supacode/Clients/Git/GitClientShellHelpers.swift
+++ b/supacode/Clients/Git/GitClientShellHelpers.swift
@@ -11,7 +11,23 @@ nonisolated func shouldFallbackToLoginShell(_ error: Error) -> Bool {
     return true
   }
   let output = "\(shellError.stderr)\n\(shellError.stdout)".lowercased()
-  return output.contains("command not found")
+  if output.contains("command not found") {
+    return true
+  }
+  // A Finder-launched app inherits the bare launchd PATH, so `git` is the Xcode
+  // shim; when it's unusable (license/active-path) a login shell finds a real git.
+  return indicatesUnusableXcodeCommandLineTools(output)
+}
+
+nonisolated private func indicatesUnusableXcodeCommandLineTools(_ lowercasedOutput: String) -> Bool {
+  let signatures = [
+    "xcode license",
+    "xcode-select: error",
+    "invalid active developer path",
+    "no developer tools were found",
+    "requires xcode",
+  ]
+  return signatures.contains { lowercasedOutput.contains($0) }
 }
 
 nonisolated func wrapShellError(

--- a/supacodeTests/GitClientShellFallbackTests.swift
+++ b/supacodeTests/GitClientShellFallbackTests.swift
@@ -1,0 +1,45 @@
+import Foundation
+import Testing
+
+@testable import supacode
+
+struct GitClientShellFallbackTests {
+  private func shellError(
+    stderr: String = "",
+    stdout: String = "",
+    exitCode: Int32 = 1
+  ) -> ShellClientError {
+    ShellClientError(command: "wt root", stdout: stdout, stderr: stderr, exitCode: exitCode)
+  }
+
+  @Test func fallsBackWhenExecutableNotFound() {
+    #expect(shouldFallbackToLoginShell(shellError(exitCode: 127)))
+  }
+
+  @Test func fallsBackOnCommandNotFoundMessage() {
+    #expect(shouldFallbackToLoginShell(shellError(stderr: "env: git: command not found")))
+  }
+
+  @Test func fallsBackWhenXcodeLicenseUnaccepted() {
+    let stderr = """
+      You have not agreed to the Xcode license agreements. Please run 'sudo xcodebuild -license' \
+      from within a Terminal window to review and agree to the Xcode and Apple SDKs license.
+      error: not a git repository
+      """
+    #expect(shouldFallbackToLoginShell(shellError(stderr: stderr, exitCode: 1)))
+  }
+
+  @Test func fallsBackOnInvalidActiveDeveloperPath() {
+    let stderr = "xcode-select: error: invalid active developer path (/Library/Developer/CommandLineTools)"
+    #expect(shouldFallbackToLoginShell(shellError(stderr: stderr, exitCode: 1)))
+  }
+
+  @Test func doesNotFallBackForGenuineNonGitDirectory() {
+    #expect(shouldFallbackToLoginShell(shellError(stderr: "fatal: not a git repository", exitCode: 128)) == false)
+  }
+
+  @Test func doesNotFallBackForNonShellError() {
+    struct OtherError: Error {}
+    #expect(shouldFallbackToLoginShell(OtherError()) == false)
+  }
+}


### PR DESCRIPTION
Closes #486

## Problem

When a repository's git detection fails, Prowl registers a real git repo as a plain folder (`kind: "plain"`). The sidebar then shows the repo row (with a terminal tab-count badge) but **no branch/worktree list**, and it can't be expanded — plain folders have no worktrees.

This reproduces reliably when the Xcode license hasn't been accepted after an Xcode update:

- A Finder/Dock-launched app inherits the bare launchd `PATH` (`/usr/bin:/bin:/usr/sbin:/sbin`), with no `/usr/local/bin` or `/opt/homebrew/bin`. So `git` resolves to the Xcode shim at `/usr/bin/git`.
- If the Xcode license is unaccepted (or the active developer dir is broken), that shim exits non-zero for **every** command:
  ```
  You have not agreed to the Xcode license agreements...
  ```
- The bundled `wt` script's `require_repo()` turns any `git rev-parse` failure into `die "not a git repository"`, so `wt root` / `wt ls` fail.
- `openRepositories` / the entry auto-upgrade treat that as `isNotGitRepositoryError` → the repo is filed as `.plain`, and its branches disappear.

Everything works fine from Terminal because the user's interactive shell finds a working git on a richer `PATH` (e.g. `/usr/local/bin/git`).

## Root cause

`shouldFallbackToLoginShell` only retried via the login shell on exit code `127` or `"command not found"`. The Xcode-shim failure exits `69` with a license/`xcode-select` message, so the login-shell fallback — which would have found the user's working git — never triggered.

## Fix

Recognize the "Xcode command line tools are unusable" signatures (unaccepted license, `xcode-select: error`, invalid active developer path, etc.) and fall back to the login shell in those cases too. The login shell sources the user's profile and resolves a working git, so detection succeeds and repos are correctly classified as git.

This is a targeted change to one pure function; it does not alter behavior for genuine non-git directories (those still classify as plain).

## Testing

- `swift-format lint --strict` and `swiftlint` — clean on changed files.
- Added `GitClientShellFallbackTests` covering: exit 127, `command not found`, unaccepted Xcode license, invalid active developer path, genuine non-git dir (no fallback), and non-shell errors (no fallback).
- The fallback decision logic was verified standalone (all cases pass).

> Note: I could not run the full `xcodebuild` build/test suite locally — this machine's Xcode (26.5) is missing a component (`DVTDownloads`/simulator plugin) and needs `xcodebuild -runFirstLaunch`, which is unrelated to this change. Please let CI validate the full build.
