### PR TITLE
fix: prevent black screen on fullscreen when closing last tab

### DIFF
--- a/supacode/App/WindowTabbingDisabler.swift
+++ b/supacode/App/WindowTabbingDisabler.swift
@@ -31,7 +31,10 @@ final class WindowTabbingView: NSView, NSWindowDelegate {
   }
 
   func windowShouldClose(_ sender: NSWindow) -> Bool {
-    sender.orderOut(nil)
+    // Prowl is a single-window app. Calling orderOut(nil) here breaks
+    // fullscreen state and destroys the Ghostty Metal render layer when
+    // terminal surfaces are closed, causing a black screen on re-show.
+    // Just return false to keep the window visible.
     return false
   }
 }


### PR DESCRIPTION
In fullscreen mode, calling `orderOut(nil)` in `windowShouldClose` breaks the fullscreen state and destroys the Ghostty Metal render layer when all terminal surfaces are closed. When the window is re-shown, there is no content to render, causing a black screen.

**Fix:** Remove the `orderOut(nil)` call and just return false to keep the window visible. Prowl is a single-window app and should not hide its main window via `orderOut`.

Fixes #490