### PR TITLE
Cancel PR cooldown when switching to a different worktree

### DIFF
--- a/supacode/Features/Repositories/BusinessLogic/WorktreeInfoWatcherManager.swift
+++ b/supacode/Features/Repositories/BusinessLogic/WorktreeInfoWatcherManager.swift
@@ -221,39 +221,17 @@ final class WorktreeInfoWatcherManager {
       emitLineChangesChanged(worktreeID: worktreeID)
       syncLineChangesActivity(for: worktreeID)
     }
-    // When switching to a different worktree within the same repo, cancel any active cooldown
-    // so the PR refresh fires immediately. Re-selecting the same worktree still respects the cooldown.
+    // When switching to a different worktree, cancel any active cooldown so the PR refresh
+    // fires immediately. Re-selecting the same worktree still respects the cooldown.
     if let previousRepository, previousRepository == nextRepository {
-      let lastWorktreeForRepo = lastSelectedWorktreeIDByRepo[previousRepository]
-      let isDifferentWorktree = lastWorktreeForRepo != worktreeID
-      if isDifferentWorktree {
-        cancelPullRequestSelectionCooldown(for: previousRepository)
-      }
-      updatePullRequestSchedule(
-        repositoryRootURL: previousRepository,
-        immediate: shouldImmediatelyRefreshPullRequests(repositoryRootURL: previousRepository)
-      )
-      if let worktreeID {
-        lastSelectedWorktreeIDByRepo[previousRepository] = worktreeID
-      }
+      handlePullRequestRefreshOnSelection(repositoryRootURL: previousRepository, worktreeID: worktreeID)
       return
     }
     if let previousRepository {
       updatePullRequestSchedule(repositoryRootURL: previousRepository, immediate: false)
     }
     if let nextRepository {
-      let lastWorktreeForRepo = lastSelectedWorktreeIDByRepo[nextRepository]
-      let isDifferentWorktree = lastWorktreeForRepo != worktreeID
-      if isDifferentWorktree {
-        cancelPullRequestSelectionCooldown(for: nextRepository)
-      }
-      updatePullRequestSchedule(
-        repositoryRootURL: nextRepository,
-        immediate: shouldImmediatelyRefreshPullRequests(repositoryRootURL: nextRepository)
-      )
-      if let worktreeID {
-        lastSelectedWorktreeIDByRepo[nextRepository] = worktreeID
-      }
+      handlePullRequestRefreshOnSelection(repositoryRootURL: nextRepository, worktreeID: worktreeID)
     }
   }
 
@@ -801,6 +779,23 @@ final class WorktreeInfoWatcherManager {
       return
     }
     eventContinuation?.yield(event)
