### PR TITLE
Add Zed Preview, IntelliJ IDEA EAP, and Nova open actions

### DIFF
--- a/docs/components/repositories-and-worktrees.md
+++ b/docs/components/repositories-and-worktrees.md
@@ -145,21 +145,22 @@ it from Prowl (closing its open terminals); it does **not** delete files on disk
 **Automatic** (the default), Prowl inspects the worktree's top-level files and
 prefers an app matching the project type: `.xcodeproj`/`.xcworkspace`/
 `Package.swift`/`Project.swift` → Xcode, Gradle files → Android Studio (then
-IntelliJ IDEA), `*.sln`/`*.csproj` → Rider, `pom.xml` → IntelliJ IDEA,
-`go.mod` → GoLand, `Cargo.toml` → RustRover, `CMakeLists.txt` → CLion,
-`composer.json` → PhpStorm, `Gemfile` → RubyMine, Python manifests → PyCharm,
-`package.json` → WebStorm. If the matching app isn't installed (or no project
-type is detected), it falls back to the generic priority — your first
-installed editor (Cursor → Zed → VS Code → Windsurf → …), falling through to
-Xcode and then **Finder only when no preferred app is found**. Use the
-**Open** dropdown in the worktree's detail toolbar to pick a different app
-(this pins it for the repo), or pick **Automatic** at the top of that dropdown
-to clear the pin and return to project-aware selection. You can also set a
-per-repo default (`openActionID`) / global default (`defaultEditorID`). Prowl
-detects: Finder, Terminal,
-`$EDITOR`, VS Code (+ Insiders), VSCodium, Cursor, Zed, Windsurf, Antigravity,
-Sublime Text, Xcode, Android Studio, JetBrains IDEs (IntelliJ IDEA, WebStorm,
-PyCharm, RustRover, Rider, GoLand, CLion, PhpStorm, RubyMine), GitHub Desktop
+IntelliJ IDEA, then IDEA EAP), `*.sln`/`*.csproj` → Rider, `pom.xml` →
+IntelliJ IDEA (then IDEA EAP), `go.mod` → GoLand, `Cargo.toml` → RustRover,
+`CMakeLists.txt` → CLion, `composer.json` → PhpStorm, `Gemfile` → RubyMine,
+Python manifests → PyCharm, `package.json` → WebStorm. If the matching app
+isn't installed (or no project type is detected), it falls back to the generic
+priority — your first installed editor (Cursor → Zed → Zed Preview →
+VS Code → Windsurf → …), falling through to Xcode and then **Finder only when
+no preferred app is found**. Use the **Open** dropdown in the worktree's
+detail toolbar to pick a different app (this pins it for the repo), or pick
+**Automatic** at the top of that dropdown to clear the pin and return to
+project-aware selection. You can also set a per-repo default (`openActionID`)
+/ global default (`defaultEditorID`). Prowl detects: Finder, Terminal,
+`$EDITOR`, VS Code (+ Insiders), VSCodium, Cursor, Zed (+ Preview), Windsurf,
+Antigravity, Sublime Text, Nova, Xcode, Android Studio, JetBrains IDEs
+(IntelliJ IDEA and IDEA EAP, WebStorm, PyCharm, RustRover, Rider, GoLand,
+CLion, PhpStorm, RubyMine), GitHub Desktop
 / Fork / Tower / GitKraken / Sourcetree / Sublime Merge / SmartGit / GitUp,
 and terminals (Alacritty, Ghostty, iTerm2, Kitty, Warp, WezTerm). If the
 chosen app isn't installed, Prowl shows an alert.

