### PR TITLE
build: remove never-used bump-and-release target

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,8 +17,7 @@ make log-stream                  # Stream app logs (subsystem: com.onevcat.prowl
 make build-cli                   # Build CLI (prowl) via SwiftPM
 make test-cli-smoke              # Run CLI smoke tests (unit-level)
 make test-cli-integration        # Run CLI integration tests (socket round-trip)
-make bump-version                # Bump version (date-based YYYY.M.DD) and create git tag
-make bump-and-release            # Bump version and push to trigger release
+make bump-version                # Bump version (date-based YYYY.M.DD) and create git tag; used by release.sh
 ```
 
 Run a single test class or method:

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ PROWL_POSTHOG_API_KEY ?=
 PROWL_POSTHOG_HOST ?=
 
 .DEFAULT_GOAL := help
-.PHONY: build-ghostty-xcframework ensure-ghostty sync-ghostty _record-ghostty-hash build-app build-cli build-cli-release embed-cli-debug embed-cli embed-docs run-app install-dev-build install-release archive export-archive format format-changed format-lint lint check test test-app test-cli-smoke test-cli-integration bump-version bump-and-release log-stream
+.PHONY: build-ghostty-xcframework ensure-ghostty sync-ghostty _record-ghostty-hash build-app build-cli build-cli-release embed-cli-debug embed-cli embed-docs run-app install-dev-build install-release archive export-archive format format-changed format-lint lint check test test-app test-cli-smoke test-cli-integration bump-version log-stream
 
 help:  # Display this help.
 	@-+echo "Run make with one of the following targets:"
@@ -421,18 +421,3 @@ bump-version: # Bump app version (usage: make bump-version [VERSION=YYYY.M.DD] [
 	git commit -m "bump v$$version"; \
 	git tag -s "v$$version" -m "v$$version"; \
 	echo "version bumped to $$version (build $$build), tagged v$$version"
-
-bump-and-release: bump-version # Bump version and push tags to trigger release
-	git push --follow-tags
-	@tag="$$(git describe --tags --abbrev=0)"; \
-	repo="$$(gh repo view --json nameWithOwner -q .nameWithOwner)"; \
-	prev="$$(gh release view --json tagName -q .tagName 2>/dev/null || echo '')"; \
-	tmp=$$(mktemp); \
-	if [ -n "$$prev" ]; then \
-		gh api "repos/$$repo/releases/generate-notes" -f tag_name="$$tag" -f previous_tag_name="$$prev" --jq '.body' > "$$tmp"; \
-	else \
-		gh api "repos/$$repo/releases/generate-notes" -f tag_name="$$tag" --jq '.body' > "$$tmp"; \
-	fi; \
-	$${EDITOR:-vim} "$$tmp"; \
-	gh release create "$$tag" --notes-file "$$tmp"; \
-	rm -f "$$tmp"


### PR DESCRIPTION
## Summary

Removes the `bump-and-release` Makefile target (and its AGENTS.md mention). Found via the docs-ai backfill (`docs-ai/001-fork-bootstrap-and-release-pipeline/001-action.md`, PR #558).

## Why

- It creates a GitHub Release with **no notarized artifacts** — conflicting with the fork's notarized-only policy (AGENTS.md rule).
- Its `release.published` event would fire `release-homebrew-cask.yml` against a missing `Prowl.dmg`.
- **It has never been used**: audited all 68 releases on this repo — every `v*` release carries `Prowl.dmg` (produced by `release.sh`); the only asset-less releases are early `onevcat-v*` snapshot tags from the retired `release-to-fork.sh`.

`bump-version` is kept — `release.sh` calls it.

## Verification

`make -n bump-version VERSION=2099.1.1` parses; `make bump-and-release` now fails with "No rule to make target". No Swift changes.
