### PR TITLE
Show launch alias names in the Agents capsule

### DIFF
--- a/docs/components/handoff.md
+++ b/docs/components/handoff.md
@@ -138,12 +138,14 @@ create handoff files for targets that have never run `prowl handoff save` or
 
 A capsule button left of the branch title identifies the selected pane's
 detected agent (badge and name — live status stays with the terminal and
-the Active Agents panel). Clicking it opens a popover whose hand-off row
-explains the action in place — "Pass this task to another agent in a new
-tab", plus "codex will summarize its progress first" when the native session
-is resumable — and opens a centered HUD. Future agent actions land in the
-same popover. The capsule is disabled when no agent is detected in the
-selected pane.
+the Active Agents panel). The name follows the same rule as the Active
+Agents rows: launch aliases with their own icon (e.g. `omp`) show the alias,
+not the semantic agent name (`pi`). Clicking it opens a popover whose
+hand-off row explains the action in place — "Pass this task to another agent
+in a new tab", plus "codex will summarize its progress first" when the
+native session is resumable — and opens a centered HUD. Future agent actions
+land in the same popover. The capsule is disabled when no agent is detected
+in the selected pane.
 
 The HUD runs in two steps:
 

--- a/supacode/Features/ActiveAgents/Models/ActiveAgentEntry.swift
+++ b/supacode/Features/ActiveAgents/Models/ActiveAgentEntry.swift
@@ -28,6 +28,13 @@ struct ActiveAgentEntry: Identifiable, Equatable, Sendable {
   let displayState: AgentDisplayState
   let lastChangedAt: Date
   var displayName: String {
+    Self.displayName(iconLookupToken: iconLookupToken, agent: agent)
+  }
+
+  /// The user-facing agent name: the launch command token (e.g. `omp`) when it
+  /// maps to a known icon, else the semantic agent name (e.g. `pi`). Shared by
+  /// the panel rows and the toolbar Agents capsule so both always agree.
+  static func displayName(iconLookupToken: String, agent: DetectedAgent) -> String {
     let trimmed = iconLookupToken.trimmingCharacters(in: .whitespacesAndNewlines)
     guard
       !trimmed.isEmpty,

--- a/supacode/Features/Repositories/Views/WorktreeDetailView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailView.swift
@@ -399,12 +399,18 @@ struct WorktreeDetailView: View {
     let iconSource =
       paneState.iconLookupToken.flatMap(CommandIconMap.iconForFirstToken)
       ?? CommandIconMap.iconForFirstToken(agent.iconLookupToken)
+    // Same naming rule as the Active Agents rows: launch aliases such as
+    // `omp` show their own name, not the semantic agent's (`pi`).
+    let displayName = ActiveAgentEntry.displayName(
+      iconLookupToken: paneState.iconLookupToken ?? agent.iconLookupToken,
+      agent: agent
+    )
     return AgentsCapsuleState(
-      displayName: agent.displayName,
+      displayName: displayName,
       iconSource: iconSource,
       infoLine: resumable
         ? "Pass this task to another agent in a new tab. "
-          + "\(agent.displayName) will summarize its progress first."
+          + "\(displayName) will summarize its progress first."
         : "Pass this task to another agent in a new tab."
     )
   }

--- a/supacodeTests/ActiveAgentsFeatureTests.swift
+++ b/supacodeTests/ActiveAgentsFeatureTests.swift
@@ -100,6 +100,24 @@ struct ActiveAgentsFeatureTests {
     #expect(cursorEntry.displayName == "cursor")
   }
 
+  @Test func sharedDisplayNamePolicyDrivesCapsuleNaming() {
+    // The toolbar Agents capsule feeds `paneState.iconLookupToken ?? agent.iconLookupToken`
+    // through this policy, so it must agree with the panel rows for every alias.
+    // Launch aliases with their own icon token keep their name…
+    #expect(ActiveAgentEntry.displayName(iconLookupToken: "omp", agent: .pi) == "omp")
+    #expect(ActiveAgentEntry.displayName(iconLookupToken: "oh-my-pi", agent: .pi) == "oh-my-pi")
+    #expect(ActiveAgentEntry.displayName(iconLookupToken: "cursor-agent", agent: .cursor) == "cursor-agent")
+    // …tokens without an icon entry and the generic `agent` entrypoint fall
+    // back to the semantic agent name.
+    #expect(ActiveAgentEntry.displayName(iconLookupToken: "omx", agent: .codex) == "codex")
+    #expect(ActiveAgentEntry.displayName(iconLookupToken: "agent", agent: .cursor) == "cursor")
+    #expect(ActiveAgentEntry.displayName(iconLookupToken: "", agent: .claude) == "claude")
+    // No pane token at all: the agent names itself.
+    #expect(
+      ActiveAgentEntry.displayName(iconLookupToken: DetectedAgent.pi.iconLookupToken, agent: .pi) == "pi"
+    )
+  }
+
   @Test func navigationReturnsNilForEmptyList() {
     let entries: IdentifiedArrayOf<ActiveAgentEntry> = []
     #expect(ActiveAgentsFeature.entryID(navigatingFrom: nil, direction: .next, in: entries) == nil)


### PR DESCRIPTION
## Problem

Running `omp` shows **pi** in the toolbar Agents capsule while the Active Agents row correctly shows **omp**. The capsule used `DetectedAgent.displayName` directly; the row prefers the launch command token when it maps to a known icon.

## Fix

- Extract the row's naming rule into `ActiveAgentEntry.displayName(iconLookupToken:agent:)` (behavior unchanged for rows).
- Feed the capsule label **and** the popover info line ("… will summarize its progress first") through the shared policy, using `paneState.iconLookupToken ?? agent.iconLookupToken` — the same inputs the rows get.

## Alias audit (`knownAgentBinaries` × `CommandIconMap`)

| token | agent | row | capsule before | capsule after |
|---|---|---|---|---|
| `omp` / `oh-my-pi` | pi | omp / oh-my-pi | pi | omp / oh-my-pi |
| `cursor-agent` | cursor | cursor-agent | cursor | cursor-agent |
| `omx` / `oh-my-codex` | codex | codex | codex | codex (unchanged) |
| `claude-code`, `ghcs`, `open-code`, `amp-local`, versioned `grok-*` | — | agent name | agent name | agent name (unchanged) |
| `agent` (Cursor entrypoint) | cursor | cursor | cursor | cursor (unchanged) |

Tokens without their own `CommandIconMap` entry already fell back to the semantic agent name in both places; only alias tokens with a dedicated icon diverged.

## Testing

- New `sharedDisplayNamePolicyDrivesCapsuleNaming` test covering every divergent and fallback case.
- `make build-app` — success; `ActiveAgentsFeatureTests` + `DetectedAgentTests` + `CommandIconMapTests`: 30 passed, 0 failed; `make check` — clean.