### PR TITLE
Fix PR status flicker when GitHub returns UNKNOWN mergeable

### DIFF
--- a/supacode/Clients/Github/GithubPullRequest.swift
+++ b/supacode/Clients/Github/GithubPullRequest.swift
@@ -8,8 +8,8 @@ nonisolated struct GithubPullRequest: Decodable, Equatable, Hashable {
   let deletions: Int
   let isDraft: Bool
   let reviewDecision: String?
-  let mergeable: String?
-  let mergeStateStatus: String?
+  var mergeable: String?
+  var mergeStateStatus: String?
   let updatedAt: Date?
   let url: String
   let headRefName: String?

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+GithubIntegration.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+GithubIntegration.swift
@@ -249,8 +249,12 @@ extension RepositoriesFeature {
           continue
         }
         let loadedPullRequest = pullRequestsByWorktreeID[worktreeID] ?? nil
-        let pullRequest = Self.displayPullRequest(loadedPullRequest, for: worktree)
+        let displayedPullRequest = Self.displayPullRequest(loadedPullRequest, for: worktree)
         let previousPullRequest = state.worktreeInfoByID[worktreeID]?.pullRequest
+        let pullRequest = Self.preservingMergeableState(
+          displayedPullRequest,
+          previous: previousPullRequest
+        )
         guard previousPullRequest != pullRequest else {
           continue
         }
@@ -958,6 +962,22 @@ extension RepositoriesFeature {
   ) -> GithubPullRequest? {
     if worktree.isMain, pullRequest?.state.uppercased() == "MERGED" {
       return nil
+    }
+    return pullRequest
+  }
+
+  nonisolated private static func preservingMergeableState(
+    _ pullRequest: GithubPullRequest?,
+    previous: GithubPullRequest?
+  ) -> GithubPullRequest? {
+    guard var pullRequest else { return pullRequest }
+    let newMergeable = pullRequest.mergeable?.uppercased()
+    let previousMergeable = previous?.mergeable?.uppercased()
+    let isUnknown = newMergeable == "UNKNOWN"
+    let hasKnownPrevious = previousMergeable != nil && previousMergeable != "UNKNOWN"
+    if isUnknown && hasKnownPrevious, let previous {
+      pullRequest.mergeable = previous.mergeable
+      pullRequest.mergeStateStatus = previous.mergeStateStatus
     }
     return pullRequest
   }

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -6257,6 +6257,229 @@ struct RepositoriesFeatureTests {
     }
   }
 
