### PR TITLE
Redesign Add to Prowl popover with clone support

### DIFF
--- a/docs/components/repositories-and-worktrees.md
+++ b/docs/components/repositories-and-worktrees.md
@@ -33,12 +33,15 @@ root; "not a git repository" → plain folder).
 
 - **Shortcut:** `⌘⇧O` (`open_repository`)
 - **Toolbar:** the **Add...** button (folder-with-plus icon) at the top of the
-  sidebar. Choose **Add Local Repository/Folder**.
+  sidebar. Use the popover to browse for a local folder, drag a folder onto the
+  drop zone, clone a remote git URL into a chosen directory, or start workspace
+  creation.
 - **Command Palette:** "Open Repository".
 
 Pick one or more directories. Prowl detects git vs plain, de-duplicates, and
 persists the list. Paths that don't exist or can't be read are reported in an
-alert after the load.
+alert after the load. Repositories added after the initial app load are selected
+automatically.
 
 ## Creating a worktree
 

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+RepositoryManagement.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+RepositoryManagement.swift
@@ -86,6 +86,8 @@ extension RepositoriesFeature {
       if failures.isEmpty, state.snapshotPersistencePhase != .active {
         state.snapshotPersistencePhase = .active
       }
+      let wasAlreadyLoaded = state.isInitialLoadComplete
+      let previousRepoIDs = Set(state.repositories.ids)
       let previousSelection = state.selectedWorktreeID
       let previousSelectedWorktree = state.worktree(for: previousSelection)
       let applyResult = applyRepositories(
@@ -161,6 +163,13 @@ extension RepositoriesFeature {
         allEffects.append(effect)
       }
       allEffects.append(refreshWorkspaceChildrenEffect(state: state))
+      if wasAlreadyLoaded, !wasRestoringSnapshot {
+        let newRepos = state.repositories.filter { !previousRepoIDs.contains($0.id) }
+        if let firstNew = newRepos.first {
+          let targetID = firstNew.worktrees.first?.id ?? firstNew.id
+          allEffects.append(.send(.selectWorktree(targetID, focusTerminal: true)))
+        }
+      }
       return .merge(allEffects)
 
     case .requestRemoveRepository(let repositoryID):

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+RepositoryManagement.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+RepositoryManagement.swift
@@ -166,8 +166,12 @@ extension RepositoriesFeature {
       if wasAlreadyLoaded, !wasRestoringSnapshot {
         let newRepos = state.repositories.filter { !previousRepoIDs.contains($0.id) }
         if let firstNew = newRepos.first {
-          let targetID = firstNew.worktrees.first?.id ?? firstNew.id
-          allEffects.append(.send(.selectWorktree(targetID, focusTerminal: true)))
+          if let worktreeID = firstNew.worktrees.first?.id {
+            allEffects.append(.send(.selectWorktree(worktreeID, focusTerminal: true)))
+          } else if firstNew.capabilities.supportsRunnableFolderActions {
+            state.pendingTerminalFocusWorktreeIDs.insert(firstNew.id)
+            allEffects.append(.send(.selectRepository(firstNew.id)))
+          }
         }
       }
       return .merge(allEffects)

--- a/supacode/Features/Repositories/Views/AddToProwlView.swift
+++ b/supacode/Features/Repositories/Views/AddToProwlView.swift
@@ -24,21 +24,21 @@ struct AddToProwlView: View {
 
   private var mainContent: some View {
     VStack(alignment: .leading, spacing: 0) {
-      HStack(spacing: 11) {
+      HStack(alignment: .center, spacing: 12) {
         Image(nsImage: NSApp.applicationIconImage)
           .resizable()
           .aspectRatio(contentMode: .fit)
-          .frame(width: 30, height: 30)
-        Text("Add to Prowl")
-          .font(.system(size: 16, weight: .semibold))
+          .frame(width: 38, height: 38)
+          .accessibilityHidden(true)
+        VStack(alignment: .leading, spacing: 2) {
+          Text("Add to Prowl")
+            .font(.system(size: 16, weight: .semibold))
+          Text("Bring a project in for an agent to work on.")
+            .font(.system(size: 12.5))
+            .foregroundStyle(.secondary)
+        }
       }
-      .padding(.bottom, 6)
-
-      Text("Bring a project in for an agent to work on.")
-        .font(.system(size: 12.5))
-        .foregroundStyle(.secondary)
-        .padding(.leading, 41)
-        .padding(.bottom, 18)
+      .padding(.bottom, 18)
 
       dropZone
 
@@ -68,6 +68,7 @@ struct AddToProwlView: View {
         .symbolRenderingMode(.hierarchical)
         .foregroundStyle(Color.accentColor)
         .frame(width: 52, height: 52)
+        .accessibilityHidden(true)
         .background(
           Color.accentColor.opacity(isDragTargeted ? 0.2 : 0.1),
           in: .rect(cornerRadius: 14)
@@ -142,6 +143,7 @@ struct AddToProwlView: View {
           .foregroundStyle(.secondary)
           .frame(width: 38, height: 38)
           .background(.quaternary, in: .rect(cornerRadius: 10))
+          .accessibilityHidden(true)
 
         VStack(alignment: .leading, spacing: 1) {
           Text("Add Workspace")
@@ -158,6 +160,7 @@ struct AddToProwlView: View {
           .font(.system(size: 12, weight: .semibold))
           .foregroundStyle(.tertiary)
           .offset(x: isWorkspaceHovered ? 2 : 0)
+          .accessibilityHidden(true)
       }
       .padding(.vertical, 13)
       .padding(.horizontal, 14)

--- a/supacode/Features/Repositories/Views/AddToProwlView.swift
+++ b/supacode/Features/Repositories/Views/AddToProwlView.swift
@@ -2,18 +2,18 @@ import AppKit
 import SwiftUI
 
 struct AddToProwlView: View {
+  let dismiss: () -> Void
   let onBrowse: () -> Void
   let onCloneCompleted: (URL) -> Void
   let onWorkspace: () -> Void
   let onDrop: ([URL]) -> Void
-  @Environment(\.dismiss) private var dismiss
   @State private var isDragTargeted = false
   @State private var isWorkspaceHovered = false
   @State private var showCloneForm = false
 
   var body: some View {
     if showCloneForm {
-      CloneRepositoryView { clonedURL in
+      CloneRepositoryView(dismiss: dismiss) { clonedURL in
         dismiss()
         onCloneCompleted(clonedURL)
       }

--- a/supacode/Features/Repositories/Views/AddToProwlView.swift
+++ b/supacode/Features/Repositories/Views/AddToProwlView.swift
@@ -3,13 +3,26 @@ import SwiftUI
 
 struct AddToProwlView: View {
   let onBrowse: () -> Void
+  let onCloneCompleted: (URL) -> Void
   let onWorkspace: () -> Void
   let onDrop: ([URL]) -> Void
   @Environment(\.dismiss) private var dismiss
   @State private var isDragTargeted = false
   @State private var isWorkspaceHovered = false
+  @State private var showCloneForm = false
 
   var body: some View {
+    if showCloneForm {
+      CloneRepositoryView { clonedURL in
+        dismiss()
+        onCloneCompleted(clonedURL)
+      }
+    } else {
+      mainContent
+    }
+  }
+
+  private var mainContent: some View {
     VStack(alignment: .leading, spacing: 0) {
       HStack(spacing: 11) {
         Image(nsImage: NSApp.applicationIconImage)
@@ -49,52 +62,52 @@ struct AddToProwlView: View {
   }
 
   private var dropZone: some View {
-    Button {
-      dismiss()
-      onBrowse()
-    } label: {
-      VStack(spacing: 2) {
-        Image(systemName: "folder.badge.plus")
-          .font(.system(size: 28))
-          .symbolRenderingMode(.hierarchical)
-          .foregroundStyle(Color.accentColor)
-          .frame(width: 52, height: 52)
-          .background(
-            Color.accentColor.opacity(isDragTargeted ? 0.2 : 0.1),
-            in: .rect(cornerRadius: 14)
-          )
-          .scaleEffect(isDragTargeted ? 1.06 : 1)
+    VStack(spacing: 2) {
+      Image(systemName: "folder.badge.plus")
+        .font(.system(size: 28))
+        .symbolRenderingMode(.hierarchical)
+        .foregroundStyle(Color.accentColor)
+        .frame(width: 52, height: 52)
+        .background(
+          Color.accentColor.opacity(isDragTargeted ? 0.2 : 0.1),
+          in: .rect(cornerRadius: 14)
+        )
+        .scaleEffect(isDragTargeted ? 1.06 : 1)
 
-        Text(isDragTargeted ? "Release to add" : "Drag a repo here")
-          .font(.system(size: 15, weight: .semibold))
-          .padding(.top, 10)
+      Text(isDragTargeted ? "Release to add" : "Drag a repo here")
+        .font(.system(size: 15, weight: .semibold))
+        .padding(.top, 10)
 
-        Text("a Git repository or any folder — opens one project root")
-          .font(.system(size: 12))
-          .foregroundStyle(.secondary)
+      Text("a Git repository or any folder — opens one project root")
+        .font(.system(size: 12))
+        .foregroundStyle(.secondary)
 
-        Text("Browse…")
-          .font(.system(size: 11, weight: .semibold))
-          .foregroundStyle(.white)
-          .padding(.vertical, 5)
-          .padding(.horizontal, 13)
-          .background(Color.accentColor, in: .rect(cornerRadius: 7))
-          .padding(.top, 14)
+      HStack(spacing: 8) {
+        Button("Browse…") {
+          dismiss()
+          onBrowse()
+        }
+        .buttonStyle(.borderedProminent)
+        .controlSize(.small)
+
+        Button("Clone…") {
+          showCloneForm = true
+        }
+        .controlSize(.small)
       }
-      .frame(maxWidth: .infinity)
-      .padding(.vertical, 26)
-      .padding(.horizontal, 20)
-      .background(.quaternary.opacity(0.3), in: .rect(cornerRadius: 15))
-      .overlay {
-        RoundedRectangle(cornerRadius: 15)
-          .strokeBorder(
-            isDragTargeted ? Color.accentColor : Color.secondary.opacity(0.3),
-            style: StrokeStyle(lineWidth: 1.5, dash: [6, 4])
-          )
-      }
-      .contentShape(.rect(cornerRadius: 15))
+      .padding(.top, 14)
     }
-    .buttonStyle(.plain)
+    .frame(maxWidth: .infinity)
+    .padding(.vertical, 26)
+    .padding(.horizontal, 20)
+    .background(.quaternary.opacity(0.3), in: .rect(cornerRadius: 15))
+    .overlay {
+      RoundedRectangle(cornerRadius: 15)
+        .strokeBorder(
+          isDragTargeted ? Color.accentColor : Color.secondary.opacity(0.3),
+          style: StrokeStyle(lineWidth: 1.5, dash: [6, 4])
+        )
+    }
     .dropDestination(for: URL.self) { urls, _ in
       let fileURLs = urls.filter(\.isFileURL)
       guard !fileURLs.isEmpty else { return false }

--- a/supacode/Features/Repositories/Views/AddToProwlView.swift
+++ b/supacode/Features/Repositories/Views/AddToProwlView.swift
@@ -14,7 +14,6 @@ struct AddToProwlView: View {
   var body: some View {
     if showCloneForm {
       CloneRepositoryView(dismiss: dismiss) { clonedURL in
-        dismiss()
         onCloneCompleted(clonedURL)
       }
     } else {

--- a/supacode/Features/Repositories/Views/AddToProwlView.swift
+++ b/supacode/Features/Repositories/Views/AddToProwlView.swift
@@ -1,0 +1,168 @@
+import AppKit
+import SwiftUI
+
+struct AddToProwlView: View {
+  let onBrowse: () -> Void
+  let onWorkspace: () -> Void
+  let onDrop: ([URL]) -> Void
+  @Environment(\.dismiss) private var dismiss
+  @State private var isDragTargeted = false
+  @State private var isWorkspaceHovered = false
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      HStack(spacing: 11) {
+        Image(nsImage: NSApp.applicationIconImage)
+          .resizable()
+          .aspectRatio(contentMode: .fit)
+          .frame(width: 30, height: 30)
+        Text("Add to Prowl")
+          .font(.system(size: 16, weight: .semibold))
+      }
+      .padding(.bottom, 6)
+
+      Text("Bring a project in for an agent to work on.")
+        .font(.system(size: 12.5))
+        .foregroundStyle(.secondary)
+        .padding(.leading, 41)
+        .padding(.bottom, 18)
+
+      dropZone
+
+      orDivider
+        .padding(.top, 16)
+        .padding(.bottom, 12)
+        .padding(.horizontal, 2)
+
+      workspaceRow
+
+      HStack {
+        Spacer()
+        Button("Cancel") {
+          dismiss()
+        }
+      }
+      .padding(.top, 16)
+    }
+    .padding(EdgeInsets(top: 26, leading: 26, bottom: 20, trailing: 26))
+    .frame(width: 400)
+  }
+
+  private var dropZone: some View {
+    Button {
+      dismiss()
+      onBrowse()
+    } label: {
+      VStack(spacing: 2) {
+        Image(systemName: "folder.badge.plus")
+          .font(.system(size: 28))
+          .symbolRenderingMode(.hierarchical)
+          .foregroundStyle(Color.accentColor)
+          .frame(width: 52, height: 52)
+          .background(
+            Color.accentColor.opacity(isDragTargeted ? 0.2 : 0.1),
+            in: .rect(cornerRadius: 14)
+          )
+          .scaleEffect(isDragTargeted ? 1.06 : 1)
+
+        Text(isDragTargeted ? "Release to add" : "Drag a repo here")
+          .font(.system(size: 15, weight: .semibold))
+          .padding(.top, 10)
+
+        Text("a Git repository or any folder — opens one project root")
+          .font(.system(size: 12))
+          .foregroundStyle(.secondary)
+
+        Text("Browse…")
+          .font(.system(size: 11, weight: .semibold))
+          .foregroundStyle(.white)
+          .padding(.vertical, 5)
+          .padding(.horizontal, 13)
+          .background(Color.accentColor, in: .rect(cornerRadius: 7))
+          .padding(.top, 14)
+      }
+      .frame(maxWidth: .infinity)
+      .padding(.vertical, 26)
+      .padding(.horizontal, 20)
+      .background(.quaternary.opacity(0.3), in: .rect(cornerRadius: 15))
+      .overlay {
+        RoundedRectangle(cornerRadius: 15)
+          .strokeBorder(
+            isDragTargeted ? Color.accentColor : Color.secondary.opacity(0.3),
+            style: StrokeStyle(lineWidth: 1.5, dash: [6, 4])
+          )
+      }
+      .contentShape(.rect(cornerRadius: 15))
+    }
+    .buttonStyle(.plain)
+    .dropDestination(for: URL.self) { urls, _ in
+      let fileURLs = urls.filter(\.isFileURL)
+      guard !fileURLs.isEmpty else { return false }
+      dismiss()
+      onDrop(fileURLs)
+      return true
+    } isTargeted: { targeted in
+      withAnimation(.easeOut(duration: 0.18)) {
+        isDragTargeted = targeted
+      }
+    }
+  }
+
+  private var orDivider: some View {
+    HStack(spacing: 12) {
+      Rectangle().fill(.separator).frame(height: 1)
+      Text("OR")
+        .font(.system(size: 10.5, weight: .semibold))
+        .foregroundStyle(.tertiary)
+      Rectangle().fill(.separator).frame(height: 1)
+    }
+  }
+
+  private var workspaceRow: some View {
+    Button {
+      dismiss()
+      onWorkspace()
+    } label: {
+      HStack(spacing: 13) {
+        Image(systemName: "rectangle.stack")
+          .font(.system(size: 18))
+          .foregroundStyle(.secondary)
+          .frame(width: 38, height: 38)
+          .background(.quaternary, in: .rect(cornerRadius: 10))
+
+        VStack(alignment: .leading, spacing: 1) {
+          Text("Add Workspace")
+            .font(.system(size: 13.5, weight: .semibold))
+          Text("A shared task folder spanning multiple repos for one agent.")
+            .font(.system(size: 11.5))
+            .foregroundStyle(.secondary)
+            .lineLimit(2)
+        }
+
+        Spacer()
+
+        Image(systemName: "chevron.right")
+          .font(.system(size: 12, weight: .semibold))
+          .foregroundStyle(.tertiary)
+          .offset(x: isWorkspaceHovered ? 2 : 0)
+      }
+      .padding(.vertical, 13)
+      .padding(.horizontal, 14)
+      .background(
+        .quaternary.opacity(isWorkspaceHovered ? 0.7 : 0.4),
+        in: .rect(cornerRadius: 13)
+      )
+      .overlay {
+        RoundedRectangle(cornerRadius: 13)
+          .strokeBorder(.separator, lineWidth: 0.5)
+      }
+      .contentShape(.rect(cornerRadius: 13))
+    }
+    .buttonStyle(.plain)
+    .onHover { hovering in
+      withAnimation(.easeOut(duration: 0.15)) {
+        isWorkspaceHovered = hovering
+      }
+    }
+  }
+}

--- a/supacode/Features/Repositories/Views/CloneRepositoryView.swift
+++ b/supacode/Features/Repositories/Views/CloneRepositoryView.swift
@@ -35,7 +35,9 @@ struct CloneRepositoryView: View {
               pickLocation()
             } label: {
               Image(systemName: "folder")
+                .accessibilityHidden(true)
             }
+            .accessibilityLabel("Choose clone destination")
             .help("Choose clone destination")
           }
         }

--- a/supacode/Features/Repositories/Views/CloneRepositoryView.swift
+++ b/supacode/Features/Repositories/Views/CloneRepositoryView.swift
@@ -1,0 +1,189 @@
+import AppKit
+import SwiftUI
+
+struct CloneRepositoryView: View {
+  @State private var urlString = ""
+  @State private var locationPath = Self.defaultClonePath
+  @State private var isCloning = false
+  @State private var errorMessage: String?
+  @Environment(\.dismiss) private var dismiss
+  let onCloned: (URL) -> Void
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 16) {
+      VStack(alignment: .leading, spacing: 4) {
+        Text("Clone")
+          .font(.system(size: 16, weight: .semibold))
+        Text("Clone a remote repository into a local directory")
+          .font(.system(size: 12.5))
+          .foregroundStyle(.secondary)
+      }
+
+      Grid(alignment: .leading, verticalSpacing: 12) {
+        GridRow {
+          Text("URL:")
+            .gridColumnAlignment(.trailing)
+          TextField("Git Repository URL", text: $urlString)
+            .textFieldStyle(.roundedBorder)
+        }
+        GridRow {
+          Text("Location:")
+          HStack(spacing: 6) {
+            TextField("Clone destination", text: $locationPath)
+              .textFieldStyle(.roundedBorder)
+            Button {
+              pickLocation()
+            } label: {
+              Image(systemName: "folder")
+            }
+            .help("Choose clone destination")
+          }
+        }
+      }
+
+      if let errorMessage {
+        Text(errorMessage)
+          .font(.caption)
+          .foregroundStyle(.red)
+          .textSelection(.enabled)
+      }
+
+      HStack {
+        Spacer()
+        Button("Cancel") {
+          dismiss()
+        }
+        .keyboardShortcut(.cancelAction)
+        Button("Clone") {
+          performClone()
+        }
+        .keyboardShortcut(.defaultAction)
+        .disabled(!isValidInput || isCloning)
+      }
+    }
+    .padding(24)
+    .frame(width: 460)
+    .onAppear { prefillFromClipboard() }
+    .opacity(isCloning ? 0 : 1)
+    .overlay {
+      if isCloning {
+        VStack(spacing: 8) {
+          ProgressView()
+          Text("Cloning…")
+            .font(.callout)
+            .foregroundStyle(.secondary)
+        }
+      }
+    }
+  }
+
+  private var isValidInput: Bool {
+    !urlString.trimmingCharacters(in: .whitespaces).isEmpty
+      && !locationPath.trimmingCharacters(in: .whitespaces).isEmpty
+  }
+
+  private func prefillFromClipboard() {
+    guard let content = NSPasteboard.general.string(forType: .string) else { return }
+    let trimmed = content.trimmingCharacters(in: .whitespacesAndNewlines)
+    if Self.isGitURL(trimmed) {
+      urlString = trimmed
+    }
+  }
+
+  private func pickLocation() {
+    let panel = NSOpenPanel()
+    panel.canChooseFiles = false
+    panel.canChooseDirectories = true
+    panel.allowsMultipleSelection = false
+    panel.canCreateDirectories = true
+    if panel.runModal() == .OK, let url = panel.url {
+      locationPath = url.path
+    }
+  }
+
+  private func performClone() {
+    let repoName = Self.extractRepoName(from: urlString)
+    let destination = URL(fileURLWithPath: locationPath).appendingPathComponent(repoName, isDirectory: true)
+    let url = urlString
+
+    isCloning = true
+    errorMessage = nil
+
+    Task {
+      let error = await Self.runGitClone(url: url, destination: destination)
+      isCloning = false
+      if let error {
+        errorMessage = error
+      } else {
+        dismiss()
+        onCloned(destination)
+      }
+    }
+  }
+
+  /// Returns `nil` on success, or an error message on failure.
+  static func runGitClone(url: String, destination: URL) async -> String? {
+    await withCheckedContinuation { continuation in
+      let process = Process()
+      process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+      process.arguments = ["clone", "--", url, destination.path]
+      let errorPipe = Pipe()
+      process.standardError = errorPipe
+      process.standardOutput = FileHandle.nullDevice
+
+      process.terminationHandler = { proc in
+        if proc.terminationStatus == 0 {
+          continuation.resume(returning: nil)
+        } else {
+          let data = errorPipe.fileHandleForReading.readDataToEndOfFile()
+          let msg =
+            String(data: data, encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? "Clone failed"
+          continuation.resume(returning: msg)
+        }
+      }
+
+      do {
+        try process.run()
+      } catch {
+        continuation.resume(returning: error.localizedDescription)
+      }
+    }
+  }
+
+  static func isGitURL(_ string: String) -> Bool {
+    if string.hasPrefix("https://") || string.hasPrefix("http://") {
+      if string.hasSuffix(".git") { return true }
+      let hosts = ["github.com", "gitlab.com", "bitbucket.org", "dev.azure.com", "gitee.com"]
+      return hosts.contains { string.contains($0) }
+    }
+    if string.hasPrefix("git@") && string.contains(":") { return true }
+    if string.hasPrefix("git://") || string.hasPrefix("ssh://") { return true }
+    return false
+  }
+
+  static func extractRepoName(from urlString: String) -> String {
+    let cleaned = urlString.hasSuffix("/") ? String(urlString.dropLast()) : urlString
+    var name: String
+    if cleaned.contains(":") && !cleaned.contains("://") {
+      name =
+        cleaned.components(separatedBy: "/").last
+        ?? cleaned.components(separatedBy: ":").last ?? cleaned
+    } else {
+      name = URL(string: cleaned)?.lastPathComponent ?? cleaned
+    }
+    if name.hasSuffix(".git") {
+      name = String(name.dropLast(4))
+    }
+    return name.isEmpty ? "repository" : name
+  }
+
+  private static var defaultClonePath: String {
+    let home = FileManager.default.homeDirectoryForCurrentUser
+    let developer = home.appendingPathComponent("Developer")
+    if FileManager.default.fileExists(atPath: developer.path) {
+      return developer.path
+    }
+    return home.path
+  }
+}

--- a/supacode/Features/Repositories/Views/CloneRepositoryView.swift
+++ b/supacode/Features/Repositories/Views/CloneRepositoryView.swift
@@ -6,7 +6,7 @@ struct CloneRepositoryView: View {
   @State private var locationPath = Self.defaultClonePath
   @State private var isCloning = false
   @State private var errorMessage: String?
-  @Environment(\.dismiss) private var dismiss
+  let dismiss: () -> Void
   let onCloned: (URL) -> Void
 
   var body: some View {

--- a/supacode/Features/Repositories/Views/CloneRepositoryView.swift
+++ b/supacode/Features/Repositories/Views/CloneRepositoryView.swift
@@ -66,7 +66,7 @@ struct CloneRepositoryView: View {
     .padding(24)
     .frame(width: 460)
     .onAppear { prefillFromClipboard() }
-    .opacity(isCloning ? 0 : 1)
+    .disabled(isCloning)
     .overlay {
       if isCloning {
         VStack(spacing: 8) {
@@ -75,13 +75,15 @@ struct CloneRepositoryView: View {
             .font(.callout)
             .foregroundStyle(.secondary)
         }
+        .padding(18)
+        .background(.regularMaterial, in: .rect(cornerRadius: 8))
       }
     }
   }
 
   private var isValidInput: Bool {
-    !urlString.trimmingCharacters(in: .whitespaces).isEmpty
-      && !locationPath.trimmingCharacters(in: .whitespaces).isEmpty
+    !urlString.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+      && !locationPath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
   }
 
   private func prefillFromClipboard() {
@@ -104,23 +106,37 @@ struct CloneRepositoryView: View {
   }
 
   private func performClone() {
-    let repoName = Self.extractRepoName(from: urlString)
-    let destination = URL(fileURLWithPath: locationPath).appendingPathComponent(repoName, isDirectory: true)
-    let url = urlString
+    guard let request = Self.cloneRequest(urlString: urlString, locationPath: locationPath) else {
+      errorMessage = "Enter a valid clone URL and destination."
+      return
+    }
 
     isCloning = true
     errorMessage = nil
 
     Task {
-      let error = await Self.runGitClone(url: url, destination: destination)
+      let error = await Self.runGitClone(url: request.url, destination: request.destination)
       isCloning = false
       if let error {
         errorMessage = error
       } else {
         dismiss()
-        onCloned(destination)
+        onCloned(request.destination)
       }
     }
+  }
+
+  static func cloneRequest(urlString: String, locationPath: String) -> CloneRequest? {
+    let trimmedURL = urlString.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmedURL.isEmpty,
+      let normalizedLocation = PathPolicy.normalizePath(locationPath, resolvingSymlinks: false)
+    else {
+      return nil
+    }
+
+    let destination = URL(fileURLWithPath: normalizedLocation, isDirectory: true)
+      .appending(path: extractRepoName(from: trimmedURL), directoryHint: .isDirectory)
+    return CloneRequest(url: trimmedURL, destination: destination)
   }
 
   /// Returns `nil` on success, or an error message on failure.
@@ -129,15 +145,29 @@ struct CloneRepositoryView: View {
       let process = Process()
       process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
       process.arguments = ["clone", "--", url, destination.path]
-      let errorPipe = Pipe()
-      process.standardError = errorPipe
       process.standardOutput = FileHandle.nullDevice
+      let errorLogURL = FileManager.default.temporaryDirectory
+        .appending(path: "prowl-git-clone-\(UUID().uuidString).log", directoryHint: .notDirectory)
+
+      guard FileManager.default.createFile(atPath: errorLogURL.path(percentEncoded: false), contents: nil),
+        let errorHandle = try? FileHandle(forWritingTo: errorLogURL)
+      else {
+        continuation.resume(returning: "Unable to prepare clone log")
+        return
+      }
+
+      process.standardError = errorHandle
 
       process.terminationHandler = { proc in
+        try? errorHandle.close()
+        defer {
+          try? FileManager.default.removeItem(at: errorLogURL)
+        }
+
         if proc.terminationStatus == 0 {
           continuation.resume(returning: nil)
         } else {
-          let data = errorPipe.fileHandleForReading.readDataToEndOfFile()
+          let data = (try? Data(contentsOf: errorLogURL)) ?? Data()
           let msg =
             String(data: data, encoding: .utf8)?
             .trimmingCharacters(in: .whitespacesAndNewlines) ?? "Clone failed"
@@ -148,36 +178,52 @@ struct CloneRepositoryView: View {
       do {
         try process.run()
       } catch {
+        try? errorHandle.close()
+        try? FileManager.default.removeItem(at: errorLogURL)
         continuation.resume(returning: error.localizedDescription)
       }
     }
   }
 
   static func isGitURL(_ string: String) -> Bool {
-    if string.hasPrefix("https://") || string.hasPrefix("http://") {
-      if string.hasSuffix(".git") { return true }
-      let hosts = ["github.com", "gitlab.com", "bitbucket.org", "dev.azure.com", "gitee.com"]
-      return hosts.contains { string.contains($0) }
+    let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
+    if trimmed.hasPrefix("git@") && trimmed.contains(":") { return true }
+
+    guard let components = URLComponents(string: trimmed),
+      let scheme = components.scheme?.lowercased()
+    else {
+      return false
     }
-    if string.hasPrefix("git@") && string.contains(":") { return true }
-    if string.hasPrefix("git://") || string.hasPrefix("ssh://") { return true }
-    return false
+
+    if scheme == "https" || scheme == "http" {
+      if components.path.hasSuffix(".git") { return true }
+      let hosts = ["github.com", "gitlab.com", "bitbucket.org", "dev.azure.com", "gitee.com"]
+      return components.host.map { hosts.contains($0.lowercased()) } ?? false
+    }
+    return scheme == "git" || scheme == "ssh"
   }
 
   static func extractRepoName(from urlString: String) -> String {
-    let cleaned = urlString.hasSuffix("/") ? String(urlString.dropLast()) : urlString
-    var name: String
+    var cleaned = urlString.trimmingCharacters(in: .whitespacesAndNewlines)
+    while cleaned.hasSuffix("/") {
+      cleaned.removeLast()
+    }
+
+    var name: String?
     if cleaned.contains(":") && !cleaned.contains("://") {
-      name =
-        cleaned.components(separatedBy: "/").last
-        ?? cleaned.components(separatedBy: ":").last ?? cleaned
+      let pathPart = cleaned.split(separator: ":", maxSplits: 1).last.map(String.init) ?? cleaned
+      name = pathPart.split(separator: "/").last.map(String.init)
     } else {
-      name = URL(string: cleaned)?.lastPathComponent ?? cleaned
+      name =
+        URLComponents(string: cleaned)?.path.split(separator: "/").last.map(String.init)
+        ?? URL(string: cleaned)?.lastPathComponent
     }
-    if name.hasSuffix(".git") {
-      name = String(name.dropLast(4))
+
+    var resolvedName = name ?? cleaned
+    if resolvedName.hasSuffix(".git") {
+      resolvedName = String(resolvedName.dropLast(4))
     }
-    return name.isEmpty ? "repository" : name
+    return resolvedName.isEmpty ? "repository" : resolvedName
   }
 
   private static var defaultClonePath: String {
@@ -187,5 +233,12 @@ struct CloneRepositoryView: View {
       return developer.path
     }
     return home.path
+  }
+}
+
+extension CloneRepositoryView {
+  struct CloneRequest: Equatable {
+    let url: String
+    let destination: URL
   }
 }

--- a/supacode/Features/Repositories/Views/EmptyStateView.swift
+++ b/supacode/Features/Repositories/Views/EmptyStateView.swift
@@ -22,6 +22,9 @@ struct EmptyStateView: View {
           onBrowse: {
             store.send(.setOpenPanelPresented(true))
           },
+          onCloneCompleted: { url in
+            store.send(.repositoryManagement(.openRepositories([url])))
+          },
           onWorkspace: {
             store.send(.workspaceCreation(.promptRequested))
           },

--- a/supacode/Features/Repositories/Views/EmptyStateView.swift
+++ b/supacode/Features/Repositories/Views/EmptyStateView.swift
@@ -17,8 +17,9 @@ struct EmptyStateView: View {
       Button("Add...") {
         isAddChoicePresented = true
       }
-      .popover(isPresented: $isAddChoicePresented) {
+      .persistentPopover(isPresented: $isAddChoicePresented) {
         AddToProwlView(
+          dismiss: { isAddChoicePresented = false },
           onBrowse: {
             store.send(.setOpenPanelPresented(true))
           },

--- a/supacode/Features/Repositories/Views/EmptyStateView.swift
+++ b/supacode/Features/Repositories/Views/EmptyStateView.swift
@@ -17,6 +17,19 @@ struct EmptyStateView: View {
       Button("Add...") {
         isAddChoicePresented = true
       }
+      .popover(isPresented: $isAddChoicePresented) {
+        AddToProwlView(
+          onBrowse: {
+            store.send(.setOpenPanelPresented(true))
+          },
+          onWorkspace: {
+            store.send(.workspaceCreation(.promptRequested))
+          },
+          onDrop: { urls in
+            store.send(.repositoryManagement(.openRepositories(urls)))
+          }
+        )
+      }
       .modifier(
         KeyboardShortcutModifier(
           shortcut: resolvedKeybindings.keyboardShortcut(for: AppShortcuts.CommandID.openRepository)
@@ -28,25 +41,6 @@ struct EmptyStateView: View {
           commandID: AppShortcuts.CommandID.openRepository,
           in: resolvedKeybindings
         ))
-    }
-    .confirmationDialog(
-      "Add to Prowl",
-      isPresented: $isAddChoicePresented,
-      titleVisibility: .visible
-    ) {
-      Button("Add Local Repository/Folder") {
-        store.send(.setOpenPanelPresented(true))
-      }
-      Button("Add Workspace") {
-        store.send(.workspaceCreation(.promptRequested))
-      }
-      Button("Cancel", role: .cancel) {}
-    } message: {
-      Text(
-        "A local repository or folder opens one project root. "
-          + "A workspace creates one shared task folder "
-          + "containing multiple repositories for one agent to work across."
-      )
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)
     .background(Color(nsColor: .windowBackgroundColor))

--- a/supacode/Features/Repositories/Views/PersistentPopover.swift
+++ b/supacode/Features/Repositories/Views/PersistentPopover.swift
@@ -64,7 +64,7 @@ private struct PersistentPopoverAnchor<PopoverContent: View>: NSViewRepresentabl
     func show(anchorHint: NSView, content: some View) {
       let hosting = NSHostingController(rootView: AnyView(content))
       let popover = NSPopover()
-      popover.behavior = .applicationDefined
+      popover.behavior = .semitransient
       popover.contentViewController = hosting
       popover.delegate = self
 

--- a/supacode/Features/Repositories/Views/PersistentPopover.swift
+++ b/supacode/Features/Repositories/Views/PersistentPopover.swift
@@ -1,0 +1,112 @@
+import AppKit
+import SwiftUI
+
+extension View {
+  func persistentPopover<Content: View>(
+    isPresented: Binding<Bool>,
+    @ViewBuilder content: @escaping () -> Content
+  ) -> some View {
+    modifier(PersistentPopoverModifier(isPresented: isPresented, popoverContent: content))
+  }
+}
+
+private struct PersistentPopoverModifier<PopoverContent: View>: ViewModifier {
+  @Binding var isPresented: Bool
+  @ViewBuilder var popoverContent: () -> PopoverContent
+
+  func body(content: Content) -> some View {
+    content
+      .background {
+        PersistentPopoverAnchor(
+          isPresented: $isPresented,
+          popoverContent: popoverContent
+        )
+        .frame(width: 1, height: 1)
+        .accessibilityHidden(true)
+      }
+  }
+}
+
+private struct PersistentPopoverAnchor<PopoverContent: View>: NSViewRepresentable {
+  @Binding var isPresented: Bool
+  @ViewBuilder var popoverContent: () -> PopoverContent
+
+  func makeNSView(context: Context) -> NSView {
+    NSView(frame: NSRect(x: 0, y: 0, width: 1, height: 1))
+  }
+
+  func updateNSView(_ nsView: NSView, context: Context) {
+    if isPresented {
+      if context.coordinator.popover == nil {
+        context.coordinator.show(anchorHint: nsView, content: popoverContent())
+      } else {
+        context.coordinator.updateContent(popoverContent())
+      }
+    } else {
+      context.coordinator.close()
+    }
+  }
+
+  func makeCoordinator() -> Coordinator {
+    Coordinator(isPresented: $isPresented)
+  }
+
+  final class Coordinator: NSObject, NSPopoverDelegate {
+    private(set) var popover: NSPopover?
+    private var hostingController: NSHostingController<AnyView>?
+    private let isPresented: Binding<Bool>
+
+    init(isPresented: Binding<Bool>) {
+      self.isPresented = isPresented
+    }
+
+    @MainActor
+    func show(anchorHint: NSView, content: some View) {
+      let hosting = NSHostingController(rootView: AnyView(content))
+      let popover = NSPopover()
+      popover.behavior = .applicationDefined
+      popover.contentViewController = hosting
+      popover.delegate = self
+
+      let anchor: NSView
+      let rect: NSRect
+
+      if anchorHint.window != nil {
+        anchor = anchorHint
+        rect = anchorHint.bounds
+      } else if let window = NSApp.keyWindow, let contentView = window.contentView {
+        anchor = contentView
+        rect = NSRect(x: 10, y: contentView.bounds.height - 10, width: 1, height: 1)
+      } else {
+        return
+      }
+
+      popover.show(relativeTo: rect, of: anchor, preferredEdge: .minY)
+      self.popover = popover
+      self.hostingController = hosting
+    }
+
+    @MainActor
+    func updateContent(_ content: some View) {
+      hostingController?.rootView = AnyView(content)
+    }
+
+    @MainActor
+    func close() {
+      let ref = popover
+      popover = nil
+      hostingController = nil
+      ref?.close()
+    }
+
+    nonisolated func popoverDidClose(_ notification: Notification) {
+      Task { @MainActor in
+        self.popover = nil
+        self.hostingController = nil
+        if self.isPresented.wrappedValue {
+          self.isPresented.wrappedValue = false
+        }
+      }
+    }
+  }
+}

--- a/supacode/Features/Repositories/Views/SidebarListView.swift
+++ b/supacode/Features/Repositories/Views/SidebarListView.swift
@@ -208,6 +208,9 @@ struct SidebarListView: View {
               onBrowse: {
                 store.send(.setOpenPanelPresented(true))
               },
+              onCloneCompleted: { url in
+                store.send(.repositoryManagement(.openRepositories([url])))
+              },
               onWorkspace: {
                 store.send(.workspaceCreation(.promptRequested))
               },

--- a/supacode/Features/Repositories/Views/SidebarListView.swift
+++ b/supacode/Features/Repositories/Views/SidebarListView.swift
@@ -203,8 +203,9 @@ struct SidebarListView: View {
             Label("Add...", systemImage: "folder.badge.plus")
           }
           .help("Add Repository or Workspace")
-          .popover(isPresented: $isAddChoicePresented) {
+          .persistentPopover(isPresented: $isAddChoicePresented) {
             AddToProwlView(
+              dismiss: { isAddChoicePresented = false },
               onBrowse: {
                 store.send(.setOpenPanelPresented(true))
               },

--- a/supacode/Features/Repositories/Views/SidebarListView.swift
+++ b/supacode/Features/Repositories/Views/SidebarListView.swift
@@ -203,26 +203,20 @@ struct SidebarListView: View {
             Label("Add...", systemImage: "folder.badge.plus")
           }
           .help("Add Repository or Workspace")
+          .popover(isPresented: $isAddChoicePresented) {
+            AddToProwlView(
+              onBrowse: {
+                store.send(.setOpenPanelPresented(true))
+              },
+              onWorkspace: {
+                store.send(.workspaceCreation(.promptRequested))
+              },
+              onDrop: { urls in
+                store.send(.repositoryManagement(.openRepositories(urls)))
+              }
+            )
+          }
         }
-      }
-      .confirmationDialog(
-        "Add to Prowl",
-        isPresented: $isAddChoicePresented,
-        titleVisibility: .visible
-      ) {
-        Button("Add Local Repository/Folder") {
-          store.send(.setOpenPanelPresented(true))
-        }
-        Button("Add Workspace") {
-          store.send(.workspaceCreation(.promptRequested))
-        }
-        Button("Cancel", role: .cancel) {}
-      } message: {
-        Text(
-          "A local repository or folder opens one project root. "
-            + "A workspace creates one shared task folder "
-            + "containing multiple repositories for one agent to work across."
-        )
       }
     }  // ScrollViewReader
   }

--- a/supacodeTests/CloneRepositoryViewTests.swift
+++ b/supacodeTests/CloneRepositoryViewTests.swift
@@ -1,0 +1,36 @@
+import Foundation
+import Testing
+
+@testable import supacode
+
+struct CloneRepositoryViewTests {
+  @Test func cloneRequestTrimsURLAndNormalizesDestinationPath() {
+    let request = CloneRepositoryView.cloneRequest(
+      urlString: " https://github.com/onevcat/Prowl.git \n",
+      locationPath: " ~/Developer "
+    )
+
+    let expectedPath = FileManager.default.homeDirectoryForCurrentUser
+      .appending(path: "Developer", directoryHint: .isDirectory)
+      .appending(path: "Prowl", directoryHint: .isDirectory)
+      .standardizedFileURL
+      .path(percentEncoded: false)
+
+    #expect(request?.url == "https://github.com/onevcat/Prowl.git")
+    #expect(request?.destination.path(percentEncoded: false) == expectedPath)
+  }
+
+  @Test func extractRepoNameHandlesCommonGitURLForms() {
+    #expect(CloneRepositoryView.extractRepoName(from: "git@github.com:onevcat/Prowl.git") == "Prowl")
+    #expect(CloneRepositoryView.extractRepoName(from: "git@github.com:Prowl.git") == "Prowl")
+    #expect(CloneRepositoryView.extractRepoName(from: "https://github.com/onevcat/Prowl.git?ref=main") == "Prowl")
+    #expect(CloneRepositoryView.extractRepoName(from: " https://github.com/onevcat/Prowl.git/ ") == "Prowl")
+  }
+
+  @Test func isGitURLTrimsClipboardContentAndRequiresKnownHostsForHTTPURLs() {
+    #expect(CloneRepositoryView.isGitURL(" https://github.com/onevcat/Prowl \n"))
+    #expect(CloneRepositoryView.isGitURL("git@github.com:onevcat/Prowl.git"))
+    #expect(CloneRepositoryView.isGitURL("ssh://git@example.com/onevcat/Prowl.git"))
+    #expect(!CloneRepositoryView.isGitURL("https://github.com.evil/onevcat/Prowl"))
+  }
+}

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -2066,6 +2066,151 @@ struct RepositoriesFeatureTests {
     #expect(savedEntries.value == expectedSavedEntries)
   }
 
+  @Test func openRepositoriesFinishedAutoSelectsNewGitRepositoryAfterInitialLoad() async {
+    let existingWorktree = makeWorktree(id: "/tmp/existing/main", name: "main", repoRoot: "/tmp/existing")
+    let existingRepository = makeRepository(id: "/tmp/existing", worktrees: [existingWorktree])
+    let newWorktree = makeWorktree(id: "/tmp/new/main", name: "main", repoRoot: "/tmp/new")
+    let newRepository = makeRepository(id: "/tmp/new", name: "new", worktrees: [newWorktree])
+    var initialState = makeState(repositories: [existingRepository])
+    initialState.isInitialLoadComplete = true
+    initialState.snapshotPersistencePhase = .active
+
+    let store = TestStore(initialState: initialState) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.gitClient.repositoryWebURL = { _ in nil }
+      $0.repositoryPersistence.saveRepositorySnapshot = { _ in }
+    }
+
+    await store.send(
+      .repositoryManagement(
+        .openRepositoriesFinished(
+          [existingRepository, newRepository],
+          failures: [],
+          invalidRoots: [],
+          openFailures: [],
+          roots: [existingRepository.rootURL, newRepository.rootURL]
+        ))
+    ) {
+      $0.repositories = [existingRepository, newRepository]
+      $0.repositoryRoots = [existingRepository.rootURL, newRepository.rootURL]
+    }
+    await store.receive(\.delegate.repositoriesChanged)
+    await store.receive(\.selectWorktree) {
+      $0.selection = .worktree(newWorktree.id)
+      $0.sidebarSelectedWorktreeIDs = [newWorktree.id]
+      $0.pendingTerminalFocusWorktreeIDs = [newWorktree.id]
+      $0.openedWorktreeIDs = [newWorktree.id]
+    }
+    await store.receive(\.delegate.selectedWorktreeChanged)
+    await store.finish()
+  }
+
+  @Test func openRepositoriesFinishedAutoSelectsNewPlainRepositoryAfterInitialLoad() async {
+    let existingWorktree = makeWorktree(id: "/tmp/existing/main", name: "main", repoRoot: "/tmp/existing")
+    let existingRepository = makeRepository(id: "/tmp/existing", worktrees: [existingWorktree])
+    let plainRepository = makeRepository(
+      id: "/tmp/plain",
+      name: "plain",
+      kind: .plain,
+      worktrees: []
+    )
+    var initialState = makeState(repositories: [existingRepository])
+    initialState.isInitialLoadComplete = true
+    initialState.snapshotPersistencePhase = .active
+
+    let store = TestStore(initialState: initialState) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.gitClient.repositoryWebURL = { _ in nil }
+      $0.repositoryPersistence.saveRepositorySnapshot = { _ in }
+    }
+
+    await store.send(
+      .repositoryManagement(
+        .openRepositoriesFinished(
+          [existingRepository, plainRepository],
+          failures: [],
+          invalidRoots: [],
+          openFailures: [],
+          roots: [existingRepository.rootURL, plainRepository.rootURL]
+        ))
+    ) {
+      $0.repositories = [existingRepository, plainRepository]
+      $0.repositoryRoots = [existingRepository.rootURL, plainRepository.rootURL]
+      $0.pendingTerminalFocusWorktreeIDs = [plainRepository.id]
+    }
+    await store.receive(\.delegate.repositoriesChanged)
+    await store.receive(\.selectRepository) {
+      $0.selection = .repository(plainRepository.id)
+      $0.openedWorktreeIDs = [plainRepository.id]
+    }
+    await store.receive(\.delegate.selectedWorktreeChanged)
+    await store.finish()
+  }
+
+  @Test func openRepositoriesFinishedDoesNotAutoSelectDuringInitialLoad() async {
+    let worktree = makeWorktree(id: "/tmp/repo/main", name: "main", repoRoot: "/tmp/repo")
+    let repository = makeRepository(id: "/tmp/repo", worktrees: [worktree])
+    let store = TestStore(initialState: RepositoriesFeature.State()) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.gitClient.repositoryWebURL = { _ in nil }
+      $0.repositoryPersistence.saveRepositorySnapshot = { _ in }
+    }
+
+    await store.send(
+      .repositoryManagement(
+        .openRepositoriesFinished(
+          [repository],
+          failures: [],
+          invalidRoots: [],
+          openFailures: [],
+          roots: [repository.rootURL]
+        ))
+    ) {
+      $0.repositories = [repository]
+      $0.repositoryRoots = [repository.rootURL]
+      $0.isInitialLoadComplete = true
+      $0.snapshotPersistencePhase = .active
+    }
+    await store.receive(\.delegate.repositoriesChanged)
+    await store.finish()
+  }
+
+  @Test func openRepositoriesFinishedDoesNotAutoSelectWhileRestoringSnapshot() async {
+    let existingWorktree = makeWorktree(id: "/tmp/existing/main", name: "main", repoRoot: "/tmp/existing")
+    let existingRepository = makeRepository(id: "/tmp/existing", worktrees: [existingWorktree])
+    let newWorktree = makeWorktree(id: "/tmp/new/main", name: "main", repoRoot: "/tmp/new")
+    let newRepository = makeRepository(id: "/tmp/new", name: "new", worktrees: [newWorktree])
+    var initialState = makeState(repositories: [existingRepository])
+    initialState.isInitialLoadComplete = true
+    initialState.snapshotPersistencePhase = .restoring
+
+    let store = TestStore(initialState: initialState) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.gitClient.repositoryWebURL = { _ in nil }
+    }
+
+    await store.send(
+      .repositoryManagement(
+        .openRepositoriesFinished(
+          [existingRepository, newRepository],
+          failures: [],
+          invalidRoots: [],
+          openFailures: [],
+          roots: [existingRepository.rootURL, newRepository.rootURL]
+        ))
+    ) {
+      $0.repositories = [existingRepository, newRepository]
+      $0.repositoryRoots = [existingRepository.rootURL, newRepository.rootURL]
+      $0.snapshotPersistencePhase = .active
+    }
+    await store.receive(\.delegate.repositoriesChanged)
+    await store.finish()
+  }
+
   @Test func revealInSidebarExpandsCollapsedRepository() async {
     let worktree = makeWorktree(id: "/tmp/repo/wt", name: "wt")
     let repository = makeRepository(id: "/tmp/repo", worktrees: [worktree])


### PR DESCRIPTION
## Summary

- Replace the system `confirmationDialog` with a custom popover featuring app icon header, drag-and-drop zone, Browse and Clone buttons, and Add Workspace option
- Add Clone button that switches the popover to a clone form with URL (auto-filled from clipboard if it contains a git URL) and location fields
- Auto-select the newly added repository after add/clone/drag-drop

## Test plan

- [x] Click "Add..." toolbar button → popover appears with app icon, drop zone, Browse/Clone buttons, workspace option
- [x] Click "Browse…" → file picker opens, adding a folder selects it in sidebar
- [x] Click "Clone…" → popover switches to clone form; paste a git URL and verify it clones correctly as a git repo (not plain folder)
- [x] Copy a git URL to clipboard, then open the popover and click Clone → URL field is pre-filled
- [x] Drag a folder from Finder onto the drop zone → repo added and selected
- [x] Click "Add Workspace" → workspace creation sheet appears
- [x] Verify app does not crash on launch (previous `.sheet` on SidebarListView caused AttributeGraph crash)
- [x] Verify initial app load does not auto-select any repo