### PR TITLE
Add Qoder CLI agent detection

### DIFF
--- a/docs/components/agent-detection.md
+++ b/docs/components/agent-detection.md
@@ -17,8 +17,8 @@ running and what state it's in. That signal drives the
 ## Agents it recognizes
 
 Claude (Claude Code), Codex, Gemini, Cursor, Cline, OpenCode, GitHub Copilot,
-Kimi, Droid, Amp, Pi (`pi`), Oh My Pi (`omp`, `oh-my-pi`), Qwen Code (`qwen`),
-and Grok Build (`grok`).
+Kimi, Droid, Amp, Pi (`pi`), Oh My Pi (`omp`, `oh-my-pi`), Qoder CLI (`qodercli`),
+Qwen Code (`qwen`), and Grok Build (`grok`).
 Detection covers
 common wrappers (node, python, bun, bash, etc.) so agents launched indirectly are
 still found. Oh My Pi reuses Pi-derived screen heuristics but uses its own command

--- a/supacode/Domain/AgentDetection/DetectedAgent.swift
+++ b/supacode/Domain/AgentDetection/DetectedAgent.swift
@@ -13,6 +13,7 @@ enum DetectedAgent: String, CaseIterable, Equatable, Identifiable, Sendable {
   case kimi
   case droid
   case amp
+  case qoder = "qodercli"
   case qwen
   case grok
 

--- a/supacode/Features/Terminal/Models/CommandIconMap.swift
+++ b/supacode/Features/Terminal/Models/CommandIconMap.swift
@@ -44,6 +44,7 @@ enum CommandIconMap {
     "gemini": TabIconSource(systemSymbol: "sparkle", assetName: "Gemini"),
     "kimi": TabIconSource(systemSymbol: "sparkle", assetName: "Kimi"),
     "opencode": TabIconSource(systemSymbol: "sparkle", assetName: "OpenCode"),
+    "qodercli": TabIconSource(systemSymbol: "sparkle"),
     "qwen": TabIconSource(systemSymbol: "sparkle", assetName: "Qwen"),
     "grok": TabIconSource(systemSymbol: "sparkle", assetName: "Grok"),
     "omp": TabIconSource(systemSymbol: "sparkle", assetName: "OMP"),

--- a/supacode/Infrastructure/AgentDetection/AgentClassifier.swift
+++ b/supacode/Infrastructure/AgentDetection/AgentClassifier.swift
@@ -25,10 +25,8 @@ func identifyAgent(processName: String) -> DetectedAgent? {
     return .droid
   case "amp", "amp-local":
     return .amp
-  case "qodercli":
-    return .qoder
-  case "qwen":
-    return .qwen
+  case "qodercli", "qwen":
+    return DetectedAgent(rawValue: lower)
   case "grok":
     return .grok
   default:

--- a/supacode/Infrastructure/AgentDetection/AgentClassifier.swift
+++ b/supacode/Infrastructure/AgentDetection/AgentClassifier.swift
@@ -25,6 +25,8 @@ func identifyAgent(processName: String) -> DetectedAgent? {
     return .droid
   case "amp", "amp-local":
     return .amp
+  case "qodercli":
+    return .qoder
   case "qwen":
     return .qwen
   case "grok":

--- a/supacode/Infrastructure/AgentDetection/AgentClassifier.swift
+++ b/supacode/Infrastructure/AgentDetection/AgentClassifier.swift
@@ -1,43 +1,36 @@
 import Foundation
 
+/// Known agent install/launcher binary names (lowercased). Aliases map to the
+/// same agent; extend this table when onboarding a new CLI.
+private let knownAgentBinaries: [String: DetectedAgent] = [
+  "pi": .pi, "omp": .pi, "oh-my-pi": .pi,
+  "claude": .claude, "claude-code": .claude,
+  "codex": .codex, "omx": .codex, "oh-my-codex": .codex,
+  "gemini": .gemini,
+  "cursor": .cursor, "cursor-agent": .cursor,
+  "cline": .cline,
+  "opencode": .opencode, "open-code": .opencode,
+  "copilot": .copilot, "github-copilot": .copilot, "ghcs": .copilot,
+  "kimi": .kimi, "kimi code": .kimi,
+  "droid": .droid,
+  "amp": .amp, "amp-local": .amp,
+  "qodercli": .qoder,
+  "qwen": .qwen,
+  "grok": .grok,
+]
+
 func identifyAgent(processName: String) -> DetectedAgent? {
   let lower = processName.lowercased()
-  switch lower {
-  case "pi", "omp", "oh-my-pi":
-    return .pi
-  case "claude", "claude-code":
-    return .claude
-  case "codex", "omx", "oh-my-codex":
-    return .codex
-  case "gemini":
-    return .gemini
-  case "cursor", "cursor-agent":
-    return .cursor
-  case "cline":
-    return .cline
-  case "opencode", "open-code":
-    return .opencode
-  case "copilot", "github-copilot", "ghcs":
-    return .copilot
-  case "kimi", "kimi code":
-    return .kimi
-  case "droid":
-    return .droid
-  case "amp", "amp-local":
-    return .amp
-  case "qodercli", "qwen":
-    return DetectedAgent(rawValue: lower)
-  case "grok":
-    return .grok
-  default:
-    // Versioned install binary only, e.g. `grok-0.2.101-macos-aarch64`.
-    // Must not match model-id tokens like `grok-4` / `grok-4.5` that show up
-    // as argv fragments of other agents (score-40 wrapped-runtime candidates).
-    if isGrokVersionedBinaryName(lower) {
-      return .grok
-    }
-    return nil
+  if let agent = knownAgentBinaries[lower] {
+    return agent
   }
+  // Versioned install binary only, e.g. `grok-0.2.101-macos-aarch64`.
+  // Must not match model-id tokens like `grok-4` / `grok-4.5` that show up
+  // as argv fragments of other agents (score-40 wrapped-runtime candidates).
+  if isGrokVersionedBinaryName(lower) {
+    return .grok
+  }
+  return nil
 }
 
 /// Install packages are named `grok-<semver>-<platform>-<arch>` (verified

--- a/supacode/Infrastructure/AgentDetection/AgentSessionProfile.swift
+++ b/supacode/Infrastructure/AgentDetection/AgentSessionProfile.swift
@@ -48,7 +48,7 @@ nonisolated struct AgentSessionProfile: Sendable {
     case .droid: .droid
     case .opencode: .opencode
     case .amp: .amp
-    case .qoder: .init()
+    case .qoder: .qoder
     case .qwen: .qwen
     case .grok: .grok
     }
@@ -198,6 +198,17 @@ nonisolated extension AgentSessionProfile {
     candidateRoots: { home, cwd, _, _ in
       guard let cwd else { return [] }
       return [home.appending(path: ".factory/sessions/\(slashDashed(cwd.path))")]
+    }
+  )
+
+  /// Qoder CLI ≥ 1.0.48: `~/.qoder/projects/<sanitized cwd>/<uuid>.jsonl`,
+  /// Claude Code's layout under a different root — every non-alphanumeric cwd
+  /// character becomes `-`. Verified against a local 1.0.48 install.
+  fileprivate static let qoder = AgentSessionProfile(
+    parsePath: { uuidJSONL(path: $0, marker: "/.qoder/projects/") },
+    candidateRoots: { home, cwd, _, _ in
+      guard let cwd else { return [] }
+      return [home.appending(path: ".qoder/projects/\(alphanumericDashed(cwd.path))")]
     }
   )
 

--- a/supacode/Infrastructure/AgentDetection/AgentSessionProfile.swift
+++ b/supacode/Infrastructure/AgentDetection/AgentSessionProfile.swift
@@ -48,6 +48,7 @@ nonisolated struct AgentSessionProfile: Sendable {
     case .droid: .droid
     case .opencode: .opencode
     case .amp: .amp
+    case .qoder: .init()
     case .qwen: .qwen
     case .grok: .grok
     }

--- a/supacode/Infrastructure/AgentDetection/ScreenHeuristics.swift
+++ b/supacode/Infrastructure/AgentDetection/ScreenHeuristics.swift
@@ -28,6 +28,8 @@ extension DetectedAgent {
       return detectDroid(screen)
     case .amp:
       return detectAmp(screen)
+    case .qoder:
+      return detectQoder(screen)
     case .qwen:
       return detectQwen(screen)
     case .grok:
@@ -516,6 +518,46 @@ nonisolated private func detectQwen(_ content: String) -> AgentRawState {
     return .working
   }
   return .idle
+}
+
+// Qoder CLI 1.0.48 renders a permission menu with the three option labels
+// below, while an active turn uses a braille spinner footer ending in
+// "(esc to cancel, <elapsed>)". Restrict both checks to the active tail so
+// completed transcript text does not keep a pane blocked or working.
+nonisolated private func detectQoder(_ content: String) -> AgentRawState {
+  let currentInteraction = qoderCurrentInteractionRegion(content)
+  if hasQoderPermissionPrompt(currentInteraction) {
+    return .blocked
+  }
+  if hasQoderWorkingFooter(currentInteraction) {
+    return .working
+  }
+  return .idle
+}
+
+nonisolated private func qoderCurrentInteractionRegion(_ content: String) -> String {
+  content
+    .split(separator: "\n", omittingEmptySubsequences: false)
+    .map { $0.trimmingCharacters(in: .whitespaces) }
+    .filter { !$0.isEmpty }
+    .suffix(8)
+    .joined(separator: "\n")
+}
+
+nonisolated private func hasQoderPermissionPrompt(_ content: String) -> Bool {
+  let lower = content.lowercased()
+  return lower.contains("allow once")
+    && lower.contains("allow for this session")
+    && lower.contains("reject and type something")
+}
+
+nonisolated private func hasQoderWorkingFooter(_ content: String) -> Bool {
+  content.split(separator: "\n", omittingEmptySubsequences: false).contains { line in
+    let trimmed = line.trimmingCharacters(in: .whitespaces)
+    guard let first = trimmed.unicodeScalars.first else { return false }
+    return (0x2800...0x28FF).contains(Int(first.value))
+      && trimmed.lowercased().contains("(esc to cancel,")
+  }
 }
 
 // Grok Build (verified 0.2.101): cancel mid-turn is Ctrl+C (Esc is a no-op).

--- a/supacode/Infrastructure/AgentDetection/ScreenHeuristics.swift
+++ b/supacode/Infrastructure/AgentDetection/ScreenHeuristics.swift
@@ -520,35 +520,37 @@ nonisolated private func detectQwen(_ content: String) -> AgentRawState {
   return .idle
 }
 
-// Qoder CLI 1.0.48 renders a permission menu with the three option labels
-// below, while an active turn uses a braille spinner footer ending in
-// "(esc to cancel, <elapsed>)". Restrict both checks to the active tail so
-// completed transcript text does not keep a pane blocked or working.
+// Qoder CLI (verified 1.0.48, live session): blocked dialogs are ephemeral
+// overlays that vanish once answered, so full-window matching is safe.
+// Permission menus always pair "Allow once" with "Reject and type something"
+// (the second row varies by tool: "Allow for this session" for edits,
+// "Always allow \"<cmd>\" for future sessions" for exec/MCP). Ask-user
+// questions render an "Asking User" header with a fixed "Type Something"
+// row; the plan-ready dialog pairs "Yes, start executing" with "Reject
+// plan". An active turn shows a braille spinner footer ending in
+// "(esc to cancel, <elapsed>)". Multi-token matches only — single labels
+// like "Allow once" or "No" can appear in transcript text.
 nonisolated private func detectQoder(_ content: String) -> AgentRawState {
-  let currentInteraction = qoderCurrentInteractionRegion(content)
-  if hasQoderPermissionPrompt(currentInteraction) {
+  let lower = content.lowercased()
+  if hasQoderPermissionMenu(lower) || hasQoderQuestionPrompt(lower) || hasQoderPlanReadyPrompt(lower) {
     return .blocked
   }
-  if hasQoderWorkingFooter(currentInteraction) {
+  if hasQoderWorkingFooter(content) {
     return .working
   }
   return .idle
 }
 
-nonisolated private func qoderCurrentInteractionRegion(_ content: String) -> String {
-  content
-    .split(separator: "\n", omittingEmptySubsequences: false)
-    .map { $0.trimmingCharacters(in: .whitespaces) }
-    .filter { !$0.isEmpty }
-    .suffix(8)
-    .joined(separator: "\n")
+nonisolated private func hasQoderPermissionMenu(_ lower: String) -> Bool {
+  lower.contains("allow once") && lower.contains("reject and type something")
 }
 
-nonisolated private func hasQoderPermissionPrompt(_ content: String) -> Bool {
-  let lower = content.lowercased()
-  return lower.contains("allow once")
-    && lower.contains("allow for this session")
-    && lower.contains("reject and type something")
+nonisolated private func hasQoderQuestionPrompt(_ lower: String) -> Bool {
+  lower.contains("asking user") && lower.contains("type something")
+}
+
+nonisolated private func hasQoderPlanReadyPrompt(_ lower: String) -> Bool {
+  lower.contains("yes, start executing") && lower.contains("reject plan")
 }
 
 nonisolated private func hasQoderWorkingFooter(_ content: String) -> Bool {

--- a/supacodeTests/AgentClassifierTests.swift
+++ b/supacodeTests/AgentClassifierTests.swift
@@ -24,7 +24,7 @@ struct AgentClassifierTests {
     #expect(identifyAgent(processName: "amp") == .amp)
     #expect(identifyAgent(processName: "amp-local") == .amp)
     #expect(identifyAgent(processName: "qwen") == .qwen)
-    #expect(identifyAgent(processName: "qodercli")?.rawValue == "qodercli")
+    #expect(identifyAgent(processName: "qodercli") == .qoder)
     #expect(identifyAgent(processName: "grok") == .grok)
     #expect(identifyAgent(processName: "grok-0.2.101-macos-aarch64") == .grok)
     // Model ids must not be treated as the install binary.
@@ -243,7 +243,7 @@ struct AgentClassifierTests {
     )
 
     let result = try #require(identifyAgentInJob(job))
-    #expect(result.agent.rawValue == "qodercli")
+    #expect(result.agent == .qoder)
     #expect(result.name == "qodercli")
   }
 

--- a/supacodeTests/AgentClassifierTests.swift
+++ b/supacodeTests/AgentClassifierTests.swift
@@ -24,6 +24,7 @@ struct AgentClassifierTests {
     #expect(identifyAgent(processName: "amp") == .amp)
     #expect(identifyAgent(processName: "amp-local") == .amp)
     #expect(identifyAgent(processName: "qwen") == .qwen)
+    #expect(identifyAgent(processName: "qodercli")?.rawValue == "qodercli")
     #expect(identifyAgent(processName: "grok") == .grok)
     #expect(identifyAgent(processName: "grok-0.2.101-macos-aarch64") == .grok)
     // Model ids must not be treated as the install binary.
@@ -226,6 +227,24 @@ struct AgentClassifierTests {
     let result = try #require(identifyAgentInJob(job))
     #expect(result.agent == .codex)
     #expect(result.name == "codex")
+  }
+
+  @Test func identifiesQoderCLIWrappedByNode() throws {
+    let job = ForegroundJob(
+      processGroupID: 42,
+      processes: [
+        ForegroundProcess(
+          pid: 100,
+          name: "node",
+          argv0: "node",
+          cmdline: "node /opt/homebrew/lib/node_modules/@qoder-ai/qodercli/bundle/qodercli.js"
+        )
+      ]
+    )
+
+    let result = try #require(identifyAgentInJob(job))
+    #expect(result.agent.rawValue == "qodercli")
+    #expect(result.name == "qodercli")
   }
 
   @Test func identifiesOmxAsCodexWrapper() throws {

--- a/supacodeTests/AgentSessionProfileTests.swift
+++ b/supacodeTests/AgentSessionProfileTests.swift
@@ -34,6 +34,25 @@ struct AgentSessionProfileTests {
     #expect(roots.map(\.path) == ["/Users/me/.claude/projects/-private-tmp-prowl556-review----caf-"])
   }
 
+  @Test func qoderReusesClaudeLayoutUnderQoderRoot() {
+    // Verified against Qoder CLI 1.0.48: ~/.qoder/projects/<sanitized cwd>/<uuid>.jsonl.
+    let profile = AgentSessionProfile.profile(for: .qoder)
+    let cwd = URL(fileURLWithPath: "/Users/me/Sync/github/Prowl", isDirectory: true)
+    #expect(
+      profile.candidateRoots(home, cwd, now, now).map(\.path)
+        == ["/Users/me/.qoder/projects/-Users-me-Sync-github-Prowl"]
+    )
+    #expect(profile.candidateRoots(home, nil, now, now).isEmpty)
+    let id = "40e2d9c9-dca4-4969-a9a0-56fb423e58e6"
+    let path = "/Users/me/.qoder/projects/-Users-me-Sync-github-Prowl/\(id).jsonl"
+    let parsed = profile.parsePath(path)
+    #expect(parsed?.id == id)
+    #expect(parsed?.transcriptPath?.path == path)
+    // Sibling checkpoint directories and foreign roots must not parse.
+    #expect(profile.parsePath("/Users/me/.qoder/projects/-Users-me-Sync-github-Prowl/\(id)") == nil)
+    #expect(profile.parsePath("/Users/me/.claude/projects/-Users-me-Sync-github-Prowl/\(id).jsonl") == nil)
+  }
+
   @Test func piAndDroidRootsKeepDotsAndSpaces() {
     let cwd = URL(fileURLWithPath: "/Users/me/.prowl/repos/My App", isDirectory: true)
     let piRoots = AgentSessionProfile.profile(for: .pi).candidateRoots(home, cwd, now, now)

--- a/supacodeTests/CommandIconMapTests.swift
+++ b/supacodeTests/CommandIconMapTests.swift
@@ -78,6 +78,7 @@ struct CommandIconMapTests {
     #expect(CommandIconMap.iconForFirstToken("cline")?.assetName == "Cline")
     #expect(CommandIconMap.iconForFirstToken("droid")?.assetName == "Droid")
     #expect(CommandIconMap.iconForFirstToken("qwen")?.assetName == "Qwen")
+    #expect(CommandIconMap.iconForFirstToken("qodercli")?.systemSymbol == "sparkle")
     #expect(CommandIconMap.iconForFirstToken("grok")?.assetName == "Grok")
     // Aider has no bundled brand asset — sparkle fallback only.
     #expect(CommandIconMap.iconForFirstToken("aider")?.systemSymbol == "sparkle")

--- a/supacodeTests/ScreenHeuristicsTests.swift
+++ b/supacodeTests/ScreenHeuristicsTests.swift
@@ -541,59 +541,97 @@ struct ScreenHeuristicsTests {
     #expect(DetectedAgent.qwen.detectState(in: "> Type your message") == .idle)
   }
 
-  @Test func qoderCLIDetection() throws {
-    let qoder = try #require(DetectedAgent(rawValue: "qodercli"))
-
+  @Test func qoderCLIDetection() {
+    // Exec permission menu captured from a live Qoder CLI 1.0.48 session; the
+    // second row is dynamic ("Always allow \"<cmd>\" for future sessions"),
+    // so detection must not require "Allow for this session".
     #expect(
-      qoder.detectState(
+      DetectedAgent.qoder.detectState(
         in: """
-          Bash(git status) needs permission
-          > Allow once
-            Allow for this session
-            Reject and type something
-            No
+           Permission Required
+           Tool: Bash
+           Command: echo hello > /tmp/qoder_perm_test.txt
+           Allow this command to run? Redirection detected.
+            ❯ 1. Allow once
+              2. Always allow "echo" for future sessions [local]
+              3. Reject and type something
+              4. No
           """
       ) == .blocked
     )
+    // Edit-style menu keeps the session-scoped row.
     #expect(
-      qoder.detectState(
-        in: "⠋ Thinking... (esc to cancel, 12s)"
+      DetectedAgent.qoder.detectState(
+        in: """
+           ❯ 1. Allow once
+             2. Allow for this session
+             3. Reject and type something
+             4. No
+          """
+      ) == .blocked
+    )
+    // Ask-user question dialog (live capture): dynamic options plus the fixed
+    // "Type Something" row under an "Asking User" header.
+    #expect(
+      DetectedAgent.qoder.detectState(
+        in: """
+           Asking User
+           Which color do you prefer?
+            ❯ 1. Red
+              2. Blue
+              3. Type Something
+           ↑↓ navigate · Enter select · Esc back
+          """
+      ) == .blocked
+    )
+    // Plan-ready dialog (live capture).
+    #expect(
+      DetectedAgent.qoder.detectState(
+        in: """
+          Qoder has written up a plan and is ready to execute. Would you like to proceed?
+           ❯ 1. Yes, start executing
+             2. Yes, execute as Goal (auto)
+             3. Refuse and say something
+             4. Reject plan
+          Ctrl+X to edit plan
+          """
+      ) == .blocked
+    )
+    // Working footer stays detected with the full input-box chrome below it
+    // (live capture: 6 persistent footer lines under the spinner).
+    #expect(
+      DetectedAgent.qoder.detectState(
+        in: """
+           ⠹ Thinking... (esc to cancel, 2s)
+          ─────────────────────────────
+           Shift+Tab to Accept Edits
+          ─────────────────────────────
+           >   Type your message or @path/to/file
+          ─────────────────────────────
+           Ultimate Model · ctx ░░░░░░░░░░ 0% · ~/Sync/github/Prowl
+          """
       ) == .working
     )
-    #expect(qoder.detectState(in: "Allow once\nNo") == .idle)
+    // Resolved dialogs vanish entirely (ephemeral overlays); the transcript
+    // only keeps the tool row, so a finished screen is idle.
     #expect(
-      qoder.detectState(
+      DetectedAgent.qoder.detectState(
         in: """
-          > Allow once
-            Allow for this session
-            Reject and type something
-            No
-          Permission resolved.
-          Current prompt is ready.
-          Use /help for commands.
-          Workspace: Prowl
-          Mode: default
-          Model: Qoder
-          ? for shortcuts
-          ❯
+           x Bash(echo hello > /tmp/qoder_perm_test.txt)
+             └ User cancelled.
+          ─────────────────────────────
+           Shift+Tab to Accept Edits
+          ─────────────────────────────
+           >   Type your message or @path/to/file
+          ─────────────────────────────
+           Ultimate Model · ctx ▓▓░░░░░░░░ 17% · ~/Sync/github/Prowl
           """
       ) == .idle
     )
-    #expect(
-      qoder.detectState(
-        in: """
-          ⠋ Thinking... (esc to cancel, 12s)
-          Previous task completed.
-          Current prompt is ready.
-          Use /help for commands.
-          Workspace: Prowl
-          Mode: default
-          Model: Qoder
-          ? for shortcuts
-          ❯
-          """
-      ) == .idle
-    )
+    // Single labels in prose must not block; a quoted footer without the
+    // braille spinner must not read as working.
+    #expect(DetectedAgent.qoder.detectState(in: "Allow once\nNo") == .idle)
+    #expect(DetectedAgent.qoder.detectState(in: "Thinking... (esc to cancel, 12s)") == .idle)
   }
 
   @Test func grokDetection() {

--- a/supacodeTests/ScreenHeuristicsTests.swift
+++ b/supacodeTests/ScreenHeuristicsTests.swift
@@ -541,6 +541,61 @@ struct ScreenHeuristicsTests {
     #expect(DetectedAgent.qwen.detectState(in: "> Type your message") == .idle)
   }
 
+  @Test func qoderCLIDetection() throws {
+    let qoder = try #require(DetectedAgent(rawValue: "qodercli"))
+
+    #expect(
+      qoder.detectState(
+        in: """
+          Bash(git status) needs permission
+          > Allow once
+            Allow for this session
+            Reject and type something
+            No
+          """
+      ) == .blocked
+    )
+    #expect(
+      qoder.detectState(
+        in: "⠋ Thinking... (esc to cancel, 12s)"
+      ) == .working
+    )
+    #expect(qoder.detectState(in: "Allow once\nNo") == .idle)
+    #expect(
+      qoder.detectState(
+        in: """
+          > Allow once
+            Allow for this session
+            Reject and type something
+            No
+          Permission resolved.
+          Current prompt is ready.
+          Use /help for commands.
+          Workspace: Prowl
+          Mode: default
+          Model: Qoder
+          ? for shortcuts
+          ❯
+          """
+      ) == .idle
+    )
+    #expect(
+      qoder.detectState(
+        in: """
+          ⠋ Thinking... (esc to cancel, 12s)
+          Previous task completed.
+          Current prompt is ready.
+          Use /help for commands.
+          Workspace: Prowl
+          Mode: default
+          Model: Qoder
+          ? for shortcuts
+          ❯
+          """
+      ) == .idle
+    )
+  }
+
   @Test func grokDetection() {
     // Permission chrome (labels verified against Grok Build 0.2.101 binary).
     #expect(


### PR DESCRIPTION
## What

- Add Qoder CLI (`qodercli`) as a detected coding agent.
- Recognize both native `qodercli` processes and Node entrypoints ending in `qodercli.js`.
- Detect Qoder permission menus as blocked and active spinner footers as working.
- Add a command icon fallback and document Qoder CLI support.

## Why

Prowl previously treated Qoder CLI as a regular terminal process, so it did not appear in Active Agents or `prowl agents`.

## How tested

- Ran focused agent classifier, screen heuristic, and icon mapping tests.
- Ran `make check`.
- Ran `make build-app`.
- Launched an isolated debug Prowl instance and verified `prowl agents --json` reported `type: "qodercli"` and `status: "working"` for a Qoder-shaped process.

Fixes #594

onevtail - an assistant to @onevcat