### PR TITLE
feat: show GitHub avatar in sidebar when no custom icon is set

### DIFF
--- a/supacode/Clients/RemoteAvatarClient.swift
+++ b/supacode/Clients/RemoteAvatarClient.swift
@@ -1,0 +1,71 @@
+import ComposableArchitecture
+import Foundation
+import SwiftUI
+
+/// Shared in-memory cache for GitHub owner names resolved from repository
+/// root URLs. Once resolved, the owner name is used to construct the
+/// public GitHub avatar URL: `https://github.com/{owner}.png?size=64`.
+@MainActor
+final class RemoteAvatarStore: Observable {
+  static let shared = RemoteAvatarStore()
+
+  /// Cache: repository root URL path → resolved GitHub owner name.
+  private(set) var ownerByRepositoryRoot: [String: String] = [:]
+
+  /// Tracks in-flight resolution tasks.
+  private var inFlight: [String: Task<Void, Never>] = [:]
+
+  private init() {}
+
+  /// Returns the GitHub avatar URL for a repository, or `nil` if the
+  /// owner hasn't been resolved yet.
+  func avatarURL(forRepositoryRoot rootURL: URL) -> URL? {
+    let key = rootURL.path(percentEncoded: false)
+    guard let owner = ownerByRepositoryRoot[key] else { return nil }
+    return Self.githubAvatarURL(for: owner)
+  }
+
+  /// Constructs the public GitHub avatar URL for a given owner.
+  /// This URL doesn't require authentication and works for both users
+  /// and organizations.
+  nonisolated static func githubAvatarURL(for owner: String) -> URL? {
+    URL(string: "https://github.com/\(owner).png?size=64")
+  }
+
+  /// Kicks off owner resolution for a repository root URL. The resolution
+  /// parses the git remote URL to extract the GitHub owner (user or org).
+  func ensureOwnerResolved(
+    forRepositoryRoot rootURL: URL,
+    gitClient: GitClientDependency
+  ) {
+    let key = rootURL.path(percentEncoded: false)
+    if ownerByRepositoryRoot[key] != nil || inFlight[key] != nil {
+      return
+    }
+
+    let task = Task {
+      // Resolve GitHub owner from git remote (origin).
+      if let remoteInfo = await gitClient.remoteInfo(rootURL) {
+        await MainActor.run {
+          self.ownerByRepositoryRoot[key] = remoteInfo.owner
+          self.inFlight[key] = nil
+        }
+        return
+      }
+      // Mark as failed (store empty string to avoid retrying).
+      await MainActor.run {
+        self.ownerByRepositoryRoot[key] = ""
+        self.inFlight[key] = nil
+      }
+    }
+    inFlight[key] = task
+  }
+
+  func clear() {
+    for task in inFlight.values {
+      task.cancel()
+    }
+    inFlight.removeAll()
+    ownerByRepositoryRoot.removeAll()
+  }
+}

--- a/supacode/Features/Repositories/Views/RepoHeaderRow.swift
+++ b/supacode/Features/Repositories/Views/RepoHeaderRow.swift
@@ -16,6 +16,9 @@ struct RepoHeaderRow: View {
   /// Repo root URL — needed by `RepositoryIconImage` to resolve
   /// user-imported image filenames into absolute file URLs.
   let repositoryRootURL: URL?
+  /// Remote avatar URL fetched from the code host (e.g. GitHub owner
+  /// avatar). Only used when `icon` is `nil`.
+  let remoteAvatarURL: URL?
   var nameTooltip: String?
 
   var body: some View {
@@ -27,6 +30,8 @@ struct RepoHeaderRow: View {
           tintColor: iconTint,
           size: 14
         )
+      } else if let remoteAvatarURL {
+        RemoteAvatarView(url: remoteAvatarURL, size: 14)
       }
       RepoDisplayName(
         fallbackName: name,
@@ -50,6 +55,46 @@ struct RepoHeaderRow: View {
           }
       }
     }
+  }
+}
+
+/// Renders a remote avatar URL as a small circular image. Shows a
+/// placeholder initials badge while loading or on failure.
+struct RemoteAvatarView: View {
+  let url: URL
+  let size: CGFloat
+
+  var body: some View {
+    AsyncImage(url: url) { phase in
+      switch phase {
+      case .empty:
+        placeholder
+      case .success(let image):
+        image
+          .resizable()
+          .aspectRatio(contentMode: .fill)
+          .clipShape(Circle())
+      case .failure:
+        placeholder
+      @unknown default:
+        placeholder
+      }
+    }
+    .frame(width: size, height: size)
+    .accessibilityHidden(true)
+  }
+
+  @ViewBuilder
+  private var placeholder: some View {
+    Circle()
+      .fill(.quaternary)
+      .overlay(
+        Image(systemName: "person.circle.fill")
+          .resizable()
+          .aspectRatio(contentMode: .fit)
+          .foregroundStyle(.tertiary)
+          .padding(size * 0.2)
+      )
   }
 }
 
