### PR TITLE
Fix sidebar not updating after git init in plain repository

### DIFF
--- a/supacode/Clients/WorktreeInfoWatcher/WorktreeInfoWatcherClient.swift
+++ b/supacode/Clients/WorktreeInfoWatcher/WorktreeInfoWatcherClient.swift
@@ -11,6 +11,7 @@ struct WorktreeInfoWatcherClient {
     case setSelectedWorktreeID(Worktree.ID?)
     case refreshLineChanges
     case setPullRequestTrackingEnabled(Bool)
+    case setPlainRepositoryRoots([URL])
     case stop
   }
 
@@ -20,6 +21,7 @@ struct WorktreeInfoWatcherClient {
     case repositoryWorktreesChanged(repositoryRootURL: URL)
     case repositoryRemoteConfigurationChanged(repositoryRootURL: URL)
     case repositoryPullRequestRefresh(repositoryRootURL: URL, worktreeIDs: [Worktree.ID])
+    case plainRepositoryBecameGitRepository(URL)
   }
 }
 

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -269,6 +269,7 @@ struct AppFeature {
         )
         let worktrees = state.repositories.worktreesForInfoWatcher()
         let openedWorktreeIDs = openedWorktreeIDsForInfoWatcher(from: state.repositories)
+        let plainRepositoryRoots = state.repositories.plainRepositoryRootsForInfoWatcher()
         let shouldRestoreLayout =
           state.launchRestoreMode == .restoreLayout
           && state.repositories.snapshotPersistencePhase == .active
