### PR TITLE
Add session log actions to Active Agents context menu

### DIFF
--- a/docs/components/active-agents.md
+++ b/docs/components/active-agents.md
@@ -57,6 +57,12 @@ Rows appear in the order agents are first detected. (See
     switching to it.
   - **Copy Path** / **Reveal in Finder** — the agent's working directory (or
     its owning worktree's directory when the agent hasn't reported one).
+  - **Copy Session Path** / **Reveal Session in Finder** — the on-disk session
+    log of the agent's native session (e.g. Claude Code's
+    `~/.claude/projects/<encoded-cwd>/<session-id>.jsonl`). Shown only when
+    Prowl has resolved the session to a file (see
+    [agent-detection](agent-detection.md)); agents with server-side or
+    store-only sessions (e.g. Amp threads) don't offer it.
 - **Keyboard navigation:** `⌥⌃↓` next agent, `⌥⌃↑` previous agent (wraps).
 - **Resize** the panel by dragging its top edge (height is remembered).
 - **Auto-show:** if `autoShowActiveAgentsPanel` is on and the panel is hidden, a

--- a/supacode/Features/ActiveAgents/Views/ActiveAgentsPanel.swift
+++ b/supacode/Features/ActiveAgents/Views/ActiveAgentsPanel.swift
@@ -146,6 +146,21 @@ struct ActiveAgentsPanel: View {
       }
       .help("Reveal the agent's working directory in Finder")
     }
+    if let transcriptPath = entry.session?.transcriptPath {
+      Divider()
+      Button("Copy Session Path") {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(transcriptPath.path, forType: .string)
+      }
+      .help("Copy the on-disk path of this agent's session log")
+      Button("Reveal Session in Finder") {
+        NSWorkspace.shared.selectFile(
+          transcriptPath.path,
+          inFileViewerRootedAtPath: transcriptPath.deletingLastPathComponent().path
+        )
+      }
+      .help("Select this agent's session log in Finder")
+    }
   }
 
   private func repositoryName(for entry: ActiveAgentEntry) -> String {

--- a/supacode/Infrastructure/AgentDetection/AgentSessionProfile.swift
+++ b/supacode/Infrastructure/AgentDetection/AgentSessionProfile.swift
@@ -294,18 +294,23 @@ nonisolated extension AgentSessionProfile {
       guard uuid(in: id) != nil else { return nil }
       // Walk up from the open path to the session root
       // (…/sessions/<cwd>/<id>/). Nested paths like `terminal/<log>.log`
-      // still resolve. The transcript is always canonicalized to
-      // chat_history.jsonl (the conversation log): the process also holds
-      // events.jsonl open, which only logs MCP/infrastructure events.
+      // still resolve.
       var dir = url.deletingLastPathComponent()
       while dir.lastPathComponent != id, dir.pathComponents.count > grokIndex + 3 {
         dir = dir.deletingLastPathComponent()
       }
       guard dir.lastPathComponent == id else { return nil }
-      let transcript: URL =
-        url.lastPathComponent == "chat_history.jsonl"
-        ? url
-        : dir.appending(path: "chat_history.jsonl")
+      // Prefer the conversation transcript. If it has not been created yet,
+      // retain the opened events log rather than claiming a nonexistent path.
+      let chatHistory = dir.appending(path: "chat_history.jsonl")
+      let transcript: URL?
+      if url.lastPathComponent == "chat_history.jsonl" || FileManager.default.fileExists(atPath: chatHistory.path) {
+        transcript = chatHistory
+      } else if url.lastPathComponent == "events.jsonl" {
+        transcript = url
+      } else {
+        transcript = nil
+      }
       return AgentSession(id: id, transcriptPath: transcript, source: .recentFile)
     },
     candidateRoots: { home, cwd, _, _ in

--- a/supacodeTests/AgentSessionProfileTests.swift
+++ b/supacodeTests/AgentSessionProfileTests.swift
@@ -556,7 +556,7 @@ struct AgentSessionProfileTests {
   @Test func grokParsePathResolvesSessionDirectoryFromNestedFiles() {
     let profile = AgentSessionProfile.profile(for: .grok)
     let id = "019f5e7e-4269-7e33-9eaf-d535ff8ebafb"
-    // Create a temp tree so transcript resolution can succeed for events.
+    // The parser must never claim a transcript path that does not exist.
     let root = FileManager.default.temporaryDirectory
       .appending(path: "prowl-grok-parse-\(UUID().uuidString)", directoryHint: .isDirectory)
     let sessionDir = root.appending(path: ".grok/sessions/%2FUsers%2Fme%2FApp/\(id)")
@@ -566,8 +566,8 @@ struct AgentSessionProfileTests {
 
     let parsedEvents = profile.parsePath(sessionDir.appending(path: "events.jsonl").path)
     #expect(parsedEvents?.id == id)
-    // Every non-chat open file canonicalizes to the conversation log.
-    #expect(parsedEvents?.transcriptPath?.lastPathComponent == "chat_history.jsonl")
+    // Before chat history exists, the opened events log is the only known log.
+    #expect(parsedEvents?.transcriptPath?.lastPathComponent == "events.jsonl")
 
     try? FileManager.default.createDirectory(
       at: sessionDir.appending(path: "terminal"),
@@ -577,9 +577,13 @@ struct AgentSessionProfileTests {
     FileManager.default.createFile(atPath: nestedPath, contents: Data())
     let parsedNested = profile.parsePath(nestedPath)
     #expect(parsedNested?.id == id)
-    // Non-transcript files resolve to the conversation log at the root.
-    #expect(parsedNested?.transcriptPath?.lastPathComponent == "chat_history.jsonl")
-    #expect(parsedNested?.transcriptPath?.deletingLastPathComponent().lastPathComponent == id)
+    // An arbitrary nested file identifies the session but is not itself a session log.
+    #expect(parsedNested?.transcriptPath == nil)
+
+    let chatHistory = sessionDir.appending(path: "chat_history.jsonl")
+    try? "{}".write(to: chatHistory, atomically: true, encoding: .utf8)
+    let parsedAfterChat = profile.parsePath(nestedPath)
+    #expect(parsedAfterChat?.transcriptPath?.path == chatHistory.path)
 
     #expect(profile.parsePath("/Users/me/.grok/sessions/%2FUsers%2Fme%2FApp/not-a-uuid/events.jsonl") == nil)
   }


### PR DESCRIPTION
## Summary

Adds a Session group to the Active Agents row context menu:

- **Copy Session Path** — copies the on-disk path of the agent's native session log.
- **Reveal Session in Finder** — selects the log file in its parent folder (unlike the working-directory reveal, which opens a directory).

The actions are shown only when `entry.session?.transcriptPath` resolves to an actual local log. Agents with server-side threads (Amp) or store-only sessions (OpenCode's sqlite) do not offer them. Grok now uses its existing `events.jsonl` until `chat_history.jsonl` exists, and does not expose arbitrary nested artifacts as transcript paths.

Docs: `docs/components/active-agents.md` context-menu section updated.

## Testing

- `xcodebuild test` filtered to `supacodeTests/AgentSessionProfileTests` — 36 passed, 0 warnings.
- `make check` clean.
- `make build-app` clean (0 errors/warnings).