### PR TITLE
feat: auto-suggest worktree branch names using Foundation Model

### DIFF
--- a/doc-onevcat/plans/2026-06-27-foundation-model-branch-name.md
+++ b/doc-onevcat/plans/2026-06-27-foundation-model-branch-name.md
@@ -207,11 +207,14 @@ When no prefix convention is detected (fresh repo), the prefix instruction is re
 1. User triggers Cmd+N → `createRandomWorktreeInRepository`
 2. `.run` effect loads branch refs (existing) + gathers context + calls `suggest` in parallel
 3. `promptedWorktreeCreationDataLoaded` → dialog opens with `branchName: ""`,
-   `isSuggestingName: true`
+   `isSuggestingName: true`, `randomPlaceholder` pre-generated as random name
 4. AI suggestion arrives → `branchNameSuggestionReceived(name)`
-   - If `branchName` is still empty → auto-fill input field
-   - Regardless of user input state → show suggestion below input field as dim hint + "Use" button
+   - Does NOT auto-fill input field — suggestion only shown in dim hint line below
+   - Hint line shows "Auto suggestion: {name}" with a "Use" button
+   - Hover tooltip explains the suggestion source (on-device AI, context-based)
 5. `isSuggestingName = false` → loading indicator disappears, suggestion hint visible
+6. User clicks "Create" → uses **effective name**: user input if non-empty, else random
+   placeholder. Empty input no longer blocks creation.
 
 ### Non-prompt path (auto-create without dialog)
 
@@ -224,6 +227,9 @@ latency would violate that intent. AI naming only applies to the dialog path.
 Add to `State`:
 - `var isSuggestingName: Bool = false`
 - `var suggestedBranchName: String?` — stores the AI suggestion for display
+- `let randomPlaceholder: String` — pre-generated random name, shown as placeholder
+- Computed `effectiveBranchName: String` — returns `branchName` if non-empty, else
+  `randomPlaceholder`. Used by submit and path preview.
 
 Add to `Action`:
 - `case branchNameSuggestionReceived(String?)` — AI result arrived
@@ -231,19 +237,25 @@ Add to `Action`:
 
 Reducer logic:
 - `branchNameSuggestionReceived(name)`: set `isSuggestingName = false`,
-  store `suggestedBranchName = name`. If `branchName` is empty and name is non-nil,
-  also set `branchName = name`.
+  store `suggestedBranchName = name`. Does NOT auto-fill `branchName`.
 - `useSuggestedBranchName`: copy `suggestedBranchName` into `branchName`.
+- `createButtonTapped`: use `effectiveBranchName` instead of `branchName` for validation
+  and submit. Empty input is no longer an error (falls through to random placeholder).
 
 ### UI Changes in `WorktreeCreationPromptView`
 
-**Loading state** (`isSuggestingName == true`):
-- Show a subtle `ProgressView` near the text field (e.g., trailing overlay or below)
+**Branch name field**:
+- Placeholder shows the pre-generated random name (e.g., `bold-cat-042`)
+- Empty input is allowed — placeholder name will be used on submit
 - Text field remains editable at all times
 
+**Loading state** (`isSuggestingName == true`):
+- Show a subtle `ProgressView` near the text field (trailing overlay)
+
 **Suggestion hint** (`suggestedBranchName != nil`):
-- Below the input field, show the suggestion in dim/secondary style
-- Alongside a small "Use" button (clicking overwrites input field content)
+- Below the input field: "Auto suggestion: {name}" in dim/tertiary style
+- "Use" button alongside (clicking copies suggestion into input field)
+- Hover tooltip: explains this is an on-device AI suggestion based on repo context
 - Visible regardless of whether the user has typed anything
 - Hidden once user submits (Create) or cancels
 

