### PR TITLE
Remember manual branch deletion choice and split automatic cleanup setting

### DIFF
--- a/docs-ai/019-worktree-creation-and-lifecycle/000-plan.md
+++ b/docs-ai/019-worktree-creation-and-lifecycle/000-plan.md
@@ -5,7 +5,7 @@
 | **Status** | Implemented (retrospective) |
 | **Anchor date** | 2026-04-12 |
 | **Documented** | 2026-07-12 (backfilled) |
-| **Primary PRs** | #167, #189, #190, #192 (initial wave); later waves #260/#419, #375/#383, #424/#427, #520 |
+| **Primary PRs** | #167, #189, #190, #192 (initial wave); later waves #260/#419, #375/#383, #424/#427, #520, #592 |
 | **Sources** | PR descriptions #167/#189/#190/#192/#260/#375/#383/#419/#424/#427/#520; fork issues #166/#175/#176/#178; `docs-ai/017-upstream-sync-process/upstream-ledger.md` (2026-04-08 and 2026-05-08 review batches) |
 | **Related** | [018-archived-worktrees](../018-archived-worktrees/000-plan.md), [028-pr-status-tracking](../028-pr-status-tracking/000-plan.md), [034-worktree-watcher-correctness](../034-worktree-watcher-correctness/000-plan.md), [044-foundation-model-branch-names](../044-foundation-model-branch-names/000-plan.md), `docs/components/repositories-and-worktrees.md` |
 
