### PR TITLE
Show yellow indicator when PR checks are still running

### DIFF
--- a/supacode/Clients/Github/PullRequestMergeReadiness.swift
+++ b/supacode/Clients/Github/PullRequestMergeReadiness.swift
@@ -4,6 +4,7 @@ nonisolated enum PullRequestMergeBlockingReason: Equatable, Hashable {
   case mergeConflicts
   case changesRequested
   case checksFailed(Int)
+  case checksPending(Int)
   case blocked
 }
 
@@ -27,6 +28,10 @@ nonisolated struct PullRequestMergeReadiness: Equatable, Hashable {
     }
     if breakdown.failed > 0 {
       self.blockingReason = .checksFailed(breakdown.failed)
+      return
+    }
+    if breakdown.inProgress > 0 {
+      self.blockingReason = .checksPending(breakdown.inProgress)
       return
     }
 
@@ -57,6 +62,9 @@ nonisolated struct PullRequestMergeReadiness: Equatable, Hashable {
     case .checksFailed(let count):
       let checksLabel = count == 1 ? "check" : "checks"
       return "\(count) \(checksLabel) failed"
+    case .checksPending(let count):
+      let checksLabel = count == 1 ? "check" : "checks"
+      return "\(count) \(checksLabel) running"
     case .blocked:
       return "Blocked"
     }

--- a/supacode/Features/Repositories/Views/WorktreeRow.swift
+++ b/supacode/Features/Repositories/Views/WorktreeRow.swift
@@ -288,10 +288,21 @@ private struct WorktreeRowInfoView: View {
     } else if let mergeReadiness {
       appendSeparator()
       var segment = AttributedString(mergeReadiness.label)
-      segment.foregroundColor = mergeReadiness.isBlocking ? .red : .green
+      segment.foregroundColor = mergeStatusColor(mergeReadiness)
       result.append(segment)
     }
     return Text(result)
+  }
+
+  private func mergeStatusColor(_ readiness: PullRequestMergeReadiness) -> Color {
+    switch readiness.blockingReason {
+    case .none:
+      return .green
+    case .mergeConflicts, .changesRequested, .checksFailed, .blocked:
+      return .red
+    case .checksPending:
+      return .yellow
+    }
   }
 }
 

--- a/supacodeTests/PullRequestMergeReadinessTests.swift
+++ b/supacodeTests/PullRequestMergeReadinessTests.swift
@@ -72,6 +72,74 @@ struct PullRequestMergeReadinessTests {
     #expect(readiness.blockingReason == .blocked)
     #expect(readiness.label == "Blocked")
   }
+
+  @Test func mergeReadinessUsesChecksPendingWhenInProgressAndNoFailures() {
+    let pullRequest = makePullRequest(
+      mergeable: "MERGEABLE",
+      mergeStateStatus: "CLEAN",
+      checks: [
+        GithubPullRequestStatusCheck(status: "PENDING", conclusion: nil, state: nil),
+        GithubPullRequestStatusCheck(status: "PENDING", conclusion: nil, state: nil),
+        GithubPullRequestStatusCheck(status: "COMPLETED", conclusion: "SUCCESS", state: nil),
+      ]
+    )
+
+    let readiness = PullRequestMergeReadiness(pullRequest: pullRequest)
+
+    #expect(readiness.blockingReason == .checksPending(2))
+    #expect(readiness.label == "2 checks running")
+    #expect(readiness.isBlocking)
+  }
+
+  @Test func mergeReadinessSingleCheckPending() {
+    let pullRequest = makePullRequest(
+      mergeable: "MERGEABLE",
+      mergeStateStatus: "CLEAN",
+      checks: [
+        GithubPullRequestStatusCheck(status: "PENDING", conclusion: nil, state: nil),
+      ]
+    )
+
+    let readiness = PullRequestMergeReadiness(pullRequest: pullRequest)
+
+    #expect(readiness.blockingReason == .checksPending(1))
+    #expect(readiness.label == "1 check running")
+  }
+
+  @Test func mergeReadinessChecksPendingTakesPriorityOverMergeable() {
+    // When checks are in progress but mergeable is already true,
+    // we should still show "checks running" rather than "Mergeable"
+    let pullRequest = makePullRequest(
+      mergeable: "MERGEABLE",
+      mergeStateStatus: "CLEAN",
+      checks: [
+        GithubPullRequestStatusCheck(status: "IN_PROGRESS", conclusion: nil, state: nil),
+      ]
+    )
+
+    let readiness = PullRequestMergeReadiness(pullRequest: pullRequest)
+
+    #expect(readiness.blockingReason == .checksPending(1))
+    #expect(readiness.label == "1 check running")
+  }
+
+  @Test func mergeReadinessChecksFailedTakesPriorityOverPending() {
+    // When there are both failed and in-progress checks,
+    // failed should take priority
+    let pullRequest = makePullRequest(
+      mergeable: "MERGEABLE",
+      mergeStateStatus: "CLEAN",
+      checks: [
+        GithubPullRequestStatusCheck(status: "COMPLETED", conclusion: "FAILURE", state: nil),
+        GithubPullRequestStatusCheck(status: "PENDING", conclusion: nil, state: nil),
+      ]
+    )
+
+    let readiness = PullRequestMergeReadiness(pullRequest: pullRequest)
+
+    #expect(readiness.blockingReason == .checksFailed(1))
+    #expect(readiness.label == "1 check failed")
+  }
 }
 
 private func makePullRequest(


### PR DESCRIPTION
## Summary

Add a yellow 'N checks running' label to worktree sidebar rows when CI checks are still in progress but none have failed. This distinguishes between 'CI still running' and 'all checks passed', which previously both showed green 'Mergeable'.

## Changes

- **PullRequestMergeReadiness.swift**: Added `.checksPending(Int)` case to `PullRequestMergeBlockingReason`, detected when `breakdown.inProgress > 0` with no failures
- **WorktreeRow.swift**: New `mergeStatusColor()` method renders pending state in yellow
- **Tests**: 4 new test cases covering pending detection, singular/plural labels, and priority ordering

## Priority logic

Failed checks > Pending checks > Mergeable

When both failed and pending checks exist, the failed count is shown first since that's the more critical information.

Closes #462