### PR TITLE
fix: remove IssueReporting build warning

### DIFF
--- a/supacode.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/supacode.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -159,8 +159,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "34e463e98ab8541c604af706c99bed7160f5ec70",
-        "version" : "1.8.1"
+        "revision" : "cb281f343fd953280336dcbd3822cdf47c182f5b",
+        "version" : "1.10.0"
       }
     },
     {

--- a/supacodeTests/AgentEntryEmissionDedupTests.swift
+++ b/supacodeTests/AgentEntryEmissionDedupTests.swift
@@ -11,8 +11,8 @@ import Testing
 /// changes so that churn never floods the terminal event stream.
 @MainActor
 struct AgentEntryEmissionDedupTests {
-  @Test func identicalEntryIsEmittedOnce() throws {
-    let fixture = try makeFixture()
+  @Test func identicalEntryIsEmittedOnce() {
+    let fixture = makeFixture()
     var received: [ActiveAgentEntry] = []
     fixture.state.onAgentEntryChanged = { received.append($0) }
 
@@ -32,8 +32,8 @@ struct AgentEntryEmissionDedupTests {
     #expect(received.map(\.rawState) == [.working, .idle])
   }
 
-  @Test func visibleChangeStillEmits() throws {
-    let fixture = try makeFixture()
+  @Test func visibleChangeStillEmits() {
+    let fixture = makeFixture()
     var received: [ActiveAgentEntry] = []
     fixture.state.onAgentEntryChanged = { received.append($0) }
 
@@ -45,8 +45,8 @@ struct AgentEntryEmissionDedupTests {
     #expect(received.map(\.displayState) == [.working, .idle])
   }
 
-  @Test func removalClearsTheCacheSoReattachEmits() throws {
-    let fixture = try makeFixture()
+  @Test func removalClearsTheCacheSoReattachEmits() {
+    let fixture = makeFixture()
     var changed: [ActiveAgentEntry] = []
     var removed: [UUID] = []
     fixture.state.onAgentEntryChanged = { changed.append($0) }
@@ -73,7 +73,7 @@ struct AgentEntryEmissionDedupTests {
     let pane: GhosttySurfaceView
   }
 
-  private func makeFixture() throws -> Fixture {
+  private func makeFixture() -> Fixture {
     let state = WorktreeTerminalState(
       runtime: GhosttyRuntime(),
       worktree: Worktree(
@@ -93,7 +93,7 @@ struct AgentEntryEmissionDedupTests {
     )
     let tabId = state.tabManager.createTab(title: "worktree 1", icon: "terminal")
     state.surfaces[pane.id] = pane
-    state.trees[tabId] = try SplitTree<GhosttySurfaceView>(view: pane)
+    state.trees[tabId] = SplitTree<GhosttySurfaceView>(view: pane)
     state.focusedSurfaceIdByTab[tabId] = pane.id
     return Fixture(state: state, tabId: tabId, pane: pane)
   }


### PR DESCRIPTION
Removes the redundant throwing fixture setup and updates xctest-dynamic-overlay to 1.10.0, which removes the upstream IssueReportingPackageSupport dependency-scan warning. The remaining Dependencies transitive-module diagnostics persist after upgrading swift-dependencies through 1.14.1 and are an Xcode explicit-module scanner issue; adding Dependencies directly to the test bundle creates a duplicate runtime and fails 57 tests, so this PR deliberately avoids that unsafe workaround. Verification: make test (2067 passed), make build-app, make check, and GitHub Actions run 30380968852.