### PR TITLE
Add Telegram bot remote control

### DIFF
--- a/docs/components/cli.md
+++ b/docs/components/cli.md
@@ -4,7 +4,7 @@
 > an agent) can list panes, read their screens, run commands and capture output,
 > send keystrokes, focus, and open/close tabs and panes programmatically.
 
-**Keywords:** prowl cli, command line, prowl list, prowl agents, prowl read, prowl send, prowl key, prowl focus, prowl tab, prowl pane, prowl open, pane id, automation, json, capture, socket
+**Keywords:** prowl cli, command line, prowl list, prowl agents, prowl read, prowl send, prowl key, prowl focus, prowl tab, prowl pane, prowl open, telegram bot, pane id, automation, json, capture, socket
 
 **Related:** [terminal](terminal.md) · [concepts](../concepts.md) · [active-agents](active-agents.md) · [agent-detection](agent-detection.md) · the bundled **`prowl-cli` skill** (`skills/prowl-cli/SKILL.md`)
 
@@ -19,6 +19,15 @@ the task is to act on a pane **other than the current one** — check a sibling
 agent, run something in another tab and grab the output, focus a worktree, open a
 project, or close a scratch tab. It is **not** for ordinary editing/building
 inside a repo, and not for how-to questions about Prowl's settings.
+
+The built-in Telegram bot uses the same command router as this CLI. Its commands
+are shorter Telegram forms (`/agents`, `/list`, `/read <pane-id> [lines]`,
+`/focus <pane-id>`, `/send <pane-id> <text>`, `/key <pane-id> <token>`,
+`/tab_create <worktree>`, `/pane_close <pane-id>`, `/tab_close <tab-id>`), but
+they resolve to the same app-side operations and target model documented here.
+By default, `/send` and `/key` require a pane ID; Settings → Telegram can allow
+those two commands to use the current Prowl focus instead. Close commands always
+require an explicit target. Configure it in Settings → Telegram.
 
 ## Install
 