+  }
+
+  private func handlePullRequestRefreshOnSelection(
+    repositoryRootURL: URL,
+    worktreeID: Worktree.ID?
+  ) {
+    let lastWorktreeForRepo = lastSelectedWorktreeIDByRepo[repositoryRootURL]
+    if lastWorktreeForRepo != worktreeID {
+      cancelPullRequestSelectionCooldown(for: repositoryRootURL)
+    }
+    updatePullRequestSchedule(
+      repositoryRootURL: repositoryRootURL,
+      immediate: shouldImmediatelyRefreshPullRequests(repositoryRootURL: repositoryRootURL)
+    )
+    if let worktreeID {
+      lastSelectedWorktreeIDByRepo[repositoryRootURL] = worktreeID
+    }
   }
 
   private func cancelPullRequestSelectionCooldown(for repositoryRootURL: URL) {

--- a/supacode/Features/Repositories/BusinessLogic/WorktreeInfoWatcherManager.swift
+++ b/supacode/Features/Repositories/BusinessLogic/WorktreeInfoWatcherManager.swift
@@ -83,6 +83,7 @@ final class WorktreeInfoWatcherManager {
   private var selectedWorktreeID: Worktree.ID?
   private var pullRequestTrackingEnabled = true
   private var pullRequestSelectionCooldownTasksByRepo: [URL: PullRequestSelectionCooldownTask] = [:]
+  private var lastSelectedWorktreeIDByRepo: [URL: Worktree.ID] = [:]
   private var eventContinuation: AsyncStream<WorktreeInfoWatcherClient.Event>.Continuation?
 
   init<C: Clock<Duration>>(
@@ -220,21 +221,39 @@ final class WorktreeInfoWatcherManager {
       emitLineChangesChanged(worktreeID: worktreeID)
       syncLineChangesActivity(for: worktreeID)
     }
+    // When switching to a different worktree within the same repo, cancel any active cooldown
+    // so the PR refresh fires immediately. Re-selecting the same worktree still respects the cooldown.
     if let previousRepository, previousRepository == nextRepository {
+      let lastWorktreeForRepo = lastSelectedWorktreeIDByRepo[previousRepository]
+      let isDifferentWorktree = lastWorktreeForRepo != worktreeID
+      if isDifferentWorktree {
+        cancelPullRequestSelectionCooldown(for: previousRepository)
+      }
       updatePullRequestSchedule(
         repositoryRootURL: previousRepository,
         immediate: shouldImmediatelyRefreshPullRequests(repositoryRootURL: previousRepository)
       )
+      if let worktreeID {
+        lastSelectedWorktreeIDByRepo[previousRepository] = worktreeID
+      }
       return
     }
     if let previousRepository {
       updatePullRequestSchedule(repositoryRootURL: previousRepository, immediate: false)
     }
     if let nextRepository {
+      let lastWorktreeForRepo = lastSelectedWorktreeIDByRepo[nextRepository]
+      let isDifferentWorktree = lastWorktreeForRepo != worktreeID
+      if isDifferentWorktree {
+        cancelPullRequestSelectionCooldown(for: nextRepository)
+      }
       updatePullRequestSchedule(
         repositoryRootURL: nextRepository,
         immediate: shouldImmediatelyRefreshPullRequests(repositoryRootURL: nextRepository)
       )
+      if let worktreeID {
+        lastSelectedWorktreeIDByRepo[nextRepository] = worktreeID
+      }
     }
   }
 
@@ -413,6 +432,7 @@ final class WorktreeInfoWatcherManager {
     openedWorktreeIDs.removeAll()
     hasCompletedInitialWorktreeLoad = false
     cancelAllPullRequestSelectionCooldownTasks()
+    lastSelectedWorktreeIDByRepo.removeAll()
     worktrees.removeAll()
     selectedWorktreeID = nil
     pullRequestTrackingEnabled = true

--- a/supacodeTests/WorktreeInfoWatcherManagerTests.swift
+++ b/supacodeTests/WorktreeInfoWatcherManagerTests.swift
@@ -378,17 +378,63 @@ struct WorktreeInfoWatcherManagerTests {
     await clock.advance(by: .milliseconds(500))
     await drainAsyncEvents()
 
+    // Selecting first worktree triggers immediate refresh.
     manager.handleCommand(.setSelectedWorktreeID(firstWorktree.id))
     await drainAsyncEvents()
     #expect(await collector.pullRequestRefreshCount(repositoryRootURL: tempRepository.tempRoot) == baselineCount + 1)
 
+    // Switching to a different worktree cancels cooldown and triggers immediate refresh.
     manager.handleCommand(.setSelectedWorktreeID(secondWorktree.id))
     await drainAsyncEvents()
-    #expect(await collector.pullRequestRefreshCount(repositoryRootURL: tempRepository.tempRoot) == baselineCount + 1)
+    #expect(await collector.pullRequestRefreshCount(repositoryRootURL: tempRepository.tempRoot) == baselineCount + 2)
+
+    // Switching back to first worktree also triggers immediate refresh (different worktree).
+    manager.handleCommand(.setSelectedWorktreeID(firstWorktree.id))
+    await drainAsyncEvents()
+    #expect(await collector.pullRequestRefreshCount(repositoryRootURL: tempRepository.tempRoot) == baselineCount + 3)
+
+    manager.handleCommand(.stop)
+    await task.value
+    try FileManager.default.removeItem(at: tempRepository.tempRoot)
+  }
+
+  @Test func reselectingSameWorktreeRespectsCooldown() async throws {
+    let clock = TestClock()
+    let tempRepository = try makeTempRepository(worktreeNames: ["sparrow", "swift"])
+    let manager = WorktreeInfoWatcherManager(
+      focusedInterval: .seconds(3_600),
+      unfocusedInterval: .seconds(3_600),
+      pullRequestSelectionRefreshCooldown: .milliseconds(500),
+      clock: clock
+    )
+    let (collector, task) = startCollecting(manager.eventStream())
+
+    manager.handleCommand(.setWorktrees(tempRepository.worktrees))
+    await drainAsyncEvents()
+    let baselineCount = await collector.pullRequestRefreshCount(repositoryRootURL: tempRepository.tempRoot)
+    #expect(baselineCount == 1)
+    let firstWorktree = try #require(tempRepository.worktrees.first)
 
     await clock.advance(by: .milliseconds(500))
     await drainAsyncEvents()
 
+    // Selecting worktree triggers immediate refresh and starts cooldown.
+    manager.handleCommand(.setSelectedWorktreeID(firstWorktree.id))
+    await drainAsyncEvents()
+    #expect(await collector.pullRequestRefreshCount(repositoryRootURL: tempRepository.tempRoot) == baselineCount + 1)
+
+    // Deselect then re-select the same worktree within cooldown — should NOT refresh.
+    manager.handleCommand(.setSelectedWorktreeID(nil))
+    await drainAsyncEvents()
+    manager.handleCommand(.setSelectedWorktreeID(firstWorktree.id))
+    await drainAsyncEvents()
+    #expect(await collector.pullRequestRefreshCount(repositoryRootURL: tempRepository.tempRoot) == baselineCount + 1)
+
+    // After cooldown expires, re-selecting the same worktree should refresh.
+    await clock.advance(by: .milliseconds(500))
+    await drainAsyncEvents()
+    manager.handleCommand(.setSelectedWorktreeID(nil))
+    await drainAsyncEvents()
     manager.handleCommand(.setSelectedWorktreeID(firstWorktree.id))
     await drainAsyncEvents()
     #expect(await collector.pullRequestRefreshCount(repositoryRootURL: tempRepository.tempRoot) == baselineCount + 2)
@@ -433,11 +479,12 @@ struct WorktreeInfoWatcherManagerTests {
     )
     #expect(afterReplacementCooldownCount == afterFirstSelectionCount + 2)
 
+    // Switching back to first worktree triggers refresh (different worktree).
     manager.handleCommand(.setSelectedWorktreeID(firstWorktree.id))
     await drainAsyncEvents()
     #expect(
       await collector.pullRequestRefreshCount(repositoryRootURL: tempRepository.tempRoot)
-        == afterReplacementCooldownCount
+        == afterReplacementCooldownCount + 1
     )
 
     manager.handleCommand(.stop)


### PR DESCRIPTION
## Problem

When switching between worktrees in the same repository, PR status is not refreshed immediately — it waits for the selection cooldown (5s) to expire before fetching new data.

**User scenario**: You have `develop` and `feature/auth` worktrees open. Switching from one to the other shows stale PR info (CI status, review comments) for up to 5 seconds.

## Root cause

`setSelectedWorktreeID` compared `previousWorktreeID` (globally last-selected worktree) instead of `lastSelectedWorktreeIDByRepo[repo]` (per-repo last-selected worktree). The `lastSelectedWorktreeIDByRepo` dictionary was written to but never read — dead code.

This meant:
- Switching between different worktrees: cooldown not cancelled → no immediate refresh ❌
- Deselecting then re-selecting the same worktree: cooldown cancelled → unnecessary refresh ❌

## Fix

- Compare against `lastSelectedWorktreeIDByRepo[repo]` instead of `previousWorktreeID`
- Extract `handlePullRequestRefreshOnSelection` helper to eliminate duplicated logic across same-repo and cross-repo branches
- Add `reselectingSameWorktreeRespectsCooldown` test to cover the previously untested path

## Changes

- `WorktreeInfoWatcherManager.swift`: core fix + extracted helper (+31/-10 → +52/-36 after refactor)
- `WorktreeInfoWatcherManagerTests.swift`: updated 2 tests + 1 new test (+51/-10)