### PR TITLE
Harden plain repository upgrade watchers

### DIFF
--- a/docs/components/repositories-and-worktrees.md
+++ b/docs/components/repositories-and-worktrees.md
@@ -27,7 +27,9 @@ an unread-notification bell, and run/agent status.
 
 A plain folder can't expand; clicking it just opens a terminal there. Prowl
 auto-detects which kind a path is when you add it (it runs `git` to find the repo
-root; "not a git repository" → plain folder).
+root; "not a git repository" → plain folder). If you later run `git init` in an
+open plain folder, Prowl automatically upgrades it to a git repository and
+refreshes the sidebar.
 
 ## Adding a repository
 

--- a/supacode/Clients/WorktreeInfoWatcher/WorktreeInfoWatcherClient.swift
+++ b/supacode/Clients/WorktreeInfoWatcher/WorktreeInfoWatcherClient.swift
@@ -11,6 +11,7 @@ struct WorktreeInfoWatcherClient {
     case setSelectedWorktreeID(Worktree.ID?)
     case refreshLineChanges
     case setPullRequestTrackingEnabled(Bool)
+    case setPlainRepositoryRoots([URL])
     case stop
   }
 
@@ -20,6 +21,7 @@ struct WorktreeInfoWatcherClient {
     case repositoryWorktreesChanged(repositoryRootURL: URL)
     case repositoryRemoteConfigurationChanged(repositoryRootURL: URL)
     case repositoryPullRequestRefresh(repositoryRootURL: URL, worktreeIDs: [Worktree.ID])
+    case plainRepositoryBecameGitRepository(URL)
   }
 }
 

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -269,6 +269,7 @@ struct AppFeature {
         )
         let worktrees = state.repositories.worktreesForInfoWatcher()
         let openedWorktreeIDs = openedWorktreeIDsForInfoWatcher(from: state.repositories)
+        let plainRepositoryRoots = state.repositories.plainRepositoryRootsForInfoWatcher()
         let shouldRestoreLayout =
           state.launchRestoreMode == .restoreLayout
           && state.repositories.snapshotPersistencePhase == .active
