### PR TITLE
Fix duplicate worktree watcher crash

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -43,3 +43,8 @@ custom_rules:
     message: "Do not mutate store state directly in views. Send actions instead."
     severity: error
     included: "supacode/.*/Views/.*\\.swift"
+  dictionary_unique_keys_with_values:
+    name: "Dictionary Unique Keys With Values"
+    regex: "\\bDictionary\\s*\\(\\s*uniqueKeysWithValues\\s*:"
+    message: "Avoid Dictionary(uniqueKeysWithValues:) because duplicate runtime data traps. Use explicit duplicate handling instead."
+    severity: error

--- a/supacode/CLIService/AgentsCommandHandler.swift
+++ b/supacode/CLIService/AgentsCommandHandler.swift
@@ -57,10 +57,10 @@ final class AgentsCommandHandler: CommandHandler {
     )
     let terminalContexts = makeTerminalContexts(from: snapshot.listSnapshot)
     let worktreeContexts = Dictionary(
-      uniqueKeysWithValues:
-        ListRuntimeSnapshotBuilder
+      ListRuntimeSnapshotBuilder
         .orderedWorktreeContexts(from: repositoriesState)
-        .map { ($0.id, $0) }
+        .map { ($0.id, $0) },
+      uniquingKeysWith: { first, _ in first }
     )
 
     let agents = repositoriesState.activeAgents.entries.compactMap { entry -> AgentsCommandAgent? in

--- a/supacode/CLIService/ListRuntimeSnapshotBuilder.swift
+++ b/supacode/CLIService/ListRuntimeSnapshotBuilder.swift
@@ -71,7 +71,10 @@ enum ListRuntimeSnapshotBuilder {
 
   static func orderedWorktreeContexts(from repositoriesState: RepositoriesFeature.State) -> [WorktreeContext] {
     var contexts: [WorktreeContext] = []
-    let repositoriesByID = Dictionary(uniqueKeysWithValues: repositoriesState.repositories.map { ($0.id, $0) })
+    let repositoriesByID = Dictionary(
+      repositoriesState.repositories.map { ($0.id, $0) },
+      uniquingKeysWith: { first, _ in first }
+    )
 
     for repositoryID in repositoriesState.orderedRepositoryIDs() {
       guard let repository = repositoriesByID[repositoryID] else {

--- a/supacode/Clients/Github/GithubCLIModels.swift
+++ b/supacode/Clients/Github/GithubCLIModels.swift
@@ -33,7 +33,7 @@ nonisolated struct GithubAuthStatusSnapshot: Equatable, Sendable {
 
   init(response: GithubAuthStatusResponse) {
     hosts = Dictionary(
-      uniqueKeysWithValues: response.hosts.map { host, accounts in
+      response.hosts.map { host, accounts in
         let statuses = accounts.map {
           GithubAuthAccountStatus(
             host: $0.host.isEmpty ? host : $0.host,
@@ -46,7 +46,9 @@ nonisolated struct GithubAuthStatusSnapshot: Equatable, Sendable {
           )
         }
         return (host, statuses)
-      })
+      },
+      uniquingKeysWith: { first, _ in first }
+    )
   }
 
   var sortedHosts: [String] {

--- a/supacode/Commands/WorktreeCommands.swift
+++ b/supacode/Commands/WorktreeCommands.swift
@@ -205,7 +205,10 @@ struct WorktreeCommands: Commands {
     }
 
     let repositories = store.repositories
-    let reposByID = Dictionary(uniqueKeysWithValues: repositories.repositories.map { ($0.id, $0) })
+    let reposByID = Dictionary(
+      repositories.repositories.map { ($0.id, $0) },
+      uniquingKeysWith: { first, _ in first }
+    )
 
     var entries: [WorktreeMenuEntry] = []
     for repoID in repositories.orderedRepositoryIDs() {

--- a/supacode/Features/Repositories/BusinessLogic/WorktreeInfoWatcherManager.swift
+++ b/supacode/Features/Repositories/BusinessLogic/WorktreeInfoWatcherManager.swift
@@ -177,7 +177,12 @@ final class WorktreeInfoWatcherManager {
 
   private func setWorktrees(_ worktrees: [Worktree]) {
     let isInitialWorktreeLoad = !hasCompletedInitialWorktreeLoad && self.worktrees.isEmpty && !worktrees.isEmpty
-    let worktreesByID = Dictionary(uniqueKeysWithValues: worktrees.map { ($0.id, $0) })
+    var worktreesByID: [Worktree.ID: Worktree] = [:]
+    var uniqueWorktrees: [Worktree] = []
+    for worktree in worktrees where worktreesByID[worktree.id] == nil {
+      worktreesByID[worktree.id] = worktree
+      uniqueWorktrees.append(worktree)
+    }
     let desiredIDs = Set(worktreesByID.keys)
     let currentIDs = Set(self.worktrees.keys)
     let removedIDs = currentIDs.subtracting(desiredIDs)
@@ -193,7 +198,7 @@ final class WorktreeInfoWatcherManager {
       deferredLineChangeIDs.formUnion(newIDs)
     }
     self.worktrees = worktreesByID
-    for worktree in worktrees {
+    for worktree in uniqueWorktrees {
       configureWatcher(for: worktree)
       if isInitialWorktreeLoad || !deferredLineChangeIDs.contains(worktree.id) {
         emitLineChangesChanged(worktreeID: worktree.id)
@@ -205,7 +210,7 @@ final class WorktreeInfoWatcherManager {
     if isInitialWorktreeLoad {
       hasCompletedInitialWorktreeLoad = true
     }
-    let repositoryRoots = Set(worktrees.map(\.repositoryRootURL))
+    let repositoryRoots = Set(uniqueWorktrees.map(\.repositoryRootURL))
     let normalizedRoots = Set(repositoryRoots.map { $0.standardizedFileURL })
     refreshRepositoryTimings(for: normalizedRoots)
     syncWorktreeRegistryMonitors(repositoryRoots: repositoryRoots)

--- a/supacode/Features/Repositories/Models/SidebarPresentation.swift
+++ b/supacode/Features/Repositories/Models/SidebarPresentation.swift
@@ -133,7 +133,10 @@ extension RepositoriesFeature.State {
     expandedRepositoryIDs: Set<Repository.ID>,
     includesArchivedWorktreesRow: Bool = false
   ) -> SidebarPresentation {
-    let repositoriesByID = Dictionary(uniqueKeysWithValues: repositories.map { ($0.id, $0) })
+    let repositoriesByID = Dictionary(
+      repositories.map { ($0.id, $0) },
+      uniquingKeysWith: { first, _ in first }
+    )
     let roots = sidebarPresentationRoots()
     let repositoryCount = roots.count
     var items: [SidebarItem] = []

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+CoreReducer.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+CoreReducer.swift
@@ -224,7 +224,8 @@ extension RepositoriesFeature {
       state.repositoryRoots = roots
       state.isInitialLoadComplete = true
       state.loadFailuresByID = Dictionary(
-        uniqueKeysWithValues: failures.map { ($0.rootID, $0.message) }
+        failures.map { ($0.rootID, $0.message) },
+        uniquingKeysWith: { first, _ in first }
       )
       let selectedWorktree = state.worktree(for: state.selectedWorktreeID)
       let selectionChanged = selectionDidChange(

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+GithubIntegration.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+GithubIntegration.swift
@@ -887,7 +887,8 @@ extension RepositoriesFeature {
       )
       guard !remoteInfos.isEmpty else {
         let clearedPullRequestsByWorktreeID = Dictionary(
-          uniqueKeysWithValues: worktreeIDs.map { ($0, Optional<GithubPullRequest>.none) }
+          worktreeIDs.map { ($0, Optional<GithubPullRequest>.none) },
+          uniquingKeysWith: { first, _ in first }
         )
         await send(
           .githubIntegration(

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+RepositoryLoading.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+RepositoryLoading.swift
@@ -242,11 +242,13 @@ extension RepositoriesFeature {
     animated: Bool
   ) -> ApplyRepositoriesResult {
     let previousCounts = Dictionary(
-      uniqueKeysWithValues: state.repositories.map { ($0.id, $0.worktrees.count) }
+      state.repositories.map { ($0.id, $0.worktrees.count) },
+      uniquingKeysWith: { first, _ in first }
     )
     let repositoryIDs = Set(repositories.map(\.id))
     let newCounts = Dictionary(
-      uniqueKeysWithValues: repositories.map { ($0.id, $0.worktrees.count) }
+      repositories.map { ($0.id, $0.worktrees.count) },
+      uniquingKeysWith: { first, _ in first }
     )
     var addedCounts: [Repository.ID: Int] = [:]
     for (id, newCount) in newCounts {

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+RepositoryManagement.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+RepositoryManagement.swift
@@ -100,7 +100,8 @@ extension RepositoriesFeature {
       state.repositoryRoots = roots
       state.isInitialLoadComplete = true
       state.loadFailuresByID = Dictionary(
-        uniqueKeysWithValues: failures.map { ($0.rootID, $0.message) }
+        failures.map { ($0.rootID, $0.message) },
+        uniquingKeysWith: { first, _ in first }
       )
       let openFailureMessages = invalidRoots.map { "\($0) is not a Git repository." } + openFailures
       if !openFailureMessages.isEmpty {

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+Selection.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+Selection.swift
@@ -322,7 +322,10 @@ func pruneWorktreeOrderByRepository(
   state: inout RepositoriesFeature.State
 ) -> Bool {
   let rootIDs = Set(roots.map { $0.standardizedFileURL.path(percentEncoded: false) })
-  let repositoriesByID = Dictionary(uniqueKeysWithValues: state.repositories.map { ($0.id, $0) })
+  let repositoriesByID = Dictionary(
+    state.repositories.map { ($0.id, $0) },
+    uniquingKeysWith: { first, _ in first }
+  )
   let pinnedSet = Set(state.pinnedWorktreeIDs)
   let archivedSet = state.archivedWorktreeIDSet
   var pruned: [Repository.ID: [Worktree.ID]] = [:]

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+StateQueries.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+StateQueries.swift
@@ -322,9 +322,10 @@ extension RepositoriesFeature.State {
 
   func orderedRepositoryRoots() -> [URL] {
     let rootsByID = Dictionary(
-      uniqueKeysWithValues: repositoryRoots.map {
+      repositoryRoots.map {
         ($0.standardizedFileURL.path(percentEncoded: false), $0.standardizedFileURL)
-      }
+      },
+      uniquingKeysWith: { first, _ in first }
     )
     var ordered: [URL] = []
     var seen: Set<Repository.ID> = []
@@ -540,7 +541,10 @@ extension RepositoriesFeature.State {
   }
 
   func orderedWorktreeRows(includingRepositoryIDs: Set<Repository.ID>) -> [WorktreeRowModel] {
-    let repositoriesByID = Dictionary(uniqueKeysWithValues: repositories.map { ($0.id, $0) })
+    let repositoriesByID = Dictionary(
+      repositories.map { ($0.id, $0) },
+      uniquingKeysWith: { first, _ in first }
+    )
     return orderedRepositoryIDs()
       .filter { includingRepositoryIDs.contains($0) }
       .compactMap { repositoriesByID[$0] }

--- a/supacode/Features/Repositories/Views/WorktreeRowsView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeRowsView.swift
@@ -30,10 +30,11 @@ struct WorktreeRowsView: View {
     let isRepositoryRemoving = state.isRemovingRepository(repository)
     let isSidebarDragActive = state.isSidebarDragActive
     let shortcutHintTextByID = Dictionary(
-      uniqueKeysWithValues: hotkeyRows.enumerated().compactMap { index, row -> (Worktree.ID, String)? in
+      hotkeyRows.enumerated().compactMap { index, row -> (Worktree.ID, String)? in
         guard let text = worktreeShortcutHint(for: index) else { return nil }
         return (row.id, text)
-      }
+      },
+      uniquingKeysWith: { first, _ in first }
     )
     let shortcutHints = WorktreeShortcutHints(
       textByID: shortcutHintTextByID,

--- a/supacode/Features/Shelf/Models/ShelfBook.swift
+++ b/supacode/Features/Shelf/Models/ShelfBook.swift
@@ -50,7 +50,7 @@ extension RepositoriesFeature.State {
   ) -> [ShelfBook] {
     // `ShelfView.body` re-runs on every TCA state change, so this method
     // is on the per-frame hot path. The previous implementation built a
-    // `Dictionary(uniqueKeysWithValues:)` per call and routed worktree
+    // a trapping dictionary initializer per call and routed worktree
     // ordering through `worktreeRowSections(in:)` — which constructs a
     // full `WorktreeRowModel` per worktree (PR/info lookups, icon
     // resolution, etc.) plus several intermediate `Set` allocations per

--- a/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
+++ b/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
@@ -648,7 +648,10 @@ final class WorktreeTerminalManager {
     _ payload: TerminalLayoutSnapshotPayload,
     availableWorktrees: [Worktree]
   ) -> Bool {
-    let worktreeByID = Dictionary(uniqueKeysWithValues: availableWorktrees.map { ($0.id, $0) })
+    let worktreeByID = Dictionary(
+      availableWorktrees.map { ($0.id, $0) },
+      uniquingKeysWith: { first, _ in first }
+    )
     var restoredStates: [WorktreeTerminalState] = []
     restoredStates.reserveCapacity(payload.worktrees.count)
 

--- a/supacode/Features/Terminal/Models/TerminalTabManager.swift
+++ b/supacode/Features/Terminal/Models/TerminalTabManager.swift
@@ -111,7 +111,10 @@ final class TerminalTabManager {
     let existingIds = Set(tabs.map(\.id))
     let incomingIds = Set(orderedIds)
     guard existingIds == incomingIds else { return }
-    let map = Dictionary(uniqueKeysWithValues: tabs.map { ($0.id, $0) })
+    let map = Dictionary(
+      tabs.map { ($0.id, $0) },
+      uniquingKeysWith: { first, _ in first }
+    )
     tabs = orderedIds.compactMap { map[$0] }
   }
 

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState+LayoutSnapshot.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState+LayoutSnapshot.swift
@@ -133,7 +133,10 @@ extension WorktreeTerminalState {
 
     trees = restoredTrees
     focusedSurfaceIdByTab = restoredFocusedSurfaceIDs
-    tabIsRunningById = Dictionary(uniqueKeysWithValues: restoredTabs.map { ($0.id, false) })
+    tabIsRunningById = Dictionary(
+      restoredTabs.map { ($0.id, false) },
+      uniquingKeysWith: { first, _ in first }
+    )
     tabManager.tabs = restoredTabs
     tabManager.selectedTabId = selectedTabID
     setRunScriptTabId(nil)

--- a/supacodeTests/AppShortcutsTests.swift
+++ b/supacodeTests/AppShortcutsTests.swift
@@ -149,8 +149,14 @@ struct AppShortcutsTests {
   }
 
   @Test func configurableSystemFixedAndLocalInteractionShortcutsAreDefinedInRegistry() {
-    let idToDisplay = Dictionary(uniqueKeysWithValues: AppShortcuts.bindings.map { ($0.id, $0.shortcut.display) })
-    let idToScope = Dictionary(uniqueKeysWithValues: AppShortcuts.bindings.map { ($0.id, $0.scope) })
+    let idToDisplay = Dictionary(
+      AppShortcuts.bindings.map { ($0.id, $0.shortcut.display) },
+      uniquingKeysWith: { first, _ in first }
+    )
+    let idToScope = Dictionary(
+      AppShortcuts.bindings.map { ($0.id, $0.scope) },
+      uniquingKeysWith: { first, _ in first }
+    )
 
     expectNoDifference(
       idToDisplay["command_palette"],

--- a/supacodeTests/CommandPaletteFeatureTests.swift
+++ b/supacodeTests/CommandPaletteFeatureTests.swift
@@ -771,9 +771,10 @@ struct CommandPaletteFeatureTests {
       )
     }
     let recency = Dictionary(
-      uniqueKeysWithValues: items.enumerated().map { idx, item in
+      items.enumerated().map { idx, item in
         (item.id, now.timeIntervalSince1970 - TimeInterval(idx + 1) * 3600)
-      }
+      },
+      uniquingKeysWith: { first, _ in first }
     )
 
     let result = CommandPaletteFeature.suggestions(items: items, recencyByID: recency, now: now)

--- a/supacodeTests/PullRequestRefreshCoordinatorTests.swift
+++ b/supacodeTests/PullRequestRefreshCoordinatorTests.swift
@@ -358,9 +358,10 @@ struct PullRequestRefreshCoordinatorTests {
       },
       legacy: { _, _, repo, branches in
         Dictionary(
-          uniqueKeysWithValues: branches.map { branch in
+          branches.map { branch in
             (branch, makeFixturePullRequest(repo: repo))
-          }
+          },
+          uniquingKeysWith: { first, _ in first }
         )
       }
     )

--- a/supacodeTests/WorktreeInfoWatcherManagerTests.swift
+++ b/supacodeTests/WorktreeInfoWatcherManagerTests.swift
@@ -65,6 +65,32 @@ struct WorktreeInfoWatcherManagerTests {
     try FileManager.default.removeItem(at: tempRepository.tempRoot)
   }
 
+  @Test func buildsWorktreeLookupWithoutTrappingOnDuplicateID() async throws {
+    let tempWorktree = try makeTempWorktree()
+    let duplicate = Worktree(
+      id: tempWorktree.worktree.id,
+      name: "eagle-duplicate",
+      detail: "duplicate",
+      workingDirectory: tempWorktree.worktree.workingDirectory,
+      repositoryRootURL: tempWorktree.worktree.repositoryRootURL
+    )
+    let manager = WorktreeInfoWatcherManager(
+      focusedInterval: .seconds(3_600),
+      unfocusedInterval: .seconds(3_600)
+    )
+    let (collector, task) = startCollecting(manager.eventStream())
+
+    manager.handleCommand(.setPullRequestTrackingEnabled(false))
+    manager.handleCommand(.setWorktrees([tempWorktree.worktree, duplicate]))
+
+    await drainAsyncEvents(120)
+    #expect(await collector.filesChangedCount(worktreeID: tempWorktree.worktree.id) == 1)
+
+    manager.handleCommand(.stop)
+    await task.value
+    try FileManager.default.removeItem(at: tempWorktree.tempRoot)
+  }
+
   @Test func staggersDeferredLineChangesAcrossWorktrees() async throws {
     let clock = TestClock()
     let tempRepository = try makeTempRepository(worktreeNames: ["sparrow", "swift", "eagle"])


### PR DESCRIPTION
## Summary

- prevent `WorktreeInfoWatcherManager` from trapping when repository loading produces duplicate `Worktree.ID` values
- add a regression test for duplicate worktree IDs in the watcher input
- add a SwiftLint custom rule that blocks direct `Dictionary(uniqueKeysWithValues:)` usage, and convert existing call sites to explicit duplicate handling

## Root cause

Sentry issue `PROWL-MACOS-D6` crashes in `WorktreeInfoWatcherManager.setWorktrees` while building a dictionary with `Dictionary(uniqueKeysWithValues:)`. That initializer traps on duplicate keys, and base-directory collisions can enumerate the same worktree path more than once.

The trapping call was introduced by `c6d14452435799a1727ccf840c5e5d41e9e1281b` on 2026-01-27. Upstream fixed the same class of crash in `84be657a46a783b5c9c8369ab950cd7eb5f2468a` on 2026-06-29, but this fork's `prowl@2026.6.27` release did not include that commit.

## Verification

- `xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -only-testing:"supacodeTests/WorktreeInfoWatcherManagerTests/buildsWorktreeLookupWithoutTrappingOnDuplicateID()" CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation 2>&1 | xcsift`
- `xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -only-testing:supacodeTests/WorktreeInfoWatcherManagerTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation 2>&1 | xcsift`
- `xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -only-testing:supacodeTests/WorktreeInfoWatcherManagerTests -only-testing:supacodeTests/AppShortcutsTests -only-testing:supacodeTests/CommandPaletteFeatureTests -only-testing:supacodeTests/PullRequestRefreshCoordinatorTests -only-testing:supacodeTests/CLIAgentsCommandHandlerTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation 2>&1 | xcsift`
- `make check`
- `make build-app 2>&1 | xcsift`
