### PR TITLE
Avoid Ghostty reentry while refreshing active agents

### DIFF
--- a/supacode/Features/Terminal/Models/WorktreeTerminalState+AgentDetection.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState+AgentDetection.swift
@@ -216,13 +216,7 @@ extension WorktreeTerminalState {
     let paneIDs = trees[tabId]?.leaves().map(\.id) ?? []
     let paneIndex = paneIDs.firstIndex(of: surfaceID).map { $0 + 1 } ?? 1
     let tabTitle = tabManager.tabs.first(where: { $0.id == tabId })?.displayTitle ?? "?"
-    // Resolve the displayed repository/branch from where the agent actually runs, not the tab's
-    // owning worktree: a user may `cd` into a different repo before launching the agent. Falls
-    // back to the surface's launch directory when the shell hasn't reported a pwd.
-    let workingDirectory = inheritedSurfaceConfig(
-      fromSurfaceId: surfaceID,
-      context: GHOSTTY_SURFACE_CONTEXT_TAB
-    ).workingDirectory
+    let workingDirectory = activeAgentWorkingDirectory(surfaceID: surfaceID)
     return ActiveAgentEntry(
       id: surfaceID,
       worktreeID: worktree.id,
@@ -238,6 +232,18 @@ extension WorktreeTerminalState {
       displayState: state.displayState,
       lastChangedAt: state.lastChangedAt
     )
+  }
+
+  func activeAgentWorkingDirectory(surfaceID: UUID) -> URL? {
+    guard let surface = surfaces[surfaceID] else { return nil }
+    // This can run while handling Ghostty callbacks, so use cached Swift state instead of
+    // re-entering Ghostty for inherited surface config.
+    if let pwd = surface.bridge.state.pwd?.trimmingCharacters(in: .whitespacesAndNewlines),
+      !pwd.isEmpty
+    {
+      return URL(fileURLWithPath: pwd, isDirectory: true)
+    }
+    return surface.launchWorkingDirectory ?? worktree.workingDirectory
   }
 
   func cleanupAgentDetectionState(forSurfaceId surfaceId: UUID) {

--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
@@ -123,6 +123,7 @@ final class GhosttySurfaceView: NSView, Identifiable {
     debugID
   }
   let bridge: GhosttySurfaceBridge
+  let launchWorkingDirectory: URL?
   private(set) var surface: ghostty_surface_t?
   private var surfaceRef: GhosttyRuntime.SurfaceReference?
   private let workingDirectoryCString: UnsafeMutablePointer<CChar>?
@@ -269,8 +270,10 @@ final class GhosttySurfaceView: NSView, Identifiable {
       let path = Self.normalizedWorkingDirectoryPath(
         workingDirectory.path(percentEncoded: false)
       )
+      launchWorkingDirectory = URL(fileURLWithPath: path, isDirectory: true)
       workingDirectoryCString = path.withCString { strdup($0) }
     } else {
+      launchWorkingDirectory = nil
       workingDirectoryCString = nil
     }
     if let initialInput {

--- a/supacodeTests/ActiveAgentEntryWorkingDirectoryTests.swift
+++ b/supacodeTests/ActiveAgentEntryWorkingDirectoryTests.swift
@@ -1,0 +1,78 @@
+import AppKit
+import Foundation
+import GhosttyKit
+import Testing
+
+@testable import supacode
+
+@MainActor
+struct ActiveAgentEntryWorkingDirectoryTests {
+  @Test func activeAgentEntryUsesCachedPWD() throws {
+    let launchDirectory = URL(fileURLWithPath: "/tmp/repo/worktree", isDirectory: true)
+    let reportedDirectory = URL(fileURLWithPath: "/tmp/repo/worktree/Sources", isDirectory: true)
+    let fixture = makeState(launchDirectory: launchDirectory)
+    fixture.surface.bridge.state.pwd = reportedDirectory.path(percentEncoded: false)
+
+    let entry = try #require(
+      fixture.state.activeAgentEntry(
+        surfaceID: fixture.surface.id,
+        tabId: fixture.tabId,
+        state: PaneAgentState(detectedAgent: .claude, state: .working)
+      )
+    )
+
+    #expect(
+      entry.workingDirectory?.path(percentEncoded: false)
+        == reportedDirectory.path(percentEncoded: false)
+    )
+  }
+
+  @Test func activeAgentEntryFallsBackToSurfaceLaunchDirectory() throws {
+    let launchDirectory = URL(fileURLWithPath: "/tmp/repo/worktree", isDirectory: true)
+    let fixture = makeState(launchDirectory: launchDirectory)
+
+    let entry = try #require(
+      fixture.state.activeAgentEntry(
+        surfaceID: fixture.surface.id,
+        tabId: fixture.tabId,
+        state: PaneAgentState(detectedAgent: .claude, state: .working)
+      )
+    )
+
+    #expect(
+      entry.workingDirectory?.path(percentEncoded: false)
+        == launchDirectory.path(percentEncoded: false)
+    )
+  }
+
+  private struct Fixture {
+    let state: WorktreeTerminalState
+    let tabId: TerminalTabID
+    let surface: GhosttySurfaceView
+  }
+
+  private func makeState(launchDirectory: URL) -> Fixture {
+    let state = WorktreeTerminalState(
+      runtime: GhosttyRuntime(),
+      worktree: Worktree(
+        id: "/tmp/repo/worktree",
+        name: "worktree",
+        detail: "",
+        workingDirectory: URL(fileURLWithPath: "/tmp/repo/worktree"),
+        repositoryRootURL: URL(fileURLWithPath: "/tmp/repo")
+      )
+    )
+    let surface = GhosttySurfaceView(
+      runtime: state.runtime,
+      workingDirectory: launchDirectory,
+      fontSize: nil,
+      context: GHOSTTY_SURFACE_CONTEXT_TAB,
+      skipsSurfaceCreationForTesting: true
+    )
+    let tabId = state.tabManager.createTab(title: "worktree 1", icon: "terminal")
+    state.surfaces[surface.id] = surface
+    state.trees[tabId] = SplitTree<GhosttySurfaceView>(view: surface)
+    state.focusedSurfaceIdByTab[tabId] = surface.id
+    return Fixture(state: state, tabId: tabId, surface: surface)
+  }
+}


### PR DESCRIPTION
## Summary

- Cache each terminal surface's launch working directory when the surface is created.
- Build Active Agents entries from cached PWD / launch directory state instead of calling `ghostty_surface_inherited_config`.
- Cover the PWD-first and launch-directory fallback paths with focused tests.

## Root Cause

Issue #506's hang stack shows title-change handling refreshing Active Agents while Ghostty is processing a render/update callback. That refresh rebuilt entries and synchronously called back into Ghostty for inherited surface config, creating a reentry point on the same surface during a sensitive callback path.

## Validation

- `xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -derivedDataPath /tmp/prowl-issue506-agent-entry-dd -only-testing:"supacodeTests/ActiveAgentEntryWorkingDirectoryTests" CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation 2>&1 | xcsift -f toon`
- `make check`
- `make build-app 2>&1 | xcsift -f toon`

Fixes #506
