### PR TITLE
Reveal canvas help on hover like the notifications bell

### DIFF
--- a/docs/components/canvas.md
+++ b/docs/components/canvas.md
@@ -68,7 +68,8 @@ Selection controls:
   — enough to follow what each agent is doing).
 
 These also appear as toolbar buttons. There's a `?` help popover (bottom-left)
-explaining pan/zoom/expand.
+explaining pan/zoom/expand — hover the button to reveal it, move away to dismiss,
+or click to pin it open.
 
 ## Visual cues
 

--- a/supacode/Features/Canvas/Views/CanvasHelpButton.swift
+++ b/supacode/Features/Canvas/Views/CanvasHelpButton.swift
@@ -1,0 +1,125 @@
+import SwiftUI
+
+/// The canvas navigation help affordance shown in the bottom-leading corner.
+///
+/// Mirrors the toolbar notifications bell: hovering the button reveals the help
+/// popover, moving away dismisses it after a short grace period (so the cursor
+/// can travel onto the popover), and clicking pins it open until clicked again.
+struct CanvasHelpButton: View {
+  @Environment(\.resolvedKeybindings) private var resolvedKeybindings
+  @State private var isPresented = false
+  @State private var isPinnedOpen = false
+  @State private var isHoveringButton = false
+  @State private var isHoveringPopover = false
+  @State private var closeTask: Task<Void, Never>?
+
+  var body: some View {
+    Button {
+      togglePresentation()
+    } label: {
+      Image(systemName: "questionmark.circle")
+        .font(.body)
+        .accessibilityLabel("Canvas navigation help")
+    }
+    .buttonStyle(.bordered)
+    .help("Canvas navigation help. Hover or click to show.")
+    .onHover { hovering in
+      isHoveringButton = hovering
+      updatePresentation()
+    }
+    .popover(isPresented: $isPresented, arrowEdge: .bottom) {
+      canvasHelpContent
+        .onHover { hovering in
+          isHoveringPopover = hovering
+          updatePresentation()
+        }
+        .onDisappear {
+          isHoveringPopover = false
+          isPinnedOpen = false
+        }
+    }
+    .onDisappear {
+      closeTask?.cancel()
+    }
+    .padding()
+  }
+
+  private var canvasHelpContent: some View {
+    let expandShortcut = AppShortcuts.display(
+      for: AppShortcuts.CommandID.expandCanvasCard,
+      in: resolvedKeybindings
+    )
+    return VStack(alignment: .leading, spacing: 14) {
+      Text("Canvas Navigation")
+        .font(.headline)
+
+      VStack(alignment: .leading, spacing: 12) {
+        canvasHelpRow(
+          icon: "plus.magnifyingglass",
+          title: "Zoom in/out",
+          detail: "⌘ + scroll, or pinch gesture"
+        )
+        canvasHelpRow(
+          icon: "hand.draw",
+          title: "Pan canvas",
+          detail: "Drag empty area, middle-click drag, or two-finger swipe"
+        )
+        canvasHelpRow(
+          icon: "arrow.up.left.and.arrow.down.right",
+          title: "Expand / restore card",
+          detail: expandShortcut.map { "\($0), or the card's title-bar button" }
+            ?? "Use the card's title-bar button"
+        )
+      }
+    }
+    .padding()
+    .frame(width: 320, alignment: .leading)
+  }
+
+  private func canvasHelpRow(icon: String, title: String, detail: String) -> some View {
+    HStack(alignment: .firstTextBaseline, spacing: 10) {
+      Image(systemName: icon)
+        .foregroundStyle(.secondary)
+        .frame(width: 18)
+        .accessibilityHidden(true)
+      VStack(alignment: .leading, spacing: 2) {
+        Text(title).font(.callout).fontWeight(.medium)
+        Text(detail)
+          .font(.caption)
+          .foregroundStyle(.secondary)
+          .fixedSize(horizontal: false, vertical: true)
+      }
+    }
+  }
+
+  private func togglePresentation() {
+    if isPinnedOpen {
+      closePopover()
+      return
+    }
+    closeTask?.cancel()
+    isPinnedOpen = true
+    isPresented = true
+  }
+
+  private func updatePresentation() {
+    if isPinnedOpen || isHoveringButton || isHoveringPopover {
+      closeTask?.cancel()
+      isPresented = true
+      return
+    }
+    closeTask?.cancel()
+    closeTask = Task { @MainActor in
+      try? await ContinuousClock().sleep(for: .milliseconds(150))
+      if !Task.isCancelled {
+        isPresented = false
+      }
+    }
+  }
+
+  private func closePopover() {
+    closeTask?.cancel()
+    isPinnedOpen = false
+    isPresented = false
+  }
+}

