### PR TITLE
Split manual and automatic worktree branch cleanup

### DIFF
--- a/docs-ai/019-worktree-creation-and-lifecycle/000-plan.md
+++ b/docs-ai/019-worktree-creation-and-lifecycle/000-plan.md
@@ -89,3 +89,6 @@ deletion-safety rework, clone-from-URL intake — all later waves (see Amendment
 - Updated 2026-07-12: worktree deletion now verifies Git registration removal and
   propagates cleanup failures (fork issue #454) — see
   [006-verified-worktree-deletion.md](006-verified-worktree-deletion.md)
+- Updated 2026-07-16: manual branch-choice persistence and separate automatic-cleanup
+  branch deletion setting — see
+  [007-manual-delete-choice-and-automatic-cleanup.md](007-manual-delete-choice-and-automatic-cleanup.md)

--- a/docs-ai/019-worktree-creation-and-lifecycle/000-plan.md
+++ b/docs-ai/019-worktree-creation-and-lifecycle/000-plan.md
@@ -5,7 +5,7 @@
 | **Status** | Implemented (retrospective) |
 | **Anchor date** | 2026-04-12 |
 | **Documented** | 2026-07-12 (backfilled) |
-| **Primary PRs** | #167, #189, #190, #192 (initial wave); later waves #260/#419, #375/#383, #424/#427, #520 |
+| **Primary PRs** | #167, #189, #190, #192 (initial wave); later waves #260/#419, #375/#383, #424/#427, #520, #591 |
 | **Sources** | PR descriptions #167/#189/#190/#192/#260/#375/#383/#419/#424/#427/#520; fork issues #166/#175/#176/#178; `docs-ai/017-upstream-sync-process/upstream-ledger.md` (2026-04-08 and 2026-05-08 review batches) |
 | **Related** | [018-archived-worktrees](../018-archived-worktrees/000-plan.md), [028-pr-status-tracking](../028-pr-status-tracking/000-plan.md), [034-worktree-watcher-correctness](../034-worktree-watcher-correctness/000-plan.md), [044-foundation-model-branch-names](../044-foundation-model-branch-names/000-plan.md), `docs/components/repositories-and-worktrees.md` |
 

--- a/docs-ai/019-worktree-creation-and-lifecycle/001-action.md
+++ b/docs-ai/019-worktree-creation-and-lifecycle/001-action.md
@@ -16,7 +16,7 @@
 | 2026-06-09 | Visible labels + caption for the Advanced fields (TextField labels are not rendered under `.roundedBorder`) | PR #427 |
 | 2026-06-27 | On-device Foundation Model branch-name suggestion added to the same dialog | PR #518 (owned by [044](../044-foundation-model-branch-names/000-plan.md)) |
 | 2026-06-28 | Add to Prowl popover redesign: drop zone, Browse, Clone-from-URL form with clipboard prefill, Add Workspace; auto-select after add — see [005-add-to-prowl-clone.md](005-add-to-prowl-clone.md) | PR #520 |
-| 2026-07-16 | Split manual branch-choice persistence from automatic branch cleanup; retain legacy setting migration and Prowl-created safety guard — see [007-manual-delete-choice-and-automatic-cleanup.md](007-manual-delete-choice-and-automatic-cleanup.md) | Pending PR |
+| 2026-07-16 | Split manual branch-choice persistence from automatic branch cleanup; retain legacy setting migration and Prowl-created safety guard — see [007-manual-delete-choice-and-automatic-cleanup.md](007-manual-delete-choice-and-automatic-cleanup.md) | PR #591 |
 
 ## Outcome & current state (as of 2026-07-16)
 

--- a/docs-ai/019-worktree-creation-and-lifecycle/001-action.md
+++ b/docs-ai/019-worktree-creation-and-lifecycle/001-action.md
@@ -16,8 +16,9 @@
 | 2026-06-09 | Visible labels + caption for the Advanced fields (TextField labels are not rendered under `.roundedBorder`) | PR #427 |
 | 2026-06-27 | On-device Foundation Model branch-name suggestion added to the same dialog | PR #518 (owned by [044](../044-foundation-model-branch-names/000-plan.md)) |
 | 2026-06-28 | Add to Prowl popover redesign: drop zone, Browse, Clone-from-URL form with clipboard prefill, Add Workspace; auto-select after add — see [005-add-to-prowl-clone.md](005-add-to-prowl-clone.md) | PR #520 |
+| 2026-07-16 | Split manual branch-choice persistence from automatic branch cleanup; retain legacy setting migration and Prowl-created safety guard — see [007-manual-delete-choice-and-automatic-cleanup.md](007-manual-delete-choice-and-automatic-cleanup.md) | Pending PR |
 
-## Outcome & current state (as of 2026-07-12)
+## Outcome & current state (as of 2026-07-16)
 
 - **Git plumbing** — `supacode/Clients/Git/GitClient.swift`: `branchRefs(for:)` returns
   local + upstream refs; `deleteLocalBranch(_:_:force:)` backs both `-d` and confirmed
@@ -48,17 +49,20 @@
   (default `.merge`); `supacode/Features/Settings/Models/MergedWorktreeAction.swift`;
   per-repo optionals in `supacode/Features/Settings/Models/RepositorySettings.swift`.
   UI: `supacode/Features/Settings/Views/WorktreeSettingsView.swift` (merged-action
-  picker, copy-flag toggles, branch-delete toggle),
+  picker, copy-flag toggles, automatic-cleanup branch toggle),
   `GithubSettingsView.swift` (merge strategy), `RepositorySettingsView.swift`
   ("Global (…)" override pickers).
 - **Merged-PR automation** —
   `supacode/Features/Repositories/Reducer/RepositoriesFeature+GithubIntegration.swift`
   switches on `state.mergedWorktreeAction`; `.delete` passes
-  `deleteBranch: deleteBranchOnDeleteWorktree && prowlCreatedWorktreeIDs.contains(id)`.
+  `deleteBranch: deleteBranchOnAutomaticWorktreeCleanup &&
+  prowlCreatedWorktreeIDs.contains(id)`.
 - **Deletion** —
   `supacode/Features/Repositories/Reducer/RepositoriesFeature+WorktreeLifecycle.swift`
-  (delete + `ForceDeleteBranchRequest` flow) and
+  (manual last-choice persistence, delete + `ForceDeleteBranchRequest` flow) and
   `supacode/Features/Repositories/Views/DeleteWorktreeConfirmationView.swift`.
+  Manual confirmation remembers only choices that were submitted; automatic branch
+  cleanup remains separately controlled and restricted to Prowl-created worktrees.
 - **History navigation** — stacks and `navigateWorktreeHistory` in
   `supacode/Features/Repositories/Reducer/RepositoriesFeature.swift` /
   `RepositoriesFeature+Selection.swift` (50-entry cap); menu commands in

--- a/docs-ai/019-worktree-creation-and-lifecycle/007-manual-delete-choice-and-automatic-cleanup.md
+++ b/docs-ai/019-worktree-creation-and-lifecycle/007-manual-delete-choice-and-automatic-cleanup.md
@@ -26,7 +26,7 @@ had created the worktree.
 
 ## Refs
 
-PR pending.
+PR #591.
 
 ## Current state
 

--- a/docs-ai/019-worktree-creation-and-lifecycle/007-manual-delete-choice-and-automatic-cleanup.md
+++ b/docs-ai/019-worktree-creation-and-lifecycle/007-manual-delete-choice-and-automatic-cleanup.md
@@ -1,0 +1,40 @@
+# 019.007 — Manual Branch Choice & Automatic Cleanup
+
+## Context
+
+The worktree deletion safety change introduced one global setting that served two
+different behaviors: the initial value of the manual deletion checkbox and branch
+deletion during merged/expired automatic cleanup. The shared meaning made the
+Settings label difficult to explain and made manual deletion depend on whether Prowl
+had created the worktree.
+
+## Change
+
+- Manual deletion now reads `lastDeleteBranchOnManualWorktreeDeletion` from
+  `@Shared(.appStorage(...))`. It defaults to `false`, is written only after the user
+  confirms a manual deletion, and is reused for later manual confirmations regardless
+  of worktree provenance. Dismissing the confirmation does not update it.
+- Automatic cleanup now uses the global setting
+  `deleteBranchOnAutomaticWorktreeCleanup`, defaulting to `false`. It controls branch
+  deletion for merged-worktree deletion and expired archived-worktree cleanup, while
+  the existing `prowlCreatedWorktreeIDs` guard remains in place.
+- `GlobalSettings` decodes the former `deleteBranchOnDeleteWorktree` key as a legacy
+  fallback. The old value migrates to the automatic-cleanup setting; the new manual
+  choice starts unchecked instead of inferring a previous manual selection.
+- Settings and agent-facing worktree documentation now describe the two behaviors
+  separately.
+
+## Refs
+
+PR pending.
+
+## Current state
+
+- Settings model and persistence: `supacode/Features/Settings/Models/GlobalSettings.swift`.
+- Settings UI: `supacode/Features/Settings/Views/WorktreeSettingsView.swift`.
+- Manual and automatic lifecycle paths:
+  `supacode/Features/Repositories/Reducer/RepositoriesFeature+WorktreeLifecycle.swift`,
+  `supacode/Features/Repositories/Reducer/RepositoriesFeature+GithubIntegration.swift`,
+  and `supacode/Features/Repositories/Reducer/RepositoriesFeature+CoreReducer.swift`.
+- Behavior coverage is in `supacodeTests/RepositoriesFeatureTests.swift`,
+  `SettingsFeatureTests.swift`, and `SettingsFilePersistenceTests.swift`.

--- a/docs/components/repositories-and-worktrees.md
+++ b/docs/components/repositories-and-worktrees.md
@@ -128,8 +128,11 @@ Deleting removes the worktree directory (and optionally its branch).
 
 - **Right-click** the row → "Delete Worktree", or **`⌘⇧⌫`**.
 - A confirmation dialog offers an **"Also delete local branch"** toggle (its
-  tooltip notes `git branch -d`). Default behavior comes from
-  `deleteBranchOnDeleteWorktree`.
+  tooltip notes `git branch -d`). It starts unchecked and remembers the last
+  choice made when a manual deletion is confirmed.
+- Automatic cleanup has a separate **"Delete local branches during automatic
+  cleanup"** setting. It is off by default and applies only to worktrees created
+  by Prowl when merged or expired worktrees are removed automatically.
 - Prowl removes the worktree (relocating + `git worktree prune` if needed), then
   verifies that Git no longer registers it. Cleanup failures keep the worktree
   visible and show Git's error. If branch deletion is rejected because the branch
