### PR TITLE
Polish the Agents capsule: plain font and sparkles fallback icon

### DIFF
--- a/supacode/Features/Repositories/Views/AgentsToolbarButton.swift
+++ b/supacode/Features/Repositories/Views/AgentsToolbarButton.swift
@@ -79,7 +79,6 @@ struct AgentsToolbarButton: View {
         agentIcon(capsule)
           .frame(width: 20, height: 20)
         Text(capsule.displayName)
-          .monospaced()
       } else {
         Image(systemName: "person.2")
           .foregroundStyle(.secondary)

--- a/supacode/Features/Repositories/Views/AgentsToolbarButton.swift
+++ b/supacode/Features/Repositories/Views/AgentsToolbarButton.swift
@@ -80,7 +80,7 @@ struct AgentsToolbarButton: View {
           .frame(width: 20, height: 20)
         Text(capsule.displayName)
       } else {
-        Image(systemName: "person.2")
+        Image(systemName: "sparkles")
           .foregroundStyle(.secondary)
           .accessibilityHidden(true)
           .frame(width: 20, height: 20)


### PR DESCRIPTION
## Summary

Two small visual tweaks to the toolbar's Agents capsule:

1. **Drop `.monospaced()` from the agent name.** The label had been mono since the capsule was introduced, and the recent bump from `callout` to `title3` made it stand out. It now uses the same plain `title3` medium system font as the neighboring branch title (`WorktreeDetailTitleView`), so the two pills read as one family.
2. **Replace `person.2` with `sparkles` for the no-agent state.** Two people read as collaboration, not AI. The plural `sparkles` matches the "Ask Agent About Prowl" entry points and pairs with the singular `sparkle` already used as the fallback for a detected agent without a brand icon.

## Changes

- `AgentsToolbarButton.swift`: remove `.monospaced()` from the display-name `Text`; swap the disabled-state symbol to `sparkles`.

## Verification

- `make build-app` succeeds with 0 errors / 0 warnings.

https://claude.ai/code/session_01U1iWbyB8WsgcRkibLziseq
