### PR TITLE
Fix custom command editor cursor jumps

### DIFF
--- a/supacode/Support/PlainTextEditor.swift
+++ b/supacode/Support/PlainTextEditor.swift
@@ -47,7 +47,11 @@ struct PlainTextEditor: NSViewRepresentable {
   func updateNSView(_ nsView: NSScrollView, context: Context) {
     guard let textView = nsView.documentView as? PlaceholderTextView else { return }
     if textView.string != text {
+      let selectedRange = textView.selectedRange()
       textView.string = text
+      let selectedLocation = min(selectedRange.location, text.utf16.count)
+      let selectedLength = min(selectedRange.length, text.utf16.count - selectedLocation)
+      textView.setSelectedRange(NSRange(location: selectedLocation, length: selectedLength))
       textView.needsDisplay = true
     }
     let updatedFont = editorFont

--- a/supacode/Support/PlainTextEditor.swift
+++ b/supacode/Support/PlainTextEditor.swift
@@ -46,7 +46,11 @@ struct PlainTextEditor: NSViewRepresentable {
 
   func updateNSView(_ nsView: NSScrollView, context: Context) {
     guard let textView = nsView.documentView as? PlaceholderTextView else { return }
-    if textView.string != text {
+    // Sync from state, but skip stale echoes of an in-flight user edit: resetting to an
+    // older value would clobber newer text and jump the caret (#608).
+    if textView.string == text {
+      context.coordinator.lastPushedText = nil
+    } else if textView.string != context.coordinator.lastPushedText {
       let selectedRange = textView.selectedRange()
       textView.string = text
       let selectedLocation = min(selectedRange.location, text.utf16.count)
@@ -78,12 +82,17 @@ struct PlainTextEditor: NSViewRepresentable {
   final class Coordinator: NSObject, NSTextViewDelegate {
     @Binding var text: String
 
+    /// Last text pushed to the binding from a user edit; cleared by `updateNSView`
+    /// once the value round-trips back from state.
+    var lastPushedText: String?
+
     init(text: Binding<String>) {
       _text = text
     }
 
     func textDidChange(_ notification: Notification) {
       guard let textView = notification.object as? PlaceholderTextView else { return }
+      lastPushedText = textView.string
       text = textView.string
       textView.needsDisplay = true
     }

--- a/supacodeTests/PlainTextEditorTests.swift
+++ b/supacodeTests/PlainTextEditorTests.swift
@@ -1,0 +1,112 @@
+import AppKit
+import SwiftUI
+import Testing
+
+@testable import supacode
+
+@MainActor
+struct PlainTextEditorTests {
+  @Test func textUpdateAfterMiddleInsertionPreservesCaret() throws {
+    let fixture = PlainTextEditorFixture(text: "abcdef")
+    let textView = try #require(fixture.textView)
+    textView.selectedRange = NSRange(location: 4, length: 0)
+
+    fixture.text = "abcXdef"
+    fixture.update()
+
+    #expect(fixture.textView === textView)
+    #expect(textView.string == "abcXdef")
+    #expect(textView.selectedRange() == NSRange(location: 4, length: 0))
+  }
+
+  @Test func textUpdateAfterMiddleDeletionPreservesCaret() throws {
+    let fixture = PlainTextEditorFixture(text: "abcdef")
+    let textView = try #require(fixture.textView)
+    textView.selectedRange = NSRange(location: 2, length: 0)
+
+    fixture.text = "abdef"
+    fixture.update()
+
+    #expect(fixture.textView === textView)
+    #expect(textView.string == "abdef")
+    #expect(textView.selectedRange() == NSRange(location: 2, length: 0))
+  }
+}
+
+@MainActor
+private final class PlainTextEditorFixture {
+  var text: String {
+    get { storage.text }
+    set { storage.text = newValue }
+  }
+
+  private let storage: PlainTextEditorTextStorage
+  private var revision = 0
+  private let textBinding: Binding<String>
+  private let window: NSWindow
+  private let hostingView: NSHostingView<EditorHost>
+
+  init(text: String) {
+    let storage = PlainTextEditorTextStorage(text: text)
+    self.storage = storage
+    textBinding = Binding(
+      get: { storage.text },
+      set: { storage.text = $0 }
+    )
+    window = NSWindow(
+      contentRect: NSRect(x: 0, y: 0, width: 320, height: 120),
+      styleMask: [.titled],
+      backing: .buffered,
+      defer: true
+    )
+    hostingView = NSHostingView(rootView: EditorHost(text: textBinding, revision: 0))
+    window.contentView = hostingView
+    hostingView.layoutSubtreeIfNeeded()
+  }
+
+  var textView: PlainTextEditor.PlaceholderTextView? {
+    findTextView(in: hostingView)
+  }
+
+  func update() {
+    revision += 1
+    hostingView.rootView = EditorHost(text: textBinding, revision: revision)
+    hostingView.layoutSubtreeIfNeeded()
+  }
+
+  private func findTextView(in view: NSView) -> PlainTextEditor.PlaceholderTextView? {
+    if let textView = view as? PlainTextEditor.PlaceholderTextView {
+      return textView
+    }
+
+    for subview in view.subviews {
+      if let textView = findTextView(in: subview) {
+        return textView
+      }
+    }
+
+    return nil
+  }
+}
+
+@MainActor
+private final class PlainTextEditorTextStorage {
+  var text: String
+
+  init(text: String) {
+    self.text = text
+  }
+}
+
+private struct EditorHost: View {
+  let text: Binding<String>
+  let revision: Int
+
+  var body: some View {
+    PlainTextEditor(
+      text: text,
+      isMonospaced: true,
+      placeholder: "Command \(revision)"
+    )
+  }
+}

--- a/supacodeTests/PlainTextEditorTests.swift
+++ b/supacodeTests/PlainTextEditorTests.swift
@@ -31,6 +31,92 @@ struct PlainTextEditorTests {
     #expect(textView.string == "abdef")
     #expect(textView.selectedRange() == NSRange(location: 2, length: 0))
   }
+
+  @Test func staleRefreshDuringMiddleTypingKeepsTextAndCaret() throws {
+    let fixture = PlainTextEditorFixture(text: "abcdef")
+    let textView = try #require(fixture.textView)
+    textView.setSelectedRange(NSRange(location: 3, length: 0))
+    textView.insertText("X", replacementRange: NSRange(location: NSNotFound, length: 0))
+    #expect(fixture.text == "abcXdef")
+    #expect(textView.selectedRange() == NSRange(location: 4, length: 0))
+
+    fixture.text = "abcdef"
+    fixture.update()
+
+    #expect(textView.string == "abcXdef")
+    #expect(textView.selectedRange() == NSRange(location: 4, length: 0))
+
+    fixture.text = "abcXdef"
+    fixture.update()
+
+    #expect(textView.string == "abcXdef")
+    #expect(textView.selectedRange() == NSRange(location: 4, length: 0))
+  }
+
+  @Test func staleRefreshDuringEndTypingKeepsTextAndCaret() throws {
+    let fixture = PlainTextEditorFixture(text: "abcdef")
+    let textView = try #require(fixture.textView)
+    textView.setSelectedRange(NSRange(location: 6, length: 0))
+    textView.insertText("X", replacementRange: NSRange(location: NSNotFound, length: 0))
+    #expect(fixture.text == "abcdefX")
+
+    fixture.text = "abcdef"
+    fixture.update()
+
+    #expect(textView.string == "abcdefX")
+
+    fixture.text = "abcdefX"
+    fixture.update()
+
+    #expect(textView.string == "abcdefX")
+    #expect(textView.selectedRange() == NSRange(location: 7, length: 0))
+  }
+
+  @Test func staleRefreshDuringMiddleDeletionKeepsTextAndCaret() throws {
+    let fixture = PlainTextEditorFixture(text: "abcdef")
+    let textView = try #require(fixture.textView)
+    textView.setSelectedRange(NSRange(location: 3, length: 0))
+    textView.deleteBackward(nil)
+    #expect(fixture.text == "abdef")
+    #expect(textView.selectedRange() == NSRange(location: 2, length: 0))
+
+    fixture.text = "abcdef"
+    fixture.update()
+
+    #expect(textView.string == "abdef")
+
+    fixture.text = "abdef"
+    fixture.update()
+
+    #expect(textView.string == "abdef")
+    #expect(textView.selectedRange() == NSRange(location: 2, length: 0))
+  }
+
+  @Test func externalChangeAfterEditRoundTripStillApplies() throws {
+    let fixture = PlainTextEditorFixture(text: "abcdef")
+    let textView = try #require(fixture.textView)
+    textView.setSelectedRange(NSRange(location: 6, length: 0))
+    textView.insertText("X", replacementRange: NSRange(location: NSNotFound, length: 0))
+    fixture.update()
+
+    fixture.text = "xyz"
+    fixture.update()
+
+    #expect(textView.string == "xyz")
+    #expect(textView.selectedRange() == NSRange(location: 3, length: 0))
+  }
+
+  @Test func externalChangeClampsSelectionToNewLength() throws {
+    let fixture = PlainTextEditorFixture(text: "abcdef")
+    let textView = try #require(fixture.textView)
+    textView.setSelectedRange(NSRange(location: 4, length: 2))
+
+    fixture.text = "abc"
+    fixture.update()
+
+    #expect(textView.string == "abc")
+    #expect(textView.selectedRange() == NSRange(location: 3, length: 0))
+  }
 }
 
 @MainActor


### PR DESCRIPTION
## What

Preserve the text selection when `PlainTextEditor` synchronizes its AppKit text view.

## Why

Editing a custom command in the middle of its text could reset the caret to the end during a SwiftUI refresh.

Fixes #608

## How tested

- Added regression coverage for middle insertion and deletion caret positions.
- Ran the targeted `PlainTextEditorTests`.
- Ran `make check`.
- Ran `make build-app`.

onevclaw - an assistant to @onevcat