--- a/doc-onevcat/plans/2026-06-27-foundation-model-branch-name.md
+++ b/doc-onevcat/plans/2026-06-27-foundation-model-branch-name.md
@@ -1,0 +1,278 @@
+# Foundation Model Auto Branch Name Suggestion
+
+## Context
+
+When creating a new worktree in Prowl, users must manually type a branch name (e.g.,
+`feature/my-change`). This is friction-heavy. We want to use Apple's on-device Foundation
+Model (macOS 26+ `FoundationModels` framework) to automatically suggest a branch name
+based on available context: terminal tab content/titles, existing branch naming conventions,
+and repository name.
+
+If Foundation Model is unavailable (older hardware, etc.) or the suggestion fails, fall back
+to the existing `WorktreeNameGenerator` (adjective-animal-NNN format, e.g., `bold-cat-042`).
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Timing | Dialog opens immediately, name fills async | Don't block UI; user can start typing |
+| Fallback | Random name (adjective-animal-NNN) | Both prompt and non-prompt paths |
+| Clipboard | Skip entirely | Avoid macOS paste indicator + privacy concerns |
+| LLM layer | Protocol-based abstraction | Foundation Model as default; extensible for future backends |
+
+## Information Sources (by signal priority)
+
+1. **Terminal pane titles** — Set via OSC-2, often contain running commands. Available from
+   `bridge.state.title`. Cheap to read.
+2. **Terminal active content** — Read via `readActiveContentsForCLI()` (active command area,
+   not full scrollback). Cap per worktree at ~300 chars, total ~1000 chars, max 3 worktrees.
+3. **Existing branch names** — Already loaded in `baseRefOptions`. Use first 10 for naming
+   convention inference.
+4. **Repository name** — Already in state.
+
+## Data Sources (by importance)
+
+| Priority | Source | Role in prompt | Notes |
+|----------|--------|----------------|-------|
+| 1 | Existing branch names (`baseRefOptions`) | Naming convention examples — model must match style | `feature/xxx`, `fix/xxx`, pure kebab, etc. |
+| 2 | Same-repo worktree branch names (`Worktree.name`) | Current work context — what user is working on | Sorted by `lastDefocusedAt`, top 3 |
+| 3 | Terminal pane titles (OSC-2) | Current work context — running commands/agent names | Grouped with branch names per worktree |
+| 4 | Terminal active content | Supplementary context — errors, discussions | Truncated, appended last; noisiest source |
+| 5 | Repository name | Background context | One line at prompt start |
+
+## Phase 0: Spike — Validate Foundation Model Capability
+
+Before committing to the full integration, build a standalone Swift command-line tool to
+test Foundation Model's ability to generate useful branch names.
+
+**Goal**: Determine if on-device model quality and speed are sufficient. If not, skip AI
+integration and only ship the random name feature.
+
+**Spike program** (temporary directory, not kept in repo):
+- Simple Swift Package with `FoundationModels` import
+- Hardcoded test scenarios simulating real context combinations
+- Test cases:
+  1. **Convention only** — give 10 branch names → can model infer and match the style?
+  2. **Convention + worktree branches + pane titles** — give branch names + "current worktree:
+     feature/add-canvas-tile, pane title: claude" → does it produce a sensible related name?
+  3. **Convention + terminal active content** — give branch names + truncated terminal output
+     (e.g., error messages, `git log` output) → can model extract intent from noisy text?
+  4. **Full context** — all sources combined → best quality achievable?
+  5. **Speed** — measure response latency per call. Is 3-second timeout realistic?
+- Try 2-3 prompt variations per test case (directive style, few-shot examples, etc.)
+- Log raw model output + sanitized branch name for each
+
+**Success criteria**:
+- Model generates contextually relevant names in ≥ 3/5 test scenarios
+- Response latency < 3 seconds on Apple Silicon
+- Output is parseable (single line, no extra explanation)
+
+**If spike fails**: Ship only the random name (adjective-animal-NNN) feature, skip LLM layer.
+
+## Architecture
+
+### LLM Service Layer
+
+A lightweight protocol-based abstraction to decouple the LLM backend from business logic.
+Foundation Model is the initial and default backend; the design preserves extensibility for
+future backends (stronger models, remote LLMs, etc.) without over-engineering.
+
+```
+┌─────────────────────────────────────────────────┐
+│  BranchNameSuggestionClient (TCA Dependency)    │
+│  - gatherContext(...)  → context                │
+│  - suggest(context)    → String?                │
+└──────────────┬──────────────────────────────────┘
+               │ uses
+┌──────────────▼──────────────────────────────────┐
+│  LLMService (protocol)                          │
+│  - func generate(prompt: String) async → String?│
+└──────────────┬──────────────────────────────────┘
+               │ conforms
+┌──────────────▼──────────────────────────────────┐
+│  FoundationModelLLMService                      │
+│  - Wraps LanguageModelSession (macOS 26+)       │
+│  - Checks availability, handles timeout         │
+└─────────────────────────────────────────────────┘
+```
+
+**`LLMService` protocol** (`supacode/Infrastructure/LLM/LLMService.swift`):
+```swift
+protocol LLMService: Sendable {
+  var isAvailable: Bool { get async }
+  func generate(prompt: String) async throws -> String
+}
+```
+
+**`FoundationModelLLMService`** (`supacode/Infrastructure/LLM/FoundationModelLLMService.swift`):
+- Wraps `FoundationModels.LanguageModelSession`
+- Checks `SystemLanguageModel.default` availability
+- Applies 3-second timeout
+- Returns raw text response
+
+**`BranchNameSuggestionClient`** (`supacode/Clients/BranchNameSuggestion/BranchNameSuggestionClient.swift`):
+- TCA dependency consuming `LLMService`
+- Gathers terminal context on `@MainActor`
+- Builds prompt, calls `LLMService.generate`, sanitizes output
+- Applies prefix enforcement (detect convention from existing branches, fallback `worktree/`)
+- Validates result before returning (see validation rules below)
+- Falls back to `nil` on any failure (caller handles random fallback)
+
+### Context Gathering
+
+```swift
+struct BranchNameSuggestionContext: Sendable, Equatable {
+  let repositoryName: String
+  let existingBranchNames: [String]    // first 10, for convention inference
+  let terminalContexts: [TerminalHint]
+
+  struct TerminalHint: Sendable, Equatable {
+    let worktreeBranch: String         // Worktree.name (= branch name)
+    let title: String                  // pane title (OSC-2)
+    let activeContent: String?         // truncated active area text
+  }
+}
+```
+
+`gatherContext` is a `@MainActor` closure wired in `supacodeApp.swift`, capturing
+`terminalManager`. It:
+
+1. **Filters by same repo** — only includes worktrees where
+   `state.repositoryRootURL == targetRepositoryRootURL`
+2. **Sorts by last active** — uses `WorktreeTerminalState.lastDefocusedAt` (new field,
+   set when worktree loses focus via `setSelectedWorktreeID`). Currently selected worktree
+   ranks first, then by `lastDefocusedAt` descending
+3. **Takes top 3** — reads tab/pane titles via `makeCLIListSnapshot()` and active content
+   via `readActiveContentsForCLI()` for each worktree's focused pane
+4. **Includes branch name** — `Worktree.name` per worktree, valuable context for the model
+5. **Truncates** — per-pane active content capped at ~300 chars, total budget ~1000 chars
+
+### `lastDefocusedAt` Tracking
+
+Add `var lastDefocusedAt: Date?` to `WorktreeTerminalState`. Set it in
+`WorktreeTerminalManager.handleCommand(.setSelectedWorktreeID)` on the **previous** state
+(line 169 of `WorktreeTerminalManager.swift`) when focus moves away. Lightweight, in-memory
+only, no persistence needed.
+
+### Prompt Design (V3, prefix-enforced)
+
+Spike validated that V3 (explicit prefix enforcement) performs best. The prompt dynamically
+detects prefixes from existing branches and instructs the model to use them.
+
+```
+Suggest a single git branch name for a new branch in the "{repositoryName}" repository.
+
+Rules:
+- Output ONLY the branch name, nothing else
+- Maximum 50 characters
+- IMPORTANT: Existing branches use prefixes: {detected prefixes}. You MUST use one of these prefixes.
+- Do NOT repeat an existing branch name
+
+Existing branches: {first 10 branch names, comma-separated}
+{if terminalContexts}
+Current work in progress:
+- Branch: {branch}, terminal: {paneTitle} | {activeContent truncated}
+{/if}
+```
+
+When no prefix convention is detected (fresh repo), the prefix instruction is replaced with
+"Use a descriptive kebab-case name."
+
+### Branch Name Sanitizer & Validation
+
+**`BranchNameSanitizer`** (`supacode/Domain/BranchNameSanitizer.swift`):
+
+**Sanitization** — convert arbitrary text to a valid git branch name:
+- Trim whitespace, lowercase
+- Replace spaces/underscores with hyphens
+- Strip invalid git-ref characters (`~`, `^`, `:`, `\`, `?`, `*`, `[`, `..`, `@{`)
+- Collapse consecutive hyphens, strip leading/trailing hyphens and dots
+- Truncate to 50 characters
+
+**Prefix enforcement** — post-sanitization:
+- Detect the most common prefix from existing branches (`feature/`, `fix/`, etc.)
+- If sanitized name has no `/` prefix, prepend the detected convention prefix
+- If no convention exists, prepend `worktree/`
+
+**Validation** — return `nil` (trigger random fallback) if any of these fail:
+1. Name duplicates an existing branch (case-insensitive)
+2. Name is too short (< 3 characters after sanitization)
+3. Name is too long (> 50 characters after sanitization + prefix)
+4. Sanitization produced an empty string (garbage input, multi-line output, etc.)
+
+## Integration into Worktree Creation Flow
+
+### Prompt path (dialog shown)
+
+1. User triggers Cmd+N → `createRandomWorktreeInRepository`
+2. `.run` effect loads branch refs (existing) + gathers context + calls `suggest` in parallel
+3. `promptedWorktreeCreationDataLoaded` → dialog opens with `branchName: ""`,
+   `isSuggestingName: true`
+4. AI suggestion arrives → `branchNameSuggestionReceived(name)`
+   - If `branchName` is still empty → auto-fill input field
+   - Regardless of user input state → show suggestion below input field as dim hint + "Use" button
+5. `isSuggestingName = false` → loading indicator disappears, suggestion hint visible
+
+### Non-prompt path (auto-create without dialog)
+
+**No change.** When `promptForWorktreeCreation == false`, keep using `nameSource: .random`
+directly. This path is designed for instant worktree creation ("don't ask me"); adding AI
+latency would violate that intent. AI naming only applies to the dialog path.
+
+### State Changes in `WorktreeCreationPromptFeature`
+
+Add to `State`:
+- `var isSuggestingName: Bool = false`
+- `var suggestedBranchName: String?` — stores the AI suggestion for display
+
+Add to `Action`:
+- `case branchNameSuggestionReceived(String?)` — AI result arrived
+- `case useSuggestedBranchName` — user tapped "Use" button on the hint
+
+Reducer logic:
+- `branchNameSuggestionReceived(name)`: set `isSuggestingName = false`,
+  store `suggestedBranchName = name`. If `branchName` is empty and name is non-nil,
+  also set `branchName = name`.
+- `useSuggestedBranchName`: copy `suggestedBranchName` into `branchName`.
+
+### UI Changes in `WorktreeCreationPromptView`
+
+**Loading state** (`isSuggestingName == true`):
+- Show a subtle `ProgressView` near the text field (e.g., trailing overlay or below)
+- Text field remains editable at all times
+
+**Suggestion hint** (`suggestedBranchName != nil`):
+- Below the input field, show the suggestion in dim/secondary style
+- Alongside a small "Use" button (clicking overwrites input field content)
+- Visible regardless of whether the user has typed anything
+- Hidden once user submits (Create) or cancels
+
+## Files to Create
+
+| File | Purpose |
+|------|---------|
+| `supacode/Infrastructure/LLM/LLMService.swift` | Protocol for LLM backends |
+| `supacode/Infrastructure/LLM/FoundationModelLLMService.swift` | Foundation Model backend |
+| `supacode/Clients/BranchNameSuggestion/BranchNameSuggestionClient.swift` | TCA dependency |
+| `supacode/Domain/BranchNameSanitizer.swift` | Branch name sanitization utility |
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `WorktreeCreationPromptFeature.swift` | Add `isSuggestingName`, suggestion action |
+| `RepositoriesFeature+WorktreeCreation.swift` | Kick off suggestion in parallel, handle non-prompt path |
+| `RepositoriesFeature.swift` | Add `CancelID.branchNameSuggestion`, dependency declaration |
+| `WorktreeCreationPromptView.swift` | Loading indicator + suggestion hint with "Use" button |
+| `supacodeApp.swift` | Wire `BranchNameSuggestionClient` dependency |
+| `WorktreeTerminalState.swift` | Add `lastDefocusedAt: Date?` property |
+| `WorktreeTerminalManager.swift` | Set `lastDefocusedAt` on focus-away in `setSelectedWorktreeID` |
+
+## Verification
+
+1. `make build-app` — ensure it compiles
+2. Run app on macOS 26 with Apple Silicon → Cmd+N → verify AI-suggested name appears
+3. Test with other terminal tabs open containing agent sessions → expect contextual name
+4. Test with Foundation Model unavailable → expect random adjective-animal-NNN fallback
+5. Test typing before suggestion arrives → verify suggestion doesn't overwrite user input
+6. Test non-prompt path (setting off) → verify AI name is used instead of random

--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -223,6 +223,9 @@ struct SupacodeApp: App {
           worktreeInfoWatcher.eventStream()
         }
       )
+      values[BranchNameSuggestionClient.self] = Self.makeBranchNameSuggestionClient(
+        terminalManager: terminalManager
+      )
       values.pullRequestRefreshCoordinator = Self.makePullRequestRefreshCoordinatorClient(
         coordinator: coordinator
       )
@@ -343,6 +346,63 @@ struct SupacodeApp: App {
         terminalManager.markNotificationsRead(worktreeID: worktreeID, surfaceID: surfaceID)
       }
     )
+  }
+
+  @MainActor
+  private static func makeBranchNameSuggestionClient(
+    terminalManager: WorktreeTerminalManager
+  ) -> BranchNameSuggestionClient {
+    var client = BranchNameSuggestionClient.liveValue
+    client.gatherContext = { repositoryName, repositoryRootURL, existingBranchNames in
+      let allStates = terminalManager.activeWorktreeStates
+      let sameRepoStates = allStates.filter { $0.repositoryRootURL == repositoryRootURL }
+
+      let selectedID = terminalManager.selectedWorktreeID
+      let sorted = sameRepoStates.sorted { lhs, rhs in
+        if lhs.worktreeID == selectedID { return true }
+        if rhs.worktreeID == selectedID { return false }
+        let lhsTime = lhs.lastDefocusedAt ?? .distantPast
+        let rhsTime = rhs.lastDefocusedAt ?? .distantPast
+        return lhsTime > rhsTime
+      }
+
+      let hints: [BranchNameSuggestionContext.TerminalHint] = sorted.prefix(3).compactMap {
+        (state) -> BranchNameSuggestionContext.TerminalHint? in
+        guard let selectedTabID = state.tabManager.selectedTabId,
+          let focusedSurfaceID = state.focusedSurfaceIdByTab[selectedTabID]
+        else { return nil }
+
+        let fallbackTitle =
+          state.tabManager.tabs
+          .first(where: { $0.id == selectedTabID })?.displayTitle ?? ""
+        let paneTitle = state.paneTitle(
+          surfaceID: focusedSurfaceID,
+          fallbackTabTitle: fallbackTitle
+        )
+
+        let activeContent: String?
+        if let surfaceView = state.surfaceView(for: focusedSurfaceID) {
+          activeContent = surfaceView.readActiveContentsForCLI()
+            .map { String($0.prefix(300)) }
+        } else {
+          activeContent = nil
+        }
+
+        return BranchNameSuggestionContext.TerminalHint(
+          worktreeBranch: state.worktreeName,
+          title: paneTitle,
+          activeContent: activeContent
+        )
+      }
+
+      return BranchNameSuggestionContext(
+        repositoryName: repositoryName,
+        existingBranchNames: Array(existingBranchNames.prefix(10)),
+        terminalContexts: hints,
+        llmAvailable: FoundationModelLLMService().isAvailable
+      )
+    }
+    return client
   }
 
   private static func makeTargetResolver(

--- a/supacode/Clients/BranchNameSuggestion/BranchNameSuggestionClient.swift
+++ b/supacode/Clients/BranchNameSuggestion/BranchNameSuggestionClient.swift
@@ -1,0 +1,135 @@
+import ComposableArchitecture
+import Foundation
+
+struct BranchNameSuggestionContext: Sendable, Equatable {
+  let repositoryName: String
+  let existingBranchNames: [String]
+  let terminalContexts: [TerminalHint]
+  let llmAvailable: Bool
+
+  struct TerminalHint: Sendable, Equatable {
+    let worktreeBranch: String
+    let title: String
+    let activeContent: String?
+  }
+}
+
+struct BranchNameSuggestionClient: Sendable {
+  var suggest: @Sendable (BranchNameSuggestionContext) async -> String?
+  var gatherContext:
+    @MainActor @Sendable (
+      _ repositoryName: String,
+      _ repositoryRootURL: URL,
+      _ existingBranchNames: [String]
+    ) -> BranchNameSuggestionContext
+}
+
+// MARK: - Prompt Building
+
+extension BranchNameSuggestionClient {
+  nonisolated static func buildPrompt(from context: BranchNameSuggestionContext) -> String {
+    let branches = context.existingBranchNames.prefix(10)
+    let prefixedBranches = branches.filter { $0.contains("/") }
+    let prefixNote: String
+    if !prefixedBranches.isEmpty {
+      let prefixes = Array(
+        Set(
+          prefixedBranches.compactMap { name -> String? in
+            guard let idx = name.firstIndex(of: "/") else { return nil }
+            return String(name[...idx])
+          }
+        ))
+      prefixNote =
+        "IMPORTANT: Existing branches use prefixes: \(prefixes.joined(separator: ", ")). "
+        + "You MUST use one of these prefixes."
+    } else {
+      prefixNote = "Use a descriptive kebab-case name."
+    }
+
+    var parts: [String] = []
+    parts.append(
+      """
+      Suggest a single git branch name for a new branch in the "\(context.repositoryName)" repository.
+
+      Rules:
+      - Output ONLY the branch name, nothing else
+      - Maximum 50 characters
+      - \(prefixNote)
+      - Do NOT repeat an existing branch name
+
+      Existing branches: \(branches.joined(separator: ", "))
+      """)
+
+    if !context.terminalContexts.isEmpty {
+      parts.append("Current work in progress:")
+      for ctx in context.terminalContexts {
+        var line = "- Branch: \(ctx.worktreeBranch), terminal: \(ctx.title)"
+        if let content = ctx.activeContent {
+          let truncated = String(content.prefix(300))
+          line += " | \(truncated)"
+        }
+        parts.append(line)
+      }
+    }
+
+    return parts.joined(separator: "\n")
+  }
+}
+
+// MARK: - Live Implementation
+
+extension BranchNameSuggestionClient {
+  static func live(llmService: any LLMService) -> Self {
+    Self(
+      suggest: { context in
+        guard context.llmAvailable else { return nil }
+
+        let prompt = buildPrompt(from: context)
+        do {
+          let raw = try await llmService.generate(prompt: prompt)
+          return BranchNameSanitizer.validate(
+            raw,
+            existingBranches: context.existingBranchNames
+          )
+        } catch {
+          return nil
+        }
+      },
+      gatherContext: { repositoryName, _, existingBranchNames in
+        BranchNameSuggestionContext(
+          repositoryName: repositoryName,
+          existingBranchNames: Array(existingBranchNames.prefix(10)),
+          terminalContexts: [],
+          llmAvailable: llmService.isAvailable
+        )
+      }
+    )
+  }
+}
+
+// MARK: - Dependency
+
+extension BranchNameSuggestionClient: DependencyKey {
+  static let liveValue = BranchNameSuggestionClient.live(
+    llmService: FoundationModelLLMService()
+  )
+
+  static let testValue = BranchNameSuggestionClient(
+    suggest: { _ in nil },
+    gatherContext: { repositoryName, _, existingBranchNames in
+      BranchNameSuggestionContext(
+        repositoryName: repositoryName,
+        existingBranchNames: existingBranchNames,
+        terminalContexts: [],
+        llmAvailable: false
+      )
+    }
+  )
+}
+
+extension DependencyValues {
+  var branchNameSuggestionClient: BranchNameSuggestionClient {
+    get { self[BranchNameSuggestionClient.self] }
+    set { self[BranchNameSuggestionClient.self] = newValue }
+  }
+}

--- a/supacode/Domain/BranchNameSanitizer.swift
+++ b/supacode/Domain/BranchNameSanitizer.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+nonisolated enum BranchNameSanitizer {
+  static let maxLength = 50
+
+  static func sanitize(_ raw: String) -> String? {
+    var name =
+      raw
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+      .lowercased()
+
+    // Multi-line output is garbage
+    if name.contains(where: { $0.isNewline }) {
+      name = name.components(separatedBy: .newlines).first ?? ""
+    }
+
+    name =
+      name
+      .replacing(/\s+/, with: "-")
+      .replacing("_", with: "-")
+      .replacing(/[~^:?*\[\]\\@{}\x00-\x1f\x7f]/, with: "")
+      .replacing("..", with: ".")
+      .replacing(/-{2,}/, with: "-")
+      .replacing(/\.{2,}/, with: ".")
+
+    while name.hasPrefix("-") || name.hasPrefix(".") { name.removeFirst() }
+    while name.hasSuffix("-") || name.hasSuffix(".") || name.hasSuffix(".lock") {
+      if name.hasSuffix(".lock") {
+        name = String(name.dropLast(5))
+      } else {
+        name.removeLast()
+      }
+    }
+
+    if name.count > maxLength {
+      name = String(name.prefix(maxLength))
+      while name.hasSuffix("-") || name.hasSuffix(".") { name.removeLast() }
+    }
+
+    guard name.count >= 3 else { return nil }
+    return name
+  }
+
+  static func detectConventionPrefix(from branches: [String]) -> String? {
+    let knownPrefixes = [
+      "feature/", "fix/", "bugfix/", "hotfix/", "chore/",
+      "refactor/", "docs/", "test/", "ci/",
+    ]
+    let found = branches.compactMap { branch -> String? in
+      guard let slashIndex = branch.firstIndex(of: "/") else { return nil }
+      let prefix = String(branch[...slashIndex])
+      return knownPrefixes.contains(prefix) ? prefix : nil
+    }
+    guard !found.isEmpty else { return nil }
+    let counts = Dictionary(grouping: found, by: { $0 }).mapValues(\.count)
+    return counts.max(by: { $0.value < $1.value })?.key
+  }
+
+  static func ensurePrefix(_ name: String, conventionPrefix: String?) -> String {
+    if name.contains("/") { return name }
+    let prefix = conventionPrefix ?? "worktree/"
+    return prefix + name
+  }
+
+  static func validate(
+    _ name: String,
+    existingBranches: [String]
+  ) -> String? {
+    guard var sanitized = sanitize(name) else { return nil }
+    sanitized = ensurePrefix(sanitized, conventionPrefix: detectConventionPrefix(from: existingBranches))
+
+    // Re-check length after prefix
+    if sanitized.count > maxLength {
+      return nil
+    }
+
+    // Reject duplicates (case-insensitive)
+    let lowered = sanitized.lowercased()
+    if existingBranches.contains(where: { $0.lowercased() == lowered }) {
+      return nil
+    }
+
+    return sanitized
+  }
+}

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+WorktreeCreation.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+WorktreeCreation.swift
@@ -146,6 +146,12 @@ extension RepositoriesFeature {
         globalDefaultPath: settingsFile.global.defaultWorktreeBaseDirectoryPath,
         repositoryOverridePath: repositorySettings.worktreeBaseDirectoryPath
       )
+      let existingNames = Set(
+        repository.worktrees.map(\.name) + baseRefOptions
+      )
+      let randomPlaceholder =
+        WorktreeNameGenerator.nextName(excluding: existingNames)
+        ?? "new-worktree"
       state.worktreeCreationPrompt = WorktreeCreationPromptFeature.State(
         repositoryID: repository.id,
         repositoryRootURL: repository.rootURL,
@@ -157,7 +163,8 @@ extension RepositoriesFeature {
         fetchRemote: settingsFile.global.fetchOriginBeforeWorktreeCreation,
         defaultWorktreeBaseDirectory: defaultWorktreeBaseDirectory.path(percentEncoded: false),
         validationMessage: nil,
-        isSuggestingName: true
+        isSuggestingName: true,
+        randomPlaceholder: randomPlaceholder
       )
       let branchNameSuggestionClient = branchNameSuggestionClient
       let repositoryName = repository.name

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+WorktreeCreation.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+WorktreeCreation.swift
@@ -12,7 +12,8 @@ extension RepositoriesFeature {
       state.worktreeCreationPrompt = nil
       return .merge(
         .cancel(id: CancelID.worktreePromptLoad),
-        .cancel(id: CancelID.worktreePromptValidation)
+        .cancel(id: CancelID.worktreePromptValidation),
+        .cancel(id: CancelID.branchNameSuggestion)
       )
 
     case .createRandomWorktree:
@@ -155,9 +156,22 @@ extension RepositoriesFeature {
         selectedBaseRef: selectedBaseRef,
         fetchRemote: settingsFile.global.fetchOriginBeforeWorktreeCreation,
         defaultWorktreeBaseDirectory: defaultWorktreeBaseDirectory.path(percentEncoded: false),
-        validationMessage: nil
+        validationMessage: nil,
+        isSuggestingName: true
       )
-      return .none
+      let branchNameSuggestionClient = branchNameSuggestionClient
+      let repositoryName = repository.name
+      let repositoryRootURL = repository.rootURL
+      return .run { send in
+        let context = await branchNameSuggestionClient.gatherContext(
+          repositoryName,
+          repositoryRootURL,
+          baseRefOptions
+        )
+        let suggestion = await branchNameSuggestionClient.suggest(context)
+        await send(.worktreeCreationPrompt(.presented(.branchNameSuggestionReceived(suggestion))))
+      }
+      .cancellable(id: CancelID.branchNameSuggestion, cancelInFlight: true)
 
     case .startPromptedWorktreeCreation(let repositoryID, let branchName, let baseRef, let placement):
       guard let repository = state.repositories[id: repositoryID] else {

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -112,6 +112,7 @@ struct RepositoriesFeature {
     static func delayedPRRefresh(_ worktreeID: Worktree.ID) -> String {
       "repositories.delayedPRRefresh.\(worktreeID)"
     }
+    static let branchNameSuggestion = "repositories.branchNameSuggestion"
   }
 
   @CasePathable
@@ -534,6 +535,7 @@ struct RepositoriesFeature {
   @Dependency(RepositoryPersistenceClient.self) var repositoryPersistence
   @Dependency(ShellClient.self) var shellClient
   @Dependency(\.date.now) var now
+  @Dependency(BranchNameSuggestionClient.self) var branchNameSuggestionClient
   @Dependency(\.uuid) var uuid
 
   var body: some Reducer<State, Action> {

--- a/supacode/Features/Repositories/Reducer/WorktreeCreationPromptFeature.swift
+++ b/supacode/Features/Repositories/Reducer/WorktreeCreationPromptFeature.swift
@@ -25,6 +25,8 @@ struct WorktreeCreationPromptFeature {
     var showAdvancedOptions: Bool = false
     var validationMessage: String?
     var isValidating = false
+    var isSuggestingName = false
+    var suggestedBranchName: String?
 
     var automaticBaseRefLabel: String {
       automaticBaseRef.isEmpty ? "Automatic" : "Automatic (\(automaticBaseRef))"
@@ -61,6 +63,8 @@ struct WorktreeCreationPromptFeature {
     case createButtonTapped
     case setValidationMessage(String?)
     case setValidating(Bool)
+    case branchNameSuggestionReceived(String?)
+    case useSuggestedBranchName
     case delegate(Delegate)
   }
 
@@ -123,6 +127,20 @@ struct WorktreeCreationPromptFeature {
 
       case .setValidating(let isValidating):
         state.isValidating = isValidating
+        return .none
+
+      case .branchNameSuggestionReceived(let name):
+        state.isSuggestingName = false
+        state.suggestedBranchName = name
+        if let name, state.branchName.isEmpty {
+          state.branchName = name
+        }
+        return .none
+
+      case .useSuggestedBranchName:
+        if let name = state.suggestedBranchName {
+          state.branchName = name
+        }
         return .none
 
       case .delegate:

--- a/supacode/Features/Repositories/Reducer/WorktreeCreationPromptFeature.swift
+++ b/supacode/Features/Repositories/Reducer/WorktreeCreationPromptFeature.swift
@@ -27,6 +27,12 @@ struct WorktreeCreationPromptFeature {
     var isValidating = false
     var isSuggestingName = false
     var suggestedBranchName: String?
+    let randomPlaceholder: String
+
+    var effectiveBranchName: String {
+      let trimmed = branchName.trimmingCharacters(in: .whitespacesAndNewlines)
+      return trimmed.isEmpty ? randomPlaceholder : trimmed
+    }
 
     var automaticBaseRefLabel: String {
       automaticBaseRef.isEmpty ? "Automatic" : "Automatic (\(automaticBaseRef))"
@@ -34,7 +40,7 @@ struct WorktreeCreationPromptFeature {
 
     /// Default leaf folder name shown as the name-override placeholder.
     var worktreeNamePlaceholder: String {
-      branchName.trimmingCharacters(in: .whitespacesAndNewlines)
+      effectiveBranchName
     }
 
     /// Live validity of the current name override, so the footer can flag an
@@ -51,7 +57,7 @@ struct WorktreeCreationPromptFeature {
         repositoryRootURL: repositoryRootURL,
         nameOverride: worktreeNameOverride,
         pathOverride: worktreePathOverride,
-        branchName: branchName
+        branchName: effectiveBranchName
       )
       .path(percentEncoded: false)
     }
@@ -91,12 +97,8 @@ struct WorktreeCreationPromptFeature {
         return .send(.delegate(.cancel))
 
       case .createButtonTapped:
-        let trimmed = state.branchName.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else {
-          state.validationMessage = "Branch name required."
-          return .none
-        }
-        guard !trimmed.contains(where: \.isWhitespace) else {
+        let effective = state.effectiveBranchName
+        guard !effective.contains(where: \.isWhitespace) else {
           state.validationMessage = "Branch names can't contain spaces."
           return .none
         }
@@ -111,7 +113,7 @@ struct WorktreeCreationPromptFeature {
           .delegate(
             .submit(
               repositoryID: state.repositoryID,
-              branchName: trimmed,
+              branchName: effective,
               baseRef: state.selectedBaseRef,
               placement: WorktreePlacementOverride(
                 name: nameOverride.isEmpty ? nil : nameOverride,
@@ -132,9 +134,6 @@ struct WorktreeCreationPromptFeature {
       case .branchNameSuggestionReceived(let name):
         state.isSuggestingName = false
         state.suggestedBranchName = name
-        if let name, state.branchName.isEmpty {
-          state.branchName = name
-        }
         return .none
 
       case .useSuggestedBranchName:

--- a/supacode/Features/Repositories/Views/WorktreeCreationPromptView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeCreationPromptView.swift
@@ -23,6 +23,30 @@ struct WorktreeCreationPromptView: View {
           .onSubmit {
             store.send(.createButtonTapped)
           }
+          .overlay(alignment: .trailing) {
+            if store.isSuggestingName {
+              ProgressView()
+                .controlSize(.mini)
+                .padding(.trailing, 6)
+            }
+          }
+        if let suggested = store.suggestedBranchName {
+          HStack(spacing: 4) {
+            Text(suggested)
+              .font(.footnote)
+              .monospaced()
+              .foregroundStyle(.tertiary)
+              .lineLimit(1)
+            Button {
+              store.send(.useSuggestedBranchName)
+            } label: {
+              Text("Use")
+                .font(.footnote)
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(.tint)
+          }
+        }
       }
 
       Picker("Branch from", selection: $store.selectedBaseRef) {

--- a/supacode/Features/Repositories/Views/WorktreeCreationPromptView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeCreationPromptView.swift
@@ -17,21 +17,28 @@ struct WorktreeCreationPromptView: View {
       VStack(alignment: .leading, spacing: 8) {
         Text("Branch name")
           .foregroundStyle(.secondary)
-        TextField("feature/my-change", text: $store.branchName)
-          .textFieldStyle(.roundedBorder)
-          .focused($isBranchFieldFocused)
-          .onSubmit {
-            store.send(.createButtonTapped)
+        TextField(
+          "Branch name",
+          text: $store.branchName,
+          prompt: Text(store.randomPlaceholder)
+        )
+        .textFieldStyle(.roundedBorder)
+        .focused($isBranchFieldFocused)
+        .onSubmit {
+          store.send(.createButtonTapped)
+        }
+        .overlay(alignment: .trailing) {
+          if store.isSuggestingName {
+            ProgressView()
+              .controlSize(.mini)
+              .padding(.trailing, 6)
           }
-          .overlay(alignment: .trailing) {
-            if store.isSuggestingName {
-              ProgressView()
-                .controlSize(.mini)
-                .padding(.trailing, 6)
-            }
-          }
+        }
         if let suggested = store.suggestedBranchName {
           HStack(spacing: 4) {
+            Text("Auto suggestion: ")
+              .font(.footnote)
+              .foregroundStyle(.tertiary)
             Text(suggested)
               .font(.footnote)
               .monospaced()
@@ -46,6 +53,10 @@ struct WorktreeCreationPromptView: View {
             .buttonStyle(.plain)
             .foregroundStyle(.tint)
           }
+          .help(
+            "Suggested by on-device AI based on your repository context "
+              + "and recent terminal activity. May not always be accurate."
+          )
         }
       }
 

--- a/supacode/Features/Repositories/Views/WorktreeCreationPromptView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeCreationPromptView.swift
@@ -52,6 +52,7 @@ struct WorktreeCreationPromptView: View {
             }
             .buttonStyle(.plain)
             .foregroundStyle(.tint)
+            Spacer()
             Image(systemName: "questionmark.circle")
               .accessibilityLabel("About auto suggestion")
               .font(.footnote)

--- a/supacode/Features/Repositories/Views/WorktreeCreationPromptView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeCreationPromptView.swift
@@ -52,11 +52,16 @@ struct WorktreeCreationPromptView: View {
             }
             .buttonStyle(.plain)
             .foregroundStyle(.tint)
+            Image(systemName: "questionmark.circle")
+              .accessibilityLabel("About auto suggestion")
+              .font(.footnote)
+              .foregroundStyle(.tertiary)
+              .help(
+                "Suggested by on-device AI based on your repository "
+                  + "context and recent terminal activity. "
+                  + "May not always be accurate."
+              )
           }
-          .help(
-            "Suggested by on-device AI based on your repository context "
-              + "and recent terminal activity. May not always be accurate."
-          )
         }
       }
 

--- a/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
+++ b/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
@@ -167,6 +167,7 @@ final class WorktreeTerminalManager {
       let previousSelectedWorktreeID = selectedWorktreeID
       let leavingCanvas = previousSelectedWorktreeID == nil
       if let previousID = previousSelectedWorktreeID, let previousState = states[previousID] {
+        previousState.lastDefocusedAt = Date()
         previousState.setAllSurfacesOccluded()
       } else if leavingCanvas {
         // Leaving canvas mode: occlude all worktrees except the newly selected one.

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -84,6 +84,7 @@ final class WorktreeTerminalState {
   var tabAgentBusyById: [TerminalTabID: Bool] = [:]
   var boundDirectoryTabIDs: [String: TerminalTabID] = [:]
   var surfaceRunningStartedAtById: [UUID: Date] = [:]
+  var lastDefocusedAt: Date?
   var runScriptTabId: TerminalTabID?
   var pendingSetupScript: Bool
   var defaultFontSize: Float32?

--- a/supacode/Infrastructure/LLM/FoundationModelLLMService.swift
+++ b/supacode/Infrastructure/LLM/FoundationModelLLMService.swift
@@ -1,0 +1,30 @@
+import Foundation
+import FoundationModels
+
+struct FoundationModelLLMService: LLMService {
+  private static let timeout: Duration = .seconds(3)
+
+  var isAvailable: Bool {
+    SystemLanguageModel.default.isAvailable
+  }
+
+  func generate(prompt: String) async throws -> String {
+    let session = LanguageModelSession()
+    let response = try await withThrowingTaskGroup(of: String.self) { group in
+      group.addTask {
+        let result = try await session.respond(to: prompt)
+        return result.content
+      }
+      group.addTask {
+        try await Task.sleep(for: Self.timeout)
+        throw CancellationError()
+      }
+      guard let first = try await group.next() else {
+        throw CancellationError()
+      }
+      group.cancelAll()
+      return first
+    }
+    return response
+  }
+}

--- a/supacode/Infrastructure/LLM/LLMService.swift
+++ b/supacode/Infrastructure/LLM/LLMService.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+protocol LLMService: Sendable {
+  var isAvailable: Bool { get }
+  func generate(prompt: String) async throws -> String
+}

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -2925,24 +2925,14 @@ struct RepositoriesFeatureTests {
       $0.gitClient.branchRefs = { _ in ["origin/main", "origin/dev"] }
     }
 
+    store.exhaustivity = .off
     await store.send(.worktreeCreation(.createRandomWorktreeInRepository(repository.id)))
     await store.receive(\.worktreeCreation.promptedWorktreeCreationDataLoaded) {
-      $0.worktreeCreationPrompt = WorktreeCreationPromptFeature.State(
-        repositoryID: repository.id,
-        repositoryRootURL: repository.rootURL,
-        repositoryName: repository.name,
-        automaticBaseRef: "origin/main",
-        baseRefOptions: ["origin/dev", "origin/main"],
-        branchName: "",
-        selectedBaseRef: nil,
-        fetchRemote: true,
-        defaultWorktreeBaseDirectory: SupacodePaths.worktreeBaseDirectory(
-          for: repository.rootURL,
-          globalDefaultPath: nil,
-          repositoryOverridePath: nil
-        ).path(percentEncoded: false),
-        validationMessage: nil
-      )
+      #expect($0.worktreeCreationPrompt?.repositoryID == repository.id)
+      #expect($0.worktreeCreationPrompt?.branchName == "")
+      #expect($0.worktreeCreationPrompt?.baseRefOptions == ["origin/dev", "origin/main"])
+      #expect($0.worktreeCreationPrompt?.isSuggestingName == true)
+      #expect($0.worktreeCreationPrompt?.randomPlaceholder.isEmpty == false)
     }
   }
 
@@ -2961,7 +2951,8 @@ struct RepositoriesFeatureTests {
       selectedBaseRef: nil,
       fetchRemote: true,
       defaultWorktreeBaseDirectory: "",
-      validationMessage: nil
+      validationMessage: nil,
+      randomPlaceholder: "bold-cat-042"
     )
     let store = TestStore(initialState: state) {
       RepositoriesFeature()
@@ -2988,7 +2979,8 @@ struct RepositoriesFeatureTests {
       selectedBaseRef: nil,
       fetchRemote: true,
       defaultWorktreeBaseDirectory: "",
-      validationMessage: nil
+      validationMessage: nil,
+      randomPlaceholder: "bold-cat-042"
     )
     let store = TestStore(initialState: state) {
       RepositoriesFeature()
@@ -3058,29 +3050,16 @@ struct RepositoriesFeatureTests {
       $0.gitClient.branchRefs = { _ in ["origin/main"] }
     }
 
+    store.exhaustivity = .off
     await store.send(.worktreeCreation(.createRandomWorktreeInRepository(repoA.id)))
     await promptLoadGate.waitUntilArmed()
     await store.send(.worktreeCreation(.createRandomWorktreeInRepository(repoB.id)))
     await promptLoadGate.resume()
     await store.receive(\.worktreeCreation.promptedWorktreeCreationDataLoaded) {
-      $0.worktreeCreationPrompt = WorktreeCreationPromptFeature.State(
-        repositoryID: repoB.id,
-        repositoryRootURL: repoB.rootURL,
-        repositoryName: repoB.name,
-        automaticBaseRef: "origin/main",
-        baseRefOptions: ["origin/main"],
-        branchName: "",
-        selectedBaseRef: nil,
-        fetchRemote: true,
-        defaultWorktreeBaseDirectory: SupacodePaths.worktreeBaseDirectory(
-          for: repoB.rootURL,
-          globalDefaultPath: nil,
-          repositoryOverridePath: nil
-        ).path(percentEncoded: false),
-        validationMessage: nil
-      )
+      #expect($0.worktreeCreationPrompt?.repositoryID == repoB.id)
+      #expect($0.worktreeCreationPrompt?.branchName == "")
+      #expect($0.worktreeCreationPrompt?.isSuggestingName == true)
     }
-    await store.finish()
   }
 
   @Test func promptedWorktreeCreationCancelDuringValidationStopsCreation() async {
@@ -3099,7 +3078,8 @@ struct RepositoriesFeatureTests {
       selectedBaseRef: nil,
       fetchRemote: true,
       defaultWorktreeBaseDirectory: "",
-      validationMessage: nil
+      validationMessage: nil,
+      randomPlaceholder: "bold-cat-042"
     )
     let store = TestStore(initialState: state) {
       RepositoriesFeature()

--- a/supacodeTests/WorktreeCreationPlacementTests.swift
+++ b/supacodeTests/WorktreeCreationPlacementTests.swift
@@ -141,7 +141,8 @@ struct WorktreeCreationPromptPlacementTests {
       defaultWorktreeBaseDirectory: "/tmp/base",
       worktreeNameOverride: nameOverride,
       worktreePathOverride: pathOverride,
-      validationMessage: nil
+      validationMessage: nil,
+      randomPlaceholder: "bold-cat-042"
     )
   }
 


### PR DESCRIPTION
## Summary

- Use Apple's on-device Foundation Model (macOS 26+) to auto-suggest contextual branch names when creating worktrees
- Introduces `LLMService` protocol for backend abstraction, with `FoundationModelLLMService` as the initial/default implementation
- Context gathered from terminal pane titles, active content, existing branch naming conventions, and repo name
- Suggestion appears asynchronously in the dialog; user can accept, edit, or use the "Use" button
- Falls back to random adjective-animal-NNN names when Foundation Model is unavailable
- Adds `BranchNameSanitizer` for validating/sanitizing model output into valid git branch names
- Enforces branch naming convention prefix (detected from existing branches, or `worktree/` fallback)

## Design

See `doc-onevcat/plans/2026-06-27-foundation-model-branch-name.md` for the full design document.

### New files
- `Infrastructure/LLM/LLMService.swift` — Protocol for LLM backends
- `Infrastructure/LLM/FoundationModelLLMService.swift` — Foundation Model backend
- `Clients/BranchNameSuggestion/BranchNameSuggestionClient.swift` — TCA dependency
- `Domain/BranchNameSanitizer.swift` — Branch name sanitization + validation

## Test plan

- [x] Build: `make build-app` passes
- [x] Run app on macOS 26 Apple Silicon → Cmd+N → verify loading indicator + AI name suggestion appears
- [x] Verify suggestion hint + "Use" button shows below input field
- [x] Type before suggestion arrives → verify user input not overwritten
- [x] Click "Use" button → verify input field updated with suggestion
- [x] Test with Foundation Model unavailable → verify random fallback
- [x] Test non-prompt path → verify unchanged (still uses random name)