### PR TITLE
Fix incomplete worktree deletion handling

### DIFF
--- a/docs-ai/019-worktree-creation-and-lifecycle/000-plan.md
+++ b/docs-ai/019-worktree-creation-and-lifecycle/000-plan.md
@@ -86,3 +86,6 @@ deletion-safety rework, clone-from-URL intake — all later waves (see Amendment
   [004-advanced-placement-overrides.md](004-advanced-placement-overrides.md)
 - Updated 2026-06-28: Add to Prowl popover redesign with clone support (#520) — see
   [005-add-to-prowl-clone.md](005-add-to-prowl-clone.md)
+- Updated 2026-07-12: worktree deletion now verifies Git registration removal and
+  propagates cleanup failures (fork issue #454) — see
+  [006-verified-worktree-deletion.md](006-verified-worktree-deletion.md)

--- a/docs-ai/019-worktree-creation-and-lifecycle/006-verified-worktree-deletion.md
+++ b/docs-ai/019-worktree-creation-and-lifecycle/006-verified-worktree-deletion.md
@@ -1,0 +1,72 @@
+# 019.006 — Verified Worktree Deletion
+
+## Context
+
+Fork issue #454 reports that a deleted worktree disappears briefly and returns after
+repository refresh. `GitClient.removeWorktree` currently treats two incomplete cleanup
+paths as success: a missing porcelain path match returns without an error, and a
+successful `git worktree prune` exit code is accepted without verifying that the target
+registration disappeared. The fallback `git worktree remove --force` also discards its
+error, so the reducer can emit `worktreeDeleted` even while Git still lists the worktree.
+
+## Planned change
+
+- Compare registered and requested worktree paths after resolving filesystem symlinks,
+  while retaining lexical normalization for paths whose final component no longer
+  exists.
+- Treat a missing registration as a deletion failure instead of a successful no-op.
+- After relocating a worktree directory and pruning, read porcelain output again. If
+  the target remains registered, run `git worktree remove --force` and propagate any
+  Git error (including a lock reason) to the existing deletion alert.
+- Propagate `git worktree remove --force` failures on the non-relocation path as well.
+- Add regression coverage for a prune-success/locked-registration failure, direct
+  removal failure, and reducer behavior when `removeWorktree` throws.
+
+## Decisions
+
+Verification uses the same `git worktree list --porcelain` source as the initial safety
+guard. This keeps the change local to `GitClient` and preserves the existing reducer
+contract: only a thrown error prevents `worktreeDeleted` and surfaces the existing
+"Unable to delete worktree" alert.
+
+An explicit forced remove remains the fallback after relocation. It does not bypass a
+Git worktree lock; Git rejects that command and its stderr becomes the user-visible
+failure reason. Branch deletion stays after verified worktree cleanup, so it cannot run
+when registration removal fails.
+
+## Refs
+
+- Fork issue #454.
+- Planned code: `supacode/Clients/Git/GitClient.swift`.
+- Planned tests: `supacodeTests/GitClientRemoveWorktreeTests.swift` and
+  `supacodeTests/RepositoriesFeatureTests.swift`.
+
+## Implementation
+
+Implemented on 2026-07-12:
+
+- `GitClient.removeWorktree` now fails when the requested path is absent from Git's
+  worktree registry instead of reporting a successful no-op.
+- A relocated worktree is pruned and then checked against a fresh porcelain listing.
+  If it remains registered, Prowl runs `git worktree remove --force` and propagates any
+  error. On failure, the relocated directory is restored before the error reaches the
+  reducer.
+- Direct `git worktree remove --force` errors are no longer discarded.
+- Worktree path identity resolves arbitrary filesystem symlinks in addition to lexical
+  normalization.
+- The existing reducer failure path keeps the worktree in state and displays Git's
+  error in the "Unable to delete worktree" alert.
+
+## Verification
+
+- `make check` passed.
+- `make test` passed 1,790 tests with no failures.
+- `make build-app` passed with no errors or warnings.
+
+Regression tests cover prune-success with a locked registration, direct removal
+failure, arbitrary symlinked parent paths, missing exact registration, directory
+restoration after fallback failure, and reducer failure behavior.
+
+## Current state
+
+Implemented and locally verified. The fork PR reference remains to be added.

--- a/docs/components/repositories-and-worktrees.md
+++ b/docs/components/repositories-and-worktrees.md
@@ -130,9 +130,10 @@ Deleting removes the worktree directory (and optionally its branch).
 - A confirmation dialog offers an **"Also delete local branch"** toggle (its
   tooltip notes `git branch -d`). Default behavior comes from
   `deleteBranchOnDeleteWorktree`.
-- Prowl removes the worktree (relocating + `git worktree prune` if needed). If
-  branch deletion is rejected because the branch isn't merged, it offers a
-  **force delete** (`git branch -D`).
+- Prowl removes the worktree (relocating + `git worktree prune` if needed), then
+  verifies that Git no longer registers it. Cleanup failures keep the worktree
+  visible and show Git's error. If branch deletion is rejected because the branch
+  isn't merged, Prowl offers a **force delete** (`git branch -D`).
 - Protected branches (`main`, `master`, and the detected default) are guarded.
 
 The **main worktree cannot be deleted.**

--- a/supacode/Clients/Git/GitClient.swift
+++ b/supacode/Clients/Git/GitClient.swift
@@ -734,9 +734,11 @@ struct GitClient {
     let rootPath = worktree.repositoryRootURL.path(percentEncoded: false)
     let worktreeURL = worktree.workingDirectory.standardizedFileURL
     let worktreePath = Self.canonicalWorktreePath(worktreeURL.path(percentEncoded: false))
-    let registeredWorktreePaths = try await registeredWorktreePaths(rootPath: rootPath)
-    guard registeredWorktreePaths.contains(worktreePath) else {
-      return worktree.workingDirectory
+    let initialWorktreePaths = try await registeredWorktreePaths(rootPath: rootPath)
+    guard initialWorktreePaths.contains(worktreePath) else {
+      throw GitClientError.worktreeNotRegistered(
+        path: worktree.workingDirectory.path(percentEncoded: false)
+      )
     }
     let relocatedURL =
       Self.worktreeDirectoryHasGitMetadata(worktreeURL)
@@ -744,12 +746,26 @@ struct GitClient {
       : nil
     if let relocatedURL {
       do {
-        _ = try await runGit(
+        _ = try? await runGit(
           operation: .worktreePrune,
           arguments: ["-C", rootPath, "worktree", "prune", "--expire=now"]
         )
+        let remainingWorktreePaths = try await registeredWorktreePaths(rootPath: rootPath)
+        if remainingWorktreePaths.contains(worktreePath) {
+          try await runGitWorktreeRemove(rootPath: rootPath, worktreePath: worktreePath)
+        }
       } catch {
-        await runGitWorktreeRemove(rootPath: rootPath, worktreePath: worktreePath)
+        let removalError = error
+        do {
+          try FileManager.default.moveItem(at: relocatedURL, to: worktreeURL)
+        } catch {
+          throw GitClientError.worktreeRecoveryFailed(
+            path: worktreeURL.path(percentEncoded: false),
+            removalError: removalError.localizedDescription,
+            recoveryError: error.localizedDescription
+          )
+        }
+        throw removalError
       }
       if deleteBranch {
         _ = try? await deleteLocalBranch(
@@ -763,7 +779,7 @@ struct GitClient {
       }
       return worktree.workingDirectory
     }
-    await runGitWorktreeRemove(rootPath: rootPath, worktreePath: worktreePath)
+    try await runGitWorktreeRemove(rootPath: rootPath, worktreePath: worktreePath)
     if deleteBranch {
       _ = try? await deleteLocalBranch(
         named: worktree.name,
@@ -1072,8 +1088,8 @@ struct GitClient {
   nonisolated private func runGitWorktreeRemove(
     rootPath: String,
     worktreePath: String
-  ) async {
-    _ = try? await runGit(
+  ) async throws {
+    _ = try await runGit(
       operation: .worktreeRemove,
       arguments: [
         "-C",
@@ -1125,11 +1141,14 @@ struct GitClient {
     return FileManager.default.fileExists(atPath: gitMetadataURL.path(percentEncoded: false))
   }
 
-  /// Normalizes a worktree path to the same canonical form `worktrees(for:)` stores, so paths
-  /// reported by git (which keep `/private` symlink prefixes) compare equal to the standardized
-  /// URLs Prowl tracks internally.
+  /// Resolves filesystem symlinks and normalizes a worktree path so Git's raw on-disk paths
+  /// compare equal to the URLs Prowl tracks internally.
   nonisolated static func canonicalWorktreePath(_ path: String) -> String {
-    URL(fileURLWithPath: path).standardizedFileURL.path(percentEncoded: false)
+    URL(fileURLWithPath: path)
+      .standardizedFileURL
+      .resolvingSymlinksInPath()
+      .standardizedFileURL
+      .path(percentEncoded: false)
   }
 
   nonisolated static func parseGitWorktreePorcelainPaths(_ output: String) -> Set<String> {

--- a/supacode/Clients/Git/GitClientTypes.swift
+++ b/supacode/Clients/Git/GitClientTypes.swift
@@ -28,6 +28,8 @@ enum GitOperation: String {
 
 enum GitClientError: LocalizedError {
   case commandFailed(command: String, message: String)
+  case worktreeNotRegistered(path: String)
+  case worktreeRecoveryFailed(path: String, removalError: String, recoveryError: String)
 
   var errorDescription: String? {
     switch self {
@@ -36,6 +38,10 @@ enum GitClientError: LocalizedError {
         return "Git command failed: \(command)"
       }
       return "Git command failed: \(command)\n\(message)"
+    case .worktreeNotRegistered(let path):
+      return "Git no longer recognizes this worktree: \(path)"
+    case .worktreeRecoveryFailed(let path, let removalError, let recoveryError):
+      return "\(removalError)\nUnable to restore the worktree directory at \(path): \(recoveryError)"
     }
   }
 }

--- a/supacodeTests/ExternalDiffToolTests.swift
+++ b/supacodeTests/ExternalDiffToolTests.swift
@@ -185,13 +185,13 @@ private func runGit(_ arguments: [String], in directory: URL) throws {
   let stdoutText = String(data: stdout.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
   let stderrText = String(data: stderr.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
   guard process.terminationStatus == 0 else {
+    let command = arguments.joined(separator: " ")
+    let path = directory.path(percentEncoded: false)
+    let message = "git \(command) failed in \(path)\nstdout: \(stdoutText)\nstderr: \(stderrText)"
     throw NSError(
       domain: "ExternalDiffToolTests.runGit",
       code: Int(process.terminationStatus),
-      userInfo: [
-        NSLocalizedDescriptionKey:
-          "git \(arguments.joined(separator: " ")) failed in \(directory.path(percentEncoded: false))\nstdout: \(stdoutText)\nstderr: \(stderrText)"
-      ]
+      userInfo: [NSLocalizedDescriptionKey: message]
     )
   }
 }

--- a/supacodeTests/ExternalDiffToolTests.swift
+++ b/supacodeTests/ExternalDiffToolTests.swift
@@ -172,9 +172,26 @@ private func runGit(_ arguments: [String], in directory: URL) throws {
   process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
   process.arguments = arguments
   process.currentDirectoryURL = directory
-  process.standardOutput = Pipe()
-  process.standardError = Pipe()
+  var environment = ProcessInfo.processInfo.environment
+  environment["GIT_CONFIG_GLOBAL"] = "/dev/null"
+  environment["GIT_CONFIG_NOSYSTEM"] = "1"
+  process.environment = environment
+  let stdout = Pipe()
+  let stderr = Pipe()
+  process.standardOutput = stdout
+  process.standardError = stderr
   try process.run()
   process.waitUntilExit()
-  #expect(process.terminationStatus == 0)
+  let stdoutText = String(data: stdout.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+  let stderrText = String(data: stderr.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+  guard process.terminationStatus == 0 else {
+    throw NSError(
+      domain: "ExternalDiffToolTests.runGit",
+      code: Int(process.terminationStatus),
+      userInfo: [
+        NSLocalizedDescriptionKey:
+          "git \(arguments.joined(separator: " ")) failed in \(directory.path(percentEncoded: false))\nstdout: \(stdoutText)\nstderr: \(stderrText)"
+      ]
+    )
+  }
 }

--- a/supacodeTests/GitClientRemoveWorktreeTests.swift
+++ b/supacodeTests/GitClientRemoveWorktreeTests.swift
@@ -78,7 +78,7 @@ struct GitClientRemoveWorktreeTests {
     #expect(calls.contains { $0.suffix(3) == ["branch", "-d", "feature"] })
   }
 
-  @Test func removeWorktreeDoesNotMoveDirectoryWhenPathIsNotRegisteredExactly() async throws {
+  @Test func removeWorktreeFailsWithoutMovingDirectoryWhenPathIsNotRegisteredExactly() async throws {
     let fileManager = FileManager.default
     let rootURL = fileManager.temporaryDirectory.appending(
       path: "prowl-remove-worktree-\(UUID().uuidString)",
@@ -119,7 +119,9 @@ struct GitClientRemoveWorktreeTests {
       repositoryRootURL: rootURL
     )
 
-    _ = try await client.removeWorktree(worktree, deleteBranch: true)
+    await #expect(throws: GitClientError.self) {
+      _ = try await client.removeWorktree(worktree, deleteBranch: true)
+    }
 
     let parentExists = fileManager.fileExists(atPath: parentURL.path(percentEncoded: false))
     let childExists = fileManager.fileExists(atPath: childURL.path(percentEncoded: false))
@@ -178,6 +180,142 @@ struct GitClientRemoveWorktreeTests {
     #expect(!stillExists)
     let calls = await store.calls
     #expect(calls.contains { $0.contains("prune") })
+  }
+
+  @Test func removeWorktreeFallsBackWhenPruneLeavesLockedRegistration() async throws {
+    let fileManager = FileManager.default
+    let worktreeURL = fileManager.temporaryDirectory.appending(
+      path: "prowl-locked-worktree-\(UUID().uuidString)",
+      directoryHint: .isDirectory
+    )
+    try fileManager.createDirectory(at: worktreeURL, withIntermediateDirectories: true)
+    try Data("gitdir: /tmp/repo/.git/worktrees/locked\n".utf8)
+      .write(to: worktreeURL.appending(path: ".git"))
+    defer {
+      try? fileManager.removeItem(at: worktreeURL)
+    }
+
+    let worktreePath = worktreeURL.path(percentEncoded: false)
+    let store = ShellCallStore()
+    let shell = ShellClient(
+      run: { _, arguments, _ in
+        await store.record(arguments)
+        if arguments.contains("--porcelain") {
+          return ShellOutput(
+            stdout: "worktree \(worktreePath)\nHEAD abc\nlocked external-lock\n",
+            stderr: "",
+            exitCode: 0
+          )
+        }
+        if arguments.contains("remove") {
+          throw ShellClientError(
+            command: "git worktree remove --force \(worktreePath)",
+            stdout: "",
+            stderr: "fatal: cannot remove a locked working tree, lock reason: external-lock",
+            exitCode: 128
+          )
+        }
+        return ShellOutput(stdout: "", stderr: "", exitCode: 0)
+      },
+      runLoginImpl: { _, _, _, _ in ShellOutput(stdout: "", stderr: "", exitCode: 0) }
+    )
+    let client = GitClient(shell: shell)
+    let worktree = Worktree(
+      id: worktreePath,
+      name: "locked",
+      detail: "../locked",
+      workingDirectory: worktreeURL,
+      repositoryRootURL: URL(fileURLWithPath: "/tmp/repo")
+    )
+
+    await #expect(throws: GitClientError.self) {
+      _ = try await client.removeWorktree(worktree, deleteBranch: false)
+    }
+
+    let calls = await store.calls
+    #expect(calls.filter { $0.contains("--porcelain") }.count == 2)
+    #expect(calls.contains { $0.contains("prune") })
+    #expect(calls.contains { $0.contains("remove") })
+    #expect(fileManager.fileExists(atPath: worktreePath))
+  }
+
+  @Test func removeWorktreePropagatesDirectRemovalFailure() async {
+    let worktreePath = "/tmp/prowl-direct-remove-\(UUID().uuidString)"
+    let shell = ShellClient(
+      run: { _, arguments, _ in
+        if arguments.contains("--porcelain") {
+          return ShellOutput(
+            stdout: "worktree \(worktreePath)\nHEAD abc\nlocked external-lock\n",
+            stderr: "",
+            exitCode: 0
+          )
+        }
+        throw ShellClientError(
+          command: "git worktree remove --force \(worktreePath)",
+          stdout: "",
+          stderr: "fatal: cannot remove a locked working tree",
+          exitCode: 128
+        )
+      },
+      runLoginImpl: { _, _, _, _ in ShellOutput(stdout: "", stderr: "", exitCode: 0) }
+    )
+    let client = GitClient(shell: shell)
+    let worktree = Worktree(
+      id: worktreePath,
+      name: "locked",
+      detail: "../locked",
+      workingDirectory: URL(fileURLWithPath: worktreePath),
+      repositoryRootURL: URL(fileURLWithPath: "/tmp/repo")
+    )
+
+    await #expect(throws: GitClientError.self) {
+      _ = try await client.removeWorktree(worktree, deleteBranch: false)
+    }
+  }
+
+  @Test func removeWorktreeMatchesArbitrarySymlinkedParentPath() async throws {
+    let fileManager = FileManager.default
+    let rootURL = fileManager.temporaryDirectory.appending(
+      path: "prowl-symlink-worktree-\(UUID().uuidString)",
+      directoryHint: .isDirectory
+    )
+    let realParentURL = rootURL.appending(path: "real", directoryHint: .isDirectory)
+    let symlinkParentURL = rootURL.appending(path: "linked", directoryHint: .isDirectory)
+    let realWorktreeURL = realParentURL.appending(path: "feature", directoryHint: .isDirectory)
+    let symlinkWorktreeURL = symlinkParentURL.appending(path: "feature", directoryHint: .isDirectory)
+    try fileManager.createDirectory(at: realWorktreeURL, withIntermediateDirectories: true)
+    try fileManager.createSymbolicLink(at: symlinkParentURL, withDestinationURL: realParentURL)
+    try Data("gitdir: /tmp/repo/.git/worktrees/feature\n".utf8)
+      .write(to: realWorktreeURL.appending(path: ".git"))
+    defer {
+      try? fileManager.removeItem(at: rootURL)
+    }
+
+    let shell = ShellClient(
+      run: { _, arguments, _ in
+        if arguments.contains("--porcelain") {
+          return ShellOutput(
+            stdout: "worktree \(realWorktreeURL.path(percentEncoded: false))\nHEAD abc\ndetached\n",
+            stderr: "",
+            exitCode: 0
+          )
+        }
+        return ShellOutput(stdout: "", stderr: "", exitCode: 0)
+      },
+      runLoginImpl: { _, _, _, _ in ShellOutput(stdout: "", stderr: "", exitCode: 0) }
+    )
+    let client = GitClient(shell: shell)
+    let worktree = Worktree(
+      id: symlinkWorktreeURL.path(percentEncoded: false),
+      name: "feature",
+      detail: "../feature",
+      workingDirectory: symlinkWorktreeURL,
+      repositoryRootURL: URL(fileURLWithPath: "/tmp/repo")
+    )
+
+    _ = try await client.removeWorktree(worktree, deleteBranch: false)
+
+    #expect(!fileManager.fileExists(atPath: realWorktreeURL.path(percentEncoded: false)))
   }
 
   @Test func forceDeleteLocalBranchUsesForceFlag() async throws {

--- a/supacodeTests/PullRequestRefreshCoordinatorTests.swift
+++ b/supacodeTests/PullRequestRefreshCoordinatorTests.swift
@@ -4,7 +4,11 @@ import Testing
 
 @testable import supacode
 
+// Serialized: these tests drive TestClock-backed debounce and timeout tasks.
+// Running them in parallel can race clock advancement ahead of task suspension
+// under full-suite load, causing the queued refresh work to never flush.
 @MainActor
+@Suite(.serialized)
 struct PullRequestRefreshCoordinatorTests {
   @Test func enqueueCoalescesMultipleReposIntoSingleBatchAfterDebounce() async throws {
     let clock = TestClock()

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -4204,6 +4204,49 @@ struct RepositoriesFeatureTests {
     #expect(forceDeleteAttempts.value == [false, true])
   }
 
+  @Test func deleteWorktreeFailureKeepsWorktreeAndShowsGitError() async {
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let worktree = makeWorktree(id: "\(repoRoot)/feature", name: "feature", repoRoot: repoRoot)
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree, worktree])
+    let store = TestStore(initialState: makeState(repositories: [repository])) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.gitClient.removeWorktree = { _, _ in
+        throw GitClientError.commandFailed(
+          command: "git worktree remove --force \(worktree.id)",
+          message: "fatal: cannot remove a locked working tree"
+        )
+      }
+    }
+
+    await store.send(
+      .worktreeLifecycle(
+        .deleteWorktreeConfirmed(worktree.id, repository.id, deleteBranch: false)
+      )
+    ) {
+      $0.deletingWorktreeIDs = [worktree.id]
+    }
+    await store.receive(\.worktreeLifecycle.deleteWorktreeFailed) {
+      $0.deletingWorktreeIDs = []
+      $0.alert = AlertState {
+        TextState("Unable to delete worktree")
+      } actions: {
+        ButtonState(role: .cancel) {
+          TextState("OK")
+        }
+      } message: {
+        TextState(
+          "Git command failed: git worktree remove --force \(worktree.id)\n"
+            + "fatal: cannot remove a locked working tree"
+        )
+      }
+    }
+    await store.finish()
+
+    #expect(store.state.repositories[id: repository.id]?.worktrees[id: worktree.id] != nil)
+  }
+
   @Test(.dependencies) func worktreeDeletedPresentsQueuedForceDeleteBranchPromptsInOrder() async {
     let repoRoot = "/tmp/repo"
     let firstRequest = ForceDeleteBranchRequest(


### PR DESCRIPTION
## What

- Verify that Git no longer registers a worktree after pruning.
- Fall back to `git worktree remove --force` when pruning leaves the registration intact.
- Propagate worktree removal errors instead of treating them as success.
- Restore relocated worktree directories when cleanup fails.
- Resolve arbitrary filesystem symlinks when comparing worktree paths.
- Treat an unregistered target as an explicit deletion failure.

## Why

A successful `git worktree prune` exit code does not guarantee that the target registration was removed. Locked worktrees could therefore disappear from the UI temporarily and return after the next repository refresh.

The previous fallback also discarded `git worktree remove` errors, preventing the existing failure alert from showing Git's diagnostic output.

## How tested

- `make check`
- `make test` — 1,790 tests passed
- `make build-app`
- Added regression coverage for locked registrations, direct removal failures, symlinked paths, missing registrations, directory recovery, and reducer failure handling.

Fixes #454

— PR prepared by onevclaw on behalf of @onevcat