### PR TITLE
Fix search field keyboard shortcuts when focused

### DIFF
--- a/supacode/App/AppShortcuts.swift
+++ b/supacode/App/AppShortcuts.swift
@@ -152,6 +152,9 @@ enum AppShortcuts {
     static let selectTerminalPaneLeft = "select_terminal_pane_left"
     static let selectTerminalPaneRight = "select_terminal_pane_right"
     static let toggleSplitZoom = "toggle_split_zoom"
+    static let startSearch = "start_search"
+    static let findNext = "find_next"
+    static let findPrevious = "find_previous"
   }
 
   enum Scope: String {
@@ -200,6 +203,9 @@ enum AppShortcuts {
   static let stopRunScript = AppShortcut(key: ".", modifiers: .command)
   static let checkForUpdates = AppShortcut(key: "u", modifiers: [.command, .shift])
   static let showDiff = AppShortcut(key: "y", modifiers: [.command, .shift])
+  static let startSearch = AppShortcut(key: "f", modifiers: .command)
+  static let findNext = AppShortcut(key: "g", modifiers: .command)
+  static let findPrevious = AppShortcut(key: "g", modifiers: [.command, .shift])
   static let toggleCanvas = AppShortcut(
     keyEquivalent: .return, ghosttyKeyName: "return", modifiers: [.command, .option]
   )
@@ -785,6 +791,24 @@ enum AppShortcuts {
       title: "Expand / Restore Canvas Card",
       scope: .localInteraction,
       shortcut: expandCanvasCard
+    ),
+    .init(
+      id: CommandID.startSearch,
+      title: "Find",
+      scope: .configurableAppAction,
+      shortcut: startSearch
+    ),
+    .init(
+      id: CommandID.findNext,
+      title: "Find Next",
+      scope: .configurableAppAction,
+      shortcut: findNext
+    ),
+    .init(
+      id: CommandID.findPrevious,
+      title: "Find Previous",
+      scope: .configurableAppAction,
+      shortcut: findPrevious
     ),
   ]
 

--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -803,7 +803,10 @@ struct SupacodeApp: App {
       Group {
         WorktreeCommands(store: store)
         SidebarCommands(store: store)
-        TerminalCommands(ghosttyShortcuts: ghosttyShortcuts)
+        TerminalCommands(
+          ghosttyShortcuts: ghosttyShortcuts,
+          resolvedKeybindings: store.resolvedKeybindings
+        )
         WindowCommands(
           store: store,
           terminalManager: terminalManager,

--- a/supacode/Commands/TerminalCommands.swift
+++ b/supacode/Commands/TerminalCommands.swift
@@ -77,7 +77,7 @@ struct TerminalCommands: Commands {
         navigateSearchNextAction?()
       }
       .modifier(
-        KeyboardShortcutModifier(shortcut: ghosttyShortcuts.keyboardShortcut(for: "navigate_search:next"))
+        KeyboardShortcutModifier(shortcut: ghosttyShortcuts.keyboardShortcut(for: "navigate_search:previous"))
       )
       .disabled(navigateSearchNextAction == nil)
 
@@ -85,7 +85,7 @@ struct TerminalCommands: Commands {
         navigateSearchPreviousAction?()
       }
       .modifier(
-        KeyboardShortcutModifier(shortcut: ghosttyShortcuts.keyboardShortcut(for: "navigate_search:previous"))
+        KeyboardShortcutModifier(shortcut: ghosttyShortcuts.keyboardShortcut(for: "navigate_search:next"))
       )
       .disabled(navigateSearchPreviousAction == nil)
 

--- a/supacode/Commands/TerminalCommands.swift
+++ b/supacode/Commands/TerminalCommands.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct TerminalCommands: Commands {
   let ghosttyShortcuts: GhosttyShortcutManager
+  let resolvedKeybindings: ResolvedKeybindingMap
   @FocusedValue(\.newTerminalAction) private var newTerminalAction
   @FocusedValue(\.closeSurfaceAction) private var closeSurfaceAction
   @FocusedValue(\.closeTabAction) private var closeTabAction
@@ -70,8 +71,7 @@ struct TerminalCommands: Commands {
       }
       .modifier(
         KeyboardShortcutModifier(
-          shortcut: ghosttyShortcuts.keyboardShortcut(for: "start_search")
-            ?? KeyboardShortcut("f", modifiers: .command)
+          shortcut: resolvedKeybindings.keyboardShortcut(for: AppShortcuts.CommandID.startSearch)
         )
       )
       .disabled(startSearchAction == nil)
@@ -81,8 +81,7 @@ struct TerminalCommands: Commands {
       }
       .modifier(
         KeyboardShortcutModifier(
-          shortcut: ghosttyShortcuts.keyboardShortcut(for: "navigate_search:previous")
-            ?? KeyboardShortcut("g", modifiers: .command)
+          shortcut: resolvedKeybindings.keyboardShortcut(for: AppShortcuts.CommandID.findNext)
         )
       )
       .disabled(navigateSearchNextAction == nil)
@@ -92,8 +91,7 @@ struct TerminalCommands: Commands {
       }
       .modifier(
         KeyboardShortcutModifier(
-          shortcut: ghosttyShortcuts.keyboardShortcut(for: "navigate_search:next")
-            ?? KeyboardShortcut("g", modifiers: [.command, .shift])
+          shortcut: resolvedKeybindings.keyboardShortcut(for: AppShortcuts.CommandID.findPrevious)
         )
       )
       .disabled(navigateSearchPreviousAction == nil)
@@ -104,10 +102,7 @@ struct TerminalCommands: Commands {
         endSearchAction?()
       }
       .modifier(
-        KeyboardShortcutModifier(
-          shortcut: ghosttyShortcuts.keyboardShortcut(for: "end_search")
-            ?? KeyboardShortcut(.escape, modifiers: [])
-        )
+        KeyboardShortcutModifier(shortcut: ghosttyShortcuts.keyboardShortcut(for: "end_search"))
       )
       .disabled(endSearchAction == nil)
 
@@ -117,10 +112,7 @@ struct TerminalCommands: Commands {
         searchSelectionAction?()
       }
       .modifier(
-        KeyboardShortcutModifier(
-          shortcut: ghosttyShortcuts.keyboardShortcut(for: "search_selection")
-            ?? KeyboardShortcut("e", modifiers: .command)
-        )
+        KeyboardShortcutModifier(shortcut: ghosttyShortcuts.keyboardShortcut(for: "search_selection"))
       )
       .disabled(searchSelectionAction == nil)
     }

--- a/supacode/Commands/TerminalCommands.swift
+++ b/supacode/Commands/TerminalCommands.swift
@@ -69,7 +69,10 @@ struct TerminalCommands: Commands {
         startSearchAction?()
       }
       .modifier(
-        KeyboardShortcutModifier(shortcut: ghosttyShortcuts.keyboardShortcut(for: "start_search"))
+        KeyboardShortcutModifier(
+          shortcut: ghosttyShortcuts.keyboardShortcut(for: "start_search")
+            ?? KeyboardShortcut("f", modifiers: .command)
+        )
       )
       .disabled(startSearchAction == nil)
 
@@ -77,7 +80,10 @@ struct TerminalCommands: Commands {
         navigateSearchNextAction?()
       }
       .modifier(
-        KeyboardShortcutModifier(shortcut: ghosttyShortcuts.keyboardShortcut(for: "navigate_search:previous"))
+        KeyboardShortcutModifier(
+          shortcut: ghosttyShortcuts.keyboardShortcut(for: "navigate_search:previous")
+            ?? KeyboardShortcut("g", modifiers: .command)
+        )
       )
       .disabled(navigateSearchNextAction == nil)
 
@@ -85,7 +91,10 @@ struct TerminalCommands: Commands {
         navigateSearchPreviousAction?()
       }
       .modifier(
-        KeyboardShortcutModifier(shortcut: ghosttyShortcuts.keyboardShortcut(for: "navigate_search:next"))
+        KeyboardShortcutModifier(
+          shortcut: ghosttyShortcuts.keyboardShortcut(for: "navigate_search:next")
+            ?? KeyboardShortcut("g", modifiers: [.command, .shift])
+        )
       )
       .disabled(navigateSearchPreviousAction == nil)
 
@@ -95,7 +104,10 @@ struct TerminalCommands: Commands {
         endSearchAction?()
       }
       .modifier(
-        KeyboardShortcutModifier(shortcut: ghosttyShortcuts.keyboardShortcut(for: "end_search"))
+        KeyboardShortcutModifier(
+          shortcut: ghosttyShortcuts.keyboardShortcut(for: "end_search")
+            ?? KeyboardShortcut(.escape, modifiers: [])
+        )
       )
       .disabled(endSearchAction == nil)
 
@@ -105,7 +117,10 @@ struct TerminalCommands: Commands {
         searchSelectionAction?()
       }
       .modifier(
-        KeyboardShortcutModifier(shortcut: ghosttyShortcuts.keyboardShortcut(for: "search_selection"))
+        KeyboardShortcutModifier(
+          shortcut: ghosttyShortcuts.keyboardShortcut(for: "search_selection")
+            ?? KeyboardShortcut("e", modifiers: .command)
+        )
       )
       .disabled(searchSelectionAction == nil)
     }

--- a/supacode/Features/Terminal/Views/GhosttySurfaceSearchOverlay.swift
+++ b/supacode/Features/Terminal/Views/GhosttySurfaceSearchOverlay.swift
@@ -5,6 +5,7 @@ struct GhosttySurfaceSearchOverlay: View {
   let surfaceView: GhosttySurfaceView
   @Bindable var state: GhosttySurfaceState
   @Environment(GhosttyShortcutManager.self) private var ghosttyShortcuts
+  @Environment(\.resolvedKeybindings) private var resolvedKeybindings
 
   @State private var searchText: String
   @State private var corner: GhosttySearchCorner = .topRight
@@ -51,24 +52,24 @@ struct GhosttySurfaceSearchOverlay: View {
           } label: {
             SearchButtonLabel(
               title: "Previous",
-              shortcut: ghosttyShortcuts.display(for: "search:next"),
+              shortcut: resolvedKeybindings.display(for: AppShortcuts.CommandID.findPrevious),
               systemImage: "chevron.up"
             )
           }
           .buttonStyle(GhosttySearchButtonStyle())
-          .help("Find Previous (⇧⌘G)")
+          .help(searchButtonHelp("Find Previous", commandID: AppShortcuts.CommandID.findPrevious))
 
           Button {
             navigateSearch(.next)
           } label: {
             SearchButtonLabel(
               title: "Next",
-              shortcut: ghosttyShortcuts.display(for: "search:previous"),
+              shortcut: resolvedKeybindings.display(for: AppShortcuts.CommandID.findNext),
               systemImage: "chevron.down"
             )
           }
           .buttonStyle(GhosttySearchButtonStyle())
-          .help("Find Next (⌘G)")
+          .help(searchButtonHelp("Find Next", commandID: AppShortcuts.CommandID.findNext))
 
           Button {
             closeSearch()
@@ -76,7 +77,7 @@ struct GhosttySurfaceSearchOverlay: View {
           } label: {
             SearchButtonLabel(
               title: "Close",
-              shortcut: ghosttyShortcuts.display(for: "end_search"),
+              shortcut: nil,
               systemImage: "xmark"
             )
           }
@@ -198,6 +199,13 @@ struct GhosttySurfaceSearchOverlay: View {
     searchTask.cancel()
     self.searchTask = nil
     emitSearch(searchText)
+  }
+
+  private func searchButtonHelp(_ title: String, commandID: String) -> String {
+    if let shortcut = resolvedKeybindings.display(for: commandID) {
+      return "\(title) (\(shortcut))"
+    }
+    return title
   }
 
   private func focusSearchField() {

--- a/supacode/Features/Terminal/Views/GhosttySurfaceSearchOverlay.swift
+++ b/supacode/Features/Terminal/Views/GhosttySurfaceSearchOverlay.swift
@@ -47,10 +47,10 @@ struct GhosttySurfaceSearchOverlay: View {
           }
 
           Button {
-            navigateSearch(.next)
+            navigateSearch(.previous)
           } label: {
             SearchButtonLabel(
-              title: "Next",
+              title: "Previous",
               shortcut: ghosttyShortcuts.display(for: "search:next"),
               systemImage: "chevron.up"
             )
@@ -58,10 +58,10 @@ struct GhosttySurfaceSearchOverlay: View {
           .buttonStyle(GhosttySearchButtonStyle())
 
           Button {
-            navigateSearch(.previous)
+            navigateSearch(.next)
           } label: {
             SearchButtonLabel(
-              title: "Previous",
+              title: "Next",
               shortcut: ghosttyShortcuts.display(for: "search:previous"),
               systemImage: "chevron.down"
             )
@@ -127,6 +127,11 @@ struct GhosttySurfaceSearchOverlay: View {
           searchText = newValue
         }
       }
+      .onChange(of: state.searchTotal) { _, newValue in
+        if let total = newValue, total > 0, state.searchSelected == nil {
+          surfaceView.performBindingAction("navigate_search:next")
+        }
+      }
       .onChange(of: state.searchFocusCount) { _, _ in
         focusSearchField()
       }
@@ -139,9 +144,8 @@ struct GhosttySurfaceSearchOverlay: View {
 
   @ViewBuilder
   private var matchLabel: some View {
-    if let selected = state.searchSelected {
-      let totalLabel = state.searchTotal.map(String.init) ?? "?"
-      Text("\(selected + 1)/\(totalLabel)")
+    if let selected = state.searchSelected, let total = state.searchTotal {
+      Text("\(total - selected)/\(total)")
         .font(.caption)
         .foregroundStyle(.secondary)
         .padding(.trailing, 8)

--- a/supacode/Features/Terminal/Views/GhosttySurfaceSearchOverlay.swift
+++ b/supacode/Features/Terminal/Views/GhosttySurfaceSearchOverlay.swift
@@ -312,6 +312,25 @@ private struct GhosttySearchField: NSViewRepresentable {
       guard let field = obj.object as? NSTextField else { return }
       text = field.stringValue
     }
+
+    func control(
+      _ control: NSControl,
+      textView: NSTextView,
+      doCommandBy commandSelector: Selector
+    ) -> Bool {
+      guard let field = control as? SearchField else { return false }
+      switch commandSelector {
+      case #selector(NSResponder.insertNewline(_:)):
+        let isShifted = NSApp.currentEvent?.modifierFlags.contains(.shift) ?? false
+        field.onSubmit?(isShifted)
+        return true
+      case #selector(NSResponder.cancelOperation(_:)):
+        field.onEscape?()
+        return true
+      default:
+        return false
+      }
+    }
   }
 
   final class SearchField: NSTextField {
@@ -320,6 +339,20 @@ private struct GhosttySearchField: NSViewRepresentable {
 
     override func cancelOperation(_ sender: Any?) {
       onEscape?()
+    }
+
+    override func performKeyEquivalent(with event: NSEvent) -> Bool {
+      guard currentEditor() != nil,
+        event.type == .keyDown,
+        event.modifierFlags.intersection(.deviceIndependentFlagsMask) == [.command]
+          || event.modifierFlags.intersection(.deviceIndependentFlagsMask) == [.command, .shift],
+        event.charactersIgnoringModifiers?.lowercased() == "g"
+      else {
+        return super.performKeyEquivalent(with: event)
+      }
+      let isShifted = event.modifierFlags.contains(.shift)
+      onSubmit?(isShifted)
+      return true
     }
 
     override func keyDown(with event: NSEvent) {

--- a/supacode/Features/Terminal/Views/GhosttySurfaceSearchOverlay.swift
+++ b/supacode/Features/Terminal/Views/GhosttySurfaceSearchOverlay.swift
@@ -56,6 +56,7 @@ struct GhosttySurfaceSearchOverlay: View {
             )
           }
           .buttonStyle(GhosttySearchButtonStyle())
+          .help("Find Previous (⇧⌘G)")
 
           Button {
             navigateSearch(.next)
@@ -67,6 +68,7 @@ struct GhosttySurfaceSearchOverlay: View {
             )
           }
           .buttonStyle(GhosttySearchButtonStyle())
+          .help("Find Next (⌘G)")
 
           Button {
             closeSearch()
@@ -78,6 +80,7 @@ struct GhosttySurfaceSearchOverlay: View {
             )
           }
           .buttonStyle(GhosttySearchButtonStyle())
+          .help("Close Find Bar (Esc)")
         }
         .padding(8)
         .background(.background)

--- a/supacode/Features/Terminal/Views/GhosttySurfaceSearchOverlay.swift
+++ b/supacode/Features/Terminal/Views/GhosttySurfaceSearchOverlay.swift
@@ -32,7 +32,7 @@ struct GhosttySurfaceSearchOverlay: View {
               navigateSearch(isShifted ? .previous : .next)
             },
             onEscape: {
-              isSearchFieldFocused = false
+              closeSearch()
               surfaceView.requestFocus()
             }
           )
@@ -72,6 +72,7 @@ struct GhosttySurfaceSearchOverlay: View {
 
           Button {
             closeSearch()
+            surfaceView.requestFocus()
           } label: {
             SearchButtonLabel(
               title: "Close",

--- a/supacode/Infrastructure/Ghostty/GhosttySearchNavigation.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySearchNavigation.swift
@@ -2,21 +2,23 @@ enum GhosttySearchDirection {
   case next
   case previous
 
+  // Ghostty indexes from newest (0) to oldest; its "next" goes toward older
+  // content. We invert so .next = forward in document = toward newer.
   var bindingAction: String {
     switch self {
     case .next:
-      return "navigate_search:next"
-    case .previous:
       return "navigate_search:previous"
+    case .previous:
+      return "navigate_search:next"
     }
   }
 
   var oppositeBindingAction: String {
     switch self {
     case .next:
-      return "navigate_search:previous"
-    case .previous:
       return "navigate_search:next"
+    case .previous:
+      return "navigate_search:previous"
     }
   }
 }
@@ -33,9 +35,9 @@ enum GhosttySearchNavigator {
     }
 
     switch direction {
-    case .next where selected == total - 1:
+    case .next where selected == 0:
       return Array(repeating: direction.oppositeBindingAction, count: total - 1)
-    case .previous where selected == 0:
+    case .previous where selected == total - 1:
       return Array(repeating: direction.oppositeBindingAction, count: total - 1)
     default:
       return [directAction]

--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceView+Keyboard.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceView+Keyboard.swift
@@ -112,6 +112,15 @@ extension GhosttySurfaceView {
     }
 
     if let bindingFlags = bindingFlags(for: event, surface: surface) {
+      let raw = bindingFlags.rawValue
+      let isPerformable = (raw & GHOSTTY_BINDING_FLAGS_PERFORMABLE.rawValue) != 0
+      let isConsumed = (raw & GHOSTTY_BINDING_FLAGS_CONSUMED.rawValue) != 0
+      let chars = event.charactersIgnoringModifiers ?? ""
+      SupaLogger("KeyEquiv").debug(
+        "binding flags=0x\(String(raw, radix: 16)) performable=\(isPerformable)"
+          + " consumed=\(isConsumed) key=\(chars) mods=\(event.modifierFlags.rawValue)"
+      )
+
       if shouldAttemptMenu(for: bindingFlags),
         let menu = NSApp.mainMenu,
         Self.mainMenuHasMatchingItem(for: event, in: menu),

--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceView+Keyboard.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceView+Keyboard.swift
@@ -112,15 +112,6 @@ extension GhosttySurfaceView {
     }
 
     if let bindingFlags = bindingFlags(for: event, surface: surface) {
-      let raw = bindingFlags.rawValue
-      let isPerformable = (raw & GHOSTTY_BINDING_FLAGS_PERFORMABLE.rawValue) != 0
-      let isConsumed = (raw & GHOSTTY_BINDING_FLAGS_CONSUMED.rawValue) != 0
-      let chars = event.charactersIgnoringModifiers ?? ""
-      SupaLogger("KeyEquiv").debug(
-        "binding flags=0x\(String(raw, radix: 16)) performable=\(isPerformable)"
-          + " consumed=\(isConsumed) key=\(chars) mods=\(event.modifierFlags.rawValue)"
-      )
-
       if shouldAttemptMenu(for: bindingFlags),
         let menu = NSApp.mainMenu,
         Self.mainMenuHasMatchingItem(for: event, in: menu),
@@ -438,9 +429,8 @@ extension GhosttySurfaceView {
     if bridge.state.keyTableDepth > 0 { return false }
     let raw = flags.rawValue
     let isAll = (raw & GHOSTTY_BINDING_FLAGS_ALL.rawValue) != 0
-    let isPerformable = (raw & GHOSTTY_BINDING_FLAGS_PERFORMABLE.rawValue) != 0
     let isConsumed = (raw & GHOSTTY_BINDING_FLAGS_CONSUMED.rawValue) != 0
-    return !isAll && !isPerformable && isConsumed
+    return !isAll && isConsumed
   }
 
   @IBAction func copy(_ sender: Any?) {

--- a/supacodeTests/GhosttySearchNavigatorTests.swift
+++ b/supacodeTests/GhosttySearchNavigatorTests.swift
@@ -3,24 +3,24 @@ import Testing
 @testable import supacode
 
 struct GhosttySearchNavigatorTests {
-  @Test func nextWrapsFromLastToFirst() {
+  @Test func nextWrapsAtNewestToOldest() {
     let actions = GhosttySearchNavigator.bindingActions(
       direction: .next,
-      selected: 4,
-      total: 5
-    )
-
-    #expect(actions == Array(repeating: "navigate_search:previous", count: 4))
-  }
-
-  @Test func previousWrapsFromFirstToLast() {
-    let actions = GhosttySearchNavigator.bindingActions(
-      direction: .previous,
       selected: 0,
       total: 5
     )
 
     #expect(actions == Array(repeating: "navigate_search:next", count: 4))
+  }
+
+  @Test func previousWrapsAtOldestToNewest() {
+    let actions = GhosttySearchNavigator.bindingActions(
+      direction: .previous,
+      selected: 4,
+      total: 5
+    )
+
+    #expect(actions == Array(repeating: "navigate_search:previous", count: 4))
   }
 
   @Test func nonBoundaryUsesDirectAction() {
@@ -30,7 +30,7 @@ struct GhosttySearchNavigatorTests {
       total: 5
     )
 
-    #expect(actions == ["navigate_search:next"])
+    #expect(actions == ["navigate_search:previous"])
   }
 
   @Test func unknownSelectionUsesDirectAction() {
@@ -40,6 +40,6 @@ struct GhosttySearchNavigatorTests {
       total: 5
     )
 
-    #expect(actions == ["navigate_search:next"])
+    #expect(actions == ["navigate_search:previous"])
   }
 }


### PR DESCRIPTION
## Summary

- Fix Enter / Shift+Enter / Escape not working in the search field during editing
- Add Cmd+G (find next) and Cmd+Shift+G (find previous) support while the search field is focused
- Invert search direction to match standard Find Next / Find Previous semantics (Cmd+G = forward in document = toward newer content)
- Auto-select the newest match when search results appear (no more `-/N` on first search)
- Invert display index so 1 = oldest (top), N = newest (bottom)

Closes #480

## Changes

### Keyboard handling (`GhosttySurfaceSearchOverlay.swift`)
- `Coordinator.control(_:textView:doCommandBy:)` — intercepts `insertNewline:` / `cancelOperation:` from the field editor delegate path
- `SearchField.performKeyEquivalent` — catches Cmd+G / Cmd+Shift+G when the field is being edited
- Buttons reordered to [Previous ↑] [Next ↓] with swapped Ghostty action mapping
- Display index: `total - selected` instead of `selected + 1`
- Auto-select newest match via `onChange(of: searchTotal)`

### Direction mapping (`GhosttySearchNavigation.swift`)
- `GhosttySearchDirection.bindingAction`: `.next` now maps to Ghostty's `navigate_search:previous` (forward in document = toward newer content)
- Wrap conditions swapped to match: `.next` wraps at index 0, `.previous` wraps at `total - 1`

### Menu shortcuts (`TerminalCommands.swift`)
- "Find Next" / "Find Previous" shortcut lookups swapped to match inverted direction

## Test plan

### Keyboard shortcuts (search field focused)
- [x] Cmd+F → type a term with multiple matches → **Enter** moves to next match (↓ in document)
- [x] **Shift+Enter** moves to previous match (↑ in document)
- [x] **Cmd+G** moves to next match
- [x] **Cmd+Shift+G** moves to previous match
- [x] **Escape** closes the search bar

### Direction & numbering
- [x] First search auto-selects the newest match, displayed as **N/N** (not `-/N`)
- [x] "Next" (↓ button / Cmd+G / Enter) moves forward: N/N → 1/N → 2/N → ...
- [x] "Previous" (↑ button) moves backward: 1/N → N/N → (N-1)/N → ...
- [x] Numbering: 1 = oldest (top of scrollback), N = newest (bottom)

### Existing behavior preserved
- [x] Next / Previous **buttons** still work
- [x] Menu Edit → Find Next / Find Previous work when terminal is focused
- [x] Search text input and live filtering work as before