@@ -93,21 +138,24 @@ struct RepoHeaderTabCountBadge: View {
       isRemoving: false,
       icon: nil,
       iconTint: nil,
-      repositoryRootURL: nil
+      repositoryRootURL: nil,
+      remoteAvatarURL: nil
     )
     RepoHeaderRow(
       name: "ghostty",
       isRemoving: false,
       icon: .sfSymbol("folder.fill"),
       iconTint: .blue,
-      repositoryRootURL: URL(fileURLWithPath: "/tmp/ghostty")
+      repositoryRootURL: URL(fileURLWithPath: "/tmp/ghostty"),
+      remoteAvatarURL: nil
     )
     RepoHeaderRow(
       name: "removing-repo",
       isRemoving: true,
       icon: .sfSymbol("hammer.fill"),
       iconTint: .orange,
-      repositoryRootURL: URL(fileURLWithPath: "/tmp/removing")
+      repositoryRootURL: URL(fileURLWithPath: "/tmp/removing"),
+      remoteAvatarURL: nil
     )
   }
   .padding()

--- a/supacode/Features/Repositories/Views/RepoHeaderRow.swift
+++ b/supacode/Features/Repositories/Views/RepoHeaderRow.swift
@@ -94,6 +94,7 @@ struct RemoteAvatarView: View {
           .aspectRatio(contentMode: .fit)
           .foregroundStyle(.tertiary)
           .padding(size * 0.2)
+          .accessibilityHidden(true)
       )
   }
 }

--- a/supacode/Features/Repositories/Views/RepositorySectionView.swift
+++ b/supacode/Features/Repositories/Views/RepositorySectionView.swift
@@ -16,6 +16,7 @@ struct RepositorySectionView: View {
   @Environment(\.colorScheme) private var colorScheme
   @Environment(\.resolvedKeybindings) private var resolvedKeybindings
   @Environment(\.accessibilityReduceMotion) private var reduceMotion
+  @Dependency(GitClientDependency.self) private var gitClient
   @State private var isHovering = false
   @Shared(.repositoryAppearances) private var repositoryAppearances
 
@@ -43,6 +44,7 @@ struct RepositorySectionView: View {
       }
     }
     let appearance = repositoryAppearances[repository.id] ?? .empty
+    let remoteAvatarURL = RemoteAvatarStore.shared.avatarURL(forRepositoryRoot: repository.rootURL)
     let header = HStack {
       // Inner HStack groups the name row and the tab-count badge so they
       // share the leading-aligned region of the outer header. Crucially
@@ -57,6 +59,7 @@ struct RepositorySectionView: View {
           icon: appearance.icon ?? (repository.isWorkspace ? .sfSymbol("folder") : nil),
           iconTint: appearance.color?.color ?? .accentColor,
           repositoryRootURL: repository.rootURL,
+          remoteAvatarURL: remoteAvatarURL,
           nameTooltip: repository.capabilities.supportsWorktrees
             ? (isExpanded ? "Collapse" : "Expand")
             : (repository.isWorkspace ? "Open terminal in workspace" : "Open terminal in folder")
@@ -216,6 +219,26 @@ struct RepositorySectionView: View {
         withAnimation(.easeOut(duration: 0.15)) {
           isHovering = hovering
         }
+      }
+    }
+    .onAppear {
+      // Kick off GitHub owner resolution if the repo has no user-set icon.
+      let appearance = repositoryAppearances[repository.id] ?? .empty
+      if appearance.icon == nil {
+        RemoteAvatarStore.shared.ensureOwnerResolved(
+          forRepositoryRoot: repository.rootURL,
+          gitClient: gitClient
+        )
+      }
+    }
+    .onChange(of: repositoryAppearances[repository.id]) { _, _ in
+      // If user clears their custom icon, re-resolve the GitHub owner.
+      let appearance = repositoryAppearances[repository.id] ?? .empty
+      if appearance.icon == nil {
+        RemoteAvatarStore.shared.ensureOwnerResolved(
+          forRepositoryRoot: repository.rootURL,
+          gitClient: gitClient
+        )
       }
     }
     .onTapGesture {


### PR DESCRIPTION
## Summary

参考 superset 项目的实现方式，在 sidebar 项目名字左边显示 GitHub 仓库的 avatar。

## Approach

直接使用 GitHub 公开的 avatar URL 格式：`https://github.com/{owner}.png?size=64`

**优点：**
- 不需要调用 `gh api`，没有网络延迟
- 不需要认证
- 不需要复杂的缓存管理（URL 是确定性的）
- 代码量大幅减少

## Data Flow

```
RepositorySectionView.onAppear
    ↓
RemoteAvatarStore.ensureOwnerResolved(rootURL, gitClient)
    ↓ (async)
gitClient.remoteInfo(rootURL) → GithubRemoteInfo.owner (from origin)
    ↓
缓存到 ownerByRepositoryRoot[rootURL] = owner
    ↓
RemoteAvatarStore.avatarURL(rootURL)
    ↓
返回 URL: https://github.com/{owner}.png?size=64
    ↓
RepoHeaderRow 用 AsyncImage 加载显示
```

## Priority

1. **用户自定义 icon**（`RepositoryAppearance.icon`）→ 最高优先
2. **GitHub avatar**（origin owner 的头像）→ fallback
3. **无 icon** → 保持原有布局

## Changes

- `supacode/Clients/RemoteAvatarClient.swift` — 新增 `RemoteAvatarStore` 单例，负责 owner 解析和 URL 构造
- `supacode/Features/Repositories/Views/RepoHeaderRow.swift` — 增加 `remoteAvatarURL` 参数和 `RemoteAvatarView` 组件
- `supacode/Features/Repositories/Views/RepositorySectionView.swift` — 触发 owner 解析，传递 avatar URL

## Verification

- ✅ Build 通过
- ✅ 逻辑简洁，参考了 superset 的成熟实现