### PR TITLE
test: cover deferred HEAD watcher refresh

### DIFF
--- a/supacode/Features/Repositories/BusinessLogic/WorktreeInfoMonitors.swift
+++ b/supacode/Features/Repositories/BusinessLogic/WorktreeInfoMonitors.swift
@@ -9,6 +9,11 @@ protocol WorktreeFileEventMonitoring: AnyObject {
 }
 
 @MainActor
+protocol WorktreeHeadEventMonitoring: AnyObject {
+  func cancel()
+}
+
+@MainActor
 protocol WorktreeRegistryMonitoring: AnyObject {
   func cancel()
 }
@@ -78,6 +83,43 @@ final class FSEventsWorktreeFileEventMonitor: WorktreeFileEventMonitoring {
     FSEventStreamInvalidate(stream)
     FSEventStreamRelease(stream)
     self.stream = nil
+  }
+}
+
+final class DispatchSourceWorktreeHeadEventMonitor: WorktreeHeadEventMonitoring {
+  private let source: DispatchSourceFileSystemObject
+
+  init?(
+    headURL: URL,
+    onEvent: @escaping @MainActor @Sendable (DispatchSource.FileSystemEvent) -> Void
+  ) {
+    let path = headURL.path(percentEncoded: false)
+    let fileDescriptor = open(path, O_EVTONLY)
+    guard fileDescriptor >= 0 else {
+      return nil
+    }
+    let queue = DispatchQueue(label: "worktree-head-event-monitor.\(path)")
+    let source = DispatchSource.makeFileSystemObjectSource(
+      fileDescriptor: fileDescriptor,
+      eventMask: [.write, .rename, .delete, .attrib],
+      queue: queue
+    )
+    self.source = source
+    source.setEventHandler { @Sendable [weak source] in
+      guard let source else { return }
+      let event = source.data
+      Task { @MainActor in
+        onEvent(event)
+      }
+    }
+    source.setCancelHandler { @Sendable in
+      close(fileDescriptor)
+    }
+    source.resume()
+  }
+
+  func cancel() {
+    source.cancel()
   }
 }
 

--- a/supacode/Features/Repositories/BusinessLogic/WorktreeInfoWatcherManager.swift
+++ b/supacode/Features/Repositories/BusinessLogic/WorktreeInfoWatcherManager.swift
@@ -1,4 +1,3 @@
-import Darwin
 import Dispatch
 import Foundation
 
@@ -11,6 +10,12 @@ final class WorktreeInfoWatcherManager {
       _ worktree: Worktree,
       _ onEvent: @escaping @MainActor @Sendable () -> Void
     ) -> WorktreeFileEventMonitoring?