--- a/supacode/Domain/OpenWorktreeAction.swift
+++ b/supacode/Domain/OpenWorktreeAction.swift
@@ -20,8 +20,10 @@ enum OpenWorktreeAction: CaseIterable, Identifiable {
   case ghostty
   case goland
   case intellij
+  case intellijEAP
   case iterm2
   case kitty
+  case nova
   case phpstorm
   case pycharm
   case rider
@@ -42,6 +44,7 @@ enum OpenWorktreeAction: CaseIterable, Identifiable {
   case windsurf
   case xcode
   case zed
+  case zedPreview
 
   var id: String { title }
 
@@ -60,8 +63,10 @@ enum OpenWorktreeAction: CaseIterable, Identifiable {
     case .ghostty: "Ghostty"
     case .goland: "GoLand"
     case .intellij: "IntelliJ IDEA"
+    case .intellijEAP: "IntelliJ IDEA EAP"
     case .iterm2: "iTerm2"
     case .kitty: "Kitty"
+    case .nova: "Nova"
     case .phpstorm: "PhpStorm"
     case .pycharm: "PyCharm"
     case .rider: "Rider"
@@ -83,6 +88,7 @@ enum OpenWorktreeAction: CaseIterable, Identifiable {
     case .xcode: "Xcode"
     case .fork: "Fork"
     case .zed: "Zed"
+    case .zedPreview: "Zed Preview"
     }
   }
 
@@ -91,9 +97,10 @@ enum OpenWorktreeAction: CaseIterable, Identifiable {
     case .finder: "Finder"
     case .editor: "$EDITOR"
     case .alacritty, .androidStudio, .antigravity, .clion, .cursor, .fork, .githubDesktop, .gitkraken,
-      .gitup, .ghostty, .goland, .intellij, .iterm2, .kitty, .phpstorm, .pycharm, .rider, .rubymine,
-      .rustrover, .smartgit, .sourcetree, .sublimeMerge, .sublimeText, .terminal, .tower, .vscode,
-      .vscodeInsiders, .vscodium, .warp, .webstorm, .wezterm, .windsurf, .xcode, .zed:
+      .gitup, .ghostty, .goland, .intellij, .intellijEAP, .iterm2, .kitty, .nova, .phpstorm, .pycharm,
+      .rider, .rubymine, .rustrover, .smartgit, .sourcetree, .sublimeMerge, .sublimeText, .terminal,
+      .tower, .vscode, .vscodeInsiders, .vscodium, .warp, .webstorm, .wezterm, .windsurf, .xcode, .zed,
+      .zedPreview:
       title
     }
   }
@@ -145,9 +152,10 @@ enum OpenWorktreeAction: CaseIterable, Identifiable {
     case .finder, .editor:
       return true
     case .alacritty, .androidStudio, .antigravity, .clion, .cursor, .fork, .githubDesktop, .gitkraken,
-      .gitup, .ghostty, .goland, .intellij, .iterm2, .kitty, .phpstorm, .pycharm, .rider, .rubymine,
-      .rustrover, .smartgit, .sourcetree, .sublimeMerge, .sublimeText, .terminal, .tower, .vscode,
-      .vscodeInsiders, .vscodium, .warp, .webstorm, .wezterm, .windsurf, .xcode, .zed:
+      .gitup, .ghostty, .goland, .intellij, .intellijEAP, .iterm2, .kitty, .nova, .phpstorm, .pycharm,
+      .rider, .rubymine, .rustrover, .smartgit, .sourcetree, .sublimeMerge, .sublimeText, .terminal,
+      .tower, .vscode, .vscodeInsiders, .vscodium, .warp, .webstorm, .wezterm, .windsurf, .xcode, .zed,
+      .zedPreview:
       return NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleIdentifier) != nil
     }
   }
@@ -168,8 +176,10 @@ enum OpenWorktreeAction: CaseIterable, Identifiable {
     case .ghostty: "ghostty"
     case .goland: "goland"
     case .intellij: "intellij"
+    case .intellijEAP: "intellijEAP"
     case .iterm2: "iterm2"
     case .kitty: "kitty"
+    case .nova: "nova"
     case .phpstorm: "phpstorm"
     case .pycharm: "pycharm"
     case .rider: "rider"
@@ -190,6 +200,7 @@ enum OpenWorktreeAction: CaseIterable, Identifiable {
     case .windsurf: "windsurf"
     case .xcode: "xcode"
     case .zed: "zed"
+    case .zedPreview: "zed-preview"
     }
   }
 
