### PR TITLE
Add Canvas default-layout setting (Uniform / Tile)

### DIFF
--- a/docs/components/canvas.md
+++ b/docs/components/canvas.md
@@ -99,6 +99,10 @@ performance.
 ## Settings that affect Canvas
 
 - `defaultViewMode` — launch directly into Canvas.
+- `canvasDefaultLayout` — how cards are first laid out when you open Canvas:
+  `uniform` (same-size cards packed to fit) or `tile` (resize cards to fill the
+  screen, the default). Only the initial auto-layout is affected; saved card
+  positions are always restored.
 - `windowTintMode` / repository colors — card and nav tinting.
 - `showRunButtonInToolbar` — whether the Run button appears in the Canvas toolbar.
 

--- a/docs/components/view-modes.md
+++ b/docs/components/view-modes.md
@@ -41,6 +41,10 @@ Toggling Canvas or Shelf with **no open worktrees** does nothing.
 `defaultViewMode` (Settings) chooses which mode Prowl opens in:
 `normal`, `shelf`, or `canvas`.
 
+`canvasDefaultLayout` (Settings) chooses how cards are first arranged when you
+open Canvas: `uniform` (same-size cards packed to fit) or `tile` (resize cards to
+fill the screen — the default).
+
 ## Which to recommend
 
 - Supervising a fleet / sending the same command everywhere → **Canvas**

--- a/docs/reference/settings-fields.md
+++ b/docs/reference/settings-fields.md
@@ -51,6 +51,7 @@ JSON is pretty-printed with sorted keys. Legacy `~/.supacode` is migrated to
 | `archivedAutoDeletePeriod` | enum? (days) | `nil` | Auto-delete archived worktrees after N days; `nil` = never. |
 | `keybindingUserOverrides` | object | empty | User keyboard-shortcut remappings. |
 | `defaultViewMode` | enum (`normal`/`shelf`/`canvas`) | `normal` | View mode on launch. |
+| `canvasDefaultLayout` | enum (`uniform`/`tile`) | `tile` | Initial Canvas layout: `uniform` packs same-size cards, `tile` resizes cards to fill the screen. |
 | `dimUnfocusedSplits` | Bool | `true` | Dim panes that aren't focused. |
 | `autoShowActiveAgentsPanel` | Bool | `false` | Auto-open the Active Agents panel on a new agent. |
 | `showActiveAgentTabTitles` | Bool | `false` | Show tab titles (vs. branch) in the agents panel. |

--- a/supacode/Features/Canvas/Views/CanvasView.swift
+++ b/supacode/Features/Canvas/Views/CanvasView.swift
@@ -24,6 +24,7 @@ struct CanvasView: View {
   var onExpandedChange: (Bool) -> Void = { _ in }
   @State var layoutStore = CanvasLayoutStore()
   @Shared(.repositoryAppearances) var repositoryAppearances
+  @Shared(.settingsFile) var settingsFile
 
   @State var canvasOffset: CGSize = .zero
   @State var lastCanvasOffset: CGSize = .zero
@@ -170,7 +171,12 @@ struct CanvasView: View {
           if !CanvasLayoutStore.hasAutoArrangedInSession {
             CanvasLayoutStore.hasAutoArrangedInSession = true
             if layoutStore.shouldAutoArrangeOnInitialEntry(for: currentCardKeys) {
-              arrangeCards()
+              switch settingsFile.global.canvasDefaultLayout {
+              case .uniform:
+                arrangeCards()
+              case .tile:
+                tileCards()
+              }
             }
           }
           fitToView(canvasSize: newSize)

--- a/supacode/Features/Settings/Models/CanvasDefaultLayout.swift
+++ b/supacode/Features/Settings/Models/CanvasDefaultLayout.swift
@@ -1,0 +1,21 @@
+/// How cards are first laid out when Canvas is opened for a fresh set of cards.
+/// `uniform` opens every card at one comfortable size, packed to fit (the
+/// historical behavior); `tile` resizes cards to tile and fill the viewport
+/// (matching the Tile toolbar action), which adapts better as the card count
+/// grows. Only the initial auto-layout is affected — once cards have saved
+/// positions, Canvas restores them regardless of this setting.
+enum CanvasDefaultLayout: String, CaseIterable, Identifiable, Codable, Sendable {
+  case uniform
+  case tile
+
+  var id: String { rawValue }
+
+  var title: String {
+    switch self {
+    case .uniform:
+      return "Uniform"
+    case .tile:
+      return "Tile"
+    }
+  }
+}

--- a/supacode/Features/Settings/Models/CanvasDefaultLayout.swift
+++ b/supacode/Features/Settings/Models/CanvasDefaultLayout.swift
@@ -18,4 +18,15 @@ enum CanvasDefaultLayout: String, CaseIterable, Identifiable, Codable, Sendable 
       return "Tile"
     }
   }
