### PR TITLE
Agent Profiles V1: preset launchers with opt-in account isolation

### DIFF
--- a/docs-ai/053-agent-profiles/000-plan.md
+++ b/docs-ai/053-agent-profiles/000-plan.md
@@ -332,7 +332,10 @@ agent 列表不变。
 
 - 2026-07-30 — Review 修正(PR #620):(a) extra args 中的 bypass flag **尊重不拦截**,
   但 domain 提供 `effectiveExecutionMode`(复用 adapter `observe` 的识别),编辑器
-  据此显示 unrestricted 警示——显示永不谎报 Standard;(b) profile home 的包含校验
+  据此显示 unrestricted 警示——显示永不谎报 Standard;二轮追审后改为**三态**:
+  识别出 bypass → 红色 unrestricted;存在任何未识别的 extra args(含
+  `--sandbox` / `--ask-for-approval` / `-c` 覆盖)→ 中性"遵循命令行参数",不再
+  声称 Standard——识别清单不可穷尽,诚实的方式是不认识就不承诺;(b) profile home 的包含校验
   升级为物理校验:拒绝 symlink leaf,并以"解析后的父目录 + 叶名"对"解析后的 base"
   做 canonical containment(symlink 的 base 本身仍合法,如同步盘场景),
   provision/reveal/trash 共用此闸;(c) Settings 快照回写不再冲掉外部写入的

--- a/docs-ai/053-agent-profiles/000-plan.md
+++ b/docs-ai/053-agent-profiles/000-plan.md
@@ -330,6 +330,11 @@ agent 列表不变。
 
 ## Amendments
 
+- 2026-07-30 — Review 三轮(P2/P3):(a) surface 的 launch 身份增加 runtime,config
+  root 只对**同 runtime 的检测**生效——bound pane 内手动启动其他 agent 时不再张冠
+  李戴、也不再压制默认布局扫描;(b) 删除确认的判断从"当前 bindsDedicatedHome 意愿"
+  改为"意愿 ∨ 磁盘上 home 实际存在"——bind→launch→unbind→delete 不再静默遗留凭据
+  目录;(c) Reveal 后回发 homeStatusRefreshed,被动状态行即时更新。
 - 2026-07-30 — Review 修正(PR #620):(a) extra args 中的 bypass flag **尊重不拦截**,
   但 domain 提供 `effectiveExecutionMode`(复用 adapter `observe` 的识别),编辑器
   据此显示 unrestricted 警示——显示永不谎报 Standard;二轮追审后改为**三态**:

--- a/docs-ai/053-agent-profiles/000-plan.md
+++ b/docs-ai/053-agent-profiles/000-plan.md
@@ -330,6 +330,9 @@ agent 列表不变。
 
 ## Amendments
 
+- 2026-07-30 — Review 四轮(P2):palette 的 Launch Agent 条目工厂改用与 launch
+  action 相同的 action-target 解析(selectedTerminalWorktree ?? Canvas 聚焦卡),
+  Canvas 模式下条目不再缺席;补 Canvas 聚焦卡回归测试。
 - 2026-07-30 — Review 三轮(P2/P3):(a) surface 的 launch 身份增加 runtime,config
   root 只对**同 runtime 的检测**生效——bound pane 内手动启动其他 agent 时不再张冠
   李戴、也不再压制默认布局扫描;(b) 删除确认的判断从"当前 bindsDedicatedHome 意愿"

--- a/docs-ai/053-agent-profiles/000-plan.md
+++ b/docs-ai/053-agent-profiles/000-plan.md
@@ -75,9 +75,12 @@ Settings 新增 **Agents** 区,持有有序的全局 profile 集合与 path rout
 不得成为仓库配置。
 
 一个 profile 包含:稳定 UUID、显示名、启用状态、runtime、可选 model、可选 reasoning
-effort、既有的显式 execution mode,以及**可选的账号绑定**。V1 暴露两家验证过的通用档位
-**Low / Medium / High**,`nil` 表示 runtime 默认;两个 adapter 各自渲染同一意图:Claude
-Code 用 `--effort`,Codex 用类型化的 `model_reasoning_effort` config override。
+effort、既有的显式 execution mode,以及**可选的账号绑定**。reasoning effort 存为自由
+字符串,`nil` 表示 runtime 默认;编辑器按 runtime 展示 adapter 自带的已知档位建议
+(两家共有的 low/medium/high,及各自的扩展档位,如 Codex 的 `minimal` / `xhigh`),同时
+允许直接填写任意值。自定义值只作为**单一参数值**渲染进类型化参数——Claude Code 的
+`--effort`、Codex 的 `model_reasoning_effort` config override——走既有的安全 argv 渲染,
+不经过 shell 解释;未知档位由 CLI 启动时自行报错,在新 tab 内直接可见,Prowl 不做预校验。
 `.unrestricted` 保留但视觉上标记为危险,保存时需要显式确认;绝不从其他 profile 或来源
 pane 推断。
 
@@ -183,7 +186,8 @@ specification 有意可被 handoff 复用,但 V1 的 handoff 目标列表维持�
 - Domain 测试:profile normalization、UUID 稳定性、非法/缺失 route、最长路径边界匹配、
   旧版 JSON 解码、无任何持久化的敏感材料;纯 preset profile 必须产生空环境 patch。
 - Adapter 测试(`supacodeTests/AgentRuntimeAdapterTests.swift`):无 prompt 的交互式
-  argv、model/effort 映射、标准与危险模式、shell 转义、能力位取值。
+  argv、model/effort 映射(含自定义 effort 值的安全渲染)、标准与危险模式、shell 转义、
+  能力位取值。
 - Settings 与 profile-home 测试:保存/重载、绑定 profile 的派生目录 owner-only 权限、
   home 缺失时的状态判定、stdout/stderr/非零退出码的登录状态解析、绝不访问真实凭据。
 - Reducer/终端测试:菜单各可用性状态、正确的 worktree/cwd/环境 patch、每次选择恰好新建
@@ -219,3 +223,6 @@ specification 有意可被 handoff 复用,但 V1 的 handoff 目标列表维持�
 - 2026-07-29 — 依据与 onevcat 的设计讨论全文重写并改用中文:profile 从"私有 runtime
   home"重新定义为"preset + 可选账号绑定";新增 adapter 能力位与永远是菜单的 Agents
   capsule;指令/skill 注入与子目录共享明确列为 follow-up;handoff 边界维持不变。
+- 2026-07-29 — reasoning effort 从固定三档改为"per-runtime 建议档位 + 自由填值":档位
+  集合随模型演进,硬编码枚举会过时;自定义值仅作为类型化参数的单一值渲染,不构成自由
+  格式 flag。execution mode 维持既有 `standard` / `unrestricted` 两档不变。

--- a/docs-ai/053-agent-profiles/000-plan.md
+++ b/docs-ai/053-agent-profiles/000-plan.md
@@ -4,7 +4,7 @@
 | --- | --- |
 | **Status** | Implemented(见 [001-action.md](001-action.md)) |
 | **Anchor date** | 2026-07-29 |
-| **Primary PRs** | pending |
+| **Primary PRs** | [#620](https://github.com/onevcat/Prowl/pull/620) |
 | **Related** | [047 cross-agent handoff](../047-cross-agent-handoff/000-plan.md), [048 agent runtime adapters](../048-agent-runtime-adapters/000-plan.md), [049 Agents toolbar entry](../049-agents-toolbar-entry/000-plan.md), closed prototype [#617](https://github.com/onevcat/Prowl/pull/617) |
 
 ## 背景

--- a/docs-ai/053-agent-profiles/000-plan.md
+++ b/docs-ai/053-agent-profiles/000-plan.md
@@ -330,6 +330,14 @@ agent 列表不变。
 
 ## Amendments
 
+- 2026-07-30 — Review 修正(PR #620):(a) extra args 中的 bypass flag **尊重不拦截**,
+  但 domain 提供 `effectiveExecutionMode`(复用 adapter `observe` 的识别),编辑器
+  据此显示 unrestricted 警示——显示永不谎报 Standard;(b) profile home 的包含校验
+  升级为物理校验:拒绝 symlink leaf,并以"解析后的父目录 + 叶名"对"解析后的 base"
+  做 canonical containment(symlink 的 base 本身仍合法,如同步盘场景),
+  provision/reveal/trash 共用此闸;(c) Settings 快照回写不再冲掉外部写入的
+  launch 记忆;空名不再静默删除 profile(持久化边界回退旧名)。
+
 - 2026-07-29 — 依据与 onevcat 的设计讨论全文重写并改用中文:profile 从"私有 runtime
   home"重新定义为"preset + 可选账号绑定";新增 adapter 能力位与永远是菜单的 Agents
   capsule;指令/skill 注入与子目录共享明确列为 follow-up;handoff 边界维持不变。

--- a/docs-ai/053-agent-profiles/000-plan.md
+++ b/docs-ai/053-agent-profiles/000-plan.md
@@ -78,8 +78,9 @@ Settings 新增独立的 **Agents** tab(`SettingsSection` 新 case,与 Custom Co
 平级;命名取 Agents 而非 Agent Profiles,与工具栏 Agents capsule 的入口层级一致,并为
 未来 agent 相关设置留出空间)。tab 内容为可排序的 profile 列表(顺序即推荐兜底的优先
 级)与选中 profile 的编辑器;per-repo 的 Default Agent Profile 选择器在既有的
-repository section 中。profile 集合本身有序存放于 `UserGlobalSettings`:
-账号与 agent 偏好是本地用户的私有配置,不得成为仓库配置。per-repo 的 Default Agent
+repository section 中。profile 集合(连同播种 flag)有序存放于 `UserGlobalSettings`
+(`~/.prowl/global.onevcat.json`):账号与 agent 偏好是本地用户的私有配置,不得成为
+仓库配置。per-repo 的 Default Agent
 Profile 指定与上次启动记忆存于 `UserRepositorySettings`(本地文件
 `~/.prowl/repo/<name>/prowl.onevcat.json`,同样不进仓库)。
 
@@ -153,8 +154,11 @@ normalization 时清理悬空的 per-repo 指定。runtime CLI 是否可用不�
 账号绑定由 adapter 能力位(`supportsAccountIsolation`)门控;两家已验证 runtime 均通过
 `CLAUDE_CONFIG_DIR` / `CODEX_HOME` 支持。
 
-绑定 profile 的 home 从其 UUID 派生,位于 Prowl 数据目录之下,绝不来自显示名或用户
-提供的路径。启动准备阶段先创建 runtime 目录(Codex 拒绝不存在的 `CODEX_HOME`)、校验
+绑定 profile 的 home 从其 UUID 派生:**`~/.prowl/agent-profiles/<uuid>/`**
+(`SupacodePaths.baseDirectory` 之下),环境变量直接指向该目录,不加中间层。绝不来自
+显示名或用户提供的路径。选 `~/.prowl` 而非 Application Support 的技术理由:后者路径
+含空格,第三方 CLI 及其子进程的引号处理是真实风险面;且与 repo 设置同根、对
+"Reveal Profile Files" 直观。启动准备阶段先创建 runtime 目录(Codex 拒绝不存在的 `CODEX_HOME`)、校验
 解析后的路径仍在 profile-home 基目录内,并施加 owner-only 权限。
 
 home 对 Prowl 是不透明的:对应环境变量只附加到新终端 surface——Claude Code 用

--- a/docs-ai/053-agent-profiles/000-plan.md
+++ b/docs-ai/053-agent-profiles/000-plan.md
@@ -37,8 +37,8 @@ Profile 的本体是 **preset**(对已知 runtime 的一组命名预置配置);�
 
 - 为两种已验证 runtime(Claude Code、Codex)定义命名 profile;同一 runtime 可有多个
   profile,profile 不等于品牌。
-- 从 Agents 菜单选择 profile 后,在当前 worktree 新建并选中一个 tab,以交互模式启动
-  agent,无初始 prompt。
+- 从 Agents 菜单选择 profile 后,在当前 worktree 新建并选中一个 surface(按 placement
+  为 tab 或 split),以交互模式启动 agent,无初始 prompt。
 - 每个 profile 持久化可选 model、可选 reasoning effort、显式 execution mode,全部以 argv
   渲染。
 - **默认形态(纯 preset)**:profile 运行在共享的默认 home,不设置任何环境变量;skills、
@@ -47,7 +47,7 @@ Profile 的本体是 **preset**(对已知 runtime 的一组命名预置配置);�
   独立登录与独立用量;仅此时出现登录/状态管理控件。
 - Agents capsule 永远是菜单:列出推荐与已启用的 profile、不可用项及原因、管理入口;有
   运行中 agent 时附带现有 Active Agents 内容。
-- 路径 route 为每个 worktree 选出初始推荐 profile。
+- 以"指定 > 记忆 > 兜底"三层规则为每个 worktree 选出菜单里的 Recommended profile。
 - Profile UUID 保持稳定,使未来的 handoff 集成可以引用 profile 而非裸 agent token。
 
 ### 非目标
@@ -57,22 +57,29 @@ Profile 的本体是 **preset**(对已知 runtime 的一组命名预置配置);�
   V1 只使用 CLI 自管认证。裸 API key 输入(需 Keychain 引用 + agent-only 启动边界)整体
   推迟。
 - 不接受任意可执行文件路径、shell 片段或自由格式 CLI flag。
-- 不在 profile 或 route 变化时修改运行中的 pane,不拦截用户在既有 shell 中手动输入的
+- 不在 profile 或推荐指定变化时修改运行中的 pane,不拦截用户在既有 shell 中手动输入的
   `claude` / `codex`。
 - 不支持检测到但未验证的 runtime。
-- 不做共享配置的自动 symlink(#617 教训);账号绑定 profile 的**子目录级显式共享**
-  (如 skills/、session 目录)列为 follow-up,不进 V1。
-- 不做 per-profile 指令/skill 注入:Claude Code 有 `--append-system-prompt` 等通道,但
-  Codex 交互式 TUI 没有已验证的等价机制;建模为未来的 adapter 能力位后再做。
+- 不做任何形式的共享配置 symlink——既不自动做(#617 教训),也不作为 follow-up 提供
+  子目录级共享开关。想在绑定 profile 间共享 skills 等目录的高级用户,经
+  "Reveal Profile Files" 自行 symlink 即可;这个决策与其风险留给用户,Prowl 不代管。
+- 不做 per-profile 指令/skill 注入:绑定 profile 的专属指令由 home 内原生指令文件
+  (`CLAUDE.md` / `AGENTS.md`)覆盖,无需注入;纯 preset 的注入通道(Claude Code 有
+  `--append-system-prompt`,Codex 交互式 TUI 无已验证等价物)不再规划,能力位仅作预留。
 - 不做 profile 导入/导出或 skills / 指令文件的可视化编辑器。
 
 ## 产品形态
 
 ### Profile 与 Settings
 
-Settings 新增 **Agents** 区,持有有序的全局 profile 集合与 path route,存放于
-`UserGlobalSettings` 而非 repository settings:账号与 agent 偏好是本地用户的私有配置,
-不得成为仓库配置。
+Settings 新增独立的 **Agents** tab(`SettingsSection` 新 case,与 Custom Commands
+平级;命名取 Agents 而非 Agent Profiles,与工具栏 Agents capsule 的入口层级一致,并为
+未来 agent 相关设置留出空间)。tab 内容为可排序的 profile 列表(顺序即推荐兜底的优先
+级)与选中 profile 的编辑器;per-repo 的 Default Agent Profile 选择器在既有的
+repository section 中。profile 集合本身有序存放于 `UserGlobalSettings`:
+账号与 agent 偏好是本地用户的私有配置,不得成为仓库配置。per-repo 的 Default Agent
+Profile 指定与上次启动记忆存于 `UserRepositorySettings`(本地文件
+`~/.prowl/repo/<name>/prowl.onevcat.json`,同样不进仓库)。
 
 一个 profile 包含:稳定 UUID、显示名、启用状态、runtime、可选 model、可选 reasoning
 effort、既有的显式 execution mode、启动位置(placement),以及**可选的账号绑定**。reasoning effort 存为自由
@@ -80,7 +87,7 @@ effort、既有的显式 execution mode、启动位置(placement),以及**可选
 (两家共有的 low/medium/high,及各自的扩展档位,如 Codex 的 `minimal` / `xhigh`),同时
 允许直接填写任意值。自定义值只作为**单一参数值**渲染进类型化参数——Claude Code 的
 `--effort`、Codex 的 `model_reasoning_effort` config override——走既有的安全 argv 渲染,
-不经过 shell 解释;未知档位由 CLI 启动时自行报错,在新 tab 内直接可见,Prowl 不做预校验。
+不经过 shell 解释;未知档位由 CLI 启动时自行报错,在新 surface 内直接可见,Prowl 不做预校验。
 `.unrestricted` 保留但视觉上标记为危险,保存时需要显式确认;绝不从其他 profile 或来源
 pane 推断。
 
@@ -111,12 +118,20 @@ custom command 既有的 `UserCustomSplitDirection`)。split 同样是全新 sur
 Prowl 启动的 surface 在创建时记录 profile UUID;检测到但非 Prowl 启动的 agent 只显示
 "检测到 Codex"这类事实,绝不猜测其归属的 profile 或账号。
 
-### 路由
+### 推荐(Recommended)
 
-Route 把标准化的本地路径前缀映射到 profile UUID。最长目录边界匹配获胜;可选的
-per-runtime 默认项覆盖未匹配的仓库。解析是只读的,不创建任何目录。Route 只决定初始
-推荐——显式选择其他 profile 永远优先。profile 在启动时记录到新 surface 上,之后的 route
-编辑绝不重新标记或修改活跃 pane。
+菜单里 Recommended 的解析是三层回退,心智模型为**指定 > 记忆 > 兜底**:
+
+1. **指定**:该 repo 在 Repository Settings 中选定的 Default Agent Profile。
+2. **记忆**:未指定时,使用**该 repo 内上一次显式启动的 profile**(per-repo 记录一个
+   UUID,该 repo 任一 worktree 从菜单启动 profile 时更新;点击推荐项同样算显式启动)。
+   记忆比显式指定弱一级,但构成"这个 repo 就该用这个 profile"的隐式默认。
+3. **兜底**:从未在该 repo 启动过任何 profile 时,取有序 profile 列表中第一个已启用的。
+
+每一层只解析到存在且已启用的 profile;悬空(已删除)或被禁用的引用直接落到下一层,
+normalization 时清理悬空的 per-repo 指定。解析是只读的,不创建任何目录。推荐只决定
+菜单排序——显式选择其他 profile 永远优先。profile 在启动时记录到新 surface 上,之后的
+指定或记忆变化绝不重新标记或修改活跃 pane。
 
 ### 账号绑定与 runtime home(opt-in)
 
@@ -129,23 +144,36 @@ per-runtime 默认项覆盖未匹配的仓库。解析是只读的,不创建任�
 
 home 对 Prowl 是不透明的:对应环境变量只附加到新终端 surface——Claude Code 用
 `CLAUDE_CONFIG_DIR`,Codex 用 `CODEX_HOME`——使启动的 agent 及其子进程看到选定上下文。
-Prowl 不解析、不复制、不展示凭据文件。用户在该 home 内自行管理 runtime 支持的文件;
-项目内的指令文件仍归项目所有。
+环境 patch 是**叠加而非替换**:新 surface 是全新的 login shell,照常继承 rc 文件构建的
+常规环境(PATH、用户自行 export 的变量等),Prowl 只追加变量、不做环境清洗;其他 tab
+中手动 export 的会话状态不会传入。
 
-Follow-up(非 V1):为绑定 profile 提供子目录级的显式共享开关(目录 symlink 接回默认
-home 的 skills/、session 目录)。#617 的分叉教训针对的是会被 CLI 原子重写的文件
-(`settings.json`、`config.toml`、`auth.json`),这几个永远不得共享;以读为主的子目录
-风险可控,但仍需逐 runtime 验证后才能提供。
+全新 home 意味着 agent 首次启动即未登录;用户在 Sign In tab 内完成 CLI 登录后,凭证
+落在该 home 中(Codex 为 `auth.json`,Claude 的凭证存储同样以 config dir 为界,#617
+实测互不串号)。`$CLAUDE_CONFIG_DIR/CLAUDE.md` 与 `$CODEX_HOME/AGENTS.md` 是两家 CLI
+全局指令文件的原生位置,搬迁后自动从新位置读取——绑定 profile 的专属指令与 skills
+直接放进 home 即可,无需任何注入机制。Prowl 不解析、不复制、不展示凭据文件;项目内的
+指令文件仍归项目所有。
+
+Prowl 不提供任何目录共享功能(V1 及以后均然)。希望在绑定 profile 与默认 home 之间
+共享 skills 等目录的高级用户,可经 "Reveal Profile Files" 自行创建 symlink;文档应
+提示:会被 CLI 原子重写的文件(`settings.json`、`config.toml`、`auth.json`)绝不可
+链接,#617 实测重写会替换 symlink 导致静默分叉。
 
 ## 实现方式
 
 1. 引入 Codable 的 `AgentProfile` domain model(preset 字段 + placement + 可选账号绑定)
-   与 route resolver 及 normalization 测试。runtime enum 限定为 Claude Code 与 Codex,校验非空
-   显示名与 UUID 唯一性,normalization 时丢弃指向不可用 profile 的 route。扩展
-   `supacode/Features/Settings/Models/UserGlobalSettings.swift` 及其 shared key,兼容缺少
-   新字段的既有 JSON。
+   与三层推荐 resolver 及 normalization 测试。runtime enum 限定为 Claude Code 与 Codex,
+   校验非空显示名与 UUID 唯一性,normalization 时清理悬空的 profile 引用。扩展
+   `supacode/Features/Settings/Models/UserGlobalSettings.swift`(profile 集合)与
+   `UserRepositorySettings`(Default Agent Profile 指定 + per-repo 上次启动记忆)及其
+   shared key,兼容缺少新字段的既有 JSON。
 2. 在 `supacode/Domain/AgentRuntime/AgentRuntimeAdapter.swift` 中把启动意图类型化为
-   `.interactive` 或 `.prompt(String)`,禁止空 prompt 哨兵。`AgentLaunchConfiguration`
+   `.interactive` / `.prompt(String)` / `.headless(String)`,禁止空 prompt 哨兵。
+   `.headless` 渲染为各家的一次性执行模式(Claude Code print 模式、`codex exec`,与
+   handoff resume 同一条已验证通道),在 domain 与 adapter 层完整实现并测试;V1 不为
+   其提供任何 UI 消费者——输出捕获、退出语义、surface 去留是留给 CLI/handoff 后续
+   波次的产品决策。带 JSON Schema 的结构化输出继续推迟。`AgentLaunchConfiguration`
    增加可选 reasoning effort,由各 adapter 自行完成 argv/config 映射与校验。为 adapter
    增加能力位:V1 实际使用 `supportsAccountIsolation`,为 handoff 与指令注入预留位置,
    取代散落的品牌硬编码判断。
@@ -155,13 +183,27 @@ home 的 skills/、session 目录)。#617 的分叉教训针对的是会被 CLI 
    `supacode/Features/Terminal/Models/WorktreeTerminalState.swift` 的 surface 创建路径,
    使新 tab 与新 split 均经 `GhosttySurfaceView(environment:)` 接收 patch;不得把环境
    变量赋值拼进 shell 输入。在既有检测状态旁记录每个 surface 的启动 profile。
-4. 新增小型 Settings reducer/view:profile 编辑、route 编辑,以及账号绑定分支的状态/登录
-   动作。文件操作全部藏在注入的 profile-home dependency 之后,测试绝不触碰真实登录目录。
-5. 扩展 `supacode/Features/Repositories/Views/AgentsToolbarButton.swift` 及其在
+4. 打通账号绑定 surface 的 session 检测与恢复。`AgentSessionResolver` 目前把
+   `FileManager.default.homeDirectoryForCurrentUser` 传入声明式布局
+   `AgentSessionProfile`,Claude/Codex 的 candidateRoots 与 parsePath 以
+   `~/.claude` / `~/.codex` 为根,对搬迁后的 home 全部失效。把这两家的布局从
+   "用户 home + 固定点目录"推广为 **config root** 参数:默认即 `~/.claude` /
+   `~/.codex`;Prowl 启动且绑定账号的 surface 以记录的 profile 推导 root(env 是
+   Prowl 自己设置的,root 是已知量,无需探测)。parsePath 的全局子串 marker 改为按
+   已知 root 前缀匹配。绑定 surface 的 resume invocation 必须携带同一环境 patch,
+   否则 CLI 会在默认 home 中查找 session。进程分类(argv)、OSC working/idle、
+   child-env session id 证据与其余 runtime 均不受影响。用户手动携带自定义
+   `CLAUDE_CONFIG_DIR` / `CODEX_HOME` 启动的 agent 维持现状(agent 本体可检测、
+   session 身份不可得);读取 TUI 进程 env 反推 root 列为 follow-up。
+5. 新增小型 Settings reducer/view:`SettingsSection` 加 `agents` case 及对应 tab,
+   承载 profile 列表/编辑与账号绑定分支的状态/登录动作;在 Repository Settings 中加入
+   Default Agent Profile 选择器。文件操作全部藏在注入的 profile-home dependency 之后,
+   测试绝不触碰真实登录目录。
+6. 扩展 `supacode/Features/Repositories/Views/AgentsToolbarButton.swift` 及其在
    `supacode/Features/Repositories/Views/WorktreeDetailView.swift` 中的接线:改为永远是
    菜单;检测态保留现有 Hand Off 动作,启动项经 `AppFeature` 派发单一 profile-launch
    action。
-6. 实现完成后,更新对应的现状文档,并以实际 PR 与测试证据撰写 `001-action.md`。
+7. 实现完成后,更新对应的现状文档,并以实际 PR 与测试证据撰写 `001-action.md`。
 
 ## 从 #617 带入的经验
 
@@ -170,14 +212,16 @@ home 的 skills/、session 目录)。#617 的分叉教训针对的是会被 CLI 
 | Per-surface 环境变量可隔离两份 CLI 登录。 | 环境变量只在新 surface 启动边界施加,且仅限账号绑定 profile。 |
 | `CODEX_HOME` 必须在 Codex 启动前存在。 | 启动或登录前先创建派生 home。 |
 | 搬迁后的 home 包含 settings 与 skills,不止认证文件。 | 隔离是全有或全无的账号轴代价,因此 preset 为默认、绑定为 opt-in。 |
-| 共享配置的 symlink 会在 CLI 重写文件时静默分叉。 | V1 不做任何自动 link;被重写的文件永不共享,子目录共享留作显式 follow-up。 |
-| 账号/路径变化不得影响活跃 pane。 | surface 创建时记录 profile ID;route 只影响后续启动。 |
+| 共享配置的 symlink 会在 CLI 重写文件时静默分叉。 | Prowl 不做任何 link;高级用户自行 symlink,文档警示被重写文件不可链接。 |
+| 账号/推荐变化不得影响活跃 pane。 | surface 创建时记录 profile ID;推荐解析只影响后续启动。 |
 | 认证状态输出对流与退出码敏感。 | 在可测试的 client 后解析两条流的已知输出。 |
 
 ## Handoff 边界
 
-Profile 是 V1 的**启动**特性,与 049 划定的边界一致。其稳定 ID 与解析后的 launch
-specification 有意可被 handoff 复用,但 V1 的 handoff 目标列表维持现有 agent 列表不变。
+Profile 是 V1 的**启动**特性,与 049 划定的边界一致。把 handoff 迁移到 profile 路径是
+**确定的后续方向**——只是不与本波同行;profile 的稳定 ID 与解析后的 launch
+specification 从第一天起就按可被 handoff 引用设计。V1 的 handoff 目标列表维持现有
+agent 列表不变。
 
 未来的 handoff 集成必须让选定 profile 同时贯穿两条路径:HUD 的注入请求与 CLI/fallback
 处理器。只更新 `supacode/Features/HandoffHud/Reducer/HandoffHudFeature.swift` 会让 fallback
@@ -187,19 +231,24 @@ specification 有意可被 handoff 复用,但 V1 的 handoff 目标列表维持�
 
 ## 验证
 
-- Domain 测试:profile normalization、UUID 稳定性、非法/缺失 route、最长路径边界匹配、
-  旧版 JSON 解码、无任何持久化的敏感材料;纯 preset profile 必须产生空环境 patch。
+- Domain 测试:profile normalization、UUID 稳定性、三层推荐回退链(指定 > 记忆 > 兜底,
+  含悬空/禁用引用逐层跳过)、旧版 JSON 解码、无任何持久化的敏感材料;纯 preset profile
+  必须产生空环境 patch。
 - Adapter 测试(`supacodeTests/AgentRuntimeAdapterTests.swift`):无 prompt 的交互式
-  argv、model/effort 映射(含自定义 effort 值的安全渲染)、标准与危险模式、shell 转义、
-  能力位取值。
+  argv、`.headless` 的一次性执行 argv、model/effort 映射(含自定义 effort 值的安全
+  渲染)、标准与危险模式、shell 转义、能力位取值。
 - Settings 与 profile-home 测试:保存/重载、绑定 profile 的派生目录 owner-only 权限、
   home 缺失时的状态判定、stdout/stderr/非零退出码的登录状态解析、绝不访问真实凭据。
 - Reducer/终端测试:菜单各可用性状态、正确的 worktree/cwd/环境 patch、每次选择恰好新建
-  一个 surface(tab 或按 placement 的 split,空 worktree 时 split 退化为 tab)、route
-  编辑后 surface 的 profile 身份保持稳定、纯 preset 启动不设任何环境变量。
+  一个 surface(tab 或按 placement 的 split,空 worktree 时 split 退化为 tab)、推荐
+  变化后 surface 的 profile 身份保持稳定、纯 preset 启动不设任何环境变量。
+- Session 检测测试:`AgentSessionResolver` 以注入的 config root 在 profile home 布局下
+  解析出 Claude/Codex session;默认 root 行为不变;绑定 surface 的 resume argv 携带
+  同一环境 patch。
 - 手动验证:(a) 同一 runtime 的两个纯 preset(不同 model/effort)并排启动,确认共享同一
   登录且 `--resume` 历史统一;(b) 两个账号绑定 profile 分别登录不同账号并排运行,确认
-  各 CLI 报告自己的身份;(c) 修改 route 后确认只有后续启动受影响。
+  各 CLI 报告自己的身份;(c) 修改 repo 指定或启动其他 profile 后,确认只有后续启动的
+  推荐受影响。
 
 ## 备选与决策
 
@@ -213,14 +262,28 @@ specification 有意可被 handoff 复用,但 V1 的 handoff 目标列表维持�
   Keychain 引用只对未来的裸 API key 场景有意义,整体推迟。
 - **新 tab 优于向当前 shell 注入。** 保护进行中的 shell 工作,并让 agent 从进程启动起
   就拥有一致环境。
-- **全局路径 route 优于 per-repository 持久化账号名。** 最长前缀解析自动完成工作/个人
-  切换,不把本地身份泄漏进仓库配置。
-- **不做自动共享配置 symlink。** 便利是真实的,但 #617 观察到的歧义与静默分叉使其不适
-  合作为 V1 默认;子目录级显式共享作为 follow-up 逐项验证。
-- **指令/skill 注入推迟。** Codex 侧没有已验证的注入机制;作为 adapter 能力位在后续
-  波次实现,避免 V1 只对单一 runtime 成立的承诺。
+- **三层推荐优于路径前缀 route 表。** 初稿设计了"路径前缀 → profile"的全局映射表
+  (最长目录边界匹配 + per-runtime 默认)。讨论后以"指定 > 记忆 > 兜底"取代:表达力
+  略低,但心智模型简单得多,且免去 route 编辑器与边界匹配的全部复杂度;per-repo 指定
+  存于本地的 `UserRepositorySettings` 文件,本地身份依然不进入仓库配置。
+- **目录共享完全不做,而非推迟。** 便利是真实的,但提供共享开关意味着 Prowl 永久背上
+  "哪些子目录对哪个 runtime 安全"的验证与维护责任;高级用户一条 symlink 即可自助,
+  不替他们做决策。
+- **指令/skill 注入不做,而非推迟。** 绑定 profile 的专属指令由 home 内原生文件覆盖,
+  注入需求已消失;Codex 侧亦无已验证注入机制。`supportsInstructionInjection` 能力位
+  仅作预留,不再规划实现波次。
 - **Handoff 后续跟进,而非部分集成。** Profile-aware 的 handoff 必须在正常与 fallback
   两条执行路径上同时正确;推迟比让两者不一致更安全。
+
+## 后续方向(非 V1 承诺)
+
+- **Handoff 迁移到 profile 路径**:确定愿景,单独波次;必须同时贯穿 HUD 与 CLI/fallback
+  两条执行路径(见「Handoff 边界」)。
+- **Headless 产品化**:输出捕获、退出语义、surface 去留,以及两家 print/exec 模式
+  flag 面(含 JSON Schema 结构化输出)的调研与实验;domain/adapter 缝已在本波就绪。
+- **更多 runtime 接入**:逐家 spike 验证(启动语义、账号隔离机制、effort/headless
+  支持度)后,由各自 adapter 声明能力位接入;domain 与 UI 无需再改判断逻辑。
+- **手动自定义 home 的 session 检测**:读取 TUI 进程 env 反推有效 config root。
 
 ## Amendments
 
@@ -233,3 +296,24 @@ specification 有意可被 handoff 复用,但 V1 的 handoff 目标列表维持�
 - 2026-07-29 — profile 新增 per-profile 启动位置(placement):New Tab(默认)或
   New Split(方向复用 custom command 的 `UserCustomSplitDirection`);无可分割 surface
   时退化为新 tab。粒度与 custom command 的 per-command 先例一致。
+- 2026-07-29 — 推荐机制从路径前缀 route 表简化为三层回退"指定 > 记忆 > 兜底":
+  Repository Settings 的 Default Agent Profile > 该 repo 内上一次显式启动的 profile >
+  有序列表中第一个已启用的。记忆按 repo 记录而非全局:它弱于显式指定,但构成该 repo
+  的隐式默认。删除 route resolver、最长边界匹配与 route 编辑 UI;为守住简单心智模型,
+  不引入"全局最近使用"层。
+- 2026-07-29 — 子目录级共享从 follow-up 降级为"完全不做":高级用户经 Reveal Profile
+  Files 自行 symlink,Prowl 不代管该决策及其风险;文档警示可被 CLI 重写的文件不可链接。
+- 2026-07-29 — 讨论中发现账号绑定会使既有 session 检测失效:`AgentSessionResolver` 与
+  Claude/Codex 的 `AgentSessionProfile` 布局以 `~/.claude` / `~/.codex` 为根,搬迁后的
+  home 无法命中。新增实现步骤 4:布局参数化为 config root(绑定 surface 从记录的
+  profile 推导,无需探测),parsePath 改按 root 前缀匹配,resume 携带同一环境 patch;
+  手动自定义 home 的 agent 维持"本体可检测、session 不可得",env 反推列为 follow-up。
+- 2026-07-29 — Settings 采用独立的 Agents tab(`SettingsSection` 新 case,与 Custom
+  Commands 平级);per-repo Default Agent Profile 选择器进既有 repository section。
+- 2026-07-29 — 启动意图 enum 在本波补全为 `.interactive` / `.prompt` / `.headless`:
+  headless argv 与 handoff resume 同通道、零增量风险,一次迁移优于二次;V1 只做
+  domain/adapter 层,不提供 UI 消费者,JSON Schema 结构化输出继续推迟。
+- 2026-07-29 — 边界讨论定稿:handoff 迁移升格为确定的后续方向;确认绑定 profile 的
+  专属指令走 home 内原生文件(`CLAUDE.md` / `AGENTS.md`),注入需求消失、不再规划;
+  明确环境 patch 为叠加语义(继承 login shell 环境,不清洗、不继承他 tab 会话状态);
+  新增「后续方向」一节。

--- a/docs-ai/053-agent-profiles/000-plan.md
+++ b/docs-ai/053-agent-profiles/000-plan.md
@@ -75,7 +75,7 @@ Settings 新增 **Agents** 区,持有有序的全局 profile 集合与 path rout
 不得成为仓库配置。
 
 一个 profile 包含:稳定 UUID、显示名、启用状态、runtime、可选 model、可选 reasoning
-effort、既有的显式 execution mode,以及**可选的账号绑定**。reasoning effort 存为自由
+effort、既有的显式 execution mode、启动位置(placement),以及**可选的账号绑定**。reasoning effort 存为自由
 字符串,`nil` 表示 runtime 默认;编辑器按 runtime 展示 adapter 自带的已知档位建议
 (两家共有的 low/medium/high,及各自的扩展档位,如 Codex 的 `minimal` / `xhigh`),同时
 允许直接填写任意值。自定义值只作为**单一参数值**渲染进类型化参数——Claude Code 的
@@ -102,8 +102,11 @@ Agents capsule 不再因无运行中 agent 而禁用,而是**永远作为菜单*
   "Manage Agent Profiles…" 直达 Settings。
 - 有运行中 agent 时:保留现有 Active Agents / Hand Off 内容,并附带上述启动项。
 
-选择 profile 即在该 worktree 新建 tab 并以交互模式启动 runtime,无初始 prompt。绝不向
-既有 shell 注入文本:Prowl 无法证明那个 shell 处于空闲、可安全接管的状态。
+选择 profile 即在该 worktree 新建一个 surface 并以交互模式启动 runtime,无初始 prompt。
+启动位置由 profile 的 placement 决定:**New Tab**(默认)或 **New Split**(带方向,复用
+custom command 既有的 `UserCustomSplitDirection`)。split 同样是全新 surface,身份记录与
+结构化启动规则完全一致;当该 worktree 尚无可分割的 surface 时,split 退化为新 tab。绝不
+向既有 shell 注入文本:Prowl 无法证明那个 shell 处于空闲、可安全接管的状态。
 
 Prowl 启动的 surface 在创建时记录 profile UUID;检测到但非 Prowl 启动的 agent 只显示
 "检测到 Codex"这类事实,绝不猜测其归属的 profile 或账号。
@@ -136,8 +139,8 @@ home 的 skills/、session 目录)。#617 的分叉教训针对的是会被 CLI 
 
 ## 实现方式
 
-1. 引入 Codable 的 `AgentProfile` domain model(preset 字段 + 可选账号绑定)与 route
-   resolver 及 normalization 测试。runtime enum 限定为 Claude Code 与 Codex,校验非空
+1. 引入 Codable 的 `AgentProfile` domain model(preset 字段 + placement + 可选账号绑定)
+   与 route resolver 及 normalization 测试。runtime enum 限定为 Claude Code 与 Codex,校验非空
    显示名与 UUID 唯一性,normalization 时丢弃指向不可用 profile 的 route。扩展
    `supacode/Features/Settings/Models/UserGlobalSettings.swift` 及其 shared key,兼容缺少
    新字段的既有 JSON。
@@ -146,11 +149,12 @@ home 的 skills/、session 目录)。#617 的分叉教训针对的是会被 CLI 
    增加可选 reasoning effort,由各 adapter 自行完成 argv/config 映射与校验。为 adapter
    增加能力位:V1 实际使用 `supportsAccountIsolation`,为 handoff 与指令注入预留位置,
    取代散落的品牌硬编码判断。
-3. 把 profile 解析为单一 launch specification:profile UUID、类型化启动请求、argv,以及
-   **仅账号绑定时非空**的环境 patch。扩展 `supacode/Clients/Terminal/TerminalClient.swift`
-   与 `supacode/Features/Terminal/Models/WorktreeTerminalState.swift` 的 surface 创建路径,
-   使新 tab 经 `GhosttySurfaceView(environment:)` 接收 patch;不得把环境变量赋值拼进
-   shell 输入。在既有检测状态旁记录每个 surface 的启动 profile。
+3. 把 profile 解析为单一 launch specification:profile UUID、类型化启动请求、argv、
+   placement,以及**仅账号绑定时非空**的环境 patch。扩展
+   `supacode/Clients/Terminal/TerminalClient.swift` 与
+   `supacode/Features/Terminal/Models/WorktreeTerminalState.swift` 的 surface 创建路径,
+   使新 tab 与新 split 均经 `GhosttySurfaceView(environment:)` 接收 patch;不得把环境
+   变量赋值拼进 shell 输入。在既有检测状态旁记录每个 surface 的启动 profile。
 4. 新增小型 Settings reducer/view:profile 编辑、route 编辑,以及账号绑定分支的状态/登录
    动作。文件操作全部藏在注入的 profile-home dependency 之后,测试绝不触碰真实登录目录。
 5. 扩展 `supacode/Features/Repositories/Views/AgentsToolbarButton.swift` 及其在
@@ -191,8 +195,8 @@ specification 有意可被 handoff 复用,但 V1 的 handoff 目标列表维持�
 - Settings 与 profile-home 测试:保存/重载、绑定 profile 的派生目录 owner-only 权限、
   home 缺失时的状态判定、stdout/stderr/非零退出码的登录状态解析、绝不访问真实凭据。
 - Reducer/终端测试:菜单各可用性状态、正确的 worktree/cwd/环境 patch、每次选择恰好新建
-  一个 tab、route 编辑后 surface 的 profile 身份保持稳定、纯 preset 启动不设任何环境
-  变量。
+  一个 surface(tab 或按 placement 的 split,空 worktree 时 split 退化为 tab)、route
+  编辑后 surface 的 profile 身份保持稳定、纯 preset 启动不设任何环境变量。
 - 手动验证:(a) 同一 runtime 的两个纯 preset(不同 model/effort)并排启动,确认共享同一
   登录且 `--resume` 历史统一;(b) 两个账号绑定 profile 分别登录不同账号并排运行,确认
   各 CLI 报告自己的身份;(c) 修改 route 后确认只有后续启动受影响。
@@ -226,3 +230,6 @@ specification 有意可被 handoff 复用,但 V1 的 handoff 目标列表维持�
 - 2026-07-29 — reasoning effort 从固定三档改为"per-runtime 建议档位 + 自由填值":档位
   集合随模型演进,硬编码枚举会过时;自定义值仅作为类型化参数的单一值渲染,不构成自由
   格式 flag。execution mode 维持既有 `standard` / `unrestricted` 两档不变。
+- 2026-07-29 — profile 新增 per-profile 启动位置(placement):New Tab(默认)或
+  New Split(方向复用 custom command 的 `UserCustomSplitDirection`);无可分割 surface
+  时退化为新 tab。粒度与 custom command 的 per-command 先例一致。

--- a/docs-ai/053-agent-profiles/000-plan.md
+++ b/docs-ai/053-agent-profiles/000-plan.md
@@ -360,6 +360,9 @@ agent 列表不变。
   专属指令走 home 内原生文件(`CLAUDE.md` / `AGENTS.md`),注入需求消失、不再规划;
   明确环境 patch 为叠加语义(继承 login shell 环境,不清洗、不继承他 tab 会话状态);
   新增「后续方向」一节。
+- 2026-07-29 — HOME path spike 完成([002-home-spike.md](002-home-spike.md)):账号
+  绑定的全部关键假设实测证实(home 预创建、rollout/transcript 跟随新根、指令文件与
+  skills 原生拾取、凭证落点、并行登录无串号、真实 home 零污染),无需修改计划。
 - 2026-07-29 — 新增 Advanced 自定义附加参数与启动预览:附加参数为字面 argv token
   (shell-words 切分、追加在预置参数后、永不经 shell 解释),相应收窄"自由格式 flag"
   非目标;预览与实际启动共用 launch spec 渲染。

--- a/docs-ai/053-agent-profiles/000-plan.md
+++ b/docs-ai/053-agent-profiles/000-plan.md
@@ -1,0 +1,178 @@
+# 053 — Agent Profiles: Plan
+
+| | |
+| --- | --- |
+| **Status** | Planned |
+| **Anchor date** | 2026-07-29 |
+| **Primary PRs** | pending |
+| **Related** | [047 cross-agent handoff](../047-cross-agent-handoff/000-plan.md), [048 agent runtime adapters](../048-agent-runtime-adapters/000-plan.md), [049 Agents toolbar entry](../049-agents-toolbar-entry/000-plan.md), closed prototype [#617](https://github.com/onevcat/Prowl/pull/617) |
+
+## Background
+
+Prowl can safely start only Claude Code and Codex today. The runtime adapter already owns
+structured model and execution-mode argv, while the no-agent form of the toolbar Agents capsule
+was deliberately reserved for a quick launcher. There is no persisted profile, user-facing
+launcher, or account selection yet.
+
+A closed, unmerged prototype (#617) proved that `CLAUDE_CONFIG_DIR` and `CODEX_HOME` allow two
+logins to run side by side, but also exposed the important constraint: each variable relocates the
+runtime's *entire* home, not only credentials. Profiles must therefore describe a complete,
+explicit runtime context rather than an account-name string or a raw shell command.
+
+## Goals
+
+- Let users define named profiles for the two verified runtimes: Claude Code and Codex.
+- Launch a selected profile as a fresh interactive agent in a new, selected tab of the current
+  worktree, with no initial prompt.
+- Persist an optional model, reasoning level, and explicit execution mode per profile.
+- Give every profile a private runtime home, so users can keep separate CLI logins, skills,
+  plugins, and runtime instruction files (`CLAUDE.md` / `AGENTS.md`) per profile.
+- Make multiple same-brand accounts practical: profile-bound login/status controls and
+  deterministic path routing select a preferred profile for a worktree launch.
+- Keep profile identity stable so a later handoff wave can select a profile rather than a bare
+  agent token.
+
+### Non-goals
+
+- Change the current Hand Off UI, `prowl handoff` contract, or inherited-configuration behavior.
+- Put API keys, OAuth tokens, or `auth.json` contents in Prowl JSON, logs, analytics, or SwiftUI
+  state; V1 uses CLI-managed authentication inside a profile runtime home.
+- Accept arbitrary executable paths, shell fragments, or free-form CLI flags in a profile.
+- Modify a running pane when a profile or route changes, or intercept a user manually typing
+  `claude` / `codex` in an existing shell.
+- Support detected-but-unverified runtimes, shared-config symlink automation, profile import/export,
+  or a custom visual editor for skills and instruction files.
+
+## Product shape
+
+### Profiles and settings
+
+Add an **Agents** section to Settings. It owns an ordered collection of global profiles and path
+routes in `UserGlobalSettings`, not repository settings: account and agent preferences are private
+to the local user and must not become repository configuration.
+
+A profile contains a stable UUID, display name, enabled state, runtime, optional model, optional
+reasoning level, and the existing explicit execution mode. V1 exposes the verified common effort
+levels **Low**, **Medium**, and **High**; `nil` means the runtime default. The adapters render the
+same intent differently: Claude Code uses `--effort`, while Codex uses its typed
+`model_reasoning_effort` config override. `.unrestricted` remains available but is visually marked
+as dangerous and requires explicit confirmation when it is saved; it is never inferred from another
+profile or a source pane.
+
+The editor also offers **Sign In**, **Refresh status**, and **Reveal Profile Files**. Sign In starts
+a new terminal tab with the profile environment already attached, then runs that runtime's normal
+login command. Status probes treat CLI output, not exit status, as authoritative: both CLIs can
+return non-zero while signed out and Codex may report on stderr. A missing profile home is simply
+“Not signed in”; it must not invoke Codex first.
+
+### Launch and routing
+
+When the selected pane has no detected agent and at least one enabled profile exists, the Agents
+capsule becomes the launcher rather than a disabled placeholder. Its popover places the current
+worktree's **Recommended** profile first, followed by all enabled profiles. Selecting one creates a
+new tab in that worktree and starts the runtime interactively with no prompt. It must not inject
+text into the focused shell: Prowl cannot prove that shell is idle or safe to replace.
+
+Routes map a standardized local path prefix to a profile UUID. The longest directory-boundary match
+wins; an optional per-runtime default covers unmatched repositories. Resolution is read-only and
+creates no directories. A route only chooses the initial recommendation—explicitly selecting another
+profile always wins. The selected profile is recorded on the new surface at launch, so later route
+edits never relabel or mutate an active pane.
+
+### Runtime home and credentials
+
+Each profile derives its home from its UUID below Prowl's data directory, never from its display
+name or a user-supplied path. Launch preparation creates the runtime's directory before spawning the
+shell (Codex refuses a nonexistent `CODEX_HOME`), checks that the resolved path remains inside the
+profile-home base, and applies restrictive owner-only permissions.
+
+The home is intentionally opaque to Prowl. The relevant environment variable is added only to the
+new terminal surface—`CLAUDE_CONFIG_DIR` for Claude Code or `CODEX_HOME` for Codex—so the launched
+agent and its children see the selected context. Prowl does not parse, copy, or display credential
+files. Users manage runtime-supported files in that home; this is where profile-specific skills,
+plugins, and instruction files live. Project-owned instructions remain project-owned.
+
+Raw API-key entry is deferred. If it is added later, it must use a Keychain reference and an
+agent-only launch boundary, never a persisted value or a key placed in a long-lived terminal shell
+environment.
+
+## Implementation approach
+
+1. Introduce a Codable `AgentProfile` domain model plus route resolver and normalization tests.
+   Restrict its runtime enum to Claude Code and Codex, validate nonempty names/unique UUIDs, and
+   discard routes to unavailable profiles during normalization. Extend
+   `supacode/Features/Settings/Models/UserGlobalSettings.swift` and its shared key without breaking
+   existing JSON that lacks the new fields.
+2. Separate interactive starts from prompted starts in
+   `supacode/Domain/AgentRuntime/AgentRuntimeAdapter.swift`. A structured start intent must be
+   `.interactive` or `.prompt(String)`, never an empty prompt sentinel. Extend
+   `AgentLaunchConfiguration` with optional reasoning effort and have each verified adapter own its
+   argv/config mapping and validation.
+3. Resolve a profile into one launch specification: profile UUID, typed start request, and
+   environment patch. Extend `supacode/Clients/Terminal/TerminalClient.swift` and the surface
+   creation path in `supacode/Features/Terminal/Models/WorktreeTerminalState.swift` so that a new
+   tab receives the patch through `GhosttySurfaceView(environment:)`; do not prepend environment
+   assignments to shell input. Record the launch profile per surface alongside the existing
+   detection state.
+4. Add a small Settings reducer/view for profile editing, status/login actions, and route editing.
+   Keep file operations behind an injected profile-home dependency so tests never touch real login
+   directories.
+5. Extend `supacode/Features/Repositories/Views/AgentsToolbarButton.swift` and its wiring in
+   `supacode/Features/Repositories/Views/WorktreeDetailView.swift`. The detected-agent state keeps
+   its current Hand Off action; the no-agent state lists profiles and dispatches one profile-launch
+   action through `AppFeature`.
+6. After implementation, update the matching current-behavior documentation and write
+   `001-action.md` with the actual PR/test evidence.
+
+## Lessons carried forward from #617
+
+| Finding | Profile decision |
+| --- | --- |
+| Per-surface environment variables isolate two CLI logins. | Apply the environment only at the new-surface launch boundary. |
+| `CODEX_HOME` must exist before Codex starts. | Provision the derived home before launch or login. |
+| A relocated home contains settings and skills as well as auth. | Treat a profile home as a complete context, not an auth-file holder. |
+| Linking shared configuration can silently diverge when a CLI rewrites a symlink. | Do not auto-link or repair shared configuration in V1; make profile files explicit. |
+| Account/path changes must not alter a live pane. | Record profile ID at surface creation; routes affect later starts only. |
+| Auth status output is stream- and exit-code-sensitive. | Parse known output from both streams behind a testable client. |
+
+## Handoff boundary
+
+Profiles are a V1 **start** feature, matching the boundary set in 049. Their stable ID and resolved
+launch specification are intentionally reusable by handoff, but V1 leaves its target list as the
+existing agent list.
+
+A later handoff integration must carry the selected profile through both paths: the HUD's injected
+request and the CLI/fallback handler. Updating only
+`supacode/Features/HandoffHud/Reducer/HandoffHudFeature.swift` would make the fallback silently
+lose the profile because `supacode/CLIService/HandoffCommandHandler.swift` currently rebuilds an
+inherited configuration. That wave should extend the structured handoff request/registry boundary;
+it must not read “whatever profile is current” after the request begins.
+
+## Verification
+
+- Domain tests: profile normalization, UUID stability, invalid/missing routes, longest path-boundary
+  routing, and no persisted secret material.
+- Adapter tests in `supacodeTests/AgentRuntimeAdapterTests.swift`: no-prompt interactive argv,
+  model/effort mapping, standard vs. dangerous mode, and shell quoting.
+- Settings and profile-home tests: legacy decode, save/reload, owner-only derived directories,
+  missing-home status, stdout/stderr/non-zero login status, and no real credential access.
+- Reducer/terminal tests: no-agent launcher availability, correct worktree/cwd/environment patch,
+  one new tab per selection, and stable surface profile identity after route edits.
+- Manual: sign into two Claude Code or Codex profiles, launch each side by side, and confirm each
+  CLI reports its own identity; then change a route and confirm only a later launch changes.
+
+## Alternatives and decisions
+
+- **Profile homes over raw credentials.** This preserves the CLI's supported authentication flow and
+  avoids turning Prowl into a secret manager. Keychain-backed API keys need a different, carefully
+  scoped execution design.
+- **New tab over current-shell injection.** It protects in-progress shell work and gives the agent a
+  coherent environment from process start.
+- **Profile routes over per-repository persisted account names.** A global, longest-prefix resolver
+  gives automatic work/personal selection without leaking local identities into repository config.
+- **No automatic shared-config symlinks.** The convenience is real, but the ambiguity and silent
+  divergence observed in #617 make it the wrong V1 default.
+- **Handoff follow-up rather than partial integration.** A profile-aware handoff must be correct in
+  both normal and fallback execution paths; postponing it is safer than making the two disagree.
+
+## Amendments

--- a/docs-ai/053-agent-profiles/000-plan.md
+++ b/docs-ai/053-agent-profiles/000-plan.md
@@ -44,7 +44,7 @@ Profile 的本体是 **preset**(对已知 runtime 的一组命名预置配置);�
 - **默认形态(纯 preset)**:profile 运行在共享的默认 home,不设置任何环境变量;skills、
   全局指令、session 历史与 `--resume` 列表保持统一。
 - **可选账号绑定(opt-in)**:profile 显式绑定独立账号时,才派生私有 runtime home,用于
-  独立登录与独立用量;仅此时出现登录/状态管理控件。
+  独立登录与独立用量;仅此时出现 profile 文件管理控件。
 - Agents capsule 永远是菜单:列出推荐与已启用的 profile、不可用项及原因、管理入口;有
   运行中 agent 时附带现有 Active Agents 内容。
 - 以"指定 > 记忆 > 兜底"三层规则为每个 worktree 选出菜单里的 Recommended profile。
@@ -67,6 +67,8 @@ Profile 的本体是 **preset**(对已知 runtime 的一组命名预置配置);�
   (`CLAUDE.md` / `AGENTS.md`)覆盖,无需注入;纯 preset 的注入通道(Claude Code 有
   `--append-system-prompt`,Codex 交互式 TUI 无已验证等价物)不再规划,能力位仅作预留。
 - 不做 profile 导入/导出或 skills / 指令文件的可视化编辑器。
+- 不新增任何 profile 相关的 analytics 事件;profile 名称、UUID 与绑定状态一律不进入
+  PostHog / Sentry。
 
 ## 产品形态
 
@@ -82,23 +84,29 @@ Profile 指定与上次启动记忆存于 `UserRepositorySettings`(本地文件
 `~/.prowl/repo/<name>/prowl.onevcat.json`,同样不进仓库)。
 
 一个 profile 包含:稳定 UUID、显示名、启用状态、runtime、可选 model、可选 reasoning
-effort、既有的显式 execution mode、启动位置(placement),以及**可选的账号绑定**。reasoning effort 存为自由
-字符串,`nil` 表示 runtime 默认;编辑器按 runtime 展示 adapter 自带的已知档位建议
-(两家共有的 low/medium/high,及各自的扩展档位,如 Codex 的 `minimal` / `xhigh`),同时
-允许直接填写任意值。自定义值只作为**单一参数值**渲染进类型化参数——Claude Code 的
+effort、既有的显式 execution mode、启动位置(placement),以及**可选的账号绑定**。
+model 与 reasoning effort 均存为自由字符串,`nil` 表示 runtime 默认;编辑器按 runtime
+展示 adapter 自带的建议列表(effort 如两家共有的 low/medium/high 及 Codex 的
+`minimal` / `xhigh` 等扩展档位),同时允许直接填写任意值。自定义值只作为**单一参数值**渲染进类型化参数——Claude Code 的
 `--effort`、Codex 的 `model_reasoning_effort` config override——走既有的安全 argv 渲染,
 不经过 shell 解释;未知档位由 CLI 启动时自行报错,在新 surface 内直接可见,Prowl 不做预校验。
 `.unrestricted` 保留但视觉上标记为危险,保存时需要显式确认;绝不从其他 profile 或来源
 pane 推断。
 
+**初始播种(seeding)**:首次启用本功能时,为每个已安装的已验证 CLI 播种一个裸
+preset(显示名即 runtime 名,无 model/effort、standard 模式、New Tab、不绑定账号),
+行为等同用户手动敲 `claude` / `codex`。播种一次性(记录 flag),用户删除后不复活;
+两家 CLI 均未安装时,菜单显示灰色说明与 "Manage Agent Profiles…" 空态。
+
 **未绑定账号的 profile(默认)**:不派生目录、不设置环境变量、不显示登录控件;状态栏
 说明其使用系统默认登录。
 
-**绑定账号的 profile**:编辑器提供 **Sign In**、**Refresh status**、**Reveal Profile
-Files**。Sign In 新开一个已附加 profile 环境的终端 tab,运行该 runtime 的常规登录命令。
-状态探测以 CLI 输出而非退出码为准:两家 CLI 都可能在未登录时返回非零,Codex 可能经
-stderr 报告。home 不存在时直接判定"未登录",不得先调用 Codex。绑定开关旁必须写明隔离
-代价:该 profile 将拥有独立的 skills、全局指令与 session 历史。
+**绑定账号的 profile**:编辑器只提供 **Reveal Profile Files** 与一行被动状态(home
+尚未初始化 / 已初始化,纯文件系统检查,绝不调用 CLI)。没有 Sign In 按钮、没有登录
+状态探测:**首次启动即登录时刻**——未登录的绑定 profile 启动后,agent TUI 走自己的
+原生登录流程,该 surface 的环境已挂好,凭证自然落入 profile home;确认登录身份用
+agent 内的 `/status`。绑定开关旁必须写明隔离代价:该 profile 将拥有独立的 skills、
+全局指令与 session 历史。
 
 ### 启动与 Agents 菜单
 
@@ -115,8 +123,14 @@ custom command 既有的 `UserCustomSplitDirection`)。split 同样是全新 sur
 结构化启动规则完全一致;当该 worktree 尚无可分割的 surface 时,split 退化为新 tab。绝不
 向既有 shell 注入文本:Prowl 无法证明那个 shell 处于空闲、可安全接管的状态。
 
+Command Palette 提供第二入口:为每个已启用 profile 动态生成 "Launch Agent: <名称>"
+条目(当前 worktree 的推荐排前),派发与菜单**完全同一个** profile-launch action——
+palette 是入口而非第二条启动路径,placement、身份记录与环境 patch 全走同一条缝。
+
 Prowl 启动的 surface 在创建时记录 profile UUID;检测到但非 Prowl 启动的 agent 只显示
-"检测到 Codex"这类事实,绝不猜测其归属的 profile 或账号。
+"检测到 Codex"这类事实,绝不猜测其归属的 profile 或账号。身份的 UI 露出:有 profile
+记录的 surface 在 Active Agents 列表与 capsule 中显示 profile 显示名(必要时附 runtime
+图标消歧义),仅检测的维持 runtime 名;tab 标题不在本波范围内,维持既有逻辑。
 
 ### 推荐(Recommended)
 
@@ -129,7 +143,8 @@ Prowl 启动的 surface 在创建时记录 profile UUID;检测到但非 Prowl �
 3. **兜底**:从未在该 repo 启动过任何 profile 时,取有序 profile 列表中第一个已启用的。
 
 每一层只解析到存在且已启用的 profile;悬空(已删除)或被禁用的引用直接落到下一层,
-normalization 时清理悬空的 per-repo 指定。解析是只读的,不创建任何目录。推荐只决定
+normalization 时清理悬空的 per-repo 指定。runtime CLI 是否可用不参与解析:推荐位照常
+给出,CLI 缺失时灰显并写明原因——让问题可见,绝不静默改推其他 profile。解析是只读的,不创建任何目录。推荐只决定
 菜单排序——显式选择其他 profile 永远优先。profile 在启动时记录到新 surface 上,之后的
 指定或记忆变化绝不重新标记或修改活跃 pane。
 
@@ -148,12 +163,19 @@ home 对 Prowl 是不透明的:对应环境变量只附加到新终端 surface�
 常规环境(PATH、用户自行 export 的变量等),Prowl 只追加变量、不做环境清洗;其他 tab
 中手动 export 的会话状态不会传入。
 
-全新 home 意味着 agent 首次启动即未登录;用户在 Sign In tab 内完成 CLI 登录后,凭证
-落在该 home 中(Codex 为 `auth.json`,Claude 的凭证存储同样以 config dir 为界,#617
-实测互不串号)。`$CLAUDE_CONFIG_DIR/CLAUDE.md` 与 `$CODEX_HOME/AGENTS.md` 是两家 CLI
+全新 home 意味着 agent 首次启动即未登录;用户在首次启动的 surface 内完成 CLI 原生
+登录后,凭证落在该 home 中(Codex 为 `auth.json`,Claude 的凭证存储同样以 config dir
+为界,#617 实测互不串号)。`$CLAUDE_CONFIG_DIR/CLAUDE.md` 与 `$CODEX_HOME/AGENTS.md` 是两家 CLI
 全局指令文件的原生位置,搬迁后自动从新位置读取——绑定 profile 的专属指令与 skills
 直接放进 home 即可,无需任何注入机制。Prowl 不解析、不复制、不展示凭据文件;项目内的
 指令文件仍归项目所有。
+
+**删除绑定 profile** 弹出确认对话框,写明登录凭证与文件仍在磁盘上:默认只删 profile
+条目、保留目录;提供显式的 "Move Profile Files to Trash" 选项(NSWorkspace 移入废纸篓,
+可找回,绝不 `rm`)。硬性不变量:删除的文件操作只作用于从该 profile UUID 派生、且通过
+profile-home 基目录包含校验的路径——与启动时同一道闸;纯 preset 没有 home 引用,删除
+时执行零文件操作;任何指向基目录之外(含 `~/.claude` / `~/.codex` 真实 agent home)的
+路径直接拒绝。
 
 Prowl 不提供任何目录共享功能(V1 及以后均然)。希望在绑定 profile 与默认 home 之间
 共享 skills 等目录的高级用户,可经 "Reveal Profile Files" 自行创建 symlink;文档应
@@ -196,13 +218,14 @@ Prowl 不提供任何目录共享功能(V1 及以后均然)。希望在绑定 pr
    `CLAUDE_CONFIG_DIR` / `CODEX_HOME` 启动的 agent 维持现状(agent 本体可检测、
    session 身份不可得);读取 TUI 进程 env 反推 root 列为 follow-up。
 5. 新增小型 Settings reducer/view:`SettingsSection` 加 `agents` case 及对应 tab,
-   承载 profile 列表/编辑与账号绑定分支的状态/登录动作;在 Repository Settings 中加入
-   Default Agent Profile 选择器。文件操作全部藏在注入的 profile-home dependency 之后,
-   测试绝不触碰真实登录目录。
+   承载 profile 列表/编辑(绑定分支仅 Reveal Profile Files 与被动 home 状态,无任何
+   后台 CLI 调用);在 Repository Settings 中加入 Default Agent Profile 选择器。文件
+   操作全部藏在注入的 profile-home dependency 之后,测试绝不触碰真实登录目录。
 6. 扩展 `supacode/Features/Repositories/Views/AgentsToolbarButton.swift` 及其在
    `supacode/Features/Repositories/Views/WorktreeDetailView.swift` 中的接线:改为永远是
    菜单;检测态保留现有 Hand Off 动作,启动项经 `AppFeature` 派发单一 profile-launch
-   action。
+   action。`CommandPaletteFeature` 按已启用 profile 动态生成 Launch Agent 条目,复用
+   同一 action(参照既有 handoff 条目工厂的模式)。
 7. 实现完成后,更新对应的现状文档,并以实际 PR 与测试证据撰写 `001-action.md`。
 
 ## 从 #617 带入的经验
@@ -210,11 +233,11 @@ Prowl 不提供任何目录共享功能(V1 及以后均然)。希望在绑定 pr
 | 发现 | Profile 决策 |
 | --- | --- |
 | Per-surface 环境变量可隔离两份 CLI 登录。 | 环境变量只在新 surface 启动边界施加,且仅限账号绑定 profile。 |
-| `CODEX_HOME` 必须在 Codex 启动前存在。 | 启动或登录前先创建派生 home。 |
+| `CODEX_HOME` 必须在 Codex 启动前存在。 | 启动前先创建派生 home。 |
 | 搬迁后的 home 包含 settings 与 skills,不止认证文件。 | 隔离是全有或全无的账号轴代价,因此 preset 为默认、绑定为 opt-in。 |
 | 共享配置的 symlink 会在 CLI 重写文件时静默分叉。 | Prowl 不做任何 link;高级用户自行 symlink,文档警示被重写文件不可链接。 |
 | 账号/推荐变化不得影响活跃 pane。 | surface 创建时记录 profile ID;推荐解析只影响后续启动。 |
-| 认证状态输出对流与退出码敏感。 | 在可测试的 client 后解析两条流的已知输出。 |
+| 认证状态输出对流与退出码敏感。 | V1 不做状态探测;登录与身份确认交给 CLI TUI 原生流程。 |
 
 ## Handoff 边界
 
@@ -238,8 +261,10 @@ agent 列表不变。
   argv、`.headless` 的一次性执行 argv、model/effort 映射(含自定义 effort 值的安全
   渲染)、标准与危险模式、shell 转义、能力位取值。
 - Settings 与 profile-home 测试:保存/重载、绑定 profile 的派生目录 owner-only 权限、
-  home 缺失时的状态判定、stdout/stderr/非零退出码的登录状态解析、绝不访问真实凭据。
-- Reducer/终端测试:菜单各可用性状态、正确的 worktree/cwd/环境 patch、每次选择恰好新建
+  home 初始化状态的被动判定(纯文件系统,不调 CLI)、绝不访问真实凭据;删除路径的
+  包含校验(基目录外一律拒绝)、纯 preset 删除零文件操作、Trash 而非删除。
+- Reducer/终端测试:菜单各可用性状态、palette 条目生成与共享 action 派发、正确的
+  worktree/cwd/环境 patch、每次选择恰好新建
   一个 surface(tab 或按 placement 的 split,空 worktree 时 split 退化为 tab)、推荐
   变化后 surface 的 profile 身份保持稳定、纯 preset 启动不设任何环境变量。
 - Session 检测测试:`AgentSessionResolver` 以注入的 config root 在 profile home 布局下
@@ -284,6 +309,8 @@ agent 列表不变。
 - **更多 runtime 接入**:逐家 spike 验证(启动语义、账号隔离机制、effort/headless
   支持度)后,由各自 adapter 声明能力位接入;domain 与 UI 无需再改判断逻辑。
 - **手动自定义 home 的 session 检测**:读取 TUI 进程 env 反推有效 config root。
+- **`prowl` CLI 的 profile 感知**:等 profile 特性定型后再研究;profile 的 CLI 引用
+  方式(名称/UUID)与 handoff 迁移波次的结构化请求一起定,避免过早固化 CLI 契约。
 
 ## Amendments
 
@@ -317,3 +344,11 @@ agent 列表不变。
   专属指令走 home 内原生文件(`CLAUDE.md` / `AGENTS.md`),注入需求消失、不再规划;
   明确环境 patch 为叠加语义(继承 login shell 环境,不清洗、不继承他 tab 会话状态);
   新增「后续方向」一节。
+- 2026-07-29 — Grill 环节定案:为已安装 CLI 一次性播种裸 preset;删除绑定 profile 走
+  "确认 + 默认保留 + 可选 Trash",文件操作硬性限定在 UUID 派生且通过包含校验的路径
+  (纯 preset 零文件操作,绝不触碰真实 agent home);Prowl 启动的 surface 在 Active
+  Agents/capsule 显示 profile 名(tab 标题不动);删除 Sign In 与登录状态探测——首次
+  启动即登录时刻,编辑器仅保留 Reveal 与被动 home 状态;Command Palette 加共享同一
+  action 的 Launch Agent 条目;`prowl` CLI 的 profile 感知缓行;model 与 effort 同构
+  为自由字符串 + 建议列表;推荐解析不考虑 CLI 可用性(灰显示因,不静默改推);不新增
+  profile 相关 analytics。

--- a/docs-ai/053-agent-profiles/000-plan.md
+++ b/docs-ai/053-agent-profiles/000-plan.md
@@ -333,6 +333,13 @@ agent 列表不变。
 - 2026-07-30 — Review 四轮(P2):palette 的 Launch Agent 条目工厂改用与 launch
   action 相同的 action-target 解析(selectedTerminalWorktree ?? Canvas 聚焦卡),
   Canvas 模式下条目不再缺席;补 Canvas 聚焦卡回归测试。
+- 2026-07-30 — Review 五轮(P2)+ 治本重构:plain-folder 聚焦卡的 ID 是 repository
+  ID,工厂用 `worktree(for:)` 解析不到(第三次同族偏差)。新增单一 resolver
+  `RepositoriesFeature.State.actionTargetTerminalWorktree(explicitTargetID:)`
+  (选中 terminal worktree ?? 显式 target 经 `terminalWorktree(for:)` 完整解析,
+  含 plain-folder 合成),palette 工厂与 `AppFeature.actionTargetWorktree` 均改为
+  调用它——生成端与执行端从此共享同一份目标解析,无法再各漏半步;配语义锁定
+  测试与 plain-folder 回归测试。
 - 2026-07-30 — Review 三轮(P2/P3):(a) surface 的 launch 身份增加 runtime,config
   root 只对**同 runtime 的检测**生效——bound pane 内手动启动其他 agent 时不再张冠
   李戴、也不再压制默认布局扫描;(b) 删除确认的判断从"当前 bindsDedicatedHome 意愿"

--- a/docs-ai/053-agent-profiles/000-plan.md
+++ b/docs-ai/053-agent-profiles/000-plan.md
@@ -2,7 +2,7 @@
 
 | | |
 | --- | --- |
-| **Status** | Planned |
+| **Status** | Implemented(见 [001-action.md](001-action.md)) |
 | **Anchor date** | 2026-07-29 |
 | **Primary PRs** | pending |
 | **Related** | [047 cross-agent handoff](../047-cross-agent-handoff/000-plan.md), [048 agent runtime adapters](../048-agent-runtime-adapters/000-plan.md), [049 Agents toolbar entry](../049-agents-toolbar-entry/000-plan.md), closed prototype [#617](https://github.com/onevcat/Prowl/pull/617) |

--- a/docs-ai/053-agent-profiles/000-plan.md
+++ b/docs-ai/053-agent-profiles/000-plan.md
@@ -56,7 +56,9 @@ Profile 的本体是 **preset**(对已知 runtime 的一组命名预置配置);�
 - 不把 API key、OAuth token、`auth.json` 内容放进 Prowl JSON、日志、分析或 SwiftUI 状态;
   V1 只使用 CLI 自管认证。裸 API key 输入(需 Keychain 引用 + agent-only 启动边界)整体
   推迟。
-- 不接受任意可执行文件路径、shell 片段或自由格式 CLI flag。
+- 不接受任意可执行文件路径或 shell 片段。自定义附加参数(Advanced)是**字面 argv
+  token**:按 shell-words 规则切分后逐个追加,永不经过 shell 解释(无变量展开、命令
+  替换或重定向)。
 - 不在 profile 或推荐指定变化时修改运行中的 pane,不拦截用户在既有 shell 中手动输入的
   `claude` / `codex`。
 - 不支持检测到但未验证的 runtime。
@@ -85,7 +87,8 @@ Profile 指定与上次启动记忆存于 `UserRepositorySettings`(本地文件
 `~/.prowl/repo/<name>/prowl.onevcat.json`,同样不进仓库)。
 
 一个 profile 包含:稳定 UUID、显示名、启用状态、runtime、可选 model、可选 reasoning
-effort、既有的显式 execution mode、启动位置(placement),以及**可选的账号绑定**。
+effort、既有的显式 execution mode、启动位置(placement)、可选的自定义附加参数
+(Advanced),以及**可选的账号绑定**。
 model 与 reasoning effort 均存为自由字符串,`nil` 表示 runtime 默认;编辑器按 runtime
 展示 adapter 自带的建议列表(effort 如两家共有的 low/medium/high 及 Codex 的
 `minimal` / `xhigh` 等扩展档位),同时允许直接填写任意值。自定义值只作为**单一参数值**渲染进类型化参数——Claude Code 的
@@ -93,6 +96,13 @@ model 与 reasoning effort 均存为自由字符串,`nil` 表示 runtime 默认;
 不经过 shell 解释;未知档位由 CLI 启动时自行报错,在新 surface 内直接可见,Prowl 不做预校验。
 `.unrestricted` 保留但视觉上标记为危险,保存时需要显式确认;绝不从其他 profile 或来源
 pane 推断。
+
+编辑器含 **Advanced 面板**(与账号绑定同区):**自定义附加参数**字段,按 shell-words
+规则切分为字面 argv token(支持引号包裹含空格值),追加在 adapter 生成参数之后
+(last-wins,用户可覆盖预置值),永不经 shell 解释。编辑器底部实时显示**启动预览**:
+最终的完整启动形态,绑定 profile 含环境前缀(如
+`CODEX_HOME=~/.prowl/agent-profiles/<uuid> codex --yolo`)——launch spec 是纯函数,
+预览与实际启动共用同一渲染,兼作附加参数切分的自查。
 
 **初始播种(seeding)**:首次启用本功能时,为每个已安装的已验证 CLI 播种一个裸
 preset(显示名即 runtime 名,无 model/effort、standard 模式、New Tab、不绑定账号),
@@ -203,8 +213,9 @@ Prowl 不提供任何目录共享功能(V1 及以后均然)。希望在绑定 pr
    增加可选 reasoning effort,由各 adapter 自行完成 argv/config 映射与校验。为 adapter
    增加能力位:V1 实际使用 `supportsAccountIsolation`,为 handoff 与指令注入预留位置,
    取代散落的品牌硬编码判断。
-3. 把 profile 解析为单一 launch specification:profile UUID、类型化启动请求、argv、
-   placement,以及**仅账号绑定时非空**的环境 patch。扩展
+3. 把 profile 解析为单一 launch specification:profile UUID、类型化启动请求、argv
+   (adapter 生成 + 附加参数 token 追加,shell-words 切分器为带测试的纯函数)、
+   placement,以及**仅账号绑定时非空**的环境 patch。启动预览与实际启动共用该解析。扩展
    `supacode/Clients/Terminal/TerminalClient.swift` 与
    `supacode/Features/Terminal/Models/WorktreeTerminalState.swift` 的 surface 创建路径,
    使新 tab 与新 split 均经 `GhosttySurfaceView(environment:)` 接收 patch;不得把环境
@@ -263,7 +274,8 @@ agent 列表不变。
   必须产生空环境 patch。
 - Adapter 测试(`supacodeTests/AgentRuntimeAdapterTests.swift`):无 prompt 的交互式
   argv、`.headless` 的一次性执行 argv、model/effort 映射(含自定义 effort 值的安全
-  渲染)、标准与危险模式、shell 转义、能力位取值。
+  渲染)、标准与危险模式、shell 转义、能力位取值;shell-words 切分器(引号、转义、
+  空输入)、附加参数追加顺序、预览与实际渲染一致。
 - Settings 与 profile-home 测试:保存/重载、绑定 profile 的派生目录 owner-only 权限、
   home 初始化状态的被动判定(纯文件系统,不调 CLI)、绝不访问真实凭据;删除路径的
   包含校验(基目录外一律拒绝)、纯 preset 删除零文件操作、Trash 而非删除。
@@ -348,6 +360,9 @@ agent 列表不变。
   专属指令走 home 内原生文件(`CLAUDE.md` / `AGENTS.md`),注入需求消失、不再规划;
   明确环境 patch 为叠加语义(继承 login shell 环境,不清洗、不继承他 tab 会话状态);
   新增「后续方向」一节。
+- 2026-07-29 — 新增 Advanced 自定义附加参数与启动预览:附加参数为字面 argv token
+  (shell-words 切分、追加在预置参数后、永不经 shell 解释),相应收窄"自由格式 flag"
+  非目标;预览与实际启动共用 launch spec 渲染。
 - 2026-07-29 — Grill 环节定案:为已安装 CLI 一次性播种裸 preset;删除绑定 profile 走
   "确认 + 默认保留 + 可选 Trash",文件操作硬性限定在 UUID 派生且通过包含校验的路径
   (纯 preset 零文件操作,绝不触碰真实 agent home);Prowl 启动的 surface 在 Active

--- a/docs-ai/053-agent-profiles/000-plan.md
+++ b/docs-ai/053-agent-profiles/000-plan.md
@@ -7,172 +7,215 @@
 | **Primary PRs** | pending |
 | **Related** | [047 cross-agent handoff](../047-cross-agent-handoff/000-plan.md), [048 agent runtime adapters](../048-agent-runtime-adapters/000-plan.md), [049 Agents toolbar entry](../049-agents-toolbar-entry/000-plan.md), closed prototype [#617](https://github.com/onevcat/Prowl/pull/617) |
 
-## Background
+## 背景
 
-Prowl can safely start only Claude Code and Codex today. The runtime adapter already owns
-structured model and execution-mode argv, while the no-agent form of the toolbar Agents capsule
-was deliberately reserved for a quick launcher. There is no persisted profile, user-facing
-launcher, or account selection yet.
+Prowl 目前只能安全启动 Claude Code 和 Codex 两种已验证的 runtime。adapter 层
+(`AgentRuntimeAdapter`) 已经拥有结构化的 model / execution-mode argv 渲染,工具栏 Agents
+capsule 的无 agent 形态被预留给快速启动入口。尚不存在持久化的 profile、面向用户的启动器,
+或账号选择能力。
 
-A closed, unmerged prototype (#617) proved that `CLAUDE_CONFIG_DIR` and `CODEX_HOME` allow two
-logins to run side by side, but also exposed the important constraint: each variable relocates the
-runtime's *entire* home, not only credentials. Profiles must therefore describe a complete,
-explicit runtime context rather than an account-name string or a raw shell command.
+已关闭的原型 [#617](https://github.com/onevcat/Prowl/pull/617) 验证了 `CLAUDE_CONFIG_DIR` 与
+`CODEX_HOME` 可以让两份登录并存,同时也暴露了关键约束:这两个环境变量搬走的是 runtime 的
+**整个 home**——skills、全局指令文件(`CLAUDE.md` / `AGENTS.md`)、session 历史、settings
+全部跟随,而不仅仅是凭据。
 
-## Goals
+### 本次重写的动因
 
-- Let users define named profiles for the two verified runtimes: Claude Code and Codex.
-- Launch a selected profile as a fresh interactive agent in a new, selected tab of the current
-  worktree, with no initial prompt.
-- Persist an optional model, reasoning level, and explicit execution mode per profile.
-- Give every profile a private runtime home, so users can keep separate CLI logins, skills,
-  plugins, and runtime instruction files (`CLAUDE.md` / `AGENTS.md`) per profile.
-- Make multiple same-brand accounts practical: profile-bound login/status controls and
-  deterministic path routing select a preferred profile for a worktree launch.
-- Keep profile identity stable so a later handoff wave can select a profile rather than a bare
-  agent token.
+本计划的初稿把"每个 profile 无条件派生一个私有 runtime home"作为核心机制。讨论后确认这
+混淆了两根正交的轴:
 
-### Non-goals
+| 轴 | 机制 | 副作用 |
+| --- | --- | --- |
+| **Preset 轴**:model、reasoning effort、execution mode | 纯 argv,adapter 已支持 | 零副作用,天然共享 skills / 全局指令 / session 历史 |
+| **Account 轴**:独立登录与用量 | 只能搬 home(#617 唯一验证过的机制) | 把 skills、指令、历史全部拖入隔离 |
 
-- Change the current Hand Off UI, `prowl handoff` contract, or inherited-configuration behavior.
-- Put API keys, OAuth tokens, or `auth.json` contents in Prowl JSON, logs, analytics, or SwiftUI
-  state; V1 uses CLI-managed authentication inside a profile runtime home.
-- Accept arbitrary executable paths, shell fragments, or free-form CLI flags in a profile.
-- Modify a running pane when a profile or route changes, or intercept a user manually typing
-  `claude` / `codex` in an existing shell.
-- Support detected-but-unverified runtimes, shared-config symlink automation, profile import/export,
-  or a custom visual editor for skills and instruction files.
+Profile 的本体是 **preset**(对已知 runtime 的一组命名预置配置);账号隔离是一个**可选的、
+按 runtime 能力位门控的绑定**,用户显式选择并知情承担隔离代价。用量跟随 OAuth 登录,
+"只分用量不分登录"不存在中间路线。
 
-## Product shape
+## 目标
 
-### Profiles and settings
+- 为两种已验证 runtime(Claude Code、Codex)定义命名 profile;同一 runtime 可有多个
+  profile,profile 不等于品牌。
+- 从 Agents 菜单选择 profile 后,在当前 worktree 新建并选中一个 tab,以交互模式启动
+  agent,无初始 prompt。
+- 每个 profile 持久化可选 model、可选 reasoning effort、显式 execution mode,全部以 argv
+  渲染。
+- **默认形态(纯 preset)**:profile 运行在共享的默认 home,不设置任何环境变量;skills、
+  全局指令、session 历史与 `--resume` 列表保持统一。
+- **可选账号绑定(opt-in)**:profile 显式绑定独立账号时,才派生私有 runtime home,用于
+  独立登录与独立用量;仅此时出现登录/状态管理控件。
+- Agents capsule 永远是菜单:列出推荐与已启用的 profile、不可用项及原因、管理入口;有
+  运行中 agent 时附带现有 Active Agents 内容。
+- 路径 route 为每个 worktree 选出初始推荐 profile。
+- Profile UUID 保持稳定,使未来的 handoff 集成可以引用 profile 而非裸 agent token。
 
-Add an **Agents** section to Settings. It owns an ordered collection of global profiles and path
-routes in `UserGlobalSettings`, not repository settings: account and agent preferences are private
-to the local user and must not become repository configuration.
+### 非目标
 
-A profile contains a stable UUID, display name, enabled state, runtime, optional model, optional
-reasoning level, and the existing explicit execution mode. V1 exposes the verified common effort
-levels **Low**, **Medium**, and **High**; `nil` means the runtime default. The adapters render the
-same intent differently: Claude Code uses `--effort`, while Codex uses its typed
-`model_reasoning_effort` config override. `.unrestricted` remains available but is visually marked
-as dangerous and requires explicit confirmation when it is saved; it is never inferred from another
-profile or a source pane.
+- 不改动现有 Hand Off UI、`prowl handoff` 契约或继承配置行为。
+- 不把 API key、OAuth token、`auth.json` 内容放进 Prowl JSON、日志、分析或 SwiftUI 状态;
+  V1 只使用 CLI 自管认证。裸 API key 输入(需 Keychain 引用 + agent-only 启动边界)整体
+  推迟。
+- 不接受任意可执行文件路径、shell 片段或自由格式 CLI flag。
+- 不在 profile 或 route 变化时修改运行中的 pane,不拦截用户在既有 shell 中手动输入的
+  `claude` / `codex`。
+- 不支持检测到但未验证的 runtime。
+- 不做共享配置的自动 symlink(#617 教训);账号绑定 profile 的**子目录级显式共享**
+  (如 skills/、session 目录)列为 follow-up,不进 V1。
+- 不做 per-profile 指令/skill 注入:Claude Code 有 `--append-system-prompt` 等通道,但
+  Codex 交互式 TUI 没有已验证的等价机制;建模为未来的 adapter 能力位后再做。
+- 不做 profile 导入/导出或 skills / 指令文件的可视化编辑器。
 
-The editor also offers **Sign In**, **Refresh status**, and **Reveal Profile Files**. Sign In starts
-a new terminal tab with the profile environment already attached, then runs that runtime's normal
-login command. Status probes treat CLI output, not exit status, as authoritative: both CLIs can
-return non-zero while signed out and Codex may report on stderr. A missing profile home is simply
-“Not signed in”; it must not invoke Codex first.
+## 产品形态
 
-### Launch and routing
+### Profile 与 Settings
 
-When the selected pane has no detected agent and at least one enabled profile exists, the Agents
-capsule becomes the launcher rather than a disabled placeholder. Its popover places the current
-worktree's **Recommended** profile first, followed by all enabled profiles. Selecting one creates a
-new tab in that worktree and starts the runtime interactively with no prompt. It must not inject
-text into the focused shell: Prowl cannot prove that shell is idle or safe to replace.
+Settings 新增 **Agents** 区,持有有序的全局 profile 集合与 path route,存放于
+`UserGlobalSettings` 而非 repository settings:账号与 agent 偏好是本地用户的私有配置,
+不得成为仓库配置。
 
-Routes map a standardized local path prefix to a profile UUID. The longest directory-boundary match
-wins; an optional per-runtime default covers unmatched repositories. Resolution is read-only and
-creates no directories. A route only chooses the initial recommendation—explicitly selecting another
-profile always wins. The selected profile is recorded on the new surface at launch, so later route
-edits never relabel or mutate an active pane.
+一个 profile 包含:稳定 UUID、显示名、启用状态、runtime、可选 model、可选 reasoning
+effort、既有的显式 execution mode,以及**可选的账号绑定**。V1 暴露两家验证过的通用档位
+**Low / Medium / High**,`nil` 表示 runtime 默认;两个 adapter 各自渲染同一意图:Claude
+Code 用 `--effort`,Codex 用类型化的 `model_reasoning_effort` config override。
+`.unrestricted` 保留但视觉上标记为危险,保存时需要显式确认;绝不从其他 profile 或来源
+pane 推断。
 
-### Runtime home and credentials
+**未绑定账号的 profile(默认)**:不派生目录、不设置环境变量、不显示登录控件;状态栏
+说明其使用系统默认登录。
 
-Each profile derives its home from its UUID below Prowl's data directory, never from its display
-name or a user-supplied path. Launch preparation creates the runtime's directory before spawning the
-shell (Codex refuses a nonexistent `CODEX_HOME`), checks that the resolved path remains inside the
-profile-home base, and applies restrictive owner-only permissions.
+**绑定账号的 profile**:编辑器提供 **Sign In**、**Refresh status**、**Reveal Profile
+Files**。Sign In 新开一个已附加 profile 环境的终端 tab,运行该 runtime 的常规登录命令。
+状态探测以 CLI 输出而非退出码为准:两家 CLI 都可能在未登录时返回非零,Codex 可能经
+stderr 报告。home 不存在时直接判定"未登录",不得先调用 Codex。绑定开关旁必须写明隔离
+代价:该 profile 将拥有独立的 skills、全局指令与 session 历史。
 
-The home is intentionally opaque to Prowl. The relevant environment variable is added only to the
-new terminal surface—`CLAUDE_CONFIG_DIR` for Claude Code or `CODEX_HOME` for Codex—so the launched
-agent and its children see the selected context. Prowl does not parse, copy, or display credential
-files. Users manage runtime-supported files in that home; this is where profile-specific skills,
-plugins, and instruction files live. Project-owned instructions remain project-owned.
+### 启动与 Agents 菜单
 
-Raw API-key entry is deferred. If it is added later, it must use a Keychain reference and an
-agent-only launch boundary, never a persisted value or a key placed in a long-lived terminal shell
-environment.
+Agents capsule 不再因无运行中 agent 而禁用,而是**永远作为菜单**存在:
 
-## Implementation approach
+- 无 agent 时:当前 worktree 的 **Recommended** profile 排最前,其后是全部已启用
+  profile;不可用项(CLI 未安装、profile 被禁用)灰显并展示原因;底部提供
+  "Manage Agent Profiles…" 直达 Settings。
+- 有运行中 agent 时:保留现有 Active Agents / Hand Off 内容,并附带上述启动项。
 
-1. Introduce a Codable `AgentProfile` domain model plus route resolver and normalization tests.
-   Restrict its runtime enum to Claude Code and Codex, validate nonempty names/unique UUIDs, and
-   discard routes to unavailable profiles during normalization. Extend
-   `supacode/Features/Settings/Models/UserGlobalSettings.swift` and its shared key without breaking
-   existing JSON that lacks the new fields.
-2. Separate interactive starts from prompted starts in
-   `supacode/Domain/AgentRuntime/AgentRuntimeAdapter.swift`. A structured start intent must be
-   `.interactive` or `.prompt(String)`, never an empty prompt sentinel. Extend
-   `AgentLaunchConfiguration` with optional reasoning effort and have each verified adapter own its
-   argv/config mapping and validation.
-3. Resolve a profile into one launch specification: profile UUID, typed start request, and
-   environment patch. Extend `supacode/Clients/Terminal/TerminalClient.swift` and the surface
-   creation path in `supacode/Features/Terminal/Models/WorktreeTerminalState.swift` so that a new
-   tab receives the patch through `GhosttySurfaceView(environment:)`; do not prepend environment
-   assignments to shell input. Record the launch profile per surface alongside the existing
-   detection state.
-4. Add a small Settings reducer/view for profile editing, status/login actions, and route editing.
-   Keep file operations behind an injected profile-home dependency so tests never touch real login
-   directories.
-5. Extend `supacode/Features/Repositories/Views/AgentsToolbarButton.swift` and its wiring in
-   `supacode/Features/Repositories/Views/WorktreeDetailView.swift`. The detected-agent state keeps
-   its current Hand Off action; the no-agent state lists profiles and dispatches one profile-launch
-   action through `AppFeature`.
-6. After implementation, update the matching current-behavior documentation and write
-   `001-action.md` with the actual PR/test evidence.
+选择 profile 即在该 worktree 新建 tab 并以交互模式启动 runtime,无初始 prompt。绝不向
+既有 shell 注入文本:Prowl 无法证明那个 shell 处于空闲、可安全接管的状态。
 
-## Lessons carried forward from #617
+Prowl 启动的 surface 在创建时记录 profile UUID;检测到但非 Prowl 启动的 agent 只显示
+"检测到 Codex"这类事实,绝不猜测其归属的 profile 或账号。
 
-| Finding | Profile decision |
+### 路由
+
+Route 把标准化的本地路径前缀映射到 profile UUID。最长目录边界匹配获胜;可选的
+per-runtime 默认项覆盖未匹配的仓库。解析是只读的,不创建任何目录。Route 只决定初始
+推荐——显式选择其他 profile 永远优先。profile 在启动时记录到新 surface 上,之后的 route
+编辑绝不重新标记或修改活跃 pane。
+
+### 账号绑定与 runtime home(opt-in)
+
+账号绑定由 adapter 能力位(`supportsAccountIsolation`)门控;两家已验证 runtime 均通过
+`CLAUDE_CONFIG_DIR` / `CODEX_HOME` 支持。
+
+绑定 profile 的 home 从其 UUID 派生,位于 Prowl 数据目录之下,绝不来自显示名或用户
+提供的路径。启动准备阶段先创建 runtime 目录(Codex 拒绝不存在的 `CODEX_HOME`)、校验
+解析后的路径仍在 profile-home 基目录内,并施加 owner-only 权限。
+
+home 对 Prowl 是不透明的:对应环境变量只附加到新终端 surface——Claude Code 用
+`CLAUDE_CONFIG_DIR`,Codex 用 `CODEX_HOME`——使启动的 agent 及其子进程看到选定上下文。
+Prowl 不解析、不复制、不展示凭据文件。用户在该 home 内自行管理 runtime 支持的文件;
+项目内的指令文件仍归项目所有。
+
+Follow-up(非 V1):为绑定 profile 提供子目录级的显式共享开关(目录 symlink 接回默认
+home 的 skills/、session 目录)。#617 的分叉教训针对的是会被 CLI 原子重写的文件
+(`settings.json`、`config.toml`、`auth.json`),这几个永远不得共享;以读为主的子目录
+风险可控,但仍需逐 runtime 验证后才能提供。
+
+## 实现方式
+
+1. 引入 Codable 的 `AgentProfile` domain model(preset 字段 + 可选账号绑定)与 route
+   resolver 及 normalization 测试。runtime enum 限定为 Claude Code 与 Codex,校验非空
+   显示名与 UUID 唯一性,normalization 时丢弃指向不可用 profile 的 route。扩展
+   `supacode/Features/Settings/Models/UserGlobalSettings.swift` 及其 shared key,兼容缺少
+   新字段的既有 JSON。
+2. 在 `supacode/Domain/AgentRuntime/AgentRuntimeAdapter.swift` 中把启动意图类型化为
+   `.interactive` 或 `.prompt(String)`,禁止空 prompt 哨兵。`AgentLaunchConfiguration`
+   增加可选 reasoning effort,由各 adapter 自行完成 argv/config 映射与校验。为 adapter
+   增加能力位:V1 实际使用 `supportsAccountIsolation`,为 handoff 与指令注入预留位置,
+   取代散落的品牌硬编码判断。
+3. 把 profile 解析为单一 launch specification:profile UUID、类型化启动请求、argv,以及
+   **仅账号绑定时非空**的环境 patch。扩展 `supacode/Clients/Terminal/TerminalClient.swift`
+   与 `supacode/Features/Terminal/Models/WorktreeTerminalState.swift` 的 surface 创建路径,
+   使新 tab 经 `GhosttySurfaceView(environment:)` 接收 patch;不得把环境变量赋值拼进
+   shell 输入。在既有检测状态旁记录每个 surface 的启动 profile。
+4. 新增小型 Settings reducer/view:profile 编辑、route 编辑,以及账号绑定分支的状态/登录
+   动作。文件操作全部藏在注入的 profile-home dependency 之后,测试绝不触碰真实登录目录。
+5. 扩展 `supacode/Features/Repositories/Views/AgentsToolbarButton.swift` 及其在
+   `supacode/Features/Repositories/Views/WorktreeDetailView.swift` 中的接线:改为永远是
+   菜单;检测态保留现有 Hand Off 动作,启动项经 `AppFeature` 派发单一 profile-launch
+   action。
+6. 实现完成后,更新对应的现状文档,并以实际 PR 与测试证据撰写 `001-action.md`。
+
+## 从 #617 带入的经验
+
+| 发现 | Profile 决策 |
 | --- | --- |
-| Per-surface environment variables isolate two CLI logins. | Apply the environment only at the new-surface launch boundary. |
-| `CODEX_HOME` must exist before Codex starts. | Provision the derived home before launch or login. |
-| A relocated home contains settings and skills as well as auth. | Treat a profile home as a complete context, not an auth-file holder. |
-| Linking shared configuration can silently diverge when a CLI rewrites a symlink. | Do not auto-link or repair shared configuration in V1; make profile files explicit. |
-| Account/path changes must not alter a live pane. | Record profile ID at surface creation; routes affect later starts only. |
-| Auth status output is stream- and exit-code-sensitive. | Parse known output from both streams behind a testable client. |
+| Per-surface 环境变量可隔离两份 CLI 登录。 | 环境变量只在新 surface 启动边界施加,且仅限账号绑定 profile。 |
+| `CODEX_HOME` 必须在 Codex 启动前存在。 | 启动或登录前先创建派生 home。 |
+| 搬迁后的 home 包含 settings 与 skills,不止认证文件。 | 隔离是全有或全无的账号轴代价,因此 preset 为默认、绑定为 opt-in。 |
+| 共享配置的 symlink 会在 CLI 重写文件时静默分叉。 | V1 不做任何自动 link;被重写的文件永不共享,子目录共享留作显式 follow-up。 |
+| 账号/路径变化不得影响活跃 pane。 | surface 创建时记录 profile ID;route 只影响后续启动。 |
+| 认证状态输出对流与退出码敏感。 | 在可测试的 client 后解析两条流的已知输出。 |
 
-## Handoff boundary
+## Handoff 边界
 
-Profiles are a V1 **start** feature, matching the boundary set in 049. Their stable ID and resolved
-launch specification are intentionally reusable by handoff, but V1 leaves its target list as the
-existing agent list.
+Profile 是 V1 的**启动**特性,与 049 划定的边界一致。其稳定 ID 与解析后的 launch
+specification 有意可被 handoff 复用,但 V1 的 handoff 目标列表维持现有 agent 列表不变。
 
-A later handoff integration must carry the selected profile through both paths: the HUD's injected
-request and the CLI/fallback handler. Updating only
-`supacode/Features/HandoffHud/Reducer/HandoffHudFeature.swift` would make the fallback silently
-lose the profile because `supacode/CLIService/HandoffCommandHandler.swift` currently rebuilds an
-inherited configuration. That wave should extend the structured handoff request/registry boundary;
-it must not read “whatever profile is current” after the request begins.
+未来的 handoff 集成必须让选定 profile 同时贯穿两条路径:HUD 的注入请求与 CLI/fallback
+处理器。只更新 `supacode/Features/HandoffHud/Reducer/HandoffHudFeature.swift` 会让 fallback
+静默丢失 profile,因为 `supacode/CLIService/HandoffCommandHandler.swift` 目前会重建继承
+配置。该阶段应扩展结构化的 handoff request/registry 边界;绝不能在请求开始后再读取
+"当前 profile"。
 
-## Verification
+## 验证
 
-- Domain tests: profile normalization, UUID stability, invalid/missing routes, longest path-boundary
-  routing, and no persisted secret material.
-- Adapter tests in `supacodeTests/AgentRuntimeAdapterTests.swift`: no-prompt interactive argv,
-  model/effort mapping, standard vs. dangerous mode, and shell quoting.
-- Settings and profile-home tests: legacy decode, save/reload, owner-only derived directories,
-  missing-home status, stdout/stderr/non-zero login status, and no real credential access.
-- Reducer/terminal tests: no-agent launcher availability, correct worktree/cwd/environment patch,
-  one new tab per selection, and stable surface profile identity after route edits.
-- Manual: sign into two Claude Code or Codex profiles, launch each side by side, and confirm each
-  CLI reports its own identity; then change a route and confirm only a later launch changes.
+- Domain 测试:profile normalization、UUID 稳定性、非法/缺失 route、最长路径边界匹配、
+  旧版 JSON 解码、无任何持久化的敏感材料;纯 preset profile 必须产生空环境 patch。
+- Adapter 测试(`supacodeTests/AgentRuntimeAdapterTests.swift`):无 prompt 的交互式
+  argv、model/effort 映射、标准与危险模式、shell 转义、能力位取值。
+- Settings 与 profile-home 测试:保存/重载、绑定 profile 的派生目录 owner-only 权限、
+  home 缺失时的状态判定、stdout/stderr/非零退出码的登录状态解析、绝不访问真实凭据。
+- Reducer/终端测试:菜单各可用性状态、正确的 worktree/cwd/环境 patch、每次选择恰好新建
+  一个 tab、route 编辑后 surface 的 profile 身份保持稳定、纯 preset 启动不设任何环境
+  变量。
+- 手动验证:(a) 同一 runtime 的两个纯 preset(不同 model/effort)并排启动,确认共享同一
+  登录且 `--resume` 历史统一;(b) 两个账号绑定 profile 分别登录不同账号并排运行,确认
+  各 CLI 报告自己的身份;(c) 修改 route 后确认只有后续启动受影响。
 
-## Alternatives and decisions
+## 备选与决策
 
-- **Profile homes over raw credentials.** This preserves the CLI's supported authentication flow and
-  avoids turning Prowl into a secret manager. Keychain-backed API keys need a different, carefully
-  scoped execution design.
-- **New tab over current-shell injection.** It protects in-progress shell work and gives the agent a
-  coherent environment from process start.
-- **Profile routes over per-repository persisted account names.** A global, longest-prefix resolver
-  gives automatic work/personal selection without leaking local identities into repository config.
-- **No automatic shared-config symlinks.** The convenience is real, but the ambiguity and silent
-  divergence observed in #617 make it the wrong V1 default.
-- **Handoff follow-up rather than partial integration.** A profile-aware handoff must be correct in
-  both normal and fallback execution paths; postponing it is safer than making the two disagree.
+- **Preset 优先,而非 home 优先。** 初稿把私有 home 当作 profile 本体,把账号轴的隔离
+  代价强加给所有 profile;重写后 preset 是默认形态,绝大多数用例零副作用。
+- **隔离 opt-in,而非无条件。** 用户显式勾选账号绑定并知情承担 skills/历史隔离的代价;
+  UI 必须写明该代价。
+- **能力位,而非品牌硬编码。** `supportsAccountIsolation` 等 adapter 能力位使 V1 仍只
+  发货两家 runtime,但结构上为后续 runtime 留门。
+- **Profile home 优于裸凭据。** 保留 CLI 支持的认证流程,避免 Prowl 变成密钥管理器;
+  Keychain 引用只对未来的裸 API key 场景有意义,整体推迟。
+- **新 tab 优于向当前 shell 注入。** 保护进行中的 shell 工作,并让 agent 从进程启动起
+  就拥有一致环境。
+- **全局路径 route 优于 per-repository 持久化账号名。** 最长前缀解析自动完成工作/个人
+  切换,不把本地身份泄漏进仓库配置。
+- **不做自动共享配置 symlink。** 便利是真实的,但 #617 观察到的歧义与静默分叉使其不适
+  合作为 V1 默认;子目录级显式共享作为 follow-up 逐项验证。
+- **指令/skill 注入推迟。** Codex 侧没有已验证的注入机制;作为 adapter 能力位在后续
+  波次实现,避免 V1 只对单一 runtime 成立的承诺。
+- **Handoff 后续跟进,而非部分集成。** Profile-aware 的 handoff 必须在正常与 fallback
+  两条执行路径上同时正确;推迟比让两者不一致更安全。
 
 ## Amendments
+
+- 2026-07-29 — 依据与 onevcat 的设计讨论全文重写并改用中文:profile 从"私有 runtime
+  home"重新定义为"preset + 可选账号绑定";新增 adapter 能力位与永远是菜单的 Agents
+  capsule;指令/skill 注入与子目录共享明确列为 follow-up;handoff 边界维持不变。

--- a/docs-ai/053-agent-profiles/001-action.md
+++ b/docs-ai/053-agent-profiles/001-action.md
@@ -1,0 +1,63 @@
+# 053 — Agent Profiles: Action
+
+| | |
+| --- | --- |
+| **日期** | 2026-07-29 |
+| **分支** | `agent/agent-profiles-v1` |
+| **前置** | [000-plan.md](000-plan.md)(含全部讨论修订)· [002-home-spike.md](002-home-spike.md)(HOME 实测) |
+
+## 实施概要
+
+按计划分五个提交块实现,每块独立通过测试、lint 与构建:
+
+1. **`8fa9c5b5` — domain 与 adapter**:`AgentProfile` 模型(preset 字段 + placement +
+   可选账号绑定)、normalization、三层推荐 resolver、`ShellWordSplitter`;
+   `AgentStartIntent`(`.interactive` / `.prompt` / `.headless`)取代恒有 prompt,
+   handoff 调用点迁移;`AgentLaunchConfiguration` 增加 effort 与 extraArguments
+   (向后兼容解码);adapter 声明能力位(`CLAUDE_CONFIG_DIR` / `CODEX_HOME`)与
+   effort 建议;`UserGlobalSettings` / `UserRepositorySettings` 扩展。
+2. **`b542cadb` — launch plan 与终端/检测**:`AgentProfileLaunchPlanner`(纯函数,
+   预览与启动共用渲染)、`AgentProfileHomeProvisioner`(0700 + 包含校验)、
+   `~/.prowl/agent-profiles/` 路径;`TerminalClient.launchAgentProfile` 经
+   `GhosttySurfaceView(environment:)` 注入补丁,split 无可分割时退化为 tab,
+   surface 记录 launch 身份;claude/codex 的 `AgentSessionProfile` 增加 rooted
+   布局,resolver 对绑定 surface 独占使用。
+3. **`ff536478` — AppFeature**:单一 `launchAgentProfile` action(解析 → 计划 →
+   终端命令 + per-repo 记忆);`AgentProfileSeeder` 启动时一次性播种(安装启发:
+   默认 home 存在),删除的种子不复活。
+4. **`a87d8f69` — Settings UI**:独立 Agents tab(列表顺序即兜底优先级、编辑器、
+   Advanced 附加参数/绑定/预览);`.unrestricted` 保存前确认;绑定 profile 删除
+   走"确认 + 默认保留 + 可选 Trash";`AgentProfileHomeClient` 统一文件操作与
+   包含闸;Repo Settings 增加 Default Agent Profile 选择器。
+5. **`cf446750` — 入口与身份露出**:Agents capsule 永远是菜单(Hand Off 领衔、
+   推荐排前、未安装灰显示因、Manage 入口);palette "Launch Agent" 行共享同一
+   action;Prowl 启动的 pane 在 Active Agents/capsule 显示 launch 时冻结的
+   profile 名。
+
+文档同步:新增 `docs/components/agent-profiles.md`,并更新 settings /
+command-palette / active-agents / handoff 与 `docs/README.md` 索引。
+
+## 测试证据
+
+- 全量套件:`make test` 通过,**2105 个测试全绿**(5 个 warning 为 SPM 依赖扫描
+  既有噪音)。
+- 新增/扩展:`AgentProfileTests`(normalization、推荐回退、splitter、launch plan、
+  包含校验、provisioner 权限、settings 兼容解码)、`AgentRuntimeAdapterTests`
+  (三态 argv、effort 映射、附加参数顺序、能力位、legacy 解码)、
+  `AgentProfilesFeatureTests`(增删改排、unrestricted 确认、绑定删除 Trash、
+  repo 默认持久化)、`AppFeatureAgentProfileTests`(launch 命令与记忆、禁用忽略、
+  播种一次性、palette 条目、身份展示)、`AgentSessionProfileTests` rooted 布局。
+- `make check` 与 `make build-app` 全程零错误零警告。
+- 前置实测见 002-home-spike.md(指令文件/skills 原生拾取、凭证落点、并行登录
+  无串号、真实 home 零污染)。
+
+## 与计划的偏差
+
+1. **model 建议列表未实现**:model 为纯自由文本,只有 effort 有 adapter 建议列表。
+   原因:没有可靠的已验证 model 目录,硬编码会立即过时;后续可与 effort 同构补上。
+2. **resume 携带环境补丁推迟到 handoff 波次**:检测层的 config root 已实现,但
+   `AgentResumeRequest` 未增加环境字段——填充它需要 handoff 的结构化请求改造
+   (正是计划明确推迟的双路径工程)。当前从绑定 pane 发起 handoff 时,briefing
+   resume 会找不到 session 并优雅降级为 context-only。已知且可接受。
+3. **Settings 列表排序用上下移动(右键菜单)而非拖拽**:Form 内拖拽在 macOS 上
+   体验不佳;顺序语义(兜底优先级)不受影响。

--- a/docs-ai/053-agent-profiles/002-home-spike.md
+++ b/docs-ai/053-agent-profiles/002-home-spike.md
@@ -1,0 +1,53 @@
+# 053 — HOME Path Spike(账号绑定可行性实测)
+
+| | |
+| --- | --- |
+| **日期** | 2026-07-29 |
+| **版本** | Claude Code 2.1.220 · codex-cli 0.144.6 · macOS 26 |
+| **方法** | 全新目录 + headless 探测(`claude -p` / `codex exec`)+ 用户交互登录 + 预埋标记文件(`CLAUDE.md` / `AGENTS.md` 魔法词、`skills/spike-probe`) |
+| **spike 目录** | `~/.prowl/agent-profiles-spike/{claude-a,codex-a}` |
+
+## 结论
+
+计划(000-plan)中账号绑定设计依赖的**全部关键假设均被实测证实**,无一需要修改。
+
+## 实测发现
+
+1. **Codex 拒绝不存在的 `CODEX_HOME`**:`Error finding codex home: … does not exist`。
+   → 证实"启动前必须创建派生 home"。
+2. **Codex 自初始化空 home**:首次运行即创建 `installation_id`、sqlite 状态库、
+   `sessions/` 日期树、`skills/.system` 等;未登录 headless 直接 401。
+3. **Codex rollout 跟随新根**:
+   `$CODEX_HOME/sessions/2026/07/29/rollout-<ts>-<uuid>.jsonl`——布局形状与
+   `AgentSessionProfile` 假设一致,但路径中**没有 `.codex` 组件**。
+   → 证实检测层 parsePath 的全局子串 marker 必须改为按已知 config root 前缀匹配
+   (实现步骤 4)。
+4. **Claude 未登录行为**:输出 `Not logged in · Please run /login`;且未登录时即在
+   config dir 内创建 `.claude.json`(状态文件跟随搬迁)与
+   `projects/<encoded cwd>/<uuid>.jsonl`(transcript 根跟随搬迁);cwd 编码与检测层
+   `alphanumericDashed` 规则吻合。
+5. **`$CLAUDE_CONFIG_DIR/CLAUDE.md` 被原生读取**:魔法词测试回答 `PROFILE-CLAUDE-A`。
+6. **`$CODEX_HOME/AGENTS.md` 被原生读取**:魔法词测试回答 `PROFILE-CODEX-A`。
+   → 5/6 共同证实:绑定 profile 的专属指令无需任何注入机制。
+7. **skills 从搬迁 home 被原生拾取**:两家对 `skills/spike-probe` 均回
+   `SKILL-LOADED-OK`。
+8. **凭证落点**:Codex 登录后 `auth.json`(0600)落在 `$CODEX_HOME`;Claude 的
+   `.claude.json`(0600)在 config dir,OAuth token 走 macOS Keychain(CLI 内部机制)。
+   spike 全程默认账号会话与 spike 账号会话**并行运行无串号**,行为层面证实隔离。
+9. **真实 home 零污染**:以基线时间戳复查,`~/.claude/projects` 与 `~/.codex/sessions`
+   在 spike 期间无任何新增写入(排除本会话自身 transcript)。
+10. **TUI 首启即登录流程成立**:用户以
+    `CLAUDE_CONFIG_DIR=… claude` / `CODEX_HOME=… codex` 启动全新 home 的 TUI,原生
+    引导完成登录——证实删除 Sign In 按钮的决策(首次启动即登录时刻)。
+
+## 对计划的确认
+
+- 账号绑定机制(env 只挂新 surface、home 预创建、0600 权限、CLI 自管认证)按原计划实施。
+- 实现步骤 4(session 检测 config root 参数化)是必要且充分的修法,发现 3/4 提供了
+  精确证据。
+- 无新增风险项;无需修改 000-plan。
+
+## Spike 残留物
+
+`~/.prowl/agent-profiles-spike/` 保留,供实现阶段手动测试复用(**内含两份真实登录
+凭证**,不再需要时应整体移入废纸篓)。

--- a/docs-ai/README.md
+++ b/docs-ai/README.md
@@ -104,4 +104,4 @@ agent-facing manual for that).
 | 050 | [sidebar-expand-active-and-worktree-tab-badges](050-sidebar-expand-active-and-worktree-tab-badges/000-plan.md) | 2026-07-25 | Sidebar Expand Active third state + per-worktree tab count badges |
 | 051 | [repository-icon-detection](051-repository-icon-detection/000-plan.md) | 2026-07-25 | High-confidence local repository icon detection on add; deferred, reviewable Foundation Model recommendations |
 | 052 | [sidebar-context-menus](052-sidebar-context-menus/000-plan.md) | 2026-07-27 | Sidebar context menu overhaul: worktree terminal actions, header/workspace path actions, PR click-through |
-| 053 | [agent-profiles](053-agent-profiles/000-plan.md) | 2026-07-29 | Agent Profile V1: typed Claude Code/Codex launch contexts, profile homes, routing, and future handoff seam |
+| 053 | [agent-profiles](053-agent-profiles/000-plan.md) | 2026-07-29 | Agent Profile V1: preset-first Claude Code/Codex launch profiles, opt-in account isolation, path routing, and future handoff seam |

--- a/docs-ai/README.md
+++ b/docs-ai/README.md
@@ -104,3 +104,4 @@ agent-facing manual for that).
 | 050 | [sidebar-expand-active-and-worktree-tab-badges](050-sidebar-expand-active-and-worktree-tab-badges/000-plan.md) | 2026-07-25 | Sidebar Expand Active third state + per-worktree tab count badges |
 | 051 | [repository-icon-detection](051-repository-icon-detection/000-plan.md) | 2026-07-25 | High-confidence local repository icon detection on add; deferred, reviewable Foundation Model recommendations |
 | 052 | [sidebar-context-menus](052-sidebar-context-menus/000-plan.md) | 2026-07-27 | Sidebar context menu overhaul: worktree terminal actions, header/workspace path actions, PR click-through |
+| 053 | [agent-profiles](053-agent-profiles/000-plan.md) | 2026-07-29 | Agent Profile V1: typed Claude Code/Codex launch contexts, profile homes, routing, and future handoff seam |

--- a/docs/README.md
+++ b/docs/README.md
@@ -51,6 +51,7 @@ its keyboard shortcuts, detailed behavior, settings, and gotchas.
 | [`components/command-palette.md`](components/command-palette.md) | `⌘P` searchable command launcher; every action category it exposes. |
 | [`components/active-agents.md`](components/active-agents.md) | The Active Agents panel: a live list of every running agent and its status, with one-click jump-to-agent. |
 | [`components/agent-detection.md`](components/agent-detection.md) | How Prowl knows an agent is Working / Blocked / Idle / Done, which agents it recognizes, and how the status indicator works. |
+| [`components/agent-profiles.md`](components/agent-profiles.md) | Agent Profiles: named launch presets for Claude Code/Codex (model, effort, mode, placement), the Agents launcher menu, recommended-profile resolution, and opt-in dedicated homes for separate accounts. |
 | [`components/notifications.md`](components/notifications.md) | Agent-finished reminders, command-finished notifications, the bell/unread indicators, and Dock badge/bounce. |
 | [`components/diff-view.md`](components/diff-view.md) | Show Diff (`⌘⇧Y`) for working-tree changes vs HEAD, plus Outgoing Changes for pull-request branch diffs. |
 | [`components/github-pull-requests.md`](components/github-pull-requests.md) | GitHub PR integration via `gh`: PR status, CI checks, merge/close/re-run actions from the command palette. |

--- a/docs/components/active-agents.md
+++ b/docs/components/active-agents.md
@@ -28,7 +28,9 @@ Command Palette → "Toggle Active Agents Panel".
   icon even though it reports as the Pi agent; unknown wrappers fall back to the
   agent icon, then a sparkle).
 - **Title** — detected command/agent name + repository (repo color-coded);
-  command aliases such as `omp` are shown directly.
+  command aliases such as `omp` are shown directly. Panes Prowl launched from
+  an [agent profile](agent-profiles.md) show the profile's display name
+  instead (frozen at launch).
 - **Subtitle** — the agent's pane title (if `showActiveAgentTabTitles`) or branch
   name. The pane title is the surface's own terminal title, falling back to the
   tab title, so agents in different splits of one tab keep distinct subtitles.

--- a/docs/components/agent-profiles.md
+++ b/docs/components/agent-profiles.md
@@ -1,0 +1,88 @@
+# Agent Profiles
+
+> Named launch presets for the verified agents (Claude Code, Codex): one click
+> in the toolbar **Agents** menu or the Command Palette starts a fresh agent in
+> the current worktree with your model, effort, mode, and — optionally — a
+> dedicated account.
+
+**Keywords:** agent profile, preset, launch agent, agents menu, dedicated home, account, CLAUDE_CONFIG_DIR, CODEX_HOME, recommended profile
+
+**Related:** [handoff](handoff.md) · [active-agents](active-agents.md) · [command-palette](command-palette.md) · [settings](settings.md)
+
+## What a profile is
+
+A profile is a named preset for one runtime: display name, optional model,
+optional reasoning effort (free text with per-runtime suggestions), execution
+mode (Standard / Unrestricted), and a launch placement (New Tab or New Split
+with a direction). By default a profile is **argv-only**: launching it is
+exactly like typing `claude`/`codex` with those flags yourself — same login,
+same skills, same session history. The same runtime can have any number of
+profiles.
+
+On first run Prowl seeds one bare profile per installed runtime. Seeds are
+ordinary profiles: rename, edit, or delete them freely — deleted seeds never
+respawn.
+
+## Launching
+
+- **Toolbar Agents capsule** — always opens a popover. With a detected agent it
+  leads with Hand Off; launch rows follow, the current worktree's
+  **Recommended** profile first. Rows for runtimes that are not installed are
+  grayed with the reason. "Manage Agent Profiles…" opens Settings → Agents.
+- **Command Palette** (`⌘P`) — "Launch Agent: <name>" rows dispatch the exact
+  same action.
+
+A launch creates a **new** tab (or split, per placement) in the current
+worktree, running the agent interactively with no initial prompt. Prowl never
+types into an existing shell. The new pane records its profile identity at
+creation: the Active Agents rows and the capsule show the profile's display
+name (frozen at launch — later renames don't relabel live panes).
+
+**Recommended** resolves in three tiers: the repo's **Default Agent Profile**
+(Repo Settings) → the last profile explicitly launched in this repo → the
+first enabled profile in the Settings list order. Each tier only matches an
+existing, enabled profile.
+
+## Dedicated home (separate account)
+
+Toggling **Use Dedicated Home** (Advanced) gives the profile its own runtime
+home under `~/.prowl/agent-profiles/<uuid>/`, attached to the new surface via
+`CLAUDE_CONFIG_DIR` / `CODEX_HOME`. That relocates the runtime's *entire*
+home: separate login and usage, but also separate skills, global instructions
+(`CLAUDE.md` / `AGENTS.md`), and session history. The first launch is the
+sign-in moment — the agent's own TUI walks through login and the credentials
+land inside the profile home. Prowl never reads or copies them; use **Reveal
+Profile Files** to manage skills and instruction files there yourself.
+
+Deleting a bound profile asks first: **Remove Profile** keeps the folder on
+disk, **Remove and Trash Files** moves it to the Trash (never `rm`). Pure
+presets are removed with no file operations at all.
+
+## Advanced extra arguments
+
+The **Extra Arguments** field appends literal argv tokens after the
+preset-generated options (quotes group values with spaces; nothing is ever
+shell-interpreted). The **Launch Preview** at the bottom of the editor shows
+the exact rendered invocation — including the env prefix for bound profiles —
+using the same rendering as the real launch.
+
+## Where things live on disk
+
+| What | Where |
+|------|-------|
+| Profiles + seeding flag | `~/.prowl/global.onevcat.json` |
+| Per-repo default + launch memory | `~/.prowl/repo/<name>/prowl.onevcat.json` |
+| Dedicated profile homes | `~/.prowl/agent-profiles/<uuid>/` |
+
+## Gotchas for agents
+
+- Session detection follows the relocated home for Prowl-launched bound panes
+  (resume and handoff artifacts resolve against the profile's config root).
+  An agent you start manually with your own `CLAUDE_CONFIG_DIR`/`CODEX_HOME`
+  is still detected, but without session identity.
+- Availability graying uses a heuristic: the runtime's default home
+  (`~/.claude` / `~/.codex`) exists iff the CLI has ever run.
+- Prowl provides no directory sharing between a bound home and the default
+  one. Symlinking read-mostly directories (e.g. `skills/`) yourself works, but
+  never link files the CLI rewrites (`settings.json`, `config.toml`,
+  `auth.json`) — atomic rewrites replace the symlink and silently diverge.

--- a/docs/components/agent-profiles.md
+++ b/docs/components/agent-profiles.md
@@ -62,7 +62,10 @@ presets are removed with no file operations at all.
 
 The **Extra Arguments** field appends literal argv tokens after the
 preset-generated options (quotes group values with spaces; nothing is ever
-shell-interpreted). The **Launch Preview** at the bottom of the editor shows
+shell-interpreted). Your flags are respected as-is — including bypass flags
+like `--yolo` or `--dangerously-skip-permissions` — but the editor recognizes
+them and shows the unrestricted-execution warning even when the Execution
+Mode picker says Standard, so the display never lies about the effective mode. The **Launch Preview** at the bottom of the editor shows
 the exact rendered invocation — including the env prefix for bound profiles —
 using the same rendering as the real launch.
 

--- a/docs/components/agent-profiles.md
+++ b/docs/components/agent-profiles.md
@@ -62,10 +62,13 @@ presets are removed with no file operations at all.
 
 The **Extra Arguments** field appends literal argv tokens after the
 preset-generated options (quotes group values with spaces; nothing is ever
-shell-interpreted). Your flags are respected as-is — including bypass flags
-like `--yolo` or `--dangerously-skip-permissions` — but the editor recognizes
-them and shows the unrestricted-execution warning even when the Execution
-Mode picker says Standard, so the display never lies about the effective mode. The **Launch Preview** at the bottom of the editor shows
+shell-interpreted). Your flags are respected as-is. The editor stays honest
+about what it can prove: recognized bypass flags (`--yolo`,
+`--dangerously-skip-permissions`, …) show the red unrestricted warning even
+when the picker says Standard; any other extra argument (including
+`--sandbox`/`--ask-for-approval`/`-c` overrides) shows a neutral "effective
+execution mode follows your extra arguments" note instead of claiming
+Standard — the semantics belong to your command line. The **Launch Preview** at the bottom of the editor shows
 the exact rendered invocation — including the env prefix for bound profiles —
 using the same rendering as the real launch.
 

--- a/docs/components/command-palette.md
+++ b/docs/components/command-palette.md
@@ -51,6 +51,10 @@ selected worktree has a pull request).
   agent to write its briefing and run the hand-off itself, with fork and
   context-only fallbacks available while you wait. Same flow as the toolbar
   Agents capsule. See [handoff](handoff.md).
+- **Agent profiles** (when a terminal worktree is selected): a
+  **Launch Agent: <name>** row per enabled profile, the current worktree's
+  Recommended profile first — the same launch action as the toolbar Agents
+  menu. See [agent-profiles](agent-profiles.md).
 - **Debug** (Debug builds only): toast/update/dock simulations.
 
 ## Behavior notes

--- a/docs/components/handoff.md
+++ b/docs/components/handoff.md
@@ -167,7 +167,11 @@ same agent family. Full flag/payload reference: [cli](cli.md#prowl-handoff).
 A capsule button left of the branch title identifies the selected pane's
 detected agent. Clicking it opens a popover whose hand-off row explains the
 action — "Pass this task to another agent in a new tab; <agent> writes its own
-briefing first" — and opens a centered HUD. The Command Palette (`⌘P`) offers
+briefing first" — and opens a centered HUD. The popover is always available:
+below the hand-off row it lists launchable
+[agent profiles](agent-profiles.md) (Recommended first) and a
+"Manage Agent Profiles…" entry, so the capsule doubles as the launcher even
+when no agent is detected. The Command Palette (`⌘P`) offers
 the same flow as a single **Hand Off…** row; so does right-clicking a row in
 the [Active Agents panel](active-agents.md), which targets the row's own pane.
 

--- a/docs/components/settings.md
+++ b/docs/components/settings.md
@@ -24,14 +24,16 @@ window is a sidebar of tabs plus a detail pane.
 | **Advanced** | Analytics, crash reports, restore terminal layout on launch (experimental) + clear saved layout, and the **Install Command Line Tool** (`prowl` CLI) action. |
 | **GitHub** | Enable GitHub integration (uses the `gh` CLI). → [github-pull-requests](github-pull-requests.md) |
 | **Commands** | Global Custom Commands. Enabled commands appear in the window toolbar; each repo can independently hide a Global command. → [custom-actions](custom-actions.md) |
-| **Repositories / Repo Settings** | Per-repository: setup/archive/run scripts, **Custom Commands**, Global-command visibility, default base ref & directory, copy-files overrides, open-with app, custom title, icon & color, PR merge strategy, line-diff & PR-state fetching. Reached from the sidebar context menu → "Repo Settings". → [custom-actions](custom-actions.md), [repositories-and-worktrees](repositories-and-worktrees.md) |
+| **Agents** | Agent Profiles: named launch presets for Claude Code/Codex (model, effort, execution mode, tab/split placement, extra arguments, opt-in dedicated home for a separate account) with a live launch preview. List order is the recommendation fallback. → [agent-profiles](agent-profiles.md) |
+| **Repositories / Repo Settings** | Per-repository: setup/archive/run scripts, **Custom Commands**, Global-command visibility, **Default Agent Profile**, default base ref & directory, copy-files overrides, open-with app, custom title, icon & color, PR merge strategy, line-diff & PR-state fetching. Reached from the sidebar context menu → "Repo Settings". → [custom-actions](custom-actions.md), [repositories-and-worktrees](repositories-and-worktrees.md) |
 
 ## Where settings live on disk
 
 - **Global:** `~/.prowl/settings.json`
-- **Global custom commands:** `~/.prowl/global.onevcat.json`
+- **Global custom commands + agent profiles:** `~/.prowl/global.onevcat.json`
 - **Per-repo:** `~/.prowl/repo/<repo-name>/prowl.json`
-- **Per-repo custom commands:** `~/.prowl/repo/<repo-name>/prowl.onevcat.json`
+- **Per-repo custom commands + agent profile default/memory:** `~/.prowl/repo/<repo-name>/prowl.onevcat.json`
+- **Dedicated agent profile homes:** `~/.prowl/agent-profiles/<uuid>/`
 
 Legacy `~/.supacode` is migrated to `~/.prowl` on first launch.
 

--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -54,6 +54,7 @@ final class SupacodeAppDelegate: NSObject, NSApplicationDelegate {
     UserDefaults.standard.register(defaults: [
       "ApplePressAndHoldEnabled": false
     ])
+    AgentProfileSeeder.seedIfNeeded()
     appStore?.send(.appLaunched)
   }
 

--- a/supacode/CLIService/HandoffCommandHandler.swift
+++ b/supacode/CLIService/HandoffCommandHandler.swift
@@ -302,7 +302,7 @@ final class HandoffCommandHandler: CommandHandler {
         target,
         AgentStartRequest(
           agent: destinationAgent,
-          prompt: Self.kickoffPrompt(hasBriefing: artifacts.hasBriefing),
+          intent: .prompt(Self.kickoffPrompt(hasBriefing: artifacts.hasBriefing)),
           configuration: configuration
         )
       )

--- a/supacode/Clients/AgentProfile/AgentProfileHomeClient.swift
+++ b/supacode/Clients/AgentProfile/AgentProfileHomeClient.swift
@@ -20,6 +20,8 @@ extension AgentProfileHomeClient: DependencyKey {
     },
     revealHome: { id in
       guard let home = containedHome(for: id) else { return }
+      // provision re-runs the physical containment gate (symlink leaf,
+      // canonical base escape) before touching anything.
       try? AgentProfileHomeProvisioner.provision(
         home: home,
         base: SupacodePaths.agentProfileHomesDirectory
@@ -28,6 +30,10 @@ extension AgentProfileHomeClient: DependencyKey {
     },
     trashHome: { id in
       guard let home = containedHome(for: id) else { return }
+      try AgentProfileHomeProvisioner.validatePhysicalContainment(
+        home: home,
+        base: SupacodePaths.agentProfileHomesDirectory
+      )
       guard FileManager.default.fileExists(atPath: AgentProfileLaunchPlanner.pathString(home)) else {
         return
       }

--- a/supacode/Clients/AgentProfile/AgentProfileHomeClient.swift
+++ b/supacode/Clients/AgentProfile/AgentProfileHomeClient.swift
@@ -1,0 +1,51 @@
+import AppKit
+import Dependencies
+import Foundation
+
+/// All filesystem access for agent profile homes (docs-ai 053). Every
+/// operation re-derives the path from the profile UUID and enforces the
+/// profile-home base containment, so no caller can ever touch a real agent
+/// home; tests inject stubs and never reach login directories.
+struct AgentProfileHomeClient: Sendable {
+  var homeExists: @Sendable (AgentProfile.ID) -> Bool
+  var revealHome: @Sendable (AgentProfile.ID) -> Void
+  var trashHome: @Sendable (AgentProfile.ID) async throws -> Void
+}
+
+extension AgentProfileHomeClient: DependencyKey {
+  static let liveValue = AgentProfileHomeClient(
+    homeExists: { id in
+      guard let home = containedHome(for: id) else { return false }
+      return FileManager.default.fileExists(atPath: AgentProfileLaunchPlanner.pathString(home))
+    },
+    revealHome: { id in
+      guard let home = containedHome(for: id) else { return }
+      try? AgentProfileHomeProvisioner.provision(
+        home: home,
+        base: SupacodePaths.agentProfileHomesDirectory
+      )
+      NSWorkspace.shared.activateFileViewerSelecting([home])
+    },
+    trashHome: { id in
+      guard let home = containedHome(for: id) else { return }
+      guard FileManager.default.fileExists(atPath: AgentProfileLaunchPlanner.pathString(home)) else {
+        return
+      }
+      // Trash, never rm: a mis-click on a home holding real credentials must
+      // stay recoverable.
+      try FileManager.default.trashItem(at: home, resultingItemURL: nil)
+    }
+  )
+
+  static let testValue = AgentProfileHomeClient(
+    homeExists: { _ in false },
+    revealHome: { _ in },
+    trashHome: { _ in }
+  )
+
+  private nonisolated static func containedHome(for id: AgentProfile.ID) -> URL? {
+    let base = SupacodePaths.agentProfileHomesDirectory
+    let home = AgentProfileLaunchPlanner.dedicatedHomeDirectory(for: id, base: base)
+    return AgentProfileLaunchPlanner.isContained(home, in: base) ? home : nil
+  }
+}

--- a/supacode/Clients/Terminal/TerminalClient.swift
+++ b/supacode/Clients/Terminal/TerminalClient.swift
@@ -46,6 +46,7 @@ struct TerminalClient {
       customCommandName: String? = nil,
       customCommandIcon: String? = nil
     )
+    case launchAgentProfile(Worktree, plan: AgentProfileLaunchPlan)
     case createTabInDirectory(Worktree, directory: URL)
     case focusOrCreateTabInDirectory(Worktree, directory: URL, title: String?)
     case ensureInitialTab(Worktree, runSetupScriptIfNew: Bool, focusing: Bool)

--- a/supacode/Domain/AgentProfile/AgentProfile.swift
+++ b/supacode/Domain/AgentProfile/AgentProfile.swift
@@ -15,6 +15,16 @@ nonisolated enum AgentProfileRuntime: String, Codable, CaseIterable, Identifiabl
     case .codex: .codex
     }
   }
+
+  /// The runtime's default home directory name under `$HOME`. Its existence
+  /// is the seeding installation heuristic: the directory exists iff the CLI
+  /// has ever run, while PATH lookups from a GUI app are unreliable.
+  var defaultHomeDirectoryName: String {
+    switch self {
+    case .claude: ".claude"
+    case .codex: ".codex"
+    }
+  }
 }
 
 nonisolated enum AgentProfilePlacement: String, Codable, CaseIterable, Identifiable, Sendable {

--- a/supacode/Domain/AgentProfile/AgentProfile.swift
+++ b/supacode/Domain/AgentProfile/AgentProfile.swift
@@ -1,0 +1,126 @@
+import Foundation
+
+/// The runtimes a profile may launch. Deliberately narrower than
+/// `DetectedAgent`: only runtimes with a verified interactive launch adapter
+/// and a verified account-isolation mechanism are eligible (docs-ai 053).
+nonisolated enum AgentProfileRuntime: String, Codable, CaseIterable, Identifiable, Sendable {
+  case claude
+  case codex
+
+  var id: String { rawValue }
+
+  var agent: DetectedAgent {
+    switch self {
+    case .claude: .claude
+    case .codex: .codex
+    }
+  }
+}
+
+nonisolated enum AgentProfilePlacement: String, Codable, CaseIterable, Identifiable, Sendable {
+  case tab
+  case split
+
+  var id: String { rawValue }
+}
+
+/// A named launch preset for a verified agent runtime (docs-ai 053).
+/// Argv-only by default; an explicit account binding adds a dedicated,
+/// UUID-derived runtime home and nothing else.
+nonisolated struct AgentProfile: Codable, Equatable, Sendable, Identifiable {
+  var id: UUID
+  var name: String
+  var isEnabled: Bool
+  var runtime: AgentProfileRuntime
+  var model: String?
+  var reasoningEffort: String?
+  var executionMode: AgentExecutionMode
+  var placement: AgentProfilePlacement
+  var splitDirection: UserCustomSplitDirection
+  var extraArguments: String
+  var bindsDedicatedHome: Bool
+
+  init(
+    id: UUID = UUID(),
+    name: String,
+    isEnabled: Bool = true,
+    runtime: AgentProfileRuntime,
+    model: String? = nil,
+    reasoningEffort: String? = nil,
+    executionMode: AgentExecutionMode = .standard,
+    placement: AgentProfilePlacement = .tab,
+    splitDirection: UserCustomSplitDirection = .right,
+    extraArguments: String = "",
+    bindsDedicatedHome: Bool = false
+  ) {
+    self.id = id
+    self.name = name
+    self.isEnabled = isEnabled
+    self.runtime = runtime
+    self.model = model
+    self.reasoningEffort = reasoningEffort
+    self.executionMode = executionMode
+    self.placement = placement
+    self.splitDirection = splitDirection
+    self.extraArguments = extraArguments
+    self.bindsDedicatedHome = bindsDedicatedHome
+  }
+
+  private enum CodingKeys: String, CodingKey {
+    case id, name, isEnabled, runtime, model, reasoningEffort, executionMode
+    case placement, splitDirection, extraArguments, bindsDedicatedHome
+  }
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    id = try container.decode(UUID.self, forKey: .id)
+    name = try container.decode(String.self, forKey: .name)
+    isEnabled = try container.decodeIfPresent(Bool.self, forKey: .isEnabled) ?? true
+    runtime = try container.decode(AgentProfileRuntime.self, forKey: .runtime)
+    model = try container.decodeIfPresent(String.self, forKey: .model)
+    reasoningEffort = try container.decodeIfPresent(String.self, forKey: .reasoningEffort)
+    executionMode =
+      try container.decodeIfPresent(AgentExecutionMode.self, forKey: .executionMode) ?? .standard
+    placement = try container.decodeIfPresent(AgentProfilePlacement.self, forKey: .placement) ?? .tab
+    splitDirection =
+      try container.decodeIfPresent(UserCustomSplitDirection.self, forKey: .splitDirection) ?? .right
+    extraArguments = try container.decodeIfPresent(String.self, forKey: .extraArguments) ?? ""
+    bindsDedicatedHome = try container.decodeIfPresent(Bool.self, forKey: .bindsDedicatedHome) ?? false
+  }
+
+  /// Drops profiles whose trimmed name is empty and keeps only the first
+  /// occurrence of each UUID.
+  static func normalizedProfiles(_ profiles: [AgentProfile]) -> [AgentProfile] {
+    var seen = Set<UUID>()
+    return profiles.compactMap { profile in
+      let name = profile.name.trimmingCharacters(in: .whitespacesAndNewlines)
+      guard !name.isEmpty, seen.insert(profile.id).inserted else { return nil }
+      var normalized = profile
+      normalized.name = name
+      return normalized
+    }
+  }
+}
+
+/// Three-tier Recommended resolution: per-repo designation, per-repo launch
+/// memory, then the first enabled profile in list order. Each tier resolves
+/// only to an existing, enabled profile; a dangling or disabled reference
+/// falls through to the next tier. Runtime CLI availability is deliberately a
+/// presentation concern: a missing CLI grays the item with a reason instead of
+/// silently recommending another profile.
+nonisolated enum AgentProfileRecommendation {
+  static func recommendedProfile(
+    profiles: [AgentProfile],
+    designatedID: UUID?,
+    lastLaunchedID: UUID?
+  ) -> AgentProfile? {
+    enabledProfile(in: profiles, id: designatedID)
+      ?? enabledProfile(in: profiles, id: lastLaunchedID)
+      ?? profiles.first(where: \.isEnabled)
+  }
+
+  private static func enabledProfile(in profiles: [AgentProfile], id: UUID?) -> AgentProfile? {
+    guard let id else { return nil }
+    return profiles.first { $0.id == id && $0.isEnabled }
+  }
+}

--- a/supacode/Domain/AgentProfile/AgentProfileLaunchPlan.swift
+++ b/supacode/Domain/AgentProfile/AgentProfileLaunchPlan.swift
@@ -25,10 +25,28 @@ nonisolated struct AgentProfileLaunchPlan: Equatable, Sendable {
   }
 }
 
+nonisolated extension AgentProfile {
+  /// The execution mode the launch will actually have. Extra arguments are
+  /// respected as explicit user configuration — never blocked or stripped —
+  /// but the display must not claim Standard while the argv says otherwise
+  /// (docs-ai 053): a bypass flag the adapter's `observe` recognizes
+  /// (`--yolo`, `--dangerously-*`, `--permission-mode bypassPermissions`)
+  /// makes the effective mode `.unrestricted`.
+  var effectiveExecutionMode: AgentExecutionMode {
+    if executionMode == .unrestricted { return .unrestricted }
+    let observed = AgentRuntimeAdapterRegistry.observe(
+      agent: runtime.agent,
+      arguments: ShellWordSplitter.split(extraArguments)
+    )
+    return observed.executionMode == .unrestricted ? .unrestricted : .standard
+  }
+}
+
 nonisolated enum AgentProfileLaunchPlanError: Error, Equatable, Sendable {
   case runtimeUnavailable(AgentProfileRuntime)
   case accountIsolationUnsupported(AgentProfileRuntime)
   case homeEscapesBase(URL)
+  case homeIsSymbolicLink(URL)
 }
 
 nonisolated enum AgentProfileLaunchPlanner {
@@ -107,6 +125,7 @@ nonisolated enum AgentProfileHomeProvisioner {
     guard AgentProfileLaunchPlanner.isContained(home, in: base) else {
       throw AgentProfileLaunchPlanError.homeEscapesBase(home)
     }
+    try validatePhysicalContainment(home: home, base: base, fileManager: fileManager)
     try fileManager.createDirectory(
       at: home,
       withIntermediateDirectories: true,
@@ -118,5 +137,38 @@ nonisolated enum AgentProfileHomeProvisioner {
       [.posixPermissions: 0o700],
       ofItemAtPath: home.path(percentEncoded: false)
     )
+  }
+
+  /// Lexical containment is not enough: a `<uuid>` leaf replaced by a symlink
+  /// to a real agent home (`~/.codex`) passes the string check while every
+  /// following file operation lands on the link target. Reject a symlink leaf
+  /// outright, then require the *canonical* home to stay inside the
+  /// *canonical* base — which deliberately keeps a symlinked base itself
+  /// legal (e.g. `~/.prowl` living on a synced volume resolves consistently
+  /// on both sides of the comparison).
+  static func validatePhysicalContainment(
+    home: URL,
+    base: URL,
+    fileManager: FileManager = .default
+  ) throws {
+    let homePath = AgentProfileLaunchPlanner.pathString(home)
+    if let attributes = try? fileManager.attributesOfItem(atPath: homePath),
+      attributes[.type] as? FileAttributeType == .typeSymbolicLink
+    {
+      throw AgentProfileLaunchPlanError.homeIsSymbolicLink(home)
+    }
+    // `resolvingSymlinksInPath()` leaves ancestors unresolved when the leaf
+    // does not exist yet (first provision), so resolve the parent — which
+    // must exist for the comparison to mean anything — and reattach the leaf.
+    // The leaf itself was just proven not to be a symlink.
+    let canonicalHome =
+      home
+      .deletingLastPathComponent()
+      .resolvingSymlinksInPath()
+      .appending(path: home.lastPathComponent, directoryHint: .isDirectory)
+    let canonicalBase = base.resolvingSymlinksInPath()
+    guard AgentProfileLaunchPlanner.isContained(canonicalHome, in: canonicalBase) else {
+      throw AgentProfileLaunchPlanError.homeEscapesBase(home)
+    }
   }
 }

--- a/supacode/Domain/AgentProfile/AgentProfileLaunchPlan.swift
+++ b/supacode/Domain/AgentProfile/AgentProfileLaunchPlan.swift
@@ -1,0 +1,122 @@
+import Foundation
+
+/// The compiled result of resolving a profile for one launch (docs-ai 053):
+/// every decision is already made, downstream layers only execute. The same
+/// plan feeds the settings editor's launch preview and the actual launch.
+nonisolated struct AgentProfileLaunchPlan: Equatable, Sendable {
+  let profileID: UUID
+  let profileName: String
+  let invocation: AgentInvocation
+  let placement: AgentProfilePlacement
+  let splitDirection: UserCustomSplitDirection
+  /// Environment patch for the new surface. Non-empty only for account-bound
+  /// profiles; additive over the shell's normal environment, never a scrub.
+  let environment: [String: String]
+  /// Dedicated home to provision before launch; nil for pure presets.
+  let dedicatedHome: URL?
+
+  var terminalInput: String { invocation.terminalInput }
+
+  /// Human-readable launch preview: env prefix plus the exact rendered
+  /// invocation. Shares the launch rendering so the preview can never lie.
+  var previewText: String {
+    let prefix = environment.sorted { $0.key < $1.key }.map { "\($0.key)=\($0.value)" }
+    return (prefix + [invocation.terminalInput]).joined(separator: " ")
+  }
+}
+
+nonisolated enum AgentProfileLaunchPlanError: Error, Equatable, Sendable {
+  case runtimeUnavailable(AgentProfileRuntime)
+  case accountIsolationUnsupported(AgentProfileRuntime)
+  case homeEscapesBase(URL)
+}
+
+nonisolated enum AgentProfileLaunchPlanner {
+  /// Resolves a profile into one launch plan. Pure: no filesystem access —
+  /// home provisioning happens at the launch boundary, not here.
+  static func plan(
+    for profile: AgentProfile,
+    homeBaseDirectory: URL
+  ) throws -> AgentProfileLaunchPlan {
+    guard let adapter = AgentRuntimeAdapterRegistry.adapter(for: profile.runtime.agent) else {
+      throw AgentProfileLaunchPlanError.runtimeUnavailable(profile.runtime)
+    }
+    let configuration = AgentLaunchConfiguration(
+      model: profile.model,
+      executionMode: profile.executionMode,
+      reasoningEffort: profile.reasoningEffort,
+      extraArguments: ShellWordSplitter.split(profile.extraArguments)
+    )
+    let invocation = try AgentRuntimeAdapterRegistry.makeStartInvocation(
+      AgentStartRequest(agent: profile.runtime.agent, intent: .interactive, configuration: configuration)
+    )
+
+    var environment: [String: String] = [:]
+    var dedicatedHome: URL?
+    if profile.bindsDedicatedHome {
+      guard let variable = adapter.accountHomeEnvironmentVariable else {
+        throw AgentProfileLaunchPlanError.accountIsolationUnsupported(profile.runtime)
+      }
+      let home = dedicatedHomeDirectory(for: profile.id, base: homeBaseDirectory)
+      guard isContained(home, in: homeBaseDirectory) else {
+        throw AgentProfileLaunchPlanError.homeEscapesBase(home)
+      }
+      environment[variable] = pathString(home)
+      dedicatedHome = home
+    }
+
+    return AgentProfileLaunchPlan(
+      profileID: profile.id,
+      profileName: profile.name,
+      invocation: invocation,
+      placement: profile.placement,
+      splitDirection: profile.splitDirection,
+      environment: environment,
+      dedicatedHome: dedicatedHome
+    )
+  }
+
+  /// Homes derive from the UUID alone — never from the display name or any
+  /// user-supplied path (docs-ai 053).
+  static func dedicatedHomeDirectory(for profileID: UUID, base: URL) -> URL {
+    base
+      .appending(path: profileID.uuidString, directoryHint: .isDirectory)
+      .standardizedFileURL
+  }
+
+  /// Directory URLs render with a trailing slash in `path()`; environment
+  /// values and comparisons want the bare path.
+  static func pathString(_ url: URL) -> String {
+    let path = url.standardizedFileURL.path(percentEncoded: false)
+    return path.count > 1 && path.hasSuffix("/") ? String(path.dropLast()) : path
+  }
+
+  static func isContained(_ url: URL, in base: URL) -> Bool {
+    let baseComponents = base.standardizedFileURL.pathComponents
+    let urlComponents = url.standardizedFileURL.pathComponents
+    guard urlComponents.count > baseComponents.count else { return false }
+    return Array(urlComponents.prefix(baseComponents.count)) == baseComponents
+  }
+}
+
+/// Creates a dedicated profile home right before launch. The containment
+/// check is the same hard gate used for deletion: file operations only ever
+/// touch UUID-derived paths inside the base — never a real agent home.
+nonisolated enum AgentProfileHomeProvisioner {
+  static func provision(home: URL, base: URL, fileManager: FileManager = .default) throws {
+    guard AgentProfileLaunchPlanner.isContained(home, in: base) else {
+      throw AgentProfileLaunchPlanError.homeEscapesBase(home)
+    }
+    try fileManager.createDirectory(
+      at: home,
+      withIntermediateDirectories: true,
+      attributes: [.posixPermissions: 0o700]
+    )
+    // createDirectory attributes only apply on creation; enforce owner-only
+    // permissions for pre-existing homes as well.
+    try fileManager.setAttributes(
+      [.posixPermissions: 0o700],
+      ofItemAtPath: home.path(percentEncoded: false)
+    )
+  }
+}

--- a/supacode/Domain/AgentProfile/AgentProfileLaunchPlan.swift
+++ b/supacode/Domain/AgentProfile/AgentProfileLaunchPlan.swift
@@ -25,20 +25,30 @@ nonisolated struct AgentProfileLaunchPlan: Equatable, Sendable {
   }
 }
 
+/// What the editor may honestly claim about a profile's execution mode.
+/// CLI flag surfaces evolve (`--sandbox danger-full-access`,
+/// `--ask-for-approval never`, arbitrary `-c` overrides), so any recognition
+/// list goes stale: instead of chasing it, unrecognized extra arguments
+/// downgrade the claim to "follows your command line" — the display never
+/// asserts Standard it cannot prove (docs-ai 053, review round 2).
+nonisolated enum AgentProfileEffectiveExecutionMode: Equatable, Sendable {
+  case standard
+  case unrestricted
+  case followsExtraArguments
+}
+
 nonisolated extension AgentProfile {
-  /// The execution mode the launch will actually have. Extra arguments are
-  /// respected as explicit user configuration — never blocked or stripped —
-  /// but the display must not claim Standard while the argv says otherwise
-  /// (docs-ai 053): a bypass flag the adapter's `observe` recognizes
+  /// Extra arguments are respected as explicit user configuration — never
+  /// blocked or stripped. A bypass flag the adapter's `observe` recognizes
   /// (`--yolo`, `--dangerously-*`, `--permission-mode bypassPermissions`)
-  /// makes the effective mode `.unrestricted`.
-  var effectiveExecutionMode: AgentExecutionMode {
+  /// upgrades the claim to `.unrestricted`; any other extra argument defers
+  /// the claim entirely.
+  var effectiveExecutionMode: AgentProfileEffectiveExecutionMode {
     if executionMode == .unrestricted { return .unrestricted }
-    let observed = AgentRuntimeAdapterRegistry.observe(
-      agent: runtime.agent,
-      arguments: ShellWordSplitter.split(extraArguments)
-    )
-    return observed.executionMode == .unrestricted ? .unrestricted : .standard
+    let tokens = ShellWordSplitter.split(extraArguments)
+    guard !tokens.isEmpty else { return .standard }
+    let observed = AgentRuntimeAdapterRegistry.observe(agent: runtime.agent, arguments: tokens)
+    return observed.executionMode == .unrestricted ? .unrestricted : .followsExtraArguments
   }
 }
 

--- a/supacode/Domain/AgentProfile/AgentProfileLaunchPlan.swift
+++ b/supacode/Domain/AgentProfile/AgentProfileLaunchPlan.swift
@@ -6,6 +6,7 @@ import Foundation
 nonisolated struct AgentProfileLaunchPlan: Equatable, Sendable {
   let profileID: UUID
   let profileName: String
+  let runtime: AgentProfileRuntime
   let invocation: AgentInvocation
   let placement: AgentProfilePlacement
   let splitDirection: UserCustomSplitDirection
@@ -96,6 +97,7 @@ nonisolated enum AgentProfileLaunchPlanner {
     return AgentProfileLaunchPlan(
       profileID: profile.id,
       profileName: profile.name,
+      runtime: profile.runtime,
       invocation: invocation,
       placement: profile.placement,
       splitDirection: profile.splitDirection,

--- a/supacode/Domain/AgentProfile/ShellWordSplitter.swift
+++ b/supacode/Domain/AgentProfile/ShellWordSplitter.swift
@@ -1,0 +1,75 @@
+import Foundation
+
+/// Splits a user-authored extra-arguments string into literal argv tokens.
+///
+/// Best-effort POSIX-style word splitting: whitespace separates tokens, single
+/// and double quotes group characters, and a backslash escapes the next
+/// character outside single quotes. There is no expansion of any kind — a
+/// token is always a literal argument value, never shell input. An
+/// unterminated quote consumes the rest of the input, so the launch preview
+/// shows exactly what would be sent instead of failing the save.
+nonisolated enum ShellWordSplitter {
+  static func split(_ input: String) -> [String] {
+    enum Quote {
+      case none, single, double
+    }
+
+    var tokens: [String] = []
+    var current = ""
+    var hasToken = false
+    var quote = Quote.none
+    var index = input.startIndex
+
+    while index < input.endIndex {
+      let character = input[index]
+      index = input.index(after: index)
+      switch quote {
+      case .none:
+        switch character {
+        case "'":
+          quote = .single
+          hasToken = true
+        case "\"":
+          quote = .double
+          hasToken = true
+        case "\\":
+          if index < input.endIndex {
+            current.append(input[index])
+            index = input.index(after: index)
+          }
+          hasToken = true
+        case let character where character.isWhitespace:
+          if hasToken {
+            tokens.append(current)
+            current = ""
+            hasToken = false
+          }
+        default:
+          current.append(character)
+          hasToken = true
+        }
+      case .single:
+        if character == "'" {
+          quote = .none
+        } else {
+          current.append(character)
+        }
+      case .double:
+        if character == "\"" {
+          quote = .none
+        } else if character == "\\", index < input.endIndex,
+          input[index] == "\"" || input[index] == "\\"
+        {
+          current.append(input[index])
+          index = input.index(after: index)
+        } else {
+          current.append(character)
+        }
+      }
+    }
+    if hasToken {
+      tokens.append(current)
+    }
+    return tokens
+  }
+}

--- a/supacode/Domain/AgentRuntime/AgentRuntimeAdapter.swift
+++ b/supacode/Domain/AgentRuntime/AgentRuntimeAdapter.swift
@@ -4,6 +4,15 @@ nonisolated protocol AgentRuntimeAdapter: Sendable {
   var agent: DetectedAgent { get }
   /// Human-readable product name for UI entry points ("Claude Code").
   var displayName: String { get }
+  /// Environment variable that relocates the runtime's entire home for
+  /// per-profile account isolation, or nil when the runtime has no verified
+  /// mechanism. Relocation is all-or-nothing: skills, instruction files, and
+  /// session history follow the home (docs-ai 053, #617).
+  var accountHomeEnvironmentVariable: String? { get }
+  /// Known reasoning-effort values offered as editor suggestions. Any
+  /// free-form value stays accepted as a literal argument; an unknown value
+  /// fails at CLI startup, visibly in the new surface.
+  var reasoningEffortSuggestions: [String] { get }
 
   func observe(arguments: [String]) -> AgentLaunchObservation
   func makeStartInvocation(_ request: AgentStartRequest) throws -> AgentInvocation
@@ -15,18 +24,67 @@ nonisolated protocol AgentRuntimeAdapter: Sendable {
   func makeResumeInvocation(_ request: AgentResumeRequest, replyFile: URL?) throws -> AgentInvocation
 }
 
+nonisolated extension AgentRuntimeAdapter {
+  var supportsAccountIsolation: Bool { accountHomeEnvironmentVariable != nil }
+}
+
 nonisolated enum AgentExecutionMode: String, Codable, Equatable, Sendable {
   case standard
   case unrestricted
 }
 
+/// How an agent process should begin. An empty prompt sentinel is forbidden by
+/// construction: interactive-with-no-prompt and prompted starts are distinct
+/// CLI semantics (docs-ai 053).
+nonisolated enum AgentStartIntent: Equatable, Sendable {
+  /// Launch the interactive TUI with no initial prompt.
+  case interactive
+  /// Launch the interactive TUI seeded with an initial prompt.
+  case prompt(String)
+  /// One-shot non-interactive execution (print/exec mode). No UI consumer in
+  /// V1; the case keeps the intent space complete for CLI/handoff waves.
+  case headless(String)
+
+  /// The prompt payload for prompted or headless starts; nil for interactive.
+  var promptText: String? {
+    switch self {
+    case .interactive: nil
+    case .prompt(let prompt), .headless(let prompt): prompt
+    }
+  }
+}
+
 nonisolated struct AgentLaunchConfiguration: Codable, Equatable, Sendable {
   var model: String?
   var executionMode: AgentExecutionMode
+  var reasoningEffort: String?
+  /// Literal argv tokens appended after adapter-generated options (last-wins)
+  /// and before any positional prompt. Never shell-interpreted.
+  var extraArguments: [String]
 
-  init(model: String? = nil, executionMode: AgentExecutionMode = .standard) {
+  init(
+    model: String? = nil,
+    executionMode: AgentExecutionMode = .standard,
+    reasoningEffort: String? = nil,
+    extraArguments: [String] = []
+  ) {
     self.model = model
     self.executionMode = executionMode
+    self.reasoningEffort = reasoningEffort
+    self.extraArguments = extraArguments
+  }
+
+  private enum CodingKeys: String, CodingKey {
+    case model, executionMode, reasoningEffort, extraArguments
+  }
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    model = try container.decodeIfPresent(String.self, forKey: .model)
+    executionMode =
+      try container.decodeIfPresent(AgentExecutionMode.self, forKey: .executionMode) ?? .standard
+    reasoningEffort = try container.decodeIfPresent(String.self, forKey: .reasoningEffort)
+    extraArguments = try container.decodeIfPresent([String].self, forKey: .extraArguments) ?? []
   }
 }
 
@@ -44,12 +102,12 @@ nonisolated struct AgentLaunchObservation: Equatable, Sendable {
 
 nonisolated struct AgentStartRequest: Equatable, Sendable {
   let agent: DetectedAgent
-  let prompt: String
+  let intent: AgentStartIntent
   let configuration: AgentLaunchConfiguration
 
-  init(agent: DetectedAgent, prompt: String, configuration: AgentLaunchConfiguration = .init()) {
+  init(agent: DetectedAgent, intent: AgentStartIntent, configuration: AgentLaunchConfiguration = .init()) {
     self.agent = agent
-    self.prompt = prompt
+    self.intent = intent
     self.configuration = configuration
   }
 }
@@ -164,6 +222,8 @@ nonisolated enum AgentRuntimeAdapterRegistry {
 nonisolated private struct CodexRuntimeAdapter: AgentRuntimeAdapter {
   let agent: DetectedAgent = .codex
   let displayName = "Codex"
+  let accountHomeEnvironmentVariable: String? = "CODEX_HOME"
+  let reasoningEffortSuggestions = ["minimal", "low", "medium", "high", "xhigh"]
 
   func observe(arguments: [String]) -> AgentLaunchObservation {
     let explicitlyBypassesSandbox =
@@ -176,7 +236,15 @@ nonisolated private struct CodexRuntimeAdapter: AgentRuntimeAdapter {
   }
 
   func makeStartInvocation(_ request: AgentStartRequest) throws -> AgentInvocation {
-    AgentInvocation(executable: "codex", arguments: options(for: request.configuration) + [request.prompt])
+    let options = options(for: request.configuration)
+    return switch request.intent {
+    case .interactive:
+      AgentInvocation(executable: "codex", arguments: options)
+    case .prompt(let prompt):
+      AgentInvocation(executable: "codex", arguments: options + [prompt])
+    case .headless(let prompt):
+      AgentInvocation(executable: "codex", arguments: ["exec"] + options + [prompt])
+    }
   }
 
   func makeResumeInvocation(_ request: AgentResumeRequest, replyFile: URL?) throws -> AgentInvocation {
@@ -200,16 +268,23 @@ nonisolated private struct CodexRuntimeAdapter: AgentRuntimeAdapter {
     if let model = configuration.model {
       options += ["--model", model]
     }
+    if let effort = configuration.reasoningEffort {
+      // Codex parses `-c` values as TOML and falls back to a string literal,
+      // so the effort value needs no extra quoting here.
+      options += ["-c", "model_reasoning_effort=\(effort)"]
+    }
     if configuration.executionMode == .unrestricted {
       options.append("--dangerously-bypass-approvals-and-sandbox")
     }
-    return options
+    return options + configuration.extraArguments
   }
 }
 
 nonisolated private struct ClaudeCodeRuntimeAdapter: AgentRuntimeAdapter {
   let agent: DetectedAgent = .claude
   let displayName = "Claude Code"
+  let accountHomeEnvironmentVariable: String? = "CLAUDE_CONFIG_DIR"
+  let reasoningEffortSuggestions = ["low", "medium", "high"]
 
   func observe(arguments: [String]) -> AgentLaunchObservation {
     let explicitlyBypassesPermissions =
@@ -222,7 +297,15 @@ nonisolated private struct ClaudeCodeRuntimeAdapter: AgentRuntimeAdapter {
   }
 
   func makeStartInvocation(_ request: AgentStartRequest) throws -> AgentInvocation {
-    AgentInvocation(executable: "claude", arguments: options(for: request.configuration) + [request.prompt])
+    let options = options(for: request.configuration)
+    return switch request.intent {
+    case .interactive:
+      AgentInvocation(executable: "claude", arguments: options)
+    case .prompt(let prompt):
+      AgentInvocation(executable: "claude", arguments: options + [prompt])
+    case .headless(let prompt):
+      AgentInvocation(executable: "claude", arguments: ["-p"] + options + [prompt])
+    }
   }
 
   func makeResumeInvocation(_ request: AgentResumeRequest, replyFile: URL?) throws -> AgentInvocation {
@@ -242,10 +325,13 @@ nonisolated private struct ClaudeCodeRuntimeAdapter: AgentRuntimeAdapter {
     if let model = configuration.model {
       options += ["--model", model]
     }
+    if let effort = configuration.reasoningEffort {
+      options += ["--effort", effort]
+    }
     if configuration.executionMode == .unrestricted {
       options.append("--dangerously-skip-permissions")
     }
-    return options
+    return options + configuration.extraArguments
   }
 }
 

--- a/supacode/Features/ActiveAgents/Models/ActiveAgentEntry.swift
+++ b/supacode/Features/ActiveAgents/Models/ActiveAgentEntry.swift
@@ -27,8 +27,12 @@ struct ActiveAgentEntry: Identifiable, Equatable, Sendable {
   let rawState: AgentRawState
   let displayState: AgentDisplayState
   let lastChangedAt: Date
+  /// Profile display name recorded at launch for Prowl-launched surfaces
+  /// (docs-ai 053). Detected-but-not-launched agents stay honest: nil, so
+  /// the row never guesses a profile attribution.
+  var launchProfileName: String?
   var displayName: String {
-    Self.displayName(iconLookupToken: iconLookupToken, agent: agent)
+    launchProfileName ?? Self.displayName(iconLookupToken: iconLookupToken, agent: agent)
   }
 
   /// The user-facing agent name: the launch command token (e.g. `omp`) when it

--- a/supacode/Features/App/Reducer/AppFeature+AgentProfiles.swift
+++ b/supacode/Features/App/Reducer/AppFeature+AgentProfiles.swift
@@ -1,0 +1,66 @@
+import ComposableArchitecture
+import Foundation
+import Sharing
+
+extension AppFeature {
+  /// The single profile-launch path (docs-ai 053): every entry point (Agents
+  /// menu, Command Palette) dispatches here, so placement, identity recording,
+  /// and the environment patch always agree. Launching also records the
+  /// per-repo launch memory that backs the Recommended resolution.
+  func launchAgentProfile(_ profileID: AgentProfile.ID, state: inout State) -> Effect<Action> {
+    @Shared(.userGlobalSettings) var userGlobalSettings
+    guard
+      let profile = userGlobalSettings.agentProfiles.first(where: { $0.id == profileID }),
+      profile.isEnabled,
+      let worktree = actionTargetWorktree(repositories: state.repositories)
+    else { return .none }
+
+    let plan: AgentProfileLaunchPlan
+    do {
+      plan = try AgentProfileLaunchPlanner.plan(
+        for: profile,
+        homeBaseDirectory: SupacodePaths.agentProfileHomesDirectory
+      )
+    } catch {
+      appLogger.warning("Agent profile launch planning failed: \(error)")
+      return .none
+    }
+
+    @Shared(.userRepositorySettings(worktree.repositoryRootURL)) var userRepositorySettings
+    $userRepositorySettings.withLock { $0.lastLaunchedAgentProfileID = profile.id }
+
+    return .run { _ in
+      await terminalClient.send(.launchAgentProfile(worktree, plan: plan))
+    }
+  }
+}
+
+/// One-shot seeding of bare presets for installed runtimes (docs-ai 053).
+/// Runs at app launch, outside the reducer: it is a migration-style side
+/// effect, and deleted seeds must never respawn (the flag flips exactly once).
+@MainActor
+enum AgentProfileSeeder {
+  static func seedIfNeeded(
+    isRuntimeInstalled: (AgentProfileRuntime) -> Bool = defaultInstallationCheck
+  ) {
+    @Shared(.userGlobalSettings) var settings
+    guard !settings.didSeedAgentProfiles else { return }
+    let seeded = AgentProfileRuntime.allCases.filter(isRuntimeInstalled).map { runtime in
+      AgentProfile(
+        name: AgentRuntimeAdapterRegistry.displayName(for: runtime.agent),
+        runtime: runtime
+      )
+    }
+    $settings.withLock {
+      $0.didSeedAgentProfiles = true
+      guard $0.agentProfiles.isEmpty else { return }
+      $0.agentProfiles = AgentProfile.normalizedProfiles(seeded)
+    }
+  }
+
+  nonisolated static func defaultInstallationCheck(_ runtime: AgentProfileRuntime) -> Bool {
+    let home = FileManager.default.homeDirectoryForCurrentUser
+      .appending(path: runtime.defaultHomeDirectoryName, directoryHint: .isDirectory)
+    return FileManager.default.fileExists(atPath: home.path(percentEncoded: false))
+  }
+}

--- a/supacode/Features/App/Reducer/AppFeature+CommandPalette.swift
+++ b/supacode/Features/App/Reducer/AppFeature+CommandPalette.swift
@@ -268,6 +268,9 @@ extension AppFeature {
     case .runCustomCommand(let id):
       return .send(.runCustomCommand(id))
 
+    case .launchAgentProfile(let profileID):
+      return .send(.launchAgentProfile(profileID))
+
     case .ghosttyCommand(let action):
       guard let worktree = actionTargetWorktree(repositories: state.repositories) else {
         return .none

--- a/supacode/Features/App/Reducer/AppFeature+Support.swift
+++ b/supacode/Features/App/Reducer/AppFeature+Support.swift
@@ -77,19 +77,24 @@ extension AppFeature {
   }
 
   func actionTargetWorktree(repositories: RepositoriesFeature.State) -> Worktree? {
-    if let worktree = repositories.selectedTerminalWorktree {
-      return worktree
-    }
-    return canvasFocusedTerminalWorktree(repositories: repositories)
+    // Same resolver as every UI entry point (palette item factories); only
+    // the source of the explicit target — the focused Canvas card — lives
+    // here, behind the terminal client dependency.
+    repositories.actionTargetTerminalWorktree(
+      explicitTargetID: canvasFocusedWorktreeID(repositories: repositories)
+    )
   }
 
   func canvasFocusedTerminalWorktree(repositories: RepositoriesFeature.State) -> Worktree? {
-    guard repositories.isShowingCanvas,
-      let worktreeID = terminalClient.canvasFocusedWorktreeID()
-    else {
+    guard let worktreeID = canvasFocusedWorktreeID(repositories: repositories) else {
       return nil
     }
     return terminalWorktree(for: worktreeID, repositories: repositories)
+  }
+
+  private func canvasFocusedWorktreeID(repositories: RepositoriesFeature.State) -> Worktree.ID? {
+    guard repositories.isShowingCanvas else { return nil }
+    return terminalClient.canvasFocusedWorktreeID()
   }
 
   func terminalWorktree(

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -71,6 +71,7 @@ struct AppFeature {
     case runScript
     case runCustomCommand(EffectiveCustomCommand.Identifier)
     case launchAgentProfile(AgentProfile.ID)
+    case openAgentProfilesSettings
     case canvasFocusedWorktreeChanged(Worktree.ID?)
     case runScriptDraftChanged(String)
     case runScriptPromptPresented(Bool)
@@ -717,6 +718,14 @@ struct AppFeature {
 
       case .launchAgentProfile(let profileID):
         return launchAgentProfile(profileID, state: &state)
+
+      case .openAgentProfilesSettings:
+        return .merge(
+          .send(.settings(.setSelection(.agents))),
+          .run { _ in
+            await settingsWindowClient.show()
+          }
+        )
 
       case .runCustomCommand(let commandID):
         guard let worktree = actionTargetWorktree(repositories: state.repositories) else {

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -70,6 +70,7 @@ struct AppFeature {
     case setLeftSidebarVisibility(NavigationSplitViewVisibility)
     case runScript
     case runCustomCommand(EffectiveCustomCommand.Identifier)
+    case launchAgentProfile(AgentProfile.ID)
     case canvasFocusedWorktreeChanged(Worktree.ID?)
     case runScriptDraftChanged(String)
     case runScriptPromptPresented(Bool)
@@ -706,6 +707,9 @@ struct AppFeature {
         return .run { _ in
           await terminalClient.send(.runScript(worktree, script: script))
         }
+
+      case .launchAgentProfile(let profileID):
+        return launchAgentProfile(profileID, state: &state)
 
       case .runCustomCommand(let commandID):
         guard let worktree = actionTargetWorktree(repositories: state.repositories) else {

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -383,6 +383,11 @@ struct AppFeature {
         case .customCommands:
           state.settings.repositorySettings = nil
           state.settings.globalCustomCommands = .init()
+          state.settings.agentProfiles = nil
+        case .agents:
+          state.settings.repositorySettings = nil
+          state.settings.globalCustomCommands = nil
+          state.settings.agentProfiles = .init()
         case .repository(let repositoryID):
           guard let repository = state.repositories.repositories[id: repositoryID] else {
             state.settings.repositorySettings = nil
@@ -405,9 +410,11 @@ struct AppFeature {
           repoSettingsState.globalPullRequestMergeStrategy = state.settings.pullRequestMergeStrategy
           state.settings.repositorySettings = repoSettingsState
           state.settings.globalCustomCommands = nil
+          state.settings.agentProfiles = nil
         case .general, .notifications, .shortcuts, .worktree, .updates, .advanced, .github:
           state.settings.repositorySettings = nil
           state.settings.globalCustomCommands = nil
+          state.settings.agentProfiles = nil
         }
         return .none
 

--- a/supacode/Features/CommandPalette/CommandPaletteItem.swift
+++ b/supacode/Features/CommandPalette/CommandPaletteItem.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 struct CommandPaletteSuggestions: Equatable {
   static let maxItems = 8
 
@@ -84,6 +86,7 @@ struct CommandPaletteItem: Identifiable, Equatable {
     case openRepositorySettings(Repository.ID)
     case runCustomCommand(EffectiveCustomCommand.Identifier, systemImage: String)
     case handOff
+    case launchAgentProfile(AgentProfile.ID)
     #if DEBUG
       case debugTestToast(RepositoriesFeature.StatusToast)
       case debugSimulateUpdateFound
@@ -171,7 +174,8 @@ struct CommandPaletteItem: Identifiable, Equatable {
       .deleteWorktree,
       .openRepositorySettings,
       .runCustomCommand,
-      .handOff:
+      .handOff,
+      .launchAgentProfile:
       return nil
     #if DEBUG
       case .debugTestToast, .debugSimulateUpdateFound, .debugLightDockNotificationDot:

--- a/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
+++ b/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
@@ -262,7 +262,12 @@ struct CommandPaletteFeature {
     }
     items.append(contentsOf: customCommandItems(customCommands))
     items.append(contentsOf: handoffCommandItems(repositories))
-    items.append(contentsOf: agentProfileLaunchItems(repositories))
+    items.append(
+      contentsOf: agentProfileLaunchItems(
+        repositories,
+        actionTargetWorktreeID: worktreeActionTargetID
+      )
+    )
     if let terminalWorktree = repositories.selectedTerminalWorktree {
       items.append(
         CommandPaletteItem(
@@ -532,12 +537,20 @@ private func customCommandItems(_ commands: [EffectiveCustomCommand]) -> [Comman
   }
 }
 
-/// Launch rows for enabled agent profiles: the selected worktree's
-/// Recommended profile first, then list order. Dispatches the same single
-/// profile-launch action as the toolbar Agents menu (docs-ai 053) — the
-/// palette is an entry point, never a second launch path. Internal for tests.
-func agentProfileLaunchItems(_ repositories: RepositoriesFeature.State) -> [CommandPaletteItem] {
-  guard let worktree = repositories.selectedTerminalWorktree else { return [] }
+/// Launch rows for enabled agent profiles: the target worktree's Recommended
+/// profile first, then list order. Dispatches the same single profile-launch
+/// action as the toolbar Agents menu (docs-ai 053) — the palette is an entry
+/// point, never a second launch path. The target mirrors the launch action's
+/// resolution: the selected terminal worktree in Normal mode, the focused
+/// Canvas card otherwise. Internal for tests.
+func agentProfileLaunchItems(
+  _ repositories: RepositoriesFeature.State,
+  actionTargetWorktreeID: Worktree.ID? = nil
+) -> [CommandPaletteItem] {
+  let target =
+    repositories.selectedTerminalWorktree
+    ?? actionTargetWorktreeID.flatMap { repositories.worktree(for: $0) }
+  guard let worktree = target else { return [] }
   @Shared(.userGlobalSettings) var globalSettings
   let profiles = globalSettings.agentProfiles
   let enabled = profiles.filter(\.isEnabled)

--- a/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
+++ b/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
@@ -547,10 +547,11 @@ func agentProfileLaunchItems(
   _ repositories: RepositoriesFeature.State,
   actionTargetWorktreeID: Worktree.ID? = nil
 ) -> [CommandPaletteItem] {
-  let target =
-    repositories.selectedTerminalWorktree
-    ?? actionTargetWorktreeID.flatMap { repositories.worktree(for: $0) }
-  guard let worktree = target else { return [] }
+  guard
+    let worktree = repositories.actionTargetTerminalWorktree(
+      explicitTargetID: actionTargetWorktreeID
+    )
+  else { return [] }
   @Shared(.userGlobalSettings) var globalSettings
   let profiles = globalSettings.agentProfiles
   let enabled = profiles.filter(\.isEnabled)

--- a/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
+++ b/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
@@ -73,6 +73,7 @@ struct CommandPaletteFeature {
     case openRepositorySettings(Repository.ID)
     case runCustomCommand(EffectiveCustomCommand.Identifier)
     case handOff
+    case launchAgentProfile(AgentProfile.ID)
     #if DEBUG
       case debugTestToast(RepositoriesFeature.StatusToast)
       case debugSimulateUpdateFound
@@ -261,6 +262,7 @@ struct CommandPaletteFeature {
     }
     items.append(contentsOf: customCommandItems(customCommands))
     items.append(contentsOf: handoffCommandItems(repositories))
+    items.append(contentsOf: agentProfileLaunchItems(repositories))
     if let terminalWorktree = repositories.selectedTerminalWorktree {
       items.append(
         CommandPaletteItem(
@@ -526,6 +528,40 @@ private func customCommandItems(_ commands: [EffectiveCustomCommand]) -> [Comman
       category: .worktree,
       defaultSuggestion: false,
       keywords: ["custom", "command", "script"]
+    )
+  }
+}
+
+/// Launch rows for enabled agent profiles: the selected worktree's
+/// Recommended profile first, then list order. Dispatches the same single
+/// profile-launch action as the toolbar Agents menu (docs-ai 053) — the
+/// palette is an entry point, never a second launch path. Internal for tests.
+func agentProfileLaunchItems(_ repositories: RepositoriesFeature.State) -> [CommandPaletteItem] {
+  guard let worktree = repositories.selectedTerminalWorktree else { return [] }
+  @Shared(.userGlobalSettings) var globalSettings
+  let profiles = globalSettings.agentProfiles
+  let enabled = profiles.filter(\.isEnabled)
+  guard !enabled.isEmpty else { return [] }
+  @Shared(.userRepositorySettings(worktree.repositoryRootURL)) var repositorySettings
+  let recommendedID = AgentProfileRecommendation.recommendedProfile(
+    profiles: profiles,
+    designatedID: repositorySettings.defaultAgentProfileID,
+    lastLaunchedID: repositorySettings.lastLaunchedAgentProfileID
+  )?.id
+  let ordered = enabled.sorted { lhs, rhs in
+    (lhs.id == recommendedID ? 0 : 1) < (rhs.id == recommendedID ? 0 : 1)
+  }
+  return ordered.map { profile in
+    let runtimeName = AgentRuntimeAdapterRegistry.displayName(for: profile.runtime.agent)
+    let placement = profile.id == recommendedID ? "Recommended · " : ""
+    return CommandPaletteItem(
+      id: CommandPaletteItemID.launchAgentProfile(profile.id),
+      title: "Launch Agent: \(profile.name)",
+      subtitle: "\(placement)New \(runtimeName) in \(worktree.name)",
+      kind: .launchAgentProfile(profile.id),
+      category: .terminal,
+      defaultSuggestion: false,
+      keywords: ["launch", "agent", "profile", "start", profile.name]
     )
   }
 }

--- a/supacode/Features/CommandPalette/Reducer/CommandPaletteSupport.swift
+++ b/supacode/Features/CommandPalette/Reducer/CommandPaletteSupport.swift
@@ -42,6 +42,10 @@ enum CommandPaletteItemID {
 
   static let handOff = "handoff.open"
 
+  static func launchAgentProfile(_ id: AgentProfile.ID) -> String {
+    "agent-profile.launch.\(id.uuidString)"
+  }
+
   static var globalIDs: [CommandPaletteItem.ID] {
     [
       globalCheckForUpdates,
@@ -165,6 +169,8 @@ func delegateAction(for kind: CommandPaletteItem.Kind) -> CommandPaletteFeature.
     return .runCustomCommand(id)
   case .handOff:
     return .handOff
+  case .launchAgentProfile(let profileID):
+    return .launchAgentProfile(profileID)
   case .openPullRequest,
     .openRepositoryOnCodeHost,
     .markPullRequestReady,
@@ -346,7 +352,8 @@ func pullRequestDelegateAction(
     .deleteWorktree,
     .openRepositorySettings,
     .runCustomCommand,
-    .handOff:
+    .handOff,
+    .launchAgentProfile:
     return nil
   #if DEBUG
     case .debugTestToast, .debugSimulateUpdateFound, .debugLightDockNotificationDot:

--- a/supacode/Features/CommandPalette/Views/CommandPaletteOverlayView.swift
+++ b/supacode/Features/CommandPalette/Views/CommandPaletteOverlayView.swift
@@ -526,7 +526,7 @@ private struct CommandPaletteRowView: View {
       .toggleShelf, .showDiff, .outgoingChanges,
       .revealInFinder, .copyPath, .revealInSidebar,
       .runScript, .stopRunScript, .togglePinWorktree, .renameBranch,
-      .openRepositorySettings, .runCustomCommand, .handOff:
+      .openRepositorySettings, .runCustomCommand, .handOff, .launchAgentProfile:
       return nil
     case .deleteWorktree:
       return "Delete"
@@ -623,6 +623,8 @@ private struct CommandPaletteRowView: View {
       return systemImage
     case .handOff:
       return "arrow.left.arrow.right"
+    case .launchAgentProfile:
+      return "play.circle"
     #if DEBUG
       case .debugTestToast:
         return "ladybug"
@@ -648,7 +650,7 @@ private struct CommandPaletteRowView: View {
       .revealInFinder, .copyPath, .revealInSidebar,
       .runScript, .stopRunScript, .togglePinWorktree, .renameBranch,
       .openRepositorySettings,
-      .deleteWorktree, .runCustomCommand, .handOff:
+      .deleteWorktree, .runCustomCommand, .handOff, .launchAgentProfile:
       return true
     case .worktreeSelect:
       return false
@@ -813,6 +815,8 @@ private struct CommandPaletteRowView: View {
     case .runCustomCommand:
       base = "Run Custom Command: \(row.title)"
     case .handOff:
+      base = row.title
+    case .launchAgentProfile:
       base = row.title
     #if DEBUG
       case .debugTestToast, .debugSimulateUpdateFound, .debugLightDockNotificationDot:

--- a/supacode/Features/HandoffHud/Reducer/HandoffHudFeature.swift
+++ b/supacode/Features/HandoffHud/Reducer/HandoffHudFeature.swift
@@ -427,7 +427,7 @@ struct HandoffHudFeature {
         )
         let request = AgentStartRequest(
           agent: destination,
-          prompt: HandoffCommandHandler.kickoffPrompt(hasBriefing: artifacts.hasBriefing),
+          intent: .prompt(HandoffCommandHandler.kickoffPrompt(hasBriefing: artifacts.hasBriefing)),
           configuration: configuration
         )
         let kickoff = try AgentRuntimeAdapterRegistry.makeStartInvocation(request).terminalInput

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+StateQueries.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+StateQueries.swift
@@ -40,6 +40,18 @@ extension RepositoriesFeature.State {
     return Self.plainFolderWorktree(for: selectedRepository)
   }
 
+  /// The single answer to "which worktree does a worktree-scoped action
+  /// target right now": the selected terminal worktree in Normal mode, else
+  /// the explicitly supplied target (the focused Canvas card, the palette's
+  /// action-target ID) resolved through the full terminal-target path,
+  /// including synthesized plain-folder worktrees. Entry points that generate
+  /// UI for an action and the action's own execution MUST both resolve
+  /// through here — three review findings came from hand-rolled halves of
+  /// this logic drifting apart (docs-ai 053).
+  func actionTargetTerminalWorktree(explicitTargetID: Worktree.ID?) -> Worktree? {
+    selectedTerminalWorktree ?? explicitTargetID.flatMap { terminalWorktree(for: $0) }
+  }
+
   /// Resolves a terminal target ID to its runnable worktree: a real worktree,
   /// or the synthesized worktree representing a runnable plain-folder
   /// repository (whose repository ID doubles as its terminal target ID).

--- a/supacode/Features/Repositories/Views/AgentsToolbarButton.swift
+++ b/supacode/Features/Repositories/Views/AgentsToolbarButton.swift
@@ -1,8 +1,8 @@
 import SwiftUI
 
 /// What the Agents capsule shows for the selected pane's detected agent.
-/// nil means no agent: the capsule renders its generic, disabled form
-/// (reserved for the future quick launcher — docs-ai 049).
+/// nil means no detected agent: the capsule renders its generic form and the
+/// popover becomes the profile launcher (docs-ai 053).
 struct AgentsCapsuleState: Equatable {
   let displayName: String
   /// Resolved branded icon; nil falls back to a generic symbol. Resolved by
@@ -14,17 +14,32 @@ struct AgentsCapsuleState: Equatable {
   let infoLine: String
 }
 
+/// One launchable agent profile row in the Agents popover (docs-ai 053).
+struct AgentsLauncherItem: Equatable, Identifiable {
+  let id: AgentProfile.ID
+  let name: String
+  let runtimeName: String
+  let isRecommended: Bool
+  /// Why the row is disabled ("Claude Code is not installed"); nil = launchable.
+  let unavailableReason: String?
+}
+
 /// Toolbar entry point for agent-scoped actions, left of the branch title.
 /// The capsule identifies the selected pane's agent (the hand-off source);
-/// clicking it opens a popover that hosts the agent actions — hand-off
-/// today, more later (docs-ai 049). Live status stays with the terminal,
-/// the Active Agents panel, and the central status toast — the capsule
-/// deliberately carries no state indicator. A `Menu` cannot host this
-/// control: macOS toolbars flatten custom menu labels to their text,
-/// dropping the badge, so the popover is the durable container here.
+/// clicking it opens a popover that hosts the agent actions — hand-off when
+/// an agent is detected, plus the profile launcher and the manage entry
+/// (docs-ai 049/053). The popover is always available: the launcher must not
+/// require a detected agent. Live status stays with the terminal, the Active
+/// Agents panel, and the central status toast — the capsule deliberately
+/// carries no state indicator. A `Menu` cannot host this control: macOS
+/// toolbars flatten custom menu labels to their text, dropping the badge, so
+/// the popover is the durable container here.
 struct AgentsToolbarButton: View {
   let capsule: AgentsCapsuleState?
+  let launcherItems: [AgentsLauncherItem]
   let onHandOff: () -> Void
+  let onLaunchProfile: (AgentProfile.ID) -> Void
+  let onManageProfiles: () -> Void
   @State private var isPopoverPresented = false
   @State private var isHovered = false
 
@@ -47,26 +62,31 @@ struct AgentsToolbarButton: View {
     // fill layered under `glassEffect` gets swallowed by the material
     // compositing, and `.interactive()` only adds press feedback on macOS.
     .glassEffect(
-      isHovered && capsule != nil
+      isHovered
         ? .regular.tint(.primary.opacity(0.12)).interactive()
         : .regular.interactive(),
       in: Capsule()
     )
-    .opacity(capsule == nil ? 0.45 : 1)
-    .disabled(capsule == nil)
     .onHover { isHovered = $0 }
     .help(helpText)
     .accessibilityLabel(accessibilityText)
     .popover(isPresented: $isPopoverPresented, arrowEdge: .bottom) {
-      if let capsule {
-        AgentsPopoverContent(
-          capsule: capsule,
-          onHandOff: {
-            isPopoverPresented = false
-            onHandOff()
-          }
-        )
-      }
+      AgentsPopoverContent(
+        capsule: capsule,
+        launcherItems: launcherItems,
+        onHandOff: {
+          isPopoverPresented = false
+          onHandOff()
+        },
+        onLaunchProfile: { id in
+          isPopoverPresented = false
+          onLaunchProfile(id)
+        },
+        onManageProfiles: {
+          isPopoverPresented = false
+          onManageProfiles()
+        }
+      )
     }
   }
 
@@ -102,31 +122,57 @@ struct AgentsToolbarButton: View {
 
   private var helpText: String {
     guard let capsule else {
-      return "No agent detected in the selected pane"
+      return "Launch an agent profile in this worktree"
     }
     return "Agent actions for \(capsule.displayName)"
   }
 
   private var accessibilityText: String {
-    guard let capsule else { return "Agents (no agent detected)" }
+    guard let capsule else { return "Agents" }
     return "Agents: \(capsule.displayName)"
   }
 }
 
 /// The agent-actions popover. Each action is one full row — title with a
-/// plain-language explanation underneath, highlighted together on hover —
-/// so future actions slot in as additional rows.
+/// plain-language explanation underneath, highlighted together on hover.
+/// Hand-off leads when an agent is detected; the launcher rows follow with
+/// the recommended profile first, and the manage entry closes the list.
 private struct AgentsPopoverContent: View {
-  let capsule: AgentsCapsuleState
+  let capsule: AgentsCapsuleState?
+  let launcherItems: [AgentsLauncherItem]
   let onHandOff: () -> Void
+  let onLaunchProfile: (AgentProfile.ID) -> Void
+  let onManageProfiles: () -> Void
 
   var body: some View {
     VStack(alignment: .leading, spacing: 0) {
+      if let capsule {
+        AgentsPopoverRow(
+          title: "Hand Off…",
+          subtitle: capsule.infoLine,
+          systemImage: "arrow.left.arrow.right",
+          action: onHandOff
+        )
+        if !launcherItems.isEmpty {
+          Divider().padding(.vertical, 4)
+        }
+      }
+      ForEach(launcherItems) { item in
+        AgentsPopoverRow(
+          title: item.isRecommended ? "Launch \(item.name) ★" : "Launch \(item.name)",
+          subtitle: item.unavailableReason
+            ?? "New agent in this worktree · \(item.runtimeName)",
+          systemImage: "play.circle",
+          isEnabled: item.unavailableReason == nil,
+          action: { onLaunchProfile(item.id) }
+        )
+      }
+      Divider().padding(.vertical, 4)
       AgentsPopoverRow(
-        title: "Hand Off…",
-        subtitle: capsule.infoLine,
-        systemImage: "arrow.left.arrow.right",
-        action: onHandOff
+        title: "Manage Agent Profiles…",
+        subtitle: "Add presets, models, and accounts in Settings",
+        systemImage: "slider.horizontal.3",
+        action: onManageProfiles
       )
     }
     .padding(6)
@@ -138,6 +184,7 @@ private struct AgentsPopoverRow: View {
   let title: String
   let subtitle: String
   let systemImage: String
+  var isEnabled: Bool = true
   let action: () -> Void
   @State private var isHovered = false
 
@@ -162,9 +209,11 @@ private struct AgentsPopoverRow: View {
       .contentShape(.rect)
     }
     .buttonStyle(.plain)
+    .disabled(!isEnabled)
+    .opacity(isEnabled ? 1 : 0.5)
     .background(
       RoundedRectangle(cornerRadius: 6)
-        .fill(isHovered ? Color.accentColor.opacity(0.2) : Color.clear)
+        .fill(isHovered && isEnabled ? Color.accentColor.opacity(0.2) : Color.clear)
     )
     .onHover { isHovered = $0 }
   }

--- a/supacode/Features/Repositories/Views/WorktreeDetailToolbarViews.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailToolbarViews.swift
@@ -309,7 +309,9 @@ private struct WorktreeToolbarPreview: View {
         onStopRunScript: {},
         onRunCustomCommand: { _ in },
         onActivateUpdateButton: {},
-        onHandOff: {}
+        onHandOff: {},
+        onLaunchProfile: { _ in },
+        onManageProfiles: {}
       )
     }
     .environment(commandKeyObserver)

--- a/supacode/Features/Repositories/Views/WorktreeDetailView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailView.swift
@@ -207,7 +207,9 @@ struct WorktreeDetailView: View {
         store.send(.runCustomCommand(index))
       },
       onActivateUpdateButton: { store.send(.updates(.activateUpdateButton)) },
-      onHandOff: { store.send(.openHandoffHud) }
+      onHandOff: { store.send(.openHandoffHud) },
+      onLaunchProfile: { store.send(.launchAgentProfile($0)) },
+      onManageProfiles: { store.send(.openAgentProfilesSettings) }
     )
   }
 
@@ -357,6 +359,7 @@ struct WorktreeDetailView: View {
     return WorktreeToolbarState(
       title: title,
       agentsCapsule: agentsCapsuleState(repositories: input.repositories),
+      agentsLauncherItems: agentsLauncherItems(repositories: input.repositories),
       statusToast: input.repositories.statusToast,
       pullRequest: matchedPullRequest(
         for: input.selectedWorktree,
@@ -380,8 +383,8 @@ struct WorktreeDetailView: View {
   }
 
   /// The selected pane's detected agent, feeding the Agents capsule. nil
-  /// (no detected agent) renders the capsule disabled — reserved for the
-  /// future quick launcher (docs-ai 049).
+  /// (no detected agent) renders the capsule in its generic form; the
+  /// popover still hosts the profile launcher (docs-ai 053).
   private func agentsCapsuleState(repositories: RepositoriesFeature.State) -> AgentsCapsuleState? {
     guard let worktree = repositories.selectedTerminalWorktree,
       let state = terminalManager.stateIfExists(for: worktree.id),
@@ -393,18 +396,57 @@ struct WorktreeDetailView: View {
     let iconSource =
       paneState.iconLookupToken.flatMap(CommandIconMap.iconForFirstToken)
       ?? CommandIconMap.iconForFirstToken(agent.iconLookupToken)
-    // Same naming rule as the Active Agents rows: launch aliases such as
-    // `omp` show their own name, not the semantic agent's (`pi`).
-    let displayName = ActiveAgentEntry.displayName(
-      iconLookupToken: paneState.iconLookupToken ?? agent.iconLookupToken,
-      agent: agent
-    )
+    // Same naming rule as the Active Agents rows: the launch profile name
+    // recorded at surface creation wins for Prowl-launched panes; launch
+    // aliases such as `omp` show their own name, not the semantic agent's.
+    let displayName =
+      state.launchProfilesBySurface[surfaceID]?.name
+      ?? ActiveAgentEntry.displayName(
+        iconLookupToken: paneState.iconLookupToken ?? agent.iconLookupToken,
+        agent: agent
+      )
     return AgentsCapsuleState(
       displayName: displayName,
       iconSource: iconSource,
       infoLine: "Pass this task to another agent in a new tab. "
         + "\(displayName) writes its own briefing first."
     )
+  }
+
+  /// Launchable profile rows for the Agents popover: the current worktree's
+  /// Recommended profile first, then the remaining enabled profiles in list
+  /// order. Availability (CLI installed) is presentation-only — a missing
+  /// runtime grays the row with a reason instead of silently recommending
+  /// another profile (docs-ai 053).
+  private func agentsLauncherItems(repositories: RepositoriesFeature.State) -> [AgentsLauncherItem] {
+    @Shared(.userGlobalSettings) var globalSettings
+    let profiles = globalSettings.agentProfiles
+    guard !profiles.isEmpty else { return [] }
+    var recommendedID: AgentProfile.ID?
+    if let worktree = repositories.selectedTerminalWorktree {
+      @Shared(.userRepositorySettings(worktree.repositoryRootURL)) var repositorySettings
+      recommendedID =
+        AgentProfileRecommendation.recommendedProfile(
+          profiles: profiles,
+          designatedID: repositorySettings.defaultAgentProfileID,
+          lastLaunchedID: repositorySettings.lastLaunchedAgentProfileID
+        )?.id
+    }
+    let enabled = profiles.filter(\.isEnabled)
+    let ordered = enabled.sorted { lhs, rhs in
+      (lhs.id == recommendedID ? 0 : 1) < (rhs.id == recommendedID ? 0 : 1)
+    }
+    return ordered.map { profile in
+      let runtimeName = AgentRuntimeAdapterRegistry.displayName(for: profile.runtime.agent)
+      let installed = AgentProfileSeeder.defaultInstallationCheck(profile.runtime)
+      return AgentsLauncherItem(
+        id: profile.id,
+        name: profile.name,
+        runtimeName: runtimeName,
+        isRecommended: profile.id == recommendedID,
+        unavailableReason: installed ? nil : "\(runtimeName) is not installed"
+      )
+    }
   }
 
   private func selectedWorktreeSummaries(
@@ -830,6 +872,7 @@ struct WorktreeDetailView: View {
   struct WorktreeToolbarState {
     let title: DetailToolbarTitle
     let agentsCapsule: AgentsCapsuleState?
+    var agentsLauncherItems: [AgentsLauncherItem] = []
     let statusToast: RepositoriesFeature.StatusToast?
     let pullRequest: GithubPullRequest?
     let codeHost: CodeHost
@@ -864,6 +907,8 @@ struct WorktreeDetailView: View {
     let onRunCustomCommand: (EffectiveCustomCommand.Identifier) -> Void
     let onActivateUpdateButton: () -> Void
     let onHandOff: () -> Void
+    let onLaunchProfile: (AgentProfile.ID) -> Void
+    let onManageProfiles: () -> Void
     @Environment(\.resolvedKeybindings) private var resolvedKeybindings
 
     var body: some ToolbarContent {
@@ -875,7 +920,10 @@ struct WorktreeDetailView: View {
       ToolbarItem(placement: .navigation) {
         AgentsToolbarButton(
           capsule: toolbarState.agentsCapsule,
-          onHandOff: onHandOff
+          launcherItems: toolbarState.agentsLauncherItems,
+          onHandOff: onHandOff,
+          onLaunchProfile: onLaunchProfile,
+          onManageProfiles: onManageProfiles
         )
       }
       .sharedBackgroundVisibility(.hidden)

--- a/supacode/Features/RepositorySettings/Reducer/RepositorySettingsFeature.swift
+++ b/supacode/Features/RepositorySettings/Reducer/RepositorySettingsFeature.swift
@@ -122,6 +122,7 @@ struct RepositorySettingsFeature {
     case dismissAppearanceImportError
     case resetAppearance
     case setGlobalCommandEnabled(UserCustomCommand.ID, Bool)
+    case setDefaultAgentProfileID(AgentProfile.ID?)
     case branchDataLoaded([String], defaultBaseRef: String)
     case delegate(Delegate)
     case binding(BindingAction<State>)
@@ -234,6 +235,14 @@ struct RepositorySettingsFeature {
           return .none
         }
         state.userSettings.setGlobalCommandEnabled(isEnabled, id: commandID)
+        let rootURL = state.rootURL
+        @Shared(.userRepositorySettings(rootURL)) var userRepositorySettings
+        $userRepositorySettings.withLock { $0 = state.userSettings }
+        return .send(.delegate(.settingsChanged(rootURL)))
+
+      case .setDefaultAgentProfileID(let profileID):
+        guard state.userSettings.defaultAgentProfileID != profileID else { return .none }
+        state.userSettings.defaultAgentProfileID = profileID
         let rootURL = state.rootURL
         @Shared(.userRepositorySettings(rootURL)) var userRepositorySettings
         $userRepositorySettings.withLock { $0 = state.userSettings }

--- a/supacode/Features/RepositorySettings/Reducer/RepositorySettingsFeature.swift
+++ b/supacode/Features/RepositorySettings/Reducer/RepositorySettingsFeature.swift
@@ -236,8 +236,11 @@ struct RepositorySettingsFeature {
         }
         state.userSettings.setGlobalCommandEnabled(isEnabled, id: commandID)
         let rootURL = state.rootURL
+        // Targeted write: `state.userSettings` is a load-time snapshot, and
+        // `lastLaunchedAgentProfileID` is written externally by profile
+        // launches — a whole-struct writeback would clobber it.
         @Shared(.userRepositorySettings(rootURL)) var userRepositorySettings
-        $userRepositorySettings.withLock { $0 = state.userSettings }
+        $userRepositorySettings.withLock { $0.setGlobalCommandEnabled(isEnabled, id: commandID) }
         return .send(.delegate(.settingsChanged(rootURL)))
 
       case .setDefaultAgentProfileID(let profileID):
@@ -245,7 +248,7 @@ struct RepositorySettingsFeature {
         state.userSettings.defaultAgentProfileID = profileID
         let rootURL = state.rootURL
         @Shared(.userRepositorySettings(rootURL)) var userRepositorySettings
-        $userRepositorySettings.withLock { $0 = state.userSettings }
+        $userRepositorySettings.withLock { $0.defaultAgentProfileID = profileID }
         return .send(.delegate(.settingsChanged(rootURL)))
 
       case .appearanceLoaded(let appearance):
@@ -388,6 +391,11 @@ struct RepositorySettingsFeature {
         @Shared(.repositorySettings(rootURL)) var repositorySettings
         @Shared(.userRepositorySettings(rootURL)) var userRepositorySettings
         $repositorySettings.withLock { $0 = normalizedSettings }
+        // `state.userSettings` is a load-time snapshot; preserve the
+        // externally-written launch memory instead of clobbering it with the
+        // stale copy (profile launches update it while Settings stays open).
+        let lastLaunched = userRepositorySettings.lastLaunchedAgentProfileID
+        state.userSettings.lastLaunchedAgentProfileID = lastLaunched
         $userRepositorySettings.withLock { $0 = state.userSettings }
         return .send(.delegate(.settingsChanged(rootURL)))
 

--- a/supacode/Features/Settings/Models/UserGlobalSettings.swift
+++ b/supacode/Features/Settings/Models/UserGlobalSettings.swift
@@ -2,14 +2,43 @@ import Foundation
 
 nonisolated struct UserGlobalSettings: Codable, Equatable, Sendable {
   var customCommands: [UserCustomCommand]
+  var agentProfiles: [AgentProfile]
+  /// One-shot seeding marker for agent profiles (docs-ai 053): seeded profiles
+  /// the user deletes must never respawn.
+  var didSeedAgentProfiles: Bool
 
   static let `default` = UserGlobalSettings(customCommands: [])
 
-  init(customCommands: [UserCustomCommand]) {
+  private enum CodingKeys: String, CodingKey {
+    case customCommands
+    case agentProfiles
+    case didSeedAgentProfiles
+  }
+
+  init(
+    customCommands: [UserCustomCommand],
+    agentProfiles: [AgentProfile] = [],
+    didSeedAgentProfiles: Bool = false
+  ) {
     self.customCommands = UserCustomCommand.normalizedCommands(customCommands)
+    self.agentProfiles = AgentProfile.normalizedProfiles(agentProfiles)
+    self.didSeedAgentProfiles = didSeedAgentProfiles
+  }
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    let commands = try container.decodeIfPresent([UserCustomCommand].self, forKey: .customCommands) ?? []
+    customCommands = UserCustomCommand.normalizedCommands(commands)
+    let profiles = try container.decodeIfPresent([AgentProfile].self, forKey: .agentProfiles) ?? []
+    agentProfiles = AgentProfile.normalizedProfiles(profiles)
+    didSeedAgentProfiles = try container.decodeIfPresent(Bool.self, forKey: .didSeedAgentProfiles) ?? false
   }
 
   func normalized() -> UserGlobalSettings {
-    UserGlobalSettings(customCommands: customCommands)
+    UserGlobalSettings(
+      customCommands: customCommands,
+      agentProfiles: agentProfiles,
+      didSeedAgentProfiles: didSeedAgentProfiles
+    )
   }
 }

--- a/supacode/Features/Settings/Models/UserRepositorySettings.swift
+++ b/supacode/Features/Settings/Models/UserRepositorySettings.swift
@@ -3,20 +3,33 @@ import Foundation
 nonisolated struct UserRepositorySettings: Codable, Equatable, Sendable {
   var customCommands: [UserCustomCommand]
   var disabledGlobalCommandIDs: Set<UserCustomCommand.ID>
+  /// Explicit per-repo Default Agent Profile designation (docs-ai 053).
+  var defaultAgentProfileID: UUID?
+  /// Per-repo launch memory: the last explicitly launched profile. One tier
+  /// below the designation in the Recommended resolution. Dangling references
+  /// are skipped at resolution time, not scrubbed here: this store cannot see
+  /// the global profile list.
+  var lastLaunchedAgentProfileID: UUID?
 
   static let `default` = UserRepositorySettings(customCommands: [])
 
   private enum CodingKeys: String, CodingKey {
     case customCommands
     case disabledGlobalCommandIDs
+    case defaultAgentProfileID
+    case lastLaunchedAgentProfileID
   }
 
   init(
     customCommands: [UserCustomCommand],
-    disabledGlobalCommandIDs: Set<UserCustomCommand.ID> = []
+    disabledGlobalCommandIDs: Set<UserCustomCommand.ID> = [],
+    defaultAgentProfileID: UUID? = nil,
+    lastLaunchedAgentProfileID: UUID? = nil
   ) {
     self.customCommands = Self.normalizedCommands(customCommands)
     self.disabledGlobalCommandIDs = disabledGlobalCommandIDs
+    self.defaultAgentProfileID = defaultAgentProfileID
+    self.lastLaunchedAgentProfileID = lastLaunchedAgentProfileID
   }
 
   init(from decoder: Decoder) throws {
@@ -25,18 +38,25 @@ nonisolated struct UserRepositorySettings: Codable, Equatable, Sendable {
     customCommands = Self.normalizedCommands(commands)
     disabledGlobalCommandIDs =
       try container.decodeIfPresent(Set<UserCustomCommand.ID>.self, forKey: .disabledGlobalCommandIDs) ?? []
+    defaultAgentProfileID = try container.decodeIfPresent(UUID.self, forKey: .defaultAgentProfileID)
+    lastLaunchedAgentProfileID =
+      try container.decodeIfPresent(UUID.self, forKey: .lastLaunchedAgentProfileID)
   }
 
   func encode(to encoder: Encoder) throws {
     var container = encoder.container(keyedBy: CodingKeys.self)
     try container.encode(customCommands, forKey: .customCommands)
     try container.encode(disabledGlobalCommandIDs.sorted(), forKey: .disabledGlobalCommandIDs)
+    try container.encodeIfPresent(defaultAgentProfileID, forKey: .defaultAgentProfileID)
+    try container.encodeIfPresent(lastLaunchedAgentProfileID, forKey: .lastLaunchedAgentProfileID)
   }
 
   func normalized() -> UserRepositorySettings {
     UserRepositorySettings(
       customCommands: customCommands,
-      disabledGlobalCommandIDs: disabledGlobalCommandIDs
+      disabledGlobalCommandIDs: disabledGlobalCommandIDs,
+      defaultAgentProfileID: defaultAgentProfileID,
+      lastLaunchedAgentProfileID: lastLaunchedAgentProfileID
     )
   }
 

--- a/supacode/Features/Settings/Reducer/AgentProfilesFeature.swift
+++ b/supacode/Features/Settings/Reducer/AgentProfilesFeature.swift
@@ -1,0 +1,238 @@
+import ComposableArchitecture
+import Foundation
+import Sharing
+import SwiftUI
+
+/// Settings → Agents: the global agent profile collection (docs-ai 053).
+/// List order is the recommendation fallback order; edits persist to
+/// `UserGlobalSettings` the same way global custom commands do.
+@Reducer
+struct AgentProfilesFeature {
+  @ObservableState
+  struct State: Equatable {
+    var settings: UserGlobalSettings = .default
+    var selectedProfileID: AgentProfile.ID?
+    /// Passive filesystem check for the selected bound profile's home; never
+    /// invokes a CLI (docs-ai 053: no login-status probing).
+    var selectedHomeInitialized = false
+    @Presents var alert: AlertState<Alert>?
+
+    var selectedProfile: AgentProfile? {
+      selectedProfileID.flatMap { id in settings.agentProfiles.first { $0.id == id } }
+    }
+  }
+
+  enum Action: BindableAction {
+    case task
+    case settingsLoaded(UserGlobalSettings)
+    case binding(BindingAction<State>)
+    case addProfile(AgentProfileRuntime)
+    case removeSelectedTapped
+    case moveProfiles(IndexSet, Int)
+    case selectProfile(AgentProfile.ID?)
+    case revealProfileFiles
+    case alert(PresentationAction<Alert>)
+    case delegate(Delegate)
+  }
+
+  enum Alert: Equatable {
+    case confirmUnrestricted(AgentProfile.ID)
+    case removeKeepingFiles(AgentProfile.ID)
+    case removeTrashingFiles(AgentProfile.ID)
+  }
+
+  @CasePathable
+  enum Delegate: Equatable {
+    case settingsChanged(UserGlobalSettings)
+  }
+
+  @Dependency(AgentProfileHomeClient.self) var homeClient
+  @Dependency(\.uuid) var uuid
+
+  var body: some Reducer<State, Action> {
+    BindingReducer()
+    Reduce { state, action in
+      switch action {
+      case .task:
+        return .run { send in
+          @Shared(.userGlobalSettings) var settings
+          await send(.settingsLoaded(settings))
+        }
+
+      case .settingsLoaded(let settings):
+        state.settings = settings.normalized()
+        if state.selectedProfileID == nil {
+          state.selectedProfileID = state.settings.agentProfiles.first?.id
+        }
+        refreshHomeStatus(&state)
+        return .none
+
+      case .binding:
+        // `.unrestricted` is never applied silently: the change reverts until
+        // the user explicitly confirms it (docs-ai 053).
+        @Shared(.userGlobalSettings) var persisted
+        if let pendingID = newlyUnrestrictedProfileID(persisted: persisted, edited: state.settings) {
+          revertExecutionMode(&state, profileID: pendingID, persisted: persisted)
+          state.alert = Self.unrestrictedAlert(profileID: pendingID)
+          return .none
+        }
+        state.settings = state.settings.normalized()
+        refreshHomeStatus(&state)
+        return persist(state.settings)
+
+      case .addProfile(let runtime):
+        let profile = AgentProfile(
+          id: uuid(),
+          name: AgentRuntimeAdapterRegistry.displayName(for: runtime.agent),
+          runtime: runtime
+        )
+        state.settings.agentProfiles.append(profile)
+        state.settings = state.settings.normalized()
+        state.selectedProfileID = profile.id
+        refreshHomeStatus(&state)
+        return persist(state.settings)
+
+      case .removeSelectedTapped:
+        guard let profile = state.selectedProfile else { return .none }
+        guard profile.bindsDedicatedHome else {
+          // Pure presets have no home reference: removal performs zero file
+          // operations by construction.
+          removeProfile(&state, id: profile.id)
+          return persist(state.settings)
+        }
+        state.alert = Self.removalAlert(profile: profile)
+        return .none
+
+      case .moveProfiles(let source, let destination):
+        state.settings.agentProfiles.move(fromOffsets: source, toOffset: destination)
+        return persist(state.settings)
+
+      case .selectProfile(let id):
+        state.selectedProfileID = id
+        refreshHomeStatus(&state)
+        return .none
+
+      case .revealProfileFiles:
+        guard let profile = state.selectedProfile, profile.bindsDedicatedHome else { return .none }
+        let id = profile.id
+        let client = homeClient
+        return .run { _ in client.revealHome(id) }
+
+      case .alert(.presented(.confirmUnrestricted(let profileID))):
+        guard let index = state.settings.agentProfiles.firstIndex(where: { $0.id == profileID })
+        else { return .none }
+        state.settings.agentProfiles[index].executionMode = .unrestricted
+        return persist(state.settings)
+
+      case .alert(.presented(.removeKeepingFiles(let profileID))):
+        removeProfile(&state, id: profileID)
+        return persist(state.settings)
+
+      case .alert(.presented(.removeTrashingFiles(let profileID))):
+        removeProfile(&state, id: profileID)
+        let client = homeClient
+        return .merge(
+          persist(state.settings),
+          .run { _ in
+            do {
+              try await client.trashHome(profileID)
+            } catch {
+              SupaLogger("Settings").warning("Unable to trash profile home: \(error)")
+            }
+          }
+        )
+
+      case .alert:
+        return .none
+
+      case .delegate:
+        return .none
+      }
+    }
+    .ifLet(\.$alert, action: \.alert)
+  }
+
+  private func persist(_ settings: UserGlobalSettings) -> Effect<Action> {
+    .run { send in
+      @Shared(.userGlobalSettings) var storedSettings
+      $storedSettings.withLock { $0 = settings }
+      await send(.delegate(.settingsChanged(settings)))
+    }
+  }
+
+  private func removeProfile(_ state: inout State, id: AgentProfile.ID) {
+    state.settings.agentProfiles.removeAll { $0.id == id }
+    if state.selectedProfileID == id {
+      state.selectedProfileID = state.settings.agentProfiles.first?.id
+    }
+    refreshHomeStatus(&state)
+  }
+
+  private func refreshHomeStatus(_ state: inout State) {
+    guard let profile = state.selectedProfile, profile.bindsDedicatedHome else {
+      state.selectedHomeInitialized = false
+      return
+    }
+    state.selectedHomeInitialized = homeClient.homeExists(profile.id)
+  }
+
+  private func newlyUnrestrictedProfileID(
+    persisted: UserGlobalSettings,
+    edited: UserGlobalSettings
+  ) -> AgentProfile.ID? {
+    edited.agentProfiles.first { profile in
+      profile.executionMode == .unrestricted
+        && persisted.agentProfiles.first { $0.id == profile.id }?.executionMode != .unrestricted
+    }?.id
+  }
+
+  private func revertExecutionMode(
+    _ state: inout State,
+    profileID: AgentProfile.ID,
+    persisted: UserGlobalSettings
+  ) {
+    guard let index = state.settings.agentProfiles.firstIndex(where: { $0.id == profileID })
+    else { return }
+    state.settings.agentProfiles[index].executionMode =
+      persisted.agentProfiles.first { $0.id == profileID }?.executionMode ?? .standard
+  }
+
+  static func unrestrictedAlert(profileID: AgentProfile.ID) -> AlertState<Alert> {
+    AlertState {
+      TextState("Allow Unrestricted Execution?")
+    } actions: {
+      ButtonState(role: .destructive, action: .confirmUnrestricted(profileID)) {
+        TextState("Allow Unrestricted")
+      }
+      ButtonState(role: .cancel) {
+        TextState("Cancel")
+      }
+    } message: {
+      TextState(
+        "The agent will run without permission prompts or sandboxing. "
+          + "It can execute any command and modify any file your user can."
+      )
+    }
+  }
+
+  static func removalAlert(profile: AgentProfile) -> AlertState<Alert> {
+    AlertState {
+      TextState("Remove “\(profile.name)”?")
+    } actions: {
+      ButtonState(action: .removeKeepingFiles(profile.id)) {
+        TextState("Remove Profile")
+      }
+      ButtonState(role: .destructive, action: .removeTrashingFiles(profile.id)) {
+        TextState("Remove and Trash Files")
+      }
+      ButtonState(role: .cancel) {
+        TextState("Cancel")
+      }
+    } message: {
+      TextState(
+        "This profile has its own home with login credentials and files. "
+          + "“Remove Profile” keeps them on disk; “Remove and Trash Files” moves the folder to the Trash."
+      )
+    }
+  }
+}

--- a/supacode/Features/Settings/Reducer/AgentProfilesFeature.swift
+++ b/supacode/Features/Settings/Reducer/AgentProfilesFeature.swift
@@ -76,7 +76,10 @@ struct AgentProfilesFeature {
           state.alert = Self.unrestrictedAlert(profileID: pendingID)
           return .none
         }
-        state.settings = state.settings.normalized()
+        // State deliberately stays as typed — normalizing here would fight
+        // the Name field (trim trailing spaces mid-word) and drop the profile
+        // outright the moment the field is cleared. Blank names are handled
+        // at the persistence boundary instead.
         refreshHomeStatus(&state)
         return persist(state.settings)
 
@@ -155,9 +158,32 @@ struct AgentProfilesFeature {
   private func persist(_ settings: UserGlobalSettings) -> Effect<Action> {
     .run { send in
       @Shared(.userGlobalSettings) var storedSettings
-      $storedSettings.withLock { $0 = settings }
-      await send(.delegate(.settingsChanged(settings)))
+      let sanitized = Self.sanitizedForPersistence(settings, persisted: storedSettings)
+      $storedSettings.withLock { $0 = sanitized }
+      await send(.delegate(.settingsChanged(sanitized)))
     }
+  }
+
+  /// A blank name must never reach disk: decode-time normalization drops
+  /// blank-named profiles, which would silently delete the profile (and
+  /// orphan a bound home) on the next load. An in-progress blank name keeps
+  /// its last persisted name — standard rename-revert semantics — while the
+  /// editor state keeps whatever the user is typing.
+  nonisolated static func sanitizedForPersistence(
+    _ edited: UserGlobalSettings,
+    persisted: UserGlobalSettings
+  ) -> UserGlobalSettings {
+    var settings = edited
+    settings.agentProfiles = settings.agentProfiles.map { profile in
+      var profile = profile
+      if profile.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+        profile.name =
+          persisted.agentProfiles.first { $0.id == profile.id }?.name
+          ?? AgentRuntimeAdapterRegistry.displayName(for: profile.runtime.agent)
+      }
+      return profile
+    }
+    return settings.normalized()
   }
 
   private func removeProfile(_ state: inout State, id: AgentProfile.ID) {

--- a/supacode/Features/Settings/Reducer/AgentProfilesFeature.swift
+++ b/supacode/Features/Settings/Reducer/AgentProfilesFeature.swift
@@ -31,6 +31,7 @@ struct AgentProfilesFeature {
     case moveProfiles(IndexSet, Int)
     case selectProfile(AgentProfile.ID?)
     case revealProfileFiles
+    case homeStatusRefreshed(AgentProfile.ID, Bool)
     case alert(PresentationAction<Alert>)
     case delegate(Delegate)
   }
@@ -97,8 +98,12 @@ struct AgentProfilesFeature {
 
       case .removeSelectedTapped:
         guard let profile = state.selectedProfile else { return .none }
-        guard profile.bindsDedicatedHome else {
-          // Pure presets have no home reference: removal performs zero file
+        // The confirmation gate keys on the *disk fact*, not the current
+        // binding intent: a profile that was bound, launched (home created),
+        // then unbound still owns credentials on disk — deleting it silently
+        // would orphan them with no UI path back.
+        guard profile.bindsDedicatedHome || homeClient.homeExists(profile.id) else {
+          // Pure presets with no home on disk: removal performs zero file
           // operations by construction.
           removeProfile(&state, id: profile.id)
           return persist(state.settings)
@@ -119,7 +124,17 @@ struct AgentProfilesFeature {
         guard let profile = state.selectedProfile, profile.bindsDedicatedHome else { return .none }
         let id = profile.id
         let client = homeClient
-        return .run { _ in client.revealHome(id) }
+        return .run { send in
+          // Reveal provisions the home when missing; report the fresh status
+          // so the passive indicator doesn't keep saying "Not initialized".
+          client.revealHome(id)
+          await send(.homeStatusRefreshed(id, client.homeExists(id)))
+        }
+
+      case .homeStatusRefreshed(let profileID, let initialized):
+        guard state.selectedProfileID == profileID else { return .none }
+        state.selectedHomeInitialized = initialized
+        return .none
 
       case .alert(.presented(.confirmUnrestricted(let profileID))):
         guard let index = state.settings.agentProfiles.firstIndex(where: { $0.id == profileID })

--- a/supacode/Features/Settings/Reducer/SettingsFeature.swift
+++ b/supacode/Features/Settings/Reducer/SettingsFeature.swift
@@ -62,6 +62,7 @@ struct SettingsFeature {
     var selection: SettingsSection? = .general
     var repositorySettings: RepositorySettingsFeature.State?
     var globalCustomCommands: GlobalCustomCommandsFeature.State?
+    var agentProfiles: AgentProfilesFeature.State?
     @Presents var alert: AlertState<Alert>?
 
     init(settings: GlobalSettings = .default) {
@@ -183,6 +184,7 @@ struct SettingsFeature {
     case showNotificationPermissionAlert(errorMessage: String?)
     case repositorySettings(RepositorySettingsFeature.Action)
     case globalCustomCommands(GlobalCustomCommandsFeature.Action)
+    case agentProfiles(AgentProfilesFeature.Action)
     case alert(PresentationAction<Alert>)
     case delegate(Delegate)
     case binding(BindingAction<State>)
@@ -445,6 +447,9 @@ struct SettingsFeature {
       case .globalCustomCommands:
         return .none
 
+      case .agentProfiles:
+        return .none
+
       case .delegate:
         return .none
       }
@@ -454,6 +459,9 @@ struct SettingsFeature {
     }
     .ifLet(\.globalCustomCommands, action: \.globalCustomCommands) {
       GlobalCustomCommandsFeature()
+    }
+    .ifLet(\.agentProfiles, action: \.agentProfiles) {
+      AgentProfilesFeature()
     }
   }
 

--- a/supacode/Features/Settings/Views/AgentProfilesSettingsView.swift
+++ b/supacode/Features/Settings/Views/AgentProfilesSettingsView.swift
@@ -1,0 +1,255 @@
+import ComposableArchitecture
+import SwiftUI
+
+/// Settings → Agents: profile list plus the editor for the selected profile.
+/// List order is the recommendation fallback order.
+struct AgentProfilesSettingsView: View {
+  @Bindable var store: StoreOf<AgentProfilesFeature>
+
+  var body: some View {
+    Form {
+      profileListSection
+      if let profile = store.selectedProfile, let binding = profileBinding(profile.id) {
+        editorSection(profile: profile, binding: binding)
+        advancedSection(profile: profile, binding: binding)
+      }
+    }
+    .formStyle(.grouped)
+    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    .task { store.send(.task) }
+    .alert($store.scope(state: \.alert, action: \.alert))
+  }
+
+  private var profileListSection: some View {
+    Section {
+      if store.settings.agentProfiles.isEmpty {
+        Text("No agent profiles yet. Add one to launch agents from the Agents menu.")
+          .foregroundStyle(.secondary)
+      }
+      ForEach(store.settings.agentProfiles) { profile in
+        profileRow(profile)
+      }
+      HStack(spacing: 8) {
+        Menu {
+          ForEach(AgentProfileRuntime.allCases) { runtime in
+            Button(AgentRuntimeAdapterRegistry.displayName(for: runtime.agent)) {
+              store.send(.addProfile(runtime))
+            }
+          }
+        } label: {
+          Label("Add Profile", systemImage: "plus")
+        }
+        .fixedSize()
+        .help("Add a new agent profile")
+
+        Button {
+          store.send(.removeSelectedTapped)
+        } label: {
+          Label("Remove", systemImage: "minus")
+        }
+        .disabled(store.selectedProfile == nil)
+        .help("Remove the selected profile")
+        Spacer()
+      }
+    } header: {
+      VStack(alignment: .leading, spacing: 4) {
+        Text("Agent Profiles")
+        Text(
+          "Named launch presets for verified agents, available from the toolbar Agents menu "
+            + "and the Command Palette. The first enabled profile is the recommendation fallback."
+        )
+        .foregroundStyle(.secondary)
+      }
+    }
+  }
+
+  private func profileRow(_ profile: AgentProfile) -> some View {
+    HStack(spacing: 8) {
+      if let binding = profileBinding(profile.id) {
+        Toggle("", isOn: binding.isEnabled)
+          .labelsHidden()
+          .toggleStyle(.checkbox)
+          .help("Show this profile in the Agents menu")
+      }
+      Button {
+        store.send(.selectProfile(profile.id))
+      } label: {
+        HStack(spacing: 8) {
+          Text(profile.name)
+          if profile.bindsDedicatedHome {
+            Image(systemName: "person.crop.circle.badge.checkmark")
+              .foregroundStyle(.secondary)
+              .accessibilityLabel("Dedicated account")
+              .help("Uses a dedicated home with its own account")
+          }
+          Spacer()
+          Text(AgentRuntimeAdapterRegistry.displayName(for: profile.runtime.agent))
+            .foregroundStyle(.secondary)
+        }
+        .contentShape(Rectangle())
+      }
+      .buttonStyle(.plain)
+      .help("Edit this profile")
+    }
+    .listRowBackground(
+      store.selectedProfileID == profile.id
+        ? Color.accentColor.opacity(0.12) : Color.clear
+    )
+    .contextMenu {
+      Button("Move Up") { move(profile.id, by: -1) }
+        .disabled(index(of: profile.id) == 0)
+      Button("Move Down") { move(profile.id, by: 1) }
+        .disabled(index(of: profile.id) == store.settings.agentProfiles.count - 1)
+    }
+  }
+
+  private func editorSection(profile: AgentProfile, binding: Binding<AgentProfile>) -> some View {
+    Section("Profile") {
+      TextField("Name", text: binding.name)
+      Picker("Agent", selection: binding.runtime) {
+        ForEach(AgentProfileRuntime.allCases) { runtime in
+          Text(AgentRuntimeAdapterRegistry.displayName(for: runtime.agent)).tag(runtime)
+        }
+      }
+      optionalTextRow(
+        title: "Model",
+        prompt: "Runtime default",
+        text: binding.model
+      )
+      effortRow(profile: profile, binding: binding)
+      Picker("Execution Mode", selection: binding.executionMode) {
+        Text("Standard").tag(AgentExecutionMode.standard)
+        Text("Unrestricted").tag(AgentExecutionMode.unrestricted)
+      }
+      if profile.executionMode == .unrestricted {
+        Text("Runs without permission prompts or sandboxing.")
+          .font(.caption)
+          .foregroundStyle(.red)
+      }
+      Picker("Open In", selection: binding.placement) {
+        Text("New Tab").tag(AgentProfilePlacement.tab)
+        Text("New Split").tag(AgentProfilePlacement.split)
+      }
+      if profile.placement == .split {
+        Picker("Split Direction", selection: binding.splitDirection) {
+          ForEach(UserCustomSplitDirection.allCases) { direction in
+            Text(direction.title).tag(direction)
+          }
+        }
+      }
+    }
+  }
+
+  private func advancedSection(profile: AgentProfile, binding: Binding<AgentProfile>) -> some View {
+    Section("Advanced") {
+      optionalTextRow(
+        title: "Extra Arguments",
+        prompt: "--flag value",
+        text: Binding(
+          get: { profile.extraArguments.isEmpty ? nil : profile.extraArguments },
+          set: { binding.wrappedValue.extraArguments = $0 ?? "" }
+        )
+      )
+      Toggle("Use Dedicated Home", isOn: binding.bindsDedicatedHome)
+        .help("Keep a separate login, usage, and configuration for this profile")
+      if profile.bindsDedicatedHome {
+        Text(
+          "This profile gets its own runtime home: separate login and usage, "
+            + "but also separate skills, global instructions, and session history. "
+            + "The first launch signs in through the agent itself."
+        )
+        .font(.caption)
+        .foregroundStyle(.secondary)
+        LabeledContent(
+          "Profile Home",
+          value: store.selectedHomeInitialized ? "Initialized" : "Not initialized yet"
+        )
+        Button("Reveal Profile Files") {
+          store.send(.revealProfileFiles)
+        }
+        .help("Open the profile's home folder in Finder")
+      }
+      launchPreview(profile: profile)
+    }
+  }
+
+  private func effortRow(profile: AgentProfile, binding: Binding<AgentProfile>) -> some View {
+    HStack {
+      optionalTextRow(
+        title: "Reasoning Effort",
+        prompt: "Runtime default",
+        text: binding.reasoningEffort
+      )
+      Menu {
+        ForEach(effortSuggestions(for: profile.runtime), id: \.self) { suggestion in
+          Button(suggestion) { binding.wrappedValue.reasoningEffort = suggestion }
+        }
+        Button("Runtime Default") { binding.wrappedValue.reasoningEffort = nil }
+      } label: {
+        Image(systemName: "chevron.up.chevron.down")
+          .accessibilityLabel("Effort suggestions")
+      }
+      .menuStyle(.borderlessButton)
+      .fixedSize()
+      .help("Pick a known effort level, or type any value")
+    }
+  }
+
+  private func launchPreview(profile: AgentProfile) -> some View {
+    VStack(alignment: .leading, spacing: 4) {
+      Text("Launch Preview")
+      Text(previewText(for: profile))
+        .font(.callout.monospaced())
+        .foregroundStyle(.secondary)
+        .textSelection(.enabled)
+        .lineLimit(nil)
+    }
+  }
+
+  private func optionalTextRow(
+    title: String,
+    prompt: String,
+    text: Binding<String?>
+  ) -> some View {
+    TextField(
+      title,
+      text: Binding(
+        get: { text.wrappedValue ?? "" },
+        set: { value in
+          let trimmed = value.trimmingCharacters(in: .whitespaces)
+          text.wrappedValue = trimmed.isEmpty ? nil : value
+        }
+      ),
+      prompt: Text(prompt)
+    )
+  }
+
+  private func previewText(for profile: AgentProfile) -> String {
+    let plan = try? AgentProfileLaunchPlanner.plan(
+      for: profile,
+      homeBaseDirectory: SupacodePaths.agentProfileHomesDirectory
+    )
+    return plan?.previewText ?? "Unavailable"
+  }
+
+  private func effortSuggestions(for runtime: AgentProfileRuntime) -> [String] {
+    AgentRuntimeAdapterRegistry.adapter(for: runtime.agent)?.reasoningEffortSuggestions ?? []
+  }
+
+  private func index(of id: AgentProfile.ID) -> Int? {
+    store.settings.agentProfiles.firstIndex { $0.id == id }
+  }
+
+  private func move(_ id: AgentProfile.ID, by offset: Int) {
+    guard let index = index(of: id) else { return }
+    let destination = offset > 0 ? index + 2 : index - 1
+    store.send(.moveProfiles(IndexSet(integer: index), destination))
+  }
+
+  private func profileBinding(_ id: AgentProfile.ID) -> Binding<AgentProfile>? {
+    guard let index = store.settings.agentProfiles.firstIndex(where: { $0.id == id }) else {
+      return nil
+    }
+    return $store.settings.agentProfiles[index]
+  }
+}

--- a/supacode/Features/Settings/Views/AgentProfilesSettingsView.swift
+++ b/supacode/Features/Settings/Views/AgentProfilesSettingsView.swift
@@ -121,10 +121,14 @@ struct AgentProfilesSettingsView: View {
         Text("Standard").tag(AgentExecutionMode.standard)
         Text("Unrestricted").tag(AgentExecutionMode.unrestricted)
       }
-      if profile.executionMode == .unrestricted {
-        Text("Runs without permission prompts or sandboxing.")
-          .font(.caption)
-          .foregroundStyle(.red)
+      if profile.effectiveExecutionMode == .unrestricted {
+        Text(
+          profile.executionMode == .unrestricted
+            ? "Runs without permission prompts or sandboxing."
+            : "Extra arguments enable unrestricted execution — no permission prompts or sandboxing."
+        )
+        .font(.caption)
+        .foregroundStyle(.red)
       }
       Picker("Open In", selection: binding.placement) {
         Text("New Tab").tag(AgentProfilePlacement.tab)

--- a/supacode/Features/Settings/Views/AgentProfilesSettingsView.swift
+++ b/supacode/Features/Settings/Views/AgentProfilesSettingsView.swift
@@ -121,7 +121,10 @@ struct AgentProfilesSettingsView: View {
         Text("Standard").tag(AgentExecutionMode.standard)
         Text("Unrestricted").tag(AgentExecutionMode.unrestricted)
       }
-      if profile.effectiveExecutionMode == .unrestricted {
+      switch profile.effectiveExecutionMode {
+      case .standard:
+        EmptyView()
+      case .unrestricted:
         Text(
           profile.executionMode == .unrestricted
             ? "Runs without permission prompts or sandboxing."
@@ -129,6 +132,10 @@ struct AgentProfilesSettingsView: View {
         )
         .font(.caption)
         .foregroundStyle(.red)
+      case .followsExtraArguments:
+        Text("Effective execution mode follows your extra arguments.")
+          .font(.caption)
+          .foregroundStyle(.secondary)
       }
       Picker("Open In", selection: binding.placement) {
         Text("New Tab").tag(AgentProfilePlacement.tab)

--- a/supacode/Features/Settings/Views/RepositorySettingsView.swift
+++ b/supacode/Features/Settings/Views/RepositorySettingsView.swift
@@ -257,6 +257,30 @@ struct RepositorySettingsView: View {
         }
       }
       Section {
+        Picker(
+          "Default Agent Profile",
+          selection: Binding(
+            get: { store.userSettings.defaultAgentProfileID },
+            set: { store.send(.setDefaultAgentProfileID($0)) }
+          )
+        ) {
+          Text("None").tag(AgentProfile.ID?.none)
+          ForEach(globalSettings.agentProfiles.filter(\.isEnabled)) { profile in
+            Text(profile.name).tag(AgentProfile.ID?.some(profile.id))
+          }
+        }
+      } header: {
+        VStack(alignment: .leading, spacing: 4) {
+          Text("Agents")
+          Text(
+            "Recommended first in the Agents menu for this repository. "
+              + "Without a designation, the last profile launched here is recommended."
+          )
+          .foregroundStyle(.secondary)
+        }
+      }
+
+      Section {
         ScriptEnvironmentRow(
           name: "PROWL_WORKTREE_PATH",
           description: "Path to the active worktree."

--- a/supacode/Features/Settings/Views/SettingsSection.swift
+++ b/supacode/Features/Settings/Views/SettingsSection.swift
@@ -9,5 +9,6 @@ enum SettingsSection: Hashable {
   case advanced
   case github
   case customCommands
+  case agents
   case repository(Repository.ID)
 }

--- a/supacode/Features/Settings/Views/SettingsView.swift
+++ b/supacode/Features/Settings/Views/SettingsView.swift
@@ -46,6 +46,8 @@ struct SettingsView: View {
             .tag(SettingsSection.github)
           Label("Commands", systemImage: "globe")
             .tag(SettingsSection.customCommands)
+          Label("Agents", systemImage: "sparkles")
+            .tag(SettingsSection.agents)
 
           Section("Repositories") {
             ForEach(repositories) { repository in
@@ -115,6 +117,20 @@ struct SettingsView: View {
             GlobalCustomCommandsView(store: globalCustomCommandsStore)
               .navigationTitle("Global Commands")
               .navigationSubtitle("Global terminal actions and toolbar buttons")
+          } else {
+            ProgressView()
+              .frame(maxWidth: .infinity, maxHeight: .infinity)
+          }
+        }
+      case .agents:
+        SettingsDetailView {
+          if let agentProfilesStore = settingsStore.scope(
+            state: \.agentProfiles,
+            action: \.agentProfiles
+          ) {
+            AgentProfilesSettingsView(store: agentProfilesStore)
+              .navigationTitle("Agents")
+              .navigationSubtitle("Agent profiles and launch presets")
           } else {
             ProgressView()
               .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
+++ b/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
@@ -90,6 +90,8 @@ final class WorktreeTerminalManager {
           customCommandIcon: customCommandIcon
         )
       }
+    case .launchAgentProfile(let worktree, let plan):
+      state(for: worktree).launchAgentProfile(plan)
     case .createTabInDirectory(let worktree, let directory):
       Task {
         createTabAsync(in: worktree, runSetupScriptIfNew: false, workingDirectory: directory)

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState+AgentDetection.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState+AgentDetection.swift
@@ -126,7 +126,8 @@ extension WorktreeTerminalState {
       identified: identified,
       previous: previous,
       workingDirectory: workingDirectory,
-      activeText: activeText
+      activeText: activeText,
+      configRoot: launchProfilesBySurface[surfaceID]?.dedicatedHome
     )
     // Re-check after the suspension: the pane may have been closed and its
     // agent state cleaned up while the resolver was doing file inspection;
@@ -193,14 +194,16 @@ extension WorktreeTerminalState {
     identified: IdentifiedAgentProcess?,
     previous: PaneAgentState,
     workingDirectory: URL?,
-    activeText: String
+    activeText: String,
+    configRoot: URL?
   ) async -> (session: AgentSession?, missStreak: Int) {
     var resolution = AgentSessionResolution(session: nil, isFresh: false)
     if let identified {
       resolution = await AgentSessionResolver.shared.resolve(
         identified: identified,
         workingDirectory: workingDirectory,
-        activeText: activeText
+        activeText: activeText,
+        configRoot: configRoot
       )
     }
     return PaneAgentState.retainedSession(

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState+AgentDetection.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState+AgentDetection.swift
@@ -301,7 +301,8 @@ extension WorktreeTerminalState {
       session: state.session,
       rawState: state.fallbackState,
       displayState: state.displayState,
-      lastChangedAt: state.lastChangedAt
+      lastChangedAt: state.lastChangedAt,
+      launchProfileName: launchProfilesBySurface[surfaceID]?.name
     )
   }
 

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState+AgentDetection.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState+AgentDetection.swift
@@ -127,7 +127,7 @@ extension WorktreeTerminalState {
       previous: previous,
       workingDirectory: workingDirectory,
       activeText: activeText,
-      configRoot: launchProfilesBySurface[surfaceID]?.dedicatedHome
+      configRoot: launchProfilesBySurface[surfaceID]?.configRoot(forDetected: agent)
     )
     // Re-check after the suspension: the pane may have been closed and its
     // agent state cleaned up while the resolver was doing file inspection;

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState+Surfaces.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState+Surfaces.swift
@@ -65,7 +65,8 @@ extension WorktreeTerminalState {
     inheritingFromSurfaceId: UUID? = nil,
     initialInput: String? = nil,
     workingDirectoryOverride: URL? = nil,
-    context: ghostty_surface_context_e = GHOSTTY_SURFACE_CONTEXT_TAB
+    context: ghostty_surface_context_e = GHOSTTY_SURFACE_CONTEXT_TAB,
+    additionalEnvironment: [String: String] = [:]
   ) -> SplitTree<GhosttySurfaceView> {
     guard tabManager.tabs.contains(where: { $0.id == tabId }) else {
       return SplitTree()
@@ -78,7 +79,8 @@ extension WorktreeTerminalState {
       initialInput: initialInput,
       inheritingFromSurfaceId: inheritingFromSurfaceId,
       workingDirectoryOverride: workingDirectoryOverride,
-      context: context
+      context: context,
+      additionalEnvironment: additionalEnvironment
     )
     let tree = SplitTree(view: surface)
     trees[tabId] = tree
@@ -91,7 +93,8 @@ extension WorktreeTerminalState {
   @discardableResult
   func createSplitOnFocusedSurface(
     direction: UserCustomSplitDirection,
-    initialInput: String
+    initialInput: String,
+    additionalEnvironment: [String: String] = [:]
   ) -> UUID? {
     guard let tabId = tabManager.selectedTabId,
       let parentSurfaceId = focusedSurfaceIdByTab[tabId],
@@ -104,7 +107,8 @@ extension WorktreeTerminalState {
       tabId: tabId,
       initialInput: runScriptInput(initialInput),
       inheritingFromSurfaceId: parentSurfaceId,
-      context: GHOSTTY_SURFACE_CONTEXT_SPLIT
+      context: GHOSTTY_SURFACE_CONTEXT_SPLIT,
+      additionalEnvironment: additionalEnvironment
     )
     do {
       let newTree = try tree.inserting(
@@ -313,6 +317,7 @@ extension WorktreeTerminalState {
       surface.closeSurface()
     }
     surfaces.removeAll()
+    launchProfilesBySurface.removeAll()
     trees.removeAll()
     focusedSurfaceIdByTab.removeAll()
     cleanupAllAgentDetectionState()
@@ -330,7 +335,8 @@ extension WorktreeTerminalState {
     initialInput: String?,
     inheritingFromSurfaceId: UUID?,
     workingDirectoryOverride: URL? = nil,
-    context: ghostty_surface_context_e
+    context: ghostty_surface_context_e,
+    additionalEnvironment: [String: String] = [:]
   ) -> GhosttySurfaceView {
     let inherited = inheritedSurfaceConfig(fromSurfaceId: inheritingFromSurfaceId, context: context)
     let resolvedFontSize = Self.resolvedFontSizeForNewSurface(
@@ -344,7 +350,7 @@ extension WorktreeTerminalState {
       initialInput: initialInput,
       fontSize: resolvedFontSize,
       context: context,
-      environment: worktree.scriptEnvironment
+      environment: worktree.scriptEnvironment.merging(additionalEnvironment) { _, patched in patched }
     )
     // Sending a no-op font size action marks the Ghostty surface as
     // "font_size_adjusted", which prevents config reloads (triggered by
@@ -611,6 +617,7 @@ extension WorktreeTerminalState {
   func forgetSurface(_ surfaceID: UUID) {
     unregisterTargetHandle(for: surfaceID)
     surfaces.removeValue(forKey: surfaceID)
+    launchProfilesBySurface.removeValue(forKey: surfaceID)
     surfaceRunningStartedAtById.removeValue(forKey: surfaceID)
     autoCloseSurfaceIds.remove(surfaceID)
     pendingCustomCommands.removeValue(forKey: surfaceID)

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -72,6 +72,9 @@ final class WorktreeTerminalState {
   var focusedSurfaceIdByTab: [TerminalTabID: UUID] = [:]
   struct SurfaceLaunchProfile: Equatable {
     let profileID: UUID
+    /// Display name recorded at launch. Deliberately frozen: later profile
+    /// renames or deletions never relabel a live pane.
+    let name: String
     /// Relocated runtime home for account-bound profiles; the session
     /// resolver uses it as the config root for this surface. Nil for pure
     /// presets (default home layout).
@@ -413,7 +416,11 @@ final class WorktreeTerminalState {
         return nil
       }
     }
-    let identity = SurfaceLaunchProfile(profileID: plan.profileID, dedicatedHome: plan.dedicatedHome)
+    let identity = SurfaceLaunchProfile(
+      profileID: plan.profileID,
+      name: plan.profileName,
+      dedicatedHome: plan.dedicatedHome
+    )
     if plan.placement == .split,
       let surfaceID = createSplitOnFocusedSurface(
         direction: plan.splitDirection,

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -70,7 +70,20 @@ final class WorktreeTerminalState {
   var trees: [TerminalTabID: SplitTree<GhosttySurfaceView>] = [:]
   var surfaces: [UUID: GhosttySurfaceView] = [:]
   var focusedSurfaceIdByTab: [TerminalTabID: UUID] = [:]
+  struct SurfaceLaunchProfile: Equatable {
+    let profileID: UUID
+    /// Relocated runtime home for account-bound profiles; the session
+    /// resolver uses it as the config root for this surface. Nil for pure
+    /// presets (default home layout).
+    let dedicatedHome: URL?
+  }
+
   var surfaceAgentStates: [UUID: PaneAgentState] = [:]
+  /// Launch identity recorded at surface creation for Prowl-launched agent
+  /// profiles (docs-ai 053). Never rewritten: recommendation or designation
+  /// edits must not relabel a live pane. Detected-but-not-launched agents
+  /// have no entry here.
+  var launchProfilesBySurface: [UUID: SurfaceLaunchProfile] = [:]
   var agentDetectionSchedules: [UUID: AgentDetectionSchedule] = [:]
   var agentDetectionTasks: [UUID: Task<Void, Never>] = [:]
   var agentDetectionPresenceBySurface: [UUID: AgentDetectionPresence] = [:]
@@ -383,6 +396,52 @@ final class WorktreeTerminalState {
     return tabId
   }
 
+  /// Launches an agent profile per its compiled plan (docs-ai 053): provisions
+  /// the dedicated home when bound, creates the placement surface with the
+  /// environment patch, and records the profile identity on the new surface.
+  /// Split placement degrades to a new tab when nothing is splittable.
+  @discardableResult
+  func launchAgentProfile(_ plan: AgentProfileLaunchPlan) -> UUID? {
+    if let home = plan.dedicatedHome {
+      do {
+        try AgentProfileHomeProvisioner.provision(
+          home: home,
+          base: SupacodePaths.agentProfileHomesDirectory
+        )
+      } catch {
+        terminalStateLogger.warning("Agent profile home provisioning failed: \(error)")
+        return nil
+      }
+    }
+    let identity = SurfaceLaunchProfile(profileID: plan.profileID, dedicatedHome: plan.dedicatedHome)
+    if plan.placement == .split,
+      let surfaceID = createSplitOnFocusedSurface(
+        direction: plan.splitDirection,
+        initialInput: plan.terminalInput,
+        additionalEnvironment: plan.environment
+      )
+    {
+      launchProfilesBySurface[surfaceID] = identity
+      return surfaceID
+    }
+    let tabId = createTab(
+      TabCreation(
+        title: plan.profileName,
+        icon: "terminal",
+        isTitleLocked: false,
+        initialInput: runScriptInput(plan.terminalInput),
+        focusing: true,
+        inheritingFromSurfaceId: currentFocusedSurfaceId(),
+        context: GHOSTTY_SURFACE_CONTEXT_TAB,
+        workingDirectoryOverride: nil,
+        additionalEnvironment: plan.environment
+      )
+    )
+    guard let tabId, let surfaceID = trees[tabId]?.root?.leftmostLeaf().id else { return nil }
+    launchProfilesBySurface[surfaceID] = identity
+    return surfaceID
+  }
+
   @discardableResult
   func focusOrCreateTab(
     boundToDirectory directory: URL,
@@ -457,6 +516,7 @@ final class WorktreeTerminalState {
     let inheritingFromSurfaceId: UUID?
     let context: ghostty_surface_context_e
     let workingDirectoryOverride: URL?
+    var additionalEnvironment: [String: String] = [:]
   }
 
   private func createTab(_ creation: TabCreation) -> TerminalTabID? {
@@ -471,7 +531,8 @@ final class WorktreeTerminalState {
       inheritingFromSurfaceId: creation.inheritingFromSurfaceId,
       initialInput: creation.initialInput,
       workingDirectoryOverride: creation.workingDirectoryOverride,
-      context: creation.context
+      context: creation.context,
+      additionalEnvironment: creation.additionalEnvironment
     )
     _ = registerTargetHandle(for: tabId)
     for surface in tree.leaves() {

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -75,10 +75,20 @@ final class WorktreeTerminalState {
     /// Display name recorded at launch. Deliberately frozen: later profile
     /// renames or deletions never relabel a live pane.
     let name: String
+    /// The runtime this profile launched. The config root only applies to
+    /// detections of the same runtime: after the launched agent exits, a
+    /// manually started *different* agent in the same pane uses its default
+    /// home, and handing it the profile home would break its session
+    /// attribution.
+    let runtime: AgentProfileRuntime
     /// Relocated runtime home for account-bound profiles; the session
     /// resolver uses it as the config root for this surface. Nil for pure
     /// presets (default home layout).
     let dedicatedHome: URL?
+
+    func configRoot(forDetected agent: DetectedAgent) -> URL? {
+      runtime.agent == agent ? dedicatedHome : nil
+    }
   }
 
   var surfaceAgentStates: [UUID: PaneAgentState] = [:]
@@ -419,6 +429,7 @@ final class WorktreeTerminalState {
     let identity = SurfaceLaunchProfile(
       profileID: plan.profileID,
       name: plan.profileName,
+      runtime: plan.runtime,
       dedicatedHome: plan.dedicatedHome
     )
     if plan.placement == .split,

--- a/supacode/Infrastructure/AgentDetection/AgentSessionProfile.swift
+++ b/supacode/Infrastructure/AgentDetection/AgentSessionProfile.swift
@@ -34,6 +34,16 @@ nonisolated struct AgentSessionProfile: Sendable {
   /// Candidate enumeration for agents whose sessions live in a shared store
   /// instead of per-session files (OpenCode's sqlite database).
   var storeCandidates: (@Sendable (_ home: URL, _ cwd: URL?, _ processStartedAt: Date) -> [AgentSessionCandidate])?
+  /// Layout under a relocated config root for account-bound Prowl-launched
+  /// surfaces (docs-ai 053): the runtime's entire home moved, so paths carry
+  /// no `.claude`/`.codex` component and the default markers cannot match.
+  /// Only runtimes with verified account isolation define these; when a
+  /// surface has a config root, the resolver uses the rooted layout
+  /// exclusively — scanning the default home would misattribute sessions.
+  var rootedCandidateRoots:
+    (@Sendable (_ configRoot: URL, _ cwd: URL?, _ processStartedAt: Date, _ now: Date) -> [URL])?
+  var rootedFallbackRoots: (@Sendable (_ configRoot: URL, _ cwd: URL?) -> [URL])?
+  var rootedParsePath: (@Sendable (_ path: String, _ configRoot: URL) -> AgentSession?)?
 
   static func profile(for agent: DetectedAgent) -> AgentSessionProfile {
     switch agent {
@@ -74,6 +84,19 @@ nonisolated extension AgentSessionProfile {
     },
     fallbackRoots: { home, _ in
       [home.appending(path: ".codex/sessions")]
+    },
+    rootedCandidateRoots: { configRoot, _, processStartedAt, now in
+      dayDirectories(
+        root: configRoot.appending(path: "sessions"),
+        from: processStartedAt,
+        to: now
+      )
+    },
+    rootedFallbackRoots: { configRoot, _ in
+      [configRoot.appending(path: "sessions")]
+    },
+    rootedParsePath: { path, configRoot in
+      uuidJSONL(path: path, underRoot: configRoot.appending(path: "sessions"))
     }
   )
 
@@ -85,6 +108,13 @@ nonisolated extension AgentSessionProfile {
     candidateRoots: { home, cwd, _, _ in
       guard let cwd else { return [] }
       return [home.appending(path: ".claude/projects/\(alphanumericDashed(cwd.path))")]
+    },
+    rootedCandidateRoots: { configRoot, cwd, _, _ in
+      guard let cwd else { return [] }
+      return [configRoot.appending(path: "projects/\(alphanumericDashed(cwd.path))")]
+    },
+    rootedParsePath: { path, configRoot in
+      uuidJSONL(path: path, underRoot: configRoot.appending(path: "projects"))
     }
   )
 
@@ -332,6 +362,18 @@ nonisolated extension AgentSessionProfile {
   fileprivate static func uuidJSONL(path: String, marker: String) -> AgentSession? {
     let url = URL(fileURLWithPath: path)
     guard path.contains(marker), url.pathExtension == "jsonl",
+      let id = uuid(in: url.deletingPathExtension().lastPathComponent)
+    else { return nil }
+    return AgentSession(id: id, transcriptPath: url, source: .recentFile)
+  }
+
+  /// Marker matching for relocated homes: the config root replaces the global
+  /// `/.codex/…` substring, so ownership is a root prefix check instead.
+  fileprivate static func uuidJSONL(path: String, underRoot root: URL) -> AgentSession? {
+    let rootPath = root.standardizedFileURL.path(percentEncoded: false)
+    guard path.hasPrefix(rootPath.hasSuffix("/") ? rootPath : rootPath + "/") else { return nil }
+    let url = URL(fileURLWithPath: path)
+    guard url.pathExtension == "jsonl",
       let id = uuid(in: url.deletingPathExtension().lastPathComponent)
     else { return nil }
     return AgentSession(id: id, transcriptPath: url, source: .recentFile)

--- a/supacode/Infrastructure/AgentDetection/AgentSessionResolver.swift
+++ b/supacode/Infrastructure/AgentDetection/AgentSessionResolver.swift
@@ -147,6 +147,7 @@ actor AgentSessionResolver {
     identified: IdentifiedAgentProcess,
     workingDirectory: URL?,
     activeText: String,
+    configRoot: URL? = nil,
     now: Date = Date()
   ) -> AgentSessionResolution {
     let process = identified.process
@@ -173,6 +174,7 @@ actor AgentSessionResolver {
       processStartedAt: startedAt,
       workingDirectory: workingDirectory,
       activeText: activeText,
+      configRoot: configRoot,
       now: now
     )
     var session = resolved
@@ -213,17 +215,32 @@ actor AgentSessionResolver {
     }
   }
 
+  /// Selects the path parser for this surface: the rooted variant when a
+  /// relocated config root is in play (docs-ai 053), the default markers
+  /// otherwise.
+  nonisolated static func pathParser(
+    profile: AgentSessionProfile,
+    configRoot: URL?
+  ) -> @Sendable (String) -> AgentSession? {
+    if let configRoot, let rooted = profile.rootedParsePath {
+      return { rooted($0, configRoot) }
+    }
+    return profile.parsePath
+  }
+
   private func resolveUncached(
     identified: IdentifiedAgentProcess,
     processStartedAt: Date,
     workingDirectory: URL?,
     activeText: String,
+    configRoot: URL? = nil,
     now: Date
   ) -> (session: AgentSession?, usedWideScan: Bool) {
     let profile = AgentSessionProfile.profile(for: identified.agent)
+    let parsePath = Self.pathParser(profile: profile, configRoot: configRoot)
 
     let openSessions = ProcessDetection.openFilePaths(pid: identified.process.pid)
-      .compactMap { profile.parsePath($0) }
+      .compactMap { parsePath($0) }
       .compactMap { session -> AgentSession? in
         guard let path = session.transcriptPath,
           let fullID = Self.sessionIDFromHeader(at: path, keys: profile.headerSessionIDKeys)
@@ -242,7 +259,11 @@ actor AgentSessionResolver {
       return (resolved, false)
     }
 
-    if let session = profile.pidKeyedSession?(homeDirectory, identified.process.pid, processStartedAt) {
+    // pid-keyed artifacts live in the default home; a relocated config root
+    // has no equivalent (no bound-capable runtime defines one).
+    if configRoot == nil,
+      let session = profile.pidKeyedSession?(homeDirectory, identified.process.pid, processStartedAt)
+    {
       return (session, false)
     }
 
@@ -270,6 +291,7 @@ actor AgentSessionResolver {
       profile: profile,
       processStartedAt: processStartedAt,
       workingDirectory: workingDirectory,
+      configRoot: configRoot,
       now: now
     )
     if let matched = AgentSessionFingerprintMatcher.bestMatch(activeText: activeText, candidates: candidates) {
@@ -294,16 +316,28 @@ actor AgentSessionResolver {
     profile: AgentSessionProfile,
     processStartedAt: Date,
     workingDirectory: URL?,
+    configRoot: URL? = nil,
     now: Date,
     visitLimit: Int = 20_000
   ) -> (candidates: [AgentSessionCandidate], usedWideScan: Bool) {
     let cwdVariants = workingDirectoryVariants(workingDirectory)
     let threshold = processStartedAt.addingTimeInterval(-2)
-    let stored = cwdVariants.flatMap { profile.storeCandidates?(homeDirectory, $0, threshold) ?? [] }
+    // Under a relocated config root the rooted layout is used exclusively:
+    // scanning the default home would misattribute another account's
+    // sessions. Store-backed agents cannot be account-bound.
+    let stored =
+      configRoot == nil
+      ? cwdVariants.flatMap { profile.storeCandidates?(homeDirectory, $0, threshold) ?? [] }
+      : []
     var primaryRoots: [URL] = []
     for cwd in cwdVariants {
-      for root in profile.candidateRoots(homeDirectory, cwd, processStartedAt, now)
-      where !primaryRoots.contains(root) {
+      let roots =
+        if let configRoot {
+          profile.rootedCandidateRoots?(configRoot, cwd, processStartedAt, now) ?? []
+        } else {
+          profile.candidateRoots(homeDirectory, cwd, processStartedAt, now)
+        }
+      for root in roots where !primaryRoots.contains(root) {
         primaryRoots.append(root)
       }
     }
@@ -312,6 +346,7 @@ actor AgentSessionResolver {
         in: primaryRoots,
         profile: profile,
         processStartedAt: processStartedAt,
+        configRoot: configRoot,
         visitLimit: visitLimit
       )
     else {
@@ -322,12 +357,18 @@ actor AgentSessionResolver {
     }
     let combined = primary + stored.uniquedBySessionID()
     guard combined.isEmpty else { return (combined, false) }
-    let fallbackRoots = profile.fallbackRoots(homeDirectory, workingDirectory)
+    let fallbackRoots =
+      if let configRoot {
+        profile.rootedFallbackRoots?(configRoot, workingDirectory) ?? []
+      } else {
+        profile.fallbackRoots(homeDirectory, workingDirectory)
+      }
     guard !fallbackRoots.isEmpty else { return ([], false) }
     let fallback = scanCandidates(
       in: fallbackRoots,
       profile: profile,
       processStartedAt: processStartedAt,
+      configRoot: configRoot,
       visitLimit: visitLimit
     )
     return (fallback ?? [], true)
@@ -348,6 +389,7 @@ actor AgentSessionResolver {
     in roots: [URL],
     profile: AgentSessionProfile,
     processStartedAt: Date,
+    configRoot: URL? = nil,
     visitLimit: Int = 20_000
   ) -> [AgentSessionCandidate]? {
     var collected: [AgentSessionCandidate] = []
@@ -360,7 +402,8 @@ actor AgentSessionResolver {
         )
       else { return nil }
       for item in files {
-        guard let candidate = enrichedCandidate(for: item, profile: profile) else { continue }
+        guard let candidate = enrichedCandidate(for: item, profile: profile, configRoot: configRoot)
+        else { continue }
         collected.append(candidate)
       }
     }
@@ -369,9 +412,10 @@ actor AgentSessionResolver {
 
   private func enrichedCandidate(
     for item: (url: URL, modifiedAt: Date),
-    profile: AgentSessionProfile
+    profile: AgentSessionProfile,
+    configRoot: URL?
   ) -> AgentSessionCandidate? {
-    guard let session = profile.parsePath(item.url.path) else { return nil }
+    guard let session = Self.pathParser(profile: profile, configRoot: configRoot)(item.url.path) else { return nil }
     if let fullID = Self.sessionIDFromHeader(at: item.url, keys: profile.headerSessionIDKeys) {
       return AgentSessionCandidate(
         session: AgentSession(id: fullID, transcriptPath: item.url, source: .recentFile),

--- a/supacode/Support/SupacodePaths.swift
+++ b/supacode/Support/SupacodePaths.swift
@@ -204,6 +204,13 @@ nonisolated enum SupacodePaths {
     baseDirectory.appending(path: "global.onevcat.json", directoryHint: .notDirectory)
   }
 
+  /// Base for account-bound agent profile homes: `~/.prowl/agent-profiles/`.
+  /// Chosen over Application Support to keep the path free of spaces handed
+  /// to third-party CLIs (docs-ai 053).
+  static var agentProfileHomesDirectory: URL {
+    baseDirectory.appending(path: "agent-profiles", directoryHint: .isDirectory)
+  }
+
   static var repositorySnapshotURL: URL {
     cacheDirectory.appending(path: "repository-snapshot.json", directoryHint: .notDirectory)
   }

--- a/supacodeTests/AgentProfileTests.swift
+++ b/supacodeTests/AgentProfileTests.swift
@@ -194,22 +194,32 @@ struct AgentProfileTests {
     )
   }
 
-  @Test func effectiveExecutionModeRecognizesBypassFlagsInExtraArguments() {
+  @Test func effectiveExecutionModeNeverClaimsStandardItCannotProve() {
     var codex = profile(name: "Codex")
     #expect(codex.effectiveExecutionMode == .standard)
 
+    // Recognized bypass flags upgrade the claim to unrestricted.
     codex.extraArguments = "--search --yolo"
     #expect(codex.effectiveExecutionMode == .unrestricted)
-
     codex.extraArguments = "--dangerously-bypass-approvals-and-sandbox"
     #expect(codex.effectiveExecutionMode == .unrestricted)
+
+    // Unrecognized safety-relevant overrides must not read as Standard:
+    // the claim defers to the command line instead.
+    codex.extraArguments = "--sandbox danger-full-access"
+    #expect(codex.effectiveExecutionMode == .followsExtraArguments)
+    codex.extraArguments = "--ask-for-approval never"
+    #expect(codex.effectiveExecutionMode == .followsExtraArguments)
+    codex.extraArguments = "-c approval_policy=never"
+    #expect(codex.effectiveExecutionMode == .followsExtraArguments)
 
     var claude = profile(name: "Claude", runtime: .claude)
     claude.extraArguments = "--permission-mode bypassPermissions"
     #expect(claude.effectiveExecutionMode == .unrestricted)
 
+    // Harmless flags also defer — any extra argument voids the Standard claim.
     claude.extraArguments = "--verbose"
-    #expect(claude.effectiveExecutionMode == .standard)
+    #expect(claude.effectiveExecutionMode == .followsExtraArguments)
     claude.executionMode = .unrestricted
     #expect(claude.effectiveExecutionMode == .unrestricted)
   }

--- a/supacodeTests/AgentProfileTests.swift
+++ b/supacodeTests/AgentProfileTests.swift
@@ -123,6 +123,101 @@ struct AgentProfileTests {
     #expect(ShellWordSplitter.split("--note 'unterminated tail") == ["--note", "unterminated tail"])
   }
 
+  // MARK: - Launch plan
+
+  @Test func purePresetPlanHasNoEnvironmentAndSplitsExtraArguments() throws {
+    var preset = profile(name: "Codex · Deep")
+    preset.model = "gpt-5.4"
+    preset.reasoningEffort = "xhigh"
+    preset.extraArguments = "--search --cd '/tmp/with space'"
+
+    let plan = try AgentProfileLaunchPlanner.plan(
+      for: preset,
+      homeBaseDirectory: URL(fileURLWithPath: "/base", isDirectory: true)
+    )
+
+    #expect(plan.environment.isEmpty)
+    #expect(plan.dedicatedHome == nil)
+    #expect(plan.invocation.executable == "codex")
+    #expect(
+      plan.invocation.arguments == [
+        "--model", "gpt-5.4",
+        "-c", "model_reasoning_effort=xhigh",
+        "--search", "--cd", "/tmp/with space",
+      ]
+    )
+    #expect(plan.previewText == plan.invocation.terminalInput)
+  }
+
+  @Test func boundProfilePlanDerivesHomeFromUUIDInsideBase() throws {
+    var bound = profile(name: "Codex · Work")
+    bound.bindsDedicatedHome = true
+    let base = URL(fileURLWithPath: "/base/agent-profiles", isDirectory: true)
+
+    let plan = try AgentProfileLaunchPlanner.plan(for: bound, homeBaseDirectory: base)
+
+    let home = try #require(plan.dedicatedHome)
+    #expect(
+      AgentProfileLaunchPlanner.pathString(home) == "/base/agent-profiles/\(bound.id.uuidString)"
+    )
+    #expect(plan.environment == ["CODEX_HOME": "/base/agent-profiles/\(bound.id.uuidString)"])
+    #expect(plan.previewText.hasPrefix("CODEX_HOME=/base/agent-profiles/"))
+    #expect(AgentProfileLaunchPlanner.isContained(home, in: base))
+  }
+
+  @Test func boundClaudeProfileUsesConfigDirVariable() throws {
+    var bound = profile(name: "Claude · Personal", runtime: .claude)
+    bound.bindsDedicatedHome = true
+
+    let plan = try AgentProfileLaunchPlanner.plan(
+      for: bound,
+      homeBaseDirectory: URL(fileURLWithPath: "/base", isDirectory: true)
+    )
+
+    #expect(plan.environment.keys.contains("CLAUDE_CONFIG_DIR"))
+  }
+
+  @Test func containmentRejectsBaseItselfAndOutsidePaths() {
+    let base = URL(fileURLWithPath: "/base/agent-profiles", isDirectory: true)
+    #expect(!AgentProfileLaunchPlanner.isContained(base, in: base))
+    #expect(
+      !AgentProfileLaunchPlanner.isContained(
+        URL(fileURLWithPath: "/base/agent-profiles/../../.codex", isDirectory: true),
+        in: base
+      )
+    )
+    #expect(
+      !AgentProfileLaunchPlanner.isContained(
+        URL(fileURLWithPath: "/base/agent-profiles-other/x", isDirectory: true),
+        in: base
+      )
+    )
+  }
+
+  @Test func provisionerRefusesHomesOutsideBase() {
+    let base = URL(fileURLWithPath: "/base/agent-profiles", isDirectory: true)
+    #expect(throws: AgentProfileLaunchPlanError.self) {
+      try AgentProfileHomeProvisioner.provision(
+        home: URL(fileURLWithPath: "/Users/x/.codex", isDirectory: true),
+        base: base
+      )
+    }
+  }
+
+  @Test func provisionerCreatesOwnerOnlyHome() throws {
+    let root = FileManager.default.temporaryDirectory
+      .appending(path: "agent-profile-tests-\(UUID().uuidString)", directoryHint: .isDirectory)
+    defer { try? FileManager.default.removeItem(at: root) }
+    let home = root.appending(path: UUID().uuidString, directoryHint: .isDirectory)
+
+    try AgentProfileHomeProvisioner.provision(home: home, base: root)
+
+    let attributes = try FileManager.default.attributesOfItem(
+      atPath: home.path(percentEncoded: false)
+    )
+    #expect((attributes[.posixPermissions] as? NSNumber)?.int16Value == 0o700)
+  }
+
   // MARK: - Settings persistence
 
   @Test func globalSettingsDecodeLegacyJSONWithoutProfileFields() throws {

--- a/supacodeTests/AgentProfileTests.swift
+++ b/supacodeTests/AgentProfileTests.swift
@@ -194,6 +194,56 @@ struct AgentProfileTests {
     )
   }
 
+  @Test func effectiveExecutionModeRecognizesBypassFlagsInExtraArguments() {
+    var codex = profile(name: "Codex")
+    #expect(codex.effectiveExecutionMode == .standard)
+
+    codex.extraArguments = "--search --yolo"
+    #expect(codex.effectiveExecutionMode == .unrestricted)
+
+    codex.extraArguments = "--dangerously-bypass-approvals-and-sandbox"
+    #expect(codex.effectiveExecutionMode == .unrestricted)
+
+    var claude = profile(name: "Claude", runtime: .claude)
+    claude.extraArguments = "--permission-mode bypassPermissions"
+    #expect(claude.effectiveExecutionMode == .unrestricted)
+
+    claude.extraArguments = "--verbose"
+    #expect(claude.effectiveExecutionMode == .standard)
+    claude.executionMode = .unrestricted
+    #expect(claude.effectiveExecutionMode == .unrestricted)
+  }
+
+  @Test func physicalContainmentRejectsSymlinkLeafAndEscapingTargets() throws {
+    let fileManager = FileManager.default
+    let root = fileManager.temporaryDirectory
+      .appending(path: "agent-profile-symlink-tests-\(UUID().uuidString)", directoryHint: .isDirectory)
+    defer { try? fileManager.removeItem(at: root) }
+    let base = root.appending(path: "agent-profiles", directoryHint: .isDirectory)
+    let outside = root.appending(path: "fake-codex-home", directoryHint: .isDirectory)
+    try fileManager.createDirectory(at: base, withIntermediateDirectories: true)
+    try fileManager.createDirectory(at: outside, withIntermediateDirectories: true)
+
+    // A <uuid> leaf replaced by a symlink to a directory outside the base
+    // must be rejected before any file operation.
+    let linkedHome = base.appending(path: UUID().uuidString, directoryHint: .isDirectory)
+    try fileManager.createSymbolicLink(at: linkedHome, withDestinationURL: outside)
+    #expect(throws: AgentProfileLaunchPlanError.self) {
+      try AgentProfileHomeProvisioner.provision(home: linkedHome, base: base)
+    }
+    #expect(throws: AgentProfileLaunchPlanError.self) {
+      try AgentProfileHomeProvisioner.validatePhysicalContainment(home: linkedHome, base: base)
+    }
+
+    // A symlinked *base* (e.g. ~/.prowl on a synced volume) stays legal:
+    // both sides of the comparison resolve consistently.
+    let baseLink = root.appending(path: "agent-profiles-link", directoryHint: .isDirectory)
+    try fileManager.createSymbolicLink(at: baseLink, withDestinationURL: base)
+    let homeViaLink = baseLink.appending(path: UUID().uuidString, directoryHint: .isDirectory)
+    try AgentProfileHomeProvisioner.provision(home: homeViaLink, base: baseLink)
+    #expect(fileManager.fileExists(atPath: AgentProfileLaunchPlanner.pathString(homeViaLink)))
+  }
+
   @Test func provisionerRefusesHomesOutsideBase() {
     let base = URL(fileURLWithPath: "/base/agent-profiles", isDirectory: true)
     #expect(throws: AgentProfileLaunchPlanError.self) {

--- a/supacodeTests/AgentProfileTests.swift
+++ b/supacodeTests/AgentProfileTests.swift
@@ -1,0 +1,174 @@
+import Foundation
+import Testing
+
+@testable import supacode
+
+struct AgentProfileTests {
+  private func profile(
+    id: UUID = UUID(),
+    name: String = "Codex · Work",
+    isEnabled: Bool = true,
+    runtime: AgentProfileRuntime = .codex
+  ) -> AgentProfile {
+    AgentProfile(id: id, name: name, isEnabled: isEnabled, runtime: runtime)
+  }
+
+  // MARK: - Normalization
+
+  @Test func normalizationDropsBlankNamesAndDuplicateIDs() {
+    let id = UUID()
+    let profiles = [
+      profile(id: id, name: "  Codex · Work  "),
+      profile(id: id, name: "Duplicate of first"),
+      profile(name: "   "),
+      profile(name: "Claude · Review", runtime: .claude),
+    ]
+
+    let normalized = AgentProfile.normalizedProfiles(profiles)
+
+    #expect(normalized.count == 2)
+    #expect(normalized[0].id == id)
+    #expect(normalized[0].name == "Codex · Work")
+    #expect(normalized[1].name == "Claude · Review")
+  }
+
+  @Test func decodeFillsDefaultsForMissingFields() throws {
+    let id = UUID()
+    let legacy = Data(#"{"id":"\#(id.uuidString)","name":"Codex","runtime":"codex"}"#.utf8)
+
+    let decoded = try JSONDecoder().decode(AgentProfile.self, from: legacy)
+
+    #expect(decoded.id == id)
+    #expect(decoded.isEnabled)
+    #expect(decoded.model == nil)
+    #expect(decoded.reasoningEffort == nil)
+    #expect(decoded.executionMode == .standard)
+    #expect(decoded.placement == .tab)
+    #expect(decoded.splitDirection == .right)
+    #expect(decoded.extraArguments.isEmpty)
+    #expect(!decoded.bindsDedicatedHome)
+  }
+
+  // MARK: - Recommendation
+
+  @Test func recommendationPrefersDesignationOverMemoryAndOrder() {
+    let designated = profile(name: "Designated")
+    let remembered = profile(name: "Remembered")
+    let first = profile(name: "First")
+    let profiles = [first, remembered, designated]
+
+    let recommended = AgentProfileRecommendation.recommendedProfile(
+      profiles: profiles,
+      designatedID: designated.id,
+      lastLaunchedID: remembered.id
+    )
+
+    #expect(recommended?.id == designated.id)
+  }
+
+  @Test func recommendationFallsThroughDisabledDesignationToMemory() {
+    let designated = profile(name: "Designated", isEnabled: false)
+    let remembered = profile(name: "Remembered")
+    let profiles = [profile(name: "First"), remembered, designated]
+
+    let recommended = AgentProfileRecommendation.recommendedProfile(
+      profiles: profiles,
+      designatedID: designated.id,
+      lastLaunchedID: remembered.id
+    )
+
+    #expect(recommended?.id == remembered.id)
+  }
+
+  @Test func recommendationFallsThroughDanglingMemoryToFirstEnabled() {
+    let disabledFirst = profile(name: "Disabled", isEnabled: false)
+    let enabled = profile(name: "Enabled")
+    let profiles = [disabledFirst, enabled]
+
+    let recommended = AgentProfileRecommendation.recommendedProfile(
+      profiles: profiles,
+      designatedID: nil,
+      lastLaunchedID: UUID()
+    )
+
+    #expect(recommended?.id == enabled.id)
+  }
+
+  @Test func recommendationIsNilWhenNothingIsEnabled() {
+    let profiles = [profile(name: "Disabled", isEnabled: false)]
+
+    let recommended = AgentProfileRecommendation.recommendedProfile(
+      profiles: profiles,
+      designatedID: nil,
+      lastLaunchedID: nil
+    )
+
+    #expect(recommended == nil)
+  }
+
+  // MARK: - Shell word splitting
+
+  @Test func splitterHandlesQuotesAndEscapes() {
+    #expect(ShellWordSplitter.split("") == [])
+    #expect(ShellWordSplitter.split("   ") == [])
+    #expect(ShellWordSplitter.split("--yolo --search") == ["--yolo", "--search"])
+    #expect(ShellWordSplitter.split("--cd '/tmp/with space'") == ["--cd", "/tmp/with space"])
+    #expect(ShellWordSplitter.split(#"--note "double \" quote""#) == ["--note", #"double " quote"#])
+    #expect(ShellWordSplitter.split(#"a\ b"#) == ["a b"])
+    #expect(ShellWordSplitter.split("''") == [""])
+    #expect(ShellWordSplitter.split("--flag=value") == ["--flag=value"])
+  }
+
+  @Test func splitterConsumesUnterminatedQuoteAsLiteralTail() {
+    #expect(ShellWordSplitter.split("--note 'unterminated tail") == ["--note", "unterminated tail"])
+  }
+
+  // MARK: - Settings persistence
+
+  @Test func globalSettingsDecodeLegacyJSONWithoutProfileFields() throws {
+    let legacy = Data(#"{"customCommands":[]}"#.utf8)
+
+    let decoded = try JSONDecoder().decode(UserGlobalSettings.self, from: legacy)
+
+    #expect(decoded.agentProfiles.isEmpty)
+    #expect(!decoded.didSeedAgentProfiles)
+  }
+
+  @Test func globalSettingsRoundTripKeepsProfilesAndSeedFlag() throws {
+    let settings = UserGlobalSettings(
+      customCommands: [],
+      agentProfiles: [profile(name: "Codex · Work")],
+      didSeedAgentProfiles: true
+    )
+
+    let data = try JSONEncoder().encode(settings)
+    let decoded = try JSONDecoder().decode(UserGlobalSettings.self, from: data)
+
+    #expect(decoded == settings)
+  }
+
+  @Test func repositorySettingsDecodeLegacyJSONWithoutProfileFields() throws {
+    let legacy = Data(#"{"customCommands":[],"disabledGlobalCommandIDs":[]}"#.utf8)
+
+    let decoded = try JSONDecoder().decode(UserRepositorySettings.self, from: legacy)
+
+    #expect(decoded.defaultAgentProfileID == nil)
+    #expect(decoded.lastLaunchedAgentProfileID == nil)
+  }
+
+  @Test func repositorySettingsRoundTripKeepsProfileReferences() throws {
+    let designated = UUID()
+    let remembered = UUID()
+    let settings = UserRepositorySettings(
+      customCommands: [],
+      defaultAgentProfileID: designated,
+      lastLaunchedAgentProfileID: remembered
+    )
+
+    let data = try JSONEncoder().encode(settings)
+    let decoded = try JSONDecoder().decode(UserRepositorySettings.self, from: data)
+
+    #expect(decoded.defaultAgentProfileID == designated)
+    #expect(decoded.lastLaunchedAgentProfileID == remembered)
+  }
+}

--- a/supacodeTests/AgentProfilesFeatureTests.swift
+++ b/supacodeTests/AgentProfilesFeatureTests.swift
@@ -157,6 +157,84 @@ struct AgentProfilesFeatureTests {
     #expect(trashed.value == [bound.id])
   }
 
+  @Test(.dependencies) func unboundProfileWithHomeOnDiskStillConfirmsRemoval() async {
+    // bind → launch (home created) → unbind → remove: the gate keys on the
+    // disk fact, so the credentials never get orphaned silently.
+    let unbound = AgentProfile(name: "Codex · Was Bound", runtime: .codex)
+    let storage = SettingsTestStorage()
+    let trashed = LockIsolated<[AgentProfile.ID]>([])
+    let store = withDependencies {
+      $0.settingsFileStorage = storage.storage
+    } operation: {
+      @Shared(.userGlobalSettings) var settings
+      $settings.withLock { $0.agentProfiles = [unbound] }
+      var initial = AgentProfilesFeature.State()
+      initial.settings = settings
+      initial.selectedProfileID = unbound.id
+      return TestStore(initialState: initial) {
+        AgentProfilesFeature()
+      } withDependencies: {
+        $0[AgentProfileHomeClient.self].homeExists = { _ in true }
+        $0[AgentProfileHomeClient.self].trashHome = { id in
+          trashed.withValue { $0.append(id) }
+        }
+      }
+    }
+
+    await store.send(.removeSelectedTapped) {
+      $0.alert = AgentProfilesFeature.removalAlert(profile: unbound)
+    }
+    await store.send(.alert(.presented(.removeTrashingFiles(unbound.id)))) {
+      $0.alert = nil
+      $0.settings.agentProfiles = []
+      $0.selectedProfileID = nil
+    }
+    await store.receive(\.delegate.settingsChanged)
+    await store.finish()
+    #expect(trashed.value == [unbound.id])
+  }
+
+  @Test(.dependencies) func revealRefreshesThePassiveHomeStatus() async {
+    var bound = AgentProfile(name: "Codex · Work", runtime: .codex)
+    bound.bindsDedicatedHome = true
+    let storage = SettingsTestStorage()
+    let homeOnDisk = LockIsolated(false)
+    let store = withDependencies {
+      $0.settingsFileStorage = storage.storage
+    } operation: {
+      @Shared(.userGlobalSettings) var settings
+      $settings.withLock { $0.agentProfiles = [bound] }
+      var initial = AgentProfilesFeature.State()
+      initial.settings = settings
+      initial.selectedProfileID = bound.id
+      return TestStore(initialState: initial) {
+        AgentProfilesFeature()
+      } withDependencies: {
+        $0[AgentProfileHomeClient.self].homeExists = { _ in homeOnDisk.value }
+        $0[AgentProfileHomeClient.self].revealHome = { _ in homeOnDisk.setValue(true) }
+      }
+    }
+
+    await store.send(.revealProfileFiles)
+    await store.receive(\.homeStatusRefreshed) {
+      $0.selectedHomeInitialized = true
+    }
+  }
+
+  @Test func launchConfigRootOnlyAppliesToTheLaunchedRuntime() {
+    let home = URL(fileURLWithPath: "/base/agent-profiles/ABC", isDirectory: true)
+    let identity = WorktreeTerminalState.SurfaceLaunchProfile(
+      profileID: UUID(),
+      name: "Codex · Work",
+      runtime: .codex,
+      dedicatedHome: home
+    )
+    #expect(identity.configRoot(forDetected: .codex) == home)
+    // A different agent started manually in the same pane uses its default
+    // home; handing it the profile home would break session attribution.
+    #expect(identity.configRoot(forDetected: .claude) == nil)
+  }
+
   @Test(.dependencies) func removingPurePresetSkipsConfirmationAndFileOperations() async {
     let preset = AgentProfile(name: "Claude", runtime: .claude)
     let storage = SettingsTestStorage()

--- a/supacodeTests/AgentProfilesFeatureTests.swift
+++ b/supacodeTests/AgentProfilesFeatureTests.swift
@@ -1,0 +1,201 @@
+import ComposableArchitecture
+import DependenciesTestSupport
+import Foundation
+import Sharing
+import Testing
+
+@testable import supacode
+
+@MainActor
+struct AgentProfilesFeatureTests {
+  @Test(.dependencies) func taskLoadsSettingsAndSelectsFirstProfile() async {
+    let profile = AgentProfile(name: "Codex", runtime: .codex)
+    let storage = SettingsTestStorage()
+    let store = withDependencies {
+      $0.settingsFileStorage = storage.storage
+    } operation: {
+      @Shared(.userGlobalSettings) var settings
+      $settings.withLock { $0.agentProfiles = [profile] }
+      return TestStore(initialState: AgentProfilesFeature.State()) {
+        AgentProfilesFeature()
+      }
+    }
+
+    await store.send(.task)
+    await store.receive(\.settingsLoaded) {
+      $0.settings.agentProfiles = [profile]
+      $0.selectedProfileID = profile.id
+    }
+  }
+
+  @Test(.dependencies) func addProfileAppendsSelectsAndPersists() async {
+    let storage = SettingsTestStorage()
+    let store = withDependencies {
+      $0.settingsFileStorage = storage.storage
+    } operation: {
+      TestStore(initialState: AgentProfilesFeature.State()) {
+        AgentProfilesFeature()
+      } withDependencies: {
+        $0.uuid = .incrementing
+      }
+    }
+
+    let expected = AgentProfile(
+      id: UUID(0),
+      name: "Claude Code",
+      runtime: .claude
+    )
+    await store.send(.addProfile(.claude)) {
+      $0.settings.agentProfiles = [expected]
+      $0.selectedProfileID = expected.id
+    }
+    await store.receive(\.delegate.settingsChanged)
+  }
+
+  @Test(.dependencies) func unrestrictedRequiresExplicitConfirmation() async {
+    let profile = AgentProfile(name: "Codex", runtime: .codex)
+    let storage = SettingsTestStorage()
+    let (store, persisted) = withDependencies {
+      $0.settingsFileStorage = storage.storage
+    } operation: {
+      @Shared(.userGlobalSettings) var settings
+      $settings.withLock { $0.agentProfiles = [profile] }
+      var initial = AgentProfilesFeature.State()
+      initial.settings = settings
+      initial.selectedProfileID = profile.id
+      let store = TestStore(initialState: initial) {
+        AgentProfilesFeature()
+      }
+      return (store, $settings)
+    }
+
+    var edited = store.state.settings
+    edited.agentProfiles[0].executionMode = .unrestricted
+
+    // The binding write reverts and asks first.
+    await store.send(.binding(.set(\.settings, edited))) {
+      $0.alert = AgentProfilesFeature.unrestrictedAlert(profileID: profile.id)
+    }
+
+    await store.send(.alert(.presented(.confirmUnrestricted(profile.id)))) {
+      $0.alert = nil
+      $0.settings.agentProfiles[0].executionMode = .unrestricted
+    }
+    await store.receive(\.delegate.settingsChanged)
+    #expect(persisted.wrappedValue.agentProfiles.first?.executionMode == .unrestricted)
+  }
+
+  @Test(.dependencies) func removingBoundProfileConfirmsAndCanTrashHome() async {
+    var bound = AgentProfile(name: "Codex · Work", runtime: .codex)
+    bound.bindsDedicatedHome = true
+    let storage = SettingsTestStorage()
+    let trashed = LockIsolated<[AgentProfile.ID]>([])
+    let store = withDependencies {
+      $0.settingsFileStorage = storage.storage
+    } operation: {
+      @Shared(.userGlobalSettings) var settings
+      $settings.withLock { $0.agentProfiles = [bound] }
+      var initial = AgentProfilesFeature.State()
+      initial.settings = settings
+      initial.selectedProfileID = bound.id
+      return TestStore(initialState: initial) {
+        AgentProfilesFeature()
+      } withDependencies: {
+        $0[AgentProfileHomeClient.self].trashHome = { id in
+          trashed.withValue { $0.append(id) }
+        }
+      }
+    }
+
+    await store.send(.removeSelectedTapped) {
+      $0.alert = AgentProfilesFeature.removalAlert(profile: bound)
+    }
+    await store.send(.alert(.presented(.removeTrashingFiles(bound.id)))) {
+      $0.alert = nil
+      $0.settings.agentProfiles = []
+      $0.selectedProfileID = nil
+    }
+    await store.receive(\.delegate.settingsChanged)
+    await store.finish()
+    #expect(trashed.value == [bound.id])
+  }
+
+  @Test(.dependencies) func removingPurePresetSkipsConfirmationAndFileOperations() async {
+    let preset = AgentProfile(name: "Claude", runtime: .claude)
+    let storage = SettingsTestStorage()
+    let store = withDependencies {
+      $0.settingsFileStorage = storage.storage
+    } operation: {
+      @Shared(.userGlobalSettings) var settings
+      $settings.withLock { $0.agentProfiles = [preset] }
+      var initial = AgentProfilesFeature.State()
+      initial.settings = settings
+      initial.selectedProfileID = preset.id
+      return TestStore(initialState: initial) {
+        AgentProfilesFeature()
+      }
+    }
+
+    await store.send(.removeSelectedTapped) {
+      $0.settings.agentProfiles = []
+      $0.selectedProfileID = nil
+    }
+    await store.receive(\.delegate.settingsChanged)
+  }
+
+  @Test(.dependencies) func moveReordersFallbackPriority() async {
+    let first = AgentProfile(name: "First", runtime: .codex)
+    let second = AgentProfile(name: "Second", runtime: .claude)
+    let storage = SettingsTestStorage()
+    let store = withDependencies {
+      $0.settingsFileStorage = storage.storage
+    } operation: {
+      @Shared(.userGlobalSettings) var settings
+      $settings.withLock { $0.agentProfiles = [first, second] }
+      var initial = AgentProfilesFeature.State()
+      initial.settings = settings
+      return TestStore(initialState: initial) {
+        AgentProfilesFeature()
+      }
+    }
+
+    await store.send(.moveProfiles(IndexSet(integer: 1), 0)) {
+      $0.settings.agentProfiles = [second, first]
+    }
+    await store.receive(\.delegate.settingsChanged)
+  }
+
+  @Test(.dependencies) func repositoryDefaultAgentProfilePersistsThroughDedicatedAction() async throws {
+    let rootURL = URL(fileURLWithPath: "/tmp/repo-\(UUID().uuidString)")
+    let localStorage = RepositoryLocalSettingsTestStorage()
+    let profileID = UUID()
+    let store = TestStore(
+      initialState: RepositorySettingsFeature.State(
+        rootURL: rootURL,
+        repositoryKind: .plain,
+        settings: .default,
+        userSettings: .default
+      )
+    ) {
+      RepositorySettingsFeature()
+    } withDependencies: {
+      $0.repositoryLocalSettingsStorage = localStorage.storage
+    }
+
+    await store.send(.setDefaultAgentProfileID(profileID)) {
+      $0.userSettings.defaultAgentProfileID = profileID
+    }
+    await store.receive(\.delegate.settingsChanged)
+
+    let persisted = try JSONDecoder().decode(
+      UserRepositorySettings.self,
+      from: #require(localStorage.data(at: SupacodePaths.userRepositorySettingsURL(for: rootURL)))
+    )
+    #expect(persisted.defaultAgentProfileID == profileID)
+
+    await store.send(.setDefaultAgentProfileID(nil)) {
+      $0.userSettings.defaultAgentProfileID = nil
+    }
+    await store.receive(\.delegate.settingsChanged)
+  }
+}

--- a/supacodeTests/AgentProfilesFeatureTests.swift
+++ b/supacodeTests/AgentProfilesFeatureTests.swift
@@ -85,6 +85,43 @@ struct AgentProfilesFeatureTests {
     #expect(persisted.wrappedValue.agentProfiles.first?.executionMode == .unrestricted)
   }
 
+  @Test(.dependencies) func blankNameNeverPersistsOrDeletesTheProfile() async {
+    let profile = AgentProfile(name: "Codex", runtime: .codex)
+    let storage = SettingsTestStorage()
+    let (store, persisted) = withDependencies {
+      $0.settingsFileStorage = storage.storage
+    } operation: {
+      @Shared(.userGlobalSettings) var settings
+      $settings.withLock { $0.agentProfiles = [profile] }
+      var initial = AgentProfilesFeature.State()
+      initial.settings = settings
+      initial.selectedProfileID = profile.id
+      let store = TestStore(initialState: initial) {
+        AgentProfilesFeature()
+      }
+      return (store, $settings)
+    }
+
+    // Clearing the Name field keeps the profile editable in state and keeps
+    // the last persisted name on disk — never a silent deletion.
+    var edited = store.state.settings
+    edited.agentProfiles[0].name = "   "
+    await store.send(.binding(.set(\.settings, edited))) {
+      $0.settings.agentProfiles[0].name = "   "
+    }
+    await store.receive(\.delegate.settingsChanged)
+    #expect(persisted.wrappedValue.agentProfiles.count == 1)
+    #expect(persisted.wrappedValue.agentProfiles.first?.name == "Codex")
+
+    // Typing the new name persists it normally.
+    edited.agentProfiles[0].name = "Codex · Deep"
+    await store.send(.binding(.set(\.settings, edited))) {
+      $0.settings.agentProfiles[0].name = "Codex · Deep"
+    }
+    await store.receive(\.delegate.settingsChanged)
+    #expect(persisted.wrappedValue.agentProfiles.first?.name == "Codex · Deep")
+  }
+
   @Test(.dependencies) func removingBoundProfileConfirmsAndCanTrashHome() async {
     var bound = AgentProfile(name: "Codex · Work", runtime: .codex)
     bound.bindsDedicatedHome = true
@@ -197,5 +234,48 @@ struct AgentProfilesFeatureTests {
       $0.userSettings.defaultAgentProfileID = nil
     }
     await store.receive(\.delegate.settingsChanged)
+  }
+
+  @Test(.dependencies) func repositorySettingsWritebacksPreserveExternalLaunchMemory() async {
+    let rootURL = URL(fileURLWithPath: "/tmp/repo-\(UUID().uuidString)")
+    let localStorage = RepositoryLocalSettingsTestStorage()
+    let launched = UUID()
+    let designated = UUID()
+    let (store, shared) = withDependencies {
+      $0.repositoryLocalSettingsStorage = localStorage.storage
+    } operation: {
+      let store = TestStore(
+        initialState: RepositorySettingsFeature.State(
+          rootURL: rootURL,
+          repositoryKind: .plain,
+          settings: .default,
+          userSettings: .default
+        )
+      ) {
+        RepositorySettingsFeature()
+      }
+      @Shared(.userRepositorySettings(rootURL)) var userRepositorySettings
+      // A profile launch writes the memory while Settings stays open with a
+      // stale snapshot.
+      $userRepositorySettings.withLock { $0.lastLaunchedAgentProfileID = launched }
+      return (store, $userRepositorySettings)
+    }
+
+    await store.send(.setDefaultAgentProfileID(designated)) {
+      $0.userSettings.defaultAgentProfileID = designated
+    }
+    await store.receive(\.delegate.settingsChanged)
+    #expect(shared.wrappedValue.lastLaunchedAgentProfileID == launched)
+    #expect(shared.wrappedValue.defaultAgentProfileID == designated)
+
+    // The whole-struct binding writeback must also preserve (and refresh) it.
+    var user = store.state.userSettings
+    user.disabledGlobalCommandIDs = ["global-build"]
+    await store.send(.binding(.set(\.userSettings, user))) {
+      $0.userSettings.disabledGlobalCommandIDs = ["global-build"]
+      $0.userSettings.lastLaunchedAgentProfileID = launched
+    }
+    await store.receive(\.delegate.settingsChanged)
+    #expect(shared.wrappedValue.lastLaunchedAgentProfileID == launched)
   }
 }

--- a/supacodeTests/AgentRuntimeAdapterTests.swift
+++ b/supacodeTests/AgentRuntimeAdapterTests.swift
@@ -10,7 +10,7 @@ struct AgentRuntimeAdapterTests {
     let invocation = try AgentRuntimeAdapterRegistry.makeStartInvocation(
       AgentStartRequest(
         agent: .codex,
-        prompt: "Continue the handoff.",
+        intent: .prompt("Continue the handoff."),
         configuration: AgentLaunchConfiguration(model: "gpt-5.4", executionMode: .unrestricted)
       )
     )
@@ -20,6 +20,91 @@ struct AgentRuntimeAdapterTests {
       invocation.arguments
         == ["--model", "gpt-5.4", "--dangerously-bypass-approvals-and-sandbox", "Continue the handoff."]
     )
+  }
+
+  @Test func interactiveStartRendersNoPromptArgument() throws {
+    let codex = try AgentRuntimeAdapterRegistry.makeStartInvocation(
+      AgentStartRequest(agent: .codex, intent: .interactive)
+    )
+    #expect(codex.executable == "codex")
+    #expect(codex.arguments.isEmpty)
+
+    let claude = try AgentRuntimeAdapterRegistry.makeStartInvocation(
+      AgentStartRequest(
+        agent: .claude,
+        intent: .interactive,
+        configuration: AgentLaunchConfiguration(model: "claude-opus-5")
+      )
+    )
+    #expect(claude.executable == "claude")
+    #expect(claude.arguments == ["--model", "claude-opus-5"])
+  }
+
+  @Test func headlessStartRendersOneShotExecutionMode() throws {
+    let codex = try AgentRuntimeAdapterRegistry.makeStartInvocation(
+      AgentStartRequest(agent: .codex, intent: .headless("Summarize the repo."))
+    )
+    #expect(codex.arguments == ["exec", "Summarize the repo."])
+
+    let claude = try AgentRuntimeAdapterRegistry.makeStartInvocation(
+      AgentStartRequest(agent: .claude, intent: .headless("Summarize the repo."))
+    )
+    #expect(claude.arguments == ["-p", "Summarize the repo."])
+  }
+
+  @Test func reasoningEffortMapsToRuntimeSpecificOptions() throws {
+    let claude = try AgentRuntimeAdapterRegistry.makeStartInvocation(
+      AgentStartRequest(
+        agent: .claude,
+        intent: .interactive,
+        configuration: AgentLaunchConfiguration(reasoningEffort: "high")
+      )
+    )
+    #expect(claude.arguments == ["--effort", "high"])
+
+    let codex = try AgentRuntimeAdapterRegistry.makeStartInvocation(
+      AgentStartRequest(
+        agent: .codex,
+        intent: .interactive,
+        configuration: AgentLaunchConfiguration(reasoningEffort: "xhigh")
+      )
+    )
+    #expect(codex.arguments == ["-c", "model_reasoning_effort=xhigh"])
+  }
+
+  @Test func extraArgumentsAppendAfterAdapterOptionsBeforePrompt() throws {
+    let invocation = try AgentRuntimeAdapterRegistry.makeStartInvocation(
+      AgentStartRequest(
+        agent: .codex,
+        intent: .prompt("Go."),
+        configuration: AgentLaunchConfiguration(
+          model: "gpt-5.4",
+          extraArguments: ["--search", "--cd", "/tmp/with space"]
+        )
+      )
+    )
+    #expect(
+      invocation.arguments == ["--model", "gpt-5.4", "--search", "--cd", "/tmp/with space", "Go."]
+    )
+  }
+
+  @Test func accountIsolationCapabilityIsDeclaredPerAdapter() {
+    let codex = AgentRuntimeAdapterRegistry.adapter(for: .codex)
+    #expect(codex?.supportsAccountIsolation == true)
+    #expect(codex?.accountHomeEnvironmentVariable == "CODEX_HOME")
+
+    let claude = AgentRuntimeAdapterRegistry.adapter(for: .claude)
+    #expect(claude?.supportsAccountIsolation == true)
+    #expect(claude?.accountHomeEnvironmentVariable == "CLAUDE_CONFIG_DIR")
+    #expect(claude?.reasoningEffortSuggestions.contains("high") == true)
+  }
+
+  @Test func launchConfigurationDecodesLegacyPayloadWithoutNewFields() throws {
+    let legacy = Data(#"{"model":"gpt-5.4","executionMode":"standard"}"#.utf8)
+    let configuration = try JSONDecoder().decode(AgentLaunchConfiguration.self, from: legacy)
+    #expect(configuration.model == "gpt-5.4")
+    #expect(configuration.reasoningEffort == nil)
+    #expect(configuration.extraArguments.isEmpty)
   }
 
   @Test func claudeResumeStaysReadOnlyAndKeepsModel() throws {

--- a/supacodeTests/AgentSessionProfileTests.swift
+++ b/supacodeTests/AgentSessionProfileTests.swift
@@ -9,6 +9,50 @@ struct AgentSessionProfileTests {
   private let home = URL(fileURLWithPath: "/Users/me", isDirectory: true)
   private let now = Date(timeIntervalSince1970: 1_783_800_000)
 
+  // MARK: - Relocated config roots (docs-ai 053)
+
+  @Test func rootedClaudeLayoutFollowsRelocatedConfigRoot() throws {
+    let configRoot = URL(fileURLWithPath: "/Users/me/.prowl/agent-profiles/ABC", isDirectory: true)
+    let cwd = URL(fileURLWithPath: "/tmp/repo")
+    let profile = AgentSessionProfile.profile(for: .claude)
+
+    let roots = try #require(profile.rootedCandidateRoots?(configRoot, cwd, now, now))
+    #expect(roots.map(\.path) == ["/Users/me/.prowl/agent-profiles/ABC/projects/-tmp-repo"])
+    #expect(profile.rootedCandidateRoots?(configRoot, nil, now, now).isEmpty == true)
+
+    let id = "3f19a50a-2bd5-49b0-a071-1f59970ebcdf"
+    let transcript = "/Users/me/.prowl/agent-profiles/ABC/projects/-tmp-repo/\(id).jsonl"
+    #expect(profile.rootedParsePath?(transcript, configRoot)?.id == id)
+    // The default marker cannot own a relocated path, and the rooted parser
+    // must not claim files from the default home.
+    #expect(profile.parsePath(transcript) == nil)
+    #expect(
+      profile.rootedParsePath?("/Users/me/.claude/projects/-tmp-repo/\(id).jsonl", configRoot) == nil
+    )
+  }
+
+  @Test func rootedCodexLayoutFollowsRelocatedConfigRoot() throws {
+    let configRoot = URL(fileURLWithPath: "/Users/me/.prowl/agent-profiles/ABC", isDirectory: true)
+    let profile = AgentSessionProfile.profile(for: .codex)
+
+    let fallback = try #require(profile.rootedFallbackRoots?(configRoot, nil))
+    #expect(fallback.map(\.path) == ["/Users/me/.prowl/agent-profiles/ABC/sessions"])
+    let dayRoots = try #require(profile.rootedCandidateRoots?(configRoot, nil, now, now))
+    #expect(dayRoots.allSatisfy { $0.path.hasPrefix("/Users/me/.prowl/agent-profiles/ABC/sessions/") })
+
+    let id = "019fadfd-9ecd-7b71-b849-70fd53ee7231"
+    let rollout =
+      "/Users/me/.prowl/agent-profiles/ABC/sessions/2026/07/29/rollout-2026-07-29T22-08-27-\(id).jsonl"
+    #expect(profile.rootedParsePath?(rollout, configRoot)?.id == id)
+    #expect(profile.parsePath(rollout) == nil)
+    #expect(
+      profile.rootedParsePath?(
+        "/Users/me/.codex/sessions/2026/07/29/rollout-2026-07-29T22-08-27-\(id).jsonl",
+        configRoot
+      ) == nil
+    )
+  }
+
   // MARK: - Working-directory encoders
 
   @Test func claudeRootSanitizesEveryNonAlphanumericCharacter() {

--- a/supacodeTests/AppFeatureAgentProfileTests.swift
+++ b/supacodeTests/AppFeatureAgentProfileTests.swift
@@ -98,6 +98,55 @@ struct AppFeatureAgentProfileTests {
     }
   }
 
+  @Test(.dependencies) func paletteBuildsLaunchItemsWithRecommendedFirst() {
+    let worktree = makeWorktree()
+    let repositories = makeRepositoriesState(worktree: worktree)
+    let storage = SettingsTestStorage()
+    let localStorage = RepositoryLocalSettingsTestStorage()
+    withDependencies {
+      $0.settingsFileStorage = storage.storage
+      $0.repositoryLocalSettingsStorage = localStorage.storage
+    } operation: {
+      let first = AgentProfile(name: "First", runtime: .codex)
+      let second = AgentProfile(name: "Second", runtime: .claude)
+      let disabled = AgentProfile(name: "Hidden", isEnabled: false, runtime: .claude)
+      @Shared(.userGlobalSettings) var settings
+      $settings.withLock { $0.agentProfiles = [first, second, disabled] }
+      @Shared(.userRepositorySettings(worktree.repositoryRootURL)) var repoSettings
+      $repoSettings.withLock { $0.defaultAgentProfileID = second.id }
+
+      let items = agentProfileLaunchItems(repositories)
+
+      #expect(items.map(\.title) == ["Launch Agent: Second", "Launch Agent: First"])
+      #expect(items.first?.kind == .launchAgentProfile(second.id))
+      #expect(items.first?.subtitle?.hasPrefix("Recommended") == true)
+      #expect(items.last?.subtitle?.hasPrefix("Recommended") == false)
+    }
+  }
+
+  @Test func launchedSurfaceEntryShowsProfileName() {
+    var entry = ActiveAgentEntry(
+      id: UUID(),
+      worktreeID: "/tmp/repo/wt-1",
+      worktreeName: "wt-1",
+      workingDirectory: nil,
+      tabID: TerminalTabID(),
+      paneTitle: "codex",
+      surfaceID: UUID(),
+      paneIndex: 1,
+      iconLookupToken: "codex",
+      agent: .codex,
+      session: nil,
+      rawState: .idle,
+      displayState: .idle,
+      lastChangedAt: Date()
+    )
+    #expect(entry.displayName == "codex")
+
+    entry.launchProfileName = "Codex · Work"
+    #expect(entry.displayName == "Codex · Work")
+  }
+
   private func makeWorktree() -> Worktree {
     Worktree(
       id: "/tmp/repo/wt-1",

--- a/supacodeTests/AppFeatureAgentProfileTests.swift
+++ b/supacodeTests/AppFeatureAgentProfileTests.swift
@@ -147,6 +147,68 @@ struct AppFeatureAgentProfileTests {
     }
   }
 
+  @Test func actionTargetResolverPrefersSelectionThenExplicitTerminalTarget() {
+    let worktree = makeWorktree()
+    var repositories = makeRepositoriesState(worktree: worktree)
+
+    // Selection wins over any explicit target.
+    #expect(
+      repositories.actionTargetTerminalWorktree(explicitTargetID: "unknown")?.id == worktree.id
+    )
+
+    // Without a selection, the explicit target resolves through the full
+    // terminal-target path — including synthesized plain-folder worktrees.
+    repositories.selection = nil
+    #expect(
+      repositories.actionTargetTerminalWorktree(explicitTargetID: worktree.id)?.id == worktree.id
+    )
+    let rootURL = URL(fileURLWithPath: "/tmp/plain-folder")
+    let plain = Repository(
+      id: rootURL.path(percentEncoded: false),
+      rootURL: rootURL,
+      name: "plain-folder",
+      kind: .plain,
+      worktrees: []
+    )
+    repositories.repositories.append(plain)
+    #expect(
+      repositories.actionTargetTerminalWorktree(explicitTargetID: plain.id)?.workingDirectory
+        == rootURL
+    )
+    #expect(repositories.actionTargetTerminalWorktree(explicitTargetID: nil) == nil)
+  }
+
+  @Test(.dependencies) func paletteBuildsLaunchItemsForFocusedPlainFolderCanvasCard() {
+    // A runnable plain folder's terminal target ID is its repository ID; the
+    // factory must resolve it through the same synthesized-worktree path the
+    // launch action uses.
+    let rootURL = URL(fileURLWithPath: "/tmp/plain-folder")
+    let plain = Repository(
+      id: rootURL.path(percentEncoded: false),
+      rootURL: rootURL,
+      name: "plain-folder",
+      kind: .plain,
+      worktrees: []
+    )
+    var repositories = RepositoriesFeature.State()
+    repositories.repositories = IdentifiedArray(uniqueElements: [plain])
+    repositories.selection = nil
+    let storage = SettingsTestStorage()
+    let localStorage = RepositoryLocalSettingsTestStorage()
+    withDependencies {
+      $0.settingsFileStorage = storage.storage
+      $0.repositoryLocalSettingsStorage = localStorage.storage
+    } operation: {
+      let profile = AgentProfile(name: "Codex", runtime: .codex)
+      @Shared(.userGlobalSettings) var settings
+      $settings.withLock { $0.agentProfiles = [profile] }
+
+      let items = agentProfileLaunchItems(repositories, actionTargetWorktreeID: plain.id)
+      #expect(items.map(\.title) == ["Launch Agent: Codex"])
+      #expect(items.first?.subtitle?.contains("plain-folder") == true)
+    }
+  }
+
   @Test func launchedSurfaceEntryShowsProfileName() {
     var entry = ActiveAgentEntry(
       id: UUID(),

--- a/supacodeTests/AppFeatureAgentProfileTests.swift
+++ b/supacodeTests/AppFeatureAgentProfileTests.swift
@@ -124,6 +124,29 @@ struct AppFeatureAgentProfileTests {
     }
   }
 
+  @Test(.dependencies) func paletteBuildsLaunchItemsForFocusedCanvasCard() {
+    let worktree = makeWorktree()
+    var repositories = makeRepositoriesState(worktree: worktree)
+    // Canvas: no selected terminal worktree, only the focused card passed as
+    // the action target.
+    repositories.selection = nil
+    let storage = SettingsTestStorage()
+    let localStorage = RepositoryLocalSettingsTestStorage()
+    withDependencies {
+      $0.settingsFileStorage = storage.storage
+      $0.repositoryLocalSettingsStorage = localStorage.storage
+    } operation: {
+      let profile = AgentProfile(name: "Codex", runtime: .codex)
+      @Shared(.userGlobalSettings) var settings
+      $settings.withLock { $0.agentProfiles = [profile] }
+
+      #expect(agentProfileLaunchItems(repositories).isEmpty)
+      let items = agentProfileLaunchItems(repositories, actionTargetWorktreeID: worktree.id)
+      #expect(items.map(\.title) == ["Launch Agent: Codex"])
+      #expect(items.first?.subtitle?.contains(worktree.name) == true)
+    }
+  }
+
   @Test func launchedSurfaceEntryShowsProfileName() {
     var entry = ActiveAgentEntry(
       id: UUID(),

--- a/supacodeTests/AppFeatureAgentProfileTests.swift
+++ b/supacodeTests/AppFeatureAgentProfileTests.swift
@@ -1,0 +1,124 @@
+import ComposableArchitecture
+import DependenciesTestSupport
+import Foundation
+import Sharing
+import Testing
+
+@testable import supacode
+
+@MainActor
+struct AppFeatureAgentProfileTests {
+  @Test(.dependencies) func launchSendsPlanAndRecordsPerRepoMemory() async throws {
+    let worktree = makeWorktree()
+    let repositories = makeRepositoriesState(worktree: worktree)
+    let profile = AgentProfile(name: "Codex · Work", runtime: .codex, model: "gpt-5.4")
+    let storage = SettingsTestStorage()
+    let sent = LockIsolated<[TerminalClient.Command]>([])
+
+    let (store, repoSettings) = withDependencies {
+      $0.settingsFileStorage = storage.storage
+    } operation: {
+      @Shared(.userGlobalSettings) var globalSettings
+      $globalSettings.withLock { $0.agentProfiles = [profile] }
+      @Shared(.userRepositorySettings(worktree.repositoryRootURL)) var repoSettings
+      let store = TestStore(
+        initialState: AppFeature.State(
+          repositories: repositories,
+          settings: SettingsFeature.State()
+        )
+      ) {
+        AppFeature()
+      } withDependencies: {
+        $0.terminalClient.send = { command in
+          sent.withValue { $0.append(command) }
+        }
+      }
+      return (store, $repoSettings)
+    }
+
+    await store.send(.launchAgentProfile(profile.id))
+    await store.finish()
+
+    let expectedPlan = try AgentProfileLaunchPlanner.plan(
+      for: profile,
+      homeBaseDirectory: SupacodePaths.agentProfileHomesDirectory
+    )
+    #expect(sent.value == [.launchAgentProfile(worktree, plan: expectedPlan)])
+    #expect(repoSettings.wrappedValue.lastLaunchedAgentProfileID == profile.id)
+  }
+
+  @Test(.dependencies) func launchIgnoresDisabledOrUnknownProfiles() async {
+    let worktree = makeWorktree()
+    let repositories = makeRepositoriesState(worktree: worktree)
+    let disabled = AgentProfile(name: "Disabled", isEnabled: false, runtime: .claude)
+    let storage = SettingsTestStorage()
+    let sent = LockIsolated<[TerminalClient.Command]>([])
+
+    let store = withDependencies {
+      $0.settingsFileStorage = storage.storage
+    } operation: {
+      @Shared(.userGlobalSettings) var globalSettings
+      $globalSettings.withLock { $0.agentProfiles = [disabled] }
+      return TestStore(
+        initialState: AppFeature.State(
+          repositories: repositories,
+          settings: SettingsFeature.State()
+        )
+      ) {
+        AppFeature()
+      } withDependencies: {
+        $0.terminalClient.send = { command in
+          sent.withValue { $0.append(command) }
+        }
+      }
+    }
+
+    await store.send(.launchAgentProfile(disabled.id))
+    await store.send(.launchAgentProfile(UUID()))
+    #expect(sent.value.isEmpty)
+  }
+
+  @Test(.dependencies) func seedingRunsOnceAndOnlyForInstalledRuntimes() {
+    let storage = SettingsTestStorage()
+    withDependencies {
+      $0.settingsFileStorage = storage.storage
+    } operation: {
+      AgentProfileSeeder.seedIfNeeded { runtime in runtime == .codex }
+
+      @Shared(.userGlobalSettings) var settings
+      #expect(settings.didSeedAgentProfiles)
+      #expect(settings.agentProfiles.map(\.name) == ["Codex"])
+      #expect(settings.agentProfiles.first?.runtime == .codex)
+      #expect(settings.agentProfiles.first?.bindsDedicatedHome == false)
+
+      // Deleting the seed must not respawn it on the next launch.
+      $settings.withLock { $0.agentProfiles = [] }
+      AgentProfileSeeder.seedIfNeeded { _ in true }
+      #expect(settings.agentProfiles.isEmpty)
+    }
+  }
+
+  private func makeWorktree() -> Worktree {
+    Worktree(
+      id: "/tmp/repo/wt-1",
+      name: "wt-1",
+      detail: "detail",
+      workingDirectory: URL(fileURLWithPath: "/tmp/repo/wt-1"),
+      repositoryRootURL: URL(fileURLWithPath: "/tmp/repo")
+    )
+  }
+
+  private func makeRepositoriesState(worktree: Worktree) -> RepositoriesFeature.State {
+    let rootURL = worktree.repositoryRootURL
+    let repository = Repository(
+      id: rootURL.path(percentEncoded: false),
+      rootURL: rootURL,
+      name: rootURL.lastPathComponent,
+      worktrees: IdentifiedArray(uniqueElements: [worktree])
+    )
+    var repositoriesState = RepositoriesFeature.State()
+    repositoriesState.repositories = IdentifiedArray(uniqueElements: [repository])
+    repositoriesState.selection = .worktree(worktree.id)
+    return repositoriesState
+  }
+}

--- a/supacodeTests/CommandPaletteFeatureTests.swift
+++ b/supacodeTests/CommandPaletteFeatureTests.swift
@@ -1778,7 +1778,7 @@ private func testCategory(for kind: CommandPaletteItem.Kind) -> CommandPaletteIt
     .mergePullRequest, .closePullRequest, .copyFailingJobURL, .copyCiFailureLogs,
     .rerunFailedJobs, .openFailingCheckDetails:
     return .pullRequest
-  case .ghosttyCommand, .handOff:
+  case .ghosttyCommand, .handOff, .launchAgentProfile:
     return .terminal
   case .toggleLeftSidebar, .toggleActiveAgentsPanel, .toggleCanvas,
     .expandCanvasCard, .arrangeCanvasCards, .organizeCanvasCards, .tileCanvasCards, .selectAllCanvasCards,
@@ -1806,7 +1806,7 @@ private func testDefaultSuggestion(for kind: CommandPaletteItem.Kind) -> Bool {
     return true
   case .worktreeSelect, .changeFocusedTabIcon,
     .ghosttyCommand, .openRepositoryOnCodeHost,
-    .deleteWorktree, .runCustomCommand, .handOff:
+    .deleteWorktree, .runCustomCommand, .handOff, .launchAgentProfile:
     return false
   #if DEBUG
     case .debugTestToast, .debugSimulateUpdateFound, .debugLightDockNotificationDot:

--- a/supacodeTests/HandoffCommandHandlerTests.swift
+++ b/supacodeTests/HandoffCommandHandlerTests.swift
@@ -470,7 +470,7 @@ struct HandoffCommandHandlerTests {
     #expect(launchedRequest?.agent == .claude)
     #expect(launchedRequest?.configuration.model == nil)
     #expect(launchedRequest?.configuration.executionMode == .unrestricted)
-    #expect(launchedRequest?.prompt.contains(".prowl/handoff/current.md") == true)
+    #expect(launchedRequest?.intent.promptText?.contains(".prowl/handoff/current.md") == true)
 
     // Log records the transition; the completion observer fired for the HUD.
     let log = try String(contentsOf: store.logURL, encoding: .utf8)
@@ -512,7 +512,7 @@ struct HandoffCommandHandlerTests {
     #expect(!store.hasCurrentArtifact)
     #expect(payload.archivedPath != nil)
     // The kickoff prompt points at context + archive, not current.md.
-    let prompt = try #require(launchedRequest?.prompt)
+    let prompt = try #require(launchedRequest?.intent.promptText)
     #expect(!prompt.contains("current.md"))
     #expect(prompt.contains(".prowl/handoff/context.md"))
     let log = try String(contentsOf: store.logURL, encoding: .utf8)


### PR DESCRIPTION
## Summary

Implements docs-ai 053 (plan + grill decisions + HOME spike, all in this branch's docs):

- **Agent Profiles**: named launch presets for the verified runtimes (Claude Code, Codex) — model, free-form reasoning effort with adapter suggestions, execution mode with confirmed-only `.unrestricted`, tab/split placement, literal extra arguments, and a live launch preview sharing the real launch rendering.
- **Launcher entry points**: the toolbar Agents capsule becomes an always-available menu (Hand Off leads when an agent is detected; Recommended profile first; missing CLIs grayed with a reason; Manage entry), plus Command Palette "Launch Agent" rows — both dispatch one `launchAgentProfile` action.
- **Recommendation**: three tiers — per-repo Default Agent Profile (Repo Settings) > per-repo last launched > first enabled profile; resolution never touches live panes.
- **Opt-in account isolation**: a bound profile gets a UUID-derived home under `~/.prowl/agent-profiles/` attached via `CLAUDE_CONFIG_DIR`/`CODEX_HOME`; first launch signs in through the CLI's native flow; deletion confirms and offers Trash (never rm), with all file operations hard-gated to contained, UUID-derived paths.
- **Session detection** learns relocated config roots (rooted layouts for claude/codex, used exclusively for bound surfaces); typed start intents (`.interactive`/`.prompt`/`.headless`) replace the always-present prompt.
- **Identity**: Prowl-launched panes record their profile at surface creation and show the frozen profile name in Active Agents and the capsule; detected-only agents keep the honest runtime name.
- One-shot seeding of bare presets for installed runtimes; agent-facing docs added/updated; implementation record in `docs-ai/053-agent-profiles/001-action.md`.

## Verification

- Full suite: `make test` — **2105 tests passing**; `make check` and `make build-app` clean at every chunk.
- Live HOME spike (`002-home-spike.md`): instruction files/skills picked up from relocated homes, credentials land inside, concurrent logins never cross-talk, real `~/.claude`/`~/.codex` untouched.

## Known deferrals (documented in 001-action.md)

- Resume env-patch for bound panes ships with the handoff-to-profile wave (handoff from a bound pane degrades gracefully to context-only).
- Model suggestions (effort has them; model stays free text).

https://claude.ai/code/session_011y9A9ZLzhQ84EWXiQ5La5b
