### PR TITLE
Treat expected checks as pending in merge readiness (follow-up to #496)

### DIFF
--- a/supacode/Clients/Github/PullRequestMergeReadiness.swift
+++ b/supacode/Clients/Github/PullRequestMergeReadiness.swift
@@ -4,6 +4,7 @@ nonisolated enum PullRequestMergeBlockingReason: Equatable, Hashable {
   case mergeConflicts
   case changesRequested
   case checksFailed(Int)
+  case checksPending(Int)
   case blocked
 }
 
@@ -27,6 +28,10 @@ nonisolated struct PullRequestMergeReadiness: Equatable, Hashable {
     }
     if breakdown.failed > 0 {
       self.blockingReason = .checksFailed(breakdown.failed)
+      return
+    }
+    if breakdown.inProgress > 0 {
+      self.blockingReason = .checksPending(breakdown.inProgress)
       return
     }
 
@@ -57,6 +62,9 @@ nonisolated struct PullRequestMergeReadiness: Equatable, Hashable {
     case .checksFailed(let count):
       let checksLabel = count == 1 ? "check" : "checks"
       return "\(count) \(checksLabel) failed"
+    case .checksPending(let count):
+      let checksLabel = count == 1 ? "check" : "checks"
+      return "\(count) \(checksLabel) running"
     case .blocked:
       return "Blocked"
     }

--- a/supacode/Clients/Github/PullRequestMergeReadiness.swift
+++ b/supacode/Clients/Github/PullRequestMergeReadiness.swift
@@ -30,8 +30,12 @@ nonisolated struct PullRequestMergeReadiness: Equatable, Hashable {
       self.blockingReason = .checksFailed(breakdown.failed)
       return
     }
-    if breakdown.inProgress > 0 {
-      self.blockingReason = .checksPending(breakdown.inProgress)
+    // `expected` checks (legacy commit-status required contexts that have not
+    // reported yet) are still in flight, so treat them like in-progress checks
+    // rather than letting the PR fall through to a green "Mergeable".
+    let pendingChecks = breakdown.inProgress + breakdown.expected
+    if pendingChecks > 0 {
+      self.blockingReason = .checksPending(pendingChecks)
       return
     }
 

--- a/supacode/Features/Repositories/Views/WorktreeRow.swift
+++ b/supacode/Features/Repositories/Views/WorktreeRow.swift
@@ -288,10 +288,21 @@ private struct WorktreeRowInfoView: View {
     } else if let mergeReadiness {
       appendSeparator()
       var segment = AttributedString(mergeReadiness.label)
-      segment.foregroundColor = mergeReadiness.isBlocking ? .red : .green
+      segment.foregroundColor = mergeStatusColor(mergeReadiness)
       result.append(segment)
     }
     return Text(result)
+  }
+
+  private func mergeStatusColor(_ readiness: PullRequestMergeReadiness) -> Color {
+    switch readiness.blockingReason {
+    case .none:
+      return .green
+    case .mergeConflicts, .changesRequested, .checksFailed, .blocked:
+      return .red
+    case .checksPending:
+      return .yellow
+    }
   }
 }
 

--- a/supacodeTests/PullRequestMergeReadinessTests.swift
+++ b/supacodeTests/PullRequestMergeReadinessTests.swift
@@ -72,6 +72,74 @@ struct PullRequestMergeReadinessTests {
     #expect(readiness.blockingReason == .blocked)
     #expect(readiness.label == "Blocked")
   }