+
+  /// One-line description shown under the Settings picker, following the
+  /// current selection.
+  var settingsDescription: String {
+    switch self {
+    case .uniform:
+      return "Cards open at the same size."
+    case .tile:
+      return "Cards resize to fill the screen, smaller as you add more."
+    }
+  }
 }

--- a/supacode/Features/Settings/Models/GlobalSettings.swift
+++ b/supacode/Features/Settings/Models/GlobalSettings.swift
@@ -27,6 +27,7 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
   var archivedAutoDeletePeriod: AutoDeletePeriod?
   var keybindingUserOverrides: KeybindingUserOverrideStore
   var defaultViewMode: DefaultViewMode
+  var canvasDefaultLayout: CanvasDefaultLayout
   var dimUnfocusedSplits: Bool
   var autoShowActiveAgentsPanel: Bool
   var showActiveAgentTabTitles: Bool
@@ -71,6 +72,7 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     terminalFontSize: nil,
     keybindingUserOverrides: .empty,
     defaultViewMode: .normal,
+    canvasDefaultLayout: .tile,
     dimUnfocusedSplits: true,
     autoShowActiveAgentsPanel: false,
     showActiveAgentTabTitles: false,
@@ -114,6 +116,7 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     terminalFontSize: Float32? = nil,
     keybindingUserOverrides: KeybindingUserOverrideStore = .empty,
     defaultViewMode: DefaultViewMode = .normal,
+    canvasDefaultLayout: CanvasDefaultLayout = .tile,
     dimUnfocusedSplits: Bool = true,
     autoShowActiveAgentsPanel: Bool = false,
     showActiveAgentTabTitles: Bool = false,
@@ -155,6 +158,7 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     self.terminalFontSize = terminalFontSize
     self.keybindingUserOverrides = keybindingUserOverrides
     self.defaultViewMode = defaultViewMode
+    self.canvasDefaultLayout = canvasDefaultLayout
     self.dimUnfocusedSplits = dimUnfocusedSplits
     self.autoShowActiveAgentsPanel = autoShowActiveAgentsPanel
     self.showActiveAgentTabTitles = showActiveAgentTabTitles
@@ -199,6 +203,7 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     try container.encodeIfPresent(terminalFontSize, forKey: .terminalFontSize)
     try container.encode(keybindingUserOverrides, forKey: .keybindingUserOverrides)
     try container.encode(defaultViewMode, forKey: .defaultViewMode)
+    try container.encode(canvasDefaultLayout, forKey: .canvasDefaultLayout)
     try container.encode(dimUnfocusedSplits, forKey: .dimUnfocusedSplits)
     try container.encode(autoShowActiveAgentsPanel, forKey: .autoShowActiveAgentsPanel)
     try container.encode(showActiveAgentTabTitles, forKey: .showActiveAgentTabTitles)
@@ -244,6 +249,7 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     case terminalFontSize
     case keybindingUserOverrides
     case defaultViewMode
+    case canvasDefaultLayout
     case dimUnfocusedSplits
     case autoShowActiveAgentsPanel
     case showActiveAgentTabTitles
@@ -339,9 +345,7 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     keybindingUserOverrides =
       try container.decodeIfPresent(KeybindingUserOverrideStore.self, forKey: .keybindingUserOverrides)
       ?? Self.default.keybindingUserOverrides
-    defaultViewMode =
-      try container.decodeIfPresent(DefaultViewMode.self, forKey: .defaultViewMode)
-      ?? Self.default.defaultViewMode
+    (defaultViewMode, canvasDefaultLayout) = try Self.decodeViewSettings(from: container)
     dimUnfocusedSplits =
       try container.decodeIfPresent(Bool.self, forKey: .dimUnfocusedSplits)
       ?? Self.default.dimUnfocusedSplits
@@ -362,6 +366,18 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     showDefaultEditorInToolbar = toolbarAndDock.showDefaultEditorInToolbar
     dockBounceMode = toolbarAndDock.dockBounceMode
     showNotificationDotOnDock = toolbarAndDock.showNotificationDotOnDock
