### PR TITLE
docs: describe arrangeCards packing strategies

### DIFF
--- a/supacode/Features/Canvas/Views/CanvasView.swift
+++ b/supacode/Features/Canvas/Views/CanvasView.swift
@@ -626,9 +626,9 @@ struct CanvasView: View {
     layoutStore.setCardLayouts(layouts, zOrder: keys)
   }
 
-  /// Arrange cards using MaxRects-BSSF bin packing. Preserves each card's
-  /// current size and finds a compact layout whose aspect ratio matches
-  /// the viewport.
+  /// Arrange cards with `CanvasCardPacker`, which chooses between waterfall
+  /// and row-break layouts. Preserves each card's current size and finds a
+  /// compact layout whose aspect ratio matches the viewport.
   func arrangeCards() {
     let keys = collectCardKeys(from: terminalManager.activeWorktreeStates)
     guard !keys.isEmpty, viewportSize.width > 0, viewportSize.height > 0 else { return }


### PR DESCRIPTION
## Summary

- I replaced the stale MaxRects-BSSF description on `arrangeCards()`.
- I documented the actual `CanvasCardPacker` behavior: choosing between waterfall and row-break layouts.

## Validation

- `git diff --check origin/main...HEAD`
- Targeted source assertion confirming the comment matches the two strategies implemented by `CanvasCardPacker`
- I could not run the macOS-only app build locally on this Linux host; the full build and repository lint workflow are deferred to CI.

Fixes #568