@@ -198,7 +201,7 @@ list. Highlights:
 - `defaultWorktreeBaseDirectoryPath` / per-repo `worktreeBaseDirectoryPath`
 - per-repo `worktreeBaseRef` (default base branch)
 - `copyIgnoredOnWorktreeCreate`, `copyUntrackedOnWorktreeCreate`
-- `deleteBranchOnDeleteWorktree`, `mergedWorktreeAction`, `archivedAutoDeletePeriod`
+- `deleteBranchOnAutomaticWorktreeCleanup`, `mergedWorktreeAction`, `archivedAutoDeletePeriod`
 - per-repo `setupScript`, `archiveScript`, `openActionID`, `customTitle`
 
 ## Gotchas for agents

--- a/docs/components/settings.md
+++ b/docs/components/settings.md
@@ -19,7 +19,7 @@ window is a sidebar of tabs plus a detail pane.
 | **General** | Appearance (system/light/dark), default app for opening worktrees, diff tool, confirm-before-quit, default view mode, window chrome tint, toolbar buttons (Run / Open-in-editor), dim unfocused splits, Active Agents panel auto-show & terminal titles. |
 | **Notifications** | In-app alerts, notification sound picker (Never / system sounds / Prowl Classic), macOS system notifications, move-notified-to-top, command-finished notification + threshold, Dock badge & bounce. → [notifications](notifications.md) |
 | **Shortcuts** | Remap app keyboard shortcuts; view defaults; resolve conflicts. → [keyboard-shortcuts](../reference/keyboard-shortcuts.md) |
