### PR TITLE
Add scoped custom command visibility controls

### DIFF
--- a/docs-ai/002-custom-commands/000-plan.md
+++ b/docs-ai/002-custom-commands/000-plan.md
@@ -77,3 +77,5 @@ integration — all of these arrived in later waves (see Amendments and the acti
 - Updated 2026-07-13: Global commands extend the repository-scoped model with local-title
   precedence, source-qualified identities, and shared settings storage — see
   [004-global-custom-commands.md](004-global-custom-commands.md)
+- Updated 2026-07-19: Visibility gates, source ordering, and per-repository Global command
+  controls — see [006-visibility-gates-and-scope-ordering.md](006-visibility-gates-and-scope-ordering.md)

--- a/docs-ai/002-custom-commands/006-visibility-gates-and-scope-ordering.md
+++ b/docs-ai/002-custom-commands/006-visibility-gates-and-scope-ordering.md
@@ -4,7 +4,7 @@
 | --- | --- |
 | **Status** | Implemented |
 | **Anchor date** | 2026-07-19 |
-| **Primary PRs** | Pending |
+| **Primary PRs** | #600 |
 | **Related** | [002 Custom Commands](000-plan.md), [012 Keybinding System](../012-keybinding-system/000-plan.md), `docs/components/custom-actions.md` |
 
 ## Background

--- a/docs-ai/002-custom-commands/006-visibility-gates-and-scope-ordering.md
+++ b/docs-ai/002-custom-commands/006-visibility-gates-and-scope-ordering.md
@@ -1,0 +1,59 @@
+# 002.006 — Command Visibility Gates and Scope Ordering: Plan
+
+| | |
+| --- | --- |
+| **Status** | Planned |
+| **Anchor date** | 2026-07-19 |
+| **Primary PRs** | Pending |
+| **Related** | [002 Custom Commands](000-plan.md), [012 Keybinding System](../012-keybinding-system/000-plan.md), `docs/components/custom-actions.md` |
+
+## Background
+
+Global commands currently appear in every repository unless a local command has a matching
+trimmed, case-insensitive title. Neither scope can disable a command without deleting it, and
+repository settings cannot show the effective command list that drives the toolbar.
+
+## Goals
+
+- Preserve commands, ordering, and shortcuts while allowing them to be disabled.
+- Show both local and global commands, even when their titles match.
+- Keep effective toolbar order deterministic: repository commands followed by global commands.
+- Let each repository opt out of an enabled global command without editing its global definition.
+- Remove disabled commands from every launch surface and shortcut dispatch.
+
+## Design / Approach
+
+- Add an `isEnabled` flag to `UserCustomCommand`, defaulting to `true` for legacy settings.
+- Store only each repository's explicitly disabled global command IDs; an absent ID means enabled.
+- Resolve both sources in repository-first order. A global command is effective only when its own
+  `isEnabled` flag and its repository gate are both enabled; a local command has one gate.
+- Build the app's toolbar, Worktrees menu, command palette, execution lookup, and keybinding
+  registration from the effective list. Keep disabled commands and shortcuts persisted so
+  re-enabling restores them.
+- Extend the shared settings table with an Enabled column and explicit drag handle. The global
+  editor owns global edits and reordering. Repository settings combine local and global rows:
+  local rows remain editable and reorderable; global rows show a Global marker and expose only
+  their This Repo gate. A globally disabled row remains configurable and says Disabled globally.
+- Preserve existing local-over-global shortcut conflict precedence.
+
+## Alternatives & decisions
+
+- **Both matching titles remain visible**: title matching no longer suppresses global commands;
+  source-qualified IDs make this safe.
+- **Repository-first grouping instead of cross-scope ordering**: each scope owns its own stable
+  order and drag interaction, avoiding a fragile per-repository ordering overlay for global IDs.
+- **Persist only global opt-outs**: default-on global commands retain their expected all-repository
+  behavior without serializing redundant `true` values.
+- **One visible repository gate for Global rows**: the row reports a disabled global gate separately
+  rather than conflating it with This Repo state.
+
+## Verification
+
+Logic tests cover decoding defaults, source/order resolution, visibility gates, and shortcut
+registration. Reducer tests prove active-worktree refresh. A debug-app smoke test verifies the
+settings table, source restrictions, drag order, overflow behavior, all command surfaces, and
+shortcut restoration after re-enabling.
+
+## Amendments
+
+(append follow-up notes here)

--- a/docs-ai/002-custom-commands/006-visibility-gates-and-scope-ordering.md
+++ b/docs-ai/002-custom-commands/006-visibility-gates-and-scope-ordering.md
@@ -2,7 +2,7 @@
 
 | | |
 | --- | --- |
-| **Status** | Planned |
+| **Status** | Implemented |
 | **Anchor date** | 2026-07-19 |
 | **Primary PRs** | Pending |
 | **Related** | [002 Custom Commands](000-plan.md), [012 Keybinding System](../012-keybinding-system/000-plan.md), `docs/components/custom-actions.md` |
@@ -49,10 +49,27 @@ repository settings cannot show the effective command list that drives the toolb
 
 ## Verification
 
-Logic tests cover decoding defaults, source/order resolution, visibility gates, and shortcut
-registration. Reducer tests prove active-worktree refresh. A debug-app smoke test verifies the
-settings table, source restrictions, drag order, overflow behavior, all command surfaces, and
-shortcut restoration after re-enabling.
+- Targeted Swift Testing passed: 42 tests across effective command resolution, repository
+  persistence/reducer behavior, app command loading, keybindings, and global command settings.
+- `make check` passed (`swift-format` and SwiftLint), and `make build-app` completed without
+  warnings or errors.
+- An isolated Debug app launched on `PROWL_CLI_SOCKET=/tmp/prowl-self-verify.sock`; the repo CLI
+  listed its worktrees, created a temporary tab, and opened the target worktree. Terminal capture
+  timed out without shell integration and the window capture was unavailable, so this record makes
+  no visual-interaction claim beyond the compiled UI and automated coverage.
+
+## Outcome
+
+- `UserCustomCommand.isEnabled` defaults to `true` when old settings files omit it.
+- `UserRepositorySettings.disabledGlobalCommandIDs` stores only Global opt-outs; absence remains
+  enabled for a repository.
+- `EffectiveCustomCommand.resolve` now filters disabled commands, preserves source-qualified IDs,
+  retains duplicate titles, and orders repository commands before Global commands.
+- The shared editor presents enable toggles and drag handles. Repository settings append read-only
+  Global rows with a Global marker and This Repo gate; a globally disabled row stays configurable.
+- The manual documents visibility, ordering, duplicate titles, gates, shortcut behavior, and the
+  updated settings entry points.
+
 
 ## Amendments
 

--- a/docs-ai/002-custom-commands/006-visibility-gates-and-scope-ordering.md
+++ b/docs-ai/002-custom-commands/006-visibility-gates-and-scope-ordering.md
@@ -65,7 +65,8 @@ repository settings cannot show the effective command list that drives the toolb
   enabled for a repository.
 - `EffectiveCustomCommand.resolve` now filters disabled commands, preserves source-qualified IDs,
   retains duplicate titles, and orders repository commands before Global commands.
-- The shared editor presents enable toggles and drag handles. Repository settings append read-only
+- The shared editor presents compact standard checkboxes and drag handles. It accepts only known
+  local-command drag payloads, supports an unconditional append drop target, and appends read-only
   Global rows with a Global marker and This Repo gate; a globally disabled row stays configurable.
 - The manual documents visibility, ordering, duplicate titles, gates, shortcut behavior, and the
   updated settings entry points.
@@ -73,4 +74,14 @@ repository settings cannot show the effective command list that drives the toolb
 
 ## Amendments
 
-(append follow-up notes here)
+### 2026-07-19 — Review follow-up
+
+- **No same-title migration**: the clean cutover remains intentional. A one-time opt-out would
+  incorrectly keep a Global command hidden after its matching local command is later deleted; the
+  release note instead calls out that both commands now appear.
+- **No eager dead-ID cleanup**: repository settings cannot validate Global IDs in isolation.
+  Deleting a Global command therefore leaves harmless historical opt-outs rather than triggering
+  cross-repository writes.
+- **Settings refinements**: the trailing reorder target is always available, drop destinations
+  reject unknown IDs, enable controls use compact standard checkboxes, and Global opt-outs encode
+  in sorted order to avoid configuration churn.

--- a/docs/.sync-meta.json
+++ b/docs/.sync-meta.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Metadata for the docs/ manual. The last_synced_commit is the commit at which docs/ was last verified against the implementation; the sync-docs skill (.claude/skills/sync-docs/SKILL.md) diffs HEAD against it and updates this file. Committed to git on purpose so the baseline persists across sessions and machines. A dotfile + .json so a future docs website does not render it as a page.",
-  "last_synced_commit": "5defd27da02d1e77fa97237226ec47dcc97c3a17",
-  "last_synced_date": "2026-07-17",
-  "note": "Release prep. User-facing changes in range (Grok Build detection #590, branch deletion settings split #592) were doc-synced in their own PRs; verified deleteBranchOnAutomaticCleanup / deleteBranchOnManualWorktreeDelete and Grok coverage still match source."
+  "last_synced_commit": "c876fe33fe7e8f2940e5e05320d79565c8b34165",
+  "last_synced_date": "2026-07-19",
+  "note": "Custom Command visibility gates: verified enabled ordering, Global per-repository opt-outs, source-aware settings controls, command surfaces, and shortcut registration."
 }

