### PR TITLE
Invert login-shell fallback for robust git detection

### DIFF
--- a/supacode/Clients/Git/GitClientShellHelpers.swift
+++ b/supacode/Clients/Git/GitClientShellHelpers.swift
@@ -7,11 +7,13 @@ nonisolated func shouldFallbackToLoginShell(_ error: Error) -> Bool {
   guard let shellError = error as? ShellClientError else {
     return false
   }
-  if shellError.exitCode == 127 {
-    return true
-  }
   let output = "\(shellError.stderr)\n\(shellError.stdout)".lowercased()
-  return output.contains("command not found")
+  // When git itself ran fine but confirmed this isn't a repo, retrying
+  // under a login shell won't change the answer.
+  if output.contains("not a git repository") {
+    return false
+  }
+  return true
 }
 
 nonisolated func wrapShellError(

--- a/supacodeTests/GitClientShellFallbackTests.swift
+++ b/supacodeTests/GitClientShellFallbackTests.swift
@@ -1,0 +1,68 @@
+import Foundation
+import Testing
+
+@testable import supacode
+
+struct GitClientShellFallbackTests {
+  private func shellError(
+    stderr: String = "",
+    stdout: String = "",
+    exitCode: Int32 = 1
+  ) -> ShellClientError {
+    ShellClientError(command: "wt root", stdout: stdout, stderr: stderr, exitCode: exitCode)
+  }
+
+  // MARK: - Should fallback
+
+  @Test func fallsBackWhenExecutableNotFound() {
+    #expect(shouldFallbackToLoginShell(shellError(exitCode: 127)))
+  }
+
+  @Test func fallsBackOnCommandNotFoundMessage() {
+    #expect(shouldFallbackToLoginShell(shellError(stderr: "env: git: command not found")))
+  }
+
+  @Test func fallsBackWhenXcodeLicenseUnaccepted() {
+    let stderr = """
+      You have not agreed to the Xcode license agreements. Please run 'sudo xcodebuild -license' \
+      from within a Terminal window to review and agree to the Xcode and Apple SDKs license.
+      """
+    #expect(shouldFallbackToLoginShell(shellError(stderr: stderr, exitCode: 69)))
+  }
+
+  @Test func fallsBackOnInvalidActiveDeveloperPath() {
+    let stderr = "xcode-select: error: invalid active developer path (/Library/Developer/CommandLineTools)"
+    #expect(shouldFallbackToLoginShell(shellError(stderr: stderr, exitCode: 1)))
+  }
+
+  @Test func fallsBackOnUnknownShellError() {
+    #expect(shouldFallbackToLoginShell(shellError(stderr: "something unexpected", exitCode: 42)))
+  }
+
+  @Test func fallsBackOnEmptyErrorOutput() {
+    #expect(shouldFallbackToLoginShell(shellError(exitCode: 1)))
+  }
+
+  // MARK: - Should NOT fallback
+
+  @Test func doesNotFallBackForGenuineNonGitDirectory() {
+    #expect(
+      shouldFallbackToLoginShell(
+        shellError(stderr: "fatal: not a git repository (or any of the parent directories)", exitCode: 128)
+      ) == false
+    )
+  }
+
+  @Test func doesNotFallBackWhenWtReportsNotGitRepo() {
+    #expect(
+      shouldFallbackToLoginShell(
+        shellError(stderr: "wt: not a git repository", exitCode: 1)
+      ) == false
+    )
+  }
+
+  @Test func doesNotFallBackForNonShellError() {
+    struct OtherError: Error {}
+    #expect(shouldFallbackToLoginShell(OtherError()) == false)
+  }
+}

--- a/supacodeTests/GitClientWorktreeDiscoveryTests.swift
+++ b/supacodeTests/GitClientWorktreeDiscoveryTests.swift
@@ -209,7 +209,43 @@ struct GitClientWorktreeDiscoveryTests {
     }
   }
 