@@ -209,8 +220,10 @@ enum OpenWorktreeAction: CaseIterable, Identifiable {
     case .ghostty: "com.mitchellh.ghostty"
     case .goland: "com.jetbrains.goland"
     case .intellij: "com.jetbrains.intellij"
+    case .intellijEAP: "com.jetbrains.intellij-EAP"
     case .iterm2: "com.googlecode.iterm2"
     case .kitty: "net.kovidgoyal.kitty"
+    case .nova: "com.panic.Nova"
     case .phpstorm: "com.jetbrains.PhpStorm"
     case .pycharm: "com.jetbrains.pycharm"
     case .rider: "com.jetbrains.rider"
@@ -231,6 +244,7 @@ enum OpenWorktreeAction: CaseIterable, Identifiable {
     case .windsurf: "com.exafunction.windsurf"
     case .xcode: "com.apple.dt.Xcode"
     case .zed: "dev.zed.Zed"
+    case .zedPreview: "dev.zed.Zed-Preview"
     }
   }
 
@@ -239,13 +253,16 @@ enum OpenWorktreeAction: CaseIterable, Identifiable {
   static let editorPriority: [OpenWorktreeAction] = [
     .cursor,
     .zed,
+    .zedPreview,
     .vscode,
     .windsurf,
     .vscodeInsiders,
     .vscodium,
     .sublimeText,
+    .nova,
     .androidStudio,
     .intellij,
+    .intellijEAP,
     .webstorm,
     .pycharm,
     .rustrover,
@@ -345,8 +362,8 @@ enum OpenWorktreeAction: CaseIterable, Identifiable {
     case .finder:
       NSWorkspace.shared.activateFileViewerSelecting([worktree.workingDirectory])
     // Apps that require CLI arguments instead of Apple Events to open directories.
-    case .androidStudio, .clion, .goland, .intellij, .phpstorm, .pycharm, .rider, .rubymine,
-      .rustrover, .webstorm:
+    case .androidStudio, .clion, .goland, .intellij, .intellijEAP, .phpstorm, .pycharm, .rider,
+      .rubymine, .rustrover, .webstorm:
       guard
         let appURL = NSWorkspace.shared.urlForApplication(
           withBundleIdentifier: bundleIdentifier
@@ -378,8 +395,8 @@ enum OpenWorktreeAction: CaseIterable, Identifiable {
         }
       }
     case .alacritty, .antigravity, .cursor, .fork, .githubDesktop, .gitkraken, .gitup, .ghostty,
-      .iterm2, .kitty, .smartgit, .sourcetree, .sublimeMerge, .sublimeText, .terminal, .tower,
-      .vscode, .vscodeInsiders, .vscodium, .warp, .wezterm, .windsurf, .xcode, .zed:
+      .iterm2, .kitty, .nova, .smartgit, .sourcetree, .sublimeMerge, .sublimeText, .terminal, .tower,
+      .vscode, .vscodeInsiders, .vscodium, .warp, .wezterm, .windsurf, .xcode, .zed, .zedPreview:
       guard
         let appURL = NSWorkspace.shared.urlForApplication(
           withBundleIdentifier: bundleIdentifier

--- a/supacode/Domain/WorktreeProjectKind.swift
+++ b/supacode/Domain/WorktreeProjectKind.swift
@@ -75,9 +75,9 @@ enum WorktreeProjectKind: CaseIterable {
   var preferredActions: [OpenWorktreeAction] {
     switch self {
     case .apple: [.xcode]
-    case .android: [.androidStudio, .intellij]
+    case .android: [.androidStudio, .intellij, .intellijEAP]
     case .dotnet: [.rider]
-    case .java: [.intellij]
+    case .java: [.intellij, .intellijEAP]
     case .golang: [.goland]
     case .rust: [.rustrover]
     case .cpp: [.clion]

--- a/supacodeTests/OpenWorktreeActionTests.swift
+++ b/supacodeTests/OpenWorktreeActionTests.swift
@@ -25,6 +25,7 @@ struct OpenWorktreeActionTests {
   @Test func jetBrainsIDEsHaveCorrectBundleIdentifiers() {
     #expect(OpenWorktreeAction.androidStudio.bundleIdentifier == "com.google.android.studio")
     #expect(OpenWorktreeAction.intellij.bundleIdentifier == "com.jetbrains.intellij")
+    #expect(OpenWorktreeAction.intellijEAP.bundleIdentifier == "com.jetbrains.intellij-EAP")
     #expect(OpenWorktreeAction.webstorm.bundleIdentifier == "com.jetbrains.WebStorm")
     #expect(OpenWorktreeAction.pycharm.bundleIdentifier == "com.jetbrains.pycharm")
     #expect(OpenWorktreeAction.rustrover.bundleIdentifier == "com.jetbrains.rustrover")
@@ -39,12 +40,15 @@ struct OpenWorktreeActionTests {
     #expect(OpenWorktreeAction.iterm2.bundleIdentifier == "com.googlecode.iterm2")
     #expect(OpenWorktreeAction.sublimeText.bundleIdentifier == "com.sublimetext.4")
     #expect(OpenWorktreeAction.tower.bundleIdentifier == "com.fournova.Tower3")
+    #expect(OpenWorktreeAction.nova.bundleIdentifier == "com.panic.Nova")
+    #expect(OpenWorktreeAction.zedPreview.bundleIdentifier == "dev.zed.Zed-Preview")
   }
 
   @Test func jetBrainsIDEsAreInEditorPriority() {
     let editors = OpenWorktreeAction.editorPriority
     #expect(editors.contains(.androidStudio))
     #expect(editors.contains(.intellij))
+    #expect(editors.contains(.intellijEAP))
     #expect(editors.contains(.webstorm))
     #expect(editors.contains(.pycharm))
     #expect(editors.contains(.rustrover))
@@ -55,9 +59,19 @@ struct OpenWorktreeActionTests {
     #expect(editors.contains(.rubymine))
   }
 
+  @Test func channelVariantsFollowTheirStableEditors() throws {
+    let editors = OpenWorktreeAction.editorPriority
+    #expect(editors.contains(.nova))
+    let zedIndex = try #require(editors.firstIndex(of: .zed))
+    #expect(editors.firstIndex(of: .zedPreview) == zedIndex + 1)
+    let intellijIndex = try #require(editors.firstIndex(of: .intellij))
+    #expect(editors.firstIndex(of: .intellijEAP) == intellijIndex + 1)
+  }
+
   @Test func projectKindsPreferMatchingSpecialistApps() {
     #expect(WorktreeProjectKind.apple.preferredActions.first == .xcode)
-    #expect(WorktreeProjectKind.android.preferredActions == [.androidStudio, .intellij])
+    #expect(WorktreeProjectKind.android.preferredActions == [.androidStudio, .intellij, .intellijEAP])
+    #expect(WorktreeProjectKind.java.preferredActions == [.intellij, .intellijEAP])
     #expect(WorktreeProjectKind.dotnet.preferredActions.first == .rider)
     #expect(WorktreeProjectKind.golang.preferredActions.first == .goland)
     #expect(WorktreeProjectKind.rust.preferredActions.first == .rustrover)
@@ -76,6 +90,14 @@ struct OpenWorktreeActionTests {
       let installed: Set<OpenWorktreeAction> = [.androidStudio, .cursor, .xcode, .finder]
       let action = OpenWorktreeAction.preferredDefault(for: directory) { installed.contains($0) }
       #expect(action == .androidStudio)
+    }
+  }
+
+  @Test func preferredDefaultPicksIntellijEAPWhenOnlyEAPInstalled() throws {
+    try withTemporaryProjectDirectory(entries: ["build.gradle.kts"]) { directory in
+      let installed: Set<OpenWorktreeAction> = [.intellijEAP, .cursor, .finder]
+      let action = OpenWorktreeAction.preferredDefault(for: directory) { installed.contains($0) }
+      #expect(action == .intellijEAP)
     }
   }
 

--- a/supacodeTests/OpenWorktreeActionTests.swift
+++ b/supacodeTests/OpenWorktreeActionTests.swift
@@ -44,6 +44,14 @@ struct OpenWorktreeActionTests {
     #expect(OpenWorktreeAction.zedPreview.bundleIdentifier == "dev.zed.Zed-Preview")
   }
 
+  // Persisted in settings and kept byte-identical to upstream; intellijEAP intentionally
+  // breaks the kebab-case convention.
+  @Test func newActionsHaveStableSettingsIDs() {
+    #expect(OpenWorktreeAction.zedPreview.settingsID == "zed-preview")
+    #expect(OpenWorktreeAction.intellijEAP.settingsID == "intellijEAP")
+    #expect(OpenWorktreeAction.nova.settingsID == "nova")
+  }
+
   @Test func jetBrainsIDEsAreInEditorPriority() {
     let editors = OpenWorktreeAction.editorPriority
     #expect(editors.contains(.androidStudio))


### PR DESCRIPTION
## Summary

Ports the three editors missing from the fork's open-with system, out of upstream's six recent editor additions (GoLand / Rider / PhpStorm already landed via `e423d2d8` on 2026-06-13 with identical bundle ids):

| Editor | Upstream | Bundle id | Placement |
| --- | --- | --- | --- |
| Zed Preview | supabitapp/supacode#447 | `dev.zed.Zed-Preview` | right after Zed in `editorPriority` (VS Code/Insiders channel convention) |
| IntelliJ IDEA EAP | supabitapp/supacode#496 | `com.jetbrains.intellij-EAP` | right after IntelliJ; JetBrains CLI-args open path; added to android/java `WorktreeProjectKind.preferredActions` as the IDEA fallback |
| Nova | supabitapp/supacode#506 | `com.panic.Nova` | after Sublime Text among Mac-native generic editors |

Fork-specific integration: IDEA EAP participates in the fork's project-type detection (Gradle/`pom.xml` projects prefer Android Studio → IntelliJ → IDEA EAP), which upstream doesn't have. Upstream's `c38c325d` OpenTarget/OpenBehavior refactor was deliberately NOT adopted (recorded in the sync plan doc) — these are additive cases in the fork's existing enum shape.

`settingsID` raw values match upstream exactly (`zed-preview`, `intellijEAP`, `nova`) so persisted selections stay portable across future syncs. (`intellijEAP` breaks the fork's kebab-case convention on purpose — it's upstream's persisted literal.)

## Tests

- Bundle-id assertions for all three; `editorPriority` membership; a new `channelVariantsFollowTheirStableEditors` test pinning Zed Preview / IDEA EAP directly after their stable channels; android/java `preferredActions` updated expectations; new `preferredDefaultPicksIntellijEAPWhenOnlyEAPInstalled` covering Automatic-mode fallback.
- The existing `menuOrderIncludesAllCases` safety net guarantees no case is forgotten from menu ordering.
- Ran: `make check` clean; `OpenWorktreeActionTests` + `WorktreeProjectKindTests` + `AppFeatureDefaultEditorTests` → 24 passed / 0 failed.

Docs: `docs/components/repositories-and-worktrees.md` detection list updated in the same change.

## 验收方式（人类确认）

1. 装有 Zed Preview / IDEA EAP / Nova 任意一个的机器上，worktree 详情工具栏的 **Open** 下拉应出现对应条目，选择后能正常打开该目录。
2. 一个 Gradle 项目 + 只装了 IDEA EAP（没有 Android Studio / 正式版 IDEA）时，Open 动作为 Automatic 应自动选中 IDEA EAP。
3. 没装这些编辑器的机器上，下拉列表不出现它们（安装检测过滤），现有行为无变化。

## 风险点

无风险 — 纯枚举扩展，无持久化格式变化；新 settingsID 只会由新选择写入，旧配置不受影响。