--- a/docs/.sync-meta.json
+++ b/docs/.sync-meta.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Metadata for the docs/ manual. The last_synced_commit is the commit at which docs/ was last verified against the implementation; the sync-docs skill (.claude/skills/sync-docs/SKILL.md) diffs HEAD against it and updates this file. Committed to git on purpose so the baseline persists across sessions and machines. A dotfile + .json so a future docs website does not render it as a page.",
-  "last_synced_commit": "c876fe33fe7e8f2940e5e05320d79565c8b34165",
+  "last_synced_commit": "9611a12d1437e6c44bb9c6f393bf2352b487373d",
   "last_synced_date": "2026-07-19",
-  "note": "Custom Command visibility gates: verified enabled ordering, Global per-repository opt-outs, source-aware settings controls, command surfaces, and shortcut registration."
+  "note": "Custom Command follow-up: verified compact checkbox controls, valid drag targets, append reorder target, and deterministic Global opt-out encoding."
 }

--- a/docs/components/command-palette.md
+++ b/docs/components/command-palette.md
@@ -43,8 +43,8 @@ selected worktree has a pull request).
   the Ghostty-bridged commands; search-only).
 - **App:** Check for Updates, Open Settings, Open Repository, **Install Command
   Line Tool**, Repo Settings.
-- **Custom commands:** local and global Custom Commands appear here with their source;
-  local title matches hide the corresponding global command.
+- **Custom commands:** enabled local and Global Custom Commands appear here with their
+  source. Same-titled commands can coexist; disabled commands do not appear.
 - **Debug** (Debug builds only): toast/update/dock simulations.
 
 ## Behavior notes

--- a/docs/components/custom-actions.md
+++ b/docs/components/custom-actions.md
@@ -72,7 +72,7 @@ Command Palette, and hotkey dispatch until re-enabled.
 globally and enabled for that repository. New Global commands are enabled in every
 repository by default; Repo Settings can turn an individual Global command off without
 changing its definition. Global command fields and order are edited only in
-Settings → Global Commands.
+Settings → Commands.
 
 **Shortcut precedence:** a repo command wins a collision with a Global command's
 shortcut. Custom Command hotkeys take **precedence over app shortcuts**; conflicts
@@ -96,7 +96,7 @@ menu, and the [Command Palette](command-palette.md). Global commands are stored 
 
 - Per repo (Repo Settings): `runScript`, `setupScript`, `archiveScript`, local Custom
   Commands, and per-repository visibility of Global Commands.
-- Global (Settings → Global Commands): Global Custom Commands and their order.
+- Global (Settings → Commands): Global Custom Commands and their order.
 - Global: `showRunButtonInToolbar`, `showDefaultEditorInToolbar`.
 
 ## Gotchas for agents

--- a/docs/components/custom-actions.md
+++ b/docs/components/custom-actions.md
@@ -62,16 +62,26 @@ success**, and optional **keyboard shortcut**.
 **Close on success** auto-closes the tab/split shortly after the command exits 0
 (a brief delay lets you see the final output).
 
-**Precedence:** a local command whose title matches a global command after trimming
-and case-folding hides the global command. Local commands also win a collision with a
-global command's shortcut. Custom Command hotkeys take **precedence over app
-shortcuts**; conflicts (with reserved app actions or other custom commands) are
-detected when you record the key, and you choose Replace / Cancel.
+**Visibility and order:** local and Global commands both appear, even when their
+titles match. Enabled local commands appear first in their repository order, followed
+by enabled Global commands in their Global order. Turning a command off preserves its
+configuration, position, and hotkey, but removes it from the toolbar, Worktrees menu,
+Command Palette, and hotkey dispatch until re-enabled.
 
-**Where they appear:** as buttons in the UI, in the Worktrees menu, and in the
-[Command Palette](command-palette.md). Global entries look identical to local ones;
-hovering shows a "Defined as a global command" tooltip note.
-Global commands are stored in `~/.prowl/global.onevcat.json`; local commands remain in
+**Global gates:** a Global command appears in a repository only when it is enabled
+globally and enabled for that repository. New Global commands are enabled in every
+repository by default; Repo Settings can turn an individual Global command off without
+changing its definition. Global command fields and order are edited only in
+Settings → Global Commands.
+
+**Shortcut precedence:** a repo command wins a collision with a Global command's
+shortcut. Custom Command hotkeys take **precedence over app shortcuts**; conflicts
+(with reserved app actions or other custom commands) are detected when you record the
+key, and you choose Replace / Cancel.
+
+**Where they appear:** enabled commands appear in the window toolbar, the Worktrees
+menu, and the [Command Palette](command-palette.md). Global commands are stored in
+`~/.prowl/global.onevcat.json`; local commands remain in
 `~/.prowl/repo/<repo-name>/prowl.onevcat.json`.
 
 ## Example uses
@@ -84,9 +94,9 @@ Global commands are stored in `~/.prowl/global.onevcat.json`; local commands rem
 
 ## Settings recap
 
-- Per repo (Repo Settings): `runScript`, `setupScript`, `archiveScript`, and local
-  Custom Commands.
-- Global (Settings → Commands): global Custom Commands shared by every repo.
+- Per repo (Repo Settings): `runScript`, `setupScript`, `archiveScript`, local Custom
+  Commands, and per-repository visibility of Global Commands.
+- Global (Settings → Global Commands): Global Custom Commands and their order.
 - Global: `showRunButtonInToolbar`, `showDefaultEditorInToolbar`.
 
 ## Gotchas for agents

--- a/docs/components/settings.md
+++ b/docs/components/settings.md
@@ -23,8 +23,8 @@ window is a sidebar of tabs plus a detail pane.
 | **Updates** | Auto-check toggle, "Check for Updates Now". → [updates](updates.md) |
 | **Advanced** | Analytics, crash reports, restore terminal layout on launch (experimental) + clear saved layout, and the **Install Command Line Tool** (`prowl` CLI) action. |
 | **GitHub** | Enable GitHub integration (uses the `gh` CLI). → [github-pull-requests](github-pull-requests.md) |