@@ -305,6 +306,9 @@ struct AppFeature {
             .run { _ in
               await worktreeInfoWatcher.send(.setOpenedWorktreeIDs(openedWorktreeIDs))
             },
+            .run { _ in
+              await worktreeInfoWatcher.send(.setPlainRepositoryRoots(plainRepositoryRoots))
+            },
           ]
           if shouldRestoreLayout {
             effects.append(
@@ -327,6 +331,9 @@ struct AppFeature {
           },
           .run { _ in
             await worktreeInfoWatcher.send(.setOpenedWorktreeIDs(openedWorktreeIDs))
+          },
+          .run { _ in
+            await worktreeInfoWatcher.send(.setPlainRepositoryRoots(plainRepositoryRoots))
           },
         ]
         if shouldRestoreLayout {

--- a/supacode/Features/Repositories/BusinessLogic/WorktreeInfoWatcherManager.swift
+++ b/supacode/Features/Repositories/BusinessLogic/WorktreeInfoWatcherManager.swift
@@ -95,6 +95,8 @@ final class WorktreeInfoWatcherManager {
   private var worktreeFileEventMonitors: [Worktree.ID: WorktreeFileEventMonitoring] = [:]
   private var worktreeRegistryMonitors: [URL: WorktreeRegistryMonitoring] = [:]
   private var remoteConfigMonitors: [URL: RemoteConfigMonitoring] = [:]
+  private var plainRepositoryMonitors: [URL: WorktreeFileEventMonitoring] = [:]
+  private let plainRepositoryDebouncer: KeyedDebouncer<URL>
   private let branchChangedDebouncer: KeyedDebouncer<Worktree.ID>
   private let repositoryWorktreesDebouncer: KeyedDebouncer<URL>
   private let remoteConfigDebouncer: KeyedDebouncer<URL>
@@ -152,6 +154,7 @@ final class WorktreeInfoWatcherManager {
     repositoryWorktreesDebouncer = KeyedDebouncer(interval: repositoryWorktreesEventDebounceInterval, clock: clock)
     remoteConfigDebouncer = KeyedDebouncer(interval: remoteConfigEventDebounceInterval, clock: clock)
     restartDebouncer = KeyedDebouncer(interval: .seconds(5), clock: clock)
+    plainRepositoryDebouncer = KeyedDebouncer(interval: .seconds(1), clock: clock)
     // Callers always pass an explicit per-worktree delay; the instance interval
     // is only a nominal default.
     lineChangesRefreshDebouncer = KeyedDebouncer(interval: defaultLineChangesTiming.eventDebounce, clock: clock)
@@ -169,6 +172,8 @@ final class WorktreeInfoWatcherManager {
       scheduleLineChangesRefreshForAllWorktrees()
     case .setPullRequestTrackingEnabled(let isEnabled):
       setPullRequestTrackingEnabled(isEnabled)
+    case .setPlainRepositoryRoots(let roots):
+      setPlainRepositoryRoots(roots)
     case .stop:
       stopAll()
     }
@@ -373,6 +378,39 @@ final class WorktreeInfoWatcherManager {
     lineChangesRefreshDebouncer.cancel(worktreeID)
   }
 
+  private func setPlainRepositoryRoots(_ roots: [URL]) {
+    let desiredRoots = Set(roots.map { $0.standardizedFileURL })
+    let currentRoots = Set(plainRepositoryMonitors.keys)
+    for root in currentRoots.subtracting(desiredRoots) {
+      plainRepositoryMonitors[root]?.cancel()
+      plainRepositoryMonitors.removeValue(forKey: root)
+      plainRepositoryDebouncer.cancel(root)
+    }
+    for root in desiredRoots.subtracting(currentRoots) {
+      guard
+        let monitor = FSEventsWorktreeFileEventMonitor(
+          rootURL: root,
+          onEvent: { [weak self] in
+            self?.handlePlainRepositoryFileEvent(root)
+          }
+        )
+      else {
+        return
+      }
+      plainRepositoryMonitors[root] = monitor
+    }
+  }
+
+  private func handlePlainRepositoryFileEvent(_ root: URL) {
+    plainRepositoryDebouncer.schedule(root) { [weak self] in
+      guard let self else { return }
+      let dotGitURL = root.appending(path: ".git")
+      if FileManager.default.fileExists(atPath: dotGitURL.path(percentEncoded: false)) {
+        emit(.plainRepositoryBecameGitRepository(root))
+      }
+    }
+  }
+
   private func stopAll() {
     for watcher in headWatchers.values {
       watcher.monitor.cancel()
@@ -397,10 +435,15 @@ final class WorktreeInfoWatcherManager {
     for monitor in remoteConfigMonitors.values {
       monitor.cancel()
     }
+    for monitor in plainRepositoryMonitors.values {
+      monitor.cancel()
+    }
+    plainRepositoryDebouncer.cancelAll()
     headWatchers.removeAll()
     worktreeFileEventMonitors.removeAll()
     worktreeRegistryMonitors.removeAll()
     remoteConfigMonitors.removeAll()
+    plainRepositoryMonitors.removeAll()
     pullRequestTasks.removeAll()
     lineChangeSafetyTasks.removeAll()
     deferredLineChangeIDs.removeAll()

--- a/supacode/Features/Repositories/BusinessLogic/WorktreeInfoWatcherManager.swift
+++ b/supacode/Features/Repositories/BusinessLogic/WorktreeInfoWatcherManager.swift
@@ -10,6 +10,11 @@ final class WorktreeInfoWatcherManager {
       _ worktree: Worktree,
       _ onEvent: @escaping @MainActor @Sendable () -> Void
     ) -> WorktreeFileEventMonitoring?
+  typealias PlainRepositoryFileEventMonitorFactory =
+    @MainActor @Sendable (
+      _ rootURL: URL,
+      _ onEvent: @escaping @MainActor @Sendable () -> Void
+    ) -> WorktreeFileEventMonitoring?
   typealias WorktreeHeadEventMonitorFactory =
     @MainActor @Sendable (
       _ worktreeID: Worktree.ID,
@@ -86,6 +91,7 @@ final class WorktreeInfoWatcherManager {
   private let lineChangePhaseOffset: WorktreePhaseOffset
   private let pullRequestPhaseOffset: RepositoryPhaseOffset
   private let worktreeFileEventMonitorFactory: WorktreeFileEventMonitorFactory
+  private let plainRepositoryFileEventMonitorFactory: PlainRepositoryFileEventMonitorFactory
   private let worktreeHeadEventMonitorFactory: WorktreeHeadEventMonitorFactory
   private let worktreeRegistryMonitorFactory: WorktreeRegistryMonitorFactory
   private let remoteConfigMonitorFactory: RemoteConfigMonitorFactory
@@ -96,6 +102,7 @@ final class WorktreeInfoWatcherManager {
   private var worktreeRegistryMonitors: [URL: WorktreeRegistryMonitoring] = [:]
   private var remoteConfigMonitors: [URL: RemoteConfigMonitoring] = [:]
   private var plainRepositoryMonitors: [URL: WorktreeFileEventMonitoring] = [:]
+  private var plainRepositoryRootsWithGitEvent: Set<URL> = []
   private let plainRepositoryDebouncer: KeyedDebouncer<URL>
   private let branchChangedDebouncer: KeyedDebouncer<Worktree.ID>
   private let repositoryWorktreesDebouncer: KeyedDebouncer<URL>
@@ -125,6 +132,8 @@ final class WorktreeInfoWatcherManager {
     pullRequestPhaseOffset: @escaping RepositoryPhaseOffset = WorktreeInfoWatcherManager.defaultPullRequestPhaseOffset,
     worktreeFileEventMonitorFactory: @escaping WorktreeFileEventMonitorFactory =
       WorktreeInfoWatcherManager.defaultWorktreeFileEventMonitorFactory,
+    plainRepositoryFileEventMonitorFactory: @escaping PlainRepositoryFileEventMonitorFactory =
+      WorktreeInfoWatcherManager.defaultPlainRepositoryFileEventMonitorFactory,
     worktreeHeadEventMonitorFactory: @escaping WorktreeHeadEventMonitorFactory =
       WorktreeInfoWatcherManager.defaultWorktreeHeadEventMonitorFactory,
     worktreeRegistryMonitorFactory: @escaping WorktreeRegistryMonitorFactory =
@@ -143,6 +152,7 @@ final class WorktreeInfoWatcherManager {
     self.lineChangePhaseOffset = lineChangePhaseOffset
     self.pullRequestPhaseOffset = pullRequestPhaseOffset
     self.worktreeFileEventMonitorFactory = worktreeFileEventMonitorFactory
+    self.plainRepositoryFileEventMonitorFactory = plainRepositoryFileEventMonitorFactory
     self.worktreeHeadEventMonitorFactory = worktreeHeadEventMonitorFactory
     self.worktreeRegistryMonitorFactory = worktreeRegistryMonitorFactory
     self.remoteConfigMonitorFactory = remoteConfigMonitorFactory
@@ -384,18 +394,19 @@ final class WorktreeInfoWatcherManager {
     for root in currentRoots.subtracting(desiredRoots) {
       plainRepositoryMonitors[root]?.cancel()
       plainRepositoryMonitors.removeValue(forKey: root)
+      plainRepositoryRootsWithGitEvent.remove(root)
       plainRepositoryDebouncer.cancel(root)
     }
     for root in desiredRoots.subtracting(currentRoots) {
       guard
-        let monitor = FSEventsWorktreeFileEventMonitor(
-          rootURL: root,
-          onEvent: { [weak self] in
+        let monitor = plainRepositoryFileEventMonitorFactory(
+          root,
+          { [weak self] in
             self?.handlePlainRepositoryFileEvent(root)
           }
         )
       else {
-        return
+        continue
       }
       plainRepositoryMonitors[root] = monitor
     }
@@ -405,9 +416,12 @@ final class WorktreeInfoWatcherManager {
     plainRepositoryDebouncer.schedule(root) { [weak self] in
       guard let self else { return }
       let dotGitURL = root.appending(path: ".git")
-      if FileManager.default.fileExists(atPath: dotGitURL.path(percentEncoded: false)) {
-        emit(.plainRepositoryBecameGitRepository(root))
+      guard FileManager.default.fileExists(atPath: dotGitURL.path(percentEncoded: false)) else {
+        plainRepositoryRootsWithGitEvent.remove(root)
+        return
       }
+      guard plainRepositoryRootsWithGitEvent.insert(root).inserted else { return }
+      emit(.plainRepositoryBecameGitRepository(root))
     }
   }
 
@@ -444,6 +458,7 @@ final class WorktreeInfoWatcherManager {
     worktreeRegistryMonitors.removeAll()
     remoteConfigMonitors.removeAll()
     plainRepositoryMonitors.removeAll()
+    plainRepositoryRootsWithGitEvent.removeAll()
     pullRequestTasks.removeAll()
     lineChangeSafetyTasks.removeAll()
     deferredLineChangeIDs.removeAll()
@@ -754,6 +769,13 @@ final class WorktreeInfoWatcherManager {
     onEvent: @escaping @MainActor @Sendable () -> Void
   ) -> WorktreeFileEventMonitoring? {
     FSEventsWorktreeFileEventMonitor(rootURL: worktree.workingDirectory, onEvent: onEvent)
+  }
+
+  private static func defaultPlainRepositoryFileEventMonitorFactory(
+    rootURL: URL,
+    onEvent: @escaping @MainActor @Sendable () -> Void
+  ) -> WorktreeFileEventMonitoring? {
+    FSEventsWorktreeFileEventMonitor(rootURL: rootURL, onEvent: onEvent)
   }
 
   private static func defaultWorktreeHeadEventMonitorFactory(

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+CoreReducer.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+CoreReducer.swift
@@ -953,6 +953,8 @@ extension RepositoriesFeature {
             )
           )
         )
+      case .plainRepositoryBecameGitRepository:
+        return .send(.reloadRepositories(animated: true))
       }
 
     case .worktreeBranchNameLoaded(let worktreeID, let name):

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+StateQueries.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+StateQueries.swift
@@ -148,6 +148,16 @@ extension RepositoriesFeature.State {
     return worktrees.filter { !archivedSet.contains($0.id) }
   }
 
+  /// Roots of plain (non-workspace) folders that should be watched for `.git`
+  /// initialization. When `git init` creates a `.git` directory inside one of
+  /// these folders, the watcher emits an event so the reducer can upgrade the
+  /// entry from `.plain` to `.git` and discover its worktrees.
+  func plainRepositoryRootsForInfoWatcher() -> [URL] {
+    repositories
+      .filter { $0.kind == .plain && !$0.isWorkspace }
+      .map { $0.rootURL }
+  }
+
   /// Child repositories materialized inside every workspace, resolved to their
   /// on-disk working directory. Used both to refresh their live status and to
   /// render their sidebar rows. Child id is the working-directory path string.

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -392,6 +392,42 @@ struct RepositoriesFeatureTests {
     await store.receive(\.delegate.repositoriesChanged)
   }
 
+  @Test func plainRepositoryBecameGitRepositoryReloadsRepositories() async {
+    let repoRoot = "/tmp/new-project"
+    let rootURL = URL(fileURLWithPath: repoRoot)
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let plainRepository = makeRepository(
+      id: repoRoot, name: "new-project", kind: .plain, worktrees: [])
+    let store = TestStore(initialState: makeState(repositories: [plainRepository])) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.repositoryPersistence.loadRepositoryEntries = {
+        [PersistedRepositoryEntry(path: repoRoot, kind: .plain)]
+      }
+      $0.repositoryPersistence.saveRepositoryEntries = { _ in }
+      $0.repositoryPersistence.saveRepositorySnapshot = { _ in }
+      $0.gitClient.repoRoot = { _ in rootURL }
+      $0.gitClient.worktrees = { _ in [mainWorktree] }
+      $0.gitClient.pruneWorktrees = { _ in }
+      $0.gitClient.repositoryWebURL = { _ in nil }
+    }
+
+    await store.send(
+      .worktreeInfoEvent(.plainRepositoryBecameGitRepository(rootURL)))
+    await store.receive(\.reloadRepositories)
+    await store.receive(\.repositoriesLoaded) {
+      $0.repositories[id: plainRepository.id] = makeRepository(
+        id: repoRoot,
+        name: "new-project",
+        kind: .git,
+        worktrees: [mainWorktree]
+      )
+      $0.isInitialLoadComplete = true
+      $0.snapshotPersistencePhase = .active
+    }
+    await store.receive(\.delegate.repositoriesChanged)
+  }
+
   @Test func repositoryRemoteConfigurationChangedRefreshesPullRequestsAndCodeHost() async {
     let repoRoot = "/tmp/repo"
     let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)

--- a/supacodeTests/WorktreeInfoWatcherManagerTests.swift
+++ b/supacodeTests/WorktreeInfoWatcherManagerTests.swift
@@ -531,6 +531,90 @@ struct WorktreeInfoWatcherManagerTests {
     try FileManager.default.removeItem(at: tempRepository.tempRoot)
   }
 
+  @Test func plainRepositoryMonitorFailuresDoNotSkipRemainingRoots() {
+    let roots = (0..<3).map { index in
+      URL(fileURLWithPath: "/tmp/plain-repository-\(index)", isDirectory: true)
+    }
+    let monitorStore = TestPlainRepositoryFileEventMonitorStore(failedRoots: Set(roots))
+    let manager = WorktreeInfoWatcherManager(
+      plainRepositoryFileEventMonitorFactory: monitorStore.makeMonitor
+    )
+
+    manager.handleCommand(.setPlainRepositoryRoots(roots))
+
+    #expect(Set(monitorStore.attemptedRoots) == Set(roots.map(\.standardizedFileURL)))
+    manager.handleCommand(.stop)
+  }
+
+  @Test func plainRepositoryMonitorsTrackRootChangesAndStop() throws {
+    let firstRoot = FileManager.default.temporaryDirectory
+      .appending(path: UUID().uuidString, directoryHint: .isDirectory)
+    let secondRoot = FileManager.default.temporaryDirectory
+      .appending(path: UUID().uuidString, directoryHint: .isDirectory)
+    let monitorStore = TestPlainRepositoryFileEventMonitorStore()
+    let manager = WorktreeInfoWatcherManager(
+      plainRepositoryFileEventMonitorFactory: monitorStore.makeMonitor
+    )
+
+    manager.handleCommand(.setPlainRepositoryRoots([firstRoot, secondRoot]))
+    let firstMonitor = try #require(monitorStore.monitor(for: firstRoot))
+    let secondMonitor = try #require(monitorStore.monitor(for: secondRoot))
+
+    manager.handleCommand(.setPlainRepositoryRoots([secondRoot]))
+    #expect(firstMonitor.isCanceled)
+    #expect(!secondMonitor.isCanceled)
+
+    manager.handleCommand(.stop)
+    #expect(secondMonitor.isCanceled)
+  }
+
+  @Test func plainRepositoryGitEventEmitsOnceUntilDotGitDisappears() async throws {
+    let clock = TestClock()
+    let root = FileManager.default.temporaryDirectory
+      .appending(path: UUID().uuidString, directoryHint: .isDirectory)
+    let dotGitURL = root.appending(path: ".git", directoryHint: .isDirectory)
+    defer { try? FileManager.default.removeItem(at: root) }
+    try FileManager.default.createDirectory(at: dotGitURL, withIntermediateDirectories: true)
+    let monitorStore = TestPlainRepositoryFileEventMonitorStore()
+    let manager = WorktreeInfoWatcherManager(
+      plainRepositoryFileEventMonitorFactory: monitorStore.makeMonitor,
+      clock: clock
+    )
+    let (collector, task) = startCollecting(manager.eventStream())
+
+    manager.handleCommand(.setPlainRepositoryRoots([root]))
+    let monitor = try #require(monitorStore.monitor(for: root))
+
+    monitor.emit()
+    await drainAsyncEvents()
+    await clock.advance(by: .seconds(1))
+    await drainAsyncEvents(120)
+    #expect(await collector.plainRepositoryGitEventCount(rootURL: root) == 1)
+
+    monitor.emit()
+    await drainAsyncEvents()
+    await clock.advance(by: .seconds(1))
+    await drainAsyncEvents(120)
+    #expect(await collector.plainRepositoryGitEventCount(rootURL: root) == 1)
+
+    try FileManager.default.removeItem(at: dotGitURL)
+    monitor.emit()
+    await drainAsyncEvents()
+    await clock.advance(by: .seconds(1))
+    await drainAsyncEvents(120)
+    #expect(await collector.plainRepositoryGitEventCount(rootURL: root) == 1)
+
+    try FileManager.default.createDirectory(at: dotGitURL, withIntermediateDirectories: true)
+    monitor.emit()
+    await drainAsyncEvents()
+    await clock.advance(by: .seconds(1))
+    await drainAsyncEvents(120)
+    #expect(await collector.plainRepositoryGitEventCount(rootURL: root) == 2)
+
+    manager.handleCommand(.stop)
+    await task.value
+  }
+
   @Test func adaptiveTimingResolvesFromIndexEntryCount() async throws {
     let clock = TestClock()
     let tempRepository = try makeTempRepository(worktreeNames: ["sparrow"])
@@ -746,6 +830,17 @@ actor EventCollector {
       }
     }
   }
+
+  func plainRepositoryGitEventCount(rootURL: URL) -> Int {
+    let expectedURL = rootURL.standardizedFileURL
+    return events.reduce(into: 0) { result, event in
+      if case .plainRepositoryBecameGitRepository(let emittedURL) = event,
+        emittedURL.standardizedFileURL == expectedURL
+      {
+        result += 1
+      }
+    }
+  }
 }
 
 private struct TempWorktree {
@@ -890,6 +985,33 @@ private final class TestWorktreeFileEventMonitor: WorktreeFileEventMonitoring {
 
   func cancel() {
     isCanceled = true
+  }
+}
+
+@MainActor
+private final class TestPlainRepositoryFileEventMonitorStore {
+  private let failedRoots: Set<URL>
+  private var monitors: [URL: TestWorktreeFileEventMonitor] = [:]
+  private(set) var attemptedRoots: [URL] = []
+
+  init(failedRoots: Set<URL> = []) {
+    self.failedRoots = Set(failedRoots.map(\.standardizedFileURL))
+  }
+
+  func makeMonitor(
+    rootURL: URL,
+    onEvent: @escaping @MainActor @Sendable () -> Void
+  ) -> WorktreeFileEventMonitoring? {
+    let root = rootURL.standardizedFileURL
+    attemptedRoots.append(root)
+    guard !failedRoots.contains(root) else { return nil }
+    let monitor = TestWorktreeFileEventMonitor(onEvent: onEvent)
+    monitors[root] = monitor
+    return monitor
+  }
+
+  func monitor(for rootURL: URL) -> TestWorktreeFileEventMonitor? {
+    monitors[rootURL.standardizedFileURL]
   }
 }
 


### PR DESCRIPTION
## Summary

Builds on #548 and retains the contributor's original commit unchanged.

- Isolate plain-root monitor creation failures so one unavailable root does not skip the remaining roots.
- Make the new monitor path injectable and cover root addition, removal, cancellation, debounce, and stop behavior.
- Treat `.git` detection as edge-triggered so a failed repository upgrade cannot turn later file events into repeated full reloads; detection is re-armed if `.git` disappears.

## Why

The original fix correctly adds the missing `.plain` → `.git` watcher path, but a failed monitor currently aborts an unordered `Set` iteration, and repeated events can keep triggering repository reloads when the upgrade does not complete. The manager behavior also had no deterministic test seam.

## Validation

- `WorktreeInfoWatcherManagerTests` — 21 tests passed, including the three new plain-root cases
- `make check`
- `make build-app`
- Debug app E2E: opened a fresh plain folder, ran `git init`, and observed `prowl list` change the target from `kind=plain` to `kind=git`