+  typealias WorktreeHeadEventMonitorFactory =
+    @MainActor @Sendable (
+      _ worktreeID: Worktree.ID,
+      _ headURL: URL,
+      _ onEvent: @escaping @MainActor @Sendable (DispatchSource.FileSystemEvent) -> Void
+    ) -> WorktreeHeadEventMonitoring?
   typealias WorktreeRegistryMonitorFactory =
     @MainActor @Sendable (
       _ repositoryRootURL: URL,
@@ -24,7 +29,7 @@ final class WorktreeInfoWatcherManager {
 
   private struct HeadWatcher {
     let headURL: URL
-    let source: DispatchSourceFileSystemObject
+    let monitor: WorktreeHeadEventMonitoring
   }
 
   private struct RefreshTask {
@@ -81,6 +86,7 @@ final class WorktreeInfoWatcherManager {
   private let lineChangePhaseOffset: WorktreePhaseOffset
   private let pullRequestPhaseOffset: RepositoryPhaseOffset
   private let worktreeFileEventMonitorFactory: WorktreeFileEventMonitorFactory
+  private let worktreeHeadEventMonitorFactory: WorktreeHeadEventMonitorFactory
   private let worktreeRegistryMonitorFactory: WorktreeRegistryMonitorFactory
   private let remoteConfigMonitorFactory: RemoteConfigMonitorFactory
   private let sleep: @Sendable (Duration) async throws -> Void
@@ -118,6 +124,8 @@ final class WorktreeInfoWatcherManager {
     pullRequestPhaseOffset: @escaping RepositoryPhaseOffset = WorktreeInfoWatcherManager.defaultPullRequestPhaseOffset,
     worktreeFileEventMonitorFactory: @escaping WorktreeFileEventMonitorFactory =
       WorktreeInfoWatcherManager.defaultWorktreeFileEventMonitorFactory,
+    worktreeHeadEventMonitorFactory: @escaping WorktreeHeadEventMonitorFactory =
+      WorktreeInfoWatcherManager.defaultWorktreeHeadEventMonitorFactory,
     worktreeRegistryMonitorFactory: @escaping WorktreeRegistryMonitorFactory =
       WorktreeInfoWatcherManager.defaultWorktreeRegistryMonitorFactory,
     remoteConfigMonitorFactory: @escaping RemoteConfigMonitorFactory =
@@ -134,6 +142,7 @@ final class WorktreeInfoWatcherManager {
     self.lineChangePhaseOffset = lineChangePhaseOffset
     self.pullRequestPhaseOffset = pullRequestPhaseOffset
     self.worktreeFileEventMonitorFactory = worktreeFileEventMonitorFactory
+    self.worktreeHeadEventMonitorFactory = worktreeHeadEventMonitorFactory
     self.worktreeRegistryMonitorFactory = worktreeRegistryMonitorFactory
     self.remoteConfigMonitorFactory = remoteConfigMonitorFactory
     self.indexEntryCountProvider = indexEntryCountProvider
@@ -281,29 +290,16 @@ final class WorktreeInfoWatcherManager {
   }
 
   private func startWatcher(worktreeID: Worktree.ID, headURL: URL) {
-    let path = headURL.path(percentEncoded: false)
-    let fileDescriptor = open(path, O_EVTONLY)
-    guard fileDescriptor >= 0 else {
+    guard
+      let monitor = worktreeHeadEventMonitorFactory(
+        worktreeID, headURL,
+        { [weak self] event in
+          self?.handleEvent(worktreeID: worktreeID, event: event)
+        })
+    else {
       return
     }
-    let queue = DispatchQueue(label: "worktree-info-watcher.\(worktreeID)")
-    let source = DispatchSource.makeFileSystemObjectSource(
-      fileDescriptor: fileDescriptor,
-      eventMask: [.write, .rename, .delete, .attrib],
-      queue: queue
-    )
-    source.setEventHandler { @Sendable [weak self, weak source] in
-      guard let source else { return }
-      let event = source.data
-      Task { @MainActor in
-        self?.handleEvent(worktreeID: worktreeID, event: event)
-      }
-    }
-    source.setCancelHandler { @Sendable in
-      close(fileDescriptor)
-    }
-    source.resume()
-    headWatchers[worktreeID] = HeadWatcher(headURL: headURL, source: source)
+    headWatchers[worktreeID] = HeadWatcher(headURL: headURL, monitor: monitor)
   }
 
   private func handleEvent(
@@ -365,7 +361,7 @@ final class WorktreeInfoWatcherManager {
 
   private func stopHeadWatcher(for worktreeID: Worktree.ID) {
     if let watcher = headWatchers.removeValue(forKey: worktreeID) {
-      watcher.source.cancel()
+      watcher.monitor.cancel()
     }
   }
 
@@ -381,7 +377,7 @@ final class WorktreeInfoWatcherManager {
 
   private func stopAll() {
     for watcher in headWatchers.values {
-      watcher.source.cancel()
+      watcher.monitor.cancel()
     }
     for task in branchDebounceTasks.values {
       task.cancel()
@@ -771,6 +767,14 @@ final class WorktreeInfoWatcherManager {
     onEvent: @escaping @MainActor @Sendable () -> Void
   ) -> WorktreeFileEventMonitoring? {
     FSEventsWorktreeFileEventMonitor(rootURL: worktree.workingDirectory, onEvent: onEvent)
+  }
+
+  private static func defaultWorktreeHeadEventMonitorFactory(
+    worktreeID _: Worktree.ID,
+    headURL: URL,
+    onEvent: @escaping @MainActor @Sendable (DispatchSource.FileSystemEvent) -> Void
+  ) -> WorktreeHeadEventMonitoring? {
+    DispatchSourceWorktreeHeadEventMonitor(headURL: headURL, onEvent: onEvent)
   }
 
   private static func defaultWorktreeRegistryMonitorFactory(

--- a/supacode/Features/Repositories/BusinessLogic/WorktreeInfoWatcherManager.swift
+++ b/supacode/Features/Repositories/BusinessLogic/WorktreeInfoWatcherManager.swift
@@ -333,17 +333,10 @@ final class WorktreeInfoWatcherManager {
   }
 
   private func scheduleFilesChanged(worktreeID: Worktree.ID) {
-    filesDebounceTasks[worktreeID]?.cancel()
-    let debounceInterval = lineChangesTiming(for: worktreeID).filesChangedDebounce
-    let sleep = self.sleep
-    let task = Task { [weak self, sleep] in
-      try? await sleep(debounceInterval)
-      await MainActor.run {
-        guard let self else { return }
-        self.emit(.filesChanged(worktreeID: worktreeID))
-      }
-    }
-    filesDebounceTasks[worktreeID] = task
+    // Route through the debounced refresh path so the scheduled task
+    // calls emitLineChangesChanged (which clears deferredLineChangeIDs)
+    // instead of emitting directly (which gets swallowed when deferred).
+    scheduleLineChangesDebouncedRefresh(worktreeID: worktreeID)
   }
 
   private func scheduleRestart(worktreeID: Worktree.ID) {

--- a/supacode/Features/Repositories/BusinessLogic/WorktreeInfoWatcherManager.swift
+++ b/supacode/Features/Repositories/BusinessLogic/WorktreeInfoWatcherManager.swift
@@ -333,10 +333,11 @@ final class WorktreeInfoWatcherManager {
   }
 
   private func scheduleFilesChanged(worktreeID: Worktree.ID) {
-    // Route through the debounced refresh path so the scheduled task
-    // calls emitLineChangesChanged (which clears deferredLineChangeIDs)
-    // instead of emitting directly (which gets swallowed when deferred).
-    scheduleLineChangesDebouncedRefresh(worktreeID: worktreeID)
+    // Route through scheduleLineChangesRefresh so the scheduled task calls
+    // emitLineChangesChanged (which clears deferredLineChangeIDs) instead of
+    // emitting directly. Keep filesChangedDebounce for fast HEAD-change refresh.
+    let delay = lineChangesTiming(for: worktreeID).filesChangedDebounce
+    scheduleLineChangesRefresh(worktreeID: worktreeID, delay: delay)
   }
 
   private func scheduleRestart(worktreeID: Worktree.ID) {

--- a/supacodeTests/WorktreeInfoWatcherManagerTests.swift
+++ b/supacodeTests/WorktreeInfoWatcherManagerTests.swift
@@ -592,6 +592,56 @@ struct WorktreeInfoWatcherManagerTests {
     await task.value
     try FileManager.default.removeItem(at: tempRepository.tempRoot)
   }
+  @Test func headWatcherEventNotBlockedByDeferredLineChanges() async throws {
+    // Regression test: scheduleFilesChanged previously emitted .filesChanged
+    // directly, which gets swallowed when the worktree is in deferredLineChangeIDs.
+    // After the fix, it routes through scheduleLineChangesRefresh which calls
+    // emitLineChangesChanged (clears deferred flag before emitting).
+    let clock = TestClock()
+    let tempRepository = try makeTempRepository(worktreeNames: ["sparrow", "swift"])
+    let firstWorktree = try #require(tempRepository.worktrees.first)
+    let secondWorktree = try #require(tempRepository.worktrees.dropFirst().first)
+    let manager = WorktreeInfoWatcherManager(
+      focusedInterval: .seconds(3_600),
+      unfocusedInterval: .seconds(3_600),
+      defaultLineChangesTiming: .init(filesChangedDebounce: .milliseconds(80), eventDebounce: .seconds(3_600)),
+      lineChangePhaseOffset: { _, _ in .zero },
+      pullRequestPhaseOffset: { _, _ in .zero },
+      clock: clock
+    )
+    let (collector, task) = startCollecting(manager.eventStream())
+
+    manager.handleCommand(.setPullRequestTrackingEnabled(false))
+    // Load only the first worktree initially — second will be deferred when added.
+    manager.handleCommand(.setWorktrees([firstWorktree]))
+    await drainAsyncEvents(120)
+    let initialCount = await collector.filesChangedCount(worktreeID: firstWorktree.id)
+    #expect(initialCount == 1)
+
+    // Add second worktree — it goes into deferredLineChangeIDs.
+    manager.handleCommand(.setWorktrees([firstWorktree, secondWorktree]))
+    await drainAsyncEvents(120)
+    #expect(await collector.filesChangedCount(worktreeID: secondWorktree.id) == 0)
+
+    // Simulate a commit by writing to HEAD file — triggers HEAD watcher.
+    let headURL = secondWorktree.workingDirectory.appending(path: ".git/HEAD")
+    try "ref: refs/heads/swift\n".write(to: headURL, atomically: true, encoding: .utf8)
+    await drainAsyncEvents(120)
+
+    // Even though secondWorktree is deferred, the event should fire after debounce.
+    await clock.advance(by: .milliseconds(79))
+    await drainAsyncEvents(120)
+    #expect(await collector.filesChangedCount(worktreeID: secondWorktree.id) == 0)
+
+    await clock.advance(by: .milliseconds(1))
+    await drainAsyncEvents(120)
+    #expect(await collector.filesChangedCount(worktreeID: secondWorktree.id) == 1)
+
+    manager.handleCommand(.stop)
+    await task.value
+    try FileManager.default.removeItem(at: tempRepository.tempRoot)
+  }
+
 }
 
 actor EventCollector {

--- a/supacodeTests/WorktreeInfoWatcherManagerTests.swift
+++ b/supacodeTests/WorktreeInfoWatcherManagerTests.swift
@@ -592,11 +592,11 @@ struct WorktreeInfoWatcherManagerTests {
     await task.value
     try FileManager.default.removeItem(at: tempRepository.tempRoot)
   }
-  @Test func headWatcherEventNotBlockedByDeferredLineChanges() async throws {
-    // Regression test: scheduleFilesChanged previously emitted .filesChanged
-    // directly, which gets swallowed when the worktree is in deferredLineChangeIDs.
-    // After the fix, it routes through scheduleLineChangesRefresh which calls
-    // emitLineChangesChanged (clears deferred flag before emitting).
+  @Test func deferredWorktreeEmitsFilesChangedOnSelection() async throws {
+    // Regression test: worktrees added after initial load go into deferredLineChangeIDs,
+    // which previously blocked all .filesChanged events until the 5-minute safety refresh.
+    // After the fix, selecting a deferred worktree calls emitLineChangesChanged which
+    // clears the deferred flag and immediately emits .filesChanged.
     let clock = TestClock()
     let tempRepository = try makeTempRepository(worktreeNames: ["sparrow", "swift"])
     let firstWorktree = try #require(tempRepository.worktrees.first)
@@ -604,7 +604,6 @@ struct WorktreeInfoWatcherManagerTests {
     let manager = WorktreeInfoWatcherManager(
       focusedInterval: .seconds(3_600),
       unfocusedInterval: .seconds(3_600),
-      defaultLineChangesTiming: .init(filesChangedDebounce: .milliseconds(80), eventDebounce: .seconds(3_600)),
       lineChangePhaseOffset: { _, _ in .zero },
       pullRequestPhaseOffset: { _, _ in .zero },
       clock: clock
@@ -615,25 +614,15 @@ struct WorktreeInfoWatcherManagerTests {
     // Load only the first worktree initially — second will be deferred when added.
     manager.handleCommand(.setWorktrees([firstWorktree]))
     await drainAsyncEvents(120)
-    let initialCount = await collector.filesChangedCount(worktreeID: firstWorktree.id)
-    #expect(initialCount == 1)
+    #expect(await collector.filesChangedCount(worktreeID: firstWorktree.id) == 1)
 
-    // Add second worktree — it goes into deferredLineChangeIDs.
+    // Add second worktree — it goes into deferredLineChangeIDs, no filesChanged yet.
     manager.handleCommand(.setWorktrees([firstWorktree, secondWorktree]))
     await drainAsyncEvents(120)
     #expect(await collector.filesChangedCount(worktreeID: secondWorktree.id) == 0)
 
-    // Simulate a commit by writing to HEAD file — triggers HEAD watcher.
-    let headURL = secondWorktree.workingDirectory.appending(path: ".git/HEAD")
-    try "ref: refs/heads/swift\n".write(to: headURL, atomically: true, encoding: .utf8)
-    await drainAsyncEvents(120)
-
-    // Even though secondWorktree is deferred, the event should fire after debounce.
-    await clock.advance(by: .milliseconds(79))
-    await drainAsyncEvents(120)
-    #expect(await collector.filesChangedCount(worktreeID: secondWorktree.id) == 0)
-
-    await clock.advance(by: .milliseconds(1))
+    // Selecting the deferred worktree clears the deferred flag and emits immediately.
+    manager.handleCommand(.setSelectedWorktreeID(secondWorktree.id))
     await drainAsyncEvents(120)
     #expect(await collector.filesChangedCount(worktreeID: secondWorktree.id) == 1)
 

--- a/supacodeTests/WorktreeInfoWatcherManagerTests.swift
+++ b/supacodeTests/WorktreeInfoWatcherManagerTests.swift
@@ -631,6 +631,49 @@ struct WorktreeInfoWatcherManagerTests {
     try FileManager.default.removeItem(at: tempRepository.tempRoot)
   }
 
+  @Test func headWatcherEventClearsDeferredLineChangesAfterFilesChangedDebounce() async throws {
+    let clock = TestClock()
+    let tempRepository = try makeTempRepository(worktreeNames: ["sparrow", "swift"])
+    let firstWorktree = try #require(tempRepository.worktrees.first)
+    let secondWorktree = try #require(tempRepository.worktrees.dropFirst().first)
+    let headMonitorStore = TestWorktreeHeadEventMonitorStore()
+    let manager = WorktreeInfoWatcherManager(
+      focusedInterval: .seconds(3_600),
+      unfocusedInterval: .seconds(3_600),
+      defaultLineChangesTiming: .init(filesChangedDebounce: .milliseconds(80), eventDebounce: .seconds(3_600)),
+      lineChangePhaseOffset: { _, _ in .zero },
+      pullRequestPhaseOffset: { _, _ in .zero },
+      worktreeHeadEventMonitorFactory: headMonitorStore.makeMonitor,
+      clock: clock
+    )
+    let (collector, task) = startCollecting(manager.eventStream())
+
+    manager.handleCommand(.setPullRequestTrackingEnabled(false))
+    manager.handleCommand(.setWorktrees([firstWorktree]))
+    await drainAsyncEvents(120)
+    #expect(await collector.filesChangedCount(worktreeID: firstWorktree.id) == 1)
+
+    manager.handleCommand(.setWorktrees([firstWorktree, secondWorktree]))
+    await drainAsyncEvents(120)
+    #expect(await collector.filesChangedCount(worktreeID: secondWorktree.id) == 0)
+
+    let monitor = try #require(headMonitorStore.monitor(for: secondWorktree.id))
+    monitor.emit(.write)
+    await drainAsyncEvents(120)
+
+    await clock.advance(by: .milliseconds(79))
+    await drainAsyncEvents(120)
+    #expect(await collector.filesChangedCount(worktreeID: secondWorktree.id) == 0)
+
+    await clock.advance(by: .milliseconds(1))
+    await drainAsyncEvents(120)
+    #expect(await collector.filesChangedCount(worktreeID: secondWorktree.id) == 1)
+
+    manager.handleCommand(.stop)
+    await task.value
+    try FileManager.default.removeItem(at: tempRepository.tempRoot)
+  }
+
 }
 
 actor EventCollector {
@@ -748,6 +791,43 @@ private func startCollecting(
 private func drainAsyncEvents(_ iterations: Int = 20) async {
   for _ in 0..<iterations {
     await Task.yield()
+  }
+}
+
+@MainActor
+private final class TestWorktreeHeadEventMonitorStore {
+  private var monitors: [Worktree.ID: TestWorktreeHeadEventMonitor] = [:]
+
+  func makeMonitor(
+    worktreeID: Worktree.ID,
+    headURL _: URL,
+    onEvent: @escaping @MainActor @Sendable (DispatchSource.FileSystemEvent) -> Void
+  ) -> WorktreeHeadEventMonitoring? {
+    let monitor = TestWorktreeHeadEventMonitor(onEvent: onEvent)
+    monitors[worktreeID] = monitor
+    return monitor
+  }
+
+  func monitor(for worktreeID: Worktree.ID) -> TestWorktreeHeadEventMonitor? {
+    monitors[worktreeID]
+  }
+}
+
+@MainActor
+private final class TestWorktreeHeadEventMonitor: WorktreeHeadEventMonitoring {
+  private let onEvent: @MainActor @Sendable (DispatchSource.FileSystemEvent) -> Void
+  private(set) var isCanceled = false
+
+  init(onEvent: @escaping @MainActor @Sendable (DispatchSource.FileSystemEvent) -> Void) {
+    self.onEvent = onEvent
+  }
+
+  func emit(_ event: DispatchSource.FileSystemEvent) {
+    onEvent(event)
+  }
+
+  func cancel() {
+    isCanceled = true
   }
 }
 


### PR DESCRIPTION
## Summary

- Includes the sidebar diff badge deferred refresh fix from #508.
- Adds a deterministic HEAD watcher regression test that does not rely on real file system event delivery.
- Extracts the HEAD watcher DispatchSource behind `WorktreeHeadEventMonitoring` so tests can emit HEAD events directly.

## Validation

- `xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -only-testing:supacodeTests/WorktreeInfoWatcherManagerTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation`
- `make build-app`

`make check` was also run, but still fails on the existing `supacodeTests/PullRequestMergeReadinessTests.swift` trailing comma lint issue from the PR base, outside this change set.
