### PR TITLE
Fix make check trailing comma lint

### DIFF
--- a/supacodeTests/PullRequestMergeReadinessTests.swift
+++ b/supacodeTests/PullRequestMergeReadinessTests.swift
@@ -96,7 +96,7 @@ struct PullRequestMergeReadinessTests {
       mergeable: "MERGEABLE",
       mergeStateStatus: "CLEAN",
       checks: [
-        GithubPullRequestStatusCheck(status: "PENDING", conclusion: nil, state: nil),
+        GithubPullRequestStatusCheck(status: "PENDING", conclusion: nil, state: nil)
       ]
     )
 
@@ -113,7 +113,7 @@ struct PullRequestMergeReadinessTests {
       mergeable: "MERGEABLE",
       mergeStateStatus: "CLEAN",
       checks: [
-        GithubPullRequestStatusCheck(status: "IN_PROGRESS", conclusion: nil, state: nil),
+        GithubPullRequestStatusCheck(status: "IN_PROGRESS", conclusion: nil, state: nil)
       ]
     )
 


### PR DESCRIPTION
## What

Fixes two `swift-format lint --strict` violations in `PullRequestMergeReadinessTests` by removing trailing commas from single-line collection literals.

## Why

`make check` currently fails on `main` during the full-tree `swift-format lint` step, even though CI only runs `make lint` and does not catch this formatting rule.

## Validation

- `make check`
