### PR TITLE
tweak: add hover link style to CI check names in PR status popover

### DIFF
--- a/supacode/Features/Repositories/Views/PullRequestChecksPopoverView.swift
+++ b/supacode/Features/Repositories/Views/PullRequestChecksPopoverView.swift
@@ -111,7 +111,7 @@ struct PullRequestChecksPopoverView: View {
                     analyticsClient.capture("github_ci_check_opened", nil)
                     openURL(url)
                   } label: {
-                    Text(check.displayName)
+                    LinkLabel(text: check.displayName)
                       .lineLimit(1)
                   }
                   .buttonStyle(.plain)
@@ -185,5 +185,21 @@ struct PullRequestChecksPopoverView: View {
       return "Open pull request on GitHub (\(display))"
     }
     return "Open pull request on GitHub"
+  }
+}
+
+private struct LinkLabel: View {
+  let text: String
+  @State private var isHovering = false
+
+  var body: some View {
+    Text(text)
+      .underline()
+      .foregroundStyle(isHovering ? .blue : .secondary)
+      .onHover { hovering in
+        isHovering = hovering
+      }
+      .pointerStyle(.link)
+      .accessibilityHint("Open check details on GitHub")
   }
 }


### PR DESCRIPTION
给 PR status popover 里的 CI check 名称添加 hover 链接效果，提升可点击性的可发现性。

**改动：**
- CI check 名称默认显示下划线
- Hover 时文字变蓝、鼠标变成手型（`.pointerStyle(.link)`）
- 添加 VoiceOver accessibility hint

没有 `detailsUrl` 的 check 保持普通文字不变。