@@ -89,3 +89,7 @@ deletion-safety rework, clone-from-URL intake — all later waves (see Amendment
 - Updated 2026-07-12: worktree deletion now verifies Git registration removal and
   propagates cleanup failures (fork issue #454) — see
   [006-verified-worktree-deletion.md](006-verified-worktree-deletion.md)
+- Updated 2026-07-16: manual delete dialog remembers the last confirmed branch choice;
+  automatic-cleanup branch deletion split into `deleteBranchOnAutomaticCleanup` (#592) —
+  see the follow-up section in
+  [003-safe-branch-deletion-and-cleanup.md](003-safe-branch-deletion-and-cleanup.md)

--- a/docs-ai/019-worktree-creation-and-lifecycle/001-action.md
+++ b/docs-ai/019-worktree-creation-and-lifecycle/001-action.md
@@ -16,8 +16,9 @@
 | 2026-06-09 | Visible labels + caption for the Advanced fields (TextField labels are not rendered under `.roundedBorder`) | PR #427 |
 | 2026-06-27 | On-device Foundation Model branch-name suggestion added to the same dialog | PR #518 (owned by [044](../044-foundation-model-branch-names/000-plan.md)) |
 | 2026-06-28 | Add to Prowl popover redesign: drop zone, Browse, Clone-from-URL form with clipboard prefill, Add Workspace; auto-select after add — see [005-add-to-prowl-clone.md](005-add-to-prowl-clone.md) | PR #520 |
+| 2026-07-16 | Manual delete dialog remembers the last confirmed branch choice; automatic-cleanup branch deletion split into `deleteBranchOnAutomaticCleanup` (default off) with legacy-key migration — see the follow-up section in [003-safe-branch-deletion-and-cleanup.md](003-safe-branch-deletion-and-cleanup.md) | PR #592 |
 
-## Outcome & current state (as of 2026-07-12)
+## Outcome & current state (as of 2026-07-16)
 
 - **Git plumbing** — `supacode/Clients/Git/GitClient.swift`: `branchRefs(for:)` returns
   local + upstream refs; `deleteLocalBranch(_:_:force:)` backs both `-d` and confirmed
@@ -48,17 +49,20 @@
   (default `.merge`); `supacode/Features/Settings/Models/MergedWorktreeAction.swift`;
   per-repo optionals in `supacode/Features/Settings/Models/RepositorySettings.swift`.
   UI: `supacode/Features/Settings/Views/WorktreeSettingsView.swift` (merged-action
-  picker, copy-flag toggles, branch-delete toggle),
+  picker, copy-flag toggles, automatic-cleanup branch toggle),
   `GithubSettingsView.swift` (merge strategy), `RepositorySettingsView.swift`
   ("Global (…)" override pickers).
 - **Merged-PR automation** —
   `supacode/Features/Repositories/Reducer/RepositoriesFeature+GithubIntegration.swift`
   switches on `state.mergedWorktreeAction`; `.delete` passes
-  `deleteBranch: deleteBranchOnDeleteWorktree && prowlCreatedWorktreeIDs.contains(id)`.
+  `deleteBranch: deleteBranchOnAutomaticCleanup && prowlCreatedWorktreeIDs.contains(id)`.
 - **Deletion** —
   `supacode/Features/Repositories/Reducer/RepositoriesFeature+WorktreeLifecycle.swift`
-  (delete + `ForceDeleteBranchRequest` flow) and
+  (manual last-choice persistence via `deleteBranchOnManualWorktreeDelete`, delete +
+  `ForceDeleteBranchRequest` flow) and
   `supacode/Features/Repositories/Views/DeleteWorktreeConfirmationView.swift`.
+  Manual confirmation remembers only submitted choices; automatic branch cleanup is
+  separately controlled and restricted to Prowl-created worktrees.
 - **History navigation** — stacks and `navigateWorktreeHistory` in
   `supacode/Features/Repositories/Reducer/RepositoriesFeature.swift` /
   `RepositoriesFeature+Selection.swift` (50-entry cap); menu commands in

--- a/docs-ai/019-worktree-creation-and-lifecycle/003-safe-branch-deletion-and-cleanup.md
+++ b/docs-ai/019-worktree-creation-and-lifecycle/003-safe-branch-deletion-and-cleanup.md
@@ -1,4 +1,4 @@
-# 019 — Amendment: Safe Branch Deletion & Cleanup Hardening (#375, #383; follow-up 2026-07)
+# 019 — Amendment: Safe Branch Deletion & Cleanup Hardening (#375, #383; follow-up #592)
 
 ## Context
 
@@ -32,7 +32,7 @@ PR #383 (merged 2026-06-03, "Harden failed worktree cleanup"):
 - Only relocate existing worktree directories that actually contain `.git` metadata.
 - Failed-creation cleanup no longer requests branch deletion at all.
 
-## Follow-up (2026-07): split manual preselect from automatic cleanup
+## Follow-up (2026-07-16, #592): split manual preselect from automatic cleanup
 
 The single `deleteBranchOnDeleteWorktree` setting from #375 drove two unrelated
 behaviors: preselecting the manual dialog toggle (gated on Prowl-created worktrees)
@@ -62,7 +62,7 @@ Decisions:
 
 ## Refs
 
-- PRs #375, #383; follow-up PR splitting the settings (2026-07); tests in
+- PRs #375, #383; follow-up PR #592 splitting the settings (2026-07-16); tests in
   `supacodeTests/GitClientRemoveWorktreeTests`, `RepositoriesFeatureTests`, and
   `SettingsFilePersistenceTests` (legacy-key migration).
 

--- a/docs-ai/019-worktree-creation-and-lifecycle/003-safe-branch-deletion-and-cleanup.md
+++ b/docs-ai/019-worktree-creation-and-lifecycle/003-safe-branch-deletion-and-cleanup.md
@@ -1,4 +1,4 @@
-# 019 — Amendment: Safe Branch Deletion & Cleanup Hardening (#375, #383)
+# 019 — Amendment: Safe Branch Deletion & Cleanup Hardening (#375, #383; follow-up 2026-07)
 
 ## Context
 
@@ -32,19 +32,51 @@ PR #383 (merged 2026-06-03, "Harden failed worktree cleanup"):
 - Only relocate existing worktree directories that actually contain `.git` metadata.
 - Failed-creation cleanup no longer requests branch deletion at all.
 
+## Follow-up (2026-07): split manual preselect from automatic cleanup
+
+The single `deleteBranchOnDeleteWorktree` setting from #375 drove two unrelated
+behaviors: preselecting the manual dialog toggle (gated on Prowl-created worktrees)
+and enabling branch deletion during automatic cleanup. The Prowl-created gate on the
+*manual* preselect proved too subtle — the checkbox was sometimes checked, sometimes
+not, with no cue in the dialog (it confused even the author). The manual path already
+has three backstops (visible toggle, `git branch -d` safe delete, force-delete
+confirmation), so ownership gating added little safety there. It remains essential on
+the automatic paths, which run with no dialog at all.
+
+Decisions:
+
+- **Manual dialog**: the toggle now simply remembers the last *confirmed* choice
+  (`@Shared(.appStorage("deleteBranchOnManualWorktreeDelete"))`, default off). No
+  settings toggle, no Prowl-created gating. Cancel does not update the memory.
+- **Automatic cleanup** (merged-PR `.delete` action and archived auto-delete expiry):
+  controlled by the new explicit `deleteBranchOnAutomaticCleanup` setting (default
+  off), still additionally gated on `prowlCreatedWorktreeIDs` — Prowl never silently
+  deletes a branch it did not create.
+- **Migration**: decode falls back from `deleteBranchOnAutomaticCleanup` to the legacy
+  `deleteBranchOnDeleteWorktree` key, because an opted-in user's expressed intent
+  included automatic-cleanup branch deletion (the old settings copy said the merged
+  `.delete` action "follows" it); letting it silently reset to off would be a worse
+  surprise than the rename. The manual memory intentionally starts fresh at off — the
+  old semantics ("preselect for Prowl-created only") don't map onto "remember last
+  choice". The legacy key is no longer written.
+
 ## Refs
 
-- PRs #375, #383; tests in `supacodeTests/GitClientRemoveWorktreeTests` and
-  `RepositoriesFeatureTests`.
+- PRs #375, #383; follow-up PR splitting the settings (2026-07); tests in
+  `supacodeTests/GitClientRemoveWorktreeTests`, `RepositoriesFeatureTests`, and
+  `SettingsFilePersistenceTests` (legacy-key migration).
 
 ## Current state
 
 Deletion flow and `ForceDeleteBranchRequest` handling in
-`supacode/Features/Repositories/Reducer/RepositoriesFeature+WorktreeLifecycle.swift`;
-sheet UI in `supacode/Features/Repositories/Views/DeleteWorktreeConfirmationView.swift`;
+`supacode/Features/Repositories/Reducer/RepositoriesFeature+WorktreeLifecycle.swift`
+(manual preselect + remember-on-confirm live here); sheet UI in
+`supacode/Features/Repositories/Views/DeleteWorktreeConfirmationView.swift`;
 `deleteLocalBranch` plus the porcelain-match/`.git`-metadata guards
 (`relocateWorktreeDirectory`) in `supacode/Clients/Git/GitClient.swift`.
 `prowlCreatedWorktreeIDs` is registered on creation in
-`RepositoriesFeature+WorktreeCreation.swift` and consulted in
-`RepositoriesFeature+CoreReducer.swift` / `+GithubIntegration.swift` /
-`+WorktreeLifecycle.swift`.
+`RepositoriesFeature+WorktreeCreation.swift` and consulted by the automatic-cleanup
+paths in `RepositoriesFeature+CoreReducer.swift` / `+GithubIntegration.swift`.
+`deleteBranchOnAutomaticCleanup` (with the legacy-key fallback) lives in
+`supacode/Features/Settings/Models/GlobalSettings.swift`; the settings UI is in
+`WorktreeSettingsView.swift`.

--- a/docs/components/repositories-and-worktrees.md
+++ b/docs/components/repositories-and-worktrees.md
@@ -128,8 +128,8 @@ Deleting removes the worktree directory (and optionally its branch).
 
 - **Right-click** the row → "Delete Worktree", or **`⌘⇧⌫`**.
 - A confirmation dialog offers an **"Also delete local branch"** toggle (its
-  tooltip notes `git branch -d`). Default behavior comes from
-  `deleteBranchOnDeleteWorktree`.
+  tooltip notes `git branch -d`). The toggle remembers the last confirmed choice
+  (`deleteBranchOnManualWorktreeDelete` in UserDefaults; defaults to off).
 - Prowl removes the worktree (relocating + `git worktree prune` if needed), then
   verifies that Git no longer registers it. Cleanup failures keep the worktree
   visible and show Git's error. If branch deletion is rejected because the branch
@@ -198,7 +198,7 @@ list. Highlights:
 - `defaultWorktreeBaseDirectoryPath` / per-repo `worktreeBaseDirectoryPath`
 - per-repo `worktreeBaseRef` (default base branch)
 - `copyIgnoredOnWorktreeCreate`, `copyUntrackedOnWorktreeCreate`
-- `deleteBranchOnDeleteWorktree`, `mergedWorktreeAction`, `archivedAutoDeletePeriod`
+- `deleteBranchOnAutomaticCleanup`, `mergedWorktreeAction`, `archivedAutoDeletePeriod`
 - per-repo `setupScript`, `archiveScript`, `openActionID`, `customTitle`
 
 ## Gotchas for agents

--- a/docs/components/settings.md
+++ b/docs/components/settings.md
@@ -19,7 +19,7 @@ window is a sidebar of tabs plus a detail pane.
 | **General** | Appearance (system/light/dark), default app for opening worktrees, diff tool, confirm-before-quit, default view mode, window chrome tint, toolbar buttons (Run / Open-in-editor), dim unfocused splits, Active Agents panel auto-show & terminal titles. |
 | **Notifications** | In-app alerts, notification sound picker (Never / system sounds / Prowl Classic), macOS system notifications, move-notified-to-top, command-finished notification + threshold, Dock badge & bounce. → [notifications](notifications.md) |
 | **Shortcuts** | Remap app keyboard shortcuts; view defaults; resolve conflicts. → [keyboard-shortcuts](../reference/keyboard-shortcuts.md) |
-| **Worktree** | Worktree creation/deletion defaults: prompt on create, fetch before create, base directory, copy ignored/untracked files, delete-branch-on-delete, merged-worktree action, archived auto-delete period. |
+| **Worktree** | Worktree creation/deletion defaults: prompt on create, fetch before create, base directory, copy ignored/untracked files, automatic local-branch cleanup, merged-worktree action, archived auto-delete period. |
 | **Updates** | Auto-check toggle, "Check for Updates Now". → [updates](updates.md) |
 | **Advanced** | Analytics, crash reports, restore terminal layout on launch (experimental) + clear saved layout, and the **Install Command Line Tool** (`prowl` CLI) action. |
 | **GitHub** | Enable GitHub integration (uses the `gh` CLI). → [github-pull-requests](github-pull-requests.md) |

--- a/docs/reference/settings-fields.md
+++ b/docs/reference/settings-fields.md
@@ -38,7 +38,7 @@ JSON is pretty-printed with sorted keys. Legacy `~/.supacode` is migrated to
 | `analyticsEnabled` | Bool | `true` | Send usage analytics (PostHog; off in Debug). |
 | `crashReportsEnabled` | Bool | `true` | Send crash reports (Sentry). |
 | `githubIntegrationEnabled` | Bool | `true` | Enable GitHub/PR features (via `gh`). |
-| `deleteBranchOnDeleteWorktree` | Bool | `false` | Default "delete branch" when deleting a worktree. |
+| `deleteBranchOnAutomaticCleanup` | Bool | `false` | Delete the local branch when automatic cleanup (merged-PR delete action, archived auto-delete) removes a Prowl-created worktree. Migrates the legacy `deleteBranchOnDeleteWorktree` key. The manual delete dialog is independent: it remembers the last confirmed choice in UserDefaults (`deleteBranchOnManualWorktreeDelete`). |
 | `mergedWorktreeAction` | enum? | `nil` | What to do with a merged worktree (e.g. auto-archive); `nil` = ask. |
 | `promptForWorktreeCreation` | Bool | `true` | Show the creation dialog vs. auto-create. |
 | `fetchOriginBeforeWorktreeCreation` | Bool | `true` | `git fetch` before creating a worktree. |

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+CoreReducer.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+CoreReducer.swift
@@ -136,7 +136,7 @@ extension RepositoriesFeature {
           continue
         }
         let shouldDeleteBranch =
-          settingsFile.global.deleteBranchOnDeleteWorktree
+          settingsFile.global.deleteBranchOnAutomaticCleanup
           && state.prowlCreatedWorktreeIDs.contains(worktree.id)
         deleteEffects.append(
           .send(

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+GithubIntegration.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+GithubIntegration.swift
@@ -290,7 +290,7 @@ extension RepositoriesFeature {
         return .merge(
           mergedWorktreeIDs.map { worktreeID in
             let shouldDeleteBranch =
-              settingsFile.global.deleteBranchOnDeleteWorktree
+              settingsFile.global.deleteBranchOnAutomaticCleanup
               && state.prowlCreatedWorktreeIDs.contains(worktreeID)
             return .send(
               .worktreeLifecycle(

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+WorktreeLifecycle.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+WorktreeLifecycle.swift
@@ -349,6 +349,7 @@ extension RepositoriesFeature {
         return .none
       }
       state.deleteWorktreeConfirmation = nil
+      state.$deleteBranchOnManualWorktreeDelete.withLock { $0 = confirmation.deleteBranch }
       return .merge(
         confirmation.targets.map { target in
           .send(
@@ -560,12 +561,8 @@ private func makeDeleteWorktreeConfirmation(
   targets: [RepositoriesFeature.DeleteWorktreeTarget],
   state: RepositoriesFeature.State
 ) -> DeleteWorktreeConfirmation {
-  @Shared(.settingsFile) var settingsFile
   let count = targets.count
-  let allProwlCreated = targets.allSatisfy { target in
-    state.prowlCreatedWorktreeIDs.contains(target.worktreeID)
-  }
-  let defaultDeleteBranch = settingsFile.global.deleteBranchOnDeleteWorktree && allProwlCreated
+  let defaultDeleteBranch = state.deleteBranchOnManualWorktreeDelete
   if count == 1,
     let target = targets.first,
     let worktree = state.repositories[id: target.repositoryID]?.worktrees[id: target.worktreeID]

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -352,6 +352,9 @@ struct RepositoriesFeature {
     var codeHostByRepositoryID: [Repository.ID: CodeHost] = [:]
     var sidebarSelectedWorktreeIDs: Set<Worktree.ID> = []
     @Shared(.appStorage("prowlCreatedWorktreeIDs")) var prowlCreatedWorktreeIDs: [Worktree.ID] = []
+    /// Last "Also delete local branch" choice confirmed in the manual delete
+    /// dialog; preselects the toggle next time.
+    @Shared(.appStorage("deleteBranchOnManualWorktreeDelete")) var deleteBranchOnManualWorktreeDelete = false
     var nextDeleteWorktreeConfirmationID = 0
     var deleteWorktreeConfirmation: DeleteWorktreeConfirmation?
     var removeWorkspaceConfirmation: RemoveWorkspaceConfirmation?

--- a/supacode/Features/Repositories/Views/DeleteWorktreeConfirmationView.swift
+++ b/supacode/Features/Repositories/Views/DeleteWorktreeConfirmationView.swift
@@ -25,10 +25,13 @@ struct DeleteWorktreeConfirmationView: View {
       )
       .help("Try to delete the local branch with git branch -d after removing the worktree.")
 
-      Text("Protected branches are kept. If safe branch deletion fails, Prowl asks before forcing it.")
-        .font(.footnote)
-        .foregroundStyle(.secondary)
-        .fixedSize(horizontal: false, vertical: true)
+      Text(
+        "Protected branches are kept. If safe branch deletion fails, Prowl asks before forcing it. "
+          + "Your choice is remembered for the next delete."
+      )
+      .font(.footnote)
+      .foregroundStyle(.secondary)
+      .fixedSize(horizontal: false, vertical: true)
 
       HStack {
         Spacer()

--- a/supacode/Features/Settings/Models/GlobalSettings.swift
+++ b/supacode/Features/Settings/Models/GlobalSettings.swift
@@ -14,7 +14,7 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
   var analyticsEnabled: Bool
   var crashReportsEnabled: Bool
   var githubIntegrationEnabled: Bool
-  var deleteBranchOnDeleteWorktree: Bool
+  var deleteBranchOnAutomaticCleanup: Bool
   var mergedWorktreeAction: MergedWorktreeAction?
   var promptForWorktreeCreation: Bool
   var fetchOriginBeforeWorktreeCreation: Bool
@@ -59,7 +59,7 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     analyticsEnabled: true,
     crashReportsEnabled: true,
     githubIntegrationEnabled: true,
-    deleteBranchOnDeleteWorktree: false,
+    deleteBranchOnAutomaticCleanup: false,
     mergedWorktreeAction: nil,
     promptForWorktreeCreation: true,
     fetchOriginBeforeWorktreeCreation: true,
@@ -103,7 +103,7 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     analyticsEnabled: Bool,
     crashReportsEnabled: Bool,
     githubIntegrationEnabled: Bool,
-    deleteBranchOnDeleteWorktree: Bool,
+    deleteBranchOnAutomaticCleanup: Bool,
     mergedWorktreeAction: MergedWorktreeAction? = nil,
     promptForWorktreeCreation: Bool,
     fetchOriginBeforeWorktreeCreation: Bool = true,
@@ -145,7 +145,7 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     self.analyticsEnabled = analyticsEnabled
     self.crashReportsEnabled = crashReportsEnabled
     self.githubIntegrationEnabled = githubIntegrationEnabled
-    self.deleteBranchOnDeleteWorktree = deleteBranchOnDeleteWorktree
+    self.deleteBranchOnAutomaticCleanup = deleteBranchOnAutomaticCleanup
     self.mergedWorktreeAction = mergedWorktreeAction
     self.promptForWorktreeCreation = promptForWorktreeCreation
     self.fetchOriginBeforeWorktreeCreation = fetchOriginBeforeWorktreeCreation
@@ -190,7 +190,7 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     try container.encode(analyticsEnabled, forKey: .analyticsEnabled)
     try container.encode(crashReportsEnabled, forKey: .crashReportsEnabled)
     try container.encode(githubIntegrationEnabled, forKey: .githubIntegrationEnabled)
-    try container.encode(deleteBranchOnDeleteWorktree, forKey: .deleteBranchOnDeleteWorktree)
+    try container.encode(deleteBranchOnAutomaticCleanup, forKey: .deleteBranchOnAutomaticCleanup)
     try container.encodeIfPresent(mergedWorktreeAction, forKey: .mergedWorktreeAction)
     try container.encode(promptForWorktreeCreation, forKey: .promptForWorktreeCreation)
     try container.encode(fetchOriginBeforeWorktreeCreation, forKey: .fetchOriginBeforeWorktreeCreation)
@@ -236,7 +236,7 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     case analyticsEnabled
     case crashReportsEnabled
     case githubIntegrationEnabled
-    case deleteBranchOnDeleteWorktree
+    case deleteBranchOnAutomaticCleanup
     case mergedWorktreeAction
     case promptForWorktreeCreation
     case fetchOriginBeforeWorktreeCreation
@@ -267,6 +267,7 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     // Legacy keys for migration
     case automaticallyArchiveMergedWorktrees
     case notificationSoundEnabled
+    case deleteBranchOnDeleteWorktree
   }
 
   init(from decoder: any Decoder) throws {
@@ -308,9 +309,7 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     githubIntegrationEnabled =
       try container.decodeIfPresent(Bool.self, forKey: .githubIntegrationEnabled)
       ?? Self.default.githubIntegrationEnabled
-    deleteBranchOnDeleteWorktree =
-      try container.decodeIfPresent(Bool.self, forKey: .deleteBranchOnDeleteWorktree)
-      ?? Self.default.deleteBranchOnDeleteWorktree
+    deleteBranchOnAutomaticCleanup = try Self.decodeDeleteBranchOnAutomaticCleanup(from: container)
     mergedWorktreeAction = try Self.decodeMergedWorktreeAction(from: container)
     promptForWorktreeCreation =
       try container.decodeIfPresent(Bool.self, forKey: .promptForWorktreeCreation)
@@ -429,6 +428,21 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
       return legacyEnabled ? Self.default.notificationSound : .never
     }
     return Self.default.notificationSound
+  }
+
+  /// Falls back to the legacy `deleteBranchOnDeleteWorktree` key: users who
+  /// opted into branch deletion before the setting was split keep branch
+  /// deletion during automatic cleanup.
+  private static func decodeDeleteBranchOnAutomaticCleanup(
+    from container: KeyedDecodingContainer<CodingKeys>
+  ) throws -> Bool {
+    if let value = try container.decodeIfPresent(Bool.self, forKey: .deleteBranchOnAutomaticCleanup) {
+      return value
+    }
+    if let legacy = try container.decodeIfPresent(Bool.self, forKey: .deleteBranchOnDeleteWorktree) {
+      return legacy
+    }
+    return Self.default.deleteBranchOnAutomaticCleanup
   }
 
   private static func decodeMergedWorktreeAction(

--- a/supacode/Features/Settings/Reducer/SettingsFeature.swift
+++ b/supacode/Features/Settings/Reducer/SettingsFeature.swift
@@ -21,7 +21,7 @@ struct SettingsFeature {
     var analyticsEnabled: Bool
     var crashReportsEnabled: Bool
     var githubIntegrationEnabled: Bool
-    var deleteBranchOnDeleteWorktree: Bool
+    var deleteBranchOnAutomaticCleanup: Bool
     var mergedWorktreeAction: MergedWorktreeAction?
     var archivedAutoDeletePeriod: AutoDeletePeriod?
     var promptForWorktreeCreation: Bool
@@ -79,7 +79,7 @@ struct SettingsFeature {
       analyticsEnabled = settings.analyticsEnabled
       crashReportsEnabled = settings.crashReportsEnabled
       githubIntegrationEnabled = settings.githubIntegrationEnabled
-      deleteBranchOnDeleteWorktree = settings.deleteBranchOnDeleteWorktree
+      deleteBranchOnAutomaticCleanup = settings.deleteBranchOnAutomaticCleanup
       mergedWorktreeAction = settings.mergedWorktreeAction
       archivedAutoDeletePeriod = settings.archivedAutoDeletePeriod
       promptForWorktreeCreation = settings.promptForWorktreeCreation
@@ -127,7 +127,7 @@ struct SettingsFeature {
         analyticsEnabled: analyticsEnabled,
         crashReportsEnabled: crashReportsEnabled,
         githubIntegrationEnabled: githubIntegrationEnabled,
-        deleteBranchOnDeleteWorktree: deleteBranchOnDeleteWorktree,
+        deleteBranchOnAutomaticCleanup: deleteBranchOnAutomaticCleanup,
         mergedWorktreeAction: mergedWorktreeAction,
         promptForWorktreeCreation: promptForWorktreeCreation,
         fetchOriginBeforeWorktreeCreation: fetchRemoteBeforeWorktreeCreation,
@@ -248,7 +248,7 @@ struct SettingsFeature {
         state.analyticsEnabled = normalizedSettings.analyticsEnabled
         state.crashReportsEnabled = normalizedSettings.crashReportsEnabled
         state.githubIntegrationEnabled = normalizedSettings.githubIntegrationEnabled
-        state.deleteBranchOnDeleteWorktree = normalizedSettings.deleteBranchOnDeleteWorktree
+        state.deleteBranchOnAutomaticCleanup = normalizedSettings.deleteBranchOnAutomaticCleanup
         state.mergedWorktreeAction = normalizedSettings.mergedWorktreeAction
         state.archivedAutoDeletePeriod = normalizedSettings.archivedAutoDeletePeriod
         state.promptForWorktreeCreation = normalizedSettings.promptForWorktreeCreation

--- a/supacode/Features/Settings/Views/WorktreeSettingsView.swift
+++ b/supacode/Features/Settings/Views/WorktreeSettingsView.swift
@@ -72,7 +72,8 @@ struct WorktreeSettingsView: View {
             case .archive:
               Text("Archives worktrees when their pull requests are merged.")
             case .delete:
-              Text("Deletes worktrees when their pull requests are merged. Uncommitted changes will be lost.")
+              Text("Deletes worktrees when their pull requests are merged. ")
+                + Text("Uncommitted changes will be lost.").foregroundStyle(.red)
             case nil:
               EmptyView()
             }

--- a/supacode/Features/Settings/Views/WorktreeSettingsView.swift
+++ b/supacode/Features/Settings/Views/WorktreeSettingsView.swift
@@ -50,14 +50,15 @@ struct WorktreeSettingsView: View {
         Section("Cleanup") {
           VStack(alignment: .leading) {
             Toggle(
-              "Preselect branch deletion for Prowl-created worktrees",
-              isOn: $store.deleteBranchOnDeleteWorktree
+              "Delete local branch during automatic cleanup",
+              isOn: $store.deleteBranchOnAutomaticCleanup
             )
-            .help("Preselect local branch deletion for worktrees created by Prowl.")
-            Text("External worktrees stay unchecked by default. Remote branches must be deleted on GitHub.")
-              .foregroundStyle(.secondary)
-            Text("Uncommitted changes will be lost.")
-              .foregroundStyle(.red)
+            .help("Delete the local branch when automatic cleanup removes a Prowl-created worktree.")
+            Text(
+              "Applies when merged or expired worktrees are cleaned up automatically, and only to branches "
+                + "created by Prowl. The manual delete dialog remembers your last choice instead."
+            )
+            .foregroundStyle(.secondary)
           }
           .frame(maxWidth: .infinity, alignment: .leading)
           Picker(selection: $store.mergedWorktreeAction) {
@@ -71,7 +72,7 @@ struct WorktreeSettingsView: View {
             case .archive:
               Text("Archives worktrees when their pull requests are merged.")
             case .delete:
-              Text("Follows the \"Also delete local branch when deleting a worktree\" option above.")
+              Text("Deletes worktrees when their pull requests are merged. Uncommitted changes will be lost.")
             case nil:
               EmptyView()
             }

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -4114,17 +4114,11 @@ struct RepositoriesFeatureTests {
     }
   }
 
-  @Test(.dependencies) func requestDeleteProwlCreatedWorktreeCanPreselectBranchDeletion() async {
+  @Test(.dependencies) func requestDeleteWorktreePreselectsRememberedBranchChoice() async {
     let worktree = makeWorktree(id: "/tmp/wt", name: "owl")
     let repository = makeRepository(id: "/tmp/repo", worktrees: [worktree])
     let state = makeState(repositories: [repository])
-    state.$prowlCreatedWorktreeIDs.withLock {
-      $0 = [worktree.id]
-    }
-    @Shared(.settingsFile) var settingsFile
-    $settingsFile.withLock {
-      $0.global.deleteBranchOnDeleteWorktree = true
-    }
+    state.$deleteBranchOnManualWorktreeDelete.withLock { $0 = true }
     let store = TestStore(initialState: state) {
       RepositoriesFeature()
     }
@@ -4142,6 +4136,70 @@ struct RepositoriesFeatureTests {
       )
       $0.nextDeleteWorktreeConfirmationID = 1
     }
+  }
+
+  @Test(.dependencies) func deletePromptConfirmedRemembersBranchChoice() async {
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let worktree = makeWorktree(id: "\(repoRoot)/feature", name: "feature", repoRoot: repoRoot)
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree, worktree])
+    var state = makeState(repositories: [repository])
+    state.deleteWorktreeConfirmation = DeleteWorktreeConfirmation(
+      id: 0,
+      title: "Delete worktree?",
+      message: "Delete feature? The worktree directory will be removed.",
+      targets: [
+        RepositoriesFeature.DeleteWorktreeTarget(
+          worktreeID: worktree.id, repositoryID: repository.id)
+      ],
+      deleteBranch: true
+    )
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.gitClient.removeWorktree = { worktree, _ in worktree.workingDirectory }
+      $0.gitClient.deleteLocalBranch = { _, _, _ in .deleted }
+      $0.gitClient.worktrees = { _ in [mainWorktree] }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.worktreeLifecycle(.deleteWorktreePromptConfirmed)) {
+      $0.deleteWorktreeConfirmation = nil
+      $0.$deleteBranchOnManualWorktreeDelete.withLock { $0 = true }
+    }
+    await store.receive(\.worktreeLifecycle.worktreeDeleted)
+  }
+
+  @Test(.dependencies) func deletePromptConfirmedRemembersUncheckedBranchChoice() async {
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let worktree = makeWorktree(id: "\(repoRoot)/feature", name: "feature", repoRoot: repoRoot)
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree, worktree])
+    var state = makeState(repositories: [repository])
+    state.deleteWorktreeConfirmation = DeleteWorktreeConfirmation(
+      id: 0,
+      title: "Delete worktree?",
+      message: "Delete feature? The worktree directory will be removed.",
+      targets: [
+        RepositoriesFeature.DeleteWorktreeTarget(
+          worktreeID: worktree.id, repositoryID: repository.id)
+      ],
+      deleteBranch: false
+    )
+    state.$deleteBranchOnManualWorktreeDelete.withLock { $0 = true }
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.gitClient.removeWorktree = { worktree, _ in worktree.workingDirectory }
+      $0.gitClient.worktrees = { _ in [mainWorktree] }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.worktreeLifecycle(.deleteWorktreePromptConfirmed)) {
+      $0.deleteWorktreeConfirmation = nil
+      $0.$deleteBranchOnManualWorktreeDelete.withLock { $0 = false }
+    }
+    await store.receive(\.worktreeLifecycle.worktreeDeleted)
   }
 
   @Test(.dependencies) func deletePromptConfirmedAsksBeforeForceDeletingBranch() async {
@@ -5496,7 +5554,7 @@ struct RepositoriesFeatureTests {
     state.mergedWorktreeAction = .delete
     @Shared(.settingsFile) var settingsFile
     $settingsFile.withLock {
-      $0.global.deleteBranchOnDeleteWorktree = true
+      $0.global.deleteBranchOnAutomaticCleanup = true
     }
     let store = TestStore(initialState: state) {
       RepositoriesFeature()
@@ -5521,6 +5579,51 @@ struct RepositoriesFeatureTests {
       $0.deletingWorktreeIDs = [externalWorktree.id]
     }
     await store.receive(\.worktreeLifecycle.worktreeDeleted)
+  }
+
+  @Test(.dependencies) func repositoryPullRequestsLoadedAutoDeleteDeletesProwlCreatedBranch() async {
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let prowlWorktree = makeWorktree(
+      id: "\(repoRoot)/feature",
+      name: "feature",
+      repoRoot: repoRoot
+    )
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree, prowlWorktree])
+    var state = makeState(repositories: [repository])
+    state.mergedWorktreeAction = .delete
+    state.$prowlCreatedWorktreeIDs.withLock { $0 = [prowlWorktree.id] }
+    @Shared(.settingsFile) var settingsFile
+    $settingsFile.withLock {
+      $0.global.deleteBranchOnAutomaticCleanup = true
+    }
+    let deletedBranches = LockIsolated<[String]>([])
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.gitClient.removeWorktree = { worktree, _ in worktree.workingDirectory }
+      $0.gitClient.deleteLocalBranch = { branchName, _, force in
+        #expect(force == false)
+        deletedBranches.withValue { $0.append(branchName) }
+        return .deleted
+      }
+    }
+    store.exhaustivity = .off
+    let mergedPullRequest = makePullRequest(state: "MERGED", headRefName: prowlWorktree.name)
+
+    await store.send(
+      .githubIntegration(
+        .repositoryPullRequestsLoaded(
+          repositoryID: repository.id,
+          pullRequestsByWorktreeID: [prowlWorktree.id: mergedPullRequest]
+        ))
+    )
+    await store.receive(\.worktreeLifecycle.deleteWorktreeConfirmed) {
+      $0.deletingWorktreeIDs = [prowlWorktree.id]
+    }
+    await store.receive(\.worktreeLifecycle.worktreeDeleted)
+
+    #expect(deletedBranches.value == [prowlWorktree.name])
   }
 
   @Test func repositoryPullRequestsLoadedSkipsAutoDeleteForMainWorktree() async {
@@ -6662,7 +6765,7 @@ struct RepositoriesFeatureTests {
     state.archivedAutoDeletePeriod = .oneDay
     @Shared(.settingsFile) var settingsFile
     $settingsFile.withLock {
-      $0.global.deleteBranchOnDeleteWorktree = true
+      $0.global.deleteBranchOnAutomaticCleanup = true
     }
     let store = TestStore(initialState: state) {
       RepositoriesFeature()

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -4202,6 +4202,47 @@ struct RepositoriesFeatureTests {
     await store.receive(\.worktreeLifecycle.worktreeDeleted)
   }
 
+  @Test(.dependencies) func dismissingDeletePromptDoesNotRememberChangedChoice() async {
+    let worktree = makeWorktree(id: "/tmp/wt", name: "owl")
+    let repository = makeRepository(id: "/tmp/repo", worktrees: [worktree])
+    let store = TestStore(initialState: makeState(repositories: [repository])) {
+      RepositoriesFeature()
+    }
+
+    await store.send(.worktreeLifecycle(.requestDeleteWorktree(worktree.id, repository.id))) {
+      $0.deleteWorktreeConfirmation = DeleteWorktreeConfirmation(
+        id: 0,
+        title: "Delete worktree?",
+        message: "Delete \(worktree.name)? The worktree directory will be removed.",
+        targets: [
+          RepositoriesFeature.DeleteWorktreeTarget(
+            worktreeID: worktree.id, repositoryID: repository.id)
+        ],
+        deleteBranch: false
+      )
+      $0.nextDeleteWorktreeConfirmationID = 1
+    }
+    await store.send(.worktreeLifecycle(.deleteWorktreePromptDeleteBranchChanged(true))) {
+      $0.deleteWorktreeConfirmation?.deleteBranch = true
+    }
+    await store.send(.worktreeLifecycle(.deleteWorktreePromptDismissed)) {
+      $0.deleteWorktreeConfirmation = nil
+    }
+    await store.send(.worktreeLifecycle(.requestDeleteWorktree(worktree.id, repository.id))) {
+      $0.deleteWorktreeConfirmation = DeleteWorktreeConfirmation(
+        id: 1,
+        title: "Delete worktree?",
+        message: "Delete \(worktree.name)? The worktree directory will be removed.",
+        targets: [
+          RepositoriesFeature.DeleteWorktreeTarget(
+            worktreeID: worktree.id, repositoryID: repository.id)
+        ],
+        deleteBranch: false
+      )
+      $0.nextDeleteWorktreeConfirmationID = 2
+    }
+  }
+
   @Test(.dependencies) func deletePromptConfirmedAsksBeforeForceDeletingBranch() async {
     let repoRoot = "/tmp/repo"
     let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)

--- a/supacodeTests/SettingsFeatureTests.swift
+++ b/supacodeTests/SettingsFeatureTests.swift
@@ -22,7 +22,7 @@ struct SettingsFeatureTests {
       analyticsEnabled: false,
       crashReportsEnabled: true,
       githubIntegrationEnabled: true,
-      deleteBranchOnDeleteWorktree: false,
+      deleteBranchOnAutomaticCleanup: false,
       mergedWorktreeAction: .archive,
       promptForWorktreeCreation: true
     )
@@ -46,7 +46,7 @@ struct SettingsFeatureTests {
       $0.analyticsEnabled = false
       $0.crashReportsEnabled = true
       $0.githubIntegrationEnabled = true
-      $0.deleteBranchOnDeleteWorktree = false
+      $0.deleteBranchOnAutomaticCleanup = false
       $0.mergedWorktreeAction = .archive
       $0.promptForWorktreeCreation = true
     }
@@ -66,7 +66,7 @@ struct SettingsFeatureTests {
       analyticsEnabled: true,
       crashReportsEnabled: false,
       githubIntegrationEnabled: true,
-      deleteBranchOnDeleteWorktree: true,
+      deleteBranchOnAutomaticCleanup: true,
       mergedWorktreeAction: nil,
       promptForWorktreeCreation: false
     )
@@ -92,7 +92,7 @@ struct SettingsFeatureTests {
       analyticsEnabled: initialSettings.analyticsEnabled,
       crashReportsEnabled: initialSettings.crashReportsEnabled,
       githubIntegrationEnabled: initialSettings.githubIntegrationEnabled,
-      deleteBranchOnDeleteWorktree: initialSettings.deleteBranchOnDeleteWorktree,
+      deleteBranchOnAutomaticCleanup: initialSettings.deleteBranchOnAutomaticCleanup,
       mergedWorktreeAction: initialSettings.mergedWorktreeAction,
       promptForWorktreeCreation: initialSettings.promptForWorktreeCreation
     )
@@ -241,7 +241,7 @@ struct SettingsFeatureTests {
       analyticsEnabled: true,
       crashReportsEnabled: false,
       githubIntegrationEnabled: true,
-      deleteBranchOnDeleteWorktree: true,
+      deleteBranchOnAutomaticCleanup: true,
       mergedWorktreeAction: .archive,
       promptForWorktreeCreation: false
     )
@@ -258,7 +258,7 @@ struct SettingsFeatureTests {
       $0.analyticsEnabled = true
       $0.crashReportsEnabled = false
       $0.githubIntegrationEnabled = true
-      $0.deleteBranchOnDeleteWorktree = true
+      $0.deleteBranchOnAutomaticCleanup = true
       $0.mergedWorktreeAction = .archive
       $0.promptForWorktreeCreation = false
       $0.selection = selection

--- a/supacodeTests/SettingsFilePersistenceTests.swift
+++ b/supacodeTests/SettingsFilePersistenceTests.swift
@@ -265,6 +265,17 @@ struct SettingsFilePersistenceTests {
     #expect(settings.global.deleteBranchOnAutomaticCleanup == false)
   }
 
+  @Test func encodesAutomaticCleanupSettingWithoutLegacyKey() throws {
+    var settings = GlobalSettings.default
+    settings.deleteBranchOnAutomaticCleanup = true
+
+    let encoded = try JSONEncoder().encode(settings)
+    let globalDict = try #require(try JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+
+    #expect(globalDict["deleteBranchOnAutomaticCleanup"] as? Bool == true)
+    #expect(globalDict["deleteBranchOnDeleteWorktree"] == nil)
+  }
+
   @Test(.dependencies) func roundTripsExplicitNotificationSound() throws {
     let storage = SettingsTestStorage()
 

--- a/supacodeTests/SettingsFilePersistenceTests.swift
+++ b/supacodeTests/SettingsFilePersistenceTests.swift
@@ -162,7 +162,7 @@ struct SettingsFilePersistenceTests {
     #expect(settings.global.analyticsEnabled == true)
     #expect(settings.global.crashReportsEnabled == true)
     #expect(settings.global.githubIntegrationEnabled == true)
-    #expect(settings.global.deleteBranchOnDeleteWorktree == false)
+    #expect(settings.global.deleteBranchOnAutomaticCleanup == false)
     #expect(settings.global.mergedWorktreeAction == nil)
     #expect(settings.global.promptForWorktreeCreation == true)
     #expect(settings.global.defaultWorktreeBaseDirectoryPath == nil)
@@ -225,6 +225,44 @@ struct SettingsFilePersistenceTests {
     }
 
     #expect(settings.global.mergedWorktreeAction == nil)
+  }
+
+  @Test(.dependencies) func legacyDeleteBranchOnDeleteWorktreeMigratesToAutomaticCleanup() throws {
+    // Files written before the setting was split carry only the legacy key;
+    // an opted-in user keeps branch deletion during automatic cleanup.
+    let encoded = try JSONEncoder().encode(GlobalSettings.default)
+    var globalDict = try #require(try JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+    globalDict.removeValue(forKey: "deleteBranchOnAutomaticCleanup")
+    globalDict["deleteBranchOnDeleteWorktree"] = true
+    let data = try JSONSerialization.data(withJSONObject: ["global": globalDict, "repositories": [:]])
+    let storage = MutableTestStorage(initialData: data)
+
+    let settings: SettingsFile = withDependencies {
+      $0.settingsFileStorage = storage.storage
+    } operation: {
+      @Shared(.settingsFile) var settings: SettingsFile
+      return settings
+    }
+
+    #expect(settings.global.deleteBranchOnAutomaticCleanup == true)
+  }
+
+  @Test(.dependencies) func explicitDeleteBranchOnAutomaticCleanupWinsOverLegacyKey() throws {
+    let encoded = try JSONEncoder().encode(GlobalSettings.default)
+    var globalDict = try #require(try JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+    globalDict["deleteBranchOnAutomaticCleanup"] = false
+    globalDict["deleteBranchOnDeleteWorktree"] = true
+    let data = try JSONSerialization.data(withJSONObject: ["global": globalDict, "repositories": [:]])
+    let storage = MutableTestStorage(initialData: data)
+
+    let settings: SettingsFile = withDependencies {
+      $0.settingsFileStorage = storage.storage
+    } operation: {
+      @Shared(.settingsFile) var settings: SettingsFile
+      return settings
+    }
+
+    #expect(settings.global.deleteBranchOnAutomaticCleanup == false)
   }
 
   @Test(.dependencies) func roundTripsExplicitNotificationSound() throws {


### PR DESCRIPTION
## Summary

Alternative implementation of the same design as #591 — review side by side and keep one.

- Manual delete dialog: the "Also delete local branch" toggle now simply remembers the last **confirmed** choice (`@Shared(.appStorage("deleteBranchOnManualWorktreeDelete"))` on `RepositoriesFeature.State`, default off). No settings toggle, no Prowl-created gating; Cancel does not update the memory.
- Automatic cleanup (merged-PR `.delete` action and archived auto-delete expiry): controlled by the new explicit `deleteBranchOnAutomaticCleanup` setting (default off), still gated on `prowlCreatedWorktreeIDs`.
- Migration: decoding falls back from `deleteBranchOnAutomaticCleanup` to the legacy `deleteBranchOnDeleteWorktree` key so opted-in users keep automatic-cleanup branch deletion; the legacy key is no longer written. Manual memory starts fresh at off.

## Differences from #591

- `@Shared(.appStorage)` lives on `RepositoriesFeature.State` (same idiom as `prowlCreatedWorktreeIDs`), so TestStore asserts the persisted choice directly.
- Delete dialog footnote now notes "Your choice is remembered for the next delete."
- The "Uncommitted changes will be lost" warning moved from the branch toggle to the merged-PR `.delete` picker description — losing uncommitted changes comes from worktree removal, not branch deletion.
- docs-ai: amends the existing `019/003-safe-branch-deletion-and-cleanup.md` instead of adding a new entry file.
- The `docs/components/settings.md` one-liner is updated here too, so coverage matches #591.

## Validation

- `make check`
- `make build-app`
- Targeted suites: `RepositoriesFeatureTests`, `SettingsFeatureTests`, `SettingsFilePersistenceTests` — 268 passed, 0 failed. New tests cover remembered preselect, remember-on-confirm (both directions), automatic-cleanup branch deletion for Prowl-created worktrees, and legacy-key migration/precedence.