### PR TITLE
Prevent fullscreen close-window black screen

### DIFF
--- a/supacode/App/WindowTabbingDisabler.swift
+++ b/supacode/App/WindowTabbingDisabler.swift
@@ -31,7 +31,13 @@ final class WindowTabbingView: NSView, NSWindowDelegate {
   }
 
   func windowShouldClose(_ sender: NSWindow) -> Bool {
-    sender.orderOut(nil)
+    if Self.shouldOrderOutOnClose(styleMask: sender.styleMask) {
+      sender.orderOut(nil)
+    }
     return false
+  }
+
+  static func shouldOrderOutOnClose(styleMask: NSWindow.StyleMask) -> Bool {
+    !styleMask.contains(.fullScreen)
   }
 }

--- a/supacodeTests/WindowTabbingDisablerTests.swift
+++ b/supacodeTests/WindowTabbingDisablerTests.swift
@@ -1,0 +1,14 @@
+import AppKit
+import Testing
+
+@testable import supacode
+
+struct WindowTabbingDisablerTests {
+  @Test func shouldNotOrderOutFullscreenWindowOnClose() {
+    #expect(WindowTabbingView.shouldOrderOutOnClose(styleMask: [.titled, .fullScreen]) == false)
+  }
+
+  @Test func shouldOrderOutNonFullscreenWindowOnClose() {
+    #expect(WindowTabbingView.shouldOrderOutOnClose(styleMask: [.titled, .closable]) == true)
+  }
+}


### PR DESCRIPTION
## Summary

- Keep the main window visible when a close-window action is triggered while the window is fullscreen
- Preserve the existing non-fullscreen behavior where Close Window hides the main window via `orderOut(nil)`
- Add focused coverage for the fullscreen vs non-fullscreen close policy

## Why

When the last terminal tab is already closed in fullscreen, another `Cmd+W` can fall through to the window close command. Hiding the fullscreen window leaves the re-shown Ghostty area black. Outside fullscreen, the existing hide-window behavior is correct and should remain unchanged.

Fixes #490

## Test plan

- `xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -only-testing:"supacodeTests/WindowTabbingDisablerTests" CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation`
- `make build-app`