@@ -198,6 +207,9 @@ identifying the target).
 prowl pane close --pane "$pane" --json
 prowl tab close --tab "$tab" --force --json
 ```
+
+Telegram bot close commands never pass `--force`; identify the pane/tab first,
+then close it from the GUI or CLI if a forced close is needed.
 
 ### `prowl open [path]` (the default command)
 Navigate Prowl to a path (or bring it to front with no argument). It may focus an

--- a/docs/components/notifications.md
+++ b/docs/components/notifications.md
@@ -3,7 +3,7 @@
 > How Prowl tells you an agent finished or needs you — system notifications, the
 > bell/unread indicators, and Dock badge/bounce.
 
-**Keywords:** notification, agent reminder, bell, unread, command finished, dock badge, dock bounce, sound, alert, finished
+**Keywords:** notification, agent reminder, bell, unread, command finished, dock badge, dock bounce, sound, alert, finished, telegram bot
 
 **Related:** [agent-detection](agent-detection.md) · [active-agents](active-agents.md) · [terminal](terminal.md) · [settings](settings.md)
 
@@ -69,6 +69,17 @@ top of its section. **Jump to Latest Unread** (`⌘⌥U`) takes you straight to 
 - `showNotificationDotOnDock`, `dockBounceMode` — Dock badge & bounce.
 
 Full field detail: [`reference/settings-fields.md`](../reference/settings-fields.md).
+
+## Telegram bot
+
+The Telegram bot is a remote-control channel, not a notification backend. It
+does not mirror bell/unread events into Telegram. Instead, authorized Telegram
+users can query and drive the same panes exposed by the [`prowl` CLI](cli.md)
+with commands such as `/agents`, `/list`, `/read`, `/send`, and `/key`.
+
+Configure it under Settings → Telegram. Keep write commands targeted by explicit
+pane/tab/worktree IDs; this avoids sending text or close requests to whichever
+pane happens to be focused.
 
 ## Gotchas for agents
 

--- a/docs/components/settings.md
+++ b/docs/components/settings.md
@@ -3,7 +3,7 @@
 > The Settings window (`⌘,`): what each tab controls. For the exhaustive
 > field-by-field list, see [`reference/settings-fields.md`](../reference/settings-fields.md).
 
-**Keywords:** settings, preferences, ⌘comma, general, notifications, shortcuts, worktree, updates, advanced, github, repo settings, appearance
+**Keywords:** settings, preferences, ⌘comma, general, notifications, shortcuts, worktree, updates, advanced, github, telegram, repo settings, appearance
 
 **Related:** [reference/settings-fields](../reference/settings-fields.md) · [custom-actions](custom-actions.md) · [updates](updates.md) · [notifications](notifications.md)
 
@@ -23,6 +23,7 @@ window is a sidebar of tabs plus a detail pane.
 | **Updates** | Update channel (Stable/Tip), auto-check toggle, "Check for Updates Now". → [updates](updates.md) |
 | **Advanced** | Analytics, crash reports, restore terminal layout on launch (experimental) + clear saved layout, and the **Install Command Line Tool** (`prowl` CLI) action. |
 | **GitHub** | Enable GitHub integration (uses the `gh` CLI). → [github-pull-requests](github-pull-requests.md) |
+| **Telegram** | Enable the built-in Telegram bot, store the Bot API token, allowlist Telegram user IDs, test `getMe`, and tune default `/read` output. The bot routes to the same command handlers as the [`prowl` CLI](cli.md). |
 | **Repositories / Repo Settings** | Per-repository: setup/archive/run scripts, **Custom Commands**, default base ref & directory, copy-files overrides, open-with app, custom title, icon & color, PR merge strategy, line-diff & PR-state fetching. Reached from the sidebar context menu → "Repo Settings". → [custom-actions](custom-actions.md), [repositories-and-worktrees](repositories-and-worktrees.md) |
 
 ## Where settings live on disk
@@ -32,6 +33,22 @@ window is a sidebar of tabs plus a detail pane.
 - **Per-repo custom commands:** `~/.prowl/repo/<repo-name>/prowl.onevcat.json`
 
 Legacy `~/.supacode` is migrated to `~/.prowl` on first launch.
+
+## Telegram bot
+
+Settings → Telegram controls the optional Bot API integration:
+
+- Enable/disable starts or stops the long-polling runtime.
+- Bot token is stored in `~/.prowl/settings.json`; logs never include it.
+- Allowed user IDs are a comma/space/newline-separated allowlist. Messages from
+  any other Telegram user are ignored.
+- Default read lines controls `/read <pane-id>` when the message omits a count.
+- `/send` and `/key` use explicit pane IDs by default; disabling the explicit
+  target toggle lets them use the current Prowl focus. `/pane_close` and
+  `/tab_close` always require explicit IDs.
+
+The Test Connection button calls Telegram `getMe` with the configured token and
+shows the bot identity or a short error.
 
 ## Install the CLI from here
 

--- a/docs/reference/settings-fields.md
+++ b/docs/reference/settings-fields.md
@@ -66,6 +66,11 @@ JSON is pretty-printed with sorted keys. Legacy `~/.supacode` is migrated to
 | `shelfSpineTintFollowsRepositoryColor` | Bool | `true` | Tint shelf spines by repo color. |
 | `externalDiffToolID` | String | `built-in` | Tool used by diff badges and Show Diff: `built-in`, `hunk`, `filemerge`, `kaleidoscope`, or `custom`. |
 | `externalDiffCustomCommand` | String | `""` | Command template for `externalDiffToolID = custom`; supports `{leftPath}`, `{rightPath}`, `{worktreePath}`, `{repoPath}`, and `{branch}`. |
+| `telegramBotEnabled` | Bool | `false` | Start the built-in Telegram bot long-polling runtime. |
+| `telegramBotToken` | String? | `nil` | Telegram Bot API token used for `getUpdates`, `getMe`, and `sendMessage`; never logged. |
+| `telegramAllowedUserIDs` | `[Int64]` | `[]` | Telegram user ID allowlist. Messages from other users are ignored. |
+| `telegramDefaultReadLines` | Int | `80` | Default line count for Telegram `/read <pane-id>` when no count is provided; decoded values are clamped to `1...500`. |
+| `telegramRequireExplicitPaneForWrite` | Bool | `true` | Require explicit pane IDs for Telegram `/send` and `/key`; close commands always require explicit IDs. |
 
 ## Per-repository settings (`RepositorySettings`)
 

--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -44,6 +44,7 @@ final class SupacodeAppDelegate: NSObject, NSApplicationDelegate {
   }
   var terminalManager: WorktreeTerminalManager?
   var cliSocketServer: CLISocketServer?
+  var telegramBotRuntime: TelegramBotRuntime?
 
   func applicationDidFinishLaunching(_ notification: Notification) {
     WindowLifecycleDiagnostics.startMainThreadHeartbeat()
@@ -81,7 +82,10 @@ final class SupacodeAppDelegate: NSObject, NSApplicationDelegate {
 
   func applicationWillTerminate(_ notification: Notification) {
     WindowLifecycleDiagnostics.logWithWindows("applicationWillTerminate")
-    defer { cliSocketServer?.stop() }
+    defer {
+      cliSocketServer?.stop()
+      telegramBotRuntime?.stop()
+    }
     guard appStore?.state.settings.restoreTerminalLayoutOnLaunch == true else { return }
     guard appStore?.state.suppressLayoutSaveUntilRelaunch != true else { return }
     terminalManager?.persistLayoutSnapshotSync()
@@ -104,6 +108,7 @@ struct SupacodeApp: App {
   @State private var pullRequestRefreshCoordinator: PullRequestRefreshCoordinator
   @State private var commandKeyObserver: CommandKeyObserver
   @State private var cliSocketServer: CLISocketServer
+  @State private var telegramBotRuntime: TelegramBotRuntime
   @State private var store: StoreOf<AppFeature>
   @State private var memoryWatchdog: MemoryWatchdog
   @State private var askAgentHelp = AskAgentHelpPresenter()
@@ -233,8 +238,17 @@ struct SupacodeApp: App {
     _store = State(initialValue: appStore)
     storeBox.store = appStore
 
-    let cliServer = Self.makeCLISocketServer(appStore: appStore, terminalManager: terminalManager)
+    let cliRouter = Self.makeCLICommandRouter(appStore: appStore, terminalManager: terminalManager)
+    let cliServer = Self.makeCLISocketServer(router: cliRouter)
     _cliSocketServer = State(initialValue: cliServer)
+    let telegramRuntime = TelegramBotRuntime(
+      client: .liveValue,
+      route: { envelope in
+        await cliRouter.route(envelope)
+      }
+    )
+    telegramRuntime.apply(configuration: initialAppState.settings.telegramBotConfiguration)
+    _telegramBotRuntime = State(initialValue: telegramRuntime)
 
     let watchdog = Self.makeMemoryWatchdog(appStore: appStore, terminalManager: terminalManager)
     #if !DEBUG
@@ -248,6 +262,7 @@ struct SupacodeApp: App {
     appDelegate.appStore = appStore
     appDelegate.terminalManager = terminalManager
     appDelegate.cliSocketServer = cliServer
+    appDelegate.telegramBotRuntime = telegramRuntime
     SettingsWindowManager.shared.configure(
       store: appStore,
       ghosttyShortcuts: shortcuts,
@@ -625,11 +640,7 @@ struct SupacodeApp: App {
     )
   }
 
-  private static func makeCLISocketServer(
-    appStore: StoreOf<AppFeature>,
-    terminalManager: WorktreeTerminalManager
-  ) -> CLISocketServer {
-    let cliRouter = makeCLICommandRouter(appStore: appStore, terminalManager: terminalManager)
+  private static func makeCLISocketServer(router cliRouter: CLICommandRouter) -> CLISocketServer {
     let cliServer = CLISocketServer(router: cliRouter)
     let logger = SupaLogger("CLIService")
     do {
@@ -846,12 +857,16 @@ struct SupacodeApp: App {
         WindowLifecycleDiagnostics.logWithWindows("mainWindow content onAppear")
         WindowLifecycleDiagnostics.noteMainWindowAppeared()
         syncGhosttyManagedShortcuts(with: store.resolvedKeybindings)
+        telegramBotRuntime.apply(configuration: store.settings.telegramBotConfiguration)
       }
       .onDisappear {
         WindowLifecycleDiagnostics.logWithWindows("mainWindow content onDisappear")
       }
       .onChange(of: store.resolvedKeybindings) { _, newValue in
         syncGhosttyManagedShortcuts(with: newValue)
+      }
+      .onChange(of: store.settings.telegramBotConfiguration) { _, newValue in
+        telegramBotRuntime.apply(configuration: newValue)
       }
       .preferredColorScheme(store.settings.appearanceMode.colorScheme)
     }

--- a/supacode/Clients/Telegram/TelegramBotClient.swift
+++ b/supacode/Clients/Telegram/TelegramBotClient.swift
@@ -1,0 +1,176 @@
+import Dependencies
+import Foundation
+
+nonisolated struct TelegramBotUser: Codable, Equatable, Sendable {
+  let id: Int64
+  let isBot: Bool
+  let firstName: String
+  let username: String?
+
+  enum CodingKeys: String, CodingKey {
+    case id
+    case isBot = "is_bot"
+    case firstName = "first_name"
+    case username
+  }
+}
+
+nonisolated struct TelegramBotChat: Codable, Equatable, Sendable {
+  let id: Int64
+}
+
+nonisolated struct TelegramBotMessage: Codable, Equatable, Sendable {
+  let messageID: Int
+  let from: TelegramBotUser?
+  let chat: TelegramBotChat
+  let text: String?
+
+  enum CodingKeys: String, CodingKey {
+    case messageID = "message_id"
+    case from
+    case chat
+    case text
+  }
+}
+
+nonisolated struct TelegramBotUpdate: Codable, Equatable, Sendable {
+  let updateID: Int
+  let message: TelegramBotMessage?
+
+  enum CodingKeys: String, CodingKey {
+    case updateID = "update_id"
+    case message
+  }
+}
+
+enum TelegramBotClientError: Error, Equatable, Sendable {
+  case invalidResponse
+  case api(errorCode: Int?, description: String)
+}
+
+struct TelegramBotClient: Sendable, DependencyKey {
+  var getMe: @Sendable (_ token: String) async throws -> TelegramBotUser
+  var getUpdates: @Sendable (_ token: String, _ offset: Int?, _ timeout: Int) async throws -> [TelegramBotUpdate]
+  var sendMessage: @Sendable (_ token: String, _ chatID: Int64, _ text: String) async throws -> Void
+
+  static let liveValue = TelegramBotClient(
+    getMe: { token in
+      try await TelegramBotHTTPClient.request(
+        token: token,
+        method: "getMe",
+        queryItems: []
+      )
+    },
+    getUpdates: { token, offset, timeout in
+      var queryItems = [
+        URLQueryItem(name: "timeout", value: String(timeout)),
+        URLQueryItem(name: "allowed_updates", value: #"["message"]"#),
+      ]
+      if let offset {
+        queryItems.append(URLQueryItem(name: "offset", value: String(offset)))
+      }
+      return try await TelegramBotHTTPClient.request(
+        token: token,
+        method: "getUpdates",
+        queryItems: queryItems
+      )
+    },
+    sendMessage: { token, chatID, text in
+      let _: TelegramBotMessage = try await TelegramBotHTTPClient.request(
+        token: token,
+        method: "sendMessage",
+        queryItems: [
+          URLQueryItem(name: "chat_id", value: String(chatID)),
+          URLQueryItem(name: "text", value: text),
+        ],
+        httpMethod: "POST"
+      )
+    }
+  )
+
+  static let testValue = TelegramBotClient(
+    getMe: { _ in
+      throw TelegramBotClientError.invalidResponse
+    },
+    getUpdates: { _, _, _ in
+      throw TelegramBotClientError.invalidResponse
+    },
+    sendMessage: { _, _, _ in
+      throw TelegramBotClientError.invalidResponse
+    }
+  )
+}
+
+extension DependencyValues {
+  var telegramBotClient: TelegramBotClient {
+    get { self[TelegramBotClient.self] }
+    set { self[TelegramBotClient.self] = newValue }
+  }
+}
+
+private enum TelegramBotHTTPClient {
+  static func request<Result: Decodable>(
+    token: String,
+    method: String,
+    queryItems: [URLQueryItem],
+    httpMethod: String = "GET"
+  ) async throws -> Result {
+    guard var components = URLComponents(string: "https://api.telegram.org/bot\(token)/\(method)") else {
+      throw TelegramBotClientError.invalidResponse
+    }
+
+    var request: URLRequest
+    if httpMethod == "GET" {
+      components.queryItems = queryItems.isEmpty ? nil : queryItems
+      guard let url = components.url else { throw TelegramBotClientError.invalidResponse }
+      request = URLRequest(url: url)
+    } else {
+      guard let url = components.url else { throw TelegramBotClientError.invalidResponse }
+      request = URLRequest(url: url)
+      request.httpMethod = httpMethod
+      request.setValue("application/x-www-form-urlencoded; charset=utf-8", forHTTPHeaderField: "Content-Type")
+      request.httpBody = formURLEncoded(queryItems).data(using: .utf8)
+    }
+
+    let (data, _) = try await URLSession.shared.data(for: request)
+    let decoded = try JSONDecoder().decode(TelegramBotAPIResponse<Result>.self, from: data)
+    if decoded.success, let result = decoded.result {
+      return result
+    }
+    throw TelegramBotClientError.api(
+      errorCode: decoded.errorCode,
+      description: decoded.description ?? "Telegram Bot API request failed."
+    )
+  }
+
+  private static func formURLEncoded(_ queryItems: [URLQueryItem]) -> String {
+    queryItems.map { item in
+      let name = item.name.addingPercentEncoding(withAllowedCharacters: .telegramFormAllowed) ?? item.name
+      let value = (item.value ?? "").addingPercentEncoding(withAllowedCharacters: .telegramFormAllowed) ?? ""
+      return "\(name)=\(value)"
+    }
+    .joined(separator: "&")
+  }
+}
+
+extension CharacterSet {
+  fileprivate static let telegramFormAllowed: CharacterSet = {
+    var allowed = CharacterSet.urlQueryAllowed
+    allowed.remove(charactersIn: "&=+")
+    return allowed
+  }()
+}
+
+nonisolated private struct TelegramBotAPIResponse<Result: Decodable>: Decodable {
+  let success: Bool
+  let result: Result?
+  let description: String?
+  let errorCode: Int?
+
+  enum CodingKeys: String, CodingKey {
+    case success = "ok"
+    case result
+    case description
+    case errorCode = "error_code"
+  }
+}

--- a/supacode/Domain/ProjectWorkspace.swift
+++ b/supacode/Domain/ProjectWorkspace.swift
@@ -597,8 +597,8 @@ nonisolated struct ProjectWorkspace: Codable, Equatable, Hashable, Sendable {
     fileManager: FileManager,
     gitRunner: ProjectWorkspaceGitRunner
   ) async {
-    nonisolated(unsafe) let fileManager = fileManager
     let task = Task.detached {
+      let fileManager = FileManager.default
       for command in ledger.cleanupCommands.reversed() {
         do {
           try await gitRunner.run(command)

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -381,7 +381,7 @@ struct AppFeature {
           repoSettingsState.globalCopyUntrackedOnWorktreeCreate = state.settings.copyUntrackedOnWorktreeCreate
           repoSettingsState.globalPullRequestMergeStrategy = state.settings.pullRequestMergeStrategy
           state.settings.repositorySettings = repoSettingsState
-        case .general, .notifications, .shortcuts, .worktree, .updates, .advanced, .github:
+        case .general, .notifications, .shortcuts, .worktree, .updates, .advanced, .github, .telegram:
           state.settings.repositorySettings = nil
         }
         return .none

--- a/supacode/Features/Settings/Models/GlobalSettings.swift
+++ b/supacode/Features/Settings/Models/GlobalSettings.swift
@@ -14,6 +14,11 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
   var analyticsEnabled: Bool
   var crashReportsEnabled: Bool
   var githubIntegrationEnabled: Bool
+  var telegramBotEnabled: Bool
+  var telegramBotToken: String?
+  var telegramAllowedUserIDs: [Int64]
+  var telegramDefaultReadLines: Int
+  var telegramRequireExplicitPaneForWrite: Bool
   var deleteBranchOnDeleteWorktree: Bool
   var mergedWorktreeAction: MergedWorktreeAction?
   var promptForWorktreeCreation: Bool
@@ -59,6 +64,11 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     analyticsEnabled: true,
     crashReportsEnabled: true,
     githubIntegrationEnabled: true,
+    telegramBotEnabled: false,
+    telegramBotToken: nil,
+    telegramAllowedUserIDs: [],
+    telegramDefaultReadLines: 80,
+    telegramRequireExplicitPaneForWrite: true,
     deleteBranchOnDeleteWorktree: false,
     mergedWorktreeAction: nil,
     promptForWorktreeCreation: true,
@@ -103,6 +113,11 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     analyticsEnabled: Bool,
     crashReportsEnabled: Bool,
     githubIntegrationEnabled: Bool,
+    telegramBotEnabled: Bool = false,
+    telegramBotToken: String? = nil,
+    telegramAllowedUserIDs: [Int64] = [],
+    telegramDefaultReadLines: Int = 80,
+    telegramRequireExplicitPaneForWrite: Bool = true,
     deleteBranchOnDeleteWorktree: Bool,
     mergedWorktreeAction: MergedWorktreeAction? = nil,
     promptForWorktreeCreation: Bool,
@@ -145,6 +160,11 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     self.analyticsEnabled = analyticsEnabled
     self.crashReportsEnabled = crashReportsEnabled
     self.githubIntegrationEnabled = githubIntegrationEnabled
+    self.telegramBotEnabled = telegramBotEnabled
+    self.telegramBotToken = telegramBotToken
+    self.telegramAllowedUserIDs = telegramAllowedUserIDs
+    self.telegramDefaultReadLines = max(1, min(telegramDefaultReadLines, 500))
+    self.telegramRequireExplicitPaneForWrite = telegramRequireExplicitPaneForWrite
     self.deleteBranchOnDeleteWorktree = deleteBranchOnDeleteWorktree
     self.mergedWorktreeAction = mergedWorktreeAction
     self.promptForWorktreeCreation = promptForWorktreeCreation
@@ -190,6 +210,11 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     try container.encode(analyticsEnabled, forKey: .analyticsEnabled)
     try container.encode(crashReportsEnabled, forKey: .crashReportsEnabled)
     try container.encode(githubIntegrationEnabled, forKey: .githubIntegrationEnabled)
+    try container.encode(telegramBotEnabled, forKey: .telegramBotEnabled)
+    try container.encodeIfPresent(telegramBotToken, forKey: .telegramBotToken)
+    try container.encode(telegramAllowedUserIDs, forKey: .telegramAllowedUserIDs)
+    try container.encode(telegramDefaultReadLines, forKey: .telegramDefaultReadLines)
+    try container.encode(telegramRequireExplicitPaneForWrite, forKey: .telegramRequireExplicitPaneForWrite)
     try container.encode(deleteBranchOnDeleteWorktree, forKey: .deleteBranchOnDeleteWorktree)
     try container.encodeIfPresent(mergedWorktreeAction, forKey: .mergedWorktreeAction)
     try container.encode(promptForWorktreeCreation, forKey: .promptForWorktreeCreation)
@@ -236,6 +261,11 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     case analyticsEnabled
     case crashReportsEnabled
     case githubIntegrationEnabled
+    case telegramBotEnabled
+    case telegramBotToken
+    case telegramAllowedUserIDs
+    case telegramDefaultReadLines
+    case telegramRequireExplicitPaneForWrite
     case deleteBranchOnDeleteWorktree
     case mergedWorktreeAction
     case promptForWorktreeCreation
@@ -270,45 +300,36 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
 
   init(from decoder: any Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
+    let base = Self.default
     appearanceMode = try container.decode(AppearanceMode.self, forKey: .appearanceMode)
-    defaultEditorID =
-      try container.decodeIfPresent(String.self, forKey: .defaultEditorID)
-      ?? Self.default.defaultEditorID
-    confirmBeforeQuit =
-      try container.decodeIfPresent(Bool.self, forKey: .confirmBeforeQuit)
-      ?? Self.default.confirmBeforeQuit
-    updateChannel =
-      try container.decodeIfPresent(UpdateChannel.self, forKey: .updateChannel)
-      ?? Self.default.updateChannel
+    defaultEditorID = try Self.value(.defaultEditorID, container, base.defaultEditorID)
+    confirmBeforeQuit = try Self.value(.confirmBeforeQuit, container, base.confirmBeforeQuit)
+    updateChannel = try Self.value(.updateChannel, container, base.updateChannel)
     updatesAutomaticallyCheckForUpdates = try container.decode(Bool.self, forKey: .updatesAutomaticallyCheckForUpdates)
     updatesAutomaticallyDownloadUpdates = try container.decode(Bool.self, forKey: .updatesAutomaticallyDownloadUpdates)
-    inAppNotificationsEnabled =
-      try container.decodeIfPresent(Bool.self, forKey: .inAppNotificationsEnabled)
-      ?? Self.default.inAppNotificationsEnabled
-    notificationSoundEnabled =
-      try container.decodeIfPresent(Bool.self, forKey: .notificationSoundEnabled)
-      ?? Self.default.notificationSoundEnabled
-    systemNotificationsEnabled =
-      try container.decodeIfPresent(Bool.self, forKey: .systemNotificationsEnabled)
-      ?? Self.default.systemNotificationsEnabled
-    moveNotifiedWorktreeToTop =
-      try container.decodeIfPresent(Bool.self, forKey: .moveNotifiedWorktreeToTop)
-      ?? Self.default.moveNotifiedWorktreeToTop
-    commandFinishedNotificationEnabled =
-      try container.decodeIfPresent(Bool.self, forKey: .commandFinishedNotificationEnabled)
-      ?? Self.default.commandFinishedNotificationEnabled
-    commandFinishedNotificationThreshold =
-      try container.decodeIfPresent(Int.self, forKey: .commandFinishedNotificationThreshold)
-      ?? Self.default.commandFinishedNotificationThreshold
-    analyticsEnabled =
-      try container.decodeIfPresent(Bool.self, forKey: .analyticsEnabled)
-      ?? Self.default.analyticsEnabled
-    crashReportsEnabled =
-      try container.decodeIfPresent(Bool.self, forKey: .crashReportsEnabled)
-      ?? Self.default.crashReportsEnabled
-    githubIntegrationEnabled =
-      try container.decodeIfPresent(Bool.self, forKey: .githubIntegrationEnabled)
-      ?? Self.default.githubIntegrationEnabled
+    inAppNotificationsEnabled = try Self.value(.inAppNotificationsEnabled, container, base.inAppNotificationsEnabled)
+    notificationSoundEnabled = try Self.value(.notificationSoundEnabled, container, base.notificationSoundEnabled)
+    systemNotificationsEnabled = try Self.value(.systemNotificationsEnabled, container, base.systemNotificationsEnabled)
+    moveNotifiedWorktreeToTop = try Self.value(.moveNotifiedWorktreeToTop, container, base.moveNotifiedWorktreeToTop)
+    commandFinishedNotificationEnabled = try Self.value(
+      .commandFinishedNotificationEnabled,
+      container,
+      base.commandFinishedNotificationEnabled
+    )
+    commandFinishedNotificationThreshold = try Self.value(
+      .commandFinishedNotificationThreshold,
+      container,
+      base.commandFinishedNotificationThreshold
+    )
+    let integrations = try Self.decodeIntegrationSettings(from: container)
+    analyticsEnabled = integrations.analyticsEnabled
+    crashReportsEnabled = integrations.crashReportsEnabled
+    githubIntegrationEnabled = integrations.githubIntegrationEnabled
+    telegramBotEnabled = integrations.telegramBotEnabled
+    telegramBotToken = integrations.telegramBotToken
+    telegramAllowedUserIDs = integrations.telegramAllowedUserIDs
+    telegramDefaultReadLines = integrations.telegramDefaultReadLines
+    telegramRequireExplicitPaneForWrite = integrations.telegramRequireExplicitPaneForWrite
     deleteBranchOnDeleteWorktree =
       try container.decodeIfPresent(Bool.self, forKey: .deleteBranchOnDeleteWorktree)
       ?? Self.default.deleteBranchOnDeleteWorktree
@@ -368,6 +389,25 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     showNotificationDotOnDock = toolbarAndDock.showNotificationDotOnDock
   }
 
+  private static func value<Value: Decodable>(
+    _ key: CodingKeys,
+    _ container: KeyedDecodingContainer<CodingKeys>,
+    _ defaultValue: Value
+  ) throws -> Value {
+    try container.decodeIfPresent(Value.self, forKey: key) ?? defaultValue
+  }
+
+  private struct IntegrationSettings {
+    let analyticsEnabled: Bool
+    let crashReportsEnabled: Bool
+    let githubIntegrationEnabled: Bool
+    let telegramBotEnabled: Bool
+    let telegramBotToken: String?
+    let telegramAllowedUserIDs: [Int64]
+    let telegramDefaultReadLines: Int
+    let telegramRequireExplicitPaneForWrite: Bool
+  }
+
   private static func decodeViewSettings(
     from container: KeyedDecodingContainer<CodingKeys>
   ) throws -> (DefaultViewMode, CanvasDefaultLayout) {
@@ -378,6 +418,37 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
       try container.decodeIfPresent(CanvasDefaultLayout.self, forKey: .canvasDefaultLayout)
       ?? Self.default.canvasDefaultLayout
     return (mode, layout)
+  }
+
+  private static func decodeIntegrationSettings(
+    from container: KeyedDecodingContainer<CodingKeys>
+  ) throws -> IntegrationSettings {
+    let decodedTelegramDefaultReadLines =
+      try container.decodeIfPresent(Int.self, forKey: .telegramDefaultReadLines)
+      ?? Self.default.telegramDefaultReadLines
+    return IntegrationSettings(
+      analyticsEnabled: try Self.value(.analyticsEnabled, container, Self.default.analyticsEnabled),
+      crashReportsEnabled: try Self.value(.crashReportsEnabled, container, Self.default.crashReportsEnabled),
+      githubIntegrationEnabled: try Self.value(
+        .githubIntegrationEnabled,
+        container,
+        Self.default.githubIntegrationEnabled
+      ),
+      telegramBotEnabled: try Self.value(.telegramBotEnabled, container, Self.default.telegramBotEnabled),
+      telegramBotToken: try container.decodeIfPresent(String.self, forKey: .telegramBotToken)
+        ?? Self.default.telegramBotToken,
+      telegramAllowedUserIDs: try Self.value(
+        .telegramAllowedUserIDs,
+        container,
+        Self.default.telegramAllowedUserIDs
+      ),
+      telegramDefaultReadLines: max(1, min(decodedTelegramDefaultReadLines, 500)),
+      telegramRequireExplicitPaneForWrite: try Self.value(
+        .telegramRequireExplicitPaneForWrite,
+        container,
+        Self.default.telegramRequireExplicitPaneForWrite
+      )
+    )
   }
 
   private static func decodeWindowTint(

--- a/supacode/Features/Settings/Reducer/SettingsFeature.swift
+++ b/supacode/Features/Settings/Reducer/SettingsFeature.swift
@@ -21,6 +21,13 @@ struct SettingsFeature {
     var analyticsEnabled: Bool
     var crashReportsEnabled: Bool
     var githubIntegrationEnabled: Bool
+    var telegramBotEnabled: Bool
+    var telegramBotToken: String
+    var telegramAllowedUserIDsText: String
+    var telegramAllowedUserIDs: [Int64]
+    var telegramDefaultReadLines: Int
+    var telegramRequireExplicitPaneForWrite: Bool
+    var telegramConnectionStatus: TelegramConnectionStatus = .idle
     var deleteBranchOnDeleteWorktree: Bool
     var mergedWorktreeAction: MergedWorktreeAction?
     var archivedAutoDeletePeriod: AutoDeletePeriod?
@@ -79,6 +86,12 @@ struct SettingsFeature {
       analyticsEnabled = settings.analyticsEnabled
       crashReportsEnabled = settings.crashReportsEnabled
       githubIntegrationEnabled = settings.githubIntegrationEnabled
+      telegramBotEnabled = settings.telegramBotEnabled
+      telegramBotToken = settings.telegramBotToken ?? ""
+      telegramAllowedUserIDs = settings.telegramAllowedUserIDs
+      telegramAllowedUserIDsText = TelegramAllowedUserIDsParser.format(settings.telegramAllowedUserIDs)
+      telegramDefaultReadLines = settings.telegramDefaultReadLines
+      telegramRequireExplicitPaneForWrite = settings.telegramRequireExplicitPaneForWrite
       deleteBranchOnDeleteWorktree = settings.deleteBranchOnDeleteWorktree
       mergedWorktreeAction = settings.mergedWorktreeAction
       archivedAutoDeletePeriod = settings.archivedAutoDeletePeriod
@@ -127,6 +140,11 @@ struct SettingsFeature {
         analyticsEnabled: analyticsEnabled,
         crashReportsEnabled: crashReportsEnabled,
         githubIntegrationEnabled: githubIntegrationEnabled,
+        telegramBotEnabled: telegramBotEnabled,
+        telegramBotToken: telegramBotToken.trimmedNilIfEmpty,
+        telegramAllowedUserIDs: telegramAllowedUserIDs,
+        telegramDefaultReadLines: telegramDefaultReadLines,
+        telegramRequireExplicitPaneForWrite: telegramRequireExplicitPaneForWrite,
         deleteBranchOnDeleteWorktree: deleteBranchOnDeleteWorktree,
         mergedWorktreeAction: mergedWorktreeAction,
         promptForWorktreeCreation: promptForWorktreeCreation,
@@ -168,6 +186,9 @@ struct SettingsFeature {
     case setSelection(SettingsSection?)
     case setSystemNotificationsEnabled(Bool)
     case setCommandFinishedNotificationThreshold(String)
+    case setTelegramAllowedUserIDsText(String)
+    case testTelegramConnectionButtonTapped
+    case telegramConnectionTestCompleted(Result<String, TelegramConnectionTestError>)
     case setTerminalFontSize(Float32?)
     case clearTerminalLayoutSnapshotButtonTapped
     case installCLIButtonTapped(showAlert: Bool = true)
@@ -194,6 +215,17 @@ struct SettingsFeature {
     case failed(message: String)
   }
 
+  enum TelegramConnectionStatus: Equatable {
+    case idle
+    case testing
+    case success(String)
+    case failure(String)
+  }
+
+  struct TelegramConnectionTestError: Error, Equatable {
+    let message: String
+  }
+
   @CasePathable
   enum Delegate: Equatable {
     case settingsChanged(GlobalSettings)
@@ -206,6 +238,7 @@ struct SettingsFeature {
   @Dependency(SystemNotificationClient.self) private var systemNotificationClient
   @Dependency(TerminalLayoutPersistenceClient.self) private var terminalLayoutPersistence
   @Dependency(CLIInstallClient.self) private var cliInstallClient
+  @Dependency(TelegramBotClient.self) private var telegramBotClient
 
   var body: some Reducer<State, Action> {
     BindingReducer()
@@ -247,6 +280,13 @@ struct SettingsFeature {
         state.analyticsEnabled = normalizedSettings.analyticsEnabled
         state.crashReportsEnabled = normalizedSettings.crashReportsEnabled
         state.githubIntegrationEnabled = normalizedSettings.githubIntegrationEnabled
+        state.telegramBotEnabled = normalizedSettings.telegramBotEnabled
+        state.telegramBotToken = normalizedSettings.telegramBotToken ?? ""
+        state.telegramAllowedUserIDs = normalizedSettings.telegramAllowedUserIDs
+        state.telegramAllowedUserIDsText = TelegramAllowedUserIDsParser.format(
+          normalizedSettings.telegramAllowedUserIDs)
+        state.telegramDefaultReadLines = normalizedSettings.telegramDefaultReadLines
+        state.telegramRequireExplicitPaneForWrite = normalizedSettings.telegramRequireExplicitPaneForWrite
         state.deleteBranchOnDeleteWorktree = normalizedSettings.deleteBranchOnDeleteWorktree
         state.mergedWorktreeAction = normalizedSettings.mergedWorktreeAction
         state.archivedAutoDeletePeriod = normalizedSettings.archivedAutoDeletePeriod
@@ -279,6 +319,7 @@ struct SettingsFeature {
 
       case .binding:
         state.commandFinishedNotificationThreshold = min(max(state.commandFinishedNotificationThreshold, 0), 600)
+        state.telegramDefaultReadLines = min(max(state.telegramDefaultReadLines, 1), 500)
         state.syncGlobalDefaults(from: state.globalSettings)
         return persist(state)
 
@@ -294,6 +335,42 @@ struct SettingsFeature {
         state.systemNotificationsEnabled = isEnabled
         state.syncGlobalDefaults(from: state.globalSettings)
         return persist(state)
+
+      case .setTelegramAllowedUserIDsText(let text):
+        state.telegramAllowedUserIDsText = text
+        guard let ids = TelegramAllowedUserIDsParser.parse(text) else {
+          return .none
+        }
+        state.telegramAllowedUserIDs = ids
+        return persist(state)
+
+      case .testTelegramConnectionButtonTapped:
+        guard let token = state.globalSettings.telegramBotToken else {
+          state.telegramConnectionStatus = .failure("Bot token is required.")
+          return .none
+        }
+        state.telegramConnectionStatus = .testing
+        return .run { [telegramBotClient] send in
+          do {
+            let user = try await telegramBotClient.getMe(token)
+            let label = user.username.map { "@\($0)" } ?? user.firstName
+            await send(.telegramConnectionTestCompleted(.success(label)))
+          } catch {
+            await send(
+              .telegramConnectionTestCompleted(
+                .failure(TelegramConnectionTestError(message: telegramConnectionErrorMessage(error)))
+              )
+            )
+          }
+        }
+
+      case .telegramConnectionTestCompleted(.success(let label)):
+        state.telegramConnectionStatus = .success(label)
+        return .none
+
+      case .telegramConnectionTestCompleted(.failure(let error)):
+        state.telegramConnectionStatus = .failure(error.message)
+        return .none
 
       case .setTerminalFontSize(let fontSize):
         guard state.terminalFontSize != fontSize else { return .none }
@@ -456,6 +533,16 @@ struct SettingsFeature {
 }
 
 extension SettingsFeature.State {
+  var telegramBotConfiguration: TelegramBotConfiguration {
+    TelegramBotConfiguration(
+      enabled: telegramBotEnabled,
+      token: telegramBotToken,
+      allowedUserIDs: telegramAllowedUserIDs,
+      defaultReadLines: telegramDefaultReadLines,
+      requireExplicitPaneForWrite: telegramRequireExplicitPaneForWrite
+    )
+  }
+
   mutating func syncGlobalDefaults(from settings: GlobalSettings) {
     repositorySettings?.globalDefaultWorktreeBaseDirectoryPath =
       settings.defaultWorktreeBaseDirectoryPath
@@ -465,5 +552,27 @@ extension SettingsFeature.State {
       settings.copyUntrackedOnWorktreeCreate
     repositorySettings?.globalPullRequestMergeStrategy =
       settings.pullRequestMergeStrategy
+  }
+}
+
+private func telegramConnectionErrorMessage(_ error: Error) -> String {
+  if let clientError = error as? TelegramBotClientError {
+    switch clientError {
+    case .invalidResponse:
+      return "Telegram returned an invalid response."
+    case .api(let errorCode, let description):
+      if let errorCode {
+        return "Telegram API error \(errorCode): \(description)"
+      }
+      return "Telegram API error: \(description)"
+    }
+  }
+  return "Could not reach Telegram Bot API."
+}
+
+extension String {
+  fileprivate var trimmedNilIfEmpty: String? {
+    let trimmed = trimmingCharacters(in: .whitespacesAndNewlines)
+    return trimmed.isEmpty ? nil : trimmed
   }
 }

--- a/supacode/Features/Settings/Views/SettingsSection.swift
+++ b/supacode/Features/Settings/Views/SettingsSection.swift
@@ -8,5 +8,6 @@ enum SettingsSection: Hashable {
   case updates
   case advanced
   case github
+  case telegram
   case repository(Repository.ID)
 }

--- a/supacode/Features/Settings/Views/SettingsView.swift
+++ b/supacode/Features/Settings/Views/SettingsView.swift
@@ -44,6 +44,8 @@ struct SettingsView: View {
             .tag(SettingsSection.advanced)
           Label("GitHub", systemImage: "arrow.triangle.branch")
             .tag(SettingsSection.github)
+          Label("Telegram", systemImage: "paperplane")
+            .tag(SettingsSection.telegram)
 
           Section("Repositories") {
             ForEach(repositories) { repository in
@@ -103,6 +105,12 @@ struct SettingsView: View {
           GithubSettingsView(store: settingsStore)
             .navigationTitle("GitHub")
             .navigationSubtitle("GitHub CLI integration")
+        }
+      case .telegram:
+        SettingsDetailView {
+          TelegramSettingsView(store: settingsStore)
+            .navigationTitle("Telegram")
+            .navigationSubtitle("Bot remote control")
         }
       case .repository(let repositoryID):
         if let repository = repositories[id: repositoryID] {

--- a/supacode/Features/Settings/Views/TelegramSettingsView.swift
+++ b/supacode/Features/Settings/Views/TelegramSettingsView.swift
@@ -1,0 +1,119 @@
+import ComposableArchitecture
+import SwiftUI
+
+struct TelegramSettingsView: View {
+  @Bindable var store: StoreOf<SettingsFeature>
+
+  var body: some View {
+    VStack(alignment: .leading) {
+      Form {
+        Section("Telegram bot") {
+          Toggle(
+            "Enable Telegram bot",
+            isOn: $store.telegramBotEnabled
+          )
+          .help("Start or stop the built-in Telegram bot")
+
+          SecureField(
+            "Bot token",
+            text: $store.telegramBotToken
+          )
+          .textContentType(.password)
+          .help("Telegram bot token from BotFather")
+
+          LabeledContent("Allowed user IDs") {
+            TextField(
+              "123456789, 987654321",
+              text: Binding(
+                get: { store.telegramAllowedUserIDsText },
+                set: { store.send(.setTelegramAllowedUserIDsText($0)) }
+              ),
+              axis: .vertical
+            )
+            .lineLimit(2...4)
+            .help("Telegram user IDs that can control Prowl")
+          }
+
+          LabeledContent("Default read lines") {
+            Stepper(value: $store.telegramDefaultReadLines, in: 1...500) {
+              Text("\(store.telegramDefaultReadLines)")
+                .monospacedDigit()
+            }
+          }
+          .help("Default number of terminal lines returned by /read")
+
+          Toggle(
+            "Require explicit pane for send and key",
+            isOn: $store.telegramRequireExplicitPaneForWrite
+          )
+          .help("Require /send and /key to name a pane instead of using the current focus")
+
+          Label(
+            "Pane and tab close commands always require an explicit target ID.",
+            systemImage: "exclamationmark.triangle"
+          )
+          .font(.callout)
+          .foregroundStyle(.secondary)
+
+          HStack(spacing: 8) {
+            Button("Test Connection") {
+              store.send(.testTelegramConnectionButtonTapped)
+            }
+            .help("Call Telegram getMe with the configured bot token")
+            .disabled(store.telegramConnectionStatus == .testing)
+
+            telegramConnectionStatusView
+          }
+        }
+
+        Section("Commands") {
+          VStack(alignment: .leading, spacing: 6) {
+            commandRow("/agents", "Show current agent roster.")
+            commandRow("/list", "Show worktree, tab, and pane summary.")
+            commandRow("/read <pane-id> [lines]", "Read recent terminal output.")
+            commandRow("/focus <pane-id>", "Focus a pane in Prowl.")
+            commandRow("/send <pane-id> <text>", "Send text and Enter to a pane.")
+            commandRow("/key <pane-id> <token>", "Send a supported key token.")
+            commandRow("/tab_create <worktree>", "Create a tab in a worktree.")
+            commandRow("/pane_close <pane-id>", "Close a pane with normal confirmation policy.")
+            commandRow("/tab_close <tab-id>", "Close a tab with normal confirmation policy.")
+          }
+          .frame(maxWidth: .infinity, alignment: .leading)
+        }
+      }
+      .formStyle(.grouped)
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+  }
+
+  @ViewBuilder
+  private var telegramConnectionStatusView: some View {
+    switch store.telegramConnectionStatus {
+    case .idle:
+      EmptyView()
+    case .testing:
+      HStack(spacing: 6) {
+        ProgressView()
+          .controlSize(.small)
+        Text("Testing...")
+          .foregroundStyle(.secondary)
+      }
+    case .success(let label):
+      Label("Connected as \(label)", systemImage: "checkmark.circle.fill")
+        .foregroundStyle(.green)
+    case .failure(let message):
+      Label(message, systemImage: "xmark.circle.fill")
+        .foregroundStyle(.red)
+    }
+  }
+
+  private func commandRow(_ command: String, _ description: String) -> some View {
+    HStack(alignment: .firstTextBaseline, spacing: 12) {
+      Text(command)
+        .font(.body.monospaced())
+      Text(description)
+        .foregroundStyle(.secondary)
+      Spacer(minLength: 0)
+    }
+  }
+}

--- a/supacode/Features/Telegram/TelegramBotCommandParser.swift
+++ b/supacode/Features/Telegram/TelegramBotCommandParser.swift
@@ -1,0 +1,242 @@
+import Foundation
+
+struct TelegramBotCommandRequest: Sendable {
+  let commandName: String
+  let envelope: CommandEnvelope
+}
+
+enum TelegramBotParseResult: Sendable, CustomStringConvertible {
+  case command(TelegramBotCommandRequest)
+  case message(String)
+
+  var description: String {
+    switch self {
+    case .command(let request):
+      return "command(\(request.commandName))"
+    case .message(let text):
+      return "message(\(text))"
+    }
+  }
+}
+
+struct TelegramBotCommandParser: Sendable {
+  let defaultReadLines: Int
+  let requireExplicitPaneForWrite: Bool
+
+  init(defaultReadLines: Int, requireExplicitPaneForWrite: Bool) {
+    self.defaultReadLines = max(1, min(defaultReadLines, 500))
+    self.requireExplicitPaneForWrite = requireExplicitPaneForWrite
+  }
+
+  func parse(text: String) -> TelegramBotParseResult {
+    let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return .message(Self.helpText) }
+    guard trimmed.hasPrefix("/") else { return .message(Self.helpText) }
+
+    let (rawCommand, rest) = splitFirst(trimmed)
+    let command =
+      rawCommand
+      .dropFirst()
+      .split(separator: "@", maxSplits: 1)
+      .first
+      .map { String($0).lowercased() } ?? ""
+
+    switch command {
+    case "agents":
+      return makeCommand("agents", .agents(AgentsInput()))
+    case "list":
+      return makeCommand("list", .list(ListInput()))
+    case "read":
+      return parseRead(rest)
+    case "focus":
+      return parseFocus(rest)
+    case "send":
+      return parseSend(rest)
+    case "key":
+      return parseKey(rest)
+    case "tab_create":
+      return parseTabCreate(rest)
+    case "pane_close":
+      return parsePaneClose(rest)
+    case "tab_close":
+      return parseTabClose(rest)
+    case "help", "start":
+      return .message(Self.helpText)
+    default:
+      return .message("Unknown command. \(Self.helpText)")
+    }
+  }
+
+  private func parseRead(_ rest: String) -> TelegramBotParseResult {
+    let (paneID, lineText) = splitFirst(rest)
+    guard !paneID.isEmpty else {
+      return .message("Usage: /read <pane-id> [lines]")
+    }
+
+    let lines: Int
+    if lineText.isEmpty {
+      lines = defaultReadLines
+    } else if let parsed = Int(lineText), (1...500).contains(parsed) {
+      lines = parsed
+    } else {
+      return .message("Usage: /read <pane-id> [lines], where lines is 1-500.")
+    }
+
+    return makeCommand(
+      "read",
+      .read(ReadInput(selector: .pane(paneID), last: lines))
+    )
+  }
+
+  private func parseFocus(_ rest: String) -> TelegramBotParseResult {
+    let paneID = rest.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !paneID.isEmpty else {
+      return .message("Usage: /focus <pane-id>")
+    }
+    return makeCommand("focus", .focus(FocusInput(selector: .pane(paneID))))
+  }
+
+  private func parseSend(_ rest: String) -> TelegramBotParseResult {
+    let (firstToken, remainder) = splitFirst(rest)
+    guard !firstToken.isEmpty else {
+      return .message("Usage: /send <pane-id> <text>")
+    }
+
+    let selector: TargetSelector
+    let text: String
+    if requireExplicitPaneForWrite || isExplicitPaneToken(firstToken) {
+      guard !remainder.isEmpty else {
+        return .message("Usage: /send <pane-id> <text>")
+      }
+      selector = .pane(firstToken)
+      text = remainder
+    } else {
+      selector = .none
+      text = rest.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    guard !text.isEmpty else {
+      return .message("Usage: /send <pane-id> <text>")
+    }
+
+    return makeCommand(
+      "send",
+      .send(
+        SendInput(
+          selector: selector,
+          text: text,
+          trailingEnter: true,
+          source: .argv,
+          wait: false,
+          timeoutSeconds: nil,
+          captureOutput: false
+        )
+      )
+    )
+  }
+
+  private func parseKey(_ rest: String) -> TelegramBotParseResult {
+    let (firstToken, remainder) = splitFirst(rest)
+    guard !firstToken.isEmpty else {
+      return .message("Usage: /key <pane-id> <token>")
+    }
+
+    let selector: TargetSelector
+    let rawToken: String
+    if requireExplicitPaneForWrite || isExplicitPaneToken(firstToken) {
+      guard !remainder.isEmpty else {
+        return .message("Usage: /key <pane-id> <token>")
+      }
+      selector = .pane(firstToken)
+      rawToken = remainder
+    } else {
+      selector = .none
+      rawToken = rest.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    guard let normalized = KeyTokens.normalize(rawToken) else {
+      return .message("The key token '\(rawToken.lowercased())' is unsupported.")
+    }
+    return makeCommand(
+      "key",
+      .key(
+        KeyInput(
+          selector: selector,
+          rawToken: rawToken,
+          token: normalized
+        )
+      )
+    )
+  }
+
+  private func parseTabCreate(_ rest: String) -> TelegramBotParseResult {
+    let worktree = rest.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !worktree.isEmpty else {
+      return .message("Usage: /tab_create <worktree>")
+    }
+    return makeCommand("tab", .tab(TabInput(action: .create, selector: .worktree(worktree), force: false)))
+  }
+
+  private func parsePaneClose(_ rest: String) -> TelegramBotParseResult {
+    let paneID = rest.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !paneID.isEmpty, !paneID.contains(" ") else {
+      return .message("Usage: /pane_close <pane-id>")
+    }
+    return makeCommand("pane", .pane(PaneInput(action: .close, selector: .pane(paneID), force: false)))
+  }
+
+  private func parseTabClose(_ rest: String) -> TelegramBotParseResult {
+    let tabID = rest.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !tabID.isEmpty, !tabID.contains(" ") else {
+      return .message("Usage: /tab_close <tab-id>")
+    }
+    return makeCommand("tab", .tab(TabInput(action: .close, selector: .tab(tabID), force: false)))
+  }
+
+  private func makeCommand(_ commandName: String, _ command: Command) -> TelegramBotParseResult {
+    .command(
+      TelegramBotCommandRequest(commandName: commandName, envelope: CommandEnvelope(output: .json, command: command)))
+  }
+
+  private func splitFirst(_ text: String) -> (String, String) {
+    let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard let separator = trimmed.firstIndex(where: \.isWhitespace) else {
+      return (trimmed, "")
+    }
+    let first = String(trimmed[..<separator])
+    let rest = String(trimmed[separator...]).trimmingCharacters(in: .whitespacesAndNewlines)
+    return (first, rest)
+  }
+
+  private func isExplicitPaneToken(_ token: String) -> Bool {
+    UUID(uuidString: token) != nil || token.hasPrefix("pane-")
+  }
+
+  static let helpText = """
+    Commands: /agents, /list, /read <pane-id> [lines], /focus <pane-id>, /send <pane-id> <text>, \
+    /key <pane-id> <token>, /tab_create <worktree>, /pane_close <pane-id>, /tab_close <tab-id>.
+    """
+}
+
+enum TelegramAllowedUserIDsParser {
+  static func parse(_ text: String) -> [Int64]? {
+    let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return [] }
+    let parts =
+      trimmed
+      .split { character in
+        character == "," || character == "\n" || character == " " || character == "\t"
+      }
+      .map(String.init)
+    var ids: [Int64] = []
+    for part in parts {
+      guard let id = Int64(part), id > 0 else { return nil }
+      ids.append(id)
+    }
+    return ids
+  }
+
+  static func format(_ ids: [Int64]) -> String {
+    ids.map(String.init).joined(separator: ", ")
+  }
+}

--- a/supacode/Features/Telegram/TelegramBotResponseFormatter.swift
+++ b/supacode/Features/Telegram/TelegramBotResponseFormatter.swift
@@ -1,0 +1,113 @@
+import Foundation
+
+struct TelegramBotResponseFormatter: Sendable {
+  let maxMessageLength: Int
+
+  init(maxMessageLength: Int = 3900) {
+    self.maxMessageLength = max(80, maxMessageLength)
+  }
+
+  func format(_ response: CommandResponse) -> String {
+    guard response.ok else {
+      if let error = response.error {
+        return truncate("Error [\(error.code)]: \(error.message)")
+      }
+      return truncate("Error: \(response.command) failed.")
+    }
+
+    switch response.command {
+    case "agents":
+      return formatPayload(response, as: AgentsCommandPayload.self, fallback: "Agents command completed.") {
+        formatAgents($0)
+      }
+    case "list":
+      return formatPayload(response, as: ListCommandPayload.self, fallback: "List command completed.") {
+        formatList($0)
+      }
+    case "read":
+      return formatPayload(response, as: ReadCommandPayload.self, fallback: "Read command completed.") {
+        formatRead($0)
+      }
+    case "focus":
+      return formatPayload(response, as: FocusCommandPayload.self, fallback: "Focus command completed.") {
+        "Focused \($0.target.pane.id) in \($0.target.worktree.name)."
+      }
+    case "send":
+      return formatPayload(response, as: SendCommandPayload.self, fallback: "Send command completed.") {
+        "Sent to \($0.target.pane.id). Use /read \($0.target.pane.id) to inspect output."
+      }
+    case "key":
+      return formatPayload(response, as: KeyCommandPayload.self, fallback: "Key command completed.") {
+        "Sent \($0.key.normalized) to \($0.target.pane.id)."
+      }
+    case "tab":
+      return formatPayload(response, as: TabCommandPayload.self, fallback: "Tab command completed.") {
+        switch $0.action {
+        case .create:
+          return "Created tab \($0.target.tab.id) in \($0.target.worktree.name)."
+        case .close:
+          return "Closed tab \($0.target.tab.id)."
+        }
+      }
+    case "pane":
+      return formatPayload(response, as: PaneCommandPayload.self, fallback: "Pane command completed.") {
+        "Closed pane \($0.target.pane.id)."
+      }
+    default:
+      return truncate("OK: \(response.command)")
+    }
+  }
+
+  private func formatPayload<Payload: Decodable>(
+    _ response: CommandResponse,
+    as payloadType: Payload.Type,
+    fallback: String,
+    render: (Payload) -> String
+  ) -> String {
+    guard let data = response.data, let payload = try? data.decode(as: payloadType) else {
+      return truncate(fallback)
+    }
+    return truncate(render(payload), hint: truncationHint(for: payload))
+  }
+
+  private func formatAgents(_ payload: AgentsCommandPayload) -> String {
+    guard !payload.agents.isEmpty else { return "No agents found." }
+    return payload.agents.map { agent in
+      "\(agent.status.rawValue)  \(agent.name)  \(agent.project.name):\(agent.project.branch)  \(agent.pane.id)"
+    }
+    .joined(separator: "\n")
+  }
+
+  private func formatList(_ payload: ListCommandPayload) -> String {
+    guard !payload.items.isEmpty else { return "No panes found." }
+    return payload.items.map { item in
+      let marker = item.pane.focused ? ">" : "-"
+      return "\(marker) \(item.worktree.name) / \(item.tab.title) / \(item.pane.title)  \(item.pane.id)"
+    }
+    .joined(separator: "\n")
+  }
+
+  private func formatRead(_ payload: ReadCommandPayload) -> String {
+    let title = "\(payload.target.worktree.name) / \(payload.target.tab.title) / \(payload.target.pane.title)"
+    let header = "\(title) (\(payload.target.pane.id))"
+    let body = payload.text.isEmpty ? "(empty)" : payload.text
+    return "\(header)\n\(body)"
+  }
+
+  private func truncate(_ text: String, hint: String? = nil) -> String {
+    guard text.count > maxMessageLength else { return text }
+    let suffix = "\n\n[Truncated] \(hint ?? "Try again with a narrower command.")"
+    guard suffix.count < maxMessageLength else {
+      return String(suffix.suffix(maxMessageLength))
+    }
+    let prefixLimit = maxMessageLength - suffix.count
+    return String(text.prefix(prefixLimit)) + suffix
+  }
+
+  private func truncationHint<Payload>(for payload: Payload) -> String? {
+    if let readPayload = payload as? ReadCommandPayload {
+      return "Try /read \(readPayload.target.pane.id) with fewer lines."
+    }
+    return nil
+  }
+}

--- a/supacode/Features/Telegram/TelegramBotRuntime.swift
+++ b/supacode/Features/Telegram/TelegramBotRuntime.swift
@@ -1,0 +1,221 @@
+import Foundation
+
+private nonisolated let telegramBotLogger = SupaLogger("TelegramBot")
+
+struct TelegramBotConfiguration: Equatable, Sendable {
+  var enabled: Bool
+  var token: String?
+  var allowedUserIDs: [Int64]
+  var defaultReadLines: Int
+  var requireExplicitPaneForWrite: Bool
+
+  var activeToken: String? {
+    let trimmed = token?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    return trimmed.isEmpty ? nil : trimmed
+  }
+
+  var canRun: Bool {
+    enabled && activeToken != nil && !allowedUserIDs.isEmpty
+  }
+
+  var normalized: TelegramBotConfiguration {
+    TelegramBotConfiguration(
+      enabled: enabled,
+      token: activeToken,
+      allowedUserIDs: allowedUserIDs,
+      defaultReadLines: max(1, min(defaultReadLines, 500)),
+      requireExplicitPaneForWrite: requireExplicitPaneForWrite
+    )
+  }
+}
+
+@MainActor
+struct TelegramBotUpdateProcessor {
+  typealias Route = @MainActor @Sendable (CommandEnvelope) async -> CommandResponse
+  typealias SendMessage = @MainActor @Sendable (_ chatID: Int64, _ text: String) async throws -> Void
+
+  let configuration: TelegramBotConfiguration
+  let parser: TelegramBotCommandParser
+  let formatter: TelegramBotResponseFormatter
+  let route: Route
+  let sendMessage: SendMessage
+
+  init(
+    configuration: TelegramBotConfiguration,
+    formatter: TelegramBotResponseFormatter = TelegramBotResponseFormatter(),
+    route: @escaping Route,
+    sendMessage: @escaping SendMessage
+  ) {
+    let normalized = configuration.normalized
+    self.configuration = normalized
+    self.parser = TelegramBotCommandParser(
+      defaultReadLines: normalized.defaultReadLines,
+      requireExplicitPaneForWrite: normalized.requireExplicitPaneForWrite
+    )
+    self.formatter = formatter
+    self.route = route
+    self.sendMessage = sendMessage
+  }
+
+  func process(updates: [TelegramBotUpdate]) async -> Int? {
+    var nextOffset: Int?
+    let allowedUserIDs = Set(configuration.allowedUserIDs)
+
+    for update in updates {
+      nextOffset = max(nextOffset ?? 0, update.updateID + 1)
+      guard let message = update.message,
+        let user = message.from,
+        let text = message.text
+      else {
+        continue
+      }
+
+      guard allowedUserIDs.contains(user.id) else {
+        telegramBotLogger.info("Rejected Telegram command from unauthorized user_id=\(user.id)")
+        continue
+      }
+
+      switch parser.parse(text: text) {
+      case .message(let responseText):
+        await send(chatID: message.chat.id, text: responseText)
+
+      case .command(let request):
+        telegramBotLogger.info("Executing Telegram command type=\(request.commandName)")
+        let response = await route(request.envelope)
+        await send(chatID: message.chat.id, text: formatter.format(response))
+      }
+    }
+
+    return nextOffset
+  }
+
+  private func send(chatID: Int64, text: String) async {
+    do {
+      try await sendMessage(chatID, text)
+    } catch {
+      telegramBotLogger.warning("Failed to send Telegram message: \(telegramBotLogMessage(for: error))")
+    }
+  }
+}
+
+@MainActor
+final class TelegramBotRuntime {
+  typealias Route = @MainActor @Sendable (CommandEnvelope) async -> CommandResponse
+  typealias Sleep = @Sendable (Duration) async -> Void
+
+  private let client: TelegramBotClient
+  private let route: Route
+  private let sleep: Sleep
+  private var task: Task<Void, Never>?
+  private var configuration: TelegramBotConfiguration = .init(
+    enabled: false,
+    token: nil,
+    allowedUserIDs: [],
+    defaultReadLines: 80,
+    requireExplicitPaneForWrite: true
+  )
+  private var offset: Int?
+
+  init(
+    client: TelegramBotClient = .liveValue,
+    route: @escaping Route,
+    sleep: @escaping Sleep = { duration in
+      try? await Task.sleep(for: duration)
+    }
+  ) {
+    self.client = client
+    self.route = route
+    self.sleep = sleep
+  }
+
+  deinit {
+    task?.cancel()
+  }
+
+  func apply(configuration newConfiguration: TelegramBotConfiguration) {
+    let normalized = newConfiguration.normalized
+    guard normalized.canRun else {
+      stop()
+      configuration = normalized
+      return
+    }
+
+    if normalized != configuration {
+      stop()
+      configuration = normalized
+      start()
+    } else if task == nil {
+      start()
+    }
+  }
+
+  func stop() {
+    guard task != nil else { return }
+    task?.cancel()
+    task = nil
+    offset = nil
+    telegramBotLogger.info("Telegram bot stopped")
+  }
+
+  func pollOnce(configuration: TelegramBotConfiguration, offset: Int?) async -> Int? {
+    do {
+      return try await pollOnceThrowing(configuration: configuration.normalized, offset: offset)
+    } catch {
+      telegramBotLogger.warning("Telegram poll failed: \(telegramBotLogMessage(for: error))")
+      return offset
+    }
+  }
+
+  private func start() {
+    guard task == nil else { return }
+    telegramBotLogger.info("Telegram bot started")
+    task = Task { [weak self] in
+      await self?.runLoop()
+    }
+  }
+
+  private func runLoop() async {
+    var backoffSeconds = 1
+    while !Task.isCancelled {
+      let currentConfiguration = configuration
+      guard currentConfiguration.canRun else { return }
+      do {
+        offset = try await pollOnceThrowing(configuration: currentConfiguration, offset: offset)
+        backoffSeconds = 1
+      } catch {
+        telegramBotLogger.warning("Telegram poll failed: \(telegramBotLogMessage(for: error))")
+        await sleep(.seconds(backoffSeconds))
+        backoffSeconds = min(backoffSeconds * 2, 60)
+      }
+    }
+  }
+
+  private func pollOnceThrowing(configuration: TelegramBotConfiguration, offset: Int?) async throws -> Int? {
+    guard let token = configuration.activeToken else { return offset }
+    let updates = try await client.getUpdates(token, offset, 30)
+    guard !updates.isEmpty else { return offset }
+    let processor = TelegramBotUpdateProcessor(
+      configuration: configuration,
+      route: route,
+      sendMessage: { [client] chatID, text in
+        try await client.sendMessage(token, chatID, text)
+      }
+    )
+    return await processor.process(updates: updates) ?? offset
+  }
+}
+
+private func telegramBotLogMessage(for error: Error) -> String {
+  if let clientError = error as? TelegramBotClientError {
+    switch clientError {
+    case .invalidResponse:
+      return "invalid_response"
+    case .api(let errorCode, let description):
+      if let errorCode {
+        return "api_error code=\(errorCode) description=\(description)"
+      }
+      return "api_error description=\(description)"
+    }
+  }
+  return "network_error"
+}

--- a/supacodeTests/SettingsFeatureTests.swift
+++ b/supacodeTests/SettingsFeatureTests.swift
@@ -410,6 +410,74 @@ struct SettingsFeatureTests {
     #expect(settingsFile.global.autoShowActiveAgentsPanel == true)
   }
 
+  @Test(.dependencies) func telegramSettingsPersistAndFanOut() async {
+    var initialSettings = GlobalSettings.default
+    initialSettings.telegramBotEnabled = false
+    initialSettings.telegramBotToken = nil
+    initialSettings.telegramAllowedUserIDs = []
+    initialSettings.telegramDefaultReadLines = 80
+    initialSettings.telegramRequireExplicitPaneForWrite = true
+    @Shared(.settingsFile) var settingsFile
+    $settingsFile.withLock { $0.global = initialSettings }
+
+    let store = TestStore(initialState: SettingsFeature.State(settings: initialSettings)) {
+      SettingsFeature()
+    }
+
+    await store.send(.binding(.set(\.telegramBotEnabled, true))) {
+      $0.telegramBotEnabled = true
+    }
+    await store.receive(\.delegate.settingsChanged)
+
+    await store.send(.binding(.set(\.telegramBotToken, " 123:abc "))) {
+      $0.telegramBotToken = " 123:abc "
+    }
+    await store.receive(\.delegate.settingsChanged)
+
+    await store.send(.setTelegramAllowedUserIDsText("42, 99")) {
+      $0.telegramAllowedUserIDsText = "42, 99"
+      $0.telegramAllowedUserIDs = [42, 99]
+    }
+    await store.receive(\.delegate.settingsChanged)
+
+    await store.send(.binding(.set(\.telegramDefaultReadLines, 25))) {
+      $0.telegramDefaultReadLines = 25
+    }
+    await store.receive(\.delegate.settingsChanged)
+
+    #expect(settingsFile.global.telegramBotEnabled == true)
+    #expect(settingsFile.global.telegramBotToken == "123:abc")
+    #expect(settingsFile.global.telegramAllowedUserIDs == [42, 99])
+    #expect(settingsFile.global.telegramDefaultReadLines == 25)
+    #expect(settingsFile.global.telegramRequireExplicitPaneForWrite == true)
+  }
+
+  @Test(.dependencies) func telegramConnectionTestUsesConfiguredToken() async {
+    var initialSettings = GlobalSettings.default
+    initialSettings.telegramBotToken = "token"
+    @Shared(.settingsFile) var settingsFile
+    $settingsFile.withLock { $0.global = initialSettings }
+    let requestedTokens = LockIsolated<[String]>([])
+
+    let store = TestStore(initialState: SettingsFeature.State(settings: initialSettings)) {
+      SettingsFeature()
+    } withDependencies: {
+      $0[TelegramBotClient.self].getMe = { token in
+        requestedTokens.withValue { $0.append(token) }
+        return TelegramBotUser(id: 1, isBot: true, firstName: "Prowl", username: "prowl_bot")
+      }
+    }
+
+    await store.send(.testTelegramConnectionButtonTapped) {
+      $0.telegramConnectionStatus = .testing
+    }
+    await store.receive(\.telegramConnectionTestCompleted) {
+      $0.telegramConnectionStatus = .success("@prowl_bot")
+    }
+
+    #expect(requestedTokens.value == ["token"])
+  }
+
   @Test(.dependencies) func showActiveAgentTabTitlesPersistsChanges() async {
     var initialSettings = GlobalSettings.default
     initialSettings.showActiveAgentTabTitles = false

--- a/supacodeTests/TelegramBotCommandParserTests.swift
+++ b/supacodeTests/TelegramBotCommandParserTests.swift
@@ -1,0 +1,168 @@
+import Testing
+
+@testable import supacode
+
+struct TelegramBotCommandParserTests {
+  @Test func parsesAgentsIntoCommandEnvelope() {
+    let parser = TelegramBotCommandParser(defaultReadLines: 80, requireExplicitPaneForWrite: true)
+
+    let result = parser.parse(text: "/agents")
+
+    guard case .command(let request) = result else {
+      Issue.record("Expected command parse result, got \(result)")
+      return
+    }
+    #expect(request.commandName == "agents")
+    guard case .agents = request.envelope.command else {
+      Issue.record("Expected agents envelope")
+      return
+    }
+    #expect(request.envelope.output == .json)
+  }
+
+  @Test func parsesReadTargetWithExplicitLineCount() {
+    let parser = TelegramBotCommandParser(defaultReadLines: 80, requireExplicitPaneForWrite: true)
+
+    let result = parser.parse(text: "/read pane-123 12")
+
+    guard case .command(let request) = result else {
+      Issue.record("Expected command parse result, got \(result)")
+      return
+    }
+    #expect(request.commandName == "read")
+    guard case .read(let input) = request.envelope.command else {
+      Issue.record("Expected read envelope")
+      return
+    }
+    #expect(input.selector == .pane("pane-123"))
+    #expect(input.last == 12)
+  }
+
+  @Test func readUsesDefaultLineCountWhenOmitted() {
+    let parser = TelegramBotCommandParser(defaultReadLines: 50, requireExplicitPaneForWrite: true)
+
+    let result = parser.parse(text: "/read pane-123")
+
+    guard case .command(let request) = result,
+      case .read(let input) = request.envelope.command
+    else {
+      Issue.record("Expected read envelope, got \(result)")
+      return
+    }
+    #expect(input.selector == .pane("pane-123"))
+    #expect(input.last == 50)
+  }
+
+  @Test func sendRequiresExplicitPaneWhenWriteProtectionIsEnabled() {
+    let parser = TelegramBotCommandParser(defaultReadLines: 80, requireExplicitPaneForWrite: true)
+
+    let result = parser.parse(text: "/send hello")
+
+    guard case .message(let text) = result else {
+      Issue.record("Expected validation message, got \(result)")
+      return
+    }
+    #expect(text.contains("/send <pane-id> <text>"))
+  }
+
+  @Test func parsesSendWithoutWaitOrCapture() {
+    let parser = TelegramBotCommandParser(defaultReadLines: 80, requireExplicitPaneForWrite: true)
+
+    let result = parser.parse(text: "/send pane-123 echo hello")
+
+    guard case .command(let request) = result,
+      case .send(let input) = request.envelope.command
+    else {
+      Issue.record("Expected send envelope, got \(result)")
+      return
+    }
+    #expect(request.commandName == "send")
+    #expect(input.selector == .pane("pane-123"))
+    #expect(input.text == "echo hello")
+    #expect(input.wait == false)
+    #expect(input.captureOutput == false)
+  }
+
+  @Test func sendCanUseFocusedPaneWhenWriteProtectionIsDisabled() {
+    let parser = TelegramBotCommandParser(defaultReadLines: 80, requireExplicitPaneForWrite: false)
+
+    let result = parser.parse(text: "/send echo hello")
+
+    guard case .command(let request) = result,
+      case .send(let input) = request.envelope.command
+    else {
+      Issue.record("Expected send envelope, got \(result)")
+      return
+    }
+    #expect(input.selector == .none)
+    #expect(input.text == "echo hello")
+  }
+
+  @Test func keyNormalizesSupportedToken() {
+    let parser = TelegramBotCommandParser(defaultReadLines: 80, requireExplicitPaneForWrite: true)
+
+    let result = parser.parse(text: "/key pane-123 Cmd+Shift+P")
+
+    guard case .command(let request) = result,
+      case .key(let input) = request.envelope.command
+    else {
+      Issue.record("Expected key envelope, got \(result)")
+      return
+    }
+    #expect(input.selector == .pane("pane-123"))
+    #expect(input.rawToken == "Cmd+Shift+P")
+    #expect(input.token == "cmd-shift-p")
+  }
+
+  @Test func keyCanUseFocusedPaneWhenWriteProtectionIsDisabled() {
+    let parser = TelegramBotCommandParser(defaultReadLines: 80, requireExplicitPaneForWrite: false)
+
+    let result = parser.parse(text: "/key cmd-k")
+
+    guard case .command(let request) = result,
+      case .key(let input) = request.envelope.command
+    else {
+      Issue.record("Expected key envelope, got \(result)")
+      return
+    }
+    #expect(input.selector == .none)
+    #expect(input.rawToken == "cmd-k")
+    #expect(input.token == "cmd-k")
+  }
+
+  @Test func keyRejectsUnsupportedToken() {
+    let parser = TelegramBotCommandParser(defaultReadLines: 80, requireExplicitPaneForWrite: true)
+
+    let result = parser.parse(text: "/key pane-123 nope-key")
+
+    guard case .message(let text) = result else {
+      Issue.record("Expected validation message, got \(result)")
+      return
+    }
+    #expect(text.contains("unsupported"))
+  }
+
+  @Test func closeCommandsAreExplicitAndNonForce() {
+    let parser = TelegramBotCommandParser(defaultReadLines: 80, requireExplicitPaneForWrite: true)
+
+    let paneResult = parser.parse(text: "/pane_close pane-123")
+    guard case .command(let paneRequest) = paneResult,
+      case .pane(let paneInput) = paneRequest.envelope.command
+    else {
+      Issue.record("Expected pane close envelope, got \(paneResult)")
+      return
+    }
+    #expect(paneInput.selector == .pane("pane-123"))
+    #expect(paneInput.force == false)
+
+    let tabResult = parser.parse(text: "/tab_close tab-123")
+    guard case .command(let tabRequest) = tabResult,
+      case .tab(let tabInput) = tabRequest.envelope.command
+    else {
+      Issue.record("Expected tab close envelope, got \(tabResult)")
+      return
+    }
+    #expect(tabInput.selector == .tab("tab-123"))
+    #expect(tabInput.force == false)
+  }
+}

--- a/supacodeTests/TelegramBotResponseFormatterTests.swift
+++ b/supacodeTests/TelegramBotResponseFormatterTests.swift
@@ -1,0 +1,39 @@
+import Foundation
+import Testing
+
+@testable import supacode
+
+struct TelegramBotResponseFormatterTests {
+  @Test func readResponseIsTruncatedWithRetryHint() throws {
+    let payload = ReadCommandPayload(
+      target: ReadTarget(
+        worktree: ReadTargetWorktree(
+          id: "wt-1",
+          name: "main",
+          path: "/Projects/Prowl",
+          rootPath: "/Projects/Prowl",
+          kind: "git"
+        ),
+        tab: ReadTargetTab(id: "tab-1", title: "zsh", selected: true),
+        pane: ReadTargetPane(id: "pane-1", title: "zsh", cwd: "/Projects/Prowl", focused: true)
+      ),
+      mode: .last,
+      last: 20,
+      source: .screen,
+      truncated: false,
+      lineCount: 1,
+      text: String(repeating: "x", count: 500)
+    )
+    let response = try CommandResponse(
+      ok: true,
+      command: "read",
+      schemaVersion: "prowl.cli.read.v1",
+      data: RawJSON(encoding: payload)
+    )
+
+    let text = TelegramBotResponseFormatter(maxMessageLength: 160).format(response)
+
+    #expect(text.count <= 160)
+    #expect(text.contains("Try /read pane-1"))
+  }
+}

--- a/supacodeTests/TelegramBotRuntimeTests.swift
+++ b/supacodeTests/TelegramBotRuntimeTests.swift
@@ -1,0 +1,140 @@
+import ComposableArchitecture
+import DependenciesTestSupport
+import Foundation
+import Testing
+
+@testable import supacode
+
+@MainActor
+struct TelegramBotRuntimeTests {
+  @Test func processorIgnoresUnauthorizedUsersAndAdvancesOffset() async {
+    let routedCommands = LockIsolated<[String]>([])
+    let sentMessages = LockIsolated<[String]>([])
+    let processor = TelegramBotUpdateProcessor(
+      configuration: TelegramBotConfiguration(
+        enabled: true,
+        token: "secret",
+        allowedUserIDs: [42],
+        defaultReadLines: 80,
+        requireExplicitPaneForWrite: true
+      ),
+      route: { envelope in
+        let commandName = envelope.command.name
+        routedCommands.withValue { $0.append(commandName) }
+        return CommandResponse(ok: true, command: commandName, schemaVersion: "prowl.cli.\(commandName).v1")
+      },
+      sendMessage: { _, text in
+        sentMessages.withValue { $0.append(text) }
+      }
+    )
+    let update = TelegramBotUpdate(
+      updateID: 10,
+      message: TelegramBotMessage(
+        messageID: 1,
+        from: TelegramBotUser(id: 7, isBot: false, firstName: "No", username: nil),
+        chat: TelegramBotChat(id: 100),
+        text: "/list"
+      )
+    )
+
+    let nextOffset = await processor.process(updates: [update])
+
+    #expect(nextOffset == 11)
+    #expect(routedCommands.value.isEmpty)
+    #expect(sentMessages.value.isEmpty)
+  }
+
+  @Test func processorRoutesAuthorizedCommandAndSendsFormattedResponse() async throws {
+    let routedCommands = LockIsolated<[String]>([])
+    let sentMessages = LockIsolated<[String]>([])
+    let payload = ListCommandPayload(count: 0, items: [])
+    let response = try CommandResponse(
+      ok: true,
+      command: "list",
+      schemaVersion: "prowl.cli.list.v1",
+      data: RawJSON(encoding: payload)
+    )
+    let processor = TelegramBotUpdateProcessor(
+      configuration: TelegramBotConfiguration(
+        enabled: true,
+        token: "secret",
+        allowedUserIDs: [42],
+        defaultReadLines: 80,
+        requireExplicitPaneForWrite: true
+      ),
+      route: { envelope in
+        let commandName = envelope.command.name
+        routedCommands.withValue { $0.append(commandName) }
+        return response
+      },
+      sendMessage: { chatID, text in
+        sentMessages.withValue { $0.append("\(chatID):\(text)") }
+      }
+    )
+    let update = TelegramBotUpdate(
+      updateID: 20,
+      message: TelegramBotMessage(
+        messageID: 1,
+        from: TelegramBotUser(id: 42, isBot: false, firstName: "Yes", username: nil),
+        chat: TelegramBotChat(id: 100),
+        text: "/list"
+      )
+    )
+
+    let nextOffset = await processor.process(updates: [update])
+
+    #expect(nextOffset == 21)
+    #expect(routedCommands.value == ["list"])
+    #expect(sentMessages.value == ["100:No panes found."])
+  }
+
+  @Test func runtimePollOnceUsesGetUpdatesOffsetAndReturnsNextOffset() async {
+    let requestedOffsets = LockIsolated<[Int?]>([])
+    let sentMessages = LockIsolated<[String]>([])
+    let client = TelegramBotClient(
+      getMe: { _ in TelegramBotUser(id: 1, isBot: true, firstName: "Prowl", username: "prowl_bot") },
+      getUpdates: { _, offset, timeout in
+        requestedOffsets.withValue { $0.append(offset) }
+        #expect(timeout == 30)
+        return [
+          TelegramBotUpdate(
+            updateID: 123,
+            message: TelegramBotMessage(
+              messageID: 1,
+              from: TelegramBotUser(id: 42, isBot: false, firstName: "Yes", username: nil),
+              chat: TelegramBotChat(id: 100),
+              text: "/agents"
+            )
+          )
+        ]
+      },
+      sendMessage: { _, chatID, text in
+        sentMessages.withValue { $0.append("\(chatID):\(text)") }
+      }
+    )
+    let runtime = TelegramBotRuntime(
+      client: client,
+      route: { envelope in
+        let commandName = envelope.command.name
+        return CommandResponse(ok: true, command: commandName, schemaVersion: "prowl.cli.\(commandName).v1")
+      },
+      sleep: { _ in }
+    )
+
+    let nextOffset = await runtime.pollOnce(
+      configuration: TelegramBotConfiguration(
+        enabled: true,
+        token: "secret",
+        allowedUserIDs: [42],
+        defaultReadLines: 80,
+        requireExplicitPaneForWrite: true
+      ),
+      offset: 120
+    )
+
+    #expect(nextOffset == 124)
+    #expect(requestedOffsets.value.count == 1)
+    #expect(requestedOffsets.value[0] == 120)
+    #expect(sentMessages.value.count == 1)
+  }
+}


### PR DESCRIPTION
## Summary
- add a built-in Telegram Bot API client/runtime using long polling
- route authorized Telegram commands through the existing CLICommandRouter
- add Settings -> Telegram configuration, tests, and docs

## Verification
- xcrun swift-format lint --strict --recursive --configuration ./.swift-format.json supacode supacodeTests
- swiftlint lint --quiet --config .swiftlint.yml
- xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -only-testing:supacodeTests/TelegramBotCommandParserTests -only-testing:supacodeTests/TelegramBotRuntimeTests -only-testing:supacodeTests/TelegramBotResponseFormatterTests -only-testing:"supacodeTests/SettingsFeatureTests/telegramSettingsPersistAndFanOut()" -only-testing:"supacodeTests/SettingsFeatureTests/telegramConnectionTestUsesConfiguredToken()" CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation
- make build-app attempted, but local wrapper failed with `mise: command not found` at `mise exec -- xcsift`
- raw underlying xcodebuild Debug build succeeded: `xcodebuild -project supacode.xcodeproj -scheme supacode -configuration Debug build -skipMacroValidation -clonedSourcePackagesDirPath /Users/waltcow/Library/Caches/supacode-spm-cache/SourcePackages SWIFT_COMPILATION_MODE=incremental`