### PR TITLE
feat: allow clearing keyboard shortcuts

### DIFF
--- a/docs/reference/keyboard-shortcuts.md
+++ b/docs/reference/keyboard-shortcuts.md
@@ -130,6 +130,9 @@ their own hotkey — see [`components/custom-actions.md`](../components/custom-a
 - **App actions** (scope `configurableAppAction`) are remappable in
   **Settings → Shortcuts**. Overrides are stored in
   `~/.prowl/settings.json` under `keybindingUserOverrides`.
+- While recording a remappable shortcut, choose **Clear** to leave the action
+  unassigned. The empty shortcut field can be recorded again, or **Reset** can
+  restore the default binding.
 - **`quit_application`** is fixed (`systemFixedAppAction`) — it can't be remapped.
 - **Canvas/local actions** (`localInteraction`, e.g. Arrange/Organize/Expand,
   Rename Branch) are remappable and conflict-checked against all remappable actions.

--- a/supacode/Features/Settings/Reducer/SettingsFeature.swift
+++ b/supacode/Features/Settings/Reducer/SettingsFeature.swift
@@ -174,6 +174,7 @@ struct SettingsFeature {
     case setSystemNotificationsEnabled(Bool)
     case setCommandFinishedNotificationThreshold(String)
     case setTerminalFontSize(Float32?)
+    case clearShortcutButtonTapped(commandID: String)
     case clearTerminalLayoutSnapshotButtonTapped
     case installCLIButtonTapped(showAlert: Bool = true)
     case uninstallCLIButtonTapped
@@ -324,6 +325,23 @@ struct SettingsFeature {
           persist(state, captureAnalytics: false, emitSettingsChanged: false),
           .send(.delegate(.terminalFontSizeChanged(fontSize)))
         )
+
+      case .clearShortcutButtonTapped(let commandID):
+        guard
+          let command = KeybindingSchemaDocument.appDefaultsV1.commands.first(where: { $0.id == commandID }),
+          command.allowUserOverride
+        else {
+          return .none
+        }
+
+        let clearedOverride = KeybindingUserOverride(binding: nil, isEnabled: false)
+        guard state.keybindingUserOverrides.overrides[commandID] != clearedOverride else {
+          return .none
+        }
+
+        state.keybindingUserOverrides.overrides[commandID] = clearedOverride
+        state.syncGlobalDefaults(from: state.globalSettings)
+        return persist(state)
 
       case .clearTerminalLayoutSnapshotButtonTapped:
         return .run { send in

--- a/supacode/Features/Settings/Views/ShortcutsSettingsView.swift
+++ b/supacode/Features/Settings/Views/ShortcutsSettingsView.swift
@@ -174,11 +174,12 @@ struct ShortcutsSettingsView: View {
           .frame(minWidth: ShortcutTableLayout.commandColumnMinWidth, maxWidth: .infinity, alignment: .leading)
           .layoutPriority(1)
 
-        sourceChip(source)
+        sourceChip(source, resolvedBinding: resolvedBinding)
           .frame(width: ShortcutTableLayout.statusColumnWidth, alignment: .leading)
 
         shortcutRecorderField(
           commandID: command.id,
+          commandTitle: command.title,
           resolvedBinding: resolvedBinding,
           isRecording: isRecording,
           isHovering: isHoveringRecorder
@@ -245,6 +246,7 @@ struct ShortcutsSettingsView: View {
 
   private func shortcutRecorderField(
     commandID: String,
+    commandTitle: String,
     resolvedBinding: Keybinding?,
     isRecording: Bool,
     isHovering: Bool
@@ -279,6 +281,8 @@ struct ShortcutsSettingsView: View {
       }
     }
     .buttonStyle(.plain)
+    .accessibilityLabel("Shortcut for \(commandTitle)")
+    .accessibilityValue(isRecording ? "Recording" : (resolvedBinding?.display ?? "No shortcut assigned"))
     .onHover { hovering in
       if hovering {
         hoveredRecorderCommandID = commandID
@@ -313,7 +317,7 @@ struct ShortcutsSettingsView: View {
     return Color(nsColor: .separatorColor)
   }
 
-  private func sourceChip(_ source: KeybindingSource) -> some View {
+  private func sourceChip(_ source: KeybindingSource, resolvedBinding: Keybinding?) -> some View {
     let isDefault = source == .appDefault
     guard !isDefault else {
       return AnyView(
@@ -323,8 +327,9 @@ struct ShortcutsSettingsView: View {
       )
     }
 
+    let title = resolvedBinding == nil ? "Disabled" : "Defined"
     return AnyView(
-      Text("Defined")
+      Text(title)
         .font(.caption2.monospaced())
         .lineLimit(1)
         .minimumScaleFactor(0.8)

--- a/supacode/Features/Settings/Views/ShortcutsSettingsView.swift
+++ b/supacode/Features/Settings/Views/ShortcutsSettingsView.swift
@@ -211,14 +211,18 @@ struct ShortcutsSettingsView: View {
 
       if isRecording {
         HStack(spacing: 8) {
-          Text(
-            "Recording: press a key with modifiers (⌘ ⇧ ⌥ ⌃). Return and arrow keys are supported. Press Esc to cancel."
-          )
+          Text("Press a key with modifiers (⌘ ⇧ ⌥ ⌃).")
           Spacer(minLength: 0)
+          Button("Clear") {
+            clearShortcut(for: command.id)
+          }
+          .buttonStyle(.link)
+          .help("Clear shortcut")
           Button("Cancel") {
             stopRecording()
           }
           .buttonStyle(.link)
+          .help("Cancel recording")
         }
         .font(.caption)
         .foregroundStyle(.secondary)
@@ -289,7 +293,7 @@ struct ShortcutsSettingsView: View {
     if isRecording {
       return "Recording…"
     }
-    return resolvedBinding?.display ?? "Unassigned"
+    return resolvedBinding?.display ?? ""
   }
 
   private func shortcutRecorderForegroundColor(resolvedBinding: Keybinding?, isRecording: Bool) -> Color {
@@ -446,6 +450,13 @@ struct ShortcutsSettingsView: View {
       return
     }
     recordingCommandID = commandID
+  }
+
+  private func clearShortcut(for commandID: String) {
+    store.send(.clearShortcutButtonTapped(commandID: commandID))
+    invalidMessageByCommandID[commandID] = nil
+    focusedConflictCommandID = nil
+    stopRecording()
   }
 
   private func stopRecording() {

--- a/supacodeTests/SettingsFeatureTests.swift
+++ b/supacodeTests/SettingsFeatureTests.swift
@@ -475,6 +475,91 @@ struct SettingsFeatureTests {
     #expect(resolved.binding(for: commandID)?.source == .userOverride)
   }
 
+  @Test(.dependencies) func clearShortcutIgnoresFixedAndUnknownCommands() async {
+    var initialSettings = GlobalSettings.default
+    initialSettings.keybindingUserOverrides = .empty
+    @Shared(.settingsFile) var settingsFile
+    $settingsFile.withLock { $0.global = initialSettings }
+
+    let store = TestStore(initialState: SettingsFeature.State(settings: initialSettings)) {
+      SettingsFeature()
+    }
+
+    await store.send(.clearShortcutButtonTapped(commandID: AppShortcuts.CommandID.quitApplication))
+    await store.send(.clearShortcutButtonTapped(commandID: "unknown_command"))
+    await store.finish()
+
+    #expect(store.state.keybindingUserOverrides == .empty)
+    #expect(settingsFile.global.keybindingUserOverrides == .empty)
+  }
+
+  @Test(.dependencies) func clearShortcutPreservesOtherOverridesAndIsIdempotent() async {
+    let commandID = AppShortcuts.CommandID.openSettings
+    let otherCommandID = AppShortcuts.CommandID.commandPalette
+    let otherOverride = KeybindingUserOverride(
+      binding: Keybinding(key: "k", modifiers: .init(command: true, shift: true))
+    )
+    var initialSettings = GlobalSettings.default
+    initialSettings.keybindingUserOverrides = KeybindingUserOverrideStore(
+      overrides: [
+        commandID: KeybindingUserOverride(
+          binding: Keybinding(key: ";", modifiers: .init(command: true))
+        ),
+        otherCommandID: otherOverride,
+      ]
+    )
+    @Shared(.settingsFile) var settingsFile
+    $settingsFile.withLock { $0.global = initialSettings }
+
+    let clearedOverride = KeybindingUserOverride(binding: nil, isEnabled: false)
+    let store = TestStore(initialState: SettingsFeature.State(settings: initialSettings)) {
+      SettingsFeature()
+    }
+
+    await store.send(.clearShortcutButtonTapped(commandID: commandID)) {
+      $0.keybindingUserOverrides.overrides[commandID] = clearedOverride
+    }
+    await store.receive(\.delegate.settingsChanged)
+    await store.send(.clearShortcutButtonTapped(commandID: commandID))
+    await store.finish()
+
+    #expect(settingsFile.global.keybindingUserOverrides.overrides[commandID] == clearedOverride)
+    #expect(settingsFile.global.keybindingUserOverrides.overrides[otherCommandID] == otherOverride)
+  }
+
+  @Test(.dependencies) func clearedShortcutDoesNotConflictWhenReassigned() async throws {
+    var initialSettings = GlobalSettings.default
+    initialSettings.keybindingUserOverrides = .empty
+    @Shared(.settingsFile) var settingsFile
+    $settingsFile.withLock { $0.global = initialSettings }
+
+    let clearedCommandID = AppShortcuts.CommandID.openSettings
+    let reassignedCommandID = AppShortcuts.CommandID.commandPalette
+    let schema = KeybindingSchemaDocument.appResolverSchema()
+    let clearedBinding = schema.commands.first { $0.id == clearedCommandID }?.defaultBinding
+    let reassignedCommand = schema.commands.first { $0.id == reassignedCommandID }
+    let store = TestStore(initialState: SettingsFeature.State(settings: initialSettings)) {
+      SettingsFeature()
+    }
+
+    await store.send(.clearShortcutButtonTapped(commandID: clearedCommandID)) {
+      $0.keybindingUserOverrides.overrides[clearedCommandID] = KeybindingUserOverride(
+        binding: nil,
+        isEnabled: false
+      )
+    }
+    await store.receive(\.delegate.settingsChanged)
+
+    let conflict = ShortcutConflictDetector.firstConflictCommandID(
+      commandID: reassignedCommandID,
+      binding: try #require(clearedBinding),
+      policy: try #require(reassignedCommand?.conflictPolicy),
+      schema: schema,
+      userOverrides: store.state.keybindingUserOverrides
+    )
+    #expect(conflict == nil)
+  }
+
   @Test(.dependencies) func autoShowActiveAgentsPanelPersistsChanges() async {
     var initialSettings = GlobalSettings.default
     initialSettings.autoShowActiveAgentsPanel = false

--- a/supacodeTests/SettingsFeatureTests.swift
+++ b/supacodeTests/SettingsFeatureTests.swift
@@ -448,6 +448,33 @@ struct SettingsFeatureTests {
     #expect(settingsFile.global.keybindingUserOverrides == overrides)
   }
 
+  @Test(.dependencies) func clearShortcutPersistsDisabledOverrideAndFansOut() async {
+    var initialSettings = GlobalSettings.default
+    initialSettings.keybindingUserOverrides = .empty
+    @Shared(.settingsFile) var settingsFile
+    $settingsFile.withLock { $0.global = initialSettings }
+
+    let commandID = AppShortcuts.CommandID.openSettings
+    let clearedOverride = KeybindingUserOverride(binding: nil, isEnabled: false)
+    let store = TestStore(initialState: SettingsFeature.State(settings: initialSettings)) {
+      SettingsFeature()
+    }
+
+    await store.send(.clearShortcutButtonTapped(commandID: commandID)) {
+      $0.keybindingUserOverrides.overrides[commandID] = clearedOverride
+    }
+    await store.receive(\.delegate.settingsChanged)
+
+    #expect(settingsFile.global.keybindingUserOverrides.overrides[commandID] == clearedOverride)
+
+    let resolved = KeybindingResolver.resolve(
+      schema: .appResolverSchema(),
+      userOverrides: settingsFile.global.keybindingUserOverrides
+    )
+    #expect(resolved.binding(for: commandID)?.binding == nil)
+    #expect(resolved.binding(for: commandID)?.source == .userOverride)
+  }
+
   @Test(.dependencies) func autoShowActiveAgentsPanelPersistsChanges() async {
     var initialSettings = GlobalSettings.default
     initialSettings.autoShowActiveAgentsPanel = false


### PR DESCRIPTION
## Summary

- Add a **Clear** action beside **Cancel** while recording a remappable shortcut.
- Persist a disabled override so the shortcut field remains blank and **Reset** restores its default.
- Guard fixed and unknown commands, preserve unrelated overrides, and make repeated clears a no-op.

## Validation

- `make check`
- Targeted shortcut-clearing tests (4 cases)
- `make build-app`
- `make test` — 2,129 tests passed, 0 failures

Fixes #619
