### PR TITLE
Track CLOSED PR state in worktrees

### DIFF
--- a/supacode/Clients/Github/GithubCLIClient.swift
+++ b/supacode/Clients/Github/GithubCLIClient.swift
@@ -578,7 +578,7 @@ nonisolated private func makeCrossRepoBatchQuery(
       branchAliasMap[branchAlias] = branch
       let escapedBranch = escapeGraphQLString(branch)
       let pullRequestsArgs =
-        "first: 5, states: [OPEN, MERGED], headRefName: \"\(escapedBranch)\", \(orderBy)"
+        "first: 5, states: [OPEN, MERGED, CLOSED], headRefName: \"\(escapedBranch)\", \(orderBy)"
       let selection = """
           \(branchAlias): pullRequests(\(pullRequestsArgs)) {
             nodes {

--- a/supacode/Clients/Github/GithubCLIClient.swift
+++ b/supacode/Clients/Github/GithubCLIClient.swift
@@ -1190,7 +1190,7 @@ nonisolated private func makeBatchPullRequestsQuery(
     let escapedBranch = escapeGraphQLString(branch)
     let orderBy = "orderBy: {field: UPDATED_AT, direction: DESC}"
     let selection = """
-      \(alias): pullRequests(first: 5, states: [OPEN, MERGED], headRefName: \"\(escapedBranch)\", \(orderBy)) {
+      \(alias): pullRequests(first: 5, states: [OPEN, MERGED, CLOSED], headRefName: \"\(escapedBranch)\", \(orderBy)) {
         nodes {
           number
           title

--- a/supacode/Features/Repositories/Views/PullRequestBadgeView.swift
+++ b/supacode/Features/Repositories/Views/PullRequestBadgeView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 enum PullRequestBadgeStyle {
   static let mergedColor = Color.purple
   static let openColor = Color.green
+  static let closedColor = Color.red
   static let queuedColor = Color.brown
 
   static func style(state: String?, number: Int?, isQueued: Bool = false) -> (text: String, color: Color)? {
@@ -14,6 +15,8 @@ enum PullRequestBadgeStyle {
       return (text: number.map { "#\($0)" } ?? "MERGED", color: mergedColor)
     case "OPEN":
       return (text: number.map { "#\($0)" } ?? "OPEN", color: isQueued ? queuedColor : openColor)
+    case "CLOSED":
+      return (text: number.map { "#\($0)" } ?? "CLOSED", color: closedColor)
     default:
       return nil
     }
@@ -26,6 +29,8 @@ enum PullRequestBadgeStyle {
       return url == nil ? "Pull request merged" : "Open merged pull request on GitHub"
     case "OPEN":
       return url == nil ? "Pull request open" : "Open pull request on GitHub"
+    case "CLOSED":
+      return url == nil ? "Pull request closed" : "Open closed pull request on GitHub"
     default:
       return url == nil ? "Pull request" : "Open pull request on GitHub"
     }

--- a/supacode/Features/Repositories/Views/PullRequestBadgeView.swift
+++ b/supacode/Features/Repositories/Views/PullRequestBadgeView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 enum PullRequestBadgeStyle {
   static let mergedColor = Color.purple
   static let openColor = Color.green
-  static let closedColor = Color.red
+  static let closedColor = Color.orange
   static let queuedColor = Color.brown
 
   static func style(state: String?, number: Int?, isQueued: Bool = false) -> (text: String, color: Color)? {

--- a/supacode/Features/Repositories/Views/PullRequestStatusButton.swift
+++ b/supacode/Features/Repositories/Views/PullRequestStatusButton.swift
@@ -76,6 +76,11 @@ struct PullRequestStatusModel: Equatable {
       self.statusChecks = []
       return
     }
+    if state == "CLOSED" {
+      self.detailText = nil
+      self.statusChecks = []
+      return
+    }
     let isDraft = pullRequest.isDraft
     let prefix = isDraft ? "(Drafted) " : ""
     let mergeReadiness = PullRequestMergeReadiness(pullRequest: pullRequest)
@@ -116,6 +121,7 @@ struct PullRequestStatusModel: Equatable {
     guard number != nil else {
       return false
     }
-    return state?.uppercased() != "CLOSED"
+    let s = state?.uppercased()
+    return s != nil && s != "UNKNOWN"
   }
 }

--- a/supacode/Features/Repositories/Views/PullRequestStatusButton.swift
+++ b/supacode/Features/Repositories/Views/PullRequestStatusButton.swift
@@ -121,7 +121,7 @@ struct PullRequestStatusModel: Equatable {
     guard number != nil else {
       return false
     }
-    let s = state?.uppercased()
-    return s != nil && s != "UNKNOWN"
+    let uppercasedState = state?.uppercased()
+    return uppercasedState != nil && uppercasedState != "UNKNOWN"
   }
 }

--- a/supacode/Features/Repositories/Views/WorktreeRow.swift
+++ b/supacode/Features/Repositories/Views/WorktreeRow.swift
@@ -278,6 +278,11 @@ private struct WorktreeRowInfoView: View {
       var segment = AttributedString("Merged")
       segment.foregroundColor = PullRequestBadgeStyle.mergedColor
       result.append(segment)
+    } else if pullRequestState == "CLOSED" {
+      appendSeparator()
+      var segment = AttributedString("Closed")
+      segment.foregroundColor = PullRequestBadgeStyle.closedColor
+      result.append(segment)
     } else if isQueued {
       // A queued PR is mid-merge, so the queue state takes priority over the
       // merge-readiness label.


### PR DESCRIPTION
## Problem

Worktrees can track OPEN and MERGED PRs, but **CLOSED PRs are completely invisible**. When a PR is closed (without being merged), it disappears from the worktree row.

## Root Cause

The batched GraphQL queries for PR refresh only requested `states: [OPEN, MERGED]`, excluding CLOSED. Two query paths both had this issue:

1. `makeBatchPullRequestsQuery` (single-repo batch)
2. `makeCrossRepoBatchQuery` (cross-repo batch — the actual code path used when querying both fork and upstream)

Additionally, several UI components explicitly hid CLOSED state.

## Changes

4 files, +19/-3:

**GithubCLIClient.swift** — Add `CLOSED` to both GraphQL query paths:
- Line 580: `states: [OPEN, MERGED]` → `[OPEN, MERGED, CLOSED]` (cross-repo)
- Line 1192: same change (single-repo)

**PullRequestBadgeView.swift** — Add CLOSED badge support:
- New `closedColor = Color.red` (orange)
- CLOSED case in `style()` returns red `#N` badge
- CLOSED case in `helpText()`

**PullRequestStatusButton.swift** — Stop hiding CLOSED PRs:
- `shouldDisplay()`: no longer returns false for CLOSED (only hides nil/UNKNOWN)
- `init()`: early return for CLOSED (no checks/details, same as MERGED)

**WorktreeRow.swift** — Show "Closed" label in summary:
- New CLOSED segment between MERGED and Queued, displayed in red