+  }
+
+  private static func decodeViewSettings(
+    from container: KeyedDecodingContainer<CodingKeys>
+  ) throws -> (DefaultViewMode, CanvasDefaultLayout) {
+    let mode =
+      try container.decodeIfPresent(DefaultViewMode.self, forKey: .defaultViewMode)
+      ?? Self.default.defaultViewMode
+    let layout =
+      try container.decodeIfPresent(CanvasDefaultLayout.self, forKey: .canvasDefaultLayout)
+      ?? Self.default.canvasDefaultLayout
+    return (mode, layout)
   }
 
   private static func decodeWindowTint(

--- a/supacode/Features/Settings/Reducer/SettingsFeature.swift
+++ b/supacode/Features/Settings/Reducer/SettingsFeature.swift
@@ -34,6 +34,7 @@ struct SettingsFeature {
     var terminalFontSize: Float32?
     var keybindingUserOverrides: KeybindingUserOverrideStore
     var defaultViewMode: DefaultViewMode
+    var canvasDefaultLayout: CanvasDefaultLayout
     var dimUnfocusedSplits: Bool
     var autoShowActiveAgentsPanel: Bool
     var showActiveAgentTabTitles: Bool
@@ -92,6 +93,7 @@ struct SettingsFeature {
       terminalFontSize = settings.terminalFontSize
       keybindingUserOverrides = settings.keybindingUserOverrides
       defaultViewMode = settings.defaultViewMode
+      canvasDefaultLayout = settings.canvasDefaultLayout
       dimUnfocusedSplits = settings.dimUnfocusedSplits
       autoShowActiveAgentsPanel = settings.autoShowActiveAgentsPanel
       showActiveAgentTabTitles = settings.showActiveAgentTabTitles
@@ -140,6 +142,7 @@ struct SettingsFeature {
         terminalFontSize: terminalFontSize,
         keybindingUserOverrides: keybindingUserOverrides,
         defaultViewMode: defaultViewMode,
+        canvasDefaultLayout: canvasDefaultLayout,
         dimUnfocusedSplits: dimUnfocusedSplits,
         autoShowActiveAgentsPanel: autoShowActiveAgentsPanel,
         showActiveAgentTabTitles: showActiveAgentTabTitles,

--- a/supacode/Features/Settings/Views/AppearanceSettingsView.swift
+++ b/supacode/Features/Settings/Views/AppearanceSettingsView.swift
@@ -109,15 +109,12 @@ struct AppearanceSettingsView: View {
           .help("Overlay detected agent status on the owning tab icon in Shelf View.")
         }
         Section("Default Views") {
-          Picker("Launch in", selection: $store.defaultViewMode) {
+          Picker("Open when launching Prowl", selection: $store.defaultViewMode) {
             ForEach(DefaultViewMode.allCases) { mode in
               Text(mode.title).tag(mode)
             }
           }
           .help("View Prowl starts in on launch. Shelf and Canvas require at least one worktree or folder.")
-          Text("The view Prowl opens in when you launch the app.")
-            .foregroundStyle(.secondary)
-            .font(.callout)
 
           Picker("Canvas layout", selection: $store.canvasDefaultLayout) {
             ForEach(CanvasDefaultLayout.allCases) { layout in
@@ -125,12 +122,9 @@ struct AppearanceSettingsView: View {
             }
           }
           .help("How cards are arranged the first time you open Canvas for a set of cards.")
-          Text(
-            "How cards are arranged when you open Canvas: Uniform keeps every card the same size; "
-              + "Tile resizes cards to fill the screen, scaling them down as you add more."
-          )
-          .foregroundStyle(.secondary)
-          .font(.callout)
+          Text(store.canvasDefaultLayout.settingsDescription)
+            .foregroundStyle(.secondary)
+            .font(.callout)
         }
         Section("Default Editor") {
           Toggle(

--- a/supacode/Features/Settings/Views/AppearanceSettingsView.swift
+++ b/supacode/Features/Settings/Views/AppearanceSettingsView.swift
@@ -108,13 +108,29 @@ struct AppearanceSettingsView: View {
           )
           .help("Overlay detected agent status on the owning tab icon in Shelf View.")
         }
-        Section("Default View") {
+        Section("Default Views") {
           Picker("Launch in", selection: $store.defaultViewMode) {
             ForEach(DefaultViewMode.allCases) { mode in
               Text(mode.title).tag(mode)
             }
           }
           .help("View Prowl starts in on launch. Shelf and Canvas require at least one worktree or folder.")
+          Text("The view Prowl opens in when you launch the app.")
+            .foregroundStyle(.secondary)
+            .font(.callout)
+
+          Picker("Canvas layout", selection: $store.canvasDefaultLayout) {
+            ForEach(CanvasDefaultLayout.allCases) { layout in
+              Text(layout.title).tag(layout)
+            }
+          }
+          .help("How cards are arranged the first time you open Canvas for a set of cards.")
+          Text(
+            "How cards are arranged when you open Canvas: Uniform keeps every card the same size; "
+              + "Tile resizes cards to fill the screen, scaling them down as you add more."
+          )
+          .foregroundStyle(.secondary)
+          .font(.callout)
         }
         Section("Default Editor") {
           Toggle(

--- a/supacodeTests/SettingsFeatureTests.swift
+++ b/supacodeTests/SettingsFeatureTests.swift
@@ -261,6 +261,21 @@ struct SettingsFeatureTests {
     #expect(settingsFile.global.defaultWorktreeBaseDirectoryPath == expectedPath)
   }
 
+  @Test(.dependencies) func changingCanvasDefaultLayoutPersists() async {
+    @Shared(.settingsFile) var settingsFile
+    $settingsFile.withLock { $0.global = .default }
+    let store = TestStore(initialState: SettingsFeature.State()) {
+      SettingsFeature()
+    }
+    // Default is Tile; switch to Uniform and confirm it persists.
+    #expect(store.state.canvasDefaultLayout == .tile)
+    await store.send(.binding(.set(\.canvasDefaultLayout, .uniform))) {
+      $0.canvasDefaultLayout = .uniform
+    }
+    await store.receive(\.delegate.settingsChanged)
+    #expect(settingsFile.global.canvasDefaultLayout == .uniform)
+  }
+
   @Test(.dependencies) func changingGlobalOverrideDefaultsUpdatesRepositorySettingsState() async {
     let rootURL = URL(fileURLWithPath: "/tmp/repo")
     @Shared(.settingsFile) var settingsFile

--- a/supacodeTests/SettingsFilePersistenceTests.swift
+++ b/supacodeTests/SettingsFilePersistenceTests.swift
@@ -174,6 +174,8 @@ struct SettingsFilePersistenceTests {
     #expect(settings.global.showActiveAgentStatusInShelf == true)
     #expect(settings.global.shelfSpineTintFallback == .neutral)
     #expect(settings.global.shelfSpineTintFollowsRepositoryColor == true)
+    // Absent from legacy payloads → falls back to the new Tile default.
+    #expect(settings.global.canvasDefaultLayout == .tile)
     #expect(settings.repositoryRoots.isEmpty)
     #expect(settings.pinnedWorktreeIDs.isEmpty)
   }


### PR DESCRIPTION
## What

Canvas's first auto-layout was hardcoded to the size-preserving pack (`arrangeCards`). This adds a **`canvasDefaultLayout`** setting so users decide how cards are first arranged when they open Canvas:

- **Uniform** — same-size cards packed to fit (the previous behavior).
- **Tile** — resize cards to tile and fill the screen, scaling them down as the count grows (the new layout from #502).

**Default is `tile`.** It's the better default for most fleets; legacy `settings.json` without the key decodes to `.tile` too, so existing installs adopt it. (We never promised the old default, so the behavior change is intentional.)

## UI

Settings → General → **Default Views** now has two pickers, each with a one-line description below it:

- **Launch in** — the view Prowl opens in at app launch.
- **Canvas layout** — how cards are arranged when Canvas opens (Uniform vs Tile).

The descriptions disambiguate the two (one is the app-launch view, the other is the Canvas arrangement), which was the motivation for adding copy here.

## How

- New `CanvasDefaultLayout` enum (`uniform` / `tile`).
- Wired through `GlobalSettings` (Codable, default `.tile`, decode-fallback via a small `decodeViewSettings` helper to stay under the init body-length limit) and `SettingsFeature.State`.
- `CanvasView` reads `@Shared(.settingsFile)` and branches the one-shot initial layout (`arrangeCards()` vs `tileCards()`); saved card positions are still restored regardless of the setting.

## Naming

Kept **Tile** to match the existing toolbar button and docs; the size-preserving option is **Uniform**. No button renames needed.

## Tests

- `SettingsFilePersistenceTests`: legacy payload without the key falls back to `.tile`.
- `SettingsFeatureTests`: changing `canvasDefaultLayout` persists to the settings file. All 27 pass; `make build-app` green.

## Docs

Updated `docs/reference/settings-fields.md`, `docs/components/canvas.md`, and `docs/components/view-modes.md`.

> Note: `make check` flags pre-existing trailing-comma lint in `supacodeTests/PullRequestMergeReadinessTests.swift` (present on `main`, unrelated). All files touched here are format- and swiftlint-clean.