+
+  @Test func mergeReadinessUsesChecksPendingWhenInProgressAndNoFailures() {
+    let pullRequest = makePullRequest(
+      mergeable: "MERGEABLE",
+      mergeStateStatus: "CLEAN",
+      checks: [
+        GithubPullRequestStatusCheck(status: "PENDING", conclusion: nil, state: nil),
+        GithubPullRequestStatusCheck(status: "PENDING", conclusion: nil, state: nil),
+        GithubPullRequestStatusCheck(status: "COMPLETED", conclusion: "SUCCESS", state: nil),
+      ]
+    )
+
+    let readiness = PullRequestMergeReadiness(pullRequest: pullRequest)
+
+    #expect(readiness.blockingReason == .checksPending(2))
+    #expect(readiness.label == "2 checks running")
+    #expect(readiness.isBlocking)
+  }
+
+  @Test func mergeReadinessSingleCheckPending() {
+    let pullRequest = makePullRequest(
+      mergeable: "MERGEABLE",
+      mergeStateStatus: "CLEAN",
+      checks: [
+        GithubPullRequestStatusCheck(status: "PENDING", conclusion: nil, state: nil),
+      ]
+    )
+
+    let readiness = PullRequestMergeReadiness(pullRequest: pullRequest)
+
+    #expect(readiness.blockingReason == .checksPending(1))
+    #expect(readiness.label == "1 check running")
+  }
+
+  @Test func mergeReadinessChecksPendingTakesPriorityOverMergeable() {
+    // When checks are in progress but mergeable is already true,
+    // we should still show "checks running" rather than "Mergeable"
+    let pullRequest = makePullRequest(
+      mergeable: "MERGEABLE",
+      mergeStateStatus: "CLEAN",
+      checks: [
+        GithubPullRequestStatusCheck(status: "IN_PROGRESS", conclusion: nil, state: nil),
+      ]
+    )
+
+    let readiness = PullRequestMergeReadiness(pullRequest: pullRequest)
+
+    #expect(readiness.blockingReason == .checksPending(1))
+    #expect(readiness.label == "1 check running")
+  }
+
+  @Test func mergeReadinessChecksFailedTakesPriorityOverPending() {
+    // When there are both failed and in-progress checks,
+    // failed should take priority
+    let pullRequest = makePullRequest(
+      mergeable: "MERGEABLE",
+      mergeStateStatus: "CLEAN",
+      checks: [
+        GithubPullRequestStatusCheck(status: "COMPLETED", conclusion: "FAILURE", state: nil),
+        GithubPullRequestStatusCheck(status: "PENDING", conclusion: nil, state: nil),
+      ]
+    )
+
+    let readiness = PullRequestMergeReadiness(pullRequest: pullRequest)
+
+    #expect(readiness.blockingReason == .checksFailed(1))
+    #expect(readiness.label == "1 check failed")
+  }
 }
 
 private func makePullRequest(

--- a/supacodeTests/PullRequestMergeReadinessTests.swift
+++ b/supacodeTests/PullRequestMergeReadinessTests.swift
@@ -123,6 +123,42 @@ struct PullRequestMergeReadinessTests {
     #expect(readiness.label == "1 check running")
   }
 
+  @Test func mergeReadinessTreatsExpectedChecksAsPending() {
+    // A required commit-status context that has not reported yet shows up as an
+    // `expected` check. It is still in flight, so the PR must not fall through to
+    // a green "Mergeable" label.
+    let pullRequest = makePullRequest(
+      mergeable: "MERGEABLE",
+      mergeStateStatus: "CLEAN",
+      checks: [
+        GithubPullRequestStatusCheck(status: nil, conclusion: nil, state: "EXPECTED")
+      ]
+    )
+
+    let readiness = PullRequestMergeReadiness(pullRequest: pullRequest)
+
+    #expect(readiness.blockingReason == .checksPending(1))
+    #expect(readiness.label == "1 check running")
+    #expect(readiness.isBlocking)
+  }
+
+  @Test func mergeReadinessCountsInProgressAndExpectedChecksTogether() {
+    let pullRequest = makePullRequest(
+      mergeable: "MERGEABLE",
+      mergeStateStatus: "CLEAN",
+      checks: [
+        GithubPullRequestStatusCheck(status: "IN_PROGRESS", conclusion: nil, state: nil),
+        GithubPullRequestStatusCheck(status: nil, conclusion: nil, state: "EXPECTED"),
+        GithubPullRequestStatusCheck(status: "COMPLETED", conclusion: "SUCCESS", state: nil),
+      ]
+    )
+
+    let readiness = PullRequestMergeReadiness(pullRequest: pullRequest)
+
+    #expect(readiness.blockingReason == .checksPending(2))
+    #expect(readiness.label == "2 checks running")
+  }
+
   @Test func mergeReadinessChecksFailedTakesPriorityOverPending() {
     // When there are both failed and in-progress checks,
     // failed should take priority


### PR DESCRIPTION
## Summary

Follow-up to #496, which adds the yellow "N checks running" sidebar state. This
PR closes a small gap in that same logic.

> **Note:** this branch is based on #496's head, so the diff includes #496's
> commit plus this one. Merge after / on top of #496 (or merge this in its place).

## The gap

#496 detects the pending state with `breakdown.inProgress > 0`. But a required
commit-status context that has been declared via branch protection yet **hasn't
reported any run yet** surfaces as an `expected` check (`state == "EXPECTED"`),
which the breakdown counts in `expected`, not `inProgress`.

So a PR whose only outstanding check is `expected` has `inProgress == 0 &&
failed == 0`, and — because `mergeable` only reflects conflicts — falls through
to a green **"Mergeable"** label even though CI is not actually complete. That is
the exact class of bug #462 set out to fix, sneaking back in through a rarer
door.

## Fix

Fold `breakdown.expected` into the pending count:

```swift
let pendingChecks = breakdown.inProgress + breakdown.expected
if pendingChecks > 0 {
  self.blockingReason = .checksPending(pendingChecks)
  return
}
```

The "running" wording is kept as-is for a minimal change; `expected` checks are
rare in practice (modern GitHub Actions report as `IN_PROGRESS`, not `EXPECTED`)
and resolve to `inProgress`/`success` within seconds, so the slight imprecision
is acceptable.

## Tests

- `mergeReadinessTreatsExpectedChecksAsPending` — an expected-only check now
  yields `.checksPending(1)` instead of a green "Mergeable".
- `mergeReadinessCountsInProgressAndExpectedChecksTogether` — in-progress and
  expected checks are summed.

## Validation

- `xcodebuild test … -only-testing:supacodeTests/PullRequestMergeReadinessTests` — 11 passed
- `swiftlint lint` + `swift-format lint` clean on the changed lines

Refs #462, #496
