### PR TITLE
fix: auxiliary windows invisible in fullscreen mode

### DIFF
--- a/supacode/Features/Debug/BusinessLogic/DebugWindowManager.swift
+++ b/supacode/Features/Debug/BusinessLogic/DebugWindowManager.swift
@@ -38,6 +38,7 @@ import SwiftUI
       new.identifier = NSUserInterfaceItemIdentifier("debug")
       new.styleMask = [.titled, .closable, .miniaturizable, .resizable]
       new.tabbingMode = .disallowed
+      new.collectionBehavior = [.moveToActiveSpace]
       new.toolbarStyle = .unified
       new.toolbar = NSToolbar(identifier: "DebugToolbar")
       if #unavailable(macOS 15.0) {

--- a/supacode/Features/DiffView/DiffWindowManager.swift
+++ b/supacode/Features/DiffView/DiffWindowManager.swift
@@ -43,6 +43,7 @@ final class DiffWindowManager {
     newWindow.identifier = NSUserInterfaceItemIdentifier("diff")
     newWindow.styleMask = [.titled, .closable, .miniaturizable, .resizable]
     newWindow.tabbingMode = .disallowed
+    newWindow.collectionBehavior = [.moveToActiveSpace]
     newWindow.toolbarStyle = .unified
     newWindow.toolbar = NSToolbar(identifier: "DiffToolbar")
     newWindow.isReleasedWhenClosed = false

--- a/supacode/Features/Settings/BusinessLogic/SettingsWindowManager.swift
+++ b/supacode/Features/Settings/BusinessLogic/SettingsWindowManager.swift
@@ -52,6 +52,7 @@ final class SettingsWindowManager {
     window.identifier = NSUserInterfaceItemIdentifier(WindowID.settings)
     window.styleMask = [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView]
     window.tabbingMode = .disallowed
+    window.collectionBehavior = [.moveToActiveSpace]
     window.titlebarAppearsTransparent = true
     window.toolbarStyle = .unified
     window.toolbar = NSToolbar(identifier: "SettingsToolbar")


### PR DESCRIPTION
## Problem

When the main app window is in fullscreen mode, auxiliary windows (Diff, Settings, Debug) are created but remain invisible on a background Space. Users see no window appear after clicking these buttons.

## Root Cause

macOS fullscreen creates an exclusive Space. New windows with only `tabbingMode = .disallowed` don't automatically join the active Space — they get created in the background.

## Fix

Add `collectionBehavior = [.moveToActiveSpace]` to all three window managers:

- `DiffWindowManager.swift`
- `SettingsWindowManager.swift`  
- `DebugWindowManager.swift`

This tells macOS to move new windows to the current active Space (including fullscreen Spaces) when they're created.

🤖 Generated with Qwen Code