### PR TITLE
tweak: add pointer cursor to PR title in checks popover

### DIFF
--- a/supacode/Features/Repositories/Views/PullRequestChecksPopoverView.swift
+++ b/supacode/Features/Repositories/Views/PullRequestChecksPopoverView.swift
@@ -59,6 +59,8 @@ struct PullRequestChecksPopoverView: View {
           }
           .buttonStyle(.plain)
           .focusable(false)
+          .onHover { _ in }
+          .pointerStyle(.link)
           .help(openPullRequestHelpText)
           .modifier(KeyboardShortcutModifier(shortcut: openPullRequestShortcut?.keyboardShortcut))
           .font(.headline)
@@ -200,6 +202,6 @@ private struct LinkLabel: View {
         isHovering = hovering
       }
       .pointerStyle(.link)
-      .accessibilityHint("Open check details on GitHub")
+      .accessibilityHint("Open on GitHub")
   }
 }


### PR DESCRIPTION
## Purpose

PR status popover 中 PR 标题点击可打开 GitHub，但缺少指针光标，用户不容易发现这是可点击的链接。与同一 popover 内的 CI check 名称（PR #521 已添加 hover link 效果）交互不一致。

## Changes

**`PullRequestChecksPopoverView.swift`** (+3, -1)
- PR 标题 Button 添加 `.onHover { _ in }` + `.pointerStyle(.link)`，hover 时显示手型光标
- `LinkLabel` 的 accessibilityHint 从 "Open check details on GitHub" 改为 "Open on GitHub"（更通用，适用于 PR 标题和 CI check）

## Impact

| Before | After |
|--------|-------|
| PR 标题无可点击视觉提示 | hover 时显示手型光标 |
| CI check 有 hover 效果，PR 标题没有 | 两者交互一致 |

## Test Plan

- `make build-app` — 确认编译通过
- 打开 PR status popover，hover PR 标题，验证手型光标出现
- hover CI check 名称，验证行为与之前一致

## Test Result

- [ ] `make build-app` 通过
- [ ] 手动验证 PR 标题 hover 手型光标
- [ ] 手动验证 CI check hover 行为一致