### PR TITLE
Add runtime-backed handoff preparation

### DIFF
--- a/ProwlCLI/Commands/HandoffCommand.swift
+++ b/ProwlCLI/Commands/HandoffCommand.swift
@@ -31,12 +31,23 @@ struct HandoffSaveCommand: ParsableCommand {
   @Option(name: .long, help: "Optional note appended to the handoff log.")
   var note: String?
 
+  @Flag(
+    name: .customLong("no-prepare"),
+    help: "Skip asking the detected source agent to refresh current.md before saving."
+  )
+  var noPrepare = false
+
   mutating func run() throws {
     try CLIExecution.run(command: "handoff", output: options.outputMode, colorEnabled: options.colorEnabled) {
       let envelope = CommandEnvelope(
         output: options.outputMode,
         command: .handoff(
-          HandoffInput(action: .save, selector: try selector.resolve(positionalTarget: target), note: note)
+          HandoffInput(
+            action: .save,
+            selector: try selector.resolve(positionalTarget: target),
+            note: note,
+            prepare: !noPrepare
+          )
         )
       )
       try CLIRunner.execute(envelope)
@@ -68,6 +79,12 @@ struct HandoffToCommand: ParsableCommand {
   @Flag(name: .customLong("no-launch"), help: "Archive + save only; do not launch the receiving agent.")
   var noLaunch = false
 
+  @Flag(
+    name: .customLong("no-prepare"),
+    help: "Skip asking the detected source agent to refresh current.md before saving."
+  )
+  var noPrepare = false
+
   mutating func run() throws {
     try CLIExecution.run(command: "handoff", output: options.outputMode, colorEnabled: options.colorEnabled) {
       let rawAgent = agent.lowercased()
@@ -92,7 +109,8 @@ struct HandoffToCommand: ParsableCommand {
             selector: try selector.resolve(positionalTarget: target),
             toAgent: normalizedAgent,
             note: note,
-            launch: !noLaunch
+            launch: !noLaunch,
+            prepare: !noPrepare
           )
         )
       )

--- a/ProwlCLI/Output/OutputRenderer.swift
+++ b/ProwlCLI/Output/OutputRenderer.swift
@@ -301,6 +301,7 @@ enum OutputRenderer {
     case .save:
       lines.append("Handoff \("saved".green.bold)  \("changed:".dim) \(payload.changedFileCount) files")
       lines.append("  \("artifact:".dim) \(payload.artifactPath)")
+      lines.append(contentsOf: renderHandoffPreparation(payload.preparation))
       lines.append(contentsOf: renderHandoffSession(payload.sessionContext))
       lines.append(contentsOf: renderHandoffRepos(payload.repos))
     case .toAgent:
@@ -311,6 +312,7 @@ enum OutputRenderer {
       if let archived = payload.archivedPath {
         lines.append("  \("archived:".dim) \(archived)")
       }
+      lines.append(contentsOf: renderHandoffPreparation(payload.preparation))
       lines.append(contentsOf: renderHandoffSession(payload.sessionContext))
       if let pane = payload.launchedPane {
         lines.append("  \("launched:".dim) \(to.green) → \(pane.paneTitle.green)  \(pane.paneID.dim)")
@@ -321,6 +323,17 @@ enum OutputRenderer {
     }
 
     return lines.joined(separator: "\n")
+  }
+
+  private static func renderHandoffPreparation(_ preparation: String?) -> [String] {
+    guard let preparation else { return [] }
+    let label =
+      switch preparation {
+      case "completed": preparation.green
+      case "failed": preparation.yellow
+      default: preparation.dim
+      }
+    return ["  \("source prep:".dim) \(label)"]
   }
 
   private static func renderHandoffRepos(_ repos: [HandoffRepoPayload]) -> [String] {

--- a/ProwlCLITests/HandoffCommandParsingTests.swift
+++ b/ProwlCLITests/HandoffCommandParsingTests.swift
@@ -12,12 +12,17 @@ final class HandoffCommandParsingTests: XCTestCase {
       .auto("App")
     )
   }
+
   func testSaveRejectsPositionalTargetAlongsideFlagSelector() throws {
     let command = try HandoffSaveCommand.parse(["App", "--worktree", "Other"])
 
     XCTAssertThrowsError(try command.selector.resolve(positionalTarget: command.target))
   }
 
+  func testSaveParsesNoPrepareFlag() throws {
+    XCTAssertFalse(try HandoffSaveCommand.parse(["App"]).noPrepare)
+    XCTAssertTrue(try HandoffSaveCommand.parse(["App", "--no-prepare"]).noPrepare)
+  }
 
   func testToAcceptsPositionalTargetAfterAgent() throws {
     let command = try HandoffToCommand.parse(["claude", "App"])
@@ -27,6 +32,13 @@ final class HandoffCommandParsingTests: XCTestCase {
       try command.selector.resolve(positionalTarget: command.target),
       .auto("App")
     )
+  }
+
+  func testToParsesNoPrepareFlag() throws {
+    let command = try HandoffToCommand.parse(["claude", "App", "--no-prepare", "--no-launch"])
+
+    XCTAssertTrue(command.noPrepare)
+    XCTAssertTrue(command.noLaunch)
   }
 
   func testStatusAcceptsPositionalTarget() throws {

--- a/docs-ai/047-cross-agent-handoff/002-resume-authored-handoff.md
+++ b/docs-ai/047-cross-agent-handoff/002-resume-authored-handoff.md
@@ -25,31 +25,48 @@ preparation request before Prowl saves generated context:
 
 1. Require a detected Claude Code or Codex source with an attached `exact` or `high` confidence
    `AgentSession`. No cwd scan, transcript recency, screen text, or heuristic status can qualify.
-2. Resume that session headlessly through `AgentRuntimeClient` with the target root as cwd. The
-   prompt asks the source agent to update semantic sections in `current.md`, preserve useful notes,
-   leave `context.md`/logs/archives alone, and avoid repository or git mutations.
-3. Record `preparation=completed`, `failed`, or `skipped` in the handoff log. Prowl then performs
-   its normal mechanical save; `to` continues with archive and destination launch.
+2. Resume that session headlessly and **read-only** through `AgentRuntimeClient` with the target
+   root as cwd. The prompt asks the source agent to reply with the complete updated `current.md`
+   document — and nothing else — in a single reply, without running commands or editing files.
+3. Prowl validates the reply (required semantic sections present, not the seeded template, chat
+   preamble and code fences stripped) and transcribes it into `current.md`. An unusable reply or
+   an error leaves the existing artifact untouched.
+4. Record `preparation=completed`, `failed`, or `skipped` on the single `save` log line (or the
+   `to` transition line). Prowl then performs its normal mechanical save; `to` continues with
+   archive and destination launch.
 
-There is deliberately no new `summarize` command, timeout flag, summary payload field, or
-`--no-summary` escape hatch. The existing command surface stays stable. A failed or unavailable
-preparation does not fabricate prose or block the existing manual handoff workflow; the existing
-`current.md` (or scaffold) remains the artifact.
+One resume turn is bounded by a 2-minute timeout (`AgentRuntimeClient.resumeTimeout`); on expiry
+the child process is terminated and preparation is `failed`. `--no-prepare` on `save` and `to`
+skips the source turn entirely — the escape hatch for mechanical refreshes and for agents that
+maintain `current.md` from inside their own session. A failed or unavailable preparation does not
+fabricate prose or block the existing manual handoff workflow.
+
+### Why reply-transcription instead of letting the agent write the file
+
+A standard-mode headless resume usually cannot write files: `claude -p` cannot approve permission
+prompts and `codex exec` may run in a read-only sandbox, so a "please edit current.md" request
+would silently no-op while exiting 0. Having the agent reply with content and Prowl transcribe it
+works in the default safe configuration of both CLIs, needs no permission escalation for the
+resume (dangerous flags are never passed on resume, by construction), and makes
+`preparation=completed` verifiable. The prose remains agent-authored; Prowl only checks shape and
+writes it verbatim.
 
 ## Launch configuration
 
-The same argv observation drives both preparation and the receiving start:
+Argv observation drives the resume model and the receiving start:
 
-- An explicit source `--model` remains only with the same adapter. A Codex model identifier is not
-  passed to Claude Code, and vice versa.
-- An explicitly observed unrestricted source mode maps between the two verified adapters:
-  Codex `--dangerously-bypass-approvals-and-sandbox` and Claude Code
-  `--dangerously-skip-permissions`.
+- An explicit source `--model` remains only with the same adapter: it is reused for the source's
+  own preparation resume, and never passed across vendors on `handoff to`.
+- An explicitly observed unrestricted source mode maps between the two verified adapters for the
+  **destination launch only**: Codex `--dangerously-bypass-approvals-and-sandbox` (or its `--yolo`
+  alias) and Claude Code `--dangerously-skip-permissions` / `--permission-mode bypassPermissions`.
+  The preparation resume itself is always standard-mode.
 - Absence of a flag means unknown source intent. Prowl uses the destination adapter's standard
   configuration rather than assuming a source configuration default.
 
 The Command Palette follows the same path. It captures the selected pane's session and observation,
-prepares the source when safe, persists the artifact, and starts the receiving tab through the
+prepares the source when safe — showing an in-progress toolbar toast during the turn and a warning
+toast if preparation fails — persists the artifact, and starts the receiving tab through the
 adapter rather than a hard-coded shell line.
 
 ## Safety boundaries
@@ -58,9 +75,11 @@ adapter rather than a hard-coded shell line.
 | --- | --- |
 | No source session, ambiguous mapping, or confidence below `high` | Skip automatic preparation; preserve the normal save/archive/launch workflow. |
 | Unsupported source or destination adapter | Skip source preparation; `handoff to` still rejects unsupported interactive launch and supports `--no-launch`. |
-| Resume command exits unsuccessfully | Mark preparation failed in `log.md`; retain existing agent prose and continue mechanical handoff. |
-| Source session resumes successfully | Prowl still never writes semantic prose itself; it saves only generated state to `context.md`. |
-| Cross-agent handoff with source model | Omit the model. Preserve only the verified unrestricted execution intent. |
+| `--no-prepare` | Skip the source turn; mechanical save/archive/launch only. |
+| Resume command exits unsuccessfully or times out (2 min) | Mark preparation failed in `log.md`; retain existing agent prose and continue mechanical handoff. |
+| Reply fails validation (empty, template echo, missing sections) | Same as failure: never overwrite `current.md` with an unusable reply. |
+| Source session resumes successfully | Prowl transcribes the agent's reply verbatim into `current.md`; it never authors semantic prose itself. |
+| Cross-agent handoff with source model | Omit the model. Preserve only the verified unrestricted execution intent, and only for the destination launch. |
 
 This is an identity-safety boundary, not proof that a source conversation has stopped. Prowl does
 not claim to own or fork a live agent session; it issues one headless resume request only when the
@@ -69,32 +88,46 @@ pid-anchored resolver already established a safe session identity.
 ## Implementation
 
 - `AgentRuntimeAdapterRegistry` owns adapter-specific launch observation, structured start/resume
-  invocation creation, and source-to-destination configuration inheritance.
+  invocation creation, and source-to-destination configuration inheritance. `AgentResumeRequest`
+  carries only a same-adapter model — no execution mode — so resume invocations cannot render
+  dangerous flags. Codex resume passes `--output-last-message <reply file>`; Claude Code's `-p`
+  prints the final reply on stdout.
+- `AgentRuntimeClient.resume` returns the reply text (preferring the reply file over stdout),
+  bounded by the 2-minute timeout with child-process termination on expiry.
+- `HandoffStore.preparedArtifact(fromAgentReply:)` normalizes and validates replies;
+  `applyPreparationReply` transcribes them. `HandoffStore.save` takes the preparation outcome and
+  records it on its single log line.
 - `PaneAgentState` retains argv-derived launch observation only while the detected process PID is
   unchanged. This prevents a stale dangerous-mode flag from leaking to a later process.
 - `HandoffCommandHandler` receives the resolved source session and observation, requests
-  preparation before save/archive, and passes `AgentStartRequest` to the composition root.
-- `AgentRuntimeClient` executes preparation through `ShellClient` using direct argv and the target
-  working directory. The tab launcher renders only the destination start invocation.
+  preparation (reply text) before save/archive, transcribes via the store, and passes
+  `AgentStartRequest` to the composition root. `HandoffInput.prepare` carries `--no-prepare`.
 - `TerminalClient` exposes selected-pane session/launch observation for the Command Palette, whose
-  reducer uses the same preparation request and runtime client.
+  reducer uses the same preparation request, runtime client, and transcription path.
 
 ## Verification
 
-- `AgentRuntimeAdapterTests` covers Codex/Claude start and resume argv, explicit unrestricted
-  observation, cross-agent model isolation, same-adapter model inheritance, and direct shell
-  execution through `AgentRuntimeClient`.
+- `AgentRuntimeAdapterTests` covers Codex/Claude start and resume argv (read-only resume, reply
+  file, `--yolo` observation), cross-agent model isolation, same-adapter model inheritance,
+  reply-file preference, direct shell execution, and the resume timeout.
+- `HandoffStoreTests` covers reply validation: fence/preamble stripping, template echo and
+  missing-section rejection, and transcription leaving unusable replies unapplied.
 - `PaneAgentStateTests` covers PID-scoped retention of launch observation.
-- `HandoffCommandHandlerTests` covers verified-source preparation before persistence, preserved
-  source-authored prose, medium-confidence rejection, destination configuration, archive, and
-  launch behavior.
-- `AppFeatureHandoffTests` covers the Command Palette's source preparation, destination argv, and
-  preserved cross-agent execution policy.
+- `HandoffCommandHandlerTests` covers verified-source reply transcription before persistence,
+  unusable-reply failure, `--no-prepare` skip, single-log-line recording, medium-confidence
+  rejection, destination configuration, archive, and launch behavior.
+- `AppFeatureHandoffTests` covers the Command Palette's source preparation with progress/dismiss
+  toasts, reply transcription, destination argv, and preserved cross-agent execution policy.
 
 ## Alternatives and decisions
 
 - **Do not render prose in Prowl.** The source session holds the reasoning that is absent from
-  repository state and terminal excerpts.
+  repository state and terminal excerpts. Transcribing a validated reply verbatim is mechanical
+  persistence, not authorship.
+- **Do not let the resume write files.** File writes require permission escalation in headless
+  mode and make success unverifiable; reply-transcription works in both CLIs' default safe
+  configuration. Rejected: passing `--dangerously-*` flags to the resume, or scoped allow-lists
+  whose semantics differ per CLI version.
 - **Do not add a second session scanner.** The existing pid-anchored resolver rejects ambiguity;
   reintroducing cwd-based matching would reintroduce sibling-pane attribution risk.
 - **Do not block handoff when preparation is unavailable.** A manual, existing `current.md` is

--- a/docs-ai/047-cross-agent-handoff/002-resume-authored-handoff.md
+++ b/docs-ai/047-cross-agent-handoff/002-resume-authored-handoff.md
@@ -2,136 +2,103 @@
 
 | | |
 | --- | --- |
-| **Status** | Planned |
+| **Status** | Implemented |
 | **Anchor date** | 2026-07-18 |
-| **Primary PRs** | #554 (base implementation); follow-up PR unassigned |
-| **Related** | [047 plan](000-plan.md), [045 native-agent-session-detection](../045-native-agent-session-detection/000-plan.md), #473, `docs/components/handoff.md` |
+| **Primary PRs** | #554 (artifact base); follow-up PR unassigned |
+| **Related** | [047 plan](000-plan.md), [048 runtime adapters](../048-agent-runtime-adapters/000-plan.md), [045 native-agent-session-detection](../045-native-agent-session-detection/000-plan.md), #473, `docs/components/handoff.md` |
 
 ## Context
 
-#554 deliberately separates agent-authored semantic state in `current.md` from Prowl-generated
-repository and terminal state in `context.md`. This prevents `save` and background auto-save from
-racing an agent or editor that is updating the handoff prose. It also leaves a material gap: a
-source agent that reaches a handoff point can leave the semantic artifact as a template or stale
-summary.
+#554 separated agent-authored semantic state in `current.md` from Prowl-generated
+repository and terminal state in `context.md`. That preserves ownership, but a handoff command
+could still create or archive a stale template when the outgoing agent had not manually updated it.
 
-The native `AgentSession` resolver introduced by #556 exists partly to enable safe future
-handoff/dispatch operations. Its research records headless resume commands for the two currently
-launchable agents:
+Prowl already attaches a pid-anchored `AgentSession` and detected launch arguments to each pane.
+The runtime-adapter work in [048](../048-agent-runtime-adapters/000-plan.md) provides verified
+direct-argv resume invocations for Claude Code and Codex. This amendment consumes that evidence
+only at the existing handoff boundary.
 
-```bash
-codex exec resume <session-id> "<prompt>"
-claude -p --resume <session-id> "<prompt>"
-```
+## Decision
 
-This amendment turns that capability into a narrow, explicit handoff preparation step. Prowl does
-not generate semantic prose; it asks the source agent, in its own native session, to author the
-artifact before Prowl creates the generated context, archive, and receiving pane.
+`prowl handoff save` and `prowl handoff to <agent>` now make a best-effort, source-authored
+preparation request before Prowl saves generated context:
 
-## Goals
+1. Require a detected Claude Code or Codex source with an attached `exact` or `high` confidence
+   `AgentSession`. No cwd scan, transcript recency, screen text, or heuristic status can qualify.
+2. Resume that session headlessly through `AgentRuntimeClient` with the target root as cwd. The
+   prompt asks the source agent to update semantic sections in `current.md`, preserve useful notes,
+   leave `context.md`/logs/archives alone, and avoid repository or git mutations.
+3. Record `preparation=completed`, `failed`, or `skipped` in the handoff log. Prowl then performs
+   its normal mechanical save; `to` continues with archive and destination launch.
 
-- Make `prowl handoff to <agent>` produce a current, agent-authored `current.md` before it saves,
-  archives, or launches the receiving agent.
-- Expose the same operation explicitly as `prowl handoff summarize [target]` for a human or agent
-  that wants to refresh semantic state without handing work to another agent.
-- Resume only a verified source session for Claude Code or Codex; never derive a session id from
-  cwd, transcript recency, or terminal text.
-- Preserve the #554 ownership boundary: Prowl writes only scaffolding and generated files, while
-  the resumed source agent writes the semantic handoff document.
-- Fail closed: without a verified summary, do not launch a receiving agent unless the caller
-  explicitly opts into the existing manual workflow.
+There is deliberately no new `summarize` command, timeout flag, summary payload field, or
+`--no-summary` escape hatch. The existing command surface stays stable. A failed or unavailable
+preparation does not fabricate prose or block the existing manual handoff workflow; the existing
+`current.md` (or scaffold) remains the artifact.
 
-### Non-goals
+## Launch configuration
 
-- Resuming an active source agent, guessing whether concurrent access to a live session is safe,
-  or using `.working`, `.done`, or `.blocked` screen heuristics as proof that it is safe.
-- General resume, fork, restore, or dispatch support for every detected agent.
-- Reconstructing a semantic handoff from a viewport, terminal scrollback, transcript, or an agent's
-  final response. The native Stop-hook design remains separate in #473.
-- Having Prowl or a local model write the prose on the source agent's behalf.
+The same argv observation drives both preparation and the receiving start:
 
-## Command contract
+- An explicit source `--model` remains only with the same adapter. A Codex model identifier is not
+  passed to Claude Code, and vice versa.
+- An explicitly observed unrestricted source mode maps between the two verified adapters:
+  Codex `--dangerously-bypass-approvals-and-sandbox` and Claude Code
+  `--dangerously-skip-permissions`.
+- Absence of a flag means unknown source intent. Prowl uses the destination adapter's standard
+  configuration rather than assuming a source configuration default.
 
-```bash
-prowl handoff summarize [target] [--timeout <seconds>]
-prowl handoff to <agent> [target] [--no-summary] [--note "…"] [--no-launch]
-```
+The Command Palette follows the same path. It captures the selected pane's session and observation,
+prepares the source when safe, persists the artifact, and starts the receiving tab through the
+adapter rather than a hard-coded shell line.
 
-- `summarize` resolves the target's source pane and makes one bounded headless resume request to
-  the source agent. Its only intended effect is an updated `.prowl/handoff/current.md`.
-- `to` runs `summarize` first by default. On success it retains the existing #554 ordering:
-  `save` → archive → launch receiving pane.
-- `--no-summary` is the explicit escape hatch for the existing manual protocol. It preserves the
-  current `save` → archive → launch behavior when an operator has already authored `current.md`.
-- `save` remains a mechanical refresh and does not spend an agent turn. It continues to seed the
-  template only when needed and update `context.md`, session excerpts, and `log.md`.
-
-## Design / approach
-
-1. Extend the shared handoff input and CLI parser with the `summarize` action, a bounded timeout,
-   and `--no-summary` for `to`. The text and JSON output must report whether semantic preparation
-   ran, the source agent, and an actionable unavailable/failed reason.
-2. Resolve the target through the existing `TargetResolver`, then obtain its already-attached
-   `PaneAgentState.session`. Summary preparation accepts only a source agent with an `exact` or
-   `high` session mapping and a dedicated Claude Code or Codex summary adapter.
-3. Add a source-ownership safety check before resuming. The adapter must refuse when the native
-   session is still owned by a live source process or Prowl cannot prove that headless resume is
-   safe for the installed CLI. Revalidate each agent's resume semantics against the installed CLI
-   during implementation; the 2026-07 research is a command contract, not a substitute for this
-   concurrency check.
-4. `HandoffStore` creates the handoff scaffold if necessary, then records the pre-request artifact
-   state. Run the adapter through an argv-based process invocation with the target root as cwd; do
-   not synthesize terminal input or interpolate the prompt into a shell command.
-5. The source prompt names the absolute target file and requires a complete replacement of the
-   semantic sections: Objective, Current State, What Has Been Done, Open Questions, Risks / Watch
-   Out, Next Steps, and Suggested Prompt For Next Agent. It forbids changing repository files,
-   mutating git state, committing, pushing, or adding secrets.
-6. After the process exits, validate that `current.md` was updated and contains substantive
-   semantic sections rather than the initial template. Only then call the existing `save`, archive,
-   and receiving-launch path. A summary failure leaves the source pane and existing artifact in
-   place, logs a diagnostic event, and returns a handoff error without creating a receiving pane.
-
-The proposed implementation boundary is a small `HandoffSummaryAdapter` selected by agent token,
-used by `HandoffCommandHandler`, and backed by `HandoffStore` validation. `HandoffStore` must not
-become a prose renderer. `ProwlCLI/Commands/HandoffCommand.swift`, shared command/payload models,
-`supacode/CLIService/HandoffCommandHandler.swift`, `supacode/App/supacodeApp.swift`, and
-`docs/components/handoff.md` / `docs/components/cli.md` are the expected touch points.
-
-## Safety and failure semantics
+## Safety boundaries
 
 | Condition | Result |
 | --- | --- |
-| No `AgentSession`, ambiguous session, or confidence below `high` | `summarize` fails; `to` does not launch the receiver. |
-| Unsupported source agent | Same failure; use `--no-summary` only after manually authoring the artifact. |
-| Live-session ownership is not disproven | Refuse to resume. |
-| Headless command times out or exits unsuccessfully | Preserve the existing artifact; do not archive or launch. |
-| `current.md` is unchanged or still only the template | Treat preparation as failed. |
-| Caller passes `--no-summary` | Execute the existing manual handoff contract without a resume request. |
+| No source session, ambiguous mapping, or confidence below `high` | Skip automatic preparation; preserve the normal save/archive/launch workflow. |
+| Unsupported source or destination adapter | Skip source preparation; `handoff to` still rejects unsupported interactive launch and supports `--no-launch`. |
+| Resume command exits unsuccessfully | Mark preparation failed in `log.md`; retain existing agent prose and continue mechanical handoff. |
+| Source session resumes successfully | Prowl still never writes semantic prose itself; it saves only generated state to `context.md`. |
+| Cross-agent handoff with source model | Omit the model. Preserve only the verified unrestricted execution intent. |
+
+This is an identity-safety boundary, not proof that a source conversation has stopped. Prowl does
+not claim to own or fork a live agent session; it issues one headless resume request only when the
+pid-anchored resolver already established a safe session identity.
+
+## Implementation
+
+- `AgentRuntimeAdapterRegistry` owns adapter-specific launch observation, structured start/resume
+  invocation creation, and source-to-destination configuration inheritance.
+- `PaneAgentState` retains argv-derived launch observation only while the detected process PID is
+  unchanged. This prevents a stale dangerous-mode flag from leaking to a later process.
+- `HandoffCommandHandler` receives the resolved source session and observation, requests
+  preparation before save/archive, and passes `AgentStartRequest` to the composition root.
+- `AgentRuntimeClient` executes preparation through `ShellClient` using direct argv and the target
+  working directory. The tab launcher renders only the destination start invocation.
+- `TerminalClient` exposes selected-pane session/launch observation for the Command Palette, whose
+  reducer uses the same preparation request and runtime client.
 
 ## Verification
 
-- Parser and socket integration coverage for `summarize`, `--no-summary`, timeout validation, and
-  output/error payloads.
-- Adapter tests asserting argv construction for Codex and Claude Code without shell interpolation.
-- Handler tests for exact/high acceptance, low/medium/ambiguous rejection, live-source rejection,
-  summary timeout/failure, and the invariant that a failed summary creates no receiving pane or
-  archive.
-- Store tests for template detection and semantic-artifact validation without overwriting agent
-  prose.
-- Manual end-to-end checks against the installed Codex and Claude Code versions: resume a stopped
-  source session, verify the semantic artifact is authored, then verify the receiver starts only
-  after save and archive complete.
+- `AgentRuntimeAdapterTests` covers Codex/Claude start and resume argv, explicit unrestricted
+  observation, cross-agent model isolation, same-adapter model inheritance, and direct shell
+  execution through `AgentRuntimeClient`.
+- `PaneAgentStateTests` covers PID-scoped retention of launch observation.
+- `HandoffCommandHandlerTests` covers verified-source preparation before persistence, preserved
+  source-authored prose, medium-confidence rejection, destination configuration, archive, and
+  launch behavior.
+- `AppFeatureHandoffTests` covers the Command Palette's source preparation, destination argv, and
+  preserved cross-agent execution policy.
 
 ## Alternatives and decisions
 
-- **Resume the source agent, rather than synthesize prose in Prowl.** The source session has the
-  missing reasoning context. Prowl has mechanical state but cannot safely infer decisions, risks,
-  or next steps from a screen snapshot.
-- **Fail closed by default.** Launching a receiver with a blank or stale semantic artifact defeats
-  the feature. `--no-summary` keeps the intentional manual path available without silently
-  weakening the default.
-- **Use exact/high native identity, not a new handoff-local scanner.** #556's pid-anchored resolver
-  already encodes ambiguity and ownership safety. A second cwd-based lookup would reintroduce the
-  sibling-pane attribution bug removed from #554.
-- **Keep Stop hooks separate.** #473 may eventually provide a reliable last assistant message, but
-  that message is not a structured handoff and cannot replace a source-authored summary.
+- **Do not render prose in Prowl.** The source session holds the reasoning that is absent from
+  repository state and terminal excerpts.
+- **Do not add a second session scanner.** The existing pid-anchored resolver rejects ambiguity;
+  reintroducing cwd-based matching would reintroduce sibling-pane attribution risk.
+- **Do not block handoff when preparation is unavailable.** A manual, existing `current.md` is
+  still valuable, and an unavailable resume path must not silently remove the documented
+  `--no-launch` workflow.
+- **Keep Stop hooks separate.** #473 may eventually provide a last assistant message, but that
+  message is neither a safe session identity nor a structured handoff document.

--- a/docs-ai/048-agent-runtime-adapters/000-plan.md
+++ b/docs-ai/048-agent-runtime-adapters/000-plan.md
@@ -157,3 +157,11 @@ or a source model string to another vendor.
   preserves a source model only for same-adapter resumes, maps explicitly
   observed unrestricted execution across Codex and Claude Code, and records
   completion, failure, or skipped preparation in the handoff log.
+- 2026-07-18 (review hardening, same PR): resume became read-only by
+  construction. `AgentResumeRequest` dropped its execution mode and carries only
+  a same-adapter model; the resumed agent replies with the artifact content
+  (Codex `--output-last-message`, Claude Code `-p` stdout) and Prowl validates
+  and transcribes it. `AgentRuntimeClient.resume` returns the reply text and is
+  bounded by a 2-minute timeout with child termination. Codex `--yolo` is
+  recognized as explicit unrestricted observation. Details in
+  [047.002](../047-cross-agent-handoff/002-resume-authored-handoff.md).

--- a/docs-ai/048-agent-runtime-adapters/000-plan.md
+++ b/docs-ai/048-agent-runtime-adapters/000-plan.md
@@ -1,0 +1,159 @@
+# 048 — Agent Runtime Adapters: Plan
+
+| | |
+| --- | --- |
+| **Status** | Implemented |
+| **Anchor date** | 2026-07-18 |
+| **Primary PRs** | Follow-up PR unassigned |
+| **Related** | [045 native-agent-session-detection](../045-native-agent-session-detection/000-plan.md), [047 cross-agent-handoff](../047-cross-agent-handoff/000-plan.md), #473 |
+
+## Background
+
+Prowl currently detects agent identity through `DetectedAgent`, resolves a native session through
+`AgentSessionProfile`, and retains that session in `PaneAgentState`. Those are observation-only
+layers. `AgentSessionProfile` is a static path-parser registry, not a lifecycle adapter.
+
+The handoff launch path has a second, independent list in `HandoffAgentSupport` and hard-codes an
+interactive shell line in `HandoffCommandHandler.kickoff(for:)`. The composition root passes that
+string as `initialInput` to `WorktreeTerminalState.createTab`. This works today for Claude Code and
+Codex, but it cannot build a resume invocation, express an execution policy, safely render argv,
+or evolve into a configurable launch surface.
+
+`ProcessDetection.processArguments(pid:)` already reads a lossless argv array, but
+`ForegroundProcess` keeps only a whitespace-joined `cmdline`. Consequently Prowl cannot distinguish
+an explicitly requested source model or dangerous-mode flag from defaults loaded by agent config.
+
+Installed CLI validation on 2026-07-18 established the v1 command contracts:
+
+```bash
+codex exec resume <session-id> <prompt>
+claude -p --resume <session-id> <prompt>
+```
+
+Both support `--model`. Codex exposes
+`--dangerously-bypass-approvals-and-sandbox`; Claude Code exposes
+`--dangerously-skip-permissions`. Those two flags form the only cross-agent execution-policy
+mapping in this wave.
+
+## Goals
+
+- Introduce one protocol-backed runtime adapter contract for agent launch observation, interactive
+  session start, and headless session resume.
+- Implement Codex and Claude Code adapters with direct argv construction and a testable execution
+  policy model.
+- Expose a stable, cancellable headless-resume operation for a native `AgentSession`; reject
+  unresolved and `medium`-confidence sessions.
+- When `handoff save` or `handoff to` has a safe native source session, resume
+  the source agent headlessly to author `current.md` before Prowl captures and
+  archives generated state.
+- Replace handoff's hard-coded `claude "…"` / `codex "…"` command generation with the adapter
+  contract, including safe shell rendering for a newly created terminal tab.
+- Preserve an explicitly observed unrestricted source mode across Codex ↔ Claude handoff. Keep the
+  target model explicit or same-adapter inherited; never pretend model identifiers are portable
+  across vendors.
+- Leave a configuration boundary that a future handoff panel or repository setting can drive
+  without exposing raw command strings.
+
+### Non-goals
+
+- Supporting start/resume for every detected agent, or inferring compatibility from an unverified
+  CLI executable.
+- Reading agent configuration files or claiming that the absence of a flag proves a safe default.
+- Cross-vendor model-name translation, UI, persistence, or a user-facing mode selector.
+- Resuming a live source process. Source-session ownership and safe handoff sequencing remain the
+  responsibility of the later summary coordinator.
+
+## Design / approach
+
+### Catalog and adapter boundary
+
+Keep the CLI-facing recognized-token catalog separate from runtime execution. The catalog continues
+to identify every `DetectedAgent` token; `AgentRuntimeAdapterRegistry` returns an execution adapter
+only for Claude Code and Codex. The registry, not `HandoffAgentSupport`, is the source of truth for
+whether Prowl can start or resume an agent.
+
+```swift
+protocol AgentRuntimeAdapter: Sendable {
+  var agent: DetectedAgent { get }
+  func observe(arguments: [String]) -> AgentLaunchObservation
+  func makeStartInvocation(_ request: AgentStartRequest) throws -> AgentInvocation
+  func makeResumeInvocation(_ request: AgentResumeRequest) throws -> AgentInvocation
+}
+```
+
+`AgentInvocation` is an executable plus an argv array, never a pre-quoted shell string. It has one
+reviewed POSIX-shell renderer for terminal injection. `AgentRuntimeClient` executes resume
+invocations directly through `ShellClient` and a login-shell PATH lookup, rather than feeding a
+headless command into an interactive terminal.
+
+### Shared runtime configuration
+
+`AgentLaunchConfiguration` separates target-owned configuration from source observation:
+
+- `model: String?` is an agent-specific model id. It can be inherited only when source and target
+  use the same adapter; a cross-agent start uses its target default or later explicit configuration.
+- `executionMode` is `.standard` or `.unrestricted`. `.unrestricted` maps to Codex
+  `--dangerously-bypass-approvals-and-sandbox` and Claude Code
+  `--dangerously-skip-permissions`.
+- `AgentLaunchObservation` marks values as observed only when explicit argv proves them. No
+  dangerous flag means `executionMode` is unknown, not `.standard`, because agent config can alter
+  effective permissions.
+
+A future UI or repository-level handoff rule supplies an explicit `AgentLaunchConfiguration`; the
+runtime adapter remains responsible only for validating and rendering it.
+
+### Detection and inheritance
+
+Promote raw argv onto `ForegroundProcess` and parse it through the adapter during agent detection.
+Store the resulting `AgentLaunchObservation` beside the session in `PaneAgentState`. Handoff uses
+an explicitly observed unrestricted mode for the destination by default. Otherwise it starts the
+destination with its standard adapter configuration. It never propagates a raw source command line
+or a source model string to another vendor.
+
+### Invocation flow
+
+1. `HandoffCommandHandler` produces a handoff prompt, an agent token, and an inherited runtime
+   configuration; it no longer formats a shell command.
+2. The composition root resolves an adapter, builds an `AgentStartRequest`, renders its invocation,
+   and gives the resulting shell line to the existing tab-creation path. Tab creation, cwd choice,
+   focus, and launch-result resolution remain unchanged.
+3. `HandoffCommandHandler` passes a verified source `AgentSession`, a
+   handoff-authoring prompt, and the target cwd to `AgentRuntimeClient.resume`
+   before saving or archiving. The client accepts only `exact` or `high`
+   confidence and runs a direct argv invocation with cancellation propagation.
+4. Unsupported adapters return structured errors. Existing `--no-launch` behavior stays available
+   for detected agents without a runtime adapter.
+
+## Verification
+
+- Test adapters first: Codex and Claude start/resume argv, explicit model selection, unrestricted
+  mapping, and shell quoting for whitespace, quotes, and newline-containing prompts.
+- Test observation separately: explicit model/unrestricted flags are captured; absent flags remain
+  unknown; enabling a dangerous flag without selecting it does not claim unrestricted execution.
+- Test `AgentRuntimeClient` with a recording `ShellClient`: direct argv, cwd, exact/high admission,
+  medium rejection, and propagated command failures.
+- Update handoff handler and app-composition tests to prove the destination tab receives an adapter
+  invocation and an observed unrestricted source maps across Codex and Claude.
+- Run focused Swift tests, CLI smoke/integration tests, `make check`, and `make build-app`; manually
+  verify the installed Codex and Claude versions before the later summary feature consumes resume.
+
+## Alternatives and decisions
+
+- **Do not extend `AgentSessionProfile`.** Session discovery is read-only evidence. Mixing command
+  construction into its filesystem profiles would make every future adapter both harder to audit and
+  harder to test.
+- **Do not store raw shell commands.** A structured executable and argv protects prompt quoting and
+  lets headless and terminal launch use the same adapter result.
+- **Do not infer effective defaults.** Only explicit source argv can safely influence inheritance;
+  defaults may come from user config, policy, or a changing CLI version.
+- **Do not introduce a generic autonomous mode yet.** Codex sandbox/approval combinations and
+  Claude permission modes are not semantically equivalent from `--help` alone. V1 supports only
+  the verified unrestricted mapping; later modes require per-agent evidence and an explicit policy.
+
+## Amendments
+
+- 2026-07-18: [047.002](../047-cross-agent-handoff/002-resume-authored-handoff.md)
+  extends the adapter foundation with source-authored handoff preparation. It
+  preserves a source model only for same-adapter resumes, maps explicitly
+  observed unrestricted execution across Codex and Claude Code, and records
+  completion, failure, or skipped preparation in the handoff log.

--- a/docs-ai/048-agent-runtime-adapters/001-action.md
+++ b/docs-ai/048-agent-runtime-adapters/001-action.md
@@ -28,7 +28,9 @@
   transcribes the reply into `current.md` via `HandoffStore`. One resume turn is bounded by a
   2-minute timeout with child termination; `--no-prepare` skips the turn; `save` records the
   outcome on a single log line; Codex's `--yolo` alias counts as observed unrestricted; the
-  Command Palette shows progress/warning toasts during preparation.
+  Command Palette shows progress/warning toasts during preparation. A validated reply first
+  snapshots the previous edited `current.md` to `archive/<ts>-preparation-backup.md`, so a reply
+  that drops sections never destroys the only copy of earlier notes.
 - Updated the handoff, CLI, and Command Palette documentation with the safety boundary and
   configuration inheritance rules.
 

--- a/docs-ai/048-agent-runtime-adapters/001-action.md
+++ b/docs-ai/048-agent-runtime-adapters/001-action.md
@@ -1,0 +1,40 @@
+# 048 — Agent Runtime Adapters: Action
+
+| | |
+| --- | --- |
+| **Status** | Completed |
+| **Anchor date** | 2026-07-18 |
+| **Primary PRs** | Follow-up PR unassigned |
+| **Plan** | [000-plan.md](000-plan.md) |
+| **Related** | [047.002 resume-authored handoff](../047-cross-agent-handoff/002-resume-authored-handoff.md) |
+
+## Delivered
+
+- Added `AgentRuntimeAdapter`, `AgentRuntimeAdapterRegistry`, structured start/resume requests,
+  `AgentInvocation`, and `AgentRuntimeClient`.
+- Implemented verified Codex and Claude Code adapters. Start input is shell-rendered only at the
+  existing terminal-tab boundary; headless resume runs direct argv through `ShellClient`.
+- Promoted lossless process argv to `ForegroundProcess`, derived explicit model/unrestricted launch
+  observations during detection, and retained each observation only for the same PID.
+- Replaced handoff's hard-coded interactive shell strings with `AgentStartRequest`. Handoff now
+  inherits only portable source intent: an explicitly observed unrestricted mode crosses between
+  Codex and Claude Code, while a model remains same-adapter only.
+- Added source-authored preparation to `handoff save`, `handoff to`, and the Command Palette. An
+  exact/high source session is resumed before Prowl saves generated context; completion, failure,
+  and skipped preparation are recorded in `log.md`.
+- Updated the handoff, CLI, and Command Palette documentation with the safety boundary and
+  configuration inheritance rules.
+
+## Verification
+
+- `make check`
+- Focused `xcodebuild test` selection covering `AgentRuntimeAdapterTests`, PID-scoped launch
+  observation, `HandoffCommandHandlerTests`, and Command Palette source preparation: 21 passed.
+- `make build-app`: Debug macOS app built successfully with zero warnings.
+
+## Deliberate limits
+
+Only Claude Code and Codex have verified runtime adapters. Prowl never infers an execution policy
+from an absent argv flag, never passes a model identifier across those agent families, and never
+falls back to a cwd-based session scan. Unsupported detected agents remain available through
+`handoff to --no-launch`.

--- a/docs-ai/048-agent-runtime-adapters/001-action.md
+++ b/docs-ai/048-agent-runtime-adapters/001-action.md
@@ -21,20 +21,31 @@
   Codex and Claude Code, while a model remains same-adapter only.
 - Added source-authored preparation to `handoff save`, `handoff to`, and the Command Palette. An
   exact/high source session is resumed before Prowl saves generated context; completion, failure,
-  and skipped preparation are recorded in `log.md`.
+  and skipped preparation are recorded in `log.md` and the CLI payload's `preparation` field.
+- Review hardening (same PR): the preparation resume is read-only by construction —
+  `AgentResumeRequest` carries no execution mode, the source agent replies with the document
+  (Codex via `--output-last-message`, Claude Code via `-p` stdout), and Prowl validates and
+  transcribes the reply into `current.md` via `HandoffStore`. One resume turn is bounded by a
+  2-minute timeout with child termination; `--no-prepare` skips the turn; `save` records the
+  outcome on a single log line; Codex's `--yolo` alias counts as observed unrestricted; the
+  Command Palette shows progress/warning toasts during preparation.
 - Updated the handoff, CLI, and Command Palette documentation with the safety boundary and
   configuration inheritance rules.
 
 ## Verification
 
 - `make check`
-- Focused `xcodebuild test` selection covering `AgentRuntimeAdapterTests`, PID-scoped launch
-  observation, `HandoffCommandHandlerTests`, and Command Palette source preparation: 21 passed.
+- Focused `xcodebuild test` selection covering `AgentRuntimeAdapterTests` (argv, reply file,
+  timeout), `HandoffStoreTests` (reply validation/transcription), PID-scoped launch observation,
+  `HandoffCommandHandlerTests` (transcription, `--no-prepare`, unusable replies), and Command
+  Palette source preparation with toasts: 63 passed.
+- `make build-cli`, `make test-cli-smoke`, `make test-cli-integration` (63 passed) for the
+  `--no-prepare` flag and payload changes.
 - `make build-app`: Debug macOS app built successfully with zero warnings.
 
 ## Deliberate limits
 
 Only Claude Code and Codex have verified runtime adapters. Prowl never infers an execution policy
-from an absent argv flag, never passes a model identifier across those agent families, and never
-falls back to a cwd-based session scan. Unsupported detected agents remain available through
-`handoff to --no-launch`.
+from an absent argv flag, never passes a model identifier across those agent families, never
+escalates permissions for a headless resume, and never falls back to a cwd-based session scan.
+Unsupported detected agents remain available through `handoff to --no-launch`.

--- a/docs-ai/README.md
+++ b/docs-ai/README.md
@@ -99,3 +99,4 @@ agent-facing manual for that).
 | 045 | [native-agent-session-detection](045-native-agent-session-detection/000-plan.md) | 2026-07-12 | Native agent session identity (successor to 030's heuristics) |
 | 046 | [cli-short-handles](046-cli-short-handles/000-plan.md) | 2026-07-13 | Session-scoped tab and pane handles for CLI targeting |
 | 047 | [cross-agent-handoff](047-cross-agent-handoff/000-plan.md) | 2026-07-17 | Durable artifact-based task handoff across coding agents |
+| 048 | [agent-runtime-adapters](048-agent-runtime-adapters/000-plan.md) | 2026-07-18 | Protocol-backed agent session resume and configurable launch invocations |

--- a/docs/components/cli.md
+++ b/docs/components/cli.md
@@ -258,19 +258,25 @@ prowl handoff to <agent> [target] [--note "…"] [--no-launch]
 prowl handoff status     [target]
 ```
 
-- **`save`** — refresh `.prowl/handoff/context.md` from live git state (per-repo
+- **`save`** — when Prowl has an exact or high-confidence native session for
+  the detected outgoing Claude Code or Codex process, it first resumes that
+  session non-interactively and asks it to update agent-authored `current.md`.
+  It then refreshes `.prowl/handoff/context.md` from live git state (per-repo
   branch + change counts, changed-file list, detected outgoing agent, and
-  captured session excerpt) and append a line to `.prowl/handoff/log.md`.
-  `current.md` contains agent-authored prose and is seeded from a template on the
-  first run; later saves never rewrite it.
-- **`to <agent>`** — `save`, then archive the current artifact to
-  `.prowl/handoff/archive/<ts>-<from>-to-<to>.md`, then launch the receiving
-  agent in a **new tab** whose kickoff prompt points it at
-  `.prowl/handoff/current.md` and generated `context.md`. Returns the launched `pane`. `--no-launch`
-  archives + saves only (you take over manually). Interactive launch is verified
-  for `claude` and `codex`; `--no-launch` accepts the full detected-agent list:
-  `pi`, `claude`, `codex`, `gemini`, `cursor-agent`, `cline`, `opencode`,
-  `copilot`, `kimi`, `droid`, `amp`, `qwen`, `grok`.
+  captured session excerpt). The log records whether source preparation
+  completed, failed, or was skipped. `current.md` is seeded from a template on
+  the first run; Prowl never directly rewrites it later.
+- **`to <agent>`** — performs the same safe source preparation, saves, archives
+  the current artifact to `.prowl/handoff/archive/<ts>-<from>-to-<to>.md`, and
+  launches the receiving agent in a **new tab** with a semantic kickoff prompt
+  for `current.md` and generated `context.md`. Returns the launched `pane`.
+  An observed unrestricted source execution policy is translated between the
+  verified Claude Code and Codex adapters; model identifiers remain with their
+  original agent family. `--no-launch` still prepares, archives, and saves.
+  Interactive launch is verified for `claude` and `codex`; `--no-launch`
+  accepts the full detected-agent list: `pi`, `claude`, `codex`, `gemini`,
+  `cursor-agent`, `cline`, `opencode`, `copilot`, `kimi`, `droid`, `amp`,
+  `qwen`, `grok`.
 - **`status`** — report the artifact path, whether it exists, the agent
   currently detected in the target, and the last handoff-log line.
 
@@ -286,7 +292,9 @@ The outgoing agent is whatever Prowl detects in the target's pane (see
 the generated excerpt path plus native `session_id` / `transcript_path` only when
 the selected pane already has unambiguous native-session evidence (the same
 identity exposed by `prowl agents`). When no session is resolved, Prowl keeps the
-terminal excerpt and omits native metadata. Full feature guide:
+terminal excerpt and omits native metadata. Unsafe or ambiguous native sessions
+are never resumed: source preparation is skipped and any existing `current.md`
+(or its template) remains the durable artifact. Full feature guide:
 [handoff](handoff.md).
 
 The generated `.prowl/handoff/` directory contains its own `.gitignore`, so its

--- a/docs/components/cli.md
+++ b/docs/components/cli.md
@@ -253,26 +253,30 @@ launch the receiving agent. Centred on [workspaces](workspaces.md), but works fo
 any runnable target. Three subcommands:
 
 ```bash
-prowl handoff save       [target] [--note "…"]              # refresh context + session excerpt
-prowl handoff to <agent> [target] [--note "…"] [--no-launch]
+prowl handoff save       [target] [--note "…"] [--no-prepare]   # refresh context + session excerpt
+prowl handoff to <agent> [target] [--note "…"] [--no-launch] [--no-prepare]
 prowl handoff status     [target]
 ```
 
 - **`save`** — when Prowl has an exact or high-confidence native session for
   the detected outgoing Claude Code or Codex process, it first resumes that
-  session non-interactively and asks it to update agent-authored `current.md`.
-  It then refreshes `.prowl/handoff/context.md` from live git state (per-repo
-  branch + change counts, changed-file list, detected outgoing agent, and
-  captured session excerpt). The log records whether source preparation
-  completed, failed, or was skipped. `current.md` is seeded from a template on
-  the first run; Prowl never directly rewrites it later.
+  session non-interactively (read-only, bounded to 2 minutes) and asks it to
+  **reply** with the updated agent-authored `current.md`; Prowl validates the
+  reply and transcribes it into the file. It then refreshes
+  `.prowl/handoff/context.md` from live git state (per-repo branch + change
+  counts, changed-file list, detected outgoing agent, and captured session
+  excerpt). The single `save` log line records whether source preparation
+  completed, failed, or was skipped. `--no-prepare` skips the source turn for a
+  fast mechanical refresh. `current.md` is seeded from a template on the first
+  run; Prowl only rewrites it to transcribe a validated preparation reply.
 - **`to <agent>`** — performs the same safe source preparation, saves, archives
   the current artifact to `.prowl/handoff/archive/<ts>-<from>-to-<to>.md`, and
   launches the receiving agent in a **new tab** with a semantic kickoff prompt
   for `current.md` and generated `context.md`. Returns the launched `pane`.
   An observed unrestricted source execution policy is translated between the
-  verified Claude Code and Codex adapters; model identifiers remain with their
-  original agent family. `--no-launch` still prepares, archives, and saves.
+  verified Claude Code and Codex adapters for the destination launch only;
+  model identifiers remain with their original agent family. `--no-launch`
+  still prepares, archives, and saves; `--no-prepare` skips the source turn.
   Interactive launch is verified for `claude` and `codex`; `--no-launch`
   accepts the full detected-agent list: `pi`, `claude`, `codex`, `gemini`,
   `cursor-agent`, `cline`, `opencode`, `copilot`, `kimi`, `droid`, `amp`,
@@ -288,7 +292,8 @@ prowl handoff save --note "ui done, api next" --json
 The outgoing agent is whatever Prowl detects in the target's pane (see
 `pane.agent` in [`list`](#prowl-list)). Response payload includes `action`,
 `artifact_path`, `outgoing_agent`, `to_agent`, `repos`, `changed_file_count`,
-`archived_path`, `session_context`, and `launched_pane`. `session_context` includes
+`archived_path`, `session_context`, `preparation` (`completed` / `failed` /
+`skipped`, for `save` and `to`), and `launched_pane`. `session_context` includes
 the generated excerpt path plus native `session_id` / `transcript_path` only when
 the selected pane already has unambiguous native-session evidence (the same
 identity exposed by `prowl agents`). When no session is resolved, Prowl keeps the

--- a/docs/components/command-palette.md
+++ b/docs/components/command-palette.md
@@ -45,8 +45,11 @@ selected worktree has a pull request).
   Line Tool**, Repo Settings.
 - **Custom commands:** your per-repo Custom Commands appear here too.
 - **Handoff** (every runnable workspace, repository/worktree, or plain folder):
-  **Hand off → Claude Code** / **Hand off → Codex** refresh + archive the handoff
-  artifact and launch the receiving agent in a new tab. See [handoff](handoff.md).
+  **Hand off → Claude Code** / **Hand off → Codex** safely resumes the outgoing
+  native session to update agent-authored notes when available, then refreshes,
+  archives, and launches the receiving agent in a new tab. An
+  observed unrestricted execution policy carries across the verified adapters;
+  cross-agent model identifiers do not. See [handoff](handoff.md).
 - **Debug** (Debug builds only): toast/update/dock simulations.
 
 ## Behavior notes

--- a/docs/components/command-palette.md
+++ b/docs/components/command-palette.md
@@ -46,10 +46,12 @@ selected worktree has a pull request).
 - **Custom commands:** your per-repo Custom Commands appear here too.
 - **Handoff** (every runnable workspace, repository/worktree, or plain folder):
   **Hand off → Claude Code** / **Hand off → Codex** safely resumes the outgoing
-  native session to update agent-authored notes when available, then refreshes,
-  archives, and launches the receiving agent in a new tab. An
-  observed unrestricted execution policy carries across the verified adapters;
-  cross-agent model identifiers do not. See [handoff](handoff.md).
+  native session read-only to collect updated agent-authored notes when
+  available — a toolbar progress toast shows while the source agent writes its
+  summary — then refreshes, archives, and launches the receiving agent in a new
+  tab. An observed unrestricted execution policy carries across the verified
+  adapters for the destination launch; cross-agent model identifiers do not.
+  See [handoff](handoff.md).
 - **Debug** (Debug builds only): toast/update/dock simulations.
 
 ## Behavior notes

--- a/docs/components/handoff.md
+++ b/docs/components/handoff.md
@@ -39,8 +39,10 @@ repository's root `.gitignore` is required.
 
 `current.md` contains only agent-authored prose: `Objective`, `Current State`,
 `What Has Been Done`, `Open Questions`, `Risks`, `Next Steps`, and
-`Suggested Prompt For Next Agent`. The outgoing agent maintains these sections;
-Prowl creates the template but never rewrites this file during a save.
+`Suggested Prompt For Next Agent`. When Prowl has an exact or high-confidence
+native session for a supported outgoing agent, `handoff save` and `handoff to`
+resume that agent non-interactively and ask it to update these sections first.
+Prowl creates the template but never directly rewrites `current.md` during a save.
 
 `context.md` contains the detected outgoing agent, a pointer to the captured
 session excerpt, each repo's branch and change counts, and the changed files.
@@ -82,13 +84,20 @@ prowl handoff to <agent> [target] [--note "…"] [--no-launch]
 prowl handoff status     [target]
 ```
 
-- **`save`** refreshes generated context from live git state and logs a line.
-- **`to <agent>`** does `save`, archives the current artifact, then launches the
-  receiving agent in a **new tab** whose kickoff prompt points it at
-  `.prowl/handoff/current.md` and `.prowl/handoff/context.md`. Interactive launch
-  is verified for `claude` and `codex`. `--no-launch` archives + saves only and accepts the full detected-agent
-  token list: `pi`, `claude`, `codex`, `gemini`, `cursor-agent`, `cline`,
-  `opencode`, `copilot`, `kimi`, `droid`, `amp`, `qwen`, `grok`.
+- **`save`** first asks the detected outgoing Claude Code or Codex session to
+  update `current.md` when its native session identity is exact or high
+  confidence. It then refreshes generated context from live git state and logs
+  whether preparation completed, failed, or was skipped.
+- **`to <agent>`** follows the same preparation path, then saves, archives the
+  current artifact, and launches the receiving agent in a **new tab** with a
+  semantic kickoff prompt for `current.md` and `context.md`. Interactive launch
+  is verified for `claude` and `codex`. When Prowl observed the outgoing launch,
+  it preserves an explicit unrestricted execution policy across those adapters;
+  model identifiers stay with the same agent family and are never translated
+  between Codex and Claude Code. `--no-launch` still prepares, archives, and
+  saves; it accepts the full detected-agent token list: `pi`, `claude`, `codex`,
+  `gemini`, `cursor-agent`, `cline`, `opencode`, `copilot`, `kimi`, `droid`,
+  `amp`, `qwen`, `grok`.
 - **`status`** reports the artifact path, whether it exists, the detected current
   agent, and the last log line.
 
@@ -106,8 +115,9 @@ for targets that have never run `prowl handoff save` or `prowl handoff to`.
 
 For any selected workspace, git repository, worktree, or plain folder, the
 Command Palette (`⌘P`) offers **Hand off → Claude Code** and **Hand off → Codex**.
-Selecting one refreshes + archives the handoff artifact and launches the
-receiving agent in a new tab — the GUI equivalent of `prowl handoff to`.
+It runs the same source-session preparation when safe, refreshes + archives the
+artifact, and starts the receiving agent in a new tab using the same adapter
+configuration rules as `prowl handoff to`.
 
 ## Safety
 
@@ -116,11 +126,15 @@ receiving agent in a new tab — the GUI equivalent of `prowl handoff to`.
 - Auto-save uses the same read-only `save` path and only updates targets with an
   existing `.prowl/handoff/current.md`.
 - Save writes generated state only to `context.md`; after scaffolding it never
-  rewrites agent-authored `current.md`.
+  directly rewrites agent-authored `current.md`. Source preparation is an
+  explicit instruction to the detected agent, not a Prowl prose overwrite.
 - `to` only **adds** a tab; it never closes the outgoing agent's session, so you
   can still read or roll back from it.
 - It always saves + archives **before** launching, so a fresh artifact exists even
   if the launch is interrupted.
+- Automatic source preparation is skipped when Prowl cannot prove an exact or
+  high-confidence native session, or when the agent has no verified resume
+  adapter. The existing artifact/template still remains usable.
 - Keep secrets/tokens out of the handoff file (the protocol asks agents not to
   write them).
 - `.prowl/handoff/` is self-ignoring; session excerpts can contain terminal
@@ -131,7 +145,8 @@ receiving agent in a new tab — the GUI equivalent of `prowl handoff to`.
 - Workspaces aggregate generated context across their child repositories. A
   regular repository or worktree covers just that repo; a plain folder omits git
   branch and diff details.
-- The artifact's prose is only as good as what the outgoing agent wrote — the
-  protocol in `AGENTS.md`/`CLAUDE.md` is what keeps it honest.
-- Launching uses the interactive agent (so you can step in); don't use
+- If no safe native source session is available, Prowl skips automatic
+  preparation rather than guessing which agent conversation to resume. Update
+  `current.md` manually in that case.
+- Launching uses the interactive receiving agent (so you can step in); don't use
   `--capture` against it — read its screen with `prowl read --wait-stable`.

--- a/docs/components/handoff.md
+++ b/docs/components/handoff.md
@@ -41,8 +41,11 @@ repository's root `.gitignore` is required.
 `What Has Been Done`, `Open Questions`, `Risks`, `Next Steps`, and
 `Suggested Prompt For Next Agent`. When Prowl has an exact or high-confidence
 native session for a supported outgoing agent, `handoff save` and `handoff to`
-resume that agent non-interactively and ask it to update these sections first.
-Prowl creates the template but never directly rewrites `current.md` during a save.
+first resume that agent in a read-only, non-interactive turn and ask it to
+**reply** with the updated document; Prowl validates the reply (required
+sections present, not the seeded template) and transcribes it into `current.md`.
+The prose is always the agent's — Prowl never authors semantic content, it only
+seeds the template and transcribes validated replies.
 
 `context.md` contains the detected outgoing agent, a pointer to the captured
 session excerpt, each repo's branch and change counts, and the changed files.
@@ -79,25 +82,31 @@ step — the receiving agent then opens in a new tab pointed at the artifact.
 ## The `prowl handoff` command
 
 ```bash
-prowl handoff save       [target] [--note "…"]              # refresh context + session excerpt + log
-prowl handoff to <agent> [target] [--note "…"] [--no-launch]
+prowl handoff save       [target] [--note "…"] [--no-prepare]   # refresh context + session excerpt + log
+prowl handoff to <agent> [target] [--note "…"] [--no-launch] [--no-prepare]
 prowl handoff status     [target]
 ```
 
 - **`save`** first asks the detected outgoing Claude Code or Codex session to
-  update `current.md` when its native session identity is exact or high
-  confidence. It then refreshes generated context from live git state and logs
-  whether preparation completed, failed, or was skipped.
+  reply with an updated `current.md` when its native session identity is exact
+  or high confidence; Prowl validates and transcribes the reply. The resume is
+  read-only (no permission flags) and bounded to **2 minutes** — a stalled or
+  unusable reply is logged as `preparation=failed` and the existing artifact
+  stays in place. It then refreshes generated context from live git state and
+  logs one `save` line recording whether preparation completed, failed, or was
+  skipped. `--no-prepare` skips the source turn entirely for a fast mechanical
+  refresh (use it when the outgoing agent already maintains `current.md`
+  itself, e.g. from inside its own session).
 - **`to <agent>`** follows the same preparation path, then saves, archives the
   current artifact, and launches the receiving agent in a **new tab** with a
   semantic kickoff prompt for `current.md` and `context.md`. Interactive launch
   is verified for `claude` and `codex`. When Prowl observed the outgoing launch,
-  it preserves an explicit unrestricted execution policy across those adapters;
-  model identifiers stay with the same agent family and are never translated
-  between Codex and Claude Code. `--no-launch` still prepares, archives, and
-  saves; it accepts the full detected-agent token list: `pi`, `claude`, `codex`,
-  `gemini`, `cursor-agent`, `cline`, `opencode`, `copilot`, `kimi`, `droid`,
-  `amp`, `qwen`, `grok`.
+  it preserves an explicit unrestricted execution policy across those adapters
+  for the **destination launch only**; model identifiers stay with the same
+  agent family and are never translated between Codex and Claude Code.
+  `--no-launch` still prepares, archives, and saves; it accepts the full
+  detected-agent token list: `pi`, `claude`, `codex`, `gemini`, `cursor-agent`,
+  `cline`, `opencode`, `copilot`, `kimi`, `droid`, `amp`, `qwen`, `grok`.
 - **`status`** reports the artifact path, whether it exists, the detected current
   agent, and the last log line.
 
@@ -115,9 +124,11 @@ for targets that have never run `prowl handoff save` or `prowl handoff to`.
 
 For any selected workspace, git repository, worktree, or plain folder, the
 Command Palette (`⌘P`) offers **Hand off → Claude Code** and **Hand off → Codex**.
-It runs the same source-session preparation when safe, refreshes + archives the
-artifact, and starts the receiving agent in a new tab using the same adapter
-configuration rules as `prowl handoff to`.
+It runs the same source-session preparation when safe — showing a progress toast
+in the toolbar while the source agent writes its summary — then refreshes +
+archives the artifact and starts the receiving agent in a new tab using the same
+adapter configuration rules as `prowl handoff to`. If preparation fails, a
+warning toast notes the handoff continued with the existing notes.
 
 ## Safety
 
@@ -125,16 +136,21 @@ configuration rules as `prowl handoff to`.
   git state (`status` / `diff --stat`).
 - Auto-save uses the same read-only `save` path and only updates targets with an
   existing `.prowl/handoff/current.md`.
-- Save writes generated state only to `context.md`; after scaffolding it never
-  directly rewrites agent-authored `current.md`. Source preparation is an
-  explicit instruction to the detected agent, not a Prowl prose overwrite.
+- Save writes generated state only to `context.md`; the only time Prowl touches
+  `current.md` after scaffolding is to transcribe a validated preparation reply
+  authored by the source agent itself.
+- The preparation resume is **read-only by construction**: it never passes
+  `--dangerously-*` flags, regardless of how the source session was launched.
+  Unrestricted-mode inheritance applies only to the interactive destination
+  launch of `handoff to`.
 - `to` only **adds** a tab; it never closes the outgoing agent's session, so you
   can still read or roll back from it.
 - It always saves + archives **before** launching, so a fresh artifact exists even
   if the launch is interrupted.
 - Automatic source preparation is skipped when Prowl cannot prove an exact or
-  high-confidence native session, or when the agent has no verified resume
-  adapter. The existing artifact/template still remains usable.
+  high-confidence native session, when the agent has no verified resume
+  adapter, or when `--no-prepare` is passed. A reply that fails validation is
+  recorded as `preparation=failed` and never overwrites the existing artifact.
 - Keep secrets/tokens out of the handoff file (the protocol asks agents not to
   write them).
 - `.prowl/handoff/` is self-ignoring; session excerpts can contain terminal

--- a/docs/components/handoff.md
+++ b/docs/components/handoff.md
@@ -30,6 +30,7 @@ Everything lives under the target's `.prowl/handoff/` directory:
   context.md            Prowl-generated repository and session state
   log.md                append-only handoff history
   archive/<ts>-<from>-to-<to>.md
+  archive/<ts>-preparation-backup.md
   sessions/<ts>-<pane>.md
 ```
 
@@ -44,8 +45,11 @@ native session for a supported outgoing agent, `handoff save` and `handoff to`
 first resume that agent in a read-only, non-interactive turn and ask it to
 **reply** with the updated document; Prowl validates the reply (required
 sections present, not the seeded template) and transcribes it into `current.md`.
-The prose is always the agent's — Prowl never authors semantic content, it only
-seeds the template and transcribes validated replies.
+Before transcription, the previous edited `current.md` is snapshotted to
+`archive/<ts>-preparation-backup.md`, so a reply that drops sections never
+destroys the only copy of earlier notes. The prose is always the agent's —
+Prowl never authors semantic content, it only seeds the template and
+transcribes validated replies.
 
 `context.md` contains the detected outgoing agent, a pointer to the captured
 session excerpt, each repo's branch and change counts, and the changed files.
@@ -151,6 +155,8 @@ warning toast notes the handoff continued with the existing notes.
   high-confidence native session, when the agent has no verified resume
   adapter, or when `--no-prepare` is passed. A reply that fails validation is
   recorded as `preparation=failed` and never overwrites the existing artifact.
+  A validated reply first snapshots the previous edited `current.md` to
+  `archive/<ts>-preparation-backup.md` before transcription.
 - Keep secrets/tokens out of the handoff file (the protocol asks agents not to
   write them).
 - `.prowl/handoff/` is self-ignoring; session excerpts can contain terminal

--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -345,6 +345,20 @@ struct SupacodeApp: App {
           terminalManager: terminalManager
         )
       },
+      handoffLaunchObservation: { worktreeID in
+        guard let state = terminalManager.stateIfExists(for: worktreeID),
+          let tabID = state.tabManager.selectedTabId,
+          let surfaceID = state.activeSurfaceID(for: tabID)
+        else { return nil }
+        return state.surfaceAgentStates[surfaceID]?.launchObservation
+      },
+      handoffAgentSession: { worktreeID in
+        guard let state = terminalManager.stateIfExists(for: worktreeID),
+          let tabID = state.tabManager.selectedTabId,
+          let surfaceID = state.activeSurfaceID(for: tabID)
+        else { return nil }
+        return state.surfaceAgentStates[surfaceID]?.session
+      },
       handoffSessionContextForSurface: { worktreeID, surfaceID in
         return makeHandoffSessionContext(
           worktreeID: worktreeID,
@@ -670,14 +684,17 @@ struct SupacodeApp: App {
           )
         }
         return resolver.resolve(selector).map { resolved in
-          let agent = terminalManager.stateIfExists(for: resolved.worktreeID)?
-            .surfaceAgentStates[resolved.paneID]?.detectedAgent?.rawValue
+          let agentState = terminalManager.stateIfExists(for: resolved.worktreeID)?
+            .surfaceAgentStates[resolved.paneID]
+          let agent = agentState?.detectedAgent?.rawValue
           return HandoffResolvedTarget(
             worktreeID: resolved.worktreeID,
             worktreeName: resolved.worktreeName,
             rootPath: resolved.worktreePath,
             paneID: resolved.paneID.uuidString,
             outgoingAgent: agent,
+            outgoingLaunchObservation: agentState?.launchObservation,
+            outgoingSession: agentState?.session,
             sessionContext: makeHandoffSessionContext(
               worktreeID: resolved.worktreeID,
               paneID: resolved.paneID,
@@ -687,39 +704,15 @@ struct SupacodeApp: App {
           )
         }
       },
-      launchProvider: { target, kickoff in
-        let repositories = Array(appStore.state.repositories.repositories)
-        guard let worktree = resolveCLITerminalWorktree(id: target.worktreeID, repositories: repositories) else {
-          return nil
-        }
-        selectCLIWorktreeContext(
-          worktreeID: target.worktreeID,
+      launchProvider: { target, request in
+        Self.launchHandoffReceiver(
+          target: target,
+          request: request,
           appStore: appStore,
           terminalManager: terminalManager
         )
-        let state = terminalManager.state(for: worktree)
-        guard
-          let tabID = state.createTab(
-            initialInput: kickoff,
-            workingDirectoryOverride: URL(fileURLWithPath: target.rootPath, isDirectory: true)
-          )
-        else {
-          return nil
-        }
-        let resolver = makeTargetResolver(appStore: appStore, terminalManager: terminalManager)
-        switch resolver.resolve(.tab(tabID.rawValue.uuidString)) {
-        case .success(let resolved):
-          return HandoffLaunchedPane(
-            worktreeID: resolved.worktreeID,
-            worktreeName: resolved.worktreeName,
-            tabID: resolved.tabID.uuidString,
-            paneID: resolved.paneID.uuidString,
-            paneTitle: resolved.paneTitle
-          )
-        case .failure:
-          return nil
-        }
-      }
+      },
+      preparationProvider: Self.prepareHandoffSource
     )
     return CLICommandRouter(
       openHandler: openHandler,
@@ -733,6 +726,60 @@ struct SupacodeApp: App {
       paneHandler: paneHandler,
       handoffHandler: handoffHandler
     )
+  }
+
+  private static func launchHandoffReceiver(
+    target: HandoffResolvedTarget,
+    request: AgentStartRequest,
+    appStore: StoreOf<AppFeature>,
+    terminalManager: WorktreeTerminalManager
+  ) -> HandoffLaunchedPane? {
+    let repositories = Array(appStore.state.repositories.repositories)
+    guard let worktree = resolveCLITerminalWorktree(id: target.worktreeID, repositories: repositories) else {
+      return nil
+    }
+    selectCLIWorktreeContext(
+      worktreeID: target.worktreeID,
+      appStore: appStore,
+      terminalManager: terminalManager
+    )
+    guard let initialInput = try? AgentRuntimeAdapterRegistry.makeStartInvocation(request).terminalInput else {
+      return nil
+    }
+    let state = terminalManager.state(for: worktree)
+    guard
+      let tabID = state.createTab(
+        initialInput: initialInput,
+        workingDirectoryOverride: URL(fileURLWithPath: target.rootPath, isDirectory: true)
+      )
+    else {
+      return nil
+    }
+    let resolver = makeTargetResolver(appStore: appStore, terminalManager: terminalManager)
+    switch resolver.resolve(.tab(tabID.rawValue.uuidString)) {
+    case .success(let resolved):
+      return HandoffLaunchedPane(
+        worktreeID: resolved.worktreeID,
+        worktreeName: resolved.worktreeName,
+        tabID: resolved.tabID.uuidString,
+        paneID: resolved.paneID.uuidString,
+        paneTitle: resolved.paneTitle
+      )
+    case .failure:
+      return nil
+    }
+  }
+
+  nonisolated private static func prepareHandoffSource(
+    request: AgentResumeRequest,
+    directory: URL
+  ) async -> HandoffPreparationOutcome {
+    do {
+      _ = try await AgentRuntimeClient.liveValue.resume(request, in: directory)
+      return .completed
+    } catch {
+      return .failed
+    }
   }
 
   private static func makeCLISocketServer(

--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -773,13 +773,8 @@ struct SupacodeApp: App {
   nonisolated private static func prepareHandoffSource(
     request: AgentResumeRequest,
     directory: URL
-  ) async -> HandoffPreparationOutcome {
-    do {
-      _ = try await AgentRuntimeClient.liveValue.resume(request, in: directory)
-      return .completed
-    } catch {
-      return .failed
-    }
+  ) async throws -> String {
+    try await AgentRuntimeClient.liveValue.resume(request, in: directory)
   }
 
   private static func makeCLISocketServer(

--- a/supacode/CLIService/HandoffCommandHandler.swift
+++ b/supacode/CLIService/HandoffCommandHandler.swift
@@ -104,7 +104,7 @@ final class HandoffCommandHandler: CommandHandler {
   ) async -> CommandResponse {
     let outgoing = target.outgoingAgent
     let note = input.note
-    let preparation = await prepareOutgoingAgent(input: input, target: target, store: store)
+    let preparation = await prepareOutgoingAgent(input: input, target: target, store: store, timestamp: timestamp)
     do {
       let result = try await Task.detached {
         try store.save(
@@ -140,7 +140,7 @@ final class HandoffCommandHandler: CommandHandler {
     guard let destinationAgent = DetectedAgent(rawValue: toAgent) else {
       return errorResponse(code: CLIErrorCode.invalidArgument, message: "Unknown handoff agent: \(toAgent).")
     }
-    let preparation = await prepareOutgoingAgent(input: input, target: target, store: store)
+    let preparation = await prepareOutgoingAgent(input: input, target: target, store: store, timestamp: timestamp)
 
     let saveResult: HandoffStore.SaveResult
     let archivedPath: String?
@@ -222,7 +222,8 @@ final class HandoffCommandHandler: CommandHandler {
   private func prepareOutgoingAgent(
     input: HandoffInput,
     target: HandoffResolvedTarget,
-    store: HandoffStore
+    store: HandoffStore,
+    timestamp: Date
   ) async -> HandoffPreparationOutcome {
     guard
       input.prepare,
@@ -240,7 +241,7 @@ final class HandoffCommandHandler: CommandHandler {
         URL(fileURLWithPath: target.rootPath, isDirectory: true)
       )
       return await Task.detached {
-        store.applyPreparationReply(reply) ? HandoffPreparationOutcome.completed : .failed
+        store.applyPreparationReply(reply, now: timestamp) ? HandoffPreparationOutcome.completed : .failed
       }.value
     } catch {
       return .failed

--- a/supacode/CLIService/HandoffCommandHandler.swift
+++ b/supacode/CLIService/HandoffCommandHandler.swift
@@ -10,6 +10,8 @@ struct HandoffResolvedTarget: Sendable, Equatable {
   let rootPath: String
   let paneID: String
   let outgoingAgent: String?
+  let outgoingLaunchObservation: AgentLaunchObservation?
+  let outgoingSession: AgentSession?
   let sessionContext: HandoffStore.SessionContext?
 }
 
@@ -22,25 +24,35 @@ struct HandoffLaunchedPane: Sendable, Equatable {
   let paneTitle: String
 }
 
+enum HandoffPreparationOutcome: String, Equatable, Sendable {
+  case completed
+  case skipped
+  case failed
+}
+
 @MainActor
 final class HandoffCommandHandler: CommandHandler {
   typealias ResolveProvider = @MainActor (TargetSelector) -> Result<HandoffResolvedTarget, TargetResolverError>
-  typealias LaunchProvider = @MainActor (HandoffResolvedTarget, String) -> HandoffLaunchedPane?
+  typealias LaunchProvider = @MainActor (HandoffResolvedTarget, AgentStartRequest) -> HandoffLaunchedPane?
+  typealias PreparationProvider = @Sendable (AgentResumeRequest, URL) async -> HandoffPreparationOutcome
 
   /// Agents this command can launch (it injects an agent-specific kickoff command).
   static let supportedAgents = HandoffAgentSupport.launchableAgents
 
   private let resolveProvider: ResolveProvider
   private let launchProvider: LaunchProvider
+  private let preparationProvider: PreparationProvider
   private let now: @Sendable () -> Date
 
   init(
     resolveProvider: @escaping ResolveProvider,
     launchProvider: @escaping LaunchProvider,
+    preparationProvider: @escaping PreparationProvider,
     now: @escaping @Sendable () -> Date = { Date() }
   ) {
     self.resolveProvider = resolveProvider
     self.launchProvider = launchProvider
+    self.preparationProvider = preparationProvider
     self.now = now
   }
 
@@ -96,6 +108,7 @@ final class HandoffCommandHandler: CommandHandler {
   ) async -> CommandResponse {
     let outgoing = target.outgoingAgent
     let note = input.note
+    let preparation = await prepareOutgoingAgent(for: target)
     do {
       let result = try await Task.detached {
         try store.save(
@@ -104,6 +117,9 @@ final class HandoffCommandHandler: CommandHandler {
           note: note,
           now: timestamp
         )
+      }.value
+      try? await Task.detached {
+        try store.appendLog("handoff save  preparation=\(preparation.rawValue)", now: timestamp)
       }.value
       return success(payload: makePayload(action: .save, save: result))
     } catch {
@@ -127,6 +143,10 @@ final class HandoffCommandHandler: CommandHandler {
     }
     let outgoing = target.outgoingAgent
     let from = outgoing ?? "agent"
+    guard let destinationAgent = DetectedAgent(rawValue: toAgent) else {
+      return errorResponse(code: CLIErrorCode.invalidArgument, message: "Unknown handoff agent: \(toAgent).")
+    }
+    let preparation = await prepareOutgoingAgent(for: target)
 
     let saveResult: HandoffStore.SaveResult
     let archivedPath: String?
@@ -150,15 +170,32 @@ final class HandoffCommandHandler: CommandHandler {
       )
     }
 
+    let configuration: AgentLaunchConfiguration
+    if let sourceAgent = outgoing.flatMap(DetectedAgent.init(rawValue:)) {
+      configuration = AgentRuntimeAdapterRegistry.inheritedConfiguration(
+        from: sourceAgent,
+        observation: target.outgoingLaunchObservation,
+        to: destinationAgent
+      )
+    } else {
+      configuration = .init()
+    }
     var launched: HandoffLaunchedPane?
     if input.launch {
-      launched = launchProvider(target, Self.kickoff(for: toAgent))
+      launched = launchProvider(
+        target,
+        AgentStartRequest(
+          agent: destinationAgent,
+          prompt: Self.kickoffPrompt(),
+          configuration: configuration
+        )
+      )
       if launched == nil {
         let archiveSuffix = archivedPath.map { "  archive=\($0)" } ?? ""
         let noteSuffix = input.note.map { "  note=\"\($0.replacing("\n", with: " "))\"" } ?? ""
         try? await Task.detached {
           try store.appendLog(
-            "\(from) → \(toAgent)  launch=failed\(archiveSuffix)\(noteSuffix)",
+            "\(from) → \(toAgent)  launch=failed  preparation=\(preparation.rawValue)\(archiveSuffix)\(noteSuffix)",
             now: timestamp
           )
         }.value
@@ -170,7 +207,10 @@ final class HandoffCommandHandler: CommandHandler {
     let paneSuffix = launched.map { "  pane=\($0.paneID)" } ?? "  (no launch)"
     let noteSuffix = note.map { "  note=\"\($0.replacing("\n", with: " "))\"" } ?? ""
     try? await Task.detached {
-      try store.appendLog("\(from) → \(toAgent)\(paneSuffix)\(noteSuffix)", now: timestamp)
+      try store.appendLog(
+        "\(from) → \(toAgent)\(paneSuffix)  preparation=\(preparation.rawValue)\(noteSuffix)",
+        now: timestamp
+      )
     }.value
 
     return success(
@@ -181,6 +221,22 @@ final class HandoffCommandHandler: CommandHandler {
         archivedPath: archivedPath,
         launched: launched
       )
+    )
+  }
+
+  private func prepareOutgoingAgent(for target: HandoffResolvedTarget) async -> HandoffPreparationOutcome {
+    guard
+      let request = Self.preparationRequest(
+        outgoingAgent: target.outgoingAgent,
+        session: target.outgoingSession,
+        observation: target.outgoingLaunchObservation
+      )
+    else {
+      return .skipped
+    }
+    return await preparationProvider(
+      request,
+      URL(fileURLWithPath: target.rootPath, isDirectory: true)
     )
   }
 
@@ -214,13 +270,44 @@ final class HandoffCommandHandler: CommandHandler {
 
   // MARK: - Kickoff prompt
 
-  nonisolated static func kickoff(for agent: String) -> String {
-    let instruction =
-      "Take over this Prowl workspace task. Read .prowl/handoff/current.md (agent notes), "
+  nonisolated static func kickoffPrompt() -> String {
+    "Take over this Prowl workspace task. Read .prowl/handoff/current.md (agent notes), "
       + ".prowl/handoff/context.md (generated state), and .prowl/workspace.json (repo layout, if present), "
       + "then continue from Next Steps. If context.md lists a Session Context excerpt, read it before changing code. "
       + "Ask before any commit/push or destructive git."
-    return "\(agent) \"\(instruction)\""
+  }
+
+  nonisolated static func preparationRequest(
+    outgoingAgent: String?,
+    session: AgentSession?,
+    observation: AgentLaunchObservation?
+  ) -> AgentResumeRequest? {
+    guard
+      let outgoingAgent,
+      let agent = DetectedAgent(rawValue: outgoingAgent),
+      let session,
+      session.confidence == .exact || session.confidence == .high,
+      AgentRuntimeAdapterRegistry.canResume(agent)
+    else {
+      return nil
+    }
+    return AgentResumeRequest(
+      agent: agent,
+      session: session,
+      prompt: preparationPrompt(),
+      configuration: AgentRuntimeAdapterRegistry.inheritedConfiguration(
+        from: agent,
+        observation: observation,
+        to: agent
+      )
+    )
+  }
+
+  nonisolated static func preparationPrompt() -> String {
+    "Prepare the Prowl handoff now. Update .prowl/handoff/current.md with the current Objective, "
+      + "Current State, What Has Been Done, Open Questions, Risks / Watch Out, and Next Steps. "
+      + "Preserve useful existing agent notes; do not edit context.md, log.md, or archives. "
+      + "Do not commit, push, or make unrelated code changes. When the handoff is complete, exit."
   }
 
   // MARK: - Payload

--- a/supacode/CLIService/HandoffCommandHandler.swift
+++ b/supacode/CLIService/HandoffCommandHandler.swift
@@ -24,17 +24,13 @@ struct HandoffLaunchedPane: Sendable, Equatable {
   let paneTitle: String
 }
 
-enum HandoffPreparationOutcome: String, Equatable, Sendable {
-  case completed
-  case skipped
-  case failed
-}
-
 @MainActor
 final class HandoffCommandHandler: CommandHandler {
   typealias ResolveProvider = @MainActor (TargetSelector) -> Result<HandoffResolvedTarget, TargetResolverError>
   typealias LaunchProvider = @MainActor (HandoffResolvedTarget, AgentStartRequest) -> HandoffLaunchedPane?
-  typealias PreparationProvider = @Sendable (AgentResumeRequest, URL) async -> HandoffPreparationOutcome
+  /// Resumes the source session headlessly and returns its reply text; the
+  /// handler validates the reply and transcribes it into `current.md`.
+  typealias PreparationProvider = @Sendable (AgentResumeRequest, URL) async throws -> String
 
   /// Agents this command can launch (it injects an agent-specific kickoff command).
   static let supportedAgents = HandoffAgentSupport.launchableAgents
@@ -108,20 +104,18 @@ final class HandoffCommandHandler: CommandHandler {
   ) async -> CommandResponse {
     let outgoing = target.outgoingAgent
     let note = input.note
-    let preparation = await prepareOutgoingAgent(for: target)
+    let preparation = await prepareOutgoingAgent(input: input, target: target, store: store)
     do {
       let result = try await Task.detached {
         try store.save(
           outgoingAgent: outgoing,
           sessionContext: target.sessionContext,
           note: note,
+          preparation: preparation,
           now: timestamp
         )
       }.value
-      try? await Task.detached {
-        try store.appendLog("handoff save  preparation=\(preparation.rawValue)", now: timestamp)
-      }.value
-      return success(payload: makePayload(action: .save, save: result))
+      return success(payload: makePayload(action: .save, save: result, preparation: preparation))
     } catch {
       return errorResponse(
         code: CLIErrorCode.handoffFailed,
@@ -146,7 +140,7 @@ final class HandoffCommandHandler: CommandHandler {
     guard let destinationAgent = DetectedAgent(rawValue: toAgent) else {
       return errorResponse(code: CLIErrorCode.invalidArgument, message: "Unknown handoff agent: \(toAgent).")
     }
-    let preparation = await prepareOutgoingAgent(for: target)
+    let preparation = await prepareOutgoingAgent(input: input, target: target, store: store)
 
     let saveResult: HandoffStore.SaveResult
     let archivedPath: String?
@@ -219,13 +213,19 @@ final class HandoffCommandHandler: CommandHandler {
         save: saveResult,
         toAgent: toAgent,
         archivedPath: archivedPath,
-        launched: launched
+        launched: launched,
+        preparation: preparation
       )
     )
   }
 
-  private func prepareOutgoingAgent(for target: HandoffResolvedTarget) async -> HandoffPreparationOutcome {
+  private func prepareOutgoingAgent(
+    input: HandoffInput,
+    target: HandoffResolvedTarget,
+    store: HandoffStore
+  ) async -> HandoffPreparationOutcome {
     guard
+      input.prepare,
       let request = Self.preparationRequest(
         outgoingAgent: target.outgoingAgent,
         session: target.outgoingSession,
@@ -234,10 +234,17 @@ final class HandoffCommandHandler: CommandHandler {
     else {
       return .skipped
     }
-    return await preparationProvider(
-      request,
-      URL(fileURLWithPath: target.rootPath, isDirectory: true)
-    )
+    do {
+      let reply = try await preparationProvider(
+        request,
+        URL(fileURLWithPath: target.rootPath, isDirectory: true)
+      )
+      return await Task.detached {
+        store.applyPreparationReply(reply) ? HandoffPreparationOutcome.completed : .failed
+      }.value
+    } catch {
+      return .failed
+    }
   }
 
   // MARK: - status
@@ -295,19 +302,18 @@ final class HandoffCommandHandler: CommandHandler {
       agent: agent,
       session: session,
       prompt: preparationPrompt(),
-      configuration: AgentRuntimeAdapterRegistry.inheritedConfiguration(
-        from: agent,
-        observation: observation,
-        to: agent
-      )
+      model: observation?.model
     )
   }
 
   nonisolated static func preparationPrompt() -> String {
-    "Prepare the Prowl handoff now. Update .prowl/handoff/current.md with the current Objective, "
-      + "Current State, What Has Been Done, Open Questions, Risks / Watch Out, and Next Steps. "
-      + "Preserve useful existing agent notes; do not edit context.md, log.md, or archives. "
-      + "Do not commit, push, or make unrelated code changes. When the handoff is complete, exit."
+    "Prowl handoff preparation. Reply with the complete updated contents of .prowl/handoff/current.md "
+      + "and nothing else: a markdown document titled \"# Handoff\" with the sections \"## Objective\", "
+      + "\"## Current State\", \"## What Has Been Done\", \"## Open Questions\", \"## Risks / Watch Out\", "
+      + "\"## Next Steps\", and \"## Suggested Prompt For Next Agent\". Carry forward still-relevant notes "
+      + "from the existing file. Base the update on what you already know from this session; do not run "
+      + "commands, read extra files, or edit anything — Prowl writes the file from your reply. "
+      + "Be concise and answer in a single reply."
   }
 
   // MARK: - Payload
@@ -317,7 +323,8 @@ final class HandoffCommandHandler: CommandHandler {
     save: HandoffStore.SaveResult,
     toAgent: String? = nil,
     archivedPath: String? = nil,
-    launched: HandoffLaunchedPane? = nil
+    launched: HandoffLaunchedPane? = nil,
+    preparation: HandoffPreparationOutcome? = nil
   ) -> HandoffCommandPayload {
     HandoffCommandPayload(
       action: action,
@@ -337,6 +344,7 @@ final class HandoffCommandHandler: CommandHandler {
       changedFileCount: save.totalChangedFiles,
       archivedPath: archivedPath,
       sessionContext: save.sessionContext,
+      preparation: preparation?.rawValue,
       launchedPane: launched.map {
         HandoffPanePayload(
           worktreeID: $0.worktreeID,

--- a/supacode/CLIService/Shared/HandoffCommandPayload.swift
+++ b/supacode/CLIService/Shared/HandoffCommandPayload.swift
@@ -13,6 +13,8 @@ public struct HandoffCommandPayload: Codable, Sendable, Equatable {
   public let archivedPath: String?
   /// Auto-captured outgoing session context saved alongside `current.md`.
   public let sessionContext: HandoffSessionPayload?
+  /// Whether source preparation completed, failed, or was skipped (save/to).
+  public let preparation: String?
   /// The pane the receiving agent was launched into (for `to` with launch).
   public let launchedPane: HandoffPanePayload?
   /// Whether `current.md` exists (for `status`).
@@ -29,6 +31,7 @@ public struct HandoffCommandPayload: Codable, Sendable, Equatable {
     case changedFileCount = "changed_file_count"
     case archivedPath = "archived_path"
     case sessionContext = "session_context"
+    case preparation
     case launchedPane = "launched_pane"
     case exists
     case lastLog = "last_log"
@@ -43,6 +46,7 @@ public struct HandoffCommandPayload: Codable, Sendable, Equatable {
     changedFileCount: Int = 0,
     archivedPath: String? = nil,
     sessionContext: HandoffSessionPayload? = nil,
+    preparation: String? = nil,
     launchedPane: HandoffPanePayload? = nil,
     exists: Bool? = nil,
     lastLog: String? = nil
@@ -55,6 +59,7 @@ public struct HandoffCommandPayload: Codable, Sendable, Equatable {
     self.changedFileCount = changedFileCount
     self.archivedPath = archivedPath
     self.sessionContext = sessionContext
+    self.preparation = preparation
     self.launchedPane = launchedPane
     self.exists = exists
     self.lastLog = lastLog

--- a/supacode/CLIService/Shared/InputModels.swift
+++ b/supacode/CLIService/Shared/InputModels.swift
@@ -188,6 +188,9 @@ public struct HandoffInput: Codable, Sendable {
   /// When false, `to` refreshes + archives the handoff but does not launch the
   /// receiving agent (the human takes over manually).
   public let launch: Bool
+  /// When false, skip asking the detected source agent to refresh `current.md`
+  /// before the save (`--no-prepare`).
+  public let prepare: Bool
 
   enum CodingKeys: String, CodingKey {
     case action
@@ -195,6 +198,7 @@ public struct HandoffInput: Codable, Sendable {
     case toAgent = "to_agent"
     case note
     case launch
+    case prepare
   }
 
   public init(
@@ -202,13 +206,15 @@ public struct HandoffInput: Codable, Sendable {
     selector: TargetSelector = .none,
     toAgent: String? = nil,
     note: String? = nil,
-    launch: Bool = true
+    launch: Bool = true,
+    prepare: Bool = true
   ) {
     self.action = action
     self.selector = selector
     self.toAgent = toAgent
     self.note = note
     self.launch = launch
+    self.prepare = prepare
   }
 
   public init(from decoder: Decoder) throws {
@@ -218,6 +224,7 @@ public struct HandoffInput: Codable, Sendable {
     self.toAgent = try container.decodeIfPresent(String.self, forKey: .toAgent)
     self.note = try container.decodeIfPresent(String.self, forKey: .note)
     self.launch = try container.decodeIfPresent(Bool.self, forKey: .launch) ?? true
+    self.prepare = try container.decodeIfPresent(Bool.self, forKey: .prepare) ?? true
   }
 }
 

--- a/supacode/Clients/AgentRuntime/AgentRuntimeClient.swift
+++ b/supacode/Clients/AgentRuntime/AgentRuntimeClient.swift
@@ -1,37 +1,66 @@
 import ComposableArchitecture
 import Foundation
 
+/// Executes a headless, read-only resume of a verified agent session and
+/// returns the agent's final reply text. The resumed agent only replies with
+/// content; Prowl itself validates and persists any artifact derived from it.
 nonisolated struct AgentRuntimeClient: Sendable {
-  var makeStartInvocation: @Sendable (AgentStartRequest) throws -> AgentInvocation
-  private var resumeImpl: @Sendable (AgentResumeRequest, URL) async throws -> ShellOutput
+  private var resumeImpl: @Sendable (AgentResumeRequest, URL) async throws -> String
 
-  init(
-    makeStartInvocation: @escaping @Sendable (AgentStartRequest) throws -> AgentInvocation,
-    resume: @escaping @Sendable (AgentResumeRequest, URL) async throws -> ShellOutput
-  ) {
-    self.makeStartInvocation = makeStartInvocation
+  init(resume: @escaping @Sendable (AgentResumeRequest, URL) async throws -> String) {
     self.resumeImpl = resume
   }
 
-  func resume(_ request: AgentResumeRequest, in workingDirectory: URL) async throws -> ShellOutput {
+  func resume(_ request: AgentResumeRequest, in workingDirectory: URL) async throws -> String {
     try await resumeImpl(request, workingDirectory)
   }
 
-  static func live(shell: ShellClient) -> Self {
+  /// Bounds one resume turn; a stalled CLI must not hang `handoff save` or the
+  /// Command Palette handoff indefinitely.
+  static let resumeTimeout: Duration = .seconds(120)
+
+  static func live(shell: ShellClient, clock: any Clock<Duration> = ContinuousClock()) -> Self {
     Self(
-      makeStartInvocation: { request in
-        try AgentRuntimeAdapterRegistry.makeStartInvocation(request)
-      },
       resume: { request, workingDirectory in
-        let invocation = try AgentRuntimeAdapterRegistry.makeResumeInvocation(request)
-        return try await shell.runLogin(
-          URL(fileURLWithPath: "/usr/bin/env"),
-          [invocation.executable] + invocation.arguments,
-          workingDirectory,
-          log: false
-        )
+        let replyFile = FileManager.default.temporaryDirectory
+          .appending(path: "prowl-agent-reply-\(UUID().uuidString).md")
+        defer { try? FileManager.default.removeItem(at: replyFile) }
+        let invocation = try AgentRuntimeAdapterRegistry.makeResumeInvocation(request, replyFile: replyFile)
+        let output = try await withResumeTimeout(clock: clock) {
+          try await shell.runLogin(
+            URL(fileURLWithPath: "/usr/bin/env"),
+            [invocation.executable] + invocation.arguments,
+            workingDirectory,
+            log: false
+          )
+        }
+        // Prefer the CLI-written reply file (codex); fall back to stdout (claude).
+        let fileReply = (try? String(contentsOf: replyFile, encoding: .utf8))?
+          .trimmingCharacters(in: .whitespacesAndNewlines)
+        if let fileReply, !fileReply.isEmpty {
+          return fileReply
+        }
+        return output.stdout
       }
     )
+  }
+
+  private static func withResumeTimeout(
+    clock: any Clock<Duration>,
+    operation: @escaping @Sendable () async throws -> ShellOutput
+  ) async throws -> ShellOutput {
+    try await withThrowingTaskGroup(of: ShellOutput.self) { group in
+      group.addTask { try await operation() }
+      group.addTask {
+        try await clock.sleep(for: resumeTimeout)
+        throw AgentRuntimeError.resumeTimedOut
+      }
+      guard let output = try await group.next() else {
+        throw AgentRuntimeError.resumeTimedOut
+      }
+      group.cancelAll()
+      return output
+    }
   }
 }
 
@@ -39,15 +68,14 @@ extension AgentRuntimeClient: DependencyKey {
   nonisolated static let liveValue = AgentRuntimeClient.live(shell: .live)
 
   nonisolated static let testValue = AgentRuntimeClient(
-    makeStartInvocation: { request in
-      try AgentRuntimeAdapterRegistry.makeStartInvocation(request)
-    },
-    resume: { request, _ in
-      _ = try AgentRuntimeAdapterRegistry.makeResumeInvocation(request)
-      return ShellOutput(stdout: "", stderr: "", exitCode: 0)
+    resume: { _, _ in
+      reportIssue("AgentRuntimeClient.resume is unimplemented")
+      throw UnimplementedAgentRuntimeError()
     }
   )
 }
+
+private struct UnimplementedAgentRuntimeError: Error {}
 
 extension DependencyValues {
   var agentRuntimeClient: AgentRuntimeClient {

--- a/supacode/Clients/AgentRuntime/AgentRuntimeClient.swift
+++ b/supacode/Clients/AgentRuntime/AgentRuntimeClient.swift
@@ -1,0 +1,57 @@
+import ComposableArchitecture
+import Foundation
+
+nonisolated struct AgentRuntimeClient: Sendable {
+  var makeStartInvocation: @Sendable (AgentStartRequest) throws -> AgentInvocation
+  private var resumeImpl: @Sendable (AgentResumeRequest, URL) async throws -> ShellOutput
+
+  init(
+    makeStartInvocation: @escaping @Sendable (AgentStartRequest) throws -> AgentInvocation,
+    resume: @escaping @Sendable (AgentResumeRequest, URL) async throws -> ShellOutput
+  ) {
+    self.makeStartInvocation = makeStartInvocation
+    self.resumeImpl = resume
+  }
+
+  func resume(_ request: AgentResumeRequest, in workingDirectory: URL) async throws -> ShellOutput {
+    try await resumeImpl(request, workingDirectory)
+  }
+
+  static func live(shell: ShellClient) -> Self {
+    Self(
+      makeStartInvocation: { request in
+        try AgentRuntimeAdapterRegistry.makeStartInvocation(request)
+      },
+      resume: { request, workingDirectory in
+        let invocation = try AgentRuntimeAdapterRegistry.makeResumeInvocation(request)
+        return try await shell.runLogin(
+          URL(fileURLWithPath: "/usr/bin/env"),
+          [invocation.executable] + invocation.arguments,
+          workingDirectory,
+          log: false
+        )
+      }
+    )
+  }
+}
+
+extension AgentRuntimeClient: DependencyKey {
+  nonisolated static let liveValue = AgentRuntimeClient.live(shell: .live)
+
+  nonisolated static let testValue = AgentRuntimeClient(
+    makeStartInvocation: { request in
+      try AgentRuntimeAdapterRegistry.makeStartInvocation(request)
+    },
+    resume: { request, _ in
+      _ = try AgentRuntimeAdapterRegistry.makeResumeInvocation(request)
+      return ShellOutput(stdout: "", stderr: "", exitCode: 0)
+    }
+  )
+}
+
+extension DependencyValues {
+  var agentRuntimeClient: AgentRuntimeClient {
+    get { self[AgentRuntimeClient.self] }
+    set { self[AgentRuntimeClient.self] = newValue }
+  }
+}

--- a/supacode/Clients/Terminal/TerminalClient.swift
+++ b/supacode/Clients/Terminal/TerminalClient.swift
@@ -10,6 +10,8 @@ struct TerminalClient {
   /// (e.g. when a palette dismisses and the leftmost pane reclaims first responder).
   var selectedSurfaceID: @MainActor @Sendable (Worktree.ID) -> UUID?
   var handoffSessionContext: @MainActor @Sendable (Worktree.ID) -> HandoffStore.SessionContext?
+  var handoffLaunchObservation: @MainActor @Sendable (Worktree.ID) -> AgentLaunchObservation? = { _ in nil }
+  var handoffAgentSession: @MainActor @Sendable (Worktree.ID) -> AgentSession? = { _ in nil }
   var handoffSessionContextForSurface: @MainActor @Sendable (Worktree.ID, UUID) -> HandoffStore.SessionContext?
   var latestUnreadNotification: @MainActor @Sendable () -> NotificationLocation?
   var focusSurface: @MainActor @Sendable (Worktree.ID, UUID) -> Bool
@@ -87,6 +89,8 @@ extension TerminalClient: DependencyKey {
     canvasFocusedWorktreeID: { nil },
     selectedSurfaceID: { _ in nil },
     handoffSessionContext: { _ in nil },
+    handoffLaunchObservation: { _ in nil },
+    handoffAgentSession: { _ in nil },
     handoffSessionContextForSurface: { _, _ in nil },
     latestUnreadNotification: { nil },
     focusSurface: { _, _ in false },
@@ -100,6 +104,8 @@ extension TerminalClient: DependencyKey {
     canvasFocusedWorktreeID: { nil },
     selectedSurfaceID: { _ in nil },
     handoffSessionContext: { _ in nil },
+    handoffLaunchObservation: { _ in nil },
+    handoffAgentSession: { _ in nil },
     handoffSessionContextForSurface: { _, _ in nil },
     latestUnreadNotification: { nil },
     focusSurface: { _, _ in false },

--- a/supacode/Domain/AgentDetection/PaneAgentState.swift
+++ b/supacode/Domain/AgentDetection/PaneAgentState.swift
@@ -3,6 +3,7 @@ import Foundation
 struct PaneAgentState: Equatable, Sendable {
   var detectedAgent: DetectedAgent?
   var agentProcessID: pid_t?
+  var launchObservation: AgentLaunchObservation?
   var session: AgentSession?
   /// Consecutive resolver misses while the same process stayed detected;
   /// bounds how long a previously resolved session may be retained.
@@ -16,6 +17,7 @@ struct PaneAgentState: Equatable, Sendable {
   init(
     detectedAgent: DetectedAgent? = nil,
     agentProcessID: pid_t? = nil,
+    launchObservation: AgentLaunchObservation? = nil,
     session: AgentSession? = nil,
     iconLookupToken: String? = nil,
     fallbackState: AgentRawState = .unknown,
@@ -25,6 +27,7 @@ struct PaneAgentState: Equatable, Sendable {
   ) {
     self.detectedAgent = detectedAgent
     self.agentProcessID = agentProcessID
+    self.launchObservation = launchObservation
     self.session = session
     self.iconLookupToken = iconLookupToken
     self.fallbackState = fallbackState
@@ -52,6 +55,18 @@ struct PaneAgentState: Equatable, Sendable {
     guard isFresh else { return (previous.session, previous.sessionMissStreak) }
     let streak = previous.sessionMissStreak + 1
     return (streak >= 3 ? nil : previous.session, streak)
+  }
+
+  /// An argv observation is usable only while it belongs to the same detected
+  /// process. Unlike sessions, an absent probe never proves a safer mode.
+  static func retainedLaunchObservation(
+    observed: AgentLaunchObservation?,
+    previous: PaneAgentState,
+    identifiedPID: pid_t?
+  ) -> AgentLaunchObservation? {
+    if let observed { return observed }
+    guard let identifiedPID, identifiedPID == previous.agentProcessID else { return nil }
+    return previous.launchObservation
   }
 
   var displayState: AgentDisplayState {

--- a/supacode/Domain/AgentRuntime/AgentRuntimeAdapter.swift
+++ b/supacode/Domain/AgentRuntime/AgentRuntimeAdapter.swift
@@ -5,7 +5,10 @@ nonisolated protocol AgentRuntimeAdapter: Sendable {
 
   func observe(arguments: [String]) -> AgentLaunchObservation
   func makeStartInvocation(_ request: AgentStartRequest) throws -> AgentInvocation
-  func makeResumeInvocation(_ request: AgentResumeRequest) throws -> AgentInvocation
+  /// Resume is read-only by design: the invocation never renders execution-mode
+  /// flags. The resumed agent replies with content; Prowl persists any artifact.
+  /// `replyFile`, when supported, asks the CLI to write its final message there.
+  func makeResumeInvocation(_ request: AgentResumeRequest, replyFile: URL?) throws -> AgentInvocation
 }
 
 nonisolated enum AgentExecutionMode: String, Codable, Equatable, Sendable {
@@ -47,22 +50,25 @@ nonisolated struct AgentStartRequest: Equatable, Sendable {
   }
 }
 
+/// A headless, read-only resume of a verified native session. Unlike
+/// `AgentStartRequest` it carries no execution mode: a resume never escalates
+/// permissions, so only the same-adapter model can be inherited.
 nonisolated struct AgentResumeRequest: Equatable, Sendable {
   let agent: DetectedAgent
   let session: AgentSession
   let prompt: String
-  let configuration: AgentLaunchConfiguration
+  let model: String?
 
   init(
     agent: DetectedAgent,
     session: AgentSession,
     prompt: String,
-    configuration: AgentLaunchConfiguration = .init()
+    model: String? = nil
   ) {
     self.agent = agent
     self.session = session
     self.prompt = prompt
-    self.configuration = configuration
+    self.model = model
   }
 }
 
@@ -88,6 +94,7 @@ nonisolated struct AgentInvocation: Equatable, Sendable {
 nonisolated enum AgentRuntimeError: Error, Equatable, Sendable {
   case unsupportedAgent(DetectedAgent)
   case unsafeSessionConfidence(AgentSession.Confidence)
+  case resumeTimedOut
 }
 
 nonisolated enum AgentRuntimeAdapterRegistry {
@@ -129,14 +136,14 @@ nonisolated enum AgentRuntimeAdapterRegistry {
     return try adapter.makeStartInvocation(request)
   }
 
-  static func makeResumeInvocation(_ request: AgentResumeRequest) throws -> AgentInvocation {
+  static func makeResumeInvocation(_ request: AgentResumeRequest, replyFile: URL? = nil) throws -> AgentInvocation {
     guard request.session.confidence == .exact || request.session.confidence == .high else {
       throw AgentRuntimeError.unsafeSessionConfidence(request.session.confidence)
     }
     guard let adapter = adapter(for: request.agent) else {
       throw AgentRuntimeError.unsupportedAgent(request.agent)
     }
-    return try adapter.makeResumeInvocation(request)
+    return try adapter.makeResumeInvocation(request, replyFile: replyFile)
   }
 }
 
@@ -144,9 +151,12 @@ nonisolated private struct CodexRuntimeAdapter: AgentRuntimeAdapter {
   let agent: DetectedAgent = .codex
 
   func observe(arguments: [String]) -> AgentLaunchObservation {
-    AgentLaunchObservation(
+    let explicitlyBypassesSandbox =
+      arguments.contains("--dangerously-bypass-approvals-and-sandbox")
+      || arguments.contains("--yolo")
+    return AgentLaunchObservation(
       model: arguments.optionValue(long: "--model", short: "-m"),
-      executionMode: arguments.contains("--dangerously-bypass-approvals-and-sandbox") ? .unrestricted : nil
+      executionMode: explicitlyBypassesSandbox ? .unrestricted : nil
     )
   }
 
@@ -154,10 +164,17 @@ nonisolated private struct CodexRuntimeAdapter: AgentRuntimeAdapter {
     AgentInvocation(executable: "codex", arguments: options(for: request.configuration) + [request.prompt])
   }
 
-  func makeResumeInvocation(_ request: AgentResumeRequest) throws -> AgentInvocation {
-    AgentInvocation(
+  func makeResumeInvocation(_ request: AgentResumeRequest, replyFile: URL?) throws -> AgentInvocation {
+    var arguments = ["exec", "resume"]
+    if let model = request.model {
+      arguments += ["--model", model]
+    }
+    if let replyFile {
+      arguments += ["--output-last-message", replyFile.path(percentEncoded: false)]
+    }
+    return AgentInvocation(
       executable: "codex",
-      arguments: ["exec", "resume"] + options(for: request.configuration) + [request.session.id, request.prompt]
+      arguments: arguments + [request.session.id, request.prompt]
     )
   }
 
@@ -190,11 +207,13 @@ nonisolated private struct ClaudeCodeRuntimeAdapter: AgentRuntimeAdapter {
     AgentInvocation(executable: "claude", arguments: options(for: request.configuration) + [request.prompt])
   }
 
-  func makeResumeInvocation(_ request: AgentResumeRequest) throws -> AgentInvocation {
-    AgentInvocation(
-      executable: "claude",
-      arguments: ["-p", "--resume", request.session.id] + options(for: request.configuration) + [request.prompt]
-    )
+  func makeResumeInvocation(_ request: AgentResumeRequest, replyFile: URL?) throws -> AgentInvocation {
+    // `claude -p` prints only the final reply on stdout, so no reply file is needed.
+    var arguments = ["-p", "--resume", request.session.id]
+    if let model = request.model {
+      arguments += ["--model", model]
+    }
+    return AgentInvocation(executable: "claude", arguments: arguments + [request.prompt])
   }
 
   private func options(for configuration: AgentLaunchConfiguration) -> [String] {

--- a/supacode/Domain/AgentRuntime/AgentRuntimeAdapter.swift
+++ b/supacode/Domain/AgentRuntime/AgentRuntimeAdapter.swift
@@ -1,0 +1,226 @@
+import Foundation
+
+nonisolated protocol AgentRuntimeAdapter: Sendable {
+  var agent: DetectedAgent { get }
+
+  func observe(arguments: [String]) -> AgentLaunchObservation
+  func makeStartInvocation(_ request: AgentStartRequest) throws -> AgentInvocation
+  func makeResumeInvocation(_ request: AgentResumeRequest) throws -> AgentInvocation
+}
+
+nonisolated enum AgentExecutionMode: String, Codable, Equatable, Sendable {
+  case standard
+  case unrestricted
+}
+
+nonisolated struct AgentLaunchConfiguration: Codable, Equatable, Sendable {
+  var model: String?
+  var executionMode: AgentExecutionMode
+
+  init(model: String? = nil, executionMode: AgentExecutionMode = .standard) {
+    self.model = model
+    self.executionMode = executionMode
+  }
+}
+
+/// Options observed from a live agent process. Nil denotes an unknown effective setting,
+/// never an inferred safe default from the absence of an argv flag.
+nonisolated struct AgentLaunchObservation: Equatable, Sendable {
+  let model: String?
+  let executionMode: AgentExecutionMode?
+
+  init(model: String? = nil, executionMode: AgentExecutionMode? = nil) {
+    self.model = model
+    self.executionMode = executionMode
+  }
+}
+
+nonisolated struct AgentStartRequest: Equatable, Sendable {
+  let agent: DetectedAgent
+  let prompt: String
+  let configuration: AgentLaunchConfiguration
+
+  init(agent: DetectedAgent, prompt: String, configuration: AgentLaunchConfiguration = .init()) {
+    self.agent = agent
+    self.prompt = prompt
+    self.configuration = configuration
+  }
+}
+
+nonisolated struct AgentResumeRequest: Equatable, Sendable {
+  let agent: DetectedAgent
+  let session: AgentSession
+  let prompt: String
+  let configuration: AgentLaunchConfiguration
+
+  init(
+    agent: DetectedAgent,
+    session: AgentSession,
+    prompt: String,
+    configuration: AgentLaunchConfiguration = .init()
+  ) {
+    self.agent = agent
+    self.session = session
+    self.prompt = prompt
+    self.configuration = configuration
+  }
+}
+
+nonisolated struct AgentInvocation: Equatable, Sendable {
+  let executable: String
+  let arguments: [String]
+
+  init(executable: String, arguments: [String]) {
+    self.executable = executable
+    self.arguments = arguments
+  }
+
+  /// One reviewed POSIX-shell rendering path for a command injected into a terminal surface.
+  var terminalInput: String {
+    ([executable] + arguments).map(Self.shellQuote).joined(separator: " ")
+  }
+
+  private static func shellQuote(_ argument: String) -> String {
+    "'" + argument.replacing("'", with: "'\"'\"'") + "'"
+  }
+}
+
+nonisolated enum AgentRuntimeError: Error, Equatable, Sendable {
+  case unsupportedAgent(DetectedAgent)
+  case unsafeSessionConfidence(AgentSession.Confidence)
+}
+
+nonisolated enum AgentRuntimeAdapterRegistry {
+  static func adapter(for agent: DetectedAgent) -> (any AgentRuntimeAdapter)? {
+    switch agent {
+    case .claude: ClaudeCodeRuntimeAdapter()
+    case .codex: CodexRuntimeAdapter()
+    default: nil
+    }
+  }
+
+  static func canStart(_ agent: DetectedAgent) -> Bool {
+    adapter(for: agent) != nil
+  }
+
+  static func canResume(_ agent: DetectedAgent) -> Bool {
+    adapter(for: agent) != nil
+  }
+
+  static func observe(agent: DetectedAgent, arguments: [String]) -> AgentLaunchObservation {
+    adapter(for: agent)?.observe(arguments: arguments) ?? .init()
+  }
+
+  static func inheritedConfiguration(
+    from sourceAgent: DetectedAgent,
+    observation: AgentLaunchObservation?,
+    to destinationAgent: DetectedAgent
+  ) -> AgentLaunchConfiguration {
+    AgentLaunchConfiguration(
+      model: sourceAgent == destinationAgent ? observation?.model : nil,
+      executionMode: observation?.executionMode ?? .standard
+    )
+  }
+
+  static func makeStartInvocation(_ request: AgentStartRequest) throws -> AgentInvocation {
+    guard let adapter = adapter(for: request.agent) else {
+      throw AgentRuntimeError.unsupportedAgent(request.agent)
+    }
+    return try adapter.makeStartInvocation(request)
+  }
+
+  static func makeResumeInvocation(_ request: AgentResumeRequest) throws -> AgentInvocation {
+    guard request.session.confidence == .exact || request.session.confidence == .high else {
+      throw AgentRuntimeError.unsafeSessionConfidence(request.session.confidence)
+    }
+    guard let adapter = adapter(for: request.agent) else {
+      throw AgentRuntimeError.unsupportedAgent(request.agent)
+    }
+    return try adapter.makeResumeInvocation(request)
+  }
+}
+
+nonisolated private struct CodexRuntimeAdapter: AgentRuntimeAdapter {
+  let agent: DetectedAgent = .codex
+
+  func observe(arguments: [String]) -> AgentLaunchObservation {
+    AgentLaunchObservation(
+      model: arguments.optionValue(long: "--model", short: "-m"),
+      executionMode: arguments.contains("--dangerously-bypass-approvals-and-sandbox") ? .unrestricted : nil
+    )
+  }
+
+  func makeStartInvocation(_ request: AgentStartRequest) throws -> AgentInvocation {
+    AgentInvocation(executable: "codex", arguments: options(for: request.configuration) + [request.prompt])
+  }
+
+  func makeResumeInvocation(_ request: AgentResumeRequest) throws -> AgentInvocation {
+    AgentInvocation(
+      executable: "codex",
+      arguments: ["exec", "resume"] + options(for: request.configuration) + [request.session.id, request.prompt]
+    )
+  }
+
+  private func options(for configuration: AgentLaunchConfiguration) -> [String] {
+    var options: [String] = []
+    if let model = configuration.model {
+      options += ["--model", model]
+    }
+    if configuration.executionMode == .unrestricted {
+      options.append("--dangerously-bypass-approvals-and-sandbox")
+    }
+    return options
+  }
+}
+
+nonisolated private struct ClaudeCodeRuntimeAdapter: AgentRuntimeAdapter {
+  let agent: DetectedAgent = .claude
+
+  func observe(arguments: [String]) -> AgentLaunchObservation {
+    let explicitlyBypassesPermissions =
+      arguments.contains("--dangerously-skip-permissions")
+      || arguments.optionValue(long: "--permission-mode") == "bypassPermissions"
+    return AgentLaunchObservation(
+      model: arguments.optionValue(long: "--model", short: "-m"),
+      executionMode: explicitlyBypassesPermissions ? .unrestricted : nil
+    )
+  }
+
+  func makeStartInvocation(_ request: AgentStartRequest) throws -> AgentInvocation {
+    AgentInvocation(executable: "claude", arguments: options(for: request.configuration) + [request.prompt])
+  }
+
+  func makeResumeInvocation(_ request: AgentResumeRequest) throws -> AgentInvocation {
+    AgentInvocation(
+      executable: "claude",
+      arguments: ["-p", "--resume", request.session.id] + options(for: request.configuration) + [request.prompt]
+    )
+  }
+
+  private func options(for configuration: AgentLaunchConfiguration) -> [String] {
+    var options: [String] = []
+    if let model = configuration.model {
+      options += ["--model", model]
+    }
+    if configuration.executionMode == .unrestricted {
+      options.append("--dangerously-skip-permissions")
+    }
+    return options
+  }
+}
+
+nonisolated extension [String] {
+  fileprivate func optionValue(long: String, short: String? = nil) -> String? {
+    for (index, argument) in enumerated() {
+      if argument == long || short == argument {
+        let next = self.index(after: index)
+        guard next < endIndex else { return nil }
+        return self[next]
+      }
+      if argument.hasPrefix(long + "=") {
+        return String(argument.dropFirst(long.count + 1))
+      }
+    }
+    return nil
+  }
+}

--- a/supacode/Domain/Handoff/HandoffStore.swift
+++ b/supacode/Domain/Handoff/HandoffStore.swift
@@ -1,6 +1,13 @@
 import Darwin
 import Foundation
 
+/// Outcome of asking the outgoing agent to refresh `current.md` before a save.
+nonisolated enum HandoffPreparationOutcome: String, Equatable, Sendable {
+  case completed
+  case skipped
+  case failed
+}
+
 /// On-disk store for the cross-agent handoff artifact that lives under a
 /// runnable target's `.prowl/handoff/` directory.
 ///
@@ -173,6 +180,7 @@ nonisolated struct HandoffStore: Sendable {
     outgoingAgent: String?,
     sessionContext: SessionContext? = nil,
     note: String?,
+    preparation: HandoffPreparationOutcome? = nil,
     now: Date
   ) throws -> SaveResult {
     try ensureScaffold()
@@ -191,7 +199,10 @@ nonisolated struct HandoffStore: Sendable {
     try appendix.write(to: contextURL, atomically: true, encoding: .utf8)
 
     let total = repos.reduce(0) { $0 + $1.changedFileCount }
-    let logLine = "save  agent=\(outgoingAgent ?? "unknown")  repos=\(repos.count)  changed=\(total)"
+    var logLine = "save  agent=\(outgoingAgent ?? "unknown")  repos=\(repos.count)  changed=\(total)"
+    if let preparation {
+      logLine += "  preparation=\(preparation.rawValue)"
+    }
     try appendLog(logLine + Self.noteSuffix(note), now: now)
 
     return SaveResult(
@@ -201,6 +212,61 @@ nonisolated struct HandoffStore: Sendable {
       repos: repos,
       changedFiles: changedFiles
     )
+  }
+
+  // MARK: - Prepared artifact
+
+  /// Validates a source agent's preparation reply and transcribes it into
+  /// `current.md`. Prowl never authors semantic prose: the reply text is the
+  /// source agent's, this method only checks shape and writes it verbatim.
+  /// Returns false (leaving the existing artifact in place) when the reply is
+  /// empty, still the seeded template, or missing the core semantic sections.
+  func applyPreparationReply(_ reply: String) -> Bool {
+    guard let artifact = Self.preparedArtifact(fromAgentReply: reply) else { return false }
+    do {
+      try FileManager.default.createDirectory(at: handoffDirectory, withIntermediateDirectories: true)
+      try artifact.write(to: currentURL, atomically: true, encoding: .utf8)
+      return true
+    } catch {
+      return false
+    }
+  }
+
+  /// Normalizes a preparation reply into artifact content, or nil when unusable.
+  static func preparedArtifact(fromAgentReply reply: String) -> String? {
+    var text = reply.trimmingCharacters(in: .whitespacesAndNewlines)
+    text = droppingOpeningFence(text)
+    text = droppingPreamble(text)
+    text = droppingClosingFence(text)
+    let requiredSections = ["## Objective", "## Current State", "## Next Steps"]
+    guard !text.isEmpty, requiredSections.allSatisfy(text.contains) else { return nil }
+    guard text != template.trimmingCharacters(in: .whitespacesAndNewlines) else { return nil }
+    return text + "\n"
+  }
+
+  /// Unwraps the opening line of a markdown code fence ("```markdown").
+  private static func droppingOpeningFence(_ text: String) -> String {
+    guard text.hasPrefix("```") else { return text }
+    let lines = text.split(separator: "\n", omittingEmptySubsequences: false)
+    return lines.dropFirst().joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
+  }
+
+  /// Drops chat preamble ahead of the artifact ("Sure, here's the file: …").
+  private static func droppingPreamble(_ text: String) -> String {
+    guard !text.hasPrefix("#") else { return text }
+    let lines = text.split(separator: "\n", omittingEmptySubsequences: false)
+    guard let start = lines.firstIndex(where: { $0.hasPrefix("# ") || $0.hasPrefix("## ") }) else {
+      return text
+    }
+    return lines[start...].joined(separator: "\n")
+  }
+
+  /// Drops a trailing code-fence line left over after preamble removal.
+  private static func droppingClosingFence(_ text: String) -> String {
+    var lines = text.split(separator: "\n", omittingEmptySubsequences: false)
+    guard let last = lines.last, last.trimmingCharacters(in: .whitespaces) == "```" else { return text }
+    lines.removeLast()
+    return lines.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
   }
 
   // MARK: - Archive

--- a/supacode/Domain/Handoff/HandoffStore.swift
+++ b/supacode/Domain/Handoff/HandoffStore.swift
@@ -221,15 +221,40 @@ nonisolated struct HandoffStore: Sendable {
   /// source agent's, this method only checks shape and writes it verbatim.
   /// Returns false (leaving the existing artifact in place) when the reply is
   /// empty, still the seeded template, or missing the core semantic sections.
-  func applyPreparationReply(_ reply: String) -> Bool {
+  /// The previous artifact is snapshotted into `archive/` first, so a reply
+  /// that drops sections never destroys the only copy of earlier notes.
+  func applyPreparationReply(_ reply: String, now: Date) -> Bool {
     guard let artifact = Self.preparedArtifact(fromAgentReply: reply) else { return false }
     do {
       try FileManager.default.createDirectory(at: handoffDirectory, withIntermediateDirectories: true)
+      try snapshotCurrentBeforePreparation(now: now)
       try artifact.write(to: currentURL, atomically: true, encoding: .utf8)
       return true
     } catch {
       return false
     }
+  }
+
+  /// Copy the existing `current.md` into `archive/<ts>-preparation-backup.md`
+  /// before a preparation reply overwrites it. The seeded template carries no
+  /// prose and is not worth archiving; a missing artifact means a first-ever
+  /// preparation. An unreadable artifact throws, failing the preparation and
+  /// leaving `current.md` untouched.
+  private func snapshotCurrentBeforePreparation(now: Date) throws {
+    guard FileManager.default.fileExists(atPath: currentURL.path(percentEncoded: false)) else { return }
+    let existing = try String(contentsOf: currentURL, encoding: .utf8)
+    guard existing != Self.template else { return }
+    try FileManager.default.createDirectory(at: archiveDirectory, withIntermediateDirectories: true)
+    let stem = "\(Self.fileStamp(now))-preparation-backup"
+    let destination = try Self.reserveFileURL(in: archiveDirectory, stem: stem, fileExtension: "md")
+    var didWrite = false
+    defer {
+      if !didWrite {
+        try? FileManager.default.removeItem(at: destination)
+      }
+    }
+    try existing.write(to: destination, atomically: true, encoding: .utf8)
+    didWrite = true
   }
 
   /// Normalizes a preparation reply into artifact content, or nil when unusable.

--- a/supacode/Features/App/Reducer/AppFeature+CommandPalette.swift
+++ b/supacode/Features/App/Reducer/AppFeature+CommandPalette.swift
@@ -289,13 +289,47 @@ extension AppFeature {
     guard let worktree = state.repositories.selectedTerminalWorktree else {
       return .none
     }
-    let kickoff = HandoffCommandHandler.kickoff(for: agent)
+    guard let destinationAgent = DetectedAgent(rawValue: agent) else { return .none }
     let rootURL = worktree.workingDirectory
     let sessionContext = terminalClient.handoffSessionContext(worktree.id)
     let outgoing = sessionContext?.agent
+    let preparationRequest = HandoffCommandHandler.preparationRequest(
+      outgoingAgent: outgoing,
+      session: terminalClient.handoffAgentSession(worktree.id),
+      observation: terminalClient.handoffLaunchObservation(worktree.id)
+    )
+    let configuration: AgentLaunchConfiguration
+    if let sourceAgent = outgoing.flatMap(DetectedAgent.init(rawValue:)) {
+      configuration = AgentRuntimeAdapterRegistry.inheritedConfiguration(
+        from: sourceAgent,
+        observation: terminalClient.handoffLaunchObservation(worktree.id),
+        to: destinationAgent
+      )
+    } else {
+      configuration = .init()
+    }
+    let request = AgentStartRequest(
+      agent: destinationAgent,
+      prompt: HandoffCommandHandler.kickoffPrompt(),
+      configuration: configuration
+    )
+    guard let kickoff = try? AgentRuntimeAdapterRegistry.makeStartInvocation(request).terminalInput else {
+      return .none
+    }
     return .run { send in
       let store = HandoffStore(rootURL: rootURL)
       let now = Date()
+      let preparation: HandoffPreparationOutcome
+      if let preparationRequest {
+        do {
+          _ = try await agentRuntimeClient.resume(preparationRequest, in: rootURL)
+          preparation = .completed
+        } catch {
+          preparation = .failed
+        }
+      } else {
+        preparation = .skipped
+      }
       do {
         try await Task.detached {
           _ = try store.save(
@@ -306,7 +340,8 @@ extension AppFeature {
           )
           _ = try store.archiveCurrent(from: outgoing ?? "agent", toAgent: agent, now: now)
           try store.appendLog(
-            "handoff prepared  from=\(outgoing ?? "agent")  to=\(agent)  launch=requested  source=command-palette",
+            "handoff prepared  from=\(outgoing ?? "agent")  to=\(agent)  preparation=\(preparation.rawValue)  "
+              + "launch=requested  source=command-palette",
             now: now
           )
         }.value

--- a/supacode/Features/App/Reducer/AppFeature+CommandPalette.swift
+++ b/supacode/Features/App/Reducer/AppFeature+CommandPalette.swift
@@ -293,16 +293,17 @@ extension AppFeature {
     let rootURL = worktree.workingDirectory
     let sessionContext = terminalClient.handoffSessionContext(worktree.id)
     let outgoing = sessionContext?.agent
+    let observation = terminalClient.handoffLaunchObservation(worktree.id)
     let preparationRequest = HandoffCommandHandler.preparationRequest(
       outgoingAgent: outgoing,
       session: terminalClient.handoffAgentSession(worktree.id),
-      observation: terminalClient.handoffLaunchObservation(worktree.id)
+      observation: observation
     )
     let configuration: AgentLaunchConfiguration
     if let sourceAgent = outgoing.flatMap(DetectedAgent.init(rawValue:)) {
       configuration = AgentRuntimeAdapterRegistry.inheritedConfiguration(
         from: sourceAgent,
-        observation: terminalClient.handoffLaunchObservation(worktree.id),
+        observation: observation,
         to: destinationAgent
       )
     } else {
@@ -321,12 +322,13 @@ extension AppFeature {
       let now = Date()
       let preparation: HandoffPreparationOutcome
       if let preparationRequest {
-        do {
-          _ = try await agentRuntimeClient.resume(preparationRequest, in: rootURL)
-          preparation = .completed
-        } catch {
-          preparation = .failed
-        }
+        await send(.repositories(.showToast(.inProgress("Preparing handoff from \(outgoing ?? "agent")…"))))
+        preparation = await Self.prepareHandoffSource(
+          request: preparationRequest,
+          store: store,
+          rootURL: rootURL,
+          runtimeClient: agentRuntimeClient
+        )
       } else {
         preparation = .skipped
       }
@@ -363,6 +365,33 @@ extension AppFeature {
           customCommandIcon: nil
         )
       )
+      if preparationRequest != nil {
+        if preparation == .completed {
+          await send(.repositories(.dismissToast))
+        } else {
+          await send(
+            .repositories(.showToast(.warning("Handed off with existing notes (source preparation failed)")))
+          )
+        }
+      }
+    }
+  }
+
+  /// Resumes the outgoing session read-only, then validates and transcribes its
+  /// reply into `current.md`. Mirrors `HandoffCommandHandler`'s CLI-side flow.
+  private static func prepareHandoffSource(
+    request: AgentResumeRequest,
+    store: HandoffStore,
+    rootURL: URL,
+    runtimeClient: AgentRuntimeClient
+  ) async -> HandoffPreparationOutcome {
+    do {
+      let reply = try await runtimeClient.resume(request, in: rootURL)
+      return await Task.detached {
+        store.applyPreparationReply(reply) ? HandoffPreparationOutcome.completed : .failed
+      }.value
+    } catch {
+      return .failed
     }
   }
 

--- a/supacode/Features/App/Reducer/AppFeature+CommandPalette.swift
+++ b/supacode/Features/App/Reducer/AppFeature+CommandPalette.swift
@@ -327,7 +327,8 @@ extension AppFeature {
           request: preparationRequest,
           store: store,
           rootURL: rootURL,
-          runtimeClient: agentRuntimeClient
+          runtimeClient: agentRuntimeClient,
+          now: now
         )
       } else {
         preparation = .skipped
@@ -383,12 +384,13 @@ extension AppFeature {
     request: AgentResumeRequest,
     store: HandoffStore,
     rootURL: URL,
-    runtimeClient: AgentRuntimeClient
+    runtimeClient: AgentRuntimeClient,
+    now: Date
   ) async -> HandoffPreparationOutcome {
     do {
       let reply = try await runtimeClient.resume(request, in: rootURL)
       return await Task.detached {
-        store.applyPreparationReply(reply) ? HandoffPreparationOutcome.completed : .failed
+        store.applyPreparationReply(reply, now: now) ? HandoffPreparationOutcome.completed : .failed
       }.value
     } catch {
       return .failed

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -103,6 +103,7 @@ struct AppFeature {
   @Dependency(SystemNotificationClient.self) var systemNotificationClient
   @Dependency(DockClient.self) var dockClient
   @Dependency(TerminalClient.self) var terminalClient
+  @Dependency(AgentRuntimeClient.self) var agentRuntimeClient
   @Dependency(WorktreeInfoWatcherClient.self) var worktreeInfoWatcher
   @Dependency(CustomShortcutRegistryClient.self) var customShortcutRegistryClient
   @Dependency(ExternalDiffToolClient.self) var externalDiffToolClient

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState+AgentDetection.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState+AgentDetection.swift
@@ -132,12 +132,14 @@ extension WorktreeTerminalState {
     // agent state cleaned up while the resolver was doing file inspection;
     // writing below would resurrect a ghost Active Agents entry.
     guard surfaces[surfaceID] != nil else { return false }
+    let launchObservation = resolvedLaunchObservation(identified: identified, previous: previous)
     let lastChangedAt = (previous.detectedAgent != agent || previous.state != stabilized) ? now : previous.lastChangedAt
     var next = PaneAgentState(
       detectedAgent: agent,
       // Presence holds keep the last known pid so a probe gap does not flap
       // the session to nil and back (the resolver re-binds on the next hit).
       agentProcessID: identified?.process.pid ?? previous.agentProcessID,
+      launchObservation: launchObservation,
       session: session,
       iconLookupToken: iconLookupToken,
       fallbackState: raw,
@@ -169,6 +171,22 @@ extension WorktreeTerminalState {
     updateTabAgentBusyState(for: tabId)
     emitAgentEntry(surfaceID: surfaceID, tabId: tabId, state: next)
     return true
+  }
+
+  private func resolvedLaunchObservation(
+    identified: IdentifiedAgentProcess?,
+    previous: PaneAgentState
+  ) -> AgentLaunchObservation? {
+    let observed = identified.flatMap { identified in
+      identified.process.arguments.map {
+        AgentRuntimeAdapterRegistry.observe(agent: identified.agent, arguments: $0)
+      }
+    }
+    return PaneAgentState.retainedLaunchObservation(
+      observed: observed,
+      previous: previous,
+      identifiedPID: identified?.process.pid
+    )
   }
 
   private func resolveRetainedSession(

--- a/supacode/Infrastructure/AgentDetection/ProcessDetection.swift
+++ b/supacode/Infrastructure/AgentDetection/ProcessDetection.swift
@@ -6,6 +6,15 @@ struct ForegroundProcess: Equatable, Sendable {
   let name: String
   let argv0: String?
   let cmdline: String?
+  let arguments: [String]?
+
+  nonisolated init(pid: pid_t, name: String, argv0: String?, cmdline: String?, arguments: [String]? = nil) {
+    self.pid = pid
+    self.name = name
+    self.argv0 = argv0
+    self.cmdline = cmdline
+    self.arguments = arguments
+  }
 }
 
 struct ForegroundJob: Equatable, Sendable {
@@ -85,7 +94,8 @@ nonisolated enum ProcessDetection {
         pid: pid,
         name: name,
         argv0: argv?.first.flatMap(basename),
-        cmdline: argv?.joined(separator: " ")
+        cmdline: argv?.joined(separator: " "),
+        arguments: argv
       )
     }
 

--- a/supacodeTests/AgentRuntimeAdapterTests.swift
+++ b/supacodeTests/AgentRuntimeAdapterTests.swift
@@ -1,3 +1,4 @@
+import Clocks
 import ComposableArchitecture
 import Foundation
 import Testing
@@ -21,7 +22,7 @@ struct AgentRuntimeAdapterTests {
     )
   }
 
-  @Test func claudeResumeBuildsUnrestrictedInvocation() throws {
+  @Test func claudeResumeStaysReadOnlyAndKeepsModel() throws {
     let session = AgentSession(
       id: "9B0E3B0E-67B3-4D45-A3A0-7DD9BC713711",
       transcriptPath: nil,
@@ -32,8 +33,8 @@ struct AgentRuntimeAdapterTests {
       AgentResumeRequest(
         agent: .claude,
         session: session,
-        prompt: "Write the handoff artifact.",
-        configuration: AgentLaunchConfiguration(model: "claude-opus-4", executionMode: .unrestricted)
+        prompt: "Reply with the handoff artifact.",
+        model: "claude-opus-4"
       )
     )
 
@@ -46,8 +47,41 @@ struct AgentRuntimeAdapterTests {
           "9B0E3B0E-67B3-4D45-A3A0-7DD9BC713711",
           "--model",
           "claude-opus-4",
-          "--dangerously-skip-permissions",
-          "Write the handoff artifact.",
+          "Reply with the handoff artifact.",
+        ]
+    )
+  }
+
+  @Test func codexResumeWritesReplyFileAndStaysReadOnly() throws {
+    let session = AgentSession(
+      id: "9B0E3B0E-67B3-4D45-A3A0-7DD9BC713711",
+      transcriptPath: nil,
+      source: .openFile,
+      confidence: .high
+    )
+    let replyFile = URL(fileURLWithPath: "/tmp/prowl-agent-reply.md")
+    let invocation = try AgentRuntimeAdapterRegistry.makeResumeInvocation(
+      AgentResumeRequest(
+        agent: .codex,
+        session: session,
+        prompt: "Reply with the handoff artifact.",
+        model: "gpt-5.4"
+      ),
+      replyFile: replyFile
+    )
+
+    #expect(invocation.executable == "codex")
+    #expect(
+      invocation.arguments
+        == [
+          "exec",
+          "resume",
+          "--model",
+          "gpt-5.4",
+          "--output-last-message",
+          "/tmp/prowl-agent-reply.md",
+          "9B0E3B0E-67B3-4D45-A3A0-7DD9BC713711",
+          "Reply with the handoff artifact.",
         ]
     )
   }
@@ -59,6 +93,9 @@ struct AgentRuntimeAdapterTests {
     )
     #expect(codex.model == "gpt-5.4")
     #expect(codex.executionMode == .unrestricted)
+
+    let yolo = AgentRuntimeAdapterRegistry.observe(agent: .codex, arguments: ["codex", "--yolo"])
+    #expect(yolo.executionMode == .unrestricted)
 
     let claude = AgentRuntimeAdapterRegistry.observe(
       agent: .claude,
@@ -113,6 +150,7 @@ struct AgentRuntimeAdapterTests {
         == "'codex' 'exec' 'resume' 'session id' 'Write '\"'\"'current.md'\"'\"'\nwithout shell injection.'"
     )
   }
+
   @Test func runtimeClientRunsResumeThroughDirectArgv() async throws {
     let recordedExecutable = LockIsolated<URL?>(nil)
     let recordedArguments = LockIsolated<[String]>([])
@@ -125,7 +163,7 @@ struct AgentRuntimeAdapterTests {
         recordedArguments.setValue(arguments)
         recordedDirectory.setValue(directory)
         recordedLog.setValue(log)
-        return ShellOutput(stdout: "complete", stderr: "", exitCode: 0)
+        return ShellOutput(stdout: "## Objective\nreply", stderr: "", exitCode: 0)
       }
     )
     let directory = URL(fileURLWithPath: "/tmp/handoff", isDirectory: true)
@@ -136,30 +174,82 @@ struct AgentRuntimeAdapterTests {
       confidence: .high
     )
 
-    let output = try await AgentRuntimeClient.live(shell: shell).resume(
+    let reply = try await AgentRuntimeClient.live(shell: shell).resume(
       AgentResumeRequest(
         agent: .codex,
         session: session,
-        prompt: "Write the handoff artifact.",
-        configuration: AgentLaunchConfiguration(executionMode: .unrestricted)
+        prompt: "Reply with the handoff artifact."
       ),
       in: directory
     )
 
-    #expect(output.stdout == "complete")
+    // The stub never writes the reply file, so stdout is the reply.
+    #expect(reply == "## Objective\nreply")
     #expect(recordedExecutable.value?.path == "/usr/bin/env")
+    let arguments = recordedArguments.value
+    #expect(arguments.prefix(3) == ["codex", "exec", "resume"])
+    #expect(arguments.contains("--output-last-message"))
+    #expect(!arguments.contains("--dangerously-bypass-approvals-and-sandbox"))
     #expect(
-      recordedArguments.value
-        == [
-          "codex",
-          "exec",
-          "resume",
-          "--dangerously-bypass-approvals-and-sandbox",
-          "9B0E3B0E-67B3-4D45-A3A0-7DD9BC713711",
-          "Write the handoff artifact.",
-        ]
+      arguments.suffix(2)
+        == ["9B0E3B0E-67B3-4D45-A3A0-7DD9BC713711", "Reply with the handoff artifact."]
     )
     #expect(recordedDirectory.value == directory)
     #expect(recordedLog.value == false)
+  }
+
+  @Test func runtimeClientPrefersReplyFileOverStdout() async throws {
+    let shell = ShellClient(
+      run: { _, _, _ in ShellOutput(stdout: "", stderr: "", exitCode: 0) },
+      runLoginImpl: { _, arguments, _, _ in
+        if let flagIndex = arguments.firstIndex(of: "--output-last-message"),
+          arguments.indices.contains(flagIndex + 1)
+        {
+          try "## Objective\nfrom reply file\n".write(
+            to: URL(fileURLWithPath: arguments[flagIndex + 1]),
+            atomically: true,
+            encoding: .utf8
+          )
+        }
+        return ShellOutput(stdout: "event noise", stderr: "", exitCode: 0)
+      }
+    )
+    let session = AgentSession(
+      id: "9B0E3B0E-67B3-4D45-A3A0-7DD9BC713711",
+      transcriptPath: nil,
+      source: .openFile,
+      confidence: .high
+    )
+
+    let reply = try await AgentRuntimeClient.live(shell: shell).resume(
+      AgentResumeRequest(agent: .codex, session: session, prompt: "Reply with the handoff artifact."),
+      in: URL(fileURLWithPath: "/tmp/handoff", isDirectory: true)
+    )
+
+    #expect(reply == "## Objective\nfrom reply file")
+  }
+
+  @Test func runtimeClientTimesOutStalledResume() async {
+    let hang = TestClock()
+    let shell = ShellClient(
+      run: { _, _, _ in ShellOutput(stdout: "", stderr: "", exitCode: 0) },
+      runLoginImpl: { _, _, _, _ in
+        try await hang.sleep(for: .seconds(600))
+        return ShellOutput(stdout: "late", stderr: "", exitCode: 0)
+      }
+    )
+    let session = AgentSession(
+      id: "9B0E3B0E-67B3-4D45-A3A0-7DD9BC713711",
+      transcriptPath: nil,
+      source: .openFile,
+      confidence: .high
+    )
+
+    await #expect(throws: AgentRuntimeError.resumeTimedOut) {
+      _ = try await AgentRuntimeClient.live(shell: shell, clock: ImmediateClock()).resume(
+        AgentResumeRequest(agent: .claude, session: session, prompt: "Reply with the handoff artifact."),
+        in: URL(fileURLWithPath: "/tmp/handoff", isDirectory: true)
+      )
+    }
   }
 }

--- a/supacodeTests/AgentRuntimeAdapterTests.swift
+++ b/supacodeTests/AgentRuntimeAdapterTests.swift
@@ -1,0 +1,165 @@
+import ComposableArchitecture
+import Foundation
+import Testing
+
+@testable import supacode
+
+struct AgentRuntimeAdapterTests {
+  @Test func codexStartBuildsUnrestrictedInvocation() throws {
+    let invocation = try AgentRuntimeAdapterRegistry.makeStartInvocation(
+      AgentStartRequest(
+        agent: .codex,
+        prompt: "Continue the handoff.",
+        configuration: AgentLaunchConfiguration(model: "gpt-5.4", executionMode: .unrestricted)
+      )
+    )
+
+    #expect(invocation.executable == "codex")
+    #expect(
+      invocation.arguments
+        == ["--model", "gpt-5.4", "--dangerously-bypass-approvals-and-sandbox", "Continue the handoff."]
+    )
+  }
+
+  @Test func claudeResumeBuildsUnrestrictedInvocation() throws {
+    let session = AgentSession(
+      id: "9B0E3B0E-67B3-4D45-A3A0-7DD9BC713711",
+      transcriptPath: nil,
+      source: .openFile,
+      confidence: .exact
+    )
+    let invocation = try AgentRuntimeAdapterRegistry.makeResumeInvocation(
+      AgentResumeRequest(
+        agent: .claude,
+        session: session,
+        prompt: "Write the handoff artifact.",
+        configuration: AgentLaunchConfiguration(model: "claude-opus-4", executionMode: .unrestricted)
+      )
+    )
+
+    #expect(invocation.executable == "claude")
+    #expect(
+      invocation.arguments
+        == [
+          "-p",
+          "--resume",
+          "9B0E3B0E-67B3-4D45-A3A0-7DD9BC713711",
+          "--model",
+          "claude-opus-4",
+          "--dangerously-skip-permissions",
+          "Write the handoff artifact.",
+        ]
+    )
+  }
+
+  @Test func observedLaunchOnlyClaimsExplicitUnrestrictedMode() {
+    let codex = AgentRuntimeAdapterRegistry.observe(
+      agent: .codex,
+      arguments: ["codex", "--model", "gpt-5.4", "--dangerously-bypass-approvals-and-sandbox"]
+    )
+    #expect(codex.model == "gpt-5.4")
+    #expect(codex.executionMode == .unrestricted)
+
+    let claude = AgentRuntimeAdapterRegistry.observe(
+      agent: .claude,
+      arguments: ["claude", "--allow-dangerously-skip-permissions"]
+    )
+    #expect(claude.executionMode == nil)
+  }
+
+  @Test func inheritedConfigurationCarriesOnlyPortableSourceIntent() {
+    let observation = AgentLaunchObservation(model: "gpt-5.4", executionMode: .unrestricted)
+
+    let claude = AgentRuntimeAdapterRegistry.inheritedConfiguration(
+      from: .codex,
+      observation: observation,
+      to: .claude
+    )
+    #expect(claude.model == nil)
+    #expect(claude.executionMode == .unrestricted)
+
+    let codex = AgentRuntimeAdapterRegistry.inheritedConfiguration(
+      from: .codex,
+      observation: observation,
+      to: .codex
+    )
+    #expect(codex.model == "gpt-5.4")
+    #expect(codex.executionMode == .unrestricted)
+  }
+
+  @Test func resumeRejectsMediumConfidenceSession() throws {
+    let session = AgentSession(
+      id: "9B0E3B0E-67B3-4D45-A3A0-7DD9BC713711",
+      transcriptPath: nil,
+      source: .recentFile,
+      confidence: .medium
+    )
+
+    #expect(throws: AgentRuntimeError.self) {
+      try AgentRuntimeAdapterRegistry.makeResumeInvocation(
+        AgentResumeRequest(agent: .codex, session: session, prompt: "Summarize the task.")
+      )
+    }
+  }
+
+  @Test func terminalInputQuotesEveryArgument() {
+    let invocation = AgentInvocation(
+      executable: "codex",
+      arguments: ["exec", "resume", "session id", "Write 'current.md'\nwithout shell injection."]
+    )
+
+    #expect(
+      invocation.terminalInput
+        == "'codex' 'exec' 'resume' 'session id' 'Write '\"'\"'current.md'\"'\"'\nwithout shell injection.'"
+    )
+  }
+  @Test func runtimeClientRunsResumeThroughDirectArgv() async throws {
+    let recordedExecutable = LockIsolated<URL?>(nil)
+    let recordedArguments = LockIsolated<[String]>([])
+    let recordedDirectory = LockIsolated<URL?>(nil)
+    let recordedLog = LockIsolated<Bool?>(nil)
+    let shell = ShellClient(
+      run: { _, _, _ in ShellOutput(stdout: "", stderr: "", exitCode: 0) },
+      runLoginImpl: { executable, arguments, directory, log in
+        recordedExecutable.setValue(executable)
+        recordedArguments.setValue(arguments)
+        recordedDirectory.setValue(directory)
+        recordedLog.setValue(log)
+        return ShellOutput(stdout: "complete", stderr: "", exitCode: 0)
+      }
+    )
+    let directory = URL(fileURLWithPath: "/tmp/handoff", isDirectory: true)
+    let session = AgentSession(
+      id: "9B0E3B0E-67B3-4D45-A3A0-7DD9BC713711",
+      transcriptPath: nil,
+      source: .openFile,
+      confidence: .high
+    )
+
+    let output = try await AgentRuntimeClient.live(shell: shell).resume(
+      AgentResumeRequest(
+        agent: .codex,
+        session: session,
+        prompt: "Write the handoff artifact.",
+        configuration: AgentLaunchConfiguration(executionMode: .unrestricted)
+      ),
+      in: directory
+    )
+
+    #expect(output.stdout == "complete")
+    #expect(recordedExecutable.value?.path == "/usr/bin/env")
+    #expect(
+      recordedArguments.value
+        == [
+          "codex",
+          "exec",
+          "resume",
+          "--dangerously-bypass-approvals-and-sandbox",
+          "9B0E3B0E-67B3-4D45-A3A0-7DD9BC713711",
+          "Write the handoff artifact.",
+        ]
+    )
+    #expect(recordedDirectory.value == directory)
+    #expect(recordedLog.value == false)
+  }
+}

--- a/supacodeTests/AppFeatureHandoffTests.swift
+++ b/supacodeTests/AppFeatureHandoffTests.swift
@@ -122,12 +122,48 @@ struct AppFeatureHandoffTests {
       settings: SettingsFeature.State()
     )
     let sent = LockIsolated<[TerminalClient.Command]>([])
+    let resumed = LockIsolated<AgentResumeRequest?>(nil)
     let store = TestStore(initialState: state) {
       AppFeature()
     } withDependencies: {
       $0.terminalClient.send = { command in
         sent.withValue { $0.append(command) }
       }
+      $0.terminalClient.handoffSessionContext = { _ in
+        HandoffStore.SessionContext(
+          agent: "codex",
+          paneID: "pane-0",
+          paneTitle: "codex",
+          source: "terminal-scrollback",
+          confidence: "fallback",
+          excerptText: ""
+        )
+      }
+      $0.terminalClient.handoffLaunchObservation = { _ in
+        AgentLaunchObservation(model: "gpt-5.4", executionMode: .unrestricted)
+      }
+      $0.terminalClient.handoffAgentSession = { _ in
+        AgentSession(
+          id: "9B0E3B0E-67B3-4D45-A3A0-7DD9BC713711",
+          transcriptPath: nil,
+          source: .openFile,
+          confidence: .exact
+        )
+      }
+      $0.agentRuntimeClient = AgentRuntimeClient(
+        makeStartInvocation: { try AgentRuntimeAdapterRegistry.makeStartInvocation($0) },
+        resume: { request, directory in
+          resumed.setValue(request)
+          let handoffURL = directory.appending(path: ".prowl/handoff", directoryHint: .isDirectory)
+          try FileManager.default.createDirectory(at: handoffURL, withIntermediateDirectories: true)
+          try "## Objective\n\nPalette source status.\n".write(
+            to: handoffURL.appending(path: "current.md"),
+            atomically: true,
+            encoding: .utf8
+          )
+          return ShellOutput(stdout: "", stderr: "", exitCode: 0)
+        }
+      )
     }
 
     await store.send(.commandPalette(.delegate(.handoffToAgent("claude"))))
@@ -148,7 +184,10 @@ struct AppFeatureHandoffTests {
       Issue.record("Expected createTabWithInput, got \(sent.value)")
       return
     }
-    #expect(input == HandoffCommandHandler.kickoff(for: "claude"))
+    #expect(input.contains("'claude'"))
+    #expect(input.contains("'--dangerously-skip-permissions'"))
+    #expect(!input.contains("gpt-5.4"))
+    #expect(input.contains(HandoffCommandHandler.kickoffPrompt()))
     #expect(runSetup == false)
     #expect(autoClose == false)
     #expect(name == "Hand off → claude")
@@ -161,6 +200,12 @@ struct AppFeatureHandoffTests {
     let log = try String(contentsOf: store2.logURL, encoding: .utf8)
     #expect(log.contains("launch=requested"))
     #expect(!log.contains("agent → claude  (command palette)"))
+    #expect(log.contains("preparation=completed"))
+    #expect(resumed.value?.agent == .codex)
+    #expect(resumed.value?.configuration.model == "gpt-5.4")
+    #expect(resumed.value?.configuration.executionMode == .unrestricted)
+    let current = try String(contentsOf: store2.currentURL, encoding: .utf8)
+    #expect(current.contains("Palette source status."))
   }
 
   @Test(.dependencies) func handoffDelegateDoesNotLaunchWhenArtifactPreparationFails() async throws {

--- a/supacodeTests/AppFeatureHandoffTests.swift
+++ b/supacodeTests/AppFeatureHandoffTests.swift
@@ -151,22 +151,31 @@ struct AppFeatureHandoffTests {
         )
       }
       $0.agentRuntimeClient = AgentRuntimeClient(
-        makeStartInvocation: { try AgentRuntimeAdapterRegistry.makeStartInvocation($0) },
-        resume: { request, directory in
+        resume: { request, _ in
           resumed.setValue(request)
-          let handoffURL = directory.appending(path: ".prowl/handoff", directoryHint: .isDirectory)
-          try FileManager.default.createDirectory(at: handoffURL, withIntermediateDirectories: true)
-          try "## Objective\n\nPalette source status.\n".write(
-            to: handoffURL.appending(path: "current.md"),
-            atomically: true,
-            encoding: .utf8
-          )
-          return ShellOutput(stdout: "", stderr: "", exitCode: 0)
+          return """
+            # Handoff
+
+            ## Objective
+            Palette source status.
+
+            ## Current State
+            Ready to hand off.
+
+            ## Next Steps
+            1. Continue in claude.
+            """
         }
       )
     }
 
     await store.send(.commandPalette(.delegate(.handoffToAgent("claude"))))
+    await store.receive(\.repositories.showToast) {
+      $0.repositories.statusToast = .inProgress("Preparing handoff from codex…")
+    }
+    await store.receive(\.repositories.dismissToast) {
+      $0.repositories.statusToast = nil
+    }
     await store.finish()
 
     #expect(sent.value.count == 1)
@@ -202,9 +211,10 @@ struct AppFeatureHandoffTests {
     #expect(!log.contains("agent → claude  (command palette)"))
     #expect(log.contains("preparation=completed"))
     #expect(resumed.value?.agent == .codex)
-    #expect(resumed.value?.configuration.model == "gpt-5.4")
-    #expect(resumed.value?.configuration.executionMode == .unrestricted)
+    #expect(resumed.value?.model == "gpt-5.4")
+    // Prowl transcribed the source reply into current.md.
     let current = try String(contentsOf: store2.currentURL, encoding: .utf8)
+    #expect(current.hasPrefix("# Handoff"))
     #expect(current.contains("Palette source status."))
   }
 

--- a/supacodeTests/HandoffCommandHandlerTests.swift
+++ b/supacodeTests/HandoffCommandHandlerTests.swift
@@ -1,3 +1,4 @@
+import ComposableArchitecture
 import Foundation
 import Testing
 
@@ -22,6 +23,16 @@ struct HandoffCommandHandlerTests {
   private func makeHandler(
     root: URL,
     outgoingAgent: String?,
+    outgoingLaunchObservation: AgentLaunchObservation? = AgentLaunchObservation(
+      model: "gpt-5.4",
+      executionMode: .unrestricted
+    ),
+    outgoingSession: AgentSession? = AgentSession(
+      id: "9B0E3B0E-67B3-4D45-A3A0-7DD9BC713711",
+      transcriptPath: nil,
+      source: .openFile,
+      confidence: .exact
+    ),
     sessionContext: HandoffStore.SessionContext? = HandoffStore.SessionContext(
       agent: "codex",
       paneID: "pane-0",
@@ -33,7 +44,8 @@ struct HandoffCommandHandlerTests {
     launched: HandoffLaunchedPane? = HandoffLaunchedPane(
       worktreeID: "ws", worktreeName: "Workspace", tabID: "tab-1", paneID: "pane-1", paneTitle: "claude"
     ),
-    launchSpy: (@MainActor (String) -> Void)? = nil
+    launchSpy: (@MainActor (AgentStartRequest) -> Void)? = nil,
+    preparationSpy: (@Sendable (AgentResumeRequest, URL) async -> HandoffPreparationOutcome)? = nil,
   ) -> HandoffCommandHandler {
     HandoffCommandHandler(
       resolveProvider: { _ in
@@ -44,13 +56,19 @@ struct HandoffCommandHandlerTests {
             rootPath: root.path(percentEncoded: false),
             paneID: "pane-0",
             outgoingAgent: outgoingAgent,
+            outgoingLaunchObservation: outgoingLaunchObservation,
+            outgoingSession: outgoingSession,
             sessionContext: sessionContext
           )
         )
       },
-      launchProvider: { _, kickoff in
-        launchSpy?(kickoff)
+      launchProvider: { _, request in
+        launchSpy?(request)
         return launched
+      },
+      preparationProvider: { request, directory in
+        guard let preparationSpy else { return .skipped }
+        return await preparationSpy(request, directory)
       },
       now: { [fixedDate] in fixedDate }
     )
@@ -80,6 +98,54 @@ struct HandoffCommandHandlerTests {
     let content = try String(contentsOf: store.contextURL, encoding: .utf8)
     #expect(content.contains("Session Context:"))
     #expect(content.contains(".prowl/handoff/sessions/"))
+  }
+
+  @Test func saveResumesVerifiedSourceBeforePersistingHandoff() async throws {
+    let root = try makeTempRoot()
+    defer { remove(root) }
+    let resumed = LockIsolated<AgentResumeRequest?>(nil)
+    let handler = makeHandler(
+      root: root,
+      outgoingAgent: "codex",
+      preparationSpy: { request, directory in
+        resumed.setValue(request)
+        let handoffURL = directory.appending(path: ".prowl/handoff", directoryHint: .isDirectory)
+        try? FileManager.default.createDirectory(at: handoffURL, withIntermediateDirectories: true)
+        try? "## Objective\n\nSource-authored status.\n".write(
+          to: handoffURL.appending(path: "current.md"),
+          atomically: true,
+          encoding: .utf8
+        )
+        return .completed
+      }
+    )
+
+    let response = await handler.handle(envelope: envelope(HandoffInput(action: .save)))
+
+    #expect(response.ok)
+    #expect(resumed.value?.agent == .codex)
+    #expect(resumed.value?.session.confidence == .exact)
+    #expect(resumed.value?.configuration.model == "gpt-5.4")
+    #expect(resumed.value?.configuration.executionMode == .unrestricted)
+    let content = try String(contentsOf: HandoffStore(rootURL: root).currentURL, encoding: .utf8)
+    #expect(content.contains("Source-authored status."))
+  }
+
+  @Test func preparationRequiresVerifiableSourceSession() {
+    let session = AgentSession(
+      id: "ambiguous-session",
+      transcriptPath: nil,
+      source: .recentFile,
+      confidence: .medium
+    )
+
+    #expect(
+      HandoffCommandHandler.preparationRequest(
+        outgoingAgent: "codex",
+        session: session,
+        observation: AgentLaunchObservation(executionMode: .unrestricted)
+      ) == nil
+    )
   }
 
   @Test func savePreservesResolvedNativeSessionContext() async throws {
@@ -114,11 +180,11 @@ struct HandoffCommandHandlerTests {
     let root = try makeTempRoot()
     defer { remove(root) }
 
-    var launchedKickoff: String?
+    var launchedRequest: AgentStartRequest?
     let handler = makeHandler(
       root: root,
       outgoingAgent: "codex",
-      launchSpy: { launchedKickoff = $0 }
+      launchSpy: { launchedRequest = $0 }
     )
 
     let response = await handler.handle(
@@ -132,10 +198,12 @@ struct HandoffCommandHandlerTests {
     #expect(payload.archivedPath?.hasPrefix("handoff/archive/") == true)
     #expect(payload.launchedPane?.paneID == "pane-1")
 
-    // The launched agent's kickoff command targets the handoff artifact.
-    #expect(launchedKickoff?.hasPrefix("claude ") == true)
-    #expect(launchedKickoff?.contains(".prowl/handoff/current.md") == true)
-    #expect(launchedKickoff?.contains("Session Context excerpt") == true)
+    // The receiving adapter gets a semantic handoff prompt and only portable
+    // source configuration. Cross-agent model identifiers must not leak.
+    #expect(launchedRequest?.agent == .claude)
+    #expect(launchedRequest?.configuration.model == nil)
+    #expect(launchedRequest?.configuration.executionMode == .unrestricted)
+    #expect(launchedRequest?.prompt.contains(".prowl/handoff/current.md") == true)
 
     // Log records the transition.
     let store = HandoffStore(rootURL: root)

--- a/supacodeTests/HandoffCommandHandlerTests.swift
+++ b/supacodeTests/HandoffCommandHandlerTests.swift
@@ -4,6 +4,21 @@ import Testing
 
 @testable import supacode
 
+/// A shape-valid preparation reply used when a test does not care about the
+/// reply content itself.
+nonisolated private let preparedHandoffReply = """
+  # Handoff
+
+  ## Objective
+  Ship the checkout flow.
+
+  ## Current State
+  Tests are green.
+
+  ## Next Steps
+  1. Review the PR.
+  """
+
 @MainActor
 struct HandoffCommandHandlerTests {
   private func makeTempRoot() throws -> URL {
@@ -45,7 +60,7 @@ struct HandoffCommandHandlerTests {
       worktreeID: "ws", worktreeName: "Workspace", tabID: "tab-1", paneID: "pane-1", paneTitle: "claude"
     ),
     launchSpy: (@MainActor (AgentStartRequest) -> Void)? = nil,
-    preparationSpy: (@Sendable (AgentResumeRequest, URL) async -> HandoffPreparationOutcome)? = nil,
+    preparationSpy: (@Sendable (AgentResumeRequest, URL) async throws -> String)? = nil,
   ) -> HandoffCommandHandler {
     HandoffCommandHandler(
       resolveProvider: { _ in
@@ -67,8 +82,8 @@ struct HandoffCommandHandlerTests {
         return launched
       },
       preparationProvider: { request, directory in
-        guard let preparationSpy else { return .skipped }
-        return await preparationSpy(request, directory)
+        guard let preparationSpy else { return preparedHandoffReply }
+        return try await preparationSpy(request, directory)
       },
       now: { [fixedDate] in fixedDate }
     )
@@ -100,23 +115,29 @@ struct HandoffCommandHandlerTests {
     #expect(content.contains(".prowl/handoff/sessions/"))
   }
 
-  @Test func saveResumesVerifiedSourceBeforePersistingHandoff() async throws {
+  @Test func saveTranscribesVerifiedSourceReplyBeforePersistingHandoff() async throws {
     let root = try makeTempRoot()
     defer { remove(root) }
     let resumed = LockIsolated<AgentResumeRequest?>(nil)
     let handler = makeHandler(
       root: root,
       outgoingAgent: "codex",
-      preparationSpy: { request, directory in
+      preparationSpy: { request, _ in
         resumed.setValue(request)
-        let handoffURL = directory.appending(path: ".prowl/handoff", directoryHint: .isDirectory)
-        try? FileManager.default.createDirectory(at: handoffURL, withIntermediateDirectories: true)
-        try? "## Objective\n\nSource-authored status.\n".write(
-          to: handoffURL.appending(path: "current.md"),
-          atomically: true,
-          encoding: .utf8
-        )
-        return .completed
+        return """
+          Here is the updated artifact:
+
+          # Handoff
+
+          ## Objective
+          Source-authored status.
+
+          ## Current State
+          Awaiting review.
+
+          ## Next Steps
+          1. Hand off.
+          """
       }
     )
 
@@ -125,10 +146,60 @@ struct HandoffCommandHandlerTests {
     #expect(response.ok)
     #expect(resumed.value?.agent == .codex)
     #expect(resumed.value?.session.confidence == .exact)
-    #expect(resumed.value?.configuration.model == "gpt-5.4")
-    #expect(resumed.value?.configuration.executionMode == .unrestricted)
+    #expect(resumed.value?.model == "gpt-5.4")
+    let payload = try #require(try response.data?.decode(as: HandoffCommandPayload.self))
+    #expect(payload.preparation == "completed")
+    // Prowl transcribed the reply (preamble dropped) into current.md.
     let content = try String(contentsOf: HandoffStore(rootURL: root).currentURL, encoding: .utf8)
+    #expect(content.hasPrefix("# Handoff"))
     #expect(content.contains("Source-authored status."))
+    // One save produces exactly one log line, carrying the preparation outcome.
+    let log = try String(contentsOf: HandoffStore(rootURL: root).logURL, encoding: .utf8)
+    let entries = log.split(separator: "\n").filter { $0.hasPrefix("- ") }
+    #expect(entries.count == 1)
+    #expect(entries.first?.contains("preparation=completed") == true)
+  }
+
+  @Test func saveMarksPreparationFailedForUnusableReply() async throws {
+    let root = try makeTempRoot()
+    defer { remove(root) }
+    let handler = makeHandler(
+      root: root,
+      outgoingAgent: "codex",
+      preparationSpy: { _, _ in "I could not update the handoff file." }
+    )
+
+    let response = await handler.handle(envelope: envelope(HandoffInput(action: .save)))
+
+    #expect(response.ok)
+    let payload = try #require(try response.data?.decode(as: HandoffCommandPayload.self))
+    #expect(payload.preparation == "failed")
+    // The scaffolded template stays in place; no reply prose leaks into it.
+    let content = try String(contentsOf: HandoffStore(rootURL: root).currentURL, encoding: .utf8)
+    #expect(content == HandoffStore.template)
+    let log = try String(contentsOf: HandoffStore(rootURL: root).logURL, encoding: .utf8)
+    #expect(log.contains("preparation=failed"))
+  }
+
+  @Test func saveSkipsPreparationWhenDisabled() async throws {
+    let root = try makeTempRoot()
+    defer { remove(root) }
+    let resumeCalled = LockIsolated(false)
+    let handler = makeHandler(
+      root: root,
+      outgoingAgent: "codex",
+      preparationSpy: { _, _ in
+        resumeCalled.setValue(true)
+        return preparedHandoffReply
+      }
+    )
+
+    let response = await handler.handle(envelope: envelope(HandoffInput(action: .save, prepare: false)))
+
+    #expect(response.ok)
+    #expect(resumeCalled.value == false)
+    let payload = try #require(try response.data?.decode(as: HandoffCommandPayload.self))
+    #expect(payload.preparation == "skipped")
   }
 
   @Test func preparationRequiresVerifiableSourceSession() {
@@ -146,6 +217,24 @@ struct HandoffCommandHandlerTests {
         observation: AgentLaunchObservation(executionMode: .unrestricted)
       ) == nil
     )
+  }
+
+  @Test func preparationRequestKeepsSameAdapterModelOnly() throws {
+    let request = try #require(
+      HandoffCommandHandler.preparationRequest(
+        outgoingAgent: "codex",
+        session: AgentSession(
+          id: "9B0E3B0E-67B3-4D45-A3A0-7DD9BC713711",
+          transcriptPath: nil,
+          source: .openFile,
+          confidence: .high
+        ),
+        observation: AgentLaunchObservation(model: "gpt-5.4", executionMode: .unrestricted)
+      )
+    )
+
+    #expect(request.agent == .codex)
+    #expect(request.model == "gpt-5.4")
   }
 
   @Test func savePreservesResolvedNativeSessionContext() async throws {

--- a/supacodeTests/HandoffStoreTests.swift
+++ b/supacodeTests/HandoffStoreTests.swift
@@ -131,14 +131,80 @@ struct HandoffStoreTests {
       ## Next Steps
       1. Review.
       """
-    #expect(store.applyPreparationReply(reply))
+    #expect(store.applyPreparationReply(reply, now: fixedDate))
     let content = try String(contentsOf: store.currentURL, encoding: .utf8)
     #expect(content == reply + "\n")
 
     // An unusable reply leaves the transcribed artifact untouched.
-    #expect(store.applyPreparationReply("nope") == false)
+    #expect(store.applyPreparationReply("nope", now: fixedDate) == false)
     let unchanged = try String(contentsOf: store.currentURL, encoding: .utf8)
     #expect(unchanged == reply + "\n")
+  }
+
+  @Test func applyPreparationReplyArchivesPreviousArtifact() throws {
+    let root = try makeTempRoot()
+    defer { remove(root) }
+    let store = HandoffStore(rootURL: root)
+    let previous = "# Handoff\n\n## Objective\nEarlier notes worth keeping.\n"
+    try FileManager.default.createDirectory(at: store.handoffDirectory, withIntermediateDirectories: true)
+    try previous.write(to: store.currentURL, atomically: true, encoding: .utf8)
+
+    let reply = """
+      # Handoff
+
+      ## Objective
+      Ship it.
+
+      ## Current State
+      Green.
+
+      ## Next Steps
+      1. Review.
+      """
+    #expect(store.applyPreparationReply(reply, now: fixedDate))
+
+    let archived = try FileManager.default.contentsOfDirectory(
+      at: store.archiveDirectory,
+      includingPropertiesForKeys: nil
+    )
+    let backup = try #require(archived.first { $0.lastPathComponent.hasSuffix("-preparation-backup.md") })
+    #expect(archived.count == 1)
+    #expect(try String(contentsOf: backup, encoding: .utf8) == previous)
+    #expect(try String(contentsOf: store.currentURL, encoding: .utf8) == reply + "\n")
+  }
+
+  @Test func applyPreparationReplySkipsArchiveForTemplateOrMissingArtifact() throws {
+    let reply = """
+      # Handoff
+
+      ## Objective
+      Ship it.
+
+      ## Current State
+      Green.
+
+      ## Next Steps
+      1. Review.
+      """
+
+    // First-ever preparation: no current.md to snapshot.
+    let freshRoot = try makeTempRoot()
+    defer { remove(freshRoot) }
+    let freshStore = HandoffStore(rootURL: freshRoot)
+    #expect(freshStore.applyPreparationReply(reply, now: fixedDate))
+    #expect(!FileManager.default.fileExists(atPath: freshStore.archiveDirectory.path(percentEncoded: false)))
+
+    // A never-edited seeded template carries no prose worth archiving.
+    let seededRoot = try makeTempRoot()
+    defer { remove(seededRoot) }
+    let seededStore = HandoffStore(rootURL: seededRoot)
+    try seededStore.ensureScaffold()
+    #expect(seededStore.applyPreparationReply(reply, now: fixedDate))
+    let archived = try FileManager.default.contentsOfDirectory(
+      at: seededStore.archiveDirectory,
+      includingPropertiesForKeys: nil
+    )
+    #expect(archived.isEmpty)
   }
 
   // MARK: - save (filesystem; non-git root)

--- a/supacodeTests/HandoffStoreTests.swift
+++ b/supacodeTests/HandoffStoreTests.swift
@@ -64,6 +64,83 @@ struct HandoffStoreTests {
     #expect(deletions == 0)
   }
 
+  // MARK: - preparedArtifact (pure)
+
+  @Test func preparedArtifactAcceptsPlainDocument() {
+    let reply = """
+      # Handoff
+
+      ## Objective
+      Ship it.
+
+      ## Current State
+      Green.
+
+      ## Next Steps
+      1. Review.
+      """
+    #expect(HandoffStore.preparedArtifact(fromAgentReply: reply) == reply + "\n")
+  }
+
+  @Test func preparedArtifactUnwrapsCodeFenceAndDropsPreamble() {
+    let reply = """
+      Sure! Here's the updated handoff:
+
+      ```markdown
+      # Handoff
+
+      ## Objective
+      Ship it.
+
+      ## Current State
+      Green.
+
+      ## Next Steps
+      1. Review.
+      ```
+      """
+    let artifact = HandoffStore.preparedArtifact(fromAgentReply: reply)
+    #expect(artifact?.hasPrefix("# Handoff") == true)
+    #expect(artifact?.contains("```") == false)
+    #expect(artifact?.contains("Sure!") == false)
+  }
+
+  @Test func preparedArtifactRejectsUnusableReplies() {
+    #expect(HandoffStore.preparedArtifact(fromAgentReply: "") == nil)
+    #expect(HandoffStore.preparedArtifact(fromAgentReply: "I could not update the file.") == nil)
+    // Missing required sections.
+    #expect(HandoffStore.preparedArtifact(fromAgentReply: "# Handoff\n\n## Objective\nOnly this.") == nil)
+    // Echoing the seeded template back is not a prepared artifact.
+    #expect(HandoffStore.preparedArtifact(fromAgentReply: HandoffStore.template) == nil)
+  }
+
+  @Test func applyPreparationReplyTranscribesIntoCurrent() throws {
+    let root = try makeTempRoot()
+    defer { remove(root) }
+    let store = HandoffStore(rootURL: root)
+
+    let reply = """
+      # Handoff
+
+      ## Objective
+      Ship it.
+
+      ## Current State
+      Green.
+
+      ## Next Steps
+      1. Review.
+      """
+    #expect(store.applyPreparationReply(reply))
+    let content = try String(contentsOf: store.currentURL, encoding: .utf8)
+    #expect(content == reply + "\n")
+
+    // An unusable reply leaves the transcribed artifact untouched.
+    #expect(store.applyPreparationReply("nope") == false)
+    let unchanged = try String(contentsOf: store.currentURL, encoding: .utf8)
+    #expect(unchanged == reply + "\n")
+  }
+
   // MARK: - save (filesystem; non-git root)
 
   @Test func scaffoldSelfIgnoresHandoffInGitRepository() throws {

--- a/supacodeTests/PaneAgentStateTests.swift
+++ b/supacodeTests/PaneAgentStateTests.swift
@@ -136,4 +136,23 @@ struct PaneAgentStateTests {
     // A plain shell (no detected agent) is never busy, even mid-output.
     #expect(!PaneAgentState(detectedAgent: nil, state: .working).isBusy)
   }
+  @Test func launchObservationRetainsOnlyForSameProcess() {
+    let observation = AgentLaunchObservation(model: "gpt-5.4", executionMode: .unrestricted)
+    let previous = PaneAgentState(agentProcessID: 42, launchObservation: observation)
+
+    #expect(
+      PaneAgentState.retainedLaunchObservation(
+        observed: nil,
+        previous: previous,
+        identifiedPID: 42
+      ) == observation
+    )
+    #expect(
+      PaneAgentState.retainedLaunchObservation(
+        observed: nil,
+        previous: previous,
+        identifiedPID: 43
+      ) == nil
+    )
+  }
 }

--- a/supacodeTests/PaneAgentStateTests.swift
+++ b/supacodeTests/PaneAgentStateTests.swift
@@ -136,6 +136,7 @@ struct PaneAgentStateTests {
     // A plain shell (no detected agent) is never busy, even mid-output.
     #expect(!PaneAgentState(detectedAgent: nil, state: .working).isBusy)
   }
+
   @Test func launchObservationRetainsOnlyForSameProcess() {
     let observation = AgentLaunchObservation(model: "gpt-5.4", executionMode: .unrestricted)
     let previous = PaneAgentState(agentProcessID: 42, launchObservation: observation)


### PR DESCRIPTION
## Summary
- add structured Claude Code and Codex runtime adapters for observed launch configuration, interactive start, and direct-argv session resume
- have `handoff save`, `handoff to`, and Command Palette handoff ask a verified source session to update agent-authored `current.md` before generated state is saved
- preserve observed unrestricted execution across the two verified adapters while preventing cross-agent model leakage
- update handoff, CLI, Command Palette, and curated design documentation

## Review hardening (second commit)
- the preparation resume is now **read-only by construction**: `AgentResumeRequest` carries only a same-adapter model and never renders dangerous flags
- the source agent **replies** with the updated `current.md` (codex `--output-last-message`, claude `-p` stdout); Prowl validates the reply (sections present, not the template, fences/preamble stripped) and transcribes it — `preparation=completed` is now verifiable and works in both CLIs' default safe configuration
- one preparation turn is bounded to **2 minutes** with child termination on expiry
- new `--no-prepare` flag on `handoff save` / `handoff to`; preparation outcome recorded on the single `save` log line and in the CLI payload
- codex `--yolo` counts as observed unrestricted; Command Palette shows progress/warning toasts during preparation; `AgentRuntimeClient.testValue` reports unstubbed use

## Verification
- `make check`
- focused `xcodebuild test` selection (adapter/store/handler/palette/pane-state suites): 63 tests passed
- `make build-cli`, `make test-cli-smoke`, `make test-cli-integration` (63 passed)
- `make build-app` (zero warnings)

https://claude.ai/code/session_016Ep1S48WqbpmVDbjL8Mh3f
