### PR TITLE
ui: make archived worktrees button toggle

### DIFF
--- a/supacode/Commands/WorktreeCommands.swift
+++ b/supacode/Commands/WorktreeCommands.swift
@@ -66,11 +66,14 @@ struct WorktreeCommands: Commands {
         worktreeMenuButton(entry: entry)
       }
       Divider()
-      Button("Archived Worktrees") {
+      Button(store.state.repositories.isShowingArchivedWorktrees ? "Exit Archived Worktrees" : "Archived Worktrees") {
         store.send(.repositories(.selectArchivedWorktrees))
       }
       .modifier(KeyboardShortcutModifier(shortcut: keyboardShortcut(for: AppShortcuts.CommandID.archivedWorktrees)))
-      .help(helpText(title: "Archived Worktrees", commandID: AppShortcuts.CommandID.archivedWorktrees))
+      .help(
+        helpText(
+          title: store.state.repositories.isShowingArchivedWorktrees ? "Exit Archived Worktrees" : "Archived Worktrees",
+          commandID: AppShortcuts.CommandID.archivedWorktrees))
     }
     CommandGroup(replacing: .newItem) {
       if !customCommands.isEmpty {

--- a/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
+++ b/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
@@ -229,7 +229,10 @@ struct CommandPaletteFeature {
     let showsNewWorktreeAction =
       repositories.repositories.isEmpty
       || repositories.repositories.contains { $0.capabilities.supportsWorktrees }
-    var items = globalCommandItems(showsNewWorktreeAction: showsNewWorktreeAction)
+    var items = globalCommandItems(
+      showsNewWorktreeAction: showsNewWorktreeAction,
+      isShowingArchivedWorktrees: repositories.isShowingArchivedWorktrees
+    )
     if repositories.isShowingCanvas {
       items.append(contentsOf: canvasCommandItems())
     }
@@ -336,7 +339,10 @@ struct CommandPaletteFeature {
   }
 }
 
-private func globalCommandItems(showsNewWorktreeAction: Bool) -> [CommandPaletteItem] {
+private func globalCommandItems(
+  showsNewWorktreeAction: Bool,
+  isShowingArchivedWorktrees: Bool
+) -> [CommandPaletteItem] {
   var items: [CommandPaletteItem] = [
     .appShortcut(
       id: CommandPaletteItemID.globalCheckForUpdates,
@@ -401,7 +407,7 @@ private func globalCommandItems(showsNewWorktreeAction: Bool) -> [CommandPalette
   items.append(
     .appShortcut(
       id: CommandPaletteItemID.globalViewArchivedWorktrees,
-      title: "View Archived Worktrees",
+      title: isShowingArchivedWorktrees ? "Exit Archived Worktrees" : "View Archived Worktrees",
       category: .worktree,
       kind: .viewArchivedWorktrees,
       keywords: ["archive", "history"]

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+CoreReducer.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+CoreReducer.swift
@@ -347,8 +347,9 @@ extension RepositoriesFeature {
       state.isShelfActive = false
       // Toggle: if already showing archived, return to the previous worktree.
       if state.isShowingArchivedWorktrees {
+        defer { state.preArchivedWorktreeID = nil }
         if let previousID = state.preArchivedWorktreeID,
-          state.worktree(for: previousID) != nil
+          isSelectionValid(previousID, state: state)
         {
           setSingleWorktreeSelection(previousID, state: &state, recordHistory: false)
           state.openedWorktreeIDs.insert(previousID)

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+CoreReducer.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+CoreReducer.swift
@@ -345,6 +345,23 @@ extension RepositoriesFeature {
 
     case .selectArchivedWorktrees:
       state.isShelfActive = false
+      // Toggle: if already showing archived, return to the previous worktree.
+      if state.isShowingArchivedWorktrees {
+        if let previousID = state.preArchivedWorktreeID,
+          state.worktree(for: previousID) != nil
+        {
+          setSingleWorktreeSelection(previousID, state: &state, recordHistory: false)
+          state.openedWorktreeIDs.insert(previousID)
+          state.pendingTerminalFocusWorktreeIDs.insert(previousID)
+          return .send(.delegate(.selectedWorktreeChanged(state.worktree(for: previousID))))
+        }
+        state.selection = nil
+        state.selectedWorkspaceChildID = nil
+        state.sidebarSelectedWorktreeIDs = []
+        return .send(.delegate(.selectedWorktreeChanged(nil)))
+      }
+      // Entering archived view — remember current worktree for later restore.
+      state.preArchivedWorktreeID = state.selectedWorktreeID
       recordWorktreeHistoryTransition(from: state.selectedWorktreeID, to: nil, state: &state)
       state.selection = .archivedWorktrees
       state.selectedWorkspaceChildID = nil

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -315,6 +315,7 @@ struct RepositoriesFeature {
     var lastFocusedWorktreeID: Worktree.ID?
     var preCanvasWorktreeID: Worktree.ID?
     var preCanvasTerminalTargetID: Worktree.ID?
+    var preArchivedWorktreeID: Worktree.ID?
     var isShelfActive: Bool = false
     var worktreeHistoryBackStack: [Worktree.ID] = []
     var worktreeHistoryForwardStack: [Worktree.ID] = []

--- a/supacode/Features/Repositories/Views/SidebarFooterView.swift
+++ b/supacode/Features/Repositories/Views/SidebarFooterView.swift
@@ -75,12 +75,12 @@ struct SidebarFooterView: View {
       Button {
         store.send(.selectArchivedWorktrees)
       } label: {
-        Image(systemName: "archivebox")
-          .accessibilityLabel("Archived Worktrees")
+        Image(systemName: store.state.isShowingArchivedWorktrees ? "arrow.uturn.left" : "archivebox")
+          .accessibilityLabel(store.state.isShowingArchivedWorktrees ? "Exit Archived Worktrees" : "Archived Worktrees")
       }
       .help(
         AppShortcuts.helpText(
-          title: "Archived Worktrees",
+          title: store.state.isShowingArchivedWorktrees ? "Exit Archived Worktrees" : "Archived Worktrees",
           commandID: AppShortcuts.CommandID.archivedWorktrees,
           in: resolvedKeybindings
         ))

--- a/supacodeTests/AppFeatureArchivedSelectionTests.swift
+++ b/supacodeTests/AppFeatureArchivedSelectionTests.swift
@@ -44,6 +44,7 @@ struct AppFeatureArchivedSelectionTests {
     await store.send(.repositories(.selectArchivedWorktrees)) {
       $0.repositories.worktreeHistoryBackStack = [worktree.id]
       $0.repositories.selection = .archivedWorktrees
+      $0.repositories.preArchivedWorktreeID = worktree.id
     }
     await store.receive(\.repositories.delegate.selectedWorktreeChanged)
     await store.finish()

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -2813,6 +2813,7 @@ struct RepositoriesFeatureTests {
       $0.worktreeHistoryBackStack = [worktree1.id]
       $0.selection = .archivedWorktrees
       $0.sidebarSelectedWorktreeIDs = []
+      $0.preArchivedWorktreeID = worktree1.id
     }
     await store.receive(\.delegate.selectedWorktreeChanged)
   }
@@ -6657,6 +6658,7 @@ struct RepositoriesFeatureTests {
       $0.worktreeHistoryForwardStack = []
       $0.selection = .archivedWorktrees
       $0.sidebarSelectedWorktreeIDs = []
+      $0.preArchivedWorktreeID = wt1.id
     }
     await store.receive(\.delegate.selectedWorktreeChanged)
   }

--- a/supacodeTests/ShelfFeatureTests.swift
+++ b/supacodeTests/ShelfFeatureTests.swift
@@ -902,6 +902,40 @@ struct ShelfFeatureTests {
       $0.sidebarSelectedWorktreeIDs = [worktree.id]
       $0.openedWorktreeIDs = [worktree.id]
       $0.pendingTerminalFocusWorktreeIDs = [worktree.id]
+      $0.preArchivedWorktreeID = nil
+    }
+    await store.receive(\.delegate.selectedWorktreeChanged)
+    await store.finish()
+  }
+
+  @Test(.dependencies) func selectArchivedWorktreesStalePreviousIDClearsSelection() async {
+    let rootURL = URL(fileURLWithPath: "/tmp/repo")
+    let worktree = Worktree(
+      id: "/tmp/repo/wt1",
+      name: "wt1",
+      detail: "",
+      workingDirectory: URL(fileURLWithPath: "/tmp/repo/wt1"),
+      repositoryRootURL: rootURL
+    )
+    let repository = Repository(
+      id: rootURL.path(percentEncoded: false),
+      rootURL: rootURL,
+      name: "repo",
+      worktrees: IdentifiedArray(uniqueElements: [worktree])
+    )
+    var state = RepositoriesFeature.State(repositories: [repository])
+    state.selection = .archivedWorktrees
+    state.sidebarSelectedWorktreeIDs = []
+    // Point to a worktree ID that no longer exists in any repository.
+    state.preArchivedWorktreeID = "/tmp/repo/wt-deleted"
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    }
+
+    await store.send(.selectArchivedWorktrees) {
+      $0.selection = nil
+      $0.sidebarSelectedWorktreeIDs = []
+      $0.preArchivedWorktreeID = nil
     }
     await store.receive(\.delegate.selectedWorktreeChanged)
     await store.finish()

--- a/supacodeTests/ShelfFeatureTests.swift
+++ b/supacodeTests/ShelfFeatureTests.swift
@@ -868,6 +868,40 @@ struct ShelfFeatureTests {
       $0.worktreeHistoryBackStack = [worktree.id]
       $0.selection = .archivedWorktrees
       $0.sidebarSelectedWorktreeIDs = []
+      $0.preArchivedWorktreeID = worktree.id
+    }
+    await store.receive(\.delegate.selectedWorktreeChanged)
+    await store.finish()
+  }
+
+  @Test(.dependencies) func selectArchivedWorktreesTogglesBackToPreviousWorktree() async {
+    let rootURL = URL(fileURLWithPath: "/tmp/repo")
+    let worktree = Worktree(
+      id: "/tmp/repo/wt1",
+      name: "wt1",
+      detail: "",
+      workingDirectory: URL(fileURLWithPath: "/tmp/repo/wt1"),
+      repositoryRootURL: rootURL
+    )
+    let repository = Repository(
+      id: rootURL.path(percentEncoded: false),
+      rootURL: rootURL,
+      name: "repo",
+      worktrees: IdentifiedArray(uniqueElements: [worktree])
+    )
+    var state = RepositoriesFeature.State(repositories: [repository])
+    state.selection = .archivedWorktrees
+    state.sidebarSelectedWorktreeIDs = []
+    state.preArchivedWorktreeID = worktree.id
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    }
+
+    await store.send(.selectArchivedWorktrees) {
+      $0.selection = .worktree(worktree.id)
+      $0.sidebarSelectedWorktreeIDs = [worktree.id]
+      $0.openedWorktreeIDs = [worktree.id]
+      $0.pendingTerminalFocusWorktreeIDs = [worktree.id]
     }
     await store.receive(\.delegate.selectedWorktreeChanged)
     await store.finish()


### PR DESCRIPTION
## Summary

The archived worktrees button now acts as a toggle — clicking it while already viewing archived worktrees returns to the previously selected worktree, matching the toggle behavior of Canvas/Shelf.

## Problem

Previously, clicking the "Archived Worktrees" button in the sidebar footer would navigate to the archived worktrees view, but there was no obvious way to exit. Users had to click on a different worktree or repository in the sidebar to leave — an unintuitive interaction with no visual feedback.

## Solution

- **Toggle behavior**: The button now toggles between the archived view and the previously selected worktree
- **Visual feedback**: Button icon changes from `archivebox` → `arrow.uturn.left` when in archived view
- **Dynamic labels**: Menu item and tooltip switch between "Archived Worktrees" and "Exit Archived Worktrees"

## Changes

- Add `preArchivedWorktreeID` to `RepositoriesFeature.State` to remember selection before entering archived view
- Convert `selectArchivedWorktrees` action into a toggle: exit restores previous worktree (or clears selection if no valid previous worktree)
- Update `SidebarFooterView` and `WorktreeCommands` to reflect current state
- Update existing tests to expect `preArchivedWorktreeID`
- Add new test `selectArchivedWorktreesTogglesBackToPreviousWorktree`

## Test plan

- [ ] Click archived worktrees button → enters archived view, icon changes to back arrow
- [ ] Click again → returns to previously selected worktree
- [ ] Menu bar "Worktrees" menu shows "Exit Archived Worktrees" when in archived view
- [ ] All existing archived worktree tests pass