### PR TITLE
Harden ShellClient process cancellation

### DIFF
--- a/supacode/Clients/Shell/ShellClient.swift
+++ b/supacode/Clients/Shell/ShellClient.swift
@@ -148,18 +148,61 @@ extension DependencyValues {
 
 private nonisolated let shellLogger = SupaLogger("Shell")
 
+/// Coordinates cancellation before and after the worker has started the
+/// subprocess. A cancellation request must never be lost while `Process.run()`
+/// is still racing with task or stream teardown.
+nonisolated final class ProcessCancellation: @unchecked Sendable {
+  private let lock = NSLock()
+  private var cancellationRequested = false
+  private var termination: (@Sendable () -> Void)?
+  private var didTerminate = false
+
+  func installTermination(_ termination: @escaping @Sendable () -> Void) {
+    let action: (@Sendable () -> Void)?
+    lock.lock()
+    self.termination = termination
+    action = takeTerminationLocked()
+    lock.unlock()
+    action?()
+  }
+
+  func cancel() {
+    let action: (@Sendable () -> Void)?
+    lock.lock()
+    cancellationRequested = true
+    action = takeTerminationLocked()
+    lock.unlock()
+    action?()
+  }
+
+  private func takeTerminationLocked() -> (@Sendable () -> Void)? {
+    guard cancellationRequested, !didTerminate, let termination else { return nil }
+    didTerminate = true
+    return termination
+  }
+}
+
+private struct ProcessExecution: Sendable {
+  let stream: AsyncThrowingStream<ShellStreamEvent, Error>
+  let cancel: @Sendable () -> Void
+}
+
 nonisolated private func runProcess(
   executableURL: URL,
   arguments: [String],
   currentDirectoryURL: URL?
 ) async throws -> ShellOutput {
-  let stream = runProcessStream(
+  let execution = makeProcessExecution(
     executableURL: executableURL,
     arguments: arguments,
     currentDirectoryURL: currentDirectoryURL
   )
   let command = ([executableURL.path(percentEncoded: false)] + arguments).joined(separator: " ")
-  return try await collectOutput(from: stream, command: command)
+  return try await withTaskCancellationHandler {
+    try await collectOutput(from: execution.stream, command: command)
+  } onCancel: {
+    execution.cancel()
+  }
 }
 
 nonisolated private func runProcessStream(
@@ -167,11 +210,20 @@ nonisolated private func runProcessStream(
   arguments: [String],
   currentDirectoryURL: URL?
 ) -> AsyncThrowingStream<ShellStreamEvent, Error> {
-  AsyncThrowingStream { continuation in
-    // Stored so onTermination can SIGTERM the process when the consumer of the
-    // stream goes away (Task cancellation, for-await throw, explicit finish).
-    // Without this hook structured-concurrency timeouts that wrap a ShellClient
-    // call would have to wait for the process to exit on its own.
+  makeProcessExecution(
+    executableURL: executableURL,
+    arguments: arguments,
+    currentDirectoryURL: currentDirectoryURL
+  ).stream
+}
+
+nonisolated private func makeProcessExecution(
+  executableURL: URL,
+  arguments: [String],
+  currentDirectoryURL: URL?
+) -> ProcessExecution {
+  let cancellation = ProcessCancellation()
+  let stream = AsyncThrowingStream<ShellStreamEvent, Error> { continuation in
     let processBox = LockIsolated<Process?>(nil)
     let workerTask = Task {
       let outputAccumulator = ShellOutputAccumulator()
@@ -189,7 +241,10 @@ nonisolated private func runProcessStream(
       let command = ([executableURL.path(percentEncoded: false)] + arguments).joined(separator: " ")
       do {
         try process.run()
-        processBox.withValue { $0 = process }
+        processBox.setValue(process)
+        cancellation.installTermination {
+          processBox.withValue { $0?.terminate() }
+        }
         let stdoutTask = Task {
           for await line in lineStream(from: outputHandle) {
             await outputAccumulator.append(line, source: .stdout)
@@ -205,7 +260,7 @@ nonisolated private func runProcessStream(
         await withTaskCancellationHandler {
           await waitForExit(of: process)
         } onCancel: {
-          process.terminate()
+          cancellation.cancel()
         }
         await stdoutTask.value
         await stderrTask.value
@@ -228,10 +283,11 @@ nonisolated private func runProcessStream(
       }
     }
     continuation.onTermination = { _ in
-      processBox.withValue { $0?.terminate() }
+      cancellation.cancel()
       workerTask.cancel()
     }
   }
+  return ProcessExecution(stream: stream, cancel: cancellation.cancel)
 }
 
 /// Waits asynchronously for `process` to exit using `terminationHandler`

--- a/supacodeTests/ShellClientStreamingTests.swift
+++ b/supacodeTests/ShellClientStreamingTests.swift
@@ -44,7 +44,40 @@ nonisolated final class LoginStreamCallRecorder: @unchecked Sendable {
   }
 }
 
+nonisolated final class TerminationCallRecorder: @unchecked Sendable {
+  private let lock = NSLock()
+  private var countValue = 0
+
+  func record() {
+    lock.lock()
+    countValue += 1
+    lock.unlock()
+  }
+
+  var count: Int {
+    lock.lock()
+    defer { lock.unlock() }
+    return countValue
+  }
+}
+
 struct ShellClientStreamingTests {
+
+  @Test func cancellationTerminatesOnceBeforeOrAfterProcessRegistration() {
+    let beforeRegistration = ProcessCancellation()
+    let beforeRecorder = TerminationCallRecorder()
+    beforeRegistration.cancel()
+    beforeRegistration.installTermination { beforeRecorder.record() }
+    beforeRegistration.cancel()
+    #expect(beforeRecorder.count == 1)
+
+    let afterRegistration = ProcessCancellation()
+    let afterRecorder = TerminationCallRecorder()
+    afterRegistration.installTermination { afterRecorder.record() }
+    afterRegistration.cancel()
+    afterRegistration.cancel()
+    #expect(afterRecorder.count == 1)
+  }
   @Test func runStreamYieldsStdoutAndStderrLines() async throws {
     let shell = ShellClient.liveValue
     let commandURL = URL(fileURLWithPath: "/bin/sh")
@@ -147,7 +180,9 @@ struct ShellClientStreamingTests {
       return lines
     }
 
-    try await Task.sleep(for: .milliseconds(120))
+    // The coordinator unit test covers cancellation before process registration.
+    // Yield once to exercise the usual already-running stream path without a timing sleep.
+    await Task.yield()
 
     let start = ContinuousClock.now
     consumer.cancel()
@@ -155,8 +190,8 @@ struct ShellClientStreamingTests {
     let elapsed = ContinuousClock.now - start
 
     #expect(
-      elapsed < .seconds(5),
-      "consumer cancel should propagate to the shell process; took \(elapsed)"
+      elapsed < .seconds(10),
+      "consumer cancellation must not wait for the process's 30-second natural exit; took \(elapsed)"
     )
   }
 
@@ -168,7 +203,8 @@ struct ShellClientStreamingTests {
       try await shell.run(commandURL, ["30"], nil)
     }
 
-    try? await Task.sleep(for: .milliseconds(120))
+    // Cancellation before process registration is covered deterministically above.
+    await Task.yield()
 
     let start = ContinuousClock.now
     runTask.cancel()
@@ -176,8 +212,8 @@ struct ShellClientStreamingTests {
     let elapsed = ContinuousClock.now - start
 
     #expect(
-      elapsed < .seconds(5),
-      "run() should propagate cancellation to the process; took \(elapsed)"
+      elapsed < .seconds(10),
+      "run() cancellation must not wait for the process's 30-second natural exit; took \(elapsed)"
     )
   }
 


### PR DESCRIPTION
## Summary
- make `ShellClient.run` cancel the underlying process directly instead of waiting for `AsyncThrowingStream` teardown
- retain cancellation requested before `Process.run()` completes and terminate exactly once after registration
- replace timing sleeps with deterministic cancellation-coordinator coverage and keep a 10-second end-to-end liveness watchdog against the 30-second process natural exit

## Verification
- `xcodebuild test` for `ShellClientStreamingTests`: 8 passed
- `make check`
- `make build-app`