@@ -305,6 +306,9 @@ struct AppFeature {
             .run { _ in
               await worktreeInfoWatcher.send(.setOpenedWorktreeIDs(openedWorktreeIDs))
             },
+            .run { _ in
+              await worktreeInfoWatcher.send(.setPlainRepositoryRoots(plainRepositoryRoots))
+            },
           ]
           if shouldRestoreLayout {
             effects.append(
@@ -327,6 +331,9 @@ struct AppFeature {
           },
           .run { _ in
             await worktreeInfoWatcher.send(.setOpenedWorktreeIDs(openedWorktreeIDs))
+          },
+          .run { _ in
+            await worktreeInfoWatcher.send(.setPlainRepositoryRoots(plainRepositoryRoots))
           },
         ]
         if shouldRestoreLayout {

--- a/supacode/Features/Repositories/BusinessLogic/WorktreeInfoWatcherManager.swift
+++ b/supacode/Features/Repositories/BusinessLogic/WorktreeInfoWatcherManager.swift
@@ -95,6 +95,8 @@ final class WorktreeInfoWatcherManager {
   private var worktreeFileEventMonitors: [Worktree.ID: WorktreeFileEventMonitoring] = [:]
   private var worktreeRegistryMonitors: [URL: WorktreeRegistryMonitoring] = [:]
   private var remoteConfigMonitors: [URL: RemoteConfigMonitoring] = [:]
+  private var plainRepositoryMonitors: [URL: WorktreeFileEventMonitoring] = [:]
+  private let plainRepositoryDebouncer: KeyedDebouncer<URL>
   private let branchChangedDebouncer: KeyedDebouncer<Worktree.ID>
   private let repositoryWorktreesDebouncer: KeyedDebouncer<URL>
   private let remoteConfigDebouncer: KeyedDebouncer<URL>
@@ -152,6 +154,7 @@ final class WorktreeInfoWatcherManager {
     repositoryWorktreesDebouncer = KeyedDebouncer(interval: repositoryWorktreesEventDebounceInterval, clock: clock)
     remoteConfigDebouncer = KeyedDebouncer(interval: remoteConfigEventDebounceInterval, clock: clock)
     restartDebouncer = KeyedDebouncer(interval: .seconds(5), clock: clock)
+    plainRepositoryDebouncer = KeyedDebouncer(interval: .seconds(1), clock: clock)
     // Callers always pass an explicit per-worktree delay; the instance interval
     // is only a nominal default.
     lineChangesRefreshDebouncer = KeyedDebouncer(interval: defaultLineChangesTiming.eventDebounce, clock: clock)
@@ -169,6 +172,8 @@ final class WorktreeInfoWatcherManager {
       scheduleLineChangesRefreshForAllWorktrees()
     case .setPullRequestTrackingEnabled(let isEnabled):
       setPullRequestTrackingEnabled(isEnabled)
+    case .setPlainRepositoryRoots(let roots):
+      setPlainRepositoryRoots(roots)
     case .stop:
       stopAll()
     }
@@ -373,6 +378,39 @@ final class WorktreeInfoWatcherManager {
     lineChangesRefreshDebouncer.cancel(worktreeID)
   }
 
+  private func setPlainRepositoryRoots(_ roots: [URL]) {
+    let desiredRoots = Set(roots.map { $0.standardizedFileURL })
+    let currentRoots = Set(plainRepositoryMonitors.keys)
+    for root in currentRoots.subtracting(desiredRoots) {
+      plainRepositoryMonitors[root]?.cancel()
+      plainRepositoryMonitors.removeValue(forKey: root)
+      plainRepositoryDebouncer.cancel(root)
+    }
+    for root in desiredRoots.subtracting(currentRoots) {
+      guard
+        let monitor = FSEventsWorktreeFileEventMonitor(
+          rootURL: root,
+          onEvent: { [weak self] in
+            self?.handlePlainRepositoryFileEvent(root)
+          }
+        )
+      else {
+        return
+      }
+      plainRepositoryMonitors[root] = monitor
+    }
+  }
+
+  private func handlePlainRepositoryFileEvent(_ root: URL) {
+    plainRepositoryDebouncer.schedule(root) { [weak self] in
+      guard let self else { return }
+      let dotGitURL = root.appending(path: ".git")
+      if FileManager.default.fileExists(atPath: dotGitURL.path(percentEncoded: false)) {
+        emit(.plainRepositoryBecameGitRepository(root))
+      }
+    }
+  }
+
   private func stopAll() {
     for watcher in headWatchers.values {
       watcher.monitor.cancel()
@@ -397,10 +435,15 @@ final class WorktreeInfoWatcherManager {
     for monitor in remoteConfigMonitors.values {
       monitor.cancel()
     }
+    for monitor in plainRepositoryMonitors.values {
+      monitor.cancel()
+    }
+    plainRepositoryDebouncer.cancelAll()
     headWatchers.removeAll()
     worktreeFileEventMonitors.removeAll()
     worktreeRegistryMonitors.removeAll()
     remoteConfigMonitors.removeAll()
+    plainRepositoryMonitors.removeAll()
     pullRequestTasks.removeAll()
     lineChangeSafetyTasks.removeAll()
     deferredLineChangeIDs.removeAll()

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+CoreReducer.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+CoreReducer.swift
@@ -953,6 +953,8 @@ extension RepositoriesFeature {
             )
           )
         )
+      case .plainRepositoryBecameGitRepository:
+        return .send(.reloadRepositories(animated: true))
       }
 
     case .worktreeBranchNameLoaded(let worktreeID, let name):

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+StateQueries.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+StateQueries.swift
@@ -148,6 +148,16 @@ extension RepositoriesFeature.State {
     return worktrees.filter { !archivedSet.contains($0.id) }
   }
 
+  /// Roots of plain (non-workspace) folders that should be watched for `.git`
+  /// initialization. When `git init` creates a `.git` directory inside one of
+  /// these folders, the watcher emits an event so the reducer can upgrade the
+  /// entry from `.plain` to `.git` and discover its worktrees.
+  func plainRepositoryRootsForInfoWatcher() -> [URL] {
+    repositories
+      .filter { $0.kind == .plain && !$0.isWorkspace }
+      .map { $0.rootURL }
+  }
+
   /// Child repositories materialized inside every workspace, resolved to their
   /// on-disk working directory. Used both to refresh their live status and to
   /// render their sidebar rows. Child id is the working-directory path string.

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -392,6 +392,42 @@ struct RepositoriesFeatureTests {
     await store.receive(\.delegate.repositoriesChanged)
   }
 
+  @Test func plainRepositoryBecameGitRepositoryReloadsRepositories() async {
+    let repoRoot = "/tmp/new-project"
+    let rootURL = URL(fileURLWithPath: repoRoot)
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let plainRepository = makeRepository(
+      id: repoRoot, name: "new-project", kind: .plain, worktrees: [])
+    let store = TestStore(initialState: makeState(repositories: [plainRepository])) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.repositoryPersistence.loadRepositoryEntries = {
+        [PersistedRepositoryEntry(path: repoRoot, kind: .plain)]
+      }
+      $0.repositoryPersistence.saveRepositoryEntries = { _ in }
+      $0.repositoryPersistence.saveRepositorySnapshot = { _ in }
+      $0.gitClient.repoRoot = { _ in rootURL }
+      $0.gitClient.worktrees = { _ in [mainWorktree] }
+      $0.gitClient.pruneWorktrees = { _ in }
+      $0.gitClient.repositoryWebURL = { _ in nil }
+    }
+
+    await store.send(
+      .worktreeInfoEvent(.plainRepositoryBecameGitRepository(rootURL)))
+    await store.receive(\.reloadRepositories)
+    await store.receive(\.repositoriesLoaded) {
+      $0.repositories[id: plainRepository.id] = makeRepository(
+        id: repoRoot,
+        name: "new-project",
+        kind: .git,
+        worktrees: [mainWorktree]
+      )
+      $0.isInitialLoadComplete = true
+      $0.snapshotPersistencePhase = .active
+    }
+    await store.receive(\.delegate.repositoriesChanged)
+  }
+
   @Test func repositoryRemoteConfigurationChangedRefreshesPullRequestsAndCodeHost() async {
     let repoRoot = "/tmp/repo"
     let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)


### PR DESCRIPTION
## Problem

When a non-git folder is opened in Prowl, it is classified as `.plain` with empty worktrees — the sidebar shows the repository name but no branch/worktree rows. If the user then runs `git init` inside the terminal, the sidebar does not update because there is no file-system watcher monitoring `.plain` repo directories for `.git` creation.

The existing `upgradedRepositoryEntriesIfNeeded` function can detect the `.plain` → `.git` transition, but it only runs during app launch, scene-active refresh, or the 30-second periodic timer — none of which fire immediately when `git init` is executed in an already-active terminal.

## Solution

Add FSEvents monitoring for `.plain` (non-workspace) repository root directories. When `.git` appears, emit a `plainRepositoryBecameGitRepository` event that triggers `reloadRepositories`. The existing upgrade logic then reclassifies the entry from `.plain` to `.git` and discovers its worktrees.

## Changes

| File | Change |
|------|--------|
| `WorktreeInfoWatcherClient.swift` | New `.setPlainRepositoryRoots` command + `.plainRepositoryBecameGitRepository` event |
| `WorktreeInfoWatcherManager.swift` | FSEvents monitors for plain repo roots with 1s debounce; checks `.git` existence before emitting |
| `RepositoriesFeature+StateQueries.swift` | `plainRepositoryRootsForInfoWatcher()` — filters `.plain` non-workspace repos |
| `AppFeature.swift` | Sends `setPlainRepositoryRoots` alongside `setWorktrees` on repository changes |
| `RepositoriesFeature+CoreReducer.swift` | Handles new event → `reloadRepositories(animated: true)` |
| `RepositoriesFeatureTests.swift` | Test: `plainRepositoryBecameGitRepositoryReloadsRepositories` |

## Test Plan

- `make build-app` — build succeeds with 0 errors
- `make check` — swift-format lint + swiftlint pass
- `plainRepositoryBecameGitRepositoryReloadsRepositories` — verifies the event triggers reload and upgrades `.plain` → `.git` with worktrees
- `WorktreeInfoWatcherManagerTests` — all existing tests pass (no regression)

## Test Result

- `make build-app`: ✅ 0 errors, 0 warnings
- `make check`: ✅ pass
- `plainRepositoryBecameGitRepositoryReloadsRepositories()`: ✅ passed (0.097s)
- `WorktreeInfoWatcherManagerTests` (18 tests): ✅ all passed