-| **Worktree** | Worktree creation/deletion defaults: prompt on create, fetch before create, base directory, copy ignored/untracked files, delete-branch-on-delete, merged-worktree action, archived auto-delete period. |
+| **Worktree** | Worktree creation/deletion defaults: prompt on create, fetch before create, base directory, copy ignored/untracked files, automatic local-branch cleanup, merged-worktree action, archived auto-delete period. |
 | **Updates** | Auto-check toggle, "Check for Updates Now". → [updates](updates.md) |
 | **Advanced** | Analytics, crash reports, restore terminal layout on launch (experimental) + clear saved layout, and the **Install Command Line Tool** (`prowl` CLI) action. |
 | **GitHub** | Enable GitHub integration (uses the `gh` CLI). → [github-pull-requests](github-pull-requests.md) |

--- a/docs/reference/settings-fields.md
+++ b/docs/reference/settings-fields.md
@@ -38,7 +38,7 @@ JSON is pretty-printed with sorted keys. Legacy `~/.supacode` is migrated to
 | `analyticsEnabled` | Bool | `true` | Send usage analytics (PostHog; off in Debug). |
 | `crashReportsEnabled` | Bool | `true` | Send crash reports (Sentry). |
 | `githubIntegrationEnabled` | Bool | `true` | Enable GitHub/PR features (via `gh`). |
-| `deleteBranchOnDeleteWorktree` | Bool | `false` | Default "delete branch" when deleting a worktree. |
+| `deleteBranchOnAutomaticWorktreeCleanup` | Bool | `false` | Delete local branches when Prowl automatically cleans up its merged or expired worktrees. |
 | `mergedWorktreeAction` | enum? | `nil` | What to do with a merged worktree (e.g. auto-archive); `nil` = ask. |
 | `promptForWorktreeCreation` | Bool | `true` | Show the creation dialog vs. auto-create. |
 | `fetchOriginBeforeWorktreeCreation` | Bool | `true` | `git fetch` before creating a worktree. |

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+CoreReducer.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+CoreReducer.swift
@@ -136,7 +136,7 @@ extension RepositoriesFeature {
           continue
         }
         let shouldDeleteBranch =
