### PR TITLE
Harden gh detection and login-shell command execution

### DIFF
--- a/docs/components/github-pull-requests.md
+++ b/docs/components/github-pull-requests.md
@@ -63,7 +63,12 @@ Open the [Command Palette](command-palette.md) (`⌘P`) on a worktree that has a
 
 ## Requirements & settings
 
-- The **`gh` CLI** must be installed and authenticated (`gh auth login`).
+- The **`gh` CLI** must be installed and authenticated (`gh auth login`). Prowl
+  locates `gh` via `which` (directly, then through a login shell), falling back to
+  common install paths (`/opt/homebrew/bin`, `/usr/local/bin`, `~/.local/bin`)
+  when the shell `PATH` misses it. Login-shell probing works even with a
+  non-POSIX login shell (nushell, pwsh, …) — Prowl falls back to `/bin/zsh` for
+  one-shot commands in that case.
 - `githubIntegrationEnabled` (global) gates all GitHub features.
 - Per repo: `fetchPullRequestState` (auto-fetch PR state; on by default — turn off
   for big/expensive repos), `pullRequestMergeStrategy` override, and

--- a/supacode/Clients/Github/GithubCLIClient.swift
+++ b/supacode/Clients/Github/GithubCLIClient.swift
@@ -195,8 +195,11 @@ struct GithubCLIClient: Sendable {
 extension GithubCLIClient: DependencyKey {
   static let liveValue = live()
 
-  static func live(shell: ShellClient = .liveValue) -> GithubCLIClient {
-    let resolver = GithubCLIExecutableResolver()
+  static func live(
+    shell: ShellClient = .liveValue,
+    fallbackExecutableURLs: [URL] = GithubCLIExecutableResolver.defaultFallbackExecutableURLs()
+  ) -> GithubCLIClient {
+    let resolver = GithubCLIExecutableResolver(fallbackExecutableURLs: fallbackExecutableURLs)
     return GithubCLIClient(
       defaultBranch: defaultBranchFetcher(shell: shell, resolver: resolver),
       resolveRemoteInfo: resolveRemoteInfoFetcher(shell: shell, resolver: resolver),

--- a/supacode/Clients/Github/GithubCLIExecutableResolver.swift
+++ b/supacode/Clients/Github/GithubCLIExecutableResolver.swift
@@ -1,8 +1,15 @@
 import Foundation
 
 actor GithubCLIExecutableResolver {
+  nonisolated private static let logger = SupaLogger("GithubCLI")
+
+  private let fallbackExecutableURLs: [URL]
   private var cachedExecutableURL: URL?
   private var inFlightResolution: Task<URL, Error>?
+
+  init(fallbackExecutableURLs: [URL]) {
+    self.fallbackExecutableURLs = fallbackExecutableURLs
+  }
 
   func executableURL(shell: ShellClient) async throws -> URL {
     if let cachedExecutableURL {
@@ -45,7 +52,26 @@ actor GithubCLIExecutableResolver {
     ) {
       return executableURL
     }
+    if let executableURL = fallbackExecutableURLs.first(where: {
+      FileManager.default.isExecutableFile(atPath: $0.path)
+    }) {
+      // Shell PATH missed gh; note the fixed-path fallback so a mismatch with the user's terminal is traceable.
+      Self.logger.info("Resolved gh via fallback path \(executableURL.path); shell PATH resolution failed.")
+      return executableURL
+    }
     throw GithubCLIError.unavailable
+  }
+
+  nonisolated static func defaultFallbackExecutableURLs(
+    environment: [String: String] = ProcessInfo.processInfo.environment
+  ) -> [URL] {
+    [
+      "/opt/homebrew/bin/gh",
+      "/usr/local/bin/gh",
+      environment["HOME"].map { "\($0)/.local/bin/gh" },
+    ]
+    .compactMap { $0 }
+    .map { URL(fileURLWithPath: $0) }
   }
 
   private func locateExecutableURL(

--- a/supacode/Clients/Shell/ShellClient.swift
+++ b/supacode/Clients/Shell/ShellClient.swift
@@ -78,8 +78,8 @@ extension ShellClient: DependencyKey {
       )
     },
     runLoginImpl: { executableURL, arguments, currentDirectoryURL, log in
-      let shellURL = URL(fileURLWithPath: defaultShellPath())
-      let execCommand = shellExecCommand(for: shellURL)
+      let (shellURL, execCommand) = ShellClient.loginShellInvocation(
+        userShell: URL(fileURLWithPath: defaultShellPath()))
       let shellArguments =
         ["-l", "-c", execCommand, "--", executableURL.path(percentEncoded: false)] + arguments
       if log {
@@ -102,8 +102,8 @@ extension ShellClient: DependencyKey {
       )
     },
     runLoginStreamImpl: { executableURL, arguments, currentDirectoryURL, log in
-      let shellURL = URL(fileURLWithPath: defaultShellPath())
-      let execCommand = shellExecCommand(for: shellURL)
+      let (shellURL, execCommand) = ShellClient.loginShellInvocation(
+        userShell: URL(fileURLWithPath: defaultShellPath()))
       let shellArguments =
         ["-l", "-c", execCommand, "--", executableURL.path(percentEncoded: false)] + arguments
       if log {
@@ -275,14 +275,41 @@ nonisolated private func collectOutput(
   return finalOutput
 }
 
-nonisolated private func shellExecCommand(for shellURL: URL) -> String {
-  switch shellURL.lastPathComponent {
-  case "fish":
-    return "test -f ~/.config/fish/config.fish; and source ~/.config/fish/config.fish >/dev/null 2>&1; exec $argv"
-  case "bash":
-    return "[ -f ~/.bashrc ] && . ~/.bashrc >/dev/null 2>&1; exec \"$@\""
-  default:
-    return "[ -f ~/.zshrc ] && . ~/.zshrc >/dev/null 2>&1; exec \"$@\""
+extension ShellClient {
+  /// Builds the `(shell, -c command)` pair for a one-shot login-shell command.
+  /// We only drive shells we have a correct rc snippet for — zsh, bash, fish.
+  /// Anything else (nushell, sh/dash/ksh, pwsh, …) falls back to /bin/zsh, which
+  /// can actually parse the snippet, so the command runs instead of failing
+  /// (upstream #100). The interactive terminal still uses the user's real shell.
+  nonisolated static func loginShellInvocation(userShell: URL) -> (shell: URL, command: String) {
+    let drivable: Set<String> = ["zsh", "bash", "fish"]
+    let shell =
+      drivable.contains(userShell.lastPathComponent)
+      ? userShell : URL(fileURLWithPath: "/bin/zsh")
+    let command: String
+    switch shell.lastPathComponent {
+    case "fish":
+      command = "test -f ~/.config/fish/config.fish; and source ~/.config/fish/config.fish >/dev/null 2>&1; exec $argv"
+    case "bash":
+      command = posixLoginCommand(rcFile: "~/.bashrc")
+    default:
+      command = posixLoginCommand(rcFile: "~/.zshrc")
+    }
+    return (shell, command)
+  }
+
+  /// Builds the zsh/bash one-shot command: capture the positional parameters, clear them, then source
+  /// the rc file and exec from the saved array. Sourcing shares `$@` with the caller, so an rc that
+  /// resets the positionals (e.g. `set --`) would otherwise wipe the command before `exec` (upstream
+  /// #441). Clearing `$@` with `set --` before sourcing also keeps the target command out of the rc's
+  /// view: a dual-mode script dispatching on `$1` (e.g. `fzf-git.sh`) would otherwise see the probe's
+  /// arguments, hit its own `exit`, and kill the probe shell before `exec` ran (upstream #477). The
+  /// exec reads from the saved array, so clearing the live positionals is safe.
+  nonisolated private static func posixLoginCommand(rcFile: String) -> String {
+    let capture = "__supacode_login_argv=(\"$@\")"
+    let clear = "set --"
+    let source = "[ -f \(rcFile) ] && . \(rcFile) >/dev/null 2>&1"
+    return "\(capture); \(clear); \(source); exec \"${__supacode_login_argv[@]}\""
   }
 }
 

--- a/supacodeTests/GithubCLIClientTests.swift
+++ b/supacodeTests/GithubCLIClientTests.swift
@@ -759,6 +759,153 @@ struct GithubCLIClientTests {
     #expect(snapshot.ghCallCount == 2)
     #expect(snapshot.loginCallCount == 2)
   }
+
+  @Test func executableResolutionFallsBackToCommonInstallPathWhenShellPathMissesGh() async throws {
+    let fallbackDirectory = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appendingPathComponent("supacode-gh-fallback-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: fallbackDirectory, withIntermediateDirectories: true)
+    defer {
+      try? FileManager.default.removeItem(at: fallbackDirectory)
+    }
+    let fallbackGh = fallbackDirectory.appendingPathComponent("gh")
+    let created = FileManager.default.createFile(
+      atPath: fallbackGh.path,
+      contents: Data("#!/bin/sh\n".utf8),
+      attributes: [.posixPermissions: 0o755]
+    )
+    #expect(created)
+
+    let probe = GithubBatchShellProbe()
+    let shell = ShellClient(
+      run: { executableURL, _, _ in
+        if executableURL.lastPathComponent == "which" {
+          await probe.recordWhichCall()
+          throw ShellClientError(command: "which gh", stdout: "", stderr: "gh not found", exitCode: 1)
+        }
+        return ShellOutput(stdout: "", stderr: "", exitCode: 0)
+      },
+      runLoginImpl: { executableURL, arguments, _, _ in
+        if executableURL.lastPathComponent == "which" {
+          await probe.recordWhichCall()
+          throw ShellClientError(command: "which gh", stdout: "", stderr: "gh not found", exitCode: 1)
+        }
+        #expect(executableURL == fallbackGh)
+        #expect(arguments == ["--version"])
+        await probe.recordLoginCall()
+        return ShellOutput(stdout: "gh version 2.79.0", stderr: "", exitCode: 0)
+      }
+    )
+    let client = GithubCLIClient.live(shell: shell, fallbackExecutableURLs: [fallbackGh])
+
+    #expect(await client.isAvailable())
+
+    let snapshot = await probe.snapshot()
+    #expect(snapshot.whichCallCount == 2)
+    #expect(snapshot.loginCallCount == 1)
+  }
+
+  @Test func executableResolutionReportsUnavailableWhenNoFallbackPathResolves() async throws {
+    let probe = GithubBatchShellProbe()
+    let shell = ShellClient(
+      run: { executableURL, _, _ in
+        if executableURL.lastPathComponent == "which" {
+          await probe.recordWhichCall()
+          throw ShellClientError(command: "which gh", stdout: "", stderr: "gh not found", exitCode: 1)
+        }
+        return ShellOutput(stdout: "", stderr: "", exitCode: 0)
+      },
+      runLoginImpl: { executableURL, _, _, _ in
+        if executableURL.lastPathComponent == "which" {
+          await probe.recordWhichCall()
+          throw ShellClientError(command: "which gh", stdout: "", stderr: "gh not found", exitCode: 1)
+        }
+        await probe.recordLoginCall()
+        return ShellOutput(stdout: "gh version 2.79.0", stderr: "", exitCode: 0)
+      }
+    )
+    let missingGh = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appendingPathComponent("supacode-gh-missing-\(UUID().uuidString)/gh")
+    let client = GithubCLIClient.live(shell: shell, fallbackExecutableURLs: [missingGh])
+
+    #expect(await client.isAvailable() == false)
+
+    let snapshot = await probe.snapshot()
+    #expect(snapshot.whichCallCount == 2)
+    #expect(snapshot.loginCallCount == 0)
+  }
+
+  @Test func executableResolutionPicksFirstExecutableFallbackAndSkipsMisses() async throws {
+    let fallbackDirectory = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appendingPathComponent("supacode-gh-order-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: fallbackDirectory, withIntermediateDirectories: true)
+    defer {
+      try? FileManager.default.removeItem(at: fallbackDirectory)
+    }
+    let missingGh = fallbackDirectory.appendingPathComponent("missing/gh")
+    let nonExecutableGh = fallbackDirectory.appendingPathComponent("non-executable-gh")
+    #expect(
+      FileManager.default.createFile(
+        atPath: nonExecutableGh.path,
+        contents: Data("#!/bin/sh\n".utf8),
+        attributes: [.posixPermissions: 0o644]
+      )
+    )
+    let firstExecutableGh = fallbackDirectory.appendingPathComponent("first-gh")
+    let laterExecutableGh = fallbackDirectory.appendingPathComponent("later-gh")
+    for executable in [firstExecutableGh, laterExecutableGh] {
+      #expect(
+        FileManager.default.createFile(
+          atPath: executable.path,
+          contents: Data("#!/bin/sh\n".utf8),
+          attributes: [.posixPermissions: 0o755]
+        )
+      )
+    }
+
+    let shell = ShellClient(
+      run: { executableURL, _, _ in
+        if executableURL.lastPathComponent == "which" {
+          throw ShellClientError(command: "which gh", stdout: "", stderr: "gh not found", exitCode: 1)
+        }
+        return ShellOutput(stdout: "", stderr: "", exitCode: 0)
+      },
+      runLoginImpl: { executableURL, _, _, _ in
+        if executableURL.lastPathComponent == "which" {
+          throw ShellClientError(command: "which gh", stdout: "", stderr: "gh not found", exitCode: 1)
+        }
+        // First executable entry wins: missing and non-executable candidates are skipped.
+        #expect(executableURL == firstExecutableGh)
+        return ShellOutput(stdout: "gh version 2.79.0", stderr: "", exitCode: 0)
+      }
+    )
+    let client = GithubCLIClient.live(
+      shell: shell,
+      fallbackExecutableURLs: [missingGh, nonExecutableGh, firstExecutableGh, laterExecutableGh]
+    )
+
+    #expect(await client.isAvailable())
+  }
+
+  @Test func defaultFallbackExecutableURLsOrdersPathsAndDropsHomeWhenAbsent() {
+    let withHome = GithubCLIExecutableResolver.defaultFallbackExecutableURLs(
+      environment: ["HOME": "/Users/tester"]
+    )
+    #expect(
+      withHome.map(\.path) == [
+        "/opt/homebrew/bin/gh",
+        "/usr/local/bin/gh",
+        "/Users/tester/.local/bin/gh",
+      ]
+    )
+
+    let withoutHome = GithubCLIExecutableResolver.defaultFallbackExecutableURLs(environment: [:])
+    #expect(
+      withoutHome.map(\.path) == [
+        "/opt/homebrew/bin/gh",
+        "/usr/local/bin/gh",
+      ]
+    )
+  }
 }
 
 nonisolated private func graphQLResponse(for arguments: [String]) -> String {

--- a/supacodeTests/ShellClientLoginShellTests.swift
+++ b/supacodeTests/ShellClientLoginShellTests.swift
@@ -1,0 +1,80 @@
+import Foundation
+import Testing
+
+@testable import supacode
+
+struct ShellClientLoginShellTests {
+  @Test func supportedShellsRunAsThemselves() {
+    for path in ["/bin/zsh", "/bin/bash", "/opt/homebrew/bin/fish"] {
+      let result = ShellClient.loginShellInvocation(userShell: URL(fileURLWithPath: path))
+      #expect(result.shell.path == path)
+    }
+  }
+
+  @Test func fishKeepsItsOwnSnippet() {
+    let result = ShellClient.loginShellInvocation(userShell: URL(fileURLWithPath: "/opt/homebrew/bin/fish"))
+    #expect(result.shell.lastPathComponent == "fish")
+    #expect(result.command.contains("exec $argv"))
+    // fish scopes argv across source, so it must NOT get the zsh/bash capture (which isn't valid fish).
+    #expect(!result.command.contains("__supacode_login_argv"))
+  }
+
+  @Test func bashSourcesBashrc() {
+    let result = ShellClient.loginShellInvocation(userShell: URL(fileURLWithPath: "/bin/bash"))
+    #expect(result.command.contains("~/.bashrc"))
+    #expect(result.command.contains("exec \"${__supacode_login_argv[@]}\""))
+  }
+
+  /// Regression for upstream #100: any shell we don't have a correct rc snippet for must
+  /// fall back to /bin/zsh, which can parse it — instead of stranding the user
+  /// with a bogus "not a git repository". Includes sh/dash/ksh, since sourcing
+  /// `~/.zshrc` under them is a parse error (the original review catch).
+  @Test func unsupportedShellsFallBackToZsh() {
+    let shells = [
+      "/run/current-system/sw/bin/nu", "/usr/bin/pwsh", "/opt/elvish", "/usr/bin/xonsh", "/bin/csh",
+      "/bin/sh", "/usr/local/bin/dash", "/usr/bin/ksh",
+    ]
+    for path in shells {
+      let result = ShellClient.loginShellInvocation(userShell: URL(fileURLWithPath: path))
+      #expect(result.shell.path == "/bin/zsh")
+      #expect(result.command.contains("exec \"${__supacode_login_argv[@]}\""))
+    }
+  }
+
+  /// Regression for upstream #441: the zsh/bash snippet must capture the positional parameters into
+  /// the saved array BEFORE sourcing the rc file. Sourcing shares `$@` with the caller, so an rc that
+  /// runs `set --` would otherwise wipe the command (`/usr/bin/which gh`) before `exec`.
+  @Test func zshAndBashCaptureArgsBeforeSourcingRc() {
+    for path in ["/bin/zsh", "/bin/bash"] {
+      let command = ShellClient.loginShellInvocation(userShell: URL(fileURLWithPath: path)).command
+      guard let captureRange = command.range(of: "__supacode_login_argv=(\"$@\")"),
+        let sourceRange = command.range(of: "~/.")
+      else {
+        Issue.record("\(path) snippet missing capture or source: \(command)")
+        continue
+      }
+      #expect(captureRange.lowerBound < sourceRange.lowerBound)
+      #expect(command.contains("exec \"${__supacode_login_argv[@]}\""))
+    }
+  }
+
+  /// Regression for upstream #477: after capturing the positional parameters, the zsh/bash snippet
+  /// must clear them (`set --`) BEFORE sourcing the rc file. The positionals otherwise leak into the
+  /// rc, so a dual-mode script dispatching on `$1` (e.g. `fzf-git.sh`) sees the probe's
+  /// `/usr/bin/which gh`, hits its own `exit`, and kills the probe shell before `gh` is ever resolved.
+  @Test func zshAndBashClearPositionalsBeforeSourcingRc() {
+    for path in ["/bin/zsh", "/bin/bash"] {
+      let command = ShellClient.loginShellInvocation(userShell: URL(fileURLWithPath: path)).command
+      guard let captureRange = command.range(of: "__supacode_login_argv=(\"$@\")"),
+        let clearRange = command.range(of: "set --"),
+        let sourceRange = command.range(of: "~/.")
+      else {
+        Issue.record("\(path) snippet missing capture, clear, or source: \(command)")
+        continue
+      }
+      #expect(captureRange.lowerBound < clearRange.lowerBound)
+      #expect(clearRange.lowerBound < sourceRange.lowerBound)
+      #expect(command.contains("exec \"${__supacode_login_argv[@]}\""))
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Ports four upstream fixes to the gh / login-shell detection subsystem. These are follow-ups to the login-shell noise fix we ported earlier as #418 — the fork still carried the pre-fix form of all four defects (verified against `supacode/Clients/Shell/ShellClient.swift` and `supacode/Clients/Github/GithubCLIExecutableResolver.swift`).

| Upstream | Fix |
| --- | --- |
| supabitapp/supacode#410 | Non-POSIX login shells (nushell, pwsh, csh, and sh/dash/ksh which can't parse the zsh rc snippet) now fall back to `/bin/zsh` for one-shot commands, instead of failing every git/wt/gh invocation as a bogus "not a git repository". The interactive terminal still uses the user's real shell. |
| supabitapp/supacode#460 | Capture `$@` into `__supacode_login_argv` before sourcing the rc file — an rc running `set --` could wipe the command before `exec`, making gh undetectable. |
| supabitapp/supacode#482 | Clear live positionals (`set --`) before sourcing — a dual-mode rc script dispatching on `$1` (e.g. `fzf-git.sh`) could see the probe's arguments, hit its own `exit`, and kill the probe shell. |
| supabitapp/supacode#535 | When both `which gh` probes fail (broken PATH/rc), fall back to common install paths: `/opt/homebrew/bin/gh`, `/usr/local/bin/gh`, `~/.local/bin/gh`, with a breadcrumb log for traceability. |

Structural adaptation: upstream's ShellClient lives in `SupacodeSettingsShared`; the fork's is `supacode/Clients/Shell/ShellClient.swift`, and the fork had already extracted `GithubCLIExecutableResolver` into its own file — the port maps cleanly onto both. The `__supacode_login_argv` variable name is kept as upstream's to minimize future sync friction.

## Tests

- New `supacodeTests/ShellClientLoginShellTests.swift` (6 tests): drivable shells run as themselves, fish keeps its own snippet (and must NOT get the zsh/bash capture), bash sources `.bashrc`, unsupported shells fall back to zsh, and the capture → `set --` → source ordering regressions.
- `supacodeTests/GithubCLIClientTests.swift` (+4 tests): fallback resolution when shell PATH misses gh, unavailable when no fallback resolves, first-executable-wins ordering (skipping missing/non-executable candidates), and default fallback URL ordering with/without `HOME`.

Ran: `make check` clean; `xcodebuild test -only-testing:supacodeTests/ShellClientLoginShellTests -only-testing:supacodeTests/GithubCLIClientTests` → 34 passed / 0 failed; `make build-app` success.

## 验收方式（人类确认）

1. 正常环境（zsh + gh 已装）：打开 Prowl，确认 PR 状态、`gh auth` 相关功能一切照旧。
2. 模拟 PATH 损坏：`chsh -s /bin/sh`（或把 SHELL 环境变量设为 `/bin/sh` 启动 app），确认仓库添加/打开不再报 "not a git repository"，PR 功能仍可用；测完记得 `chsh -s /bin/zsh` 恢复。
3. （可选）在 `~/.zshrc` 末尾临时加一行 `set --`，重启 Prowl，确认 GitHub 集成仍能找到 gh。

## 风险点

- 行为变化仅影响**一次性登录 shell 命令**的包装方式；交互式终端 spawn 的仍是用户真实 shell，无变化。
- sh/dash/ksh 用户的一次性命令现在跑在 `/bin/zsh` 下（之前是在他们的 shell 里 source zsh 语法 → 必然失败），属于严格改善。
- fallback 路径命中时会以 INFO 级别打一条日志，无其他副作用。
