### PR TITLE
Fix Diff window to follow app appearance instead of system

### DIFF
--- a/supacode/Clients/ExternalDiff/ExternalDiffToolClient.swift
+++ b/supacode/Clients/ExternalDiff/ExternalDiffToolClient.swift
@@ -19,10 +19,12 @@ extension ExternalDiffToolClient: DependencyKey {
 
     switch settings.tool {
     case .builtIn:
+      @Shared(.settingsFile) var settingsFile
       DiffWindowManager.shared.show(
         worktreeURL: worktree.workingDirectory,
         branchName: worktree.name,
-        resolvedKeybindings: resolvedKeybindings
+        resolvedKeybindings: resolvedKeybindings,
+        colorScheme: settingsFile.global.appearanceMode.colorScheme
       )
 
     case .hunk:

--- a/supacode/Features/DiffView/DiffWindowContentView.swift
+++ b/supacode/Features/DiffView/DiffWindowContentView.swift
@@ -1,3 +1,4 @@
+import ComposableArchitecture
 import SwiftUI
 import YiTong
 
@@ -6,9 +7,19 @@ struct DiffWindowContentView: View {
   @State private var columnVisibility: NavigationSplitViewVisibility = .automatic
   @AppStorage("diffViewStyle") private var diffStyleRaw = DiffStyle.split.rawValue
   @Environment(\.resolvedKeybindings) private var resolvedKeybindings
+  @Shared(.settingsFile) private var settingsFile
+  @Environment(\.colorScheme) private var colorScheme
 
   private var diffStyle: DiffStyle {
     DiffStyle(rawValue: diffStyleRaw) ?? .split
+  }
+
+  private var resolvedDiffAppearance: DiffAppearance {
+    switch settingsFile.global.appearanceMode {
+    case .system: colorScheme == .dark ? .dark : .light
+    case .light: .light
+    case .dark: .dark
+    }
   }
 
   private var selectedFileID: Binding<String?> {
@@ -62,6 +73,9 @@ struct DiffWindowContentView: View {
         .help("Diff Style")
       }
     }
+    .background {
+      WindowAppearanceSetter(colorScheme: settingsFile.global.appearanceMode.colorScheme)
+    }
   }
 
   private func toggleSidebar() {
@@ -101,6 +115,7 @@ struct DiffWindowContentView: View {
         DiffView(
           document: document,
           configuration: DiffConfiguration(
+            appearance: resolvedDiffAppearance,
             style: diffStyle,
             showsFileHeaders: false,
           ),

--- a/supacode/Features/DiffView/DiffWindowManager.swift
+++ b/supacode/Features/DiffView/DiffWindowManager.swift
@@ -15,7 +15,8 @@ final class DiffWindowManager {
   func show(
     worktreeURL: URL,
     branchName: String,
-    resolvedKeybindings: ResolvedKeybindingMap = .appDefaults
+    resolvedKeybindings: ResolvedKeybindingMap = .appDefaults,
+    colorScheme: ColorScheme? = nil
   ) {
     state.load(worktreeURL: worktreeURL, branchName: branchName)
     skipNextFocusRefresh = true
@@ -24,11 +25,14 @@ final class DiffWindowManager {
         .environment(\.resolvedKeybindings, resolvedKeybindings)
     )
 
+    let appearance = NSAppearance.from(colorScheme)
+
     if let existingWindow = window {
       if let hostingController = existingWindow.contentViewController as? NSHostingController<AnyView> {
         hostingController.rootView = rootView
       }
       existingWindow.title = windowTitle(branchName: branchName)
+      existingWindow.appearance = appearance
       if existingWindow.isMiniaturized {
         existingWindow.deminiaturize(nil)
       }
@@ -47,6 +51,7 @@ final class DiffWindowManager {
     newWindow.toolbarStyle = .unified
     newWindow.toolbar = NSToolbar(identifier: "DiffToolbar")
     newWindow.isReleasedWhenClosed = false
+    newWindow.appearance = appearance
     newWindow.minSize = NSSize(width: 600, height: 400)
     let hasSavedFrame = UserDefaults.standard.string(forKey: "NSWindow Frame DiffWindow") != nil
     newWindow.setFrameAutosaveName("DiffWindow")
@@ -91,5 +96,16 @@ final class DiffWindowManager {
       return
     }
     state.refresh()
+  }
+}
+
+extension NSAppearance {
+  fileprivate static func from(_ colorScheme: ColorScheme?) -> NSAppearance? {
+    switch colorScheme {
+    case .none: nil
+    case .light: NSAppearance(named: .aqua)
+    case .dark: NSAppearance(named: .darkAqua)
+    @unknown default: nil
+    }
   }
 }


### PR DESCRIPTION
## Purpose

The Diff window (⌘⇧Y) followed the **system** appearance instead of the app's `appearanceMode` setting. For example, when the system was in Light mode but the app was set to Dark, the Diff window incorrectly displayed a Light background.

**Root cause:** The Diff window is a standalone `NSWindow` managed by `DiffWindowManager`, not a SwiftUI `WindowGroup` scene. It never read the app's `appearanceMode` from `settingsFile`, so `.preferredColorScheme()` had no effect and the window fell back to the system appearance. Additionally, YiTong's `DiffView` (WKWebView-backed) used `.automatic` appearance, which resolves via `view.effectiveAppearance` in `viewDidLoad()` — before the view enters the window hierarchy — returning the system default on first render.

## Changes

| File | Change |
|------|--------|
| `DiffWindowManager.swift` | Add `colorScheme` parameter; set `window.appearance` before `makeKeyAndOrderFront` for both new and existing windows; add `NSAppearance.from(_:)` helper |
| `DiffWindowContentView.swift` | Add `@Shared(.settingsFile)` + `@Environment(\.colorScheme)`; add `WindowAppearanceSetter` in `.background`; pass explicit `appearance` to `DiffConfiguration` instead of `.automatic` |
| `ExternalDiffToolClient.swift` | Read `@Shared(.settingsFile)` and pass `colorScheme` to `DiffWindowManager.show()` |

The fix makes the Diff window read the app's `appearanceMode` setting (Dark/Light/System) and apply it at three levels:
1. **Window chrome** — `window.appearance` set before first render
2. **Live updates** — `WindowAppearanceSetter` responds to settings changes at runtime (same pattern as `SettingsView` and `DebugView`)
3. **WKWebView content** — explicit `appearance` passed to `DiffConfiguration`, bypassing `.automatic` which reads `effectiveAppearance` too early in `viewDidLoad()`

## Test Plan

- Set app appearance to Dark (system in Light) → open Diff window → window chrome and diff content should be Dark
- Set app appearance to Light (system in Dark) → open Diff window → should be Light
- Set app appearance to System → open Diff window → should match system appearance
- Open Diff window, then change appearance in Settings → window should update live

## Test Result

- `make build-app` — ✅ pass
- `make check` — ✅ pass (swift-format lint + swiftlint)
- Manual: confirmed app appearance setting is respected on first open and updates live