-| **Commands** | Global Custom Commands available in every repository. Local commands with the same title take precedence. → [custom-actions](custom-actions.md) |
-| **Repositories / Repo Settings** | Per-repository: setup/archive/run scripts, **Custom Commands**, default base ref & directory, copy-files overrides, open-with app, custom title, icon & color, PR merge strategy, line-diff & PR-state fetching. Reached from the sidebar context menu → "Repo Settings". → [custom-actions](custom-actions.md), [repositories-and-worktrees](repositories-and-worktrees.md) |
+| **Commands** | Global Custom Commands. Enabled commands appear in the window toolbar; each repo can independently hide a Global command. → [custom-actions](custom-actions.md) |
+| **Repositories / Repo Settings** | Per-repository: setup/archive/run scripts, **Custom Commands**, Global-command visibility, default base ref & directory, copy-files overrides, open-with app, custom title, icon & color, PR merge strategy, line-diff & PR-state fetching. Reached from the sidebar context menu → "Repo Settings". → [custom-actions](custom-actions.md), [repositories-and-worktrees](repositories-and-worktrees.md) |
 
 ## Where settings live on disk
 

--- a/docs/reference/keyboard-shortcuts.md
+++ b/docs/reference/keyboard-shortcuts.md
@@ -121,8 +121,8 @@ your Ghostty config (`~/.config/ghostty/config`). Typical defaults in parenthese
 | Check for Updates | ⌘⇧U | `check_for_updates` | yes |
 | Quit Application | ⌘Q | `quit_application` | **no** (fixed) |
 
-Plus any global or per-repository **Custom Commands**, which can each carry their own
-hotkey — see [`components/custom-actions.md`](../components/custom-actions.md).
+Plus any enabled global or per-repository **Custom Commands**, which can each carry
+their own hotkey — see [`components/custom-actions.md`](../components/custom-actions.md).
 
 ## Remapping & customization
 
@@ -135,6 +135,8 @@ hotkey — see [`components/custom-actions.md`](../components/custom-actions.md)
 - **Custom Command** hotkeys take precedence over app shortcuts within the focused
   repository. Local commands win global-command collisions; global bindings use a
   separate internal command ID namespace. Conflicts are surfaced when recording.
+- Disabling a Custom Command unregisters its hotkey with every other command surface,
+  but preserves the configured key so re-enabling restores it.
 - **Terminal engine keys** are owned by Ghostty. Prowl automatically *unbinds*
   any Ghostty key that collides with an app shortcut, and re-binds the
   tab/pane-navigation actions into Ghostty so they work inside the terminal. You

--- a/docs/reference/settings-fields.md
+++ b/docs/reference/settings-fields.md
@@ -89,14 +89,16 @@ Stored at `~/.prowl/repo/<repo-name>/prowl.json` (schema v2). For the tri-state
 | `observeLineDiffsAutomatically` | Bool? | `nil` (= on) | Keep worktree line-change badges updated; set `false` for large repos. |
 | `fetchPullRequestState` | Bool? | `nil` (= on) | Background-fetch PR state; set `false` to save GitHub rate limit. |
 
-**Custom Commands** (per-repo buttons/hotkeys) live separately in
-`prowl.onevcat.json`. See [`components/custom-actions.md`](../components/custom-actions.md)
-for their structure (title, icon, command, execution mode, close-on-success,
-shortcut).
+**Custom Commands** live separately in `prowl.onevcat.json`. Each command has an
+`isEnabled` Boolean that defaults to `true`; turning it off preserves its structure
+(title, icon, command, execution mode, close-on-success, shortcut, and order) but
+removes it from every command surface and hotkey dispatch.
 
 **Global Custom Commands** use the same command structure in
-`~/.prowl/global.onevcat.json`. A trimmed, case-insensitive title match in a
-repository's local list hides the corresponding global command.
+`~/.prowl/global.onevcat.json`. Repository `prowl.onevcat.json` files additionally
+store `disabledGlobalCommandIDs`: an absent ID means enabled for that repository, while
+an included ID hides that Global command there. Local commands are ordered before Global
+commands; matching titles do not hide either command.
 
 ## Notes for agents
 

