### PR TITLE
Add sidebar Expand Active state and per-worktree tab badges

### DIFF
--- a/docs-ai/050-sidebar-expand-active-and-worktree-tab-badges/000-plan.md
+++ b/docs-ai/050-sidebar-expand-active-and-worktree-tab-badges/000-plan.md
@@ -145,3 +145,15 @@ _Each entry supersedes the draft above._
 - Manual smoke: mixed repos (with/without tabs), workspace, plain folder;
   cycle through the three states; single- vs multi-worktree badge visibility.
 - `make check`, `make build-app`.
+
+## Amendments
+
+- 2026-07-25 (post-PR review by onevcat): **badges are exclusive per level,
+  not duplicated.** Showing `repo 5 / main 2 / other 3` simultaneously reads
+  as redundant. Revised rule supersedes Decisions #4's multi-worktree gate:
+  - git repo **collapsed** → header shows the aggregate count;
+  - git repo **expanded** → header badge hidden, every worktree row shows its
+    own count (single-worktree repos included — the `worktrees.count >= 2`
+    gate is removed, unifying the code path);
+  - workspaces keep the header badge even when expanded (child rows carry no
+    per-row count; Decisions #5 unchanged) and plain folders never expand.

--- a/docs-ai/050-sidebar-expand-active-and-worktree-tab-badges/000-plan.md
+++ b/docs-ai/050-sidebar-expand-active-and-worktree-tab-badges/000-plan.md
@@ -1,0 +1,147 @@
+# 050 — Sidebar: Expand-Active Third State + Per-Worktree Tab Badges: Plan
+
+| | |
+| --- | --- |
+| **Status** | Implemented — see [001-action.md](001-action.md) |
+| **Anchor date** | 2026-07-25 |
+| **Primary PRs** | TBD |
+| **Related** | [026 sidebar-container-refactor](../026-sidebar-container-refactor/000-plan.md), [033 ui-refresh-2026-05](../033-ui-refresh-2026-05/000-plan.md), [042 project-workspaces](../042-project-workspaces/000-plan.md) |
+
+## Background
+
+The sidebar's repository list header has a single toggle button that flips
+between `Expand All` and `Collapse All` (`SidebarListView.repositoryListHeaderAction`:
+any expandable repo expanded → offers Collapse All; none expanded → offers
+Expand All). Expansion state is persisted as the *collapsed* ID set in
+`@Shared(.appStorage("sidebarCollapsedRepositoryIDs"))` and derived into
+`RepositoriesFeature.State.expandedRepositoryIDs`.
+
+The open-tab count badge exists only on the repository section header
+(`RepoHeaderTabCountBadge`, backed by `RepositorySectionView.openTabCount`):
+for git repos it sums `tabManager.tabs.count` over all worktrees; for plain
+folders and workspaces it reads the terminal state keyed by `repository.id`
+(workspace child tabs all live under the workspace's own ID). The badge hides
+at count 0.
+
+Worktree rows (`WorktreeRowsView` → `WorktreeRow`) render main / pinned /
+pending / unpinned sections and carry no per-worktree tab information today.
+
+## Goals
+
+1. **Third header-button state — "Expand Active"**: clicking the header button
+   cycles through a state that expands exactly the repos/workspaces that have
+   at least one open terminal tab, collapsing the rest.
+2. **Per-worktree tab count badge**: inside an expanded git repo with more
+   than one worktree, each worktree row shows its own open-tab count badge.
+   A repo with a single worktree shows no extra UI.
+
+### Non-goals
+
+- Changing what "open tab" means (no agent-status coupling).
+- Canvas / Shelf segments; this is the Default (tabbed) sidebar list only.
+
+## Proposed design (pre-interview draft; open points below)
+
+### A. Expand-Active third state
+
+- Semantics (draft): a one-shot *repo-level* expansion action — set
+  `expandedRepoIDs` to `{ repo ∈ expandable | openTabCount(repo) > 0 }`.
+  Worktree rows inside expanded repos are NOT filtered; persistence flows
+  through the existing collapsed-set binding like the other two actions.
+- Cycle (draft): Expand All → Expand Active → Collapse All → Expand All …,
+  derived from the current expansion state (button keeps showing the *next*
+  action).
+- Icon (draft): keep chevron family for the two existing states; third state
+  needs a distinct glyph + tooltip (`Expand Active`), TBD in interview.
+
+### B. Per-worktree tab badges
+
+- Reuse the visual style of `RepoHeaderTabCountBadge` (caption2, monospaced
+  digit, capsule quaternary background), rendered as an isolated leaf view so
+  only the badge subtree subscribes to `WorktreeTerminalManager` churn
+  (same isolation rationale as the repo header badge).
+- Show on worktree rows only when the repo has ≥ 2 worktrees; count for a row
+  is `tabManager.tabs.count` of that worktree; hide at 0 (draft).
+
+## Open questions (interview queue)
+
+1. ~~Third-state semantics~~ → resolved, see Decisions #1.
+2. ~~Cycle order~~ → resolved, see Decisions #2.
+3. ~~Third-state icon / tooltip~~ → resolved, see Decisions #3.
+4. ~~No-active-tab behavior~~ → resolved, folded into Decisions #2.
+5. ~~Worktree badge placement/visibility~~ → resolved, see Decisions #4.
+6. ~~Workspace children / plain folders~~ → resolved, see Decisions #5.
+
+All questions resolved on 2026-07-25; see Decisions.
+
+## Decisions (interview record)
+_Each entry supersedes the draft above._
+
+1. **Expand Active is a repo-level one-shot action** (2026-07-25). Clicking it
+   sets the expanded set to exactly the expandable repos/workspaces with
+   `openTabCount > 0`; worktree rows inside expanded repos are never filtered.
+   No persistent mode; persistence flows through the existing collapsed-set
+   binding, and manual expand/collapse afterwards behaves as today. "只显示"
+   means display-side expansion only — no side effects on tabs.
+2. **Cycle: Collapsed → Expand Active → Expand All → Collapse All**
+   (2026-07-25). Derivation stays a pure function of the current expansion
+   state, no stored mode/cursor:
+   - all collapsed → Expand Active (degrades to Expand All when the active
+     set is empty or equals the full expandable set);
+   - expanded == active set (non-empty, proper subset) → Expand All;
+   - all expanded → Collapse All;
+   - any other mixed state → Collapse All (matches today's behavior).
+   Accepted cost: reaching "expand everything" from fully collapsed takes two
+   clicks when an active set exists.
+3. **Icon: `chevron.right` + accent dot overlay** (2026-07-25). The third
+   state keeps the disclosure glyph family: `chevron.right` with a small
+   (~4pt) accent-colored filled circle at the top-trailing corner (drawn as an
+   overlay, not a new symbol). Three-state visuals: right+dot (Expand Active)
+   → right (Expand All) → down (Collapse All). Title/tooltip: "Expand
+   Active"; help text "Expand repositories with open tabs". The 45°-rotation
+   idea was rejected as visually mushy; filter/bolt glyphs rejected for
+   wrong or broken semantics.
+4. **Worktree badge: after the name, hide at 0, all rows equal**
+   (2026-07-25). Badge sits right after the worktree name (before the
+   Spacer), mirroring the repo header's name→badge layout; visual style
+   reuses `RepoHeaderTabCountBadge` (caption2 monospaced digits, quaternary
+   capsule), implemented as an isolated leaf view so only the badge subtree
+   subscribes to `WorktreeTerminalManager`. Hidden at count 0. Main worktree
+   participates like any other row (no exemption). Pending rows have no
+   terminal state so they hide naturally; deleting/archiving rows follow
+   plain count logic. Multi-worktree gate: `repository.worktrees.count >= 2`.
+5. **No per-row badge for workspace children or plain folders**
+   (2026-07-25). Workspace child tabs are keyed by the workspace's own ID
+   (`focusOrCreateTabInDirectory`); per-child attribution would need
+   working-directory bucketing with fuzzy semantics. Plain folders have no
+   child rows. Both keep only the existing header badge. Workspaces still
+   participate in Expand Active via their aggregate `openTabCount`.
+
+## Implementation sketch
+
+- `SidebarListView.RepositoryListHeaderAction` gains `.expandActive`:
+  title "Expand Active", dedicated help text ("Expand repositories with open
+  tabs"), glyph = `chevron.right` (no rotation) + ~4pt accent dot overlay at
+  top-trailing.
+- `repositoryListHeaderAction(...)` gains an `activeRepositoryIDs` parameter
+  and implements the Decisions #2 table; stays a pure static function, tests
+  extended in `RepositorySectionViewTests.swift`.
+- Active set = expandable repos with
+  `RepositorySectionView.openTabCount(for:terminalManager:) > 0`. To avoid
+  subscribing `SidebarListView.body` to `WorktreeTerminalManager` churn, the
+  header button moves into an isolated leaf view that owns the
+  terminalManager read (same pattern as `RepoHeaderTabCountBadge`) and
+  writes the new expanded set through the existing binding
+  (`expandedRepoIDs = activeIDs` for `.expandActive`).
+- Worktree badge: shared capsule style extracted from
+  `RepoHeaderTabCountBadge`; new leaf view (terminalManager + worktree ID)
+  injected into `WorktreeRow` after the name; `WorktreeRowsView` gates it on
+  `repository.worktrees.count >= 2`.
+
+## Verification
+
+- Unit tests for the new header-action derivation (pure function over
+  expansion state + active set).
+- Manual smoke: mixed repos (with/without tabs), workspace, plain folder;
+  cycle through the three states; single- vs multi-worktree badge visibility.
+- `make check`, `make build-app`.

--- a/docs-ai/050-sidebar-expand-active-and-worktree-tab-badges/000-plan.md
+++ b/docs-ai/050-sidebar-expand-active-and-worktree-tab-badges/000-plan.md
@@ -4,7 +4,7 @@
 | --- | --- |
 | **Status** | Implemented — see [001-action.md](001-action.md) |
 | **Anchor date** | 2026-07-25 |
-| **Primary PRs** | TBD |
+| **Primary PRs** | [#612](https://github.com/onevcat/Prowl/pull/612) |
 | **Related** | [026 sidebar-container-refactor](../026-sidebar-container-refactor/000-plan.md), [033 ui-refresh-2026-05](../033-ui-refresh-2026-05/000-plan.md), [042 project-workspaces](../042-project-workspaces/000-plan.md) |
 
 ## Background

--- a/docs-ai/050-sidebar-expand-active-and-worktree-tab-badges/000-plan.md
+++ b/docs-ai/050-sidebar-expand-active-and-worktree-tab-badges/000-plan.md
@@ -157,3 +157,7 @@ _Each entry supersedes the draft above._
     gate is removed, unifying the code path);
   - workspaces keep the header badge even when expanded (child rows carry no
     per-row count; Decisions #5 unchanged) and plain folders never expand.
+- 2026-07-25: **Expand Active icon is `chevron.right.2`, not chevron + accent
+  dot.** The dot was too subtle and stole the accent color for a state hint.
+  The cycle now reads as remaining depth: `»` (two levels still collapsed) →
+  `›` (one level) → `v` (all expanded).

--- a/docs-ai/050-sidebar-expand-active-and-worktree-tab-badges/001-action.md
+++ b/docs-ai/050-sidebar-expand-active-and-worktree-tab-badges/001-action.md
@@ -1,0 +1,82 @@
+# 050 — Sidebar: Expand-Active Third State + Per-Worktree Tab Badges: Action
+
+| | |
+| --- | --- |
+| **Status** | Implemented on `feature/sidebar-expand-active` |
+| **Date** | 2026-07-25 |
+| **Plan** | [000-plan.md](000-plan.md) — implemented as decided; no deviations |
+
+## What was built
+
+### Expand Active third state (`SidebarListView.swift`)
+
+- `RepositoryListHeaderAction` gained `.expandActive` with `title`
+  ("Expand Active"), a dedicated `helpText` ("Expand repositories with open
+  tabs"; the other two states keep `title` as help), and zero rotation
+  (chevron.right family).
+- `repositoryListHeaderAction(expandedRepoIDs:expandableRepositoryIDs:activeRepositoryIDs:)`
+  implements the Decisions #2 table as a pure static function. New
+  `activeRepositoryIDs(in:expandableRepositoryIDs:terminalManager:)` filters
+  expandable repos through `RepositorySectionView.openTabCount > 0`.
+- The header button moved out of `SidebarListView.body` into a private leaf
+  view `RepositoryListHeaderToggle` (same file). It owns both the
+  `WorktreeTerminalManager` read (isolation: the sidebar body never
+  subscribes to terminal churn) and the click handler; `.expandActive`
+  assigns `expanded = (expanded − expandable) ∪ active` through the existing
+  binding in a single write.
+- Glyph: `chevron.right` + 4pt `Color.accentColor` circle overlaid at
+  top-trailing (`offset(x: -3, y: 3)`), `accessibilityHidden`.
+
+### Per-worktree tab badges (`RepoHeaderRow.swift`, `WorktreeRow.swift`, `WorktreeRowsView.swift`)
+
+- Extracted the capsule visual into `TabCountBadge(count:)` (hidden at 0);
+  `RepoHeaderTabCountBadge` now delegates to it.
+- New `WorktreeTabCountBadge(worktreeID:terminalManager:)` leaf view — the
+  per-row analogue with the same subscription isolation.
+- `WorktreeRow` gained an optional `tabCountBadge: WorktreeTabCountBadge?`
+  (default `nil`), rendered right after the name text, before the Spacer.
+  Workspace child rows and previews are untouched (nil default).
+- `WorktreeRowsView.worktreeRowView` injects the badge only when
+  `repository.worktrees.count >= 2`.
+
+## Tests
+
+`RepositorySectionViewTests` (all 14 pass):
+
+- existing `sidebarHeaderActionCollapsesWhenAnyExpandableRepositoryIsOpen`
+  extended with `activeRepositoryIDs: []` (verifies the empty-active-set
+  degradation keeps today's two-state behavior).
+- new `sidebarHeaderActionCyclesThroughExpandActive` — full decision table:
+  collapsed→expandActive, ==active→expandAll, full→collapseAll,
+  mixed→collapseAll, active==all degradation both ways.
+- new `activeRepositoryIDsIncludesOnlyExpandableReposWithOpenTabs` —
+  terminal-manager fixture; plain folder with tabs excluded (not expandable).
+
+## End-to-end verification (self-verify-prowl, 2026-07-25)
+
+Debug instance on `/tmp/prowl-self-verify.sock`, driven via `prowl` CLI +
+AX presses (`AXUIElementPerformAction`), single-window screenshots:
+
+1. Repo with 3 worktrees (Kingfisher) + CLI-opened tab on main: worktree row
+   shows its own "1" badge; sibling worktrees with 0 tabs show nothing;
+   single-worktree repo (Prowl) shows no row badge. Header badges correct
+   (Kingfisher 1, Prowl 1, relay 2).
+2. Full cycle: Collapse All → all collapsed, button becomes chevron+dot
+   (Expand Active, correct AX help) → press → exactly the repos with open
+   tabs expand → button becomes Expand All → press → everything expands →
+   button returns to Collapse All.
+3. Buttons expose correct AX descriptions/help ("Collapse All",
+   "Expand repositories with open tabs", "Expand All").
+
+Note: one stale-render observation on the first debug session (header badge
+not appearing for a CLI-created tab) did not reproduce after relaunch;
+probe logging confirmed the header badge body re-evaluates with the correct
+count on tab creation. Pre-existing rendering territory, not introduced by
+this change.
+
+`make check` clean; app + tests build clean (0 warnings).
+
+## Docs
+
+`docs/components/repositories-and-worktrees.md` — "Pinning & ordering"
+section documents the three-state cycle and both badge levels.

--- a/docs-ai/050-sidebar-expand-active-and-worktree-tab-badges/001-action.md
+++ b/docs-ai/050-sidebar-expand-active-and-worktree-tab-badges/001-action.md
@@ -4,7 +4,7 @@
 | --- | --- |
 | **Status** | Implemented on `feature/sidebar-expand-active` |
 | **Date** | 2026-07-25 |
-| **Plan** | [000-plan.md](000-plan.md) — implemented as decided; no deviations |
+| **Plan** | [000-plan.md](000-plan.md) — implemented as decided, then revised per PR #612 review (see the plan's Amendments and "Post-review follow-ups" below) |
 
 ## What was built
 
@@ -24,8 +24,9 @@
   subscribes to terminal churn) and the click handler; `.expandActive`
   assigns `expanded = (expanded − expandable) ∪ active` through the existing
   binding in a single write.
-- Glyph: `chevron.right` + 4pt `Color.accentColor` circle overlaid at
-  top-trailing (`offset(x: -3, y: 3)`), `accessibilityHidden`.
+- Glyph: `chevron.right.2` (double chevron). Initially shipped as
+  `chevron.right` + 4pt accent-dot overlay; replaced post-review — the cycle
+  now reads as remaining depth: `»` → `›` → rotated-down chevron.
 
 ### Per-worktree tab badges (`RepoHeaderRow.swift`, `WorktreeRow.swift`, `WorktreeRowsView.swift`)
 
@@ -36,8 +37,24 @@
 - `WorktreeRow` gained an optional `tabCountBadge: WorktreeTabCountBadge?`
   (default `nil`), rendered right after the name text, before the Spacer.
   Workspace child rows and previews are untouched (nil default).
-- `WorktreeRowsView.worktreeRowView` injects the badge only when
-  `repository.worktrees.count >= 2`.
+- `WorktreeRowsView.worktreeRowView` injects the badge unconditionally for
+  git-repo worktree rows; it hides itself at count 0. (Initially gated on
+  `repository.worktrees.count >= 2`; the gate was removed post-review when
+  badges became exclusive per level — see plan Amendments.)
+
+## Post-review follow-ups (2026-07-25)
+
+- **Badges exclusive per level:** collapsed git repo → aggregate count on the
+  header; expanded → header badge hidden, every worktree row shows its own
+  count. Workspaces keep the header badge when expanded; plain folders never
+  expand. (`RepositorySectionView` gates `RepoHeaderTabCountBadge` on
+  `!(isExpanded && supportsWorktrees)`.)
+- **Badge compression fix:** `TabCountBadge` gained `.fixedSize()` — the
+  name text's `layoutPriority(1)` otherwise squeezed the capsule below its
+  natural size next to long branch names.
+- **Expand Active glyph:** `chevron.right.2` replaced the chevron+dot combo
+  (see above). The e2e verification section below predates this swap and the
+  badge-exclusivity change; the recorded cycle behavior is unchanged.
 
 ## Tests
 

--- a/docs-ai/README.md
+++ b/docs-ai/README.md
@@ -101,3 +101,4 @@ agent-facing manual for that).
 | 047 | [cross-agent-handoff](047-cross-agent-handoff/000-plan.md) | 2026-07-17 | Durable artifact-based task handoff across coding agents |
 | 048 | [agent-runtime-adapters](048-agent-runtime-adapters/000-plan.md) | 2026-07-18 | Protocol-backed agent session resume and configurable launch invocations |
 | 049 | [agents-toolbar-entry](049-agents-toolbar-entry/000-plan.md) | 2026-07-20 | Agents status capsule + staged handoff HUD toolbar entry |
+| 050 | [sidebar-expand-active-and-worktree-tab-badges](050-sidebar-expand-active-and-worktree-tab-badges/000-plan.md) | 2026-07-25 | Sidebar Expand Active third state + per-worktree tab count badges |

--- a/docs/components/repositories-and-worktrees.md
+++ b/docs/components/repositories-and-worktrees.md
@@ -108,9 +108,10 @@ new worktree (see [custom-actions](custom-actions.md)).
   terminal tabs), then **Expand All**, then **Collapse All**. Expand Active is
   skipped when no repo (or every repo) has open tabs. Collapsed state is
   remembered.
-- **Tab count badges:** a repo header shows its total open-tab count; in repos
-  with more than one worktree, each worktree row also shows its own count
-  (hidden at zero).
+- **Tab count badges:** a collapsed repo header shows its total open-tab count;
+  expanding a git repo moves the count onto the individual worktree rows
+  (hidden at zero). Workspaces and plain folders always show the count on the
+  header.
 
 ## Archiving a worktree
 

--- a/docs/components/repositories-and-worktrees.md
+++ b/docs/components/repositories-and-worktrees.md
@@ -102,8 +102,15 @@ new worktree (see [custom-actions](custom-actions.md)).
   the main worktree.)
 - **Reorder:** drag repositories or worktrees to rearrange; a thin accent line
   shows the drop target. Order is persisted.
-- **Expand / Collapse:** click the chevron on a repo header, or use the sidebar's
-  **Expand All / Collapse All** buttons. Collapsed state is remembered.
+- **Expand / Collapse:** click the chevron on a repo header, or cycle the
+  sidebar's header button: from all-collapsed it offers **Expand Active**
+  (chevron with an accent dot — expands only repos/workspaces that have open
+  terminal tabs), then **Expand All**, then **Collapse All**. Expand Active is
+  skipped when no repo (or every repo) has open tabs. Collapsed state is
+  remembered.
+- **Tab count badges:** a repo header shows its total open-tab count; in repos
+  with more than one worktree, each worktree row also shows its own count
+  (hidden at zero).
 
 ## Archiving a worktree
 

--- a/docs/components/repositories-and-worktrees.md
+++ b/docs/components/repositories-and-worktrees.md
@@ -104,10 +104,10 @@ new worktree (see [custom-actions](custom-actions.md)).
   shows the drop target. Order is persisted.
 - **Expand / Collapse:** click the chevron on a repo header, or cycle the
   sidebar's header button: from all-collapsed it offers **Expand Active**
-  (chevron with an accent dot — expands only repos/workspaces that have open
-  terminal tabs), then **Expand All**, then **Collapse All**. Expand Active is
-  skipped when no repo (or every repo) has open tabs. Collapsed state is
-  remembered.
+  (double chevron `»` — expands only repos/workspaces that have open terminal
+  tabs), then **Expand All** (single chevron `›`), then **Collapse All**
+  (chevron rotated down). Expand Active is skipped when no repo (or every
+  repo) has open tabs. Collapsed state is remembered.
 - **Tab count badges:** a collapsed repo header shows its total open-tab count;
   expanding a git repo moves the count onto the individual worktree rows
   (hidden at zero). Workspaces and plain folders always show the count on the

--- a/supacode/Features/Repositories/Views/RepoHeaderRow.swift
+++ b/supacode/Features/Repositories/Views/RepoHeaderRow.swift
@@ -67,10 +67,35 @@ struct RepoHeaderTabCountBadge: View {
   let terminalManager: WorktreeTerminalManager
 
   var body: some View {
-    let count = RepositorySectionView.openTabCount(
-      for: repository,
-      terminalManager: terminalManager
+    TabCountBadge(
+      count: RepositorySectionView.openTabCount(
+        for: repository,
+        terminalManager: terminalManager
+      )
     )
+  }
+}
+
+/// Leaf view that renders the open-tab count badge for a single worktree
+/// row. Isolated for the same reason as `RepoHeaderTabCountBadge`: only
+/// this subtree subscribes to terminal state churn.
+struct WorktreeTabCountBadge: View {
+  let worktreeID: Worktree.ID
+  let terminalManager: WorktreeTerminalManager
+
+  var body: some View {
+    TabCountBadge(
+      count: terminalManager.stateIfExists(for: worktreeID)?.tabManager.tabs.count ?? 0
+    )
+  }
+}
+
+/// Capsule open-tab count badge shared by the repository header and
+/// worktree rows. Hidden at count 0.
+struct TabCountBadge: View {
+  let count: Int
+
+  var body: some View {
     if count > 0 {
       Text("\(count)")
         .font(.caption2)

--- a/supacode/Features/Repositories/Views/RepoHeaderRow.swift
+++ b/supacode/Features/Repositories/Views/RepoHeaderRow.swift
@@ -104,6 +104,9 @@ struct TabCountBadge: View {
         .padding(.horizontal, 5)
         .padding(.vertical, 1)
         .background(.quaternary, in: .capsule)
+        // Keep natural size when the row is width-starved; the sibling
+        // name text (higher layout priority) truncates instead.
+        .fixedSize()
         .help("\(count) active \(count == 1 ? "tab" : "tabs")")
     }
   }

--- a/supacode/Features/Repositories/Views/RepositorySectionView.swift
+++ b/supacode/Features/Repositories/Views/RepositorySectionView.swift
@@ -61,10 +61,16 @@ struct RepositorySectionView: View {
             ? (isExpanded ? "Collapse" : "Expand")
             : (repository.isWorkspace ? "Open terminal in workspace" : "Open terminal in folder")
         )
-        RepoHeaderTabCountBadge(
-          repository: repository,
-          terminalManager: terminalManager
-        )
+        // Expanded git repos move the count into the worktree rows, so the
+        // header stays quiet. Workspaces keep the header badge even when
+        // expanded (child rows carry no per-row count — tab attribution is
+        // by directory, not by child); plain folders never expand.
+        if !(isExpanded && repository.capabilities.supportsWorktrees) {
+          RepoHeaderTabCountBadge(
+            repository: repository,
+            terminalManager: terminalManager
+          )
+        }
       }
       .frame(maxWidth: .infinity, alignment: .leading)
       .background {

--- a/supacode/Features/Repositories/Views/SidebarListView.swift
+++ b/supacode/Features/Repositories/Views/SidebarListView.swift
@@ -7,14 +7,26 @@ import SwiftUI
 struct SidebarListView: View {
   enum RepositoryListHeaderAction: Equatable {
     case expandAll
+    case expandActive
     case collapseAll
 
     var title: String {
       switch self {
       case .expandAll:
         return "Expand All"
+      case .expandActive:
+        return "Expand Active"
       case .collapseAll:
         return "Collapse All"
+      }
+    }
+
+    var helpText: String {
+      switch self {
+      case .expandActive:
+        return "Expand repositories with open tabs"
+      case .expandAll, .collapseAll:
+        return title
       }
     }
 
@@ -24,7 +36,7 @@ struct SidebarListView: View {
 
     var rotation: Angle {
       switch self {
-      case .expandAll:
+      case .expandAll, .expandActive:
         return .zero
       case .collapseAll:
         return .degrees(90)
@@ -53,10 +65,6 @@ struct SidebarListView: View {
     let hotkeyRows = state.orderedWorktreeRows(includingRepositoryIDs: expandedRepoIDs)
     let presentation = state.sidebarPresentation(expandedRepositoryIDs: expandedRepoIDs)
     let expandableRepositoryIDs = Self.expandableRepositoryIDs(in: state.repositories)
-    let repositoryListHeaderAction = Self.repositoryListHeaderAction(
-      expandedRepoIDs: expandedRepoIDs,
-      expandableRepositoryIDs: expandableRepositoryIDs
-    )
     let repositoryItems = presentation.items.filter(\.isRepositoryOrderItem)
     let selectedWorktreeIDs = Self.selectedWorktreeIDs(in: state)
     let selectedSurfaceID = state.selectedWorktreeID.flatMap { worktreeID in
@@ -100,7 +108,6 @@ struct SidebarListView: View {
           // carries the prompt and the Add button instead.
           if !repositoryItems.isEmpty {
             repositoryListHeader(
-              action: repositoryListHeaderAction,
               expandableRepositoryIDs: expandableRepositoryIDs
             )
           }
@@ -316,7 +323,6 @@ struct SidebarListView: View {
   }
 
   private func repositoryListHeader(
-    action: RepositoryListHeaderAction,
     expandableRepositoryIDs: Set<Repository.ID>
   ) -> some View {
     HStack(spacing: 4) {
@@ -325,25 +331,12 @@ struct SidebarListView: View {
         .foregroundStyle(.tertiary)
         .frame(maxWidth: .infinity, alignment: .leading)
       if !expandableRepositoryIDs.isEmpty {
-        Button {
-          withAnimation(.easeOut(duration: 0.2)) {
-            switch action {
-            case .expandAll:
-              expandedRepoIDs.formUnion(expandableRepositoryIDs)
-            case .collapseAll:
-              expandedRepoIDs.subtract(expandableRepositoryIDs)
-            }
-          }
-        } label: {
-          Label(action.title, systemImage: action.systemImageName)
-            .labelStyle(.iconOnly)
-            .frame(width: 20, height: 20)
-            .rotationEffect(action.rotation)
-            .contentShape(.rect)
-        }
-        .buttonStyle(.plain)
-        .foregroundStyle(.secondary)
-        .help(action.title)
+        RepositoryListHeaderToggle(
+          repositories: store.state.repositories,
+          expandableRepositoryIDs: expandableRepositoryIDs,
+          expandedRepoIDs: $expandedRepoIDs,
+          terminalManager: terminalManager
+        )
       }
     }
     .frame(maxWidth: .infinity, minHeight: 26, alignment: .center)
@@ -506,13 +499,42 @@ struct SidebarListView: View {
     )
   }
 
+  /// Expandable repositories/workspaces with at least one open terminal tab.
+  static func activeRepositoryIDs<Repositories: Sequence>(
+    in repositories: Repositories,
+    expandableRepositoryIDs: Set<Repository.ID>,
+    terminalManager: WorktreeTerminalManager
+  ) -> Set<Repository.ID> where Repositories.Element == Repository {
+    Set(
+      repositories
+        .filter { expandableRepositoryIDs.contains($0.id) }
+        .filter {
+          RepositorySectionView.openTabCount(for: $0, terminalManager: terminalManager) > 0
+        }
+        .map(\.id)
+    )
+  }
+
+  /// Next action offered by the header toggle, derived purely from the
+  /// current expansion state (no stored mode). Cycle from fully collapsed:
+  /// Expand Active → Expand All → Collapse All. Expand Active is skipped
+  /// when the active set is empty or covers every expandable repository,
+  /// and any manually mixed state falls back to Collapse All.
   static func repositoryListHeaderAction(
     expandedRepoIDs: Set<Repository.ID>,
-    expandableRepositoryIDs: Set<Repository.ID>
+    expandableRepositoryIDs: Set<Repository.ID>,
+    activeRepositoryIDs: Set<Repository.ID>
   ) -> RepositoryListHeaderAction {
-    !expandedRepoIDs.isDisjoint(with: expandableRepositoryIDs)
-      ? .collapseAll
-      : .expandAll
+    let expanded = expandedRepoIDs.intersection(expandableRepositoryIDs)
+    let active = activeRepositoryIDs.intersection(expandableRepositoryIDs)
+    let activeIsProperSubset = !active.isEmpty && active != expandableRepositoryIDs
+    if expanded.isEmpty {
+      return activeIsProperSubset ? .expandActive : .expandAll
+    }
+    if activeIsProperSubset, expanded == active {
+      return .expandAll
+    }
+    return .collapseAll
   }
 
   static func selectedWorktreeIDs(in state: RepositoriesFeature.State) -> Set<Worktree.ID> {
@@ -663,6 +685,63 @@ struct SidebarListView: View {
       repository.capabilities.supportsRunnableFolderActions
     else { return nil }
     return repository.rootURL
+  }
+}
+
+/// Header expand/collapse toggle as its own leaf view: deriving the offered
+/// action needs per-repository open-tab counts, and this split keeps the
+/// `WorktreeTerminalManager` read out of `SidebarListView.body` (same
+/// isolation rationale as `RepoHeaderTabCountBadge`).
+private struct RepositoryListHeaderToggle: View {
+  let repositories: IdentifiedArrayOf<Repository>
+  let expandableRepositoryIDs: Set<Repository.ID>
+  @Binding var expandedRepoIDs: Set<Repository.ID>
+  let terminalManager: WorktreeTerminalManager
+
+  var body: some View {
+    let activeRepositoryIDs = SidebarListView.activeRepositoryIDs(
+      in: repositories,
+      expandableRepositoryIDs: expandableRepositoryIDs,
+      terminalManager: terminalManager
+    )
+    let action = SidebarListView.repositoryListHeaderAction(
+      expandedRepoIDs: expandedRepoIDs,
+      expandableRepositoryIDs: expandableRepositoryIDs,
+      activeRepositoryIDs: activeRepositoryIDs
+    )
+    Button {
+      withAnimation(.easeOut(duration: 0.2)) {
+        switch action {
+        case .expandAll:
+          expandedRepoIDs.formUnion(expandableRepositoryIDs)
+        case .expandActive:
+          var next = expandedRepoIDs
+          next.subtract(expandableRepositoryIDs)
+          next.formUnion(activeRepositoryIDs)
+          expandedRepoIDs = next
+        case .collapseAll:
+          expandedRepoIDs.subtract(expandableRepositoryIDs)
+        }
+      }
+    } label: {
+      Label(action.title, systemImage: action.systemImageName)
+        .labelStyle(.iconOnly)
+        .frame(width: 20, height: 20)
+        .rotationEffect(action.rotation)
+        .overlay(alignment: .topTrailing) {
+          if action == .expandActive {
+            Circle()
+              .fill(Color.accentColor)
+              .frame(width: 4, height: 4)
+              .offset(x: -3, y: 3)
+              .accessibilityHidden(true)
+          }
+        }
+        .contentShape(.rect)
+    }
+    .buttonStyle(.plain)
+    .foregroundStyle(.secondary)
+    .help(action.helpText)
   }
 }
 

--- a/supacode/Features/Repositories/Views/SidebarListView.swift
+++ b/supacode/Features/Repositories/Views/SidebarListView.swift
@@ -31,7 +31,12 @@ struct SidebarListView: View {
     }
 
     var systemImageName: String {
-      "chevron.right"
+      switch self {
+      case .expandActive:
+        return "chevron.right.2"
+      case .expandAll, .collapseAll:
+        return "chevron.right"
+      }
     }
 
     var rotation: Angle {
@@ -728,15 +733,6 @@ private struct RepositoryListHeaderToggle: View {
         .labelStyle(.iconOnly)
         .frame(width: 20, height: 20)
         .rotationEffect(action.rotation)
-        .overlay(alignment: .topTrailing) {
-          if action == .expandActive {
-            Circle()
-              .fill(Color.accentColor)
-              .frame(width: 4, height: 4)
-              .offset(x: -3, y: 3)
-              .accessibilityHidden(true)
-          }
-        }
         .contentShape(.rect)
     }
     .buttonStyle(.plain)

--- a/supacode/Features/Repositories/Views/WorktreeRow.swift
+++ b/supacode/Features/Repositories/Views/WorktreeRow.swift
@@ -5,6 +5,9 @@ struct WorktreeRow: View {
   let name: String
   let worktreeName: String
   let info: WorktreeInfoEntry?
+  /// Per-worktree open-tab count badge; `nil` hides the badge entirely
+  /// (single-worktree repos and workspace child rows pass nil).
+  let tabCountBadge: WorktreeTabCountBadge?
   let iconSystemName: String?
   let showsPullRequestInfo: Bool
   let isHovered: Bool
@@ -30,6 +33,7 @@ struct WorktreeRow: View {
     name: String,
     worktreeName: String,
     info: WorktreeInfoEntry?,
+    tabCountBadge: WorktreeTabCountBadge? = nil,
     iconSystemName: String? = nil,
     showsPullRequestInfo: Bool,
     isHovered: Bool,
@@ -52,6 +56,7 @@ struct WorktreeRow: View {
     self.name = name
     self.worktreeName = worktreeName
     self.info = info
+    self.tabCountBadge = tabCountBadge
     self.iconSystemName = iconSystemName
     self.showsPullRequestInfo = showsPullRequestInfo
     self.isHovered = isHovered
@@ -128,6 +133,9 @@ struct WorktreeRow: View {
           .truncationMode(.middle)
           .layoutPriority(1)
           .help(name)
+        if let tabCountBadge {
+          tabCountBadge
+        }
         Spacer(minLength: 4)
         if isHovered, pinAction != nil {
           Button {

--- a/supacode/Features/Repositories/Views/WorktreeRow.swift
+++ b/supacode/Features/Repositories/Views/WorktreeRow.swift
@@ -6,7 +6,7 @@ struct WorktreeRow: View {
   let worktreeName: String
   let info: WorktreeInfoEntry?
   /// Per-worktree open-tab count badge; `nil` hides the badge entirely
-  /// (single-worktree repos and workspace child rows pass nil).
+  /// (workspace child rows — tab attribution is per directory, not per child).
   let tabCountBadge: WorktreeTabCountBadge?
   let iconSystemName: String?
   let showsPullRequestInfo: Bool

--- a/supacode/Features/Repositories/Views/WorktreeRowsView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeRowsView.swift
@@ -364,6 +364,9 @@ struct WorktreeRowsView: View {
       name: config.displayName,
       worktreeName: config.worktreeName,
       info: row.info,
+      tabCountBadge: repository.worktrees.count >= 2
+        ? WorktreeTabCountBadge(worktreeID: row.id, terminalManager: terminalManager)
+        : nil,
       showsPullRequestInfo: !isWorktreeDragActive,
       isHovered: config.isHovered,
       isPinned: row.isPinned,

--- a/supacode/Features/Repositories/Views/WorktreeRowsView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeRowsView.swift
@@ -364,9 +364,7 @@ struct WorktreeRowsView: View {
       name: config.displayName,
       worktreeName: config.worktreeName,
       info: row.info,
-      tabCountBadge: repository.worktrees.count >= 2
-        ? WorktreeTabCountBadge(worktreeID: row.id, terminalManager: terminalManager)
-        : nil,
+      tabCountBadge: WorktreeTabCountBadge(worktreeID: row.id, terminalManager: terminalManager),
       showsPullRequestInfo: !isWorktreeDragActive,
       isHovered: config.isHovered,
       isPinned: row.isPinned,

--- a/supacodeTests/RepositorySectionViewTests.swift
+++ b/supacodeTests/RepositorySectionViewTests.swift
@@ -29,37 +29,149 @@ struct RepositorySectionViewTests {
     #expect(
       SidebarListView.repositoryListHeaderAction(
         expandedRepoIDs: [],
-        expandableRepositoryIDs: []
+        expandableRepositoryIDs: [],
+        activeRepositoryIDs: []
       )
         == .expandAll
     )
     #expect(
       SidebarListView.repositoryListHeaderAction(
         expandedRepoIDs: [],
-        expandableRepositoryIDs: expandableIDs
+        expandableRepositoryIDs: expandableIDs,
+        activeRepositoryIDs: []
       )
         == .expandAll
     )
     #expect(
       SidebarListView.repositoryListHeaderAction(
         expandedRepoIDs: [gitRepository.id],
-        expandableRepositoryIDs: expandableIDs
+        expandableRepositoryIDs: expandableIDs,
+        activeRepositoryIDs: []
       )
         == .collapseAll
     )
     #expect(
       SidebarListView.repositoryListHeaderAction(
         expandedRepoIDs: [gitRepository.id, plainRepository.id],
-        expandableRepositoryIDs: expandableIDs
+        expandableRepositoryIDs: expandableIDs,
+        activeRepositoryIDs: []
       )
         == .collapseAll
     )
     #expect(
       SidebarListView.repositoryListHeaderAction(
         expandedRepoIDs: [plainRepository.id],
-        expandableRepositoryIDs: expandableIDs
+        expandableRepositoryIDs: expandableIDs,
+        activeRepositoryIDs: []
       )
         == .expandAll
+    )
+  }
+
+  @Test func sidebarHeaderActionCyclesThroughExpandActive() {
+    let repoA: Repository.ID = "/tmp/a"
+    let repoB: Repository.ID = "/tmp/b"
+    let expandableIDs: Set<Repository.ID> = [repoA, repoB]
+    let activeIDs: Set<Repository.ID> = [repoA]
+
+    // Fully collapsed + proper-subset active set → Expand Active.
+    #expect(
+      SidebarListView.repositoryListHeaderAction(
+        expandedRepoIDs: [],
+        expandableRepositoryIDs: expandableIDs,
+        activeRepositoryIDs: activeIDs
+      )
+        == .expandActive
+    )
+    // Expanded set matches the active set exactly → Expand All.
+    #expect(
+      SidebarListView.repositoryListHeaderAction(
+        expandedRepoIDs: [repoA],
+        expandableRepositoryIDs: expandableIDs,
+        activeRepositoryIDs: activeIDs
+      )
+        == .expandAll
+    )
+    // Fully expanded → Collapse All.
+    #expect(
+      SidebarListView.repositoryListHeaderAction(
+        expandedRepoIDs: expandableIDs,
+        expandableRepositoryIDs: expandableIDs,
+        activeRepositoryIDs: activeIDs
+      )
+        == .collapseAll
+    )
+    // Mixed state different from the active set → Collapse All.
+    #expect(
+      SidebarListView.repositoryListHeaderAction(
+        expandedRepoIDs: [repoB],
+        expandableRepositoryIDs: expandableIDs,
+        activeRepositoryIDs: activeIDs
+      )
+        == .collapseAll
+    )
+    // Active set covering every expandable repo degrades to the plain
+    // two-state cycle: Expand All from collapsed, Collapse All from expanded.
+    #expect(
+      SidebarListView.repositoryListHeaderAction(
+        expandedRepoIDs: [],
+        expandableRepositoryIDs: expandableIDs,
+        activeRepositoryIDs: expandableIDs
+      )
+        == .expandAll
+    )
+    #expect(
+      SidebarListView.repositoryListHeaderAction(
+        expandedRepoIDs: expandableIDs,
+        expandableRepositoryIDs: expandableIDs,
+        activeRepositoryIDs: expandableIDs
+      )
+        == .collapseAll
+    )
+  }
+
+  @Test func activeRepositoryIDsIncludesOnlyExpandableReposWithOpenTabs() {
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    let busyWorktree = makeWorktree(repoRoot: "/tmp/busy", path: "/tmp/busy/main", branch: "main")
+    let busyRepository = makeRepository(
+      id: "/tmp/busy",
+      name: "busy",
+      worktrees: [busyWorktree]
+    )
+    let idleRepository = makeRepository(
+      id: "/tmp/idle",
+      name: "idle",
+      worktrees: [makeWorktree(repoRoot: "/tmp/idle", path: "/tmp/idle/main", branch: "main")]
+    )
+    // Plain folder with a tab: not expandable, so never part of the active set.
+    let plainRepository = makeRepository(
+      id: "/tmp/plain",
+      name: "plain",
+      kind: .plain,
+      worktrees: []
+    )
+    let repositories: IdentifiedArrayOf<Repository> = [
+      busyRepository, idleRepository, plainRepository,
+    ]
+    let expandableIDs = SidebarListView.expandableRepositoryIDs(in: repositories)
+
+    _ = manager.state(for: busyWorktree).tabManager.createTab(title: "work", icon: nil)
+    let plainTarget = Worktree(
+      id: plainRepository.id,
+      name: plainRepository.name,
+      detail: plainRepository.rootURL.path(percentEncoded: false),
+      workingDirectory: plainRepository.rootURL,
+      repositoryRootURL: plainRepository.rootURL
+    )
+    _ = manager.state(for: plainTarget).tabManager.createTab(title: "folder", icon: nil)
+
+    #expect(
+      SidebarListView.activeRepositoryIDs(
+        in: repositories,
+        expandableRepositoryIDs: expandableIDs,
+        terminalManager: manager
+      )
+        == [busyRepository.id]
     )
   }
 


### PR DESCRIPTION
## Summary

- The repository list header button now cycles **Collapse All → Expand Active → Expand All**: from a fully collapsed sidebar it first expands only the repos/workspaces that have open terminal tabs (chevron glyph with an accent dot at top-trailing), then everything, then collapses.
- The offered action derives purely from the current expansion state (no stored mode): Expand Active is skipped when no repo (or every repo) has open tabs; any manually mixed state keeps offering Collapse All, matching today's muscle memory.
- Worktree rows in repos with **2+ worktrees** show their own open-tab count badge right after the name (hidden at zero; main worktree included). Single-worktree repos, workspace child rows, and plain folders are unchanged.
- The capsule visual is extracted into a shared `TabCountBadge`; both the header toggle (`RepositoryListHeaderToggle`) and the row badge (`WorktreeTabCountBadge`) are isolated leaf views so terminal-state churn never re-evaluates the sidebar body (same rationale as `RepoHeaderTabCountBadge`).

Design record: `docs-ai/050-sidebar-expand-active-and-worktree-tab-badges/` (full interview log + decision table).

## Testing

- `RepositorySectionViewTests`: full decision-table coverage for the new three-state derivation, empty-active-set degradation of the legacy test, and an `activeRepositoryIDs` terminal-manager fixture (14/14 pass).
- End-to-end via self-verify debug instance: CLI-opened tabs → per-row "1" badge on a 3-worktree repo, no badge on 0-tab siblings or single-worktree repos; full button cycle (collapse → dot glyph → expand active expands exactly the tabbed repos → expand all → back to collapse) driven by AX presses with screenshots.
- `make check` clean; app + tests build with 0 warnings.
- `docs/components/repositories-and-worktrees.md` updated in the same change.