+  @Test func repositoryPullRequestsLoadedPreservesMergeableWhenNewIsUnknown() async {
+    let repoRoot = "/tmp/repo"
+    let featureWorktree = makeWorktree(
+      id: "\(repoRoot)/feature",
+      name: "feature",
+      repoRoot: repoRoot
+    )
+    let repository = makeRepository(id: repoRoot, worktrees: [featureWorktree])
+    let previousPR = GithubPullRequest(
+      number: 1,
+      title: "PR",
+      state: "OPEN",
+      additions: 10,
+      deletions: 5,
+      isDraft: false,
+      reviewDecision: nil,
+      mergeable: "MERGEABLE",
+      mergeStateStatus: "CLEAN",
+      updatedAt: nil,
+      url: "https://example.com/pull/1",
+      headRefName: "feature",
+      baseRefName: "main",
+      commitsCount: 1,
+      authorLogin: "khoi",
+      statusCheckRollup: nil
+    )
+    var newPR = previousPR
+    newPR.mergeable = "UNKNOWN"
+    newPR.mergeStateStatus = "BEHIND"
+    var state = makeState(repositories: [repository])
+    state.worktreeInfoByID[featureWorktree.id] = WorktreeInfoEntry(
+      addedLines: nil,
+      removedLines: nil,
+      pullRequest: previousPR
+    )
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    }
+    await store.send(
+      .githubIntegration(
+        .repositoryPullRequestsLoaded(
+          repositoryID: repository.id,
+          pullRequestsByWorktreeID: [featureWorktree.id: newPR]
+        ))
+    )
+    await store.finish()
+  }
+
+  @Test func repositoryPullRequestsLoadedPreservesMergeableButUpdatesOtherFields() async {
+    let repoRoot = "/tmp/repo"
+    let featureWorktree = makeWorktree(
+      id: "\(repoRoot)/feature",
+      name: "feature",
+      repoRoot: repoRoot
+    )
+    let repository = makeRepository(id: repoRoot, worktrees: [featureWorktree])
+    let previousPR = GithubPullRequest(
+      number: 1,
+      title: "Old title",
+      state: "OPEN",
+      additions: 10,
+      deletions: 5,
+      isDraft: false,
+      reviewDecision: nil,
+      mergeable: "MERGEABLE",
+      mergeStateStatus: "CLEAN",
+      updatedAt: nil,
+      url: "https://example.com/pull/1",
+      headRefName: "feature",
+      baseRefName: "main",
+      commitsCount: 1,
+      authorLogin: "khoi",
+      statusCheckRollup: nil
+    )
+    let newPR = GithubPullRequest(
+      number: 1,
+      title: "New title",
+      state: "OPEN",
+      additions: 10,
+      deletions: 5,
+      isDraft: false,
+      reviewDecision: nil,
+      mergeable: "UNKNOWN",
+      mergeStateStatus: "BEHIND",
+      updatedAt: nil,
+      url: "https://example.com/pull/1",
+      headRefName: "feature",
+      baseRefName: "main",
+      commitsCount: 1,
+      authorLogin: "khoi",
+      statusCheckRollup: nil
+    )
+    var expectedPR = newPR
+    expectedPR.mergeable = "MERGEABLE"
+    expectedPR.mergeStateStatus = "CLEAN"
+    var state = makeState(repositories: [repository])
+    state.worktreeInfoByID[featureWorktree.id] = WorktreeInfoEntry(
+      addedLines: nil,
+      removedLines: nil,
+      pullRequest: previousPR
+    )
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    }
+    await store.send(
+      .githubIntegration(
+        .repositoryPullRequestsLoaded(
+          repositoryID: repository.id,
+          pullRequestsByWorktreeID: [featureWorktree.id: newPR]
+        ))
+    ) {
+      $0.worktreeInfoByID[featureWorktree.id]?.pullRequest = expectedPR
+    }
+  }
+
+  @Test func repositoryPullRequestsLoadedKeepsUnknownWhenNoPreviousPR() async {
+    let repoRoot = "/tmp/repo"
+    let featureWorktree = makeWorktree(
+      id: "\(repoRoot)/feature",
+      name: "feature",
+      repoRoot: repoRoot
+    )
+    let repository = makeRepository(id: repoRoot, worktrees: [featureWorktree])
+    let newPR = GithubPullRequest(
+      number: 1,
+      title: "PR",
+      state: "OPEN",
+      additions: 10,
+      deletions: 5,
+      isDraft: false,
+      reviewDecision: nil,
+      mergeable: "UNKNOWN",
+      mergeStateStatus: nil,
+      updatedAt: nil,
+      url: "https://example.com/pull/1",
+      headRefName: "feature",
+      baseRefName: "main",
+      commitsCount: 1,
+      authorLogin: "khoi",
+      statusCheckRollup: nil
+    )
+    let store = TestStore(initialState: makeState(repositories: [repository])) {
+      RepositoriesFeature()
+    }
+    await store.send(
+      .githubIntegration(
+        .repositoryPullRequestsLoaded(
+          repositoryID: repository.id,
+          pullRequestsByWorktreeID: [featureWorktree.id: newPR]
+        ))
+    ) {
+      $0.worktreeInfoByID[featureWorktree.id] = WorktreeInfoEntry(
+        addedLines: nil,
+        removedLines: nil,
+        pullRequest: newPR
+      )
+    }
+  }
+
+  @Test func repositoryPullRequestsLoadedKeepsUnknownWhenPreviousAlsoUnknown() async {
+    let repoRoot = "/tmp/repo"
+    let featureWorktree = makeWorktree(
+      id: "\(repoRoot)/feature",
+      name: "feature",
+      repoRoot: repoRoot
+    )
+    let repository = makeRepository(id: repoRoot, worktrees: [featureWorktree])
+    let previousPR = GithubPullRequest(
+      number: 1,
+      title: "Old title",
+      state: "OPEN",
+      additions: 10,
+      deletions: 5,
+      isDraft: false,
+      reviewDecision: nil,
+      mergeable: "UNKNOWN",
+      mergeStateStatus: "BEHIND",
+      updatedAt: nil,
+      url: "https://example.com/pull/1",
+      headRefName: "feature",
+      baseRefName: "main",
+      commitsCount: 1,
+      authorLogin: "khoi",
+      statusCheckRollup: nil
+    )
+    let newPR = GithubPullRequest(
+      number: 1,
+      title: "New title",
+      state: "OPEN",
+      additions: 10,
+      deletions: 5,
+      isDraft: false,
+      reviewDecision: nil,
+      mergeable: "UNKNOWN",
+      mergeStateStatus: "BEHIND",
+      updatedAt: nil,
+      url: "https://example.com/pull/1",
+      headRefName: "feature",
+      baseRefName: "main",
+      commitsCount: 1,
+      authorLogin: "khoi",
+      statusCheckRollup: nil
+    )
+    var state = makeState(repositories: [repository])
+    state.worktreeInfoByID[featureWorktree.id] = WorktreeInfoEntry(
+      addedLines: nil,
+      removedLines: nil,
+      pullRequest: previousPR
+    )
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    }
+    await store.send(
+      .githubIntegration(
+        .repositoryPullRequestsLoaded(
+          repositoryID: repository.id,
+          pullRequestsByWorktreeID: [featureWorktree.id: newPR]
+        ))
+    ) {
+      $0.worktreeInfoByID[featureWorktree.id]?.pullRequest = newPR
+    }
+  }
+
   @Test func unarchiveWorktreeNoopsWhenNotArchived() async {
     let worktree = makeWorktree(id: "/tmp/wt", name: "owl")
     let repository = makeRepository(id: "/tmp/repo", worktrees: [worktree])


### PR DESCRIPTION
## Problem

When refreshing PR status in the sidebar, the PR badge briefly flashes red **"Blocked"** before settling on the correct state (e.g. green "Mergeable").

## Root Cause

GitHub GraphQL API asynchronously calculates the `mergeable` field. When the calculation hasn't finished yet, it returns `"UNKNOWN"`. The existing `PullRequestMergeReadiness` code falls through to `.blocked` for any value that isn't `"MERGEABLE"` or `"CONFLICTING"`:

```swift
if mergeable == "MERGEABLE" {
  self.blockingReason = nil
  return
}
self.blockingReason = .blocked  // ← UNKNOWN lands here
```

This means every refresh where GitHub hasn't finished computing `mergeable` temporarily shows "Blocked".

PR #538 fixed a separate flicker issue (confirmed-no-PR clearing), but did not address the `UNKNOWN` → `.blocked` path.

## Fix

Preserve the last-known `mergeable` and `mergeStateStatus` values at the reducer level when the new value is `UNKNOWN`. All other fields (title, checks, commits, etc.) update normally — only the mergeable state is carried over from the previous PR data.

This is applied in `repositoryPullRequestsLoaded` before the equality check, so the UI never sees the intermediate `UNKNOWN` state.

## Tests

4 new test cases in `RepositoriesFeatureTests`:

| Test | Scenario |
|------|----------|
| `PreservesMergeableWhenNewIsUnknown` | New PR has UNKNOWN, old has MERGEABLE → noop (preserved) |
| `PreservesMergeableButUpdatesOtherFields` | New PR has UNKNOWN + new title → mergeable preserved, title updated |
| `KeepsUnknownWhenNoPreviousPR` | First load with UNKNOWN → stays UNKNOWN (no old value to preserve) |
| `KeepsUnknownWhenPreviousAlsoUnknown` | Both old and new are UNKNOWN → stays UNKNOWN (no known value to preserve) |
