### PR TITLE
Reorder agent profile editor sections

### DIFF
--- a/docs/components/agent-profiles.md
+++ b/docs/components/agent-profiles.md
@@ -89,9 +89,11 @@ when the picker says Standard; any other extra argument (including
 `--sandbox`/`--ask-for-approval`/`-c` overrides) shows a neutral "effective
 execution mode follows your extra arguments" note instead of claiming
 Standard — the semantics belong to your command line.
-The editor's first section is **Launch Preview**. It shows the exact rendered
-invocation — including the env prefix for bound profiles — using the same
-rendering as the real launch.
+The editor opens with a **Profile** section (name, agent, icon), followed by
+**Launch Preview** — the exact rendered invocation, including the env prefix
+for bound profiles, using the same rendering as the real launch — then a
+**Details** section with the remaining launch options (model, reasoning
+effort, execution mode, placement).
 
 ## Where things live on disk
 

--- a/supacode/Features/Settings/Views/AgentProfileEditorView.swift
+++ b/supacode/Features/Settings/Views/AgentProfileEditorView.swift
@@ -10,8 +10,9 @@ struct AgentProfileEditorView: View {
 
   var body: some View {
     Form {
-      launchPreviewSection
       profileSection
+      launchPreviewSection
+      detailsSection
       advancedSection
       removalSection
     }
@@ -50,6 +51,11 @@ struct AgentProfileEditorView: View {
         }
       }
       iconRow
+    }
+  }
+
+  private var detailsSection: some View {
+    Section("Details") {
       suggestedTextRow(
         title: "Model",
         prompt: "Runtime default",


### PR DESCRIPTION
## Summary
- Split the agent profile editor's former Profile section into **Profile** (Name, Agent, Icon) and **Details** (Model, Reasoning Effort, Execution Mode, Open In / Split Direction).
- Move **Launch Preview** between Profile and Details, so the editor reads: Profile → Launch Preview → Details → Advanced → Remove.
- Update `docs/components/agent-profiles.md` to match the new section order.

## Testing
- `make check`
- `make build-app`

https://claude.ai/code/session_01EiT5G1tAXpq2m3BpBCEmfD