--- a/supacode/Features/App/Reducer/AppFeature+Support.swift
+++ b/supacode/Features/App/Reducer/AppFeature+Support.swift
@@ -193,7 +193,8 @@ extension AppFeature {
   ) -> Effect<Action> {
     state.selectedCustomCommands = EffectiveCustomCommand.resolve(
       repositoryCommands: settings.customCommands,
-      globalCommands: globalSettings.customCommands
+      globalCommands: globalSettings.customCommands,
+      disabledGlobalCommandIDs: settings.disabledGlobalCommandIDs
     )
     state.resolvedKeybindings = resolvedKeybindings(
       settings: state.settings,

--- a/supacode/Features/RepositorySettings/Reducer/RepositorySettingsFeature.swift
+++ b/supacode/Features/RepositorySettings/Reducer/RepositorySettingsFeature.swift
@@ -97,6 +97,7 @@ struct RepositorySettingsFeature {
     case userImageImportFailed(String)
     case dismissAppearanceImportError
     case resetAppearance
+    case setGlobalCommandEnabled(UserCustomCommand.ID, Bool)
     case branchDataLoaded([String], defaultBaseRef: String)
     case delegate(Delegate)
     case binding(BindingAction<State>)
@@ -201,6 +202,16 @@ struct RepositorySettingsFeature {
         let rootURL = state.rootURL
         @Shared(.repositorySettings(rootURL)) var repositorySettings
         $repositorySettings.withLock { $0 = updatedSettings }
+        return .send(.delegate(.settingsChanged(rootURL)))
+
+      case .setGlobalCommandEnabled(let commandID, let isEnabled):
+        guard state.userSettings.isGlobalCommandEnabled(commandID) != isEnabled else {
+          return .none
+        }
+        state.userSettings.setGlobalCommandEnabled(isEnabled, id: commandID)
+        let rootURL = state.rootURL
+        @Shared(.userRepositorySettings(rootURL)) var userRepositorySettings
+        $userRepositorySettings.withLock { $0 = state.userSettings }
         return .send(.delegate(.settingsChanged(rootURL)))
 
       case .appearanceLoaded(let appearance):

--- a/supacode/Features/Settings/Models/UserRepositorySettings.swift
+++ b/supacode/Features/Settings/Models/UserRepositorySettings.swift
@@ -2,29 +2,52 @@ import Foundation
 
 nonisolated struct UserRepositorySettings: Codable, Equatable, Sendable {
   var customCommands: [UserCustomCommand]
+  var disabledGlobalCommandIDs: Set<UserCustomCommand.ID>
 
   static let `default` = UserRepositorySettings(customCommands: [])
 
   private enum CodingKeys: String, CodingKey {
     case customCommands
+    case disabledGlobalCommandIDs
   }
 
-  init(customCommands: [UserCustomCommand]) {
+  init(
+    customCommands: [UserCustomCommand],
+    disabledGlobalCommandIDs: Set<UserCustomCommand.ID> = []
+  ) {
     self.customCommands = Self.normalizedCommands(customCommands)
+    self.disabledGlobalCommandIDs = disabledGlobalCommandIDs
   }
 
   init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     let commands = try container.decodeIfPresent([UserCustomCommand].self, forKey: .customCommands) ?? []
     customCommands = Self.normalizedCommands(commands)
+    disabledGlobalCommandIDs =
+      try container.decodeIfPresent(Set<UserCustomCommand.ID>.self, forKey: .disabledGlobalCommandIDs) ?? []
   }
 
   func normalized() -> UserRepositorySettings {
-    UserRepositorySettings(customCommands: customCommands)
+    UserRepositorySettings(
+      customCommands: customCommands,
+      disabledGlobalCommandIDs: disabledGlobalCommandIDs
+    )
   }
 
   static func normalizedCommands(_ commands: [UserCustomCommand]) -> [UserCustomCommand] {
     UserCustomCommand.normalizedCommands(commands)
+  }
+
+  func isGlobalCommandEnabled(_ id: UserCustomCommand.ID) -> Bool {
+    !disabledGlobalCommandIDs.contains(id)
+  }
+
+  mutating func setGlobalCommandEnabled(_ isEnabled: Bool, id: UserCustomCommand.ID) {
+    if isEnabled {
+      disabledGlobalCommandIDs.remove(id)
+    } else {
+      disabledGlobalCommandIDs.insert(id)
+    }
   }
 }
 
@@ -37,6 +60,7 @@ nonisolated struct UserCustomCommand: Codable, Equatable, Sendable, Identifiable
   var splitDirection: UserCustomSplitDirection
   var closeOnSuccess: Bool
   var shortcut: UserCustomShortcut?
+  var isEnabled: Bool
 
   init(
     id: String = UUID().uuidString,
@@ -46,7 +70,8 @@ nonisolated struct UserCustomCommand: Codable, Equatable, Sendable, Identifiable
     execution: UserCustomCommandExecution,
     splitDirection: UserCustomSplitDirection = .right,
     closeOnSuccess: Bool = false,
-    shortcut: UserCustomShortcut?
+    shortcut: UserCustomShortcut?,
+    isEnabled: Bool = true
   ) {
     self.id = id
     self.title = title
@@ -56,12 +81,11 @@ nonisolated struct UserCustomCommand: Codable, Equatable, Sendable, Identifiable
     self.splitDirection = splitDirection
     self.closeOnSuccess = closeOnSuccess
     self.shortcut = shortcut?.normalized()
+    self.isEnabled = isEnabled
   }
-
   private enum CodingKeys: String, CodingKey {
-    case id, title, systemImage, command, execution, splitDirection, closeOnSuccess, shortcut
+    case id, title, systemImage, command, execution, splitDirection, closeOnSuccess, shortcut, isEnabled
   }
-
   init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     self.id = try container.decode(String.self, forKey: .id)
@@ -74,6 +98,7 @@ nonisolated struct UserCustomCommand: Codable, Equatable, Sendable, Identifiable
     self.closeOnSuccess = try container.decodeIfPresent(Bool.self, forKey: .closeOnSuccess) ?? false
     // Preserves raw shortcut so downstream migration/validation can inspect the original key.
     self.shortcut = try container.decodeIfPresent(UserCustomShortcut.self, forKey: .shortcut)
+    self.isEnabled = try container.decodeIfPresent(Bool.self, forKey: .isEnabled) ?? true
   }
 
   static func `default`(index: Int) -> UserCustomCommand {
@@ -95,10 +120,10 @@ nonisolated struct UserCustomCommand: Codable, Equatable, Sendable, Identifiable
       execution: execution,
       splitDirection: splitDirection,
       closeOnSuccess: closeOnSuccess,
-      shortcut: shortcut?.normalized()
+      shortcut: shortcut?.normalized(),
+      isEnabled: isEnabled
     )
   }
-
   static func normalizedCommands(_ commands: [UserCustomCommand]) -> [UserCustomCommand] {
     commands.map { $0.normalized() }
   }
@@ -172,20 +197,15 @@ nonisolated struct EffectiveCustomCommand: Equatable, Sendable, Identifiable {
 
   static func resolve(
     repositoryCommands: [UserCustomCommand],
-    globalCommands: [UserCustomCommand]
+    globalCommands: [UserCustomCommand],
+    disabledGlobalCommandIDs: Set<UserCustomCommand.ID> = []
   ) -> [EffectiveCustomCommand] {
-    let local = UserCustomCommand.normalizedCommands(repositoryCommands)
-    let localTitles = Set(local.map { $0.titleComparisonKey })
-    return local.map { .init(source: .repository, command: $0) }
+    UserCustomCommand.normalizedCommands(repositoryCommands)
+      .filter(\.isEnabled)
+      .map { .init(source: .repository, command: $0) }
       + UserCustomCommand.normalizedCommands(globalCommands)
-      .filter { !localTitles.contains($0.titleComparisonKey) }
+      .filter { $0.isEnabled && !disabledGlobalCommandIDs.contains($0.id) }
       .map { .init(source: .global, command: $0) }
-  }
-}
-
-nonisolated extension UserCustomCommand {
-  fileprivate var titleComparisonKey: String {
-    title.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
   }
 }
 

--- a/supacode/Features/Settings/Models/UserRepositorySettings.swift
+++ b/supacode/Features/Settings/Models/UserRepositorySettings.swift
@@ -27,6 +27,12 @@ nonisolated struct UserRepositorySettings: Codable, Equatable, Sendable {
       try container.decodeIfPresent(Set<UserCustomCommand.ID>.self, forKey: .disabledGlobalCommandIDs) ?? []
   }
 
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(customCommands, forKey: .customCommands)
+    try container.encode(disabledGlobalCommandIDs.sorted(), forKey: .disabledGlobalCommandIDs)
+  }
+
   func normalized() -> UserRepositorySettings {
     UserRepositorySettings(
       customCommands: customCommands,

--- a/supacode/Features/Settings/Views/CustomCommandsEditor.swift
+++ b/supacode/Features/Settings/Views/CustomCommandsEditor.swift
@@ -26,6 +26,11 @@ struct CustomCommandsEditor: View {
     self.globalCommandEnabled = globalCommandEnabled
   }
 
+  private enum ReorderDestination: Equatable {
+    case before(UserCustomCommand.ID)
+    case append
+  }
+
   @State private var selectedCustomCommandID: UserCustomCommand.ID?
   @State private var recordingCustomCommandID: UserCustomCommand.ID?
   @State private var recorderMonitor: Any?
@@ -38,6 +43,7 @@ struct CustomCommandsEditor: View {
   @State private var commandEditorCommandID: UserCustomCommand.ID?
   @State private var editingNameCommandID: UserCustomCommand.ID?
   @FocusState private var focusedNameEditorCommandID: UserCustomCommand.ID?
+  @State private var reorderDestination: ReorderDestination?
 
   private let keyTokenResolver = ShortcutKeyTokenResolver()
 
@@ -424,21 +430,33 @@ struct CustomCommandsEditor: View {
       RoundedRectangle(cornerRadius: 8)
         .fill(isSelected ? Color.accentColor.opacity(0.35) : .clear)
     }
+    .overlay(alignment: .top) {
+      if reorderDestination == .before(command.id) {
+        reorderInsertionIndicator
+      }
+    }
     .contentShape(RoundedRectangle(cornerRadius: 8))
     .accessibilityAddTraits(.isButton)
     .onTapGesture {
       selectCustomCommand(command.id)
     }
-    .dropDestination(for: String.self) { commandIDs, _ in
-      guard
-        let commandID = commandIDs.first,
-        commands.contains(where: { $0.id == commandID })
-      else {
-        return false
+    .dropDestination(
+      for: String.self,
+      action: { commandIDs, _ in
+        guard
+          let commandID = commandIDs.first,
+          commands.contains(where: { $0.id == commandID })
+        else {
+          return false
+        }
+        moveCustomCommand(commandID, before: command.id)
+        reorderDestination = nil
+        return true
+      },
+      isTargeted: { isTargeted in
+        updateReorderDestination(isTargeted, destination: .before(command.id))
       }
-      moveCustomCommand(commandID, before: command.id)
-      return true
-    }
+    )
   }
 
   @ViewBuilder
@@ -1180,18 +1198,46 @@ struct CustomCommandsEditor: View {
 
   private var localCommandDropTarget: some View {
     Color.clear
-      .frame(height: 8)
-      .contentShape(Rectangle())
-      .dropDestination(for: String.self) { commandIDs, _ in
-        guard
-          let commandID = commandIDs.first,
-          commands.contains(where: { $0.id == commandID })
-        else {
-          return false
+      .frame(height: 12)
+      .overlay {
+        if reorderDestination == .append {
+          reorderInsertionIndicator
         }
-        moveCustomCommand(commandID)
-        return true
       }
+      .contentShape(Rectangle())
+      .dropDestination(
+        for: String.self,
+        action: { commandIDs, _ in
+          guard
+            let commandID = commandIDs.first,
+            commands.contains(where: { $0.id == commandID })
+          else {
+            return false
+          }
+          moveCustomCommand(commandID)
+          reorderDestination = nil
+          return true
+        },
+        isTargeted: { isTargeted in
+          updateReorderDestination(isTargeted, destination: .append)
+        }
+      )
+  }
+
+  private var reorderInsertionIndicator: some View {
+    Rectangle()
+      .fill(Color.accentColor)
+      .frame(height: 2)
+      .padding(.horizontal, 4)
+      .accessibilityHidden(true)
+  }
+
+  private func updateReorderDestination(_ isTargeted: Bool, destination: ReorderDestination) {
+    if isTargeted {
+      reorderDestination = destination
+    } else if reorderDestination == destination {
+      reorderDestination = nil
+    }
   }
 
   private var customCommandsDragColumnWidth: CGFloat { 24 }

--- a/supacode/Features/Settings/Views/CustomCommandsEditor.swift
+++ b/supacode/Features/Settings/Views/CustomCommandsEditor.swift
@@ -386,10 +386,7 @@ struct CustomCommandsEditor: View {
   private var customCommandsHeaderRow: some View {
     HStack(spacing: 8) {
       customCommandHeaderCell("", width: customCommandsDragColumnWidth, alignment: .center)
-      Image(systemName: "checkmark")
-        .frame(width: customCommandsEnabledColumnWidth, alignment: .center)
-        .accessibilityLabel("Enabled")
-        .help("Enabled")
+      customCommandHeaderCell("", width: customCommandsEnabledColumnWidth, alignment: .center)
       customCommandHeaderCell("", width: customCommandsIconColumnWidth, alignment: .center)
       customCommandHeaderCell("Name", width: customCommandsNameColumnWidth)
       customCommandHeaderCell("Command")

--- a/supacode/Features/Settings/Views/CustomCommandsEditor.swift
+++ b/supacode/Features/Settings/Views/CustomCommandsEditor.swift
@@ -85,8 +85,8 @@ struct CustomCommandsEditor: View {
               customCommandRow(command)
                 .id(command.id)
             }
+            localCommandDropTarget
             if showsGlobalCommands {
-              localCommandDropTarget
               ForEach(globalCommands) { command in
                 globalCustomCommandRow(command)
                   .id("global-\(command.id)")
@@ -380,7 +380,10 @@ struct CustomCommandsEditor: View {
   private var customCommandsHeaderRow: some View {
     HStack(spacing: 8) {
       customCommandHeaderCell("", width: customCommandsDragColumnWidth, alignment: .center)
-      customCommandHeaderCell("Enabled", width: customCommandsEnabledColumnWidth, alignment: .center)
+      Image(systemName: "checkmark")
+        .frame(width: customCommandsEnabledColumnWidth, alignment: .center)
+        .accessibilityLabel("Enabled")
+        .help("Enabled")
       customCommandHeaderCell("", width: customCommandsIconColumnWidth, alignment: .center)
       customCommandHeaderCell("Name", width: customCommandsNameColumnWidth)
       customCommandHeaderCell("Command")
@@ -427,7 +430,10 @@ struct CustomCommandsEditor: View {
       selectCustomCommand(command.id)
     }
     .dropDestination(for: String.self) { commandIDs, _ in
-      guard let commandID = commandIDs.first else {
+      guard
+        let commandID = commandIDs.first,
+        commands.contains(where: { $0.id == commandID })
+      else {
         return false
       }
       moveCustomCommand(commandID, before: command.id)
@@ -510,7 +516,7 @@ struct CustomCommandsEditor: View {
     if let binding = bindingForCustomCommand(id: command.id) {
       Toggle("Enable \(command.resolvedTitle)", isOn: binding.isEnabled)
         .labelsHidden()
-        .toggleStyle(.switch)
+        .toggleStyle(.checkbox)
         .controlSize(.small)
         .help("Enable \(command.resolvedTitle)")
     }
@@ -521,7 +527,7 @@ struct CustomCommandsEditor: View {
     if let binding = globalCommandEnabled?(command.id) {
       Toggle("Enable \(command.resolvedTitle) in this repository", isOn: binding)
         .labelsHidden()
-        .toggleStyle(.switch)
+        .toggleStyle(.checkbox)
         .controlSize(.small)
         .help("Enable \(command.resolvedTitle) in this repository")
     }
@@ -1177,7 +1183,10 @@ struct CustomCommandsEditor: View {
       .frame(height: 8)
       .contentShape(Rectangle())
       .dropDestination(for: String.self) { commandIDs, _ in
-        guard let commandID = commandIDs.first else {
+        guard
+          let commandID = commandIDs.first,
+          commands.contains(where: { $0.id == commandID })
+        else {
           return false
         }
         moveCustomCommand(commandID)
@@ -1187,7 +1196,7 @@ struct CustomCommandsEditor: View {
 
   private var customCommandsDragColumnWidth: CGFloat { 24 }
 
-  private var customCommandsEnabledColumnWidth: CGFloat { 56 }
+  private var customCommandsEnabledColumnWidth: CGFloat { 24 }
 
   private var customCommandsIconColumnWidth: CGFloat { 32 }
 

--- a/supacode/Features/Settings/Views/CustomCommandsEditor.swift
+++ b/supacode/Features/Settings/Views/CustomCommandsEditor.swift
@@ -9,6 +9,22 @@ struct CustomCommandsEditor: View {
   @Binding var commands: [UserCustomCommand]
   let source: CustomCommandSource
   let keybindingUserOverrides: KeybindingUserOverrideStore
+  let globalCommands: [UserCustomCommand]
+  let globalCommandEnabled: ((UserCustomCommand.ID) -> Binding<Bool>)?
+
+  init(
+    commands: Binding<[UserCustomCommand]>,
+    source: CustomCommandSource,
+    keybindingUserOverrides: KeybindingUserOverrideStore,
+    globalCommands: [UserCustomCommand] = [],
+    globalCommandEnabled: ((UserCustomCommand.ID) -> Binding<Bool>)? = nil
+  ) {
+    _commands = commands
+    self.source = source
+    self.keybindingUserOverrides = keybindingUserOverrides
+    self.globalCommands = globalCommands
+    self.globalCommandEnabled = globalCommandEnabled
+  }
 
   @State private var selectedCustomCommandID: UserCustomCommand.ID?
   @State private var recordingCustomCommandID: UserCustomCommand.ID?
@@ -69,6 +85,13 @@ struct CustomCommandsEditor: View {
               customCommandRow(command)
                 .id(command.id)
             }
+            if showsGlobalCommands {
+              localCommandDropTarget
+              ForEach(globalCommands) { command in
+                globalCustomCommandRow(command)
+                  .id("global-\(command.id)")
+              }
+            }
           }
           .padding(.horizontal, 6)
           .padding(.vertical, 6)
@@ -109,7 +132,7 @@ struct CustomCommandsEditor: View {
 
         Spacer(minLength: 0)
 
-        Text("\(commands.count) commands")
+        Text("\(displayedCommandCount) commands")
           .font(.caption)
           .foregroundStyle(.secondary)
       }
@@ -118,9 +141,13 @@ struct CustomCommandsEditor: View {
           .font(.caption)
           .foregroundStyle(.red)
       } else {
-        Text("Click cells to edit icon, name, command, and shortcut inline.")
-          .font(.caption)
-          .foregroundStyle(.secondary)
+        Text(
+          showsGlobalCommands
+            ? "Global commands are managed in Settings → Commands."
+            : "Click cells to edit icon, name, command, and shortcut inline."
+        )
+        .font(.caption)
+        .foregroundStyle(.secondary)
       }
     }
     .background {
@@ -352,6 +379,8 @@ struct CustomCommandsEditor: View {
 
   private var customCommandsHeaderRow: some View {
     HStack(spacing: 8) {
+      customCommandHeaderCell("", width: customCommandsDragColumnWidth, alignment: .center)
+      customCommandHeaderCell("Enabled", width: customCommandsEnabledColumnWidth, alignment: .center)
       customCommandHeaderCell("", width: customCommandsIconColumnWidth, alignment: .center)
       customCommandHeaderCell("Name", width: customCommandsNameColumnWidth)
       customCommandHeaderCell("Command")
@@ -367,6 +396,12 @@ struct CustomCommandsEditor: View {
   private func customCommandRow(_ command: UserCustomCommand) -> some View {
     let isSelected = selectedCustomCommandID == command.id
     HStack(spacing: 8) {
+      customCommandRowCell(width: customCommandsDragColumnWidth, alignment: .center) {
+        customCommandReorderHandle(command)
+      }
+      customCommandRowCell(width: customCommandsEnabledColumnWidth, alignment: .center) {
+        customCommandEnabledCell(command)
+      }
       customCommandRowCell(width: customCommandsIconColumnWidth, alignment: .center) {
         customCommandIconCell(command)
       }
@@ -390,6 +425,105 @@ struct CustomCommandsEditor: View {
     .accessibilityAddTraits(.isButton)
     .onTapGesture {
       selectCustomCommand(command.id)
+    }
+    .dropDestination(for: String.self) { commandIDs, _ in
+      guard let commandID = commandIDs.first else {
+        return false
+      }
+      moveCustomCommand(commandID, before: command.id)
+      return true
+    }
+  }
+
+  @ViewBuilder
+  private func globalCustomCommandRow(_ command: UserCustomCommand) -> some View {
+    HStack(spacing: 8) {
+      customCommandRowCell(width: customCommandsDragColumnWidth, alignment: .center) {
+        Image(systemName: "lock.fill")
+          .font(.caption2)
+          .foregroundStyle(.tertiary)
+          .accessibilityHidden(true)
+      }
+      customCommandRowCell(width: customCommandsEnabledColumnWidth, alignment: .center) {
+        globalCommandEnabledCell(command)
+      }
+      customCommandRowCell(width: customCommandsIconColumnWidth, alignment: .center) {
+        Image(systemName: command.resolvedSystemImage)
+          .foregroundStyle(.secondary)
+          .frame(width: 16, alignment: .center)
+          .accessibilityHidden(true)
+      }
+      customCommandRowCell(width: customCommandsNameColumnWidth) {
+        VStack(alignment: .leading, spacing: 2) {
+          HStack(spacing: 4) {
+            Text(command.resolvedTitle)
+              .lineLimit(1)
+            Text("Global")
+              .font(.caption2)
+              .foregroundStyle(.secondary)
+          }
+          if !command.isEnabled {
+            Text("Disabled globally")
+              .font(.caption2)
+              .foregroundStyle(.secondary)
+          }
+        }
+      }
+      customCommandRowCell {
+        VStack(alignment: .leading, spacing: 2) {
+          Text(inlineCommandTitle(for: command.execution))
+            .font(.caption)
+            .foregroundStyle(.secondary)
+          Text(inlineCommandScriptPreview(for: command.command))
+            .lineLimit(1)
+        }
+      }
+      customCommandRowCell(width: customCommandsShortcutColumnWidth) {
+        let binding = resolvedCustomCommandBindings.keybinding(
+          for: customCommandBindingID(for: command.id, source: .global)
+        )
+        Text(binding?.display ?? "Unassigned")
+          .font(.body.monospaced())
+          .foregroundStyle(binding == nil ? .secondary : .primary)
+          .lineLimit(1)
+      }
+    }
+    .padding(.horizontal, 8)
+    .padding(.vertical, 2)
+    .opacity(command.isEnabled ? 1 : 0.6)
+    .help("Global command. Edit it in Settings → Commands.")
+  }
+
+  @ViewBuilder
+  private func customCommandReorderHandle(_ command: UserCustomCommand) -> some View {
+    Image(systemName: "line.3.horizontal")
+      .foregroundStyle(.tertiary)
+      .frame(width: 16, height: 16)
+      .contentShape(Rectangle())
+      .accessibilityLabel("Drag \(command.resolvedTitle) to reorder")
+      .help("Drag to reorder command")
+      .draggable(command.id)
+  }
+
+  @ViewBuilder
+  private func customCommandEnabledCell(_ command: UserCustomCommand) -> some View {
+    if let binding = bindingForCustomCommand(id: command.id) {
+      Toggle("Enable \(command.resolvedTitle)", isOn: binding.isEnabled)
+        .labelsHidden()
+        .toggleStyle(.switch)
+        .controlSize(.small)
+        .help("Enable \(command.resolvedTitle)")
+    }
+  }
+
+  @ViewBuilder
+  private func globalCommandEnabledCell(_ command: UserCustomCommand) -> some View {
+    if let binding = globalCommandEnabled?(command.id) {
+      Toggle("Enable \(command.resolvedTitle) in this repository", isOn: binding)
+        .labelsHidden()
+        .toggleStyle(.switch)
+        .controlSize(.small)
+        .help("Enable \(command.resolvedTitle) in this repository")
     }
   }
 
@@ -688,7 +822,9 @@ struct CustomCommandsEditor: View {
   }
 
   private var resolvedCustomCommandBindings: ResolvedKeybindingMap {
-    let effectiveCommands = commands.map { EffectiveCustomCommand(source: source, command: $0) }
+    let effectiveCommands =
+      commands.map { EffectiveCustomCommand(source: source, command: $0) }
+      + globalCommands.map { EffectiveCustomCommand(source: .global, command: $0) }
     let migration = LegacyCustomCommandShortcutMigration.migrate(commands: effectiveCommands)
     return KeybindingResolver.resolve(
       schema: .appResolverSchema(effectiveCustomCommands: effectiveCommands),
@@ -697,8 +833,11 @@ struct CustomCommandsEditor: View {
     )
   }
 
-  private func customCommandBindingID(for commandID: String) -> String {
-    LegacyCustomCommandShortcutMigration.customCommandBindingID(for: commandID, source: source)
+  private func customCommandBindingID(
+    for commandID: String,
+    source: CustomCommandSource? = nil
+  ) -> String {
+    LegacyCustomCommandShortcutMigration.customCommandBindingID(for: commandID, source: source ?? self.source)
   }
 
   private func bindingForCustomCommand(id commandID: UserCustomCommand.ID) -> Binding<UserCustomCommand>? {
@@ -727,6 +866,7 @@ struct CustomCommandsEditor: View {
           command.splitDirection = updatedCommand.splitDirection
           command.closeOnSuccess = updatedCommand.closeOnSuccess
           command.shortcut = updatedCommand.shortcut
+          command.isEnabled = updatedCommand.isEnabled
         }
       }
     )
@@ -855,6 +995,27 @@ struct CustomCommandsEditor: View {
 
     update(&updatedCommands[index])
     commands = UserCustomCommand.normalizedCommands(updatedCommands)
+  }
+
+  private func moveCustomCommand(
+    _ commandID: UserCustomCommand.ID,
+    before destinationID: UserCustomCommand.ID? = nil
+  ) {
+    guard commandID != destinationID else {
+      return
+    }
+    var updatedCommands = commands
+    guard let sourceIndex = updatedCommands.firstIndex(where: { $0.id == commandID }) else {
+      return
+    }
+    let command = updatedCommands.remove(at: sourceIndex)
+    let destinationIndex =
+      destinationID.flatMap { destinationID in
+        updatedCommands.firstIndex(where: { $0.id == destinationID })
+      } ?? updatedCommands.endIndex
+    updatedCommands.insert(command, at: destinationIndex)
+    commands = UserCustomCommand.normalizedCommands(updatedCommands)
+    selectCustomCommand(commandID)
   }
 
   private func toggleRecording(for commandID: UserCustomCommand.ID) {
@@ -1003,7 +1164,32 @@ struct CustomCommandsEditor: View {
     )
   }
 
-  private var customCommandsIconColumnWidth: CGFloat { 48 }
+  private var showsGlobalCommands: Bool {
+    source == .repository && !globalCommands.isEmpty
+  }
+
+  private var displayedCommandCount: Int {
+    commands.count + (showsGlobalCommands ? globalCommands.count : 0)
+  }
+
+  private var localCommandDropTarget: some View {
+    Color.clear
+      .frame(height: 8)
+      .contentShape(Rectangle())
+      .dropDestination(for: String.self) { commandIDs, _ in
+        guard let commandID = commandIDs.first else {
+          return false
+        }
+        moveCustomCommand(commandID)
+        return true
+      }
+  }
+
+  private var customCommandsDragColumnWidth: CGFloat { 24 }
+
+  private var customCommandsEnabledColumnWidth: CGFloat { 56 }
+
+  private var customCommandsIconColumnWidth: CGFloat { 32 }
 
   private var customCommandsNameColumnWidth: CGFloat { 130 }
 

--- a/supacode/Features/Settings/Views/GlobalCustomCommandsView.swift
+++ b/supacode/Features/Settings/Views/GlobalCustomCommandsView.swift
@@ -14,10 +14,10 @@ struct GlobalCustomCommandsView: View {
         )
       } header: {
         VStack(alignment: .leading, spacing: 4) {
-          Text("Custom Commands")
+          Text("Global Custom Commands")
           Text(
             "Global terminal actions available in every repository. "
-              + "A local command with the same title takes precedence."
+              + "Enabled commands appear in the top-right of the window toolbar."
           )
           .foregroundStyle(.secondary)
         }

--- a/supacode/Features/Settings/Views/RepositorySettingsView.swift
+++ b/supacode/Features/Settings/Views/RepositorySettingsView.swift
@@ -1,5 +1,6 @@
 import AppKit
 import ComposableArchitecture
+import Sharing
 import SwiftUI
 
 struct RepositorySettingsView: View {
@@ -7,6 +8,7 @@ struct RepositorySettingsView: View {
   @State private var isBranchPickerPresented = false
   @State private var branchSearchText = ""
   @State private var githubIdentityViewModel = RepositoryGithubIdentityViewModel()
+  @Shared(.userGlobalSettings) private var globalSettings
 
   var body: some View {
     let baseRefOptions =
@@ -325,13 +327,23 @@ struct RepositorySettingsView: View {
           CustomCommandsEditor(
             commands: $store.userSettings.customCommands,
             source: .repository,
-            keybindingUserOverrides: store.keybindingUserOverrides
+            keybindingUserOverrides: store.keybindingUserOverrides,
+            globalCommands: globalSettings.customCommands,
+            globalCommandEnabled: { commandID in
+              Binding(
+                get: { store.userSettings.isGlobalCommandEnabled(commandID) },
+                set: { isEnabled in
+                  store.send(.setGlobalCommandEnabled(commandID, isEnabled))
+                }
+              )
+            }
           )
         } header: {
           VStack(alignment: .leading, spacing: 4) {
             Text("Custom Commands")
             Text(
-              "Repository-local terminal actions. Custom command shortcuts take precedence in this repository."
+              "Repository and global terminal actions. Enabled commands appear in repository order, "
+                + "then global order. Edit global commands in Settings → Commands."
             )
             .foregroundStyle(.secondary)
           }

--- a/supacode/Features/Settings/Views/SettingsView.swift
+++ b/supacode/Features/Settings/Views/SettingsView.swift
@@ -113,8 +113,8 @@ struct SettingsView: View {
             action: \.globalCustomCommands
           ) {
             GlobalCustomCommandsView(store: globalCustomCommandsStore)
-              .navigationTitle("Commands")
-              .navigationSubtitle("Global terminal actions")
+              .navigationTitle("Global Commands")
+              .navigationSubtitle("Global terminal actions and toolbar buttons")
           } else {
             ProgressView()
               .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/supacodeTests/AppFeatureCustomCommandTests.swift
+++ b/supacodeTests/AppFeatureCustomCommandTests.swift
@@ -205,6 +205,7 @@ struct AppFeatureCustomCommandTests {
     #expect(decoded.splitDirection == .right)
     #expect(decoded.closeOnSuccess == false)
     #expect(decoded.execution == .shellScript)
+    #expect(decoded.isEnabled)
   }
 
   @Test(.dependencies) func invalidCommandIndexDoesNothing() async {
@@ -471,6 +472,89 @@ struct AppFeatureCustomCommandTests {
           .overrides
       )
     }
+  }
+
+  @Test(.dependencies) func loadingUserSettingsExcludesDisabledCommandsFromDispatch() async {
+    let worktree = makeWorktree()
+    let localEnabled = UserCustomCommand(
+      id: "local-enabled",
+      title: "Build",
+      systemImage: "hammer",
+      command: "make build",
+      execution: .shellScript,
+      shortcut: nil
+    )
+    let localDisabled = UserCustomCommand(
+      id: "local-disabled",
+      title: "Test",
+      systemImage: "checkmark",
+      command: "make test",
+      execution: .shellScript,
+      shortcut: nil,
+      isEnabled: false
+    )
+    let globalEnabled = UserCustomCommand(
+      id: "global-enabled",
+      title: "Lint",
+      systemImage: "checkmark.circle",
+      command: "make lint",
+      execution: .shellScript,
+      shortcut: nil
+    )
+    let globalDisabled = UserCustomCommand(
+      id: "global-disabled",
+      title: "Format",
+      systemImage: "paintbrush",
+      command: "make format",
+      execution: .shellScript,
+      shortcut: nil,
+      isEnabled: false
+    )
+    let globalOptedOut = UserCustomCommand(
+      id: "global-opted-out",
+      title: "Deploy",
+      systemImage: "paperplane",
+      command: "make deploy",
+      execution: .shellScript,
+      shortcut: nil
+    )
+    let settings = UserRepositorySettings(
+      customCommands: [localEnabled, localDisabled],
+      disabledGlobalCommandIDs: ["global-opted-out"]
+    )
+    let expectedCommands = [
+      EffectiveCustomCommand(source: .repository, command: localEnabled),
+      EffectiveCustomCommand(source: .global, command: globalEnabled),
+    ]
+    let store = withDependencies {
+      $0.defaultFileStorage = .inMemory
+    } operation: {
+      @Shared(.userGlobalSettings) var globalSettings
+      $globalSettings.withLock {
+        $0 = UserGlobalSettings(customCommands: [globalEnabled, globalDisabled, globalOptedOut])
+      }
+      return TestStore(
+        initialState: AppFeature.State(
+          repositories: makeRepositoriesState(worktree: worktree),
+          settings: SettingsFeature.State()
+        )
+      ) {
+        AppFeature()
+      }
+    }
+
+    await store.send(.worktreeUserSettingsLoaded(settings, worktreeID: worktree.id)) {
+      $0.selectedCustomCommands = expectedCommands
+      $0.resolvedKeybindings = KeybindingResolver.resolve(
+        schema: .appResolverSchema(effectiveCustomCommands: expectedCommands),
+        migratedOverrides: LegacyCustomCommandShortcutMigration.migrate(commands: expectedCommands).overrides
+      )
+    }
+
+    await store.send(.runCustomCommand(.init(source: .repository, commandID: "local-disabled")))
+    await store.send(.runCustomCommand(.init(source: .global, commandID: "global-disabled")))
+    await store.send(.runCustomCommand(.init(source: .global, commandID: "global-opted-out")))
+    await store.finish()
   }
 
   @Test(.dependencies) func customCommandUsesCanvasFocusedWorktree() async {

--- a/supacodeTests/EffectiveCustomCommandTests.swift
+++ b/supacodeTests/EffectiveCustomCommandTests.swift
@@ -3,23 +3,46 @@ import Testing
 @testable import supacode
 
 struct EffectiveCustomCommandTests {
-  @Test func localCommandsKeepOrderAndHideMatchingGlobalTitles() {
+  @Test func repositoryCommandsKeepOrderAndGlobalCommandsFollowIncludingMatchingTitles() {
     let localBuild = command(id: "local-build", title: " Build ")
     let localTest = command(id: "local-test", title: "Test")
-    let hiddenGlobalBuild = command(id: "global-build", title: "build")
+    let globalBuild = command(id: "global-build", title: "build")
     let globalLint = command(id: "global-lint", title: "Lint")
 
     let resolved = EffectiveCustomCommand.resolve(
       repositoryCommands: [localBuild, localTest],
-      globalCommands: [hiddenGlobalBuild, globalLint]
+      globalCommands: [globalBuild, globalLint]
     )
 
     #expect(
       resolved.map(\.id) == [
         .init(source: .repository, commandID: "local-build"),
         .init(source: .repository, commandID: "local-test"),
+        .init(source: .global, commandID: "global-build"),
         .init(source: .global, commandID: "global-lint"),
-      ])
+      ]
+    )
+  }
+
+  @Test func visibilityGatesExcludeDisabledCommands() {
+    let localEnabled = command(id: "local-enabled", title: "Build")
+    let localDisabled = command(id: "local-disabled", title: "Test", isEnabled: false)
+    let globalEnabled = command(id: "global-enabled", title: "Lint")
+    let globalDisabled = command(id: "global-disabled", title: "Format", isEnabled: false)
+    let globalOptedOut = command(id: "global-opted-out", title: "Deploy")
+
+    let resolved = EffectiveCustomCommand.resolve(
+      repositoryCommands: [localEnabled, localDisabled],
+      globalCommands: [globalEnabled, globalDisabled, globalOptedOut],
+      disabledGlobalCommandIDs: ["global-opted-out"]
+    )
+
+    #expect(
+      resolved.map(\.id) == [
+        .init(source: .repository, commandID: "local-enabled"),
+        .init(source: .global, commandID: "global-enabled"),
+      ]
+    )
   }
 
   @Test func sourceQualifiedIdentityPreventsLocalGlobalUUIDCollisions() {
@@ -33,14 +56,15 @@ struct EffectiveCustomCommandTests {
     #expect(global.paletteID == "custom-command.global.same")
   }
 
-  private func command(id: String, title: String) -> UserCustomCommand {
+  private func command(id: String, title: String, isEnabled: Bool = true) -> UserCustomCommand {
     UserCustomCommand(
       id: id,
       title: title,
       systemImage: "terminal",
       command: "echo \(title)",
       execution: .shellScript,
-      shortcut: nil
+      shortcut: nil,
+      isEnabled: isEnabled
     )
   }
 }

--- a/supacodeTests/RepositorySettingsFeatureTests.swift
+++ b/supacodeTests/RepositorySettingsFeatureTests.swift
@@ -159,6 +159,39 @@ struct RepositorySettingsFeatureTests {
     #expect(decoded.customCommands.first?.shortcut == conflicted.customCommands.first?.shortcut)
   }
 
+  @Test(.dependencies) func globalCommandOptOutPersistsThroughDedicatedAction() async throws {
+    let rootURL = URL(fileURLWithPath: "/tmp/repo-\(UUID().uuidString)")
+    let localStorage = RepositoryLocalSettingsTestStorage()
+    let store = TestStore(
+      initialState: RepositorySettingsFeature.State(
+        rootURL: rootURL,
+        repositoryKind: .plain,
+        settings: .default,
+        userSettings: .default
+      )
+    ) {
+      RepositorySettingsFeature()
+    } withDependencies: {
+      $0.repositoryLocalSettingsStorage = localStorage.storage
+    }
+
+    await store.send(.setGlobalCommandEnabled("global-build", false)) {
+      $0.userSettings.disabledGlobalCommandIDs = ["global-build"]
+    }
+    await store.receive(\.delegate.settingsChanged)
+
+    let persisted = try JSONDecoder().decode(
+      UserRepositorySettings.self,
+      from: #require(localStorage.data(at: SupacodePaths.userRepositorySettingsURL(for: rootURL)))
+    )
+    #expect(!persisted.isGlobalCommandEnabled("global-build"))
+
+    await store.send(.setGlobalCommandEnabled("global-build", true)) {
+      $0.userSettings.disabledGlobalCommandIDs = []
+    }
+    await store.receive(\.delegate.settingsChanged)
+  }
+
   @Test(.dependencies) func customTitleBindingPersistsToRepositoryFile() async throws {
     let rootURL = URL(fileURLWithPath: "/tmp/repo-\(UUID().uuidString)")
     let settingsStorage = SettingsTestStorage()

--- a/supacodeTests/UserRepositorySettingsKeyTests.swift
+++ b/supacodeTests/UserRepositorySettingsKeyTests.swift
@@ -128,4 +128,37 @@ struct UserRepositorySettingsKeyTests {
     #expect(decoded.customCommands.count == 5)
     #expect(decoded == customSettings)
   }
+
+  @Test func globalCommandOptOutPersistsAndLegacyCommandsDefaultToEnabled() throws {
+    let legacyData = Data(
+      #"""
+      {
+        "customCommands": [
+          {
+            "id": "legacy-build",
+            "title": "Build",
+            "systemImage": "hammer",
+            "command": "make build",
+            "execution": "shellScript"
+          }
+        ]
+      }
+      """#.utf8
+    )
+    let legacy = try JSONDecoder().decode(UserRepositorySettings.self, from: legacyData)
+    #expect(legacy.customCommands[0].isEnabled)
+
+    let settings = UserRepositorySettings(
+      customCommands: legacy.customCommands,
+      disabledGlobalCommandIDs: ["global-build"]
+    )
+    #expect(!settings.isGlobalCommandEnabled("global-build"))
+    #expect(settings.isGlobalCommandEnabled("global-test"))
+
+    let persisted = try JSONDecoder().decode(
+      UserRepositorySettings.self,
+      from: JSONEncoder().encode(settings)
+    )
+    #expect(persisted == settings)
+  }
 }

--- a/supacodeTests/UserRepositorySettingsKeyTests.swift
+++ b/supacodeTests/UserRepositorySettingsKeyTests.swift
@@ -161,4 +161,26 @@ struct UserRepositorySettingsKeyTests {
     )
     #expect(persisted == settings)
   }
+
+  @Test func globalCommandOptOutsEncodeInStableOrder() throws {
+    let disabledIDs: Set<UserCustomCommand.ID> = [
+      "zulu",
+      "alpha",
+      "middle",
+      "bravo",
+      "tango",
+      "delta",
+      "uniform",
+      "echo",
+      "charlie",
+      "foxtrot",
+    ]
+    let settings = UserRepositorySettings(customCommands: [], disabledGlobalCommandIDs: disabledIDs)
+
+    let encoded = try JSONEncoder().encode(settings)
+    let object = try #require(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+    let optOutIDs = try #require(object["disabledGlobalCommandIDs"] as? [String])
+
+    #expect(optOutIDs == disabledIDs.sorted())
+  }
 }


### PR DESCRIPTION
## Summary
- add persistent enable gates for local commands and per-repository Global-command opt-outs
- surface the effective repo-then-Global order in Settings, with source-aware read-only Global rows and scoped drag reordering
- show a system-accent insertion rule at the hovered reorder destination, including the append target
- remove disabled commands from the toolbar, Worktrees menu, Command Palette, and shortcut dispatch while preserving their configuration
- refine the settings table with compact standard checkboxes, validated drag payloads, and deterministic opt-out encoding
- update the Custom Commands design record and agent manual

## Upgrade note
If a repository-local command and a Global command have the same name, Prowl now shows both. To hide the Global command for one repository, turn off its **This Repo** checkbox in Repo Settings → Custom Commands.

## Verification
- `xcodebuild test ...` (43 targeted Custom Commands, keybinding, AppFeature, repository settings, and Global settings tests)
- `make check`
- `make build-app`
- isolated Debug Prowl launch and CLI worktree/tab smoke test