### PR TITLE
Report prowl as TERM_PROGRAM in terminal surfaces

### DIFF
--- a/docs/components/terminal.md
+++ b/docs/components/terminal.md
@@ -101,6 +101,11 @@ sequences:
 `--capture` in the CLI **requires OSC 133** on the target pane; without it you get
 `CAPTURE_UNSUPPORTED` (read the screen with `read --wait-stable` instead).
 
+Every pane's environment reports **`TERM_PROGRAM=prowl`** (with
+`TERM_PROGRAM_VERSION` set to the app version), so scripts and agents can detect
+they're running inside Prowl rather than standalone Ghostty. `TERM` itself stays
+`xterm-ghostty` — terminfo-based feature detection is unaffected.
+
 ## Command-finished behavior
 
 When a command finishes (via OSC 133), Prowl can:

--- a/supacode/Infrastructure/Ghostty/GhosttyRuntime+ThemeFallback.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttyRuntime+ThemeFallback.swift
@@ -104,6 +104,7 @@ extension GhosttyRuntime {
     ghostty_config_load_default_files(updated)
     ghostty_config_load_recursive_files(updated)
     ghostty_config_load_cli_args(updated)
+    Self.loadTerminalProgramOverrides(into: updated)
     for url in overrideURLs {
       url.path.withCString { path in
         ghostty_config_load_file(updated, path)

--- a/supacode/Infrastructure/Ghostty/GhosttyRuntime.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttyRuntime.swift
@@ -337,8 +337,44 @@ final class GhosttyRuntime {
     ghostty_config_load_default_files(config)
     ghostty_config_load_recursive_files(config)
     ghostty_config_load_cli_args(config)
+    loadTerminalProgramOverrides(into: config)
     ghostty_config_finalize(config)
     return config
+  }
+
+  /// Reports Prowl in `TERM_PROGRAM` so programs detect the real host terminal;
+  /// loaded after the user config so it wins. The version is always emitted
+  /// because Ghostty's `env` map can override a key but not clear its seeded
+  /// value, so a blank value falls back to a placeholder.
+  nonisolated static func terminalProgramOverrides(version: String?) -> String {
+    // Trim like Ghostty's `env` parser, which strips whitespace then drops a
+    // now-empty value, leaving its seeded version.
+    let trimmed = version?.trimmingCharacters(in: .whitespacesAndNewlines)
+    let resolved = trimmed.flatMap { $0.isEmpty ? nil : $0 } ?? "unknown"
+    return """
+      env = TERM_PROGRAM=prowl
+      env = TERM_PROGRAM_VERSION=\(resolved)
+      """
+  }
+
+  nonisolated private static var appVersion: String? {
+    let info = Bundle.main.infoDictionary
+    let candidates = [info?["CFBundleShortVersionString"], info?["CFBundleVersion"]]
+    return candidates.lazy.compactMap { $0 as? String }.first { !$0.isEmpty }
+  }
+
+  nonisolated static func loadTerminalProgramOverrides(into config: ghostty_config_t) {
+    let url = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appendingPathComponent("prowl-ghostty-term-program.conf")
+    do {
+      try terminalProgramOverrides(version: appVersion).write(to: url, atomically: true, encoding: .utf8)
+    } catch {
+      ghosttyLogger.warning("Failed to write TERM_PROGRAM override file: \(error.localizedDescription)")
+      return
+    }
+    url.path.withCString { path in
+      ghostty_config_load_file(config, path)
+    }
   }
 
   func keyboardShortcut(for action: String) -> KeyboardShortcut? {

--- a/supacodeTests/GhosttyRuntimeTerminalProgramTests.swift
+++ b/supacodeTests/GhosttyRuntimeTerminalProgramTests.swift
@@ -1,0 +1,39 @@
+import Foundation
+import Testing
+
+@testable import supacode
+
+struct GhosttyRuntimeTerminalProgramTests {
+  /// `TERM_PROGRAM` reports Prowl with its version (upstream #440).
+  @Test func terminalProgramOverridesIdentifyProwl() {
+    let overrides = GhosttyRuntime.terminalProgramOverrides(version: "2026.7.6")
+    #expect(overrides.contains("env = TERM_PROGRAM=prowl"))
+    #expect(overrides.contains("env = TERM_PROGRAM_VERSION=2026.7.6"))
+  }
+
+  /// A missing or blank version still emits a placeholder, never Ghostty's.
+  @Test func terminalProgramOverridesFallBackWhenVersionUnavailable() {
+    for version: String? in [nil, "", "   "] {
+      let overrides = GhosttyRuntime.terminalProgramOverrides(version: version)
+      #expect(overrides.contains("env = TERM_PROGRAM=prowl"))
+      #expect(overrides.contains("env = TERM_PROGRAM_VERSION=unknown"))
+    }
+  }
+
+  /// Surrounding whitespace is trimmed from the emitted version.
+  @Test func terminalProgramOverridesTrimVersionWhitespace() {
+    let overrides = GhosttyRuntime.terminalProgramOverrides(version: " 2026.7.6 ")
+    #expect(overrides.contains("env = TERM_PROGRAM_VERSION=2026.7.6"))
+  }
+
+  @Test func terminalProgramOverridesAreKeyValueDirectives() {
+    let lines = GhosttyRuntime.terminalProgramOverrides(version: "9.9.9")
+      .split(whereSeparator: \.isNewline)
+      .map { $0.trimmingCharacters(in: .whitespaces) }
+      .filter { !$0.isEmpty }
+    #expect(!lines.isEmpty)
+    for line in lines {
+      #expect(line.contains("="), "Override line missing `=`: \(line)")
+    }
+  }
+}


### PR DESCRIPTION
## Summary

你问的 `7a5c9ab1` #458 是这个：Ghostty 给每个 surface 注入 `TERM_PROGRAM=ghostty`，导致终端里的程序（prompt、脚本、agent）以为宿主是 Ghostty.app。上游把它覆写成自家标识；本 PR 移植并 rebrand 为 **`TERM_PROGRAM=prowl`**，同时注入 `TERM_PROGRAM_VERSION=<app version>`（Ghostty 的 `env` map 只能覆写不能清空 seeded key，所以 version 永远发出，取不到时用 `unknown` 占位）。

对 fork 的实际价值：终端内的脚本和 coding agent 可以检测到自己跑在 Prowl 里（而不是普通 Ghostty），为将来 agent 感知 Prowl 环境（如提示可用 `prowl` CLI）打基础。

## Implementation

Fork 没有上游的 bundled-overrides 机制，因此适配到 fork 自己的 runtime-override 体系：新增 `GhosttyRuntime.terminalProgramOverrides(version:)`（纯函数，upstream 逐字对应）+ `loadTerminalProgramOverrides(into:)`（写入 `prowl-ghostty-term-program.conf` 并 `ghostty_config_load_file`），并在**两条 config 构建路径**都加载：`loadConfig()`（启动/重载）与 `applyRuntimeOverridesIfNeeded()`（keybind/theme override 重建）。加载顺序在用户 config 之后，因此 app 覆写生效。

## Tests

新增 `GhosttyRuntimeTerminalProgramTests`（4 个，对应上游测试）：标识+版本注入、nil/空白版本回退 `unknown`、版本 trim、指令均为 key=value 形式。`make check` clean；4 passed / 0 failed；app 构建通过。

## 验收方式（人类确认）

1. 构建运行后开一个新终端 tab，执行 `echo $TERM_PROGRAM $TERM_PROGRAM_VERSION` → 应输出 `prowl 2026.x.x`。
2. `echo $TERM` → 仍为 `xterm-ghostty`（terminfo 行为不变）。
3. 在 Ghostty 配置里改点东西触发 reload（或 Settings 里 reload config），再开新 tab 确认覆写仍在。

## 风险点

- 个别工具会对 `TERM_PROGRAM == "ghostty"` 做特性检测（如启用特定图形协议）；这类工具在 Prowl 里会走保守路径。缓解：`TERM=xterm-ghostty` 不变，绝大多数特性检测走 terminfo；Ghostty 官方 shell integration 依赖 `GHOSTTY_RESOURCES_DIR` 而非 TERM_PROGRAM，不受影响。上游同款改动已发布一个月无回退。
- 仅影响**新创建**的 surface；已开的终端 env 不变（重启后全量生效）。