--- a/supacode/Features/Canvas/Views/CanvasView.swift
+++ b/supacode/Features/Canvas/Views/CanvasView.swift
@@ -36,7 +36,6 @@ struct CanvasView: View {
   @State var hasPerformedInitialFit = false
   @State var hasSeenCanvasCards = false
   @State var viewportSize: CGSize = .zero
-  @State var showsCanvasHelp = false
   @State var configReloadCounter = 0
   @State var focusViewportAnimationID = 0
   /// The tab currently expanded in place (near-fullscreen overlay) on canvas,
@@ -187,7 +186,7 @@ struct CanvasView: View {
       canvasToolbar
     }
     .overlay(alignment: .bottomLeading) {
-      canvasHelpButton
+      CanvasHelpButton()
     }
     .onKeyPress(.escape) {
       guard selectionState.isBroadcasting else { return .ignored }
@@ -740,70 +739,6 @@ struct CanvasView: View {
     let visibleKeys = Set(collectCardKeys(from: terminalManager.activeWorktreeStates))
     guard !visibleKeys.isEmpty || hasSeenCanvasCards else { return }
     layoutStore.prune(to: visibleKeys)
-  }
-
-  var canvasHelpButton: some View {
-    Button {
-      showsCanvasHelp.toggle()
-    } label: {
-      Image(systemName: "questionmark.circle")
-        .font(.body)
-        .accessibilityLabel("Canvas navigation help")
-    }
-    .buttonStyle(.bordered)
-    .help("Canvas navigation help")
-    .popover(isPresented: $showsCanvasHelp, arrowEdge: .bottom) {
-      canvasHelpContent
-    }
-    .padding()
-  }
-
-  var canvasHelpContent: some View {
-    let expandShortcut = AppShortcuts.display(
-      for: AppShortcuts.CommandID.expandCanvasCard,
-      in: resolvedKeybindings
-    )
-    return VStack(alignment: .leading, spacing: 14) {
-      Text("Canvas Navigation")
-        .font(.headline)
-
-      VStack(alignment: .leading, spacing: 12) {
-        canvasHelpRow(
-          icon: "plus.magnifyingglass",
-          title: "Zoom in/out",
-          detail: "⌘ + scroll, or pinch gesture"
-        )
-        canvasHelpRow(
-          icon: "hand.draw",
-          title: "Pan canvas",
-          detail: "Drag empty area, middle-click drag, or two-finger swipe"
-        )
-        canvasHelpRow(
-          icon: "arrow.up.left.and.arrow.down.right",
-          title: "Expand / restore card",
-          detail: expandShortcut.map { "\($0), or the card's title-bar button" }
-            ?? "Use the card's title-bar button"
-        )
-      }
-    }
-    .padding()
-    .frame(width: 320, alignment: .leading)
-  }
-
-  func canvasHelpRow(icon: String, title: String, detail: String) -> some View {
-    HStack(alignment: .firstTextBaseline, spacing: 10) {
-      Image(systemName: icon)
-        .foregroundStyle(.secondary)
-        .frame(width: 18)
-        .accessibilityHidden(true)
-      VStack(alignment: .leading, spacing: 2) {
-        Text(title).font(.callout).fontWeight(.medium)
-        Text(detail)
-          .font(.caption)
-          .foregroundStyle(.secondary)
-          .fixedSize(horizontal: false, vertical: true)
-      }
-    }
   }
 
   var canvasToolbar: some View {


### PR DESCRIPTION
## What

The bottom-left canvas `?` help affordance previously required a **click** to toggle its popover. This changes it to a **hover** interaction matching the toolbar notifications bell:

- Hover the button → help popover appears immediately.
- Move the cursor away → popover dismisses after a short (150 ms) grace period, so you can travel onto the popover without it vanishing.
- Click → pins the popover open until clicked again.

## How

- Extracted the help button, its popover content, and the help rows out of `CanvasView` into a dedicated `CanvasHelpButton` view.
- The new view reuses the exact hover/pin/auto-dismiss logic from `ToolbarNotificationsPopoverButton` (`onHover` on both button and popover, a cancellable close `Task`, and an `isPinnedOpen` latch for click-to-pin).
- Removed the now-unused `showsCanvasHelp` state and the old `canvasHelpButton` / `canvasHelpContent` / `canvasHelpRow` members from `CanvasView`.
- Updated `docs/components/canvas.md` to describe the hover behavior.

## Verification

- `make build-app` — success, 0 errors/warnings.
- `make check` — format + swift-format lint + swiftlint all pass.