-          settingsFile.global.deleteBranchOnDeleteWorktree
+          settingsFile.global.deleteBranchOnAutomaticWorktreeCleanup
           && state.prowlCreatedWorktreeIDs.contains(worktree.id)
         deleteEffects.append(
           .send(

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+GithubIntegration.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+GithubIntegration.swift
@@ -290,7 +290,7 @@ extension RepositoriesFeature {
         return .merge(
           mergedWorktreeIDs.map { worktreeID in
             let shouldDeleteBranch =
-              settingsFile.global.deleteBranchOnDeleteWorktree
+              settingsFile.global.deleteBranchOnAutomaticWorktreeCleanup
               && state.prowlCreatedWorktreeIDs.contains(worktreeID)
             return .send(
               .worktreeLifecycle(

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+WorktreeLifecycle.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+WorktreeLifecycle.swift
@@ -348,6 +348,9 @@ extension RepositoriesFeature {
       guard let confirmation = state.deleteWorktreeConfirmation else {
         return .none
       }
+      @Shared(.appStorage(WorktreeDeletionPreferences.lastDeleteBranchOnManualWorktreeDeletion))
+      var lastDeleteBranch = false
+      $lastDeleteBranch.withLock { $0 = confirmation.deleteBranch }
       state.deleteWorktreeConfirmation = nil
       return .merge(
         confirmation.targets.map { target in
@@ -560,12 +563,9 @@ private func makeDeleteWorktreeConfirmation(
   targets: [RepositoriesFeature.DeleteWorktreeTarget],
   state: RepositoriesFeature.State
 ) -> DeleteWorktreeConfirmation {
-  @Shared(.settingsFile) var settingsFile
+  @Shared(.appStorage(WorktreeDeletionPreferences.lastDeleteBranchOnManualWorktreeDeletion))
+  var lastDeleteBranch = false
   let count = targets.count
-  let allProwlCreated = targets.allSatisfy { target in
-    state.prowlCreatedWorktreeIDs.contains(target.worktreeID)
-  }
-  let defaultDeleteBranch = settingsFile.global.deleteBranchOnDeleteWorktree && allProwlCreated
   if count == 1,
     let target = targets.first,
     let worktree = state.repositories[id: target.repositoryID]?.worktrees[id: target.worktreeID]
@@ -575,7 +575,7 @@ private func makeDeleteWorktreeConfirmation(
       title: "Delete worktree?",
       message: "Delete \(worktree.name)? The worktree directory will be removed.",
       targets: targets,
-      deleteBranch: defaultDeleteBranch
+      deleteBranch: lastDeleteBranch
     )
   }
   return DeleteWorktreeConfirmation(
@@ -583,7 +583,7 @@ private func makeDeleteWorktreeConfirmation(
     title: "Delete \(count) worktrees?",
     message: "Delete \(count) worktrees? Their worktree directories will be removed.",
     targets: targets,
-    deleteBranch: defaultDeleteBranch
+    deleteBranch: lastDeleteBranch
   )
 }
 

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -63,6 +63,10 @@ struct DeleteWorktreeConfirmation: Equatable, Identifiable {
   var deleteBranch: Bool
 }
 
+enum WorktreeDeletionPreferences {
+  static let lastDeleteBranchOnManualWorktreeDeletion = "lastDeleteBranchOnManualWorktreeDeletion"
+}
+
 struct ForceDeleteBranchRequest: Equatable {
   let branchName: String
   let repositoryRootURL: URL

--- a/supacode/Features/Settings/Models/GlobalSettings.swift
+++ b/supacode/Features/Settings/Models/GlobalSettings.swift
@@ -14,7 +14,7 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
   var analyticsEnabled: Bool
   var crashReportsEnabled: Bool
   var githubIntegrationEnabled: Bool
-  var deleteBranchOnDeleteWorktree: Bool
+  var deleteBranchOnAutomaticWorktreeCleanup: Bool
   var mergedWorktreeAction: MergedWorktreeAction?
   var promptForWorktreeCreation: Bool
   var fetchOriginBeforeWorktreeCreation: Bool
@@ -59,7 +59,7 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     analyticsEnabled: true,
     crashReportsEnabled: true,
     githubIntegrationEnabled: true,
-    deleteBranchOnDeleteWorktree: false,
+    deleteBranchOnAutomaticWorktreeCleanup: false,
     mergedWorktreeAction: nil,
     promptForWorktreeCreation: true,
     fetchOriginBeforeWorktreeCreation: true,
@@ -103,7 +103,7 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     analyticsEnabled: Bool,
     crashReportsEnabled: Bool,
     githubIntegrationEnabled: Bool,
-    deleteBranchOnDeleteWorktree: Bool,
+    deleteBranchOnAutomaticWorktreeCleanup: Bool,
     mergedWorktreeAction: MergedWorktreeAction? = nil,
     promptForWorktreeCreation: Bool,
     fetchOriginBeforeWorktreeCreation: Bool = true,
@@ -145,7 +145,7 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     self.analyticsEnabled = analyticsEnabled
     self.crashReportsEnabled = crashReportsEnabled
     self.githubIntegrationEnabled = githubIntegrationEnabled
-    self.deleteBranchOnDeleteWorktree = deleteBranchOnDeleteWorktree
+    self.deleteBranchOnAutomaticWorktreeCleanup = deleteBranchOnAutomaticWorktreeCleanup
     self.mergedWorktreeAction = mergedWorktreeAction
     self.promptForWorktreeCreation = promptForWorktreeCreation
     self.fetchOriginBeforeWorktreeCreation = fetchOriginBeforeWorktreeCreation
@@ -190,7 +190,10 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     try container.encode(analyticsEnabled, forKey: .analyticsEnabled)
     try container.encode(crashReportsEnabled, forKey: .crashReportsEnabled)
     try container.encode(githubIntegrationEnabled, forKey: .githubIntegrationEnabled)
-    try container.encode(deleteBranchOnDeleteWorktree, forKey: .deleteBranchOnDeleteWorktree)
+    try container.encode(
+      deleteBranchOnAutomaticWorktreeCleanup,
+      forKey: .deleteBranchOnAutomaticWorktreeCleanup
+    )
     try container.encodeIfPresent(mergedWorktreeAction, forKey: .mergedWorktreeAction)
     try container.encode(promptForWorktreeCreation, forKey: .promptForWorktreeCreation)
     try container.encode(fetchOriginBeforeWorktreeCreation, forKey: .fetchOriginBeforeWorktreeCreation)
@@ -236,7 +239,7 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     case analyticsEnabled
     case crashReportsEnabled
     case githubIntegrationEnabled
-    case deleteBranchOnDeleteWorktree
+    case deleteBranchOnAutomaticWorktreeCleanup
     case mergedWorktreeAction
     case promptForWorktreeCreation
     case fetchOriginBeforeWorktreeCreation
@@ -265,6 +268,7 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     case externalDiffToolID
     case externalDiffCustomCommand
     // Legacy keys for migration
+    case deleteBranchOnDeleteWorktree
     case automaticallyArchiveMergedWorktrees
     case notificationSoundEnabled
   }
@@ -308,9 +312,10 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     githubIntegrationEnabled =
       try container.decodeIfPresent(Bool.self, forKey: .githubIntegrationEnabled)
       ?? Self.default.githubIntegrationEnabled
-    deleteBranchOnDeleteWorktree =
-      try container.decodeIfPresent(Bool.self, forKey: .deleteBranchOnDeleteWorktree)
-      ?? Self.default.deleteBranchOnDeleteWorktree
+    deleteBranchOnAutomaticWorktreeCleanup =
+      try container.decodeIfPresent(Bool.self, forKey: .deleteBranchOnAutomaticWorktreeCleanup)
+      ?? (try container.decodeIfPresent(Bool.self, forKey: .deleteBranchOnDeleteWorktree))
+      ?? Self.default.deleteBranchOnAutomaticWorktreeCleanup
     mergedWorktreeAction = try Self.decodeMergedWorktreeAction(from: container)
     promptForWorktreeCreation =
       try container.decodeIfPresent(Bool.self, forKey: .promptForWorktreeCreation)

--- a/supacode/Features/Settings/Reducer/SettingsFeature.swift
+++ b/supacode/Features/Settings/Reducer/SettingsFeature.swift
@@ -21,7 +21,7 @@ struct SettingsFeature {
     var analyticsEnabled: Bool
     var crashReportsEnabled: Bool
     var githubIntegrationEnabled: Bool
-    var deleteBranchOnDeleteWorktree: Bool
+    var deleteBranchOnAutomaticWorktreeCleanup: Bool
     var mergedWorktreeAction: MergedWorktreeAction?
     var archivedAutoDeletePeriod: AutoDeletePeriod?
     var promptForWorktreeCreation: Bool
@@ -79,7 +79,7 @@ struct SettingsFeature {
       analyticsEnabled = settings.analyticsEnabled
       crashReportsEnabled = settings.crashReportsEnabled
       githubIntegrationEnabled = settings.githubIntegrationEnabled
-      deleteBranchOnDeleteWorktree = settings.deleteBranchOnDeleteWorktree
+      deleteBranchOnAutomaticWorktreeCleanup = settings.deleteBranchOnAutomaticWorktreeCleanup
       mergedWorktreeAction = settings.mergedWorktreeAction
       archivedAutoDeletePeriod = settings.archivedAutoDeletePeriod
       promptForWorktreeCreation = settings.promptForWorktreeCreation
@@ -127,7 +127,7 @@ struct SettingsFeature {
         analyticsEnabled: analyticsEnabled,
         crashReportsEnabled: crashReportsEnabled,
         githubIntegrationEnabled: githubIntegrationEnabled,
-        deleteBranchOnDeleteWorktree: deleteBranchOnDeleteWorktree,
+        deleteBranchOnAutomaticWorktreeCleanup: deleteBranchOnAutomaticWorktreeCleanup,
         mergedWorktreeAction: mergedWorktreeAction,
         promptForWorktreeCreation: promptForWorktreeCreation,
         fetchOriginBeforeWorktreeCreation: fetchRemoteBeforeWorktreeCreation,
@@ -248,7 +248,7 @@ struct SettingsFeature {
         state.analyticsEnabled = normalizedSettings.analyticsEnabled
         state.crashReportsEnabled = normalizedSettings.crashReportsEnabled
         state.githubIntegrationEnabled = normalizedSettings.githubIntegrationEnabled
-        state.deleteBranchOnDeleteWorktree = normalizedSettings.deleteBranchOnDeleteWorktree
+        state.deleteBranchOnAutomaticWorktreeCleanup = normalizedSettings.deleteBranchOnAutomaticWorktreeCleanup
         state.mergedWorktreeAction = normalizedSettings.mergedWorktreeAction
         state.archivedAutoDeletePeriod = normalizedSettings.archivedAutoDeletePeriod
         state.promptForWorktreeCreation = normalizedSettings.promptForWorktreeCreation

--- a/supacode/Features/Settings/Views/WorktreeSettingsView.swift
+++ b/supacode/Features/Settings/Views/WorktreeSettingsView.swift
@@ -50,13 +50,13 @@ struct WorktreeSettingsView: View {
         Section("Cleanup") {
           VStack(alignment: .leading) {
             Toggle(
-              "Preselect branch deletion for Prowl-created worktrees",
-              isOn: $store.deleteBranchOnDeleteWorktree
+              "Delete local branches during automatic cleanup",
+              isOn: $store.deleteBranchOnAutomaticWorktreeCleanup
             )
-            .help("Preselect local branch deletion for worktrees created by Prowl.")
-            Text("External worktrees stay unchecked by default. Remote branches must be deleted on GitHub.")
+            .help("Also delete the local branch when Prowl automatically cleans up a worktree it created.")
+            Text("Applies to merged worktrees and expired archived worktrees created by Prowl.")
               .foregroundStyle(.secondary)
-            Text("Uncommitted changes will be lost.")
+            Text("Uncommitted changes will be lost when a worktree is deleted.")
               .foregroundStyle(.red)
           }
           .frame(maxWidth: .infinity, alignment: .leading)
@@ -71,7 +71,7 @@ struct WorktreeSettingsView: View {
             case .archive:
               Text("Archives worktrees when their pull requests are merged.")
             case .delete:
-              Text("Follows the \"Also delete local branch when deleting a worktree\" option above.")
+              Text("Follows the automatic branch cleanup option above.")
             case nil:
               EmptyView()
             }

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -4092,7 +4092,8 @@ struct RepositoriesFeatureTests {
     #expect(store.state.pendingWorktrees.isEmpty)
   }
 
-  @Test func requestDeleteWorktreeShowsConfirmation() async {
+  @Test(.dependencies) func requestDeleteWorktreeDefaultsToUnchecked() async {
+    setLastDeleteBranchOnManualWorktreeDeletion(false)
     let worktree = makeWorktree(id: "/tmp/wt", name: "owl")
     let repository = makeRepository(id: "/tmp/repo", worktrees: [worktree])
     let store = TestStore(initialState: makeState(repositories: [repository])) {
@@ -4114,17 +4115,11 @@ struct RepositoriesFeatureTests {
     }
   }
 
-  @Test(.dependencies) func requestDeleteProwlCreatedWorktreeCanPreselectBranchDeletion() async {
+  @Test(.dependencies) func requestDeleteWorktreeUsesLastManualBranchChoice() async {
+    setLastDeleteBranchOnManualWorktreeDeletion(true)
     let worktree = makeWorktree(id: "/tmp/wt", name: "owl")
     let repository = makeRepository(id: "/tmp/repo", worktrees: [worktree])
     let state = makeState(repositories: [repository])
-    state.$prowlCreatedWorktreeIDs.withLock {
-      $0 = [worktree.id]
-    }
-    @Shared(.settingsFile) var settingsFile
-    $settingsFile.withLock {
-      $0.global.deleteBranchOnDeleteWorktree = true
-    }
     let store = TestStore(initialState: state) {
       RepositoriesFeature()
     }
@@ -4142,6 +4137,91 @@ struct RepositoriesFeatureTests {
       )
       $0.nextDeleteWorktreeConfirmationID = 1
     }
+    setLastDeleteBranchOnManualWorktreeDeletion(false)
+  }
+
+  @Test(.dependencies) func dismissingDeletePromptDoesNotRememberChangedChoice() async {
+    setLastDeleteBranchOnManualWorktreeDeletion(false)
+    let worktree = makeWorktree(id: "/tmp/wt", name: "owl")
+    let repository = makeRepository(id: "/tmp/repo", worktrees: [worktree])
+    let store = TestStore(initialState: makeState(repositories: [repository])) {
+      RepositoriesFeature()
+    }
+
+    await store.send(.worktreeLifecycle(.requestDeleteWorktree(worktree.id, repository.id))) {
+      $0.deleteWorktreeConfirmation = DeleteWorktreeConfirmation(
+        id: 0,
+        title: "Delete worktree?",
+        message: "Delete \(worktree.name)? The worktree directory will be removed.",
+        targets: [
+          RepositoriesFeature.DeleteWorktreeTarget(
+            worktreeID: worktree.id, repositoryID: repository.id)
+        ],
+        deleteBranch: false
+      )
+      $0.nextDeleteWorktreeConfirmationID = 1
+    }
+    await store.send(.worktreeLifecycle(.deleteWorktreePromptDeleteBranchChanged(true))) {
+      $0.deleteWorktreeConfirmation?.deleteBranch = true
+    }
+    await store.send(.worktreeLifecycle(.deleteWorktreePromptDismissed)) {
+      $0.deleteWorktreeConfirmation = nil
+    }
+    await store.send(.worktreeLifecycle(.requestDeleteWorktree(worktree.id, repository.id))) {
+      $0.deleteWorktreeConfirmation = DeleteWorktreeConfirmation(
+        id: 1,
+        title: "Delete worktree?",
+        message: "Delete \(worktree.name)? The worktree directory will be removed.",
+        targets: [
+          RepositoriesFeature.DeleteWorktreeTarget(
+            worktreeID: worktree.id, repositoryID: repository.id)
+        ],
+        deleteBranch: false
+      )
+      $0.nextDeleteWorktreeConfirmationID = 2
+    }
+  }
+
+  @Test(.dependencies) func confirmingUncheckedDeleteRemembersFalse() async {
+    setLastDeleteBranchOnManualWorktreeDeletion(true)
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let worktree = makeWorktree(id: "\(repoRoot)/feature", name: "feature", repoRoot: repoRoot)
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree, worktree])
+    var state = makeState(repositories: [repository])
+    state.deleteWorktreeConfirmation = DeleteWorktreeConfirmation(
+      id: 0,
+      title: "Delete worktree?",
+      message: "Delete feature? The worktree directory will be removed.",
+      targets: [
+        RepositoriesFeature.DeleteWorktreeTarget(
+          worktreeID: worktree.id, repositoryID: repository.id)
+      ],
+      deleteBranch: false
+    )
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.gitClient.removeWorktree = { worktree, deleteBranch in
+        #expect(deleteBranch == false)
+        return worktree.workingDirectory
+      }
+      $0.gitClient.worktrees = { _ in [mainWorktree] }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.worktreeLifecycle(.deleteWorktreePromptConfirmed)) {
+      $0.deleteWorktreeConfirmation = nil
+    }
+    await store.receive(\.worktreeLifecycle.deleteWorktreeConfirmed) {
+      $0.deletingWorktreeIDs = [worktree.id]
+    }
+    await store.receive(\.worktreeLifecycle.worktreeDeleted)
+
+    @Shared(.appStorage(WorktreeDeletionPreferences.lastDeleteBranchOnManualWorktreeDeletion))
+    var lastDeleteBranch = true
+    #expect(lastDeleteBranch == false)
+    setLastDeleteBranchOnManualWorktreeDeletion(false)
   }
 
   @Test(.dependencies) func deletePromptConfirmedAsksBeforeForceDeletingBranch() async {
@@ -4202,6 +4282,10 @@ struct RepositoriesFeatureTests {
             )))))
 
     #expect(forceDeleteAttempts.value == [false, true])
+    @Shared(.appStorage(WorktreeDeletionPreferences.lastDeleteBranchOnManualWorktreeDeletion))
+    var lastDeleteBranch = false
+    #expect(lastDeleteBranch == true)
+    setLastDeleteBranchOnManualWorktreeDeletion(false)
   }
 
   @Test func deleteWorktreeFailureKeepsWorktreeAndShowsGitError() async {
@@ -4326,6 +4410,7 @@ struct RepositoriesFeatureTests {
     }
   }
   @Test func requestDeleteWorktreesShowsBatchConfirmation() async {
+    setLastDeleteBranchOnManualWorktreeDeletion(false)
     let worktree1 = makeWorktree(id: "/tmp/repo/wt1", name: "owl", repoRoot: "/tmp/repo")
     let worktree2 = makeWorktree(id: "/tmp/repo/wt2", name: "hawk", repoRoot: "/tmp/repo")
     let repository = makeRepository(id: "/tmp/repo", worktrees: [worktree1, worktree2])
@@ -5496,7 +5581,7 @@ struct RepositoriesFeatureTests {
     state.mergedWorktreeAction = .delete
     @Shared(.settingsFile) var settingsFile
     $settingsFile.withLock {
-      $0.global.deleteBranchOnDeleteWorktree = true
+      $0.global.deleteBranchOnAutomaticWorktreeCleanup = true
     }
     let store = TestStore(initialState: state) {
       RepositoriesFeature()
@@ -5521,6 +5606,59 @@ struct RepositoriesFeatureTests {
       $0.deletingWorktreeIDs = [externalWorktree.id]
     }
     await store.receive(\.worktreeLifecycle.worktreeDeleted)
+  }
+
+  @Test(.dependencies) func repositoryPullRequestsLoadedAutoDeletesProwlCreatedBranchWhenEnabled()
+    async
+  {
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let featureWorktree = makeWorktree(
+      id: "\(repoRoot)/feature",
+      name: "feature",
+      repoRoot: repoRoot
+    )
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree, featureWorktree])
+    var state = makeState(repositories: [repository])
+    state.mergedWorktreeAction = .delete
+    state.$prowlCreatedWorktreeIDs.withLock {
+      $0 = [featureWorktree.id]
+    }
+    @Shared(.settingsFile) var settingsFile
+    $settingsFile.withLock {
+      $0.global.deleteBranchOnAutomaticWorktreeCleanup = true
+    }
+    let deletedBranches = LockIsolated<[String]>([])
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.gitClient.removeWorktree = { worktree, deleteBranch in
+        #expect(worktree.id == featureWorktree.id)
+        #expect(deleteBranch == false)
+        return worktree.workingDirectory
+      }
+      $0.gitClient.deleteLocalBranch = { name, _, force in
+        #expect(force == false)
+        deletedBranches.withValue { $0.append(name) }
+        return .deleted
+      }
+      $0.gitClient.worktrees = { _ in [mainWorktree] }
+    }
+    store.exhaustivity = .off
+    let mergedPullRequest = makePullRequest(state: "MERGED", headRefName: featureWorktree.name)
+
+    await store.send(
+      .githubIntegration(
+        .repositoryPullRequestsLoaded(
+          repositoryID: repository.id,
+          pullRequestsByWorktreeID: [featureWorktree.id: mergedPullRequest]
+        )))
+    await store.receive(\.worktreeLifecycle.deleteWorktreeConfirmed) {
+      $0.deletingWorktreeIDs = [featureWorktree.id]
+    }
+    await store.receive(\.worktreeLifecycle.worktreeDeleted)
+
+    #expect(deletedBranches.value == [featureWorktree.name])
   }
 
   @Test func repositoryPullRequestsLoadedSkipsAutoDeleteForMainWorktree() async {
@@ -6662,7 +6800,7 @@ struct RepositoriesFeatureTests {
     state.archivedAutoDeletePeriod = .oneDay
     @Shared(.settingsFile) var settingsFile
     $settingsFile.withLock {
-      $0.global.deleteBranchOnDeleteWorktree = true
+      $0.global.deleteBranchOnAutomaticWorktreeCleanup = true
     }
     let store = TestStore(initialState: state) {
       RepositoriesFeature()
@@ -7535,6 +7673,12 @@ struct RepositoriesFeatureTests {
       worktrees: IdentifiedArray(uniqueElements: worktrees),
       workspace: workspace
     )
+  }
+
+  private func setLastDeleteBranchOnManualWorktreeDeletion(_ value: Bool) {
+    @Shared(.appStorage(WorktreeDeletionPreferences.lastDeleteBranchOnManualWorktreeDeletion))
+    var preference = false
+    $preference.withLock { $0 = value }
   }
 
   private func makeState(repositories: [Repository]) -> RepositoriesFeature.State {

--- a/supacodeTests/SettingsFeatureTests.swift
+++ b/supacodeTests/SettingsFeatureTests.swift
@@ -22,7 +22,7 @@ struct SettingsFeatureTests {
       analyticsEnabled: false,
       crashReportsEnabled: true,
       githubIntegrationEnabled: true,
-      deleteBranchOnDeleteWorktree: false,
+      deleteBranchOnAutomaticWorktreeCleanup: false,
       mergedWorktreeAction: .archive,
       promptForWorktreeCreation: true
     )
@@ -46,7 +46,7 @@ struct SettingsFeatureTests {
       $0.analyticsEnabled = false
       $0.crashReportsEnabled = true
       $0.githubIntegrationEnabled = true
-      $0.deleteBranchOnDeleteWorktree = false
+      $0.deleteBranchOnAutomaticWorktreeCleanup = false
       $0.mergedWorktreeAction = .archive
       $0.promptForWorktreeCreation = true
     }
@@ -66,7 +66,7 @@ struct SettingsFeatureTests {
       analyticsEnabled: true,
       crashReportsEnabled: false,
       githubIntegrationEnabled: true,
-      deleteBranchOnDeleteWorktree: true,
+      deleteBranchOnAutomaticWorktreeCleanup: true,
       mergedWorktreeAction: nil,
       promptForWorktreeCreation: false
     )
@@ -92,7 +92,7 @@ struct SettingsFeatureTests {
       analyticsEnabled: initialSettings.analyticsEnabled,
       crashReportsEnabled: initialSettings.crashReportsEnabled,
       githubIntegrationEnabled: initialSettings.githubIntegrationEnabled,
-      deleteBranchOnDeleteWorktree: initialSettings.deleteBranchOnDeleteWorktree,
+      deleteBranchOnAutomaticWorktreeCleanup: initialSettings.deleteBranchOnAutomaticWorktreeCleanup,
       mergedWorktreeAction: initialSettings.mergedWorktreeAction,
       promptForWorktreeCreation: initialSettings.promptForWorktreeCreation
     )
@@ -241,7 +241,7 @@ struct SettingsFeatureTests {
       analyticsEnabled: true,
       crashReportsEnabled: false,
       githubIntegrationEnabled: true,
-      deleteBranchOnDeleteWorktree: true,
+      deleteBranchOnAutomaticWorktreeCleanup: true,
       mergedWorktreeAction: .archive,
       promptForWorktreeCreation: false
     )
@@ -258,7 +258,7 @@ struct SettingsFeatureTests {
       $0.analyticsEnabled = true
       $0.crashReportsEnabled = false
       $0.githubIntegrationEnabled = true
-      $0.deleteBranchOnDeleteWorktree = true
+      $0.deleteBranchOnAutomaticWorktreeCleanup = true
       $0.mergedWorktreeAction = .archive
       $0.promptForWorktreeCreation = false
       $0.selection = selection

--- a/supacodeTests/SettingsFilePersistenceTests.swift
+++ b/supacodeTests/SettingsFilePersistenceTests.swift
@@ -162,7 +162,7 @@ struct SettingsFilePersistenceTests {
     #expect(settings.global.analyticsEnabled == true)
     #expect(settings.global.crashReportsEnabled == true)
     #expect(settings.global.githubIntegrationEnabled == true)
-    #expect(settings.global.deleteBranchOnDeleteWorktree == false)
+    #expect(settings.global.deleteBranchOnAutomaticWorktreeCleanup == false)
     #expect(settings.global.mergedWorktreeAction == nil)
     #expect(settings.global.promptForWorktreeCreation == true)
     #expect(settings.global.defaultWorktreeBaseDirectoryPath == nil)
@@ -225,6 +225,53 @@ struct SettingsFilePersistenceTests {
     }
 
     #expect(settings.global.mergedWorktreeAction == nil)
+  }
+
+  @Test(.dependencies) func legacyDeleteBranchSettingMigratesToAutomaticCleanup() throws {
+    let encoded = try JSONEncoder().encode(GlobalSettings.default)
+    var global = try #require(try JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+    global["deleteBranchOnDeleteWorktree"] = true
+    global.removeValue(forKey: "deleteBranchOnAutomaticWorktreeCleanup")
+    let data = try JSONSerialization.data(withJSONObject: ["global": global, "repositories": [:]])
+    let storage = MutableTestStorage(initialData: data)
+
+    let settings: SettingsFile = withDependencies {
+      $0.settingsFileStorage = storage.storage
+    } operation: {
+      @Shared(.settingsFile) var settings: SettingsFile
+      return settings
+    }
+
+    #expect(settings.global.deleteBranchOnAutomaticWorktreeCleanup == true)
+  }
+
+  @Test(.dependencies) func explicitAutomaticCleanupSettingTakesPrecedenceOverLegacySetting() throws {
+    let encoded = try JSONEncoder().encode(GlobalSettings.default)
+    var global = try #require(try JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+    global["deleteBranchOnDeleteWorktree"] = true
+    global["deleteBranchOnAutomaticWorktreeCleanup"] = false
+    let data = try JSONSerialization.data(withJSONObject: ["global": global, "repositories": [:]])
+    let storage = MutableTestStorage(initialData: data)
+
+    let settings: SettingsFile = withDependencies {
+      $0.settingsFileStorage = storage.storage
+    } operation: {
+      @Shared(.settingsFile) var settings: SettingsFile
+      return settings
+    }
+
+    #expect(settings.global.deleteBranchOnAutomaticWorktreeCleanup == false)
+  }
+
+  @Test func encodesAutomaticCleanupSettingWithoutLegacyKey() throws {
+    var settings = GlobalSettings.default
+    settings.deleteBranchOnAutomaticWorktreeCleanup = true
+
+    let encoded = try JSONEncoder().encode(settings)
+    let global = try #require(try JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+
+    #expect(global["deleteBranchOnAutomaticWorktreeCleanup"] as? Bool == true)
+    #expect(global["deleteBranchOnDeleteWorktree"] == nil)
   }
 
   @Test(.dependencies) func roundTripsExplicitNotificationSound() throws {


### PR DESCRIPTION
## Summary

- Remember the last confirmed local-branch choice for manual worktree deletion.
- Separate automatic cleanup branch deletion into a disabled-by-default setting.
- Migrate the legacy setting and update user-facing and lifecycle documentation.

## Validation

- Targeted settings and worktree lifecycle tests: 45 passed.
- `make check`
- `make build-app`
- Self-verification with the repo-built `prowl` against a separate debug app instance: temporary tab creation, command execution, and pane readback succeeded; temporary tab and debug app were cleaned up.