-  @Test func worktreesDoNotFallbackToLoginShellForRegularFailures() async {
+  @Test func worktreesDoNotFallbackToLoginShellForNonGitDirectory() async {
+    let recorder = GitWorktreeDiscoveryRecorder()
+    let shell = ShellClient(
+      run: { executableURL, arguments, currentDirectoryURL in
+        recorder.recordRun(
+          executableURL: executableURL,
+          arguments: arguments,
+          currentDirectoryURL: currentDirectoryURL
+        )
+        throw ShellClientError(
+          command: "wt ls --json",
+          stdout: "",
+          stderr: "fatal: not a git repository (or any of the parent directories): .git",
+          exitCode: 128
+        )
+      },
+      runLoginImpl: { executableURL, arguments, currentDirectoryURL, _ in
+        recorder.recordLogin(
+          executableURL: executableURL,
+          arguments: arguments,
+          currentDirectoryURL: currentDirectoryURL
+        )
+        Issue.record("worktrees should not fallback to runLogin for non-git directories")
+        return ShellOutput(stdout: "", stderr: "", exitCode: 0)
+      }
+    )
+    let client = GitClient(shell: shell)
+
+    await #expect(throws: GitClientError.self) {
+      _ = try await client.worktrees(for: URL(fileURLWithPath: "/tmp/not-a-repo"))
+    }
+
+    #expect(recorder.runInvocations().count == 1)
+    #expect(recorder.loginInvocations().isEmpty)
+  }
+
+  @Test func worktreesFallbackToLoginShellForEnvironmentErrors() async throws {
     let recorder = GitWorktreeDiscoveryRecorder()
     let shell = ShellClient(
       run: { executableURL, arguments, currentDirectoryURL in
@@ -231,17 +267,21 @@ struct GitClientWorktreeDiscoveryTests {
           arguments: arguments,
           currentDirectoryURL: currentDirectoryURL
         )
-        Issue.record("worktrees should not fallback to runLogin for regular command failures")
-        return ShellOutput(stdout: "", stderr: "", exitCode: 0)
+        return ShellOutput(
+          stdout: """
+            [{"branch":"main","path":"/tmp/repo","head":"abc","is_bare":false}]
+            """,
+          stderr: "",
+          exitCode: 0
+        )
       }
     )
     let client = GitClient(shell: shell)
 
-    await #expect(throws: GitClientError.self) {
-      _ = try await client.worktrees(for: URL(fileURLWithPath: "/tmp/repo"))
-    }
+    let worktrees = try await client.worktrees(for: URL(fileURLWithPath: "/tmp/repo"))
 
+    #expect(worktrees.count == 1)
     #expect(recorder.runInvocations().count == 1)
-    #expect(recorder.loginInvocations().isEmpty)
+    #expect(recorder.loginInvocations().count == 1)
   }
 }


### PR DESCRIPTION
Closes #486
Alternative approach to #487

## Summary

- Inverts the fallback logic in `shouldFallbackToLoginShell`: instead of maintaining an allowlist of errors that trigger the login-shell retry, **fallback for all shell errors except** the one case where it's pointless — git ran successfully but confirmed the path isn't a git repository (`"not a git repository"`).
- This handles Xcode shim failures (unaccepted license, broken developer path, etc.) and any future unknown environment errors without tracking Apple's error messages.
- The worst case for an unnecessary fallback is one extra shell invocation that also fails — negligible cost.

## Why not an allowlist?

The approach in #487 pattern-matches specific Xcode error strings (`"xcode license"`, `"xcode-select: error"`, `"invalid active developer path"`, etc.). This is fragile: Apple can change wording, add new error types, or localize messages. The inverted approach is future-proof — new failure modes are covered by default.

## Test plan

- [x] `make build-app` — clean build
- [x] Added `GitClientShellFallbackTests` (9 tests) covering:
  - Fallback triggers: exit 127, "command not found", Xcode license, invalid developer path, unknown errors, empty output
  - No fallback: genuine non-git directory, `wt`'s "not a git repository", non-shell errors
