### PR TITLE
Add per-profile environment variable overrides

### DIFF
--- a/docs-ai/053-agent-profiles/000-plan.md
+++ b/docs-ai/053-agent-profiles/000-plan.md
@@ -330,6 +330,10 @@ agent 列表不变。
 
 ## Amendments
 
+- Updated 2026-07-31: 新增用户可配置的 per-profile 环境变量覆盖(base url / api key
+  临时改写,如 "Codex but using DeepSeek")— see
+  [004-environment-overrides.md](004-environment-overrides.md).
+
 - Updated 2026-07-31: profile launcher 图标的持久化、fallback 与 surface 范围决策 — see
   [003-profile-icons.md](003-profile-icons.md).
 

--- a/docs-ai/053-agent-profiles/004-environment-overrides.md
+++ b/docs-ai/053-agent-profiles/004-environment-overrides.md
@@ -1,7 +1,7 @@
 # 053 修订:Profile 自定义环境变量(Environment Overrides)
 
 - 日期:2026-07-31
-- 状态:计划(实现前);实现结果回填至本文档末尾
+- 状态:已实现(PR #632);实现结果见文末
 - 关联:[000-plan.md](000-plan.md)(launch plan 管道)、[001-action.md](001-action.md)
   (resume 环境补丁的既有推迟)
 
@@ -115,3 +115,32 @@ Advanced section 内、Extra Arguments 之下:紧凑两列表格——表头(Nam
   空 name 过滤、preview 引用。
 - `make check` + `make build-app`;手动:override `OPENAI_BASE_URL` 的 profile,
   预览显示带引号前缀,启动后 pane 内 `echo $OPENAI_BASE_URL` 命中。
+
+## 实现结果(2026-07-31,PR #632)
+
+按本文档实现,无实质偏差。落点:
+
+- `AgentProfile.swift`:`AgentProfileEnvironmentOverride` 行类型(id/name/value)
+  + `environmentOverrides` 字段,`decodeIfPresent ?? []` 零迁移。
+- `AgentProfileLaunchPlan.swift`:`AgentProfileEnvironmentPolicy`(名校验/保留名/
+  NUL 值/`effectiveOverrides`)由 planner 与编辑器共享;planner 先施加用户行、
+  后写 dedicated-home 变量;`previewText` 渲染 `NAME='value'` 并对
+  KEY/TOKEN/SECRET/PASSWORD 样名字掩码。保留名单从 adapter 的
+  `accountHomeEnvironmentVariable` 推导,未硬编码。
+- `AgentProfileEditorFeature.swift`:`addEnvironmentOverride` /
+  `removeEnvironmentOverride(id:)` 专用 action(UUID 走 `@Dependency(\.uuid)`);
+  `runtimeChanged` 一并清空 overrides。
+- `AgentProfileEditorView.swift`:Advanced 内 Extra Arguments 下方的行编辑表格
+  (Add Variable 表头行 + 每行双 monospaced TextField + 行内 warning 图标 +
+  删除按钮);Launch Preview 文案改为不再承诺 env 前缀逐字执行。
+- `SymlinkPreservingFileWriter.swift`:所有 settings 写入统一 `0600`(经共享
+  writer,同时覆盖 `settings.json`/`global.onevcat.json`/repo entries/appearances)。
+
+测试证据:相关 5 个测试类 68 个测试全绿(新增合并语义、精度、脱敏、权限、
+增删行、runtime 清空用例);`make check` 与 `make build-app` 零错误零警告。
+
+实现注记(非偏差):
+
+- chmod 发生在 atomic 写入之后,每次保存存在极短的默认权限窗口;单用户场景
+  可接受,如需严格可改为先建 0600 temp 再 rename,列为可选精化。
+- 手动放宽 settings 文件权限会在下一次保存时被改回 0600(每次写入强制)。

--- a/docs-ai/053-agent-profiles/004-environment-overrides.md
+++ b/docs-ai/053-agent-profiles/004-environment-overrides.md
@@ -1,0 +1,117 @@
+# 053 修订:Profile 自定义环境变量(Environment Overrides)
+
+- 日期:2026-07-31
+- 状态:计划(实现前);实现结果回填至本文档末尾
+- 关联:[000-plan.md](000-plan.md)(launch plan 管道)、[001-action.md](001-action.md)
+  (resume 环境补丁的既有推迟)
+
+## 背景与动机
+
+053 的环境补丁(`AgentProfileLaunchPlan.environment`)目前只有一个内部来源:
+`bindsDedicatedHome` 写入 `CLAUDE_CONFIG_DIR` / `CODEX_HOME`。onevcat 需要用户可
+配置的 per-profile 环境变量覆盖,典型场景是临时改写 base url / api key——例如
+`OPENAI_BASE_URL` + `OPENAI_API_KEY` 指向 DeepSeek,得到一个 "Codex but using
+DeepSeek" 的 profile。
+
+管道已经全通:plan.environment → `TerminalClient.launchAgentProfile` →
+`WorktreeTerminalState`(`additionalEnvironment`)→ `GhosttySurfaceView` 把补丁
+以 `ghostty_env_var_s` 数组交给 libghostty 在 spawn 时施加(非 shell 字符串,
+无注入面)。缺的只有:模型字段、planner 合并、编辑器 UI。
+
+## 设计
+
+### 模型
+
+`AgentProfile` 新增有序数组字段(非字典:table UI 需要稳定的行身份与顺序,且要
+容忍编辑中的半成品行):
+
+```swift
+nonisolated struct AgentProfileEnvironmentOverride:
+  Codable, Equatable, Sendable, Identifiable
+{
+  var id: UUID
+  var name: String
+  var value: String
+}
+
+var environmentOverrides: [AgentProfileEnvironmentOverride] = []
+```
+
+- 解码沿用既有 per-field 迁移模式:`decodeIfPresent ?? []`,旧数据零迁移。
+- 持久化按原样保存(允许空行存在);**合法性在 plan 时刻裁决**,不在持久化时刻。
+
+### Planner 合并语义(`AgentProfileLaunchPlanner.plan`)
+
+1. 先施加用户 overrides:name 做 trim;trim 后为空的行跳过(编辑中间态);
+   **name 必须是合法 POSIX 名**(`[A-Za-z_][A-Za-z0-9_]*`,天然排除 `=`/NUL),
+   **保留名被拒绝**(见下);value 原样保留(空 value 是合法的"设为空",不是
+   忽略),含 NUL 的 value 拒绝(strdup 会静默截断)。同名重复时后者胜(shell
+   export 语义)。被拒绝的行在 UI 上可见标记,不静默消失。
+2. 再写 dedicated-home 变量——**账号绑定永远压过同名用户行**,账号隔离的安全
+   推理必须保持可证明。
+3. **保留名单**:`PROWL_` 前缀(worktree/root 内部事实不可伪造)与各 runtime 的
+   account-home 变量(`CLAUDE_CONFIG_DIR` / `CODEX_HOME`,从 adapter 的
+   `accountHomeEnvironmentVariable` 推导,不硬编码)。未绑定 profile 若允许设
+   `CODEX_HOME`,会绕过目录 provision、删除保护与 rooted session 检测——
+   "自定义 home"是另一个需要完整支持的能力,不从 env 表格后门进入。
+4. 下游 surface 合并(patch 压过 worktree 注入变量)保持不变:保留名已在
+   planner 被过滤,到达下游的补丁均为合法用户覆盖。
+
+### Launch Preview 引用修复与脱敏
+
+`previewText` 目前把 env 前缀渲染为裸 `KEY=value`,用户值一旦含空格/引号/`$`,
+预览即失真。修复:渲染为 `NAME=<quoted-value>`——只对 value 加引号(`'` →
+`'"'"'` 习语),不把整个赋值当作一个 token。同时:
+
+- **脱敏**:name 命中 secret 样模式(`KEY`/`TOKEN`/`SECRET`/`PASSWORD`,大小写
+  不敏感)的值在预览中以掩码显示,绝不展示完整 secret。
+- 预览语义澄清:env 前缀是"等价的可复制 shell 表示";真实注入走 Ghostty spawn
+  的 env 数组,不经 shell。UI 文案从 "this exact command" 调整为不再对 env
+  前缀作逐字承诺。
+
+### 编辑器 UI
+
+Advanced section 内、Extra Arguments 之下:紧凑两列表格——表头(Name / Value)、
+每行两个 `.monospaced()` TextField、行尾删除按钮、底部 "Add Variable" 按钮;空列表
+只渲染添加按钮。SwiftUI `Table` 与 `Form` 在高度/选中上互相打架,故用 ForEach 网格
+保持 Form 原生观感。行文本编辑走既有 `BindingReducer` 通道自动持久化;增删行用
+专用 action(`addEnvironmentOverride` / `removeEnvironmentOverride(id:)`),沿
+`.setIcon` 模式。`runtimeChanged` **清空** overrides——与 extraArguments 一致:
+`OPENAI_BASE_URL` 之类的值属于所选 runtime 的语义,切换 runtime 后残留只会造成
+静默错配。非法/保留名的行内联标记(warning 图标 + help),不阻塞输入。
+
+## 已知边界(与 053 既有推迟一致,本波不扩)
+
+- **resume/handoff 不携带环境补丁**:`AgentResumeRequest` 无 env 字段、
+  `ShellClient.runLogin` 无 env 缝。dedicatedHome 在 001-action.md 偏差 2 已推迟至
+  handoff 波次,自定义 env 继承同一缺口——绑定/覆盖 pane 的 briefing resume 降级
+  为 context-only。
+- **布局恢复不重放补丁**:`WorktreeTerminalState+LayoutSnapshot` 重建 surface 时
+  不带 `additionalEnvironment`,dedicatedHome 已有同样缺口,一并留待后续波次。
+- **明文存储(边界的显式放宽)**:000-plan.md:56 原本把"裸 API key 进 Prowl
+  JSON"排除在外(Keychain 引用整体推迟)。本修订按 onevcat 的显式需求放宽:
+  用户在 env 表格中输入的值(可能含 api key)明文存于 `global.onevcat.json`。
+  配套硬化:settings 写入统一收紧文件权限至 `0600`(此前落盘为 0644,同机
+  他用户可读);预览对 secret 样名字掩码。Keychain 引用仍列为后续方向,不在
+  本波实现。
+
+## Codex 审阅(2026-07-31)
+
+实现前由并行 codex(gpt-5.6-terra xhigh)审阅本文档与相关源码,四条意见全部或
+部分采纳:
+
+1. **明文密钥 P0** → 部分采纳:不上 Keychain(v1 过重,保持 053 的推迟),但
+   采纳 0600 权限收紧、预览脱敏、文档显式声明边界放宽(见上节)。
+2. **name 只 trim 不足** → 采纳:POSIX 名校验、空 value 语义为"设为空"、
+   无效行 UI 可见。
+3. **保留变量策略漏洞**(未绑定 profile 可设 `CODEX_HOME` 绕过防护;`PROWL_*`
+   可被伪造)→ 采纳:全局保留名单,planner 过滤 + UI 标记。
+4. **quoting 精确化**(`NAME=<quoted-value>`、预览是等价表示非执行路径、
+   不展示 secret)→ 采纳。
+
+## 验证
+
+- 单测:解码默认值、round-trip、合并顺序(后者胜)、home 变量压过同名用户行、
+  空 name 过滤、preview 引用。
+- `make check` + `make build-app`;手动:override `OPENAI_BASE_URL` 的 profile,
+  预览显示带引号前缀,启动后 pane 内 `echo $OPENAI_BASE_URL` 命中。

--- a/docs/components/agent-profiles.md
+++ b/docs/components/agent-profiles.md
@@ -63,6 +63,26 @@ agent.
 first enabled profile in the Settings list order. Each tier only matches an
 existing, enabled profile.
 
+## Environment variables
+
+The **Environment Variables** table (Advanced, below Extra Arguments) adds
+per-profile environment overrides to the launched process, on top of the
+shell's normal environment — e.g. `OPENAI_BASE_URL` + `OPENAI_API_KEY` to get
+a "Codex but using DeepSeek" profile. Rules:
+
+- Names must be valid POSIX names (`[A-Za-z_][A-Za-z0-9_]*`). An empty value
+  legitimately sets the variable to the empty string.
+- Reserved names are ignored at launch and flagged inline: anything starting
+  with `PROWL_`, plus the account-home variables (`CLAUDE_CONFIG_DIR`,
+  `CODEX_HOME`) — a custom home must go through **Use Dedicated Home**, which
+  always wins over a same-named row.
+- Later duplicate names win (shell-export semantics).
+- Values are stored in plaintext in `~/.prowl/global.onevcat.json` (kept
+  owner-only, `0600`). The Launch Preview masks secret-looking values
+  (names containing `KEY`/`TOKEN`/`SECRET`/`PASSWORD`).
+- Overrides apply to profile launches only; resumed or restored panes do not
+  re-apply them (same limitation as dedicated homes).
+
 ## Dedicated home (separate account)
 
 Toggling **Use Dedicated Home** (Advanced) gives the profile its own runtime

--- a/supacode/Domain/AgentProfile/AgentProfile.swift
+++ b/supacode/Domain/AgentProfile/AgentProfile.swift
@@ -27,6 +27,24 @@ nonisolated enum AgentProfileRuntime: String, Codable, CaseIterable, Identifiabl
   }
 }
 
+/// One user-configured environment variable override, applied to the launched
+/// process (docs-ai 053/004). An ordered row list rather than a dictionary:
+/// the editor table needs stable row identity while a name is being typed, and
+/// must tolerate in-progress rows — validity is judged at plan time, not here.
+nonisolated struct AgentProfileEnvironmentOverride: Codable, Equatable, Sendable, Identifiable {
+  var id: UUID
+  var name: String
+  var value: String
+
+  init(id: UUID = UUID(), name: String = "", value: String = "") {
+    self.id = id
+    self.name = name
+    self.value = value
+  }
+
+  var trimmedName: String { name.trimmingCharacters(in: .whitespaces) }
+}
+
 nonisolated enum AgentProfilePlacement: String, Codable, CaseIterable, Identifiable, Sendable {
   case tab
   case split
@@ -50,6 +68,7 @@ nonisolated struct AgentProfile: Codable, Equatable, Sendable, Identifiable {
   var placement: AgentProfilePlacement
   var splitDirection: UserCustomSplitDirection
   var extraArguments: String
+  var environmentOverrides: [AgentProfileEnvironmentOverride]
   var bindsDedicatedHome: Bool
 
   init(
@@ -64,6 +83,7 @@ nonisolated struct AgentProfile: Codable, Equatable, Sendable, Identifiable {
     placement: AgentProfilePlacement = .tab,
     splitDirection: UserCustomSplitDirection = .right,
     extraArguments: String = "",
+    environmentOverrides: [AgentProfileEnvironmentOverride] = [],
     bindsDedicatedHome: Bool = false
   ) {
     self.id = id
@@ -77,12 +97,13 @@ nonisolated struct AgentProfile: Codable, Equatable, Sendable, Identifiable {
     self.placement = placement
     self.splitDirection = splitDirection
     self.extraArguments = extraArguments
+    self.environmentOverrides = environmentOverrides
     self.bindsDedicatedHome = bindsDedicatedHome
   }
 
   private enum CodingKeys: String, CodingKey {
     case id, name, isEnabled, runtime, icon, model, reasoningEffort, executionMode
-    case placement, splitDirection, extraArguments, bindsDedicatedHome
+    case placement, splitDirection, extraArguments, environmentOverrides, bindsDedicatedHome
   }
 
   init(from decoder: Decoder) throws {
@@ -100,6 +121,10 @@ nonisolated struct AgentProfile: Codable, Equatable, Sendable, Identifiable {
     splitDirection =
       try container.decodeIfPresent(UserCustomSplitDirection.self, forKey: .splitDirection) ?? .right
     extraArguments = try container.decodeIfPresent(String.self, forKey: .extraArguments) ?? ""
+    environmentOverrides =
+      try container.decodeIfPresent(
+        [AgentProfileEnvironmentOverride].self, forKey: .environmentOverrides
+      ) ?? []
     bindsDedicatedHome = try container.decodeIfPresent(Bool.self, forKey: .bindsDedicatedHome) ?? false
   }
 

--- a/supacode/Domain/AgentProfile/AgentProfileLaunchPlan.swift
+++ b/supacode/Domain/AgentProfile/AgentProfileLaunchPlan.swift
@@ -19,10 +19,102 @@ nonisolated struct AgentProfileLaunchPlan: Equatable, Sendable {
   var terminalInput: String { invocation.terminalInput }
 
   /// Human-readable launch preview: env prefix plus the exact rendered
-  /// invocation. Shares the launch rendering so the preview can never lie.
+  /// invocation. The prefix is an equivalent shell rendering — the real patch
+  /// goes through Ghostty's spawn env array, never a shell — so values are
+  /// quoted for faithfulness and secret-looking values are masked rather than
+  /// displayed (docs-ai 053/004).
   var previewText: String {
-    let prefix = environment.sorted { $0.key < $1.key }.map { "\($0.key)=\($0.value)" }
+    let prefix = environment.sorted { $0.key < $1.key }.map { pair in
+      "\(pair.key)=\(Self.previewValue(name: pair.key, value: pair.value))"
+    }
     return (prefix + [invocation.terminalInput]).joined(separator: " ")
+  }
+
+  private static let secretNameFragments = ["KEY", "TOKEN", "SECRET", "PASSWORD"]
+
+  private static func previewValue(name: String, value: String) -> String {
+    let upper = name.uppercased()
+    if secretNameFragments.contains(where: { upper.contains($0) }) {
+      return "•••"
+    }
+    return "'" + value.replacing("'", with: "'\"'\"'") + "'"
+  }
+}
+
+/// Which env variable names a profile override may set, shared by the planner
+/// (filtering) and the editor (inline row diagnostics) so they can never
+/// disagree (docs-ai 053/004).
+nonisolated enum AgentProfileEnvironmentPolicy {
+  enum RowIssue: Equatable, Sendable {
+    case invalidName
+    case reservedName
+    case invalidValue
+  }
+
+  /// Account-home variables come from the adapters, not a hardcoded list; the
+  /// `PROWL_` prefix protects the worktree/root facts Prowl injects itself.
+  /// Letting an override set `CODEX_HOME` on an unbound profile would bypass
+  /// home provisioning, deletion protection, and rooted session detection —
+  /// custom homes are a separate capability, not an env-table backdoor.
+  static var reservedNames: Set<String> {
+    Set(
+      AgentProfileRuntime.allCases.compactMap {
+        AgentRuntimeAdapterRegistry.adapter(for: $0.agent)?.accountHomeEnvironmentVariable
+      }
+    )
+  }
+
+  static func isValidName(_ name: String) -> Bool {
+    guard let first = name.utf8.first else { return false }
+    guard first == UInt8(ascii: "_") || isASCIILetter(first) else { return false }
+    return name.utf8.dropFirst().allSatisfy {
+      $0 == UInt8(ascii: "_") || isASCIILetter($0) || isASCIIDigit($0)
+    }
+  }
+
+  static func isReserved(_ name: String) -> Bool {
+    name.hasPrefix("PROWL_") || reservedNames.contains(name)
+  }
+
+  /// A NUL would be silently truncated at the C-string boundary; refuse the
+  /// row instead of launching with a value the user never wrote.
+  static func isValidValue(_ value: String) -> Bool {
+    !value.contains("\0")
+  }
+
+  /// nil for a row the planner will apply; blank names are in-progress rows,
+  /// reported as nil issue too — they are ignored without being an error.
+  static func issue(for override: AgentProfileEnvironmentOverride) -> RowIssue? {
+    let name = override.trimmedName
+    guard !name.isEmpty else { return nil }
+    if !isValidName(name) { return .invalidName }
+    if isReserved(name) { return .reservedName }
+    if !isValidValue(override.value) { return .invalidValue }
+    return nil
+  }
+
+  /// The applied subset: trimmed names, invalid/reserved rows dropped, later
+  /// duplicates win (shell-export semantics). Values stay verbatim — an empty
+  /// value legitimately sets the variable to the empty string.
+  static func effectiveOverrides(
+    _ overrides: [AgentProfileEnvironmentOverride]
+  ) -> [String: String] {
+    var environment: [String: String] = [:]
+    for override in overrides {
+      let name = override.trimmedName
+      guard !name.isEmpty, issue(for: override) == nil else { continue }
+      environment[name] = override.value
+    }
+    return environment
+  }
+
+  private static func isASCIILetter(_ byte: UInt8) -> Bool {
+    (UInt8(ascii: "A")...UInt8(ascii: "Z")).contains(byte)
+      || (UInt8(ascii: "a")...UInt8(ascii: "z")).contains(byte)
+  }
+
+  private static func isASCIIDigit(_ byte: UInt8) -> Bool {
+    (UInt8(ascii: "0")...UInt8(ascii: "9")).contains(byte)
   }
 }
 
@@ -80,7 +172,10 @@ nonisolated enum AgentProfileLaunchPlanner {
       AgentStartRequest(agent: profile.runtime.agent, intent: .interactive, configuration: configuration)
     )
 
-    var environment: [String: String] = [:]
+    // User overrides first; the dedicated-home variable is written after, so
+    // an account binding always beats a same-named user row — the account
+    // isolation reasoning must stay provable (docs-ai 053/004).
+    var environment = AgentProfileEnvironmentPolicy.effectiveOverrides(profile.environmentOverrides)
     var dedicatedHome: URL?
     if profile.bindsDedicatedHome {
       guard let variable = adapter.accountHomeEnvironmentVariable else {

--- a/supacode/Features/Settings/BusinessLogic/SymlinkPreservingFileWriter.swift
+++ b/supacode/Features/Settings/BusinessLogic/SymlinkPreservingFileWriter.swift
@@ -28,6 +28,13 @@ nonisolated enum SymlinkPreservingFileWriter {
     // The atomic temp+rename happens in the target's directory, so a symlink at
     // `url` is written through and preserved instead of replaced.
     try data.write(to: target, options: [.atomic])
+    // Settings may carry secrets (agent profile env overrides can hold API
+    // keys, docs-ai 053/004); keep every settings file owner-only instead of
+    // the default 0644.
+    try FileManager.default.setAttributes(
+      [.posixPermissions: 0o600],
+      ofItemAtPath: target.path(percentEncoded: false)
+    )
   }
 
   /// macOS resolves at most MAXSYMLINKS (32) links before ELOOP, so a deeper

--- a/supacode/Features/Settings/Reducer/AgentProfileEditorFeature.swift
+++ b/supacode/Features/Settings/Reducer/AgentProfileEditorFeature.swift
@@ -27,6 +27,8 @@ struct AgentProfileEditorFeature {
     case task
     case runtimeChanged(AgentProfileRuntime)
     case setIcon(String?)
+    case addEnvironmentOverride
+    case removeEnvironmentOverride(AgentProfileEnvironmentOverride.ID)
     case binding(BindingAction<State>)
     case removeTapped
     case revealProfileFiles
@@ -50,6 +52,7 @@ struct AgentProfileEditorFeature {
   }
 
   @Dependency(AgentProfileHomeClient.self) var homeClient
+  @Dependency(\.uuid) var uuid
 
   var body: some Reducer<State, Action> {
     BindingReducer()
@@ -61,13 +64,15 @@ struct AgentProfileEditorFeature {
 
       case .runtimeChanged(let runtime):
         guard state.profile.runtime != runtime else { return .none }
-        // Model, effort, literal CLI arguments, and unrestricted approval
-        // belong to the selected runtime. The target CLI requires its own
-        // explicit confirmation before it can bypass safeguards.
+        // Model, effort, literal CLI arguments, environment overrides, and
+        // unrestricted approval belong to the selected runtime. The target CLI
+        // requires its own explicit confirmation before it can bypass
+        // safeguards.
         state.profile.runtime = runtime
         state.profile.model = nil
         state.profile.reasoningEffort = nil
         state.profile.extraArguments = ""
+        state.profile.environmentOverrides = []
         state.profile.executionMode = .standard
         refreshHomeStatus(&state)
         return .send(.delegate(.profileEdited(state.profile)))
@@ -75,6 +80,14 @@ struct AgentProfileEditorFeature {
       case .setIcon(let icon):
         guard state.profile.icon != icon else { return .none }
         state.profile.icon = icon
+        return .send(.delegate(.profileEdited(state.profile)))
+
+      case .addEnvironmentOverride:
+        state.profile.environmentOverrides.append(AgentProfileEnvironmentOverride(id: uuid()))
+        return .send(.delegate(.profileEdited(state.profile)))
+
+      case .removeEnvironmentOverride(let id):
+        state.profile.environmentOverrides.removeAll { $0.id == id }
         return .send(.delegate(.profileEdited(state.profile)))
       case .binding:
         // `.unrestricted` is never applied silently: the change reverts until

--- a/supacode/Features/Settings/Views/AgentProfileEditorView.swift
+++ b/supacode/Features/Settings/Views/AgentProfileEditorView.swift
@@ -112,6 +112,10 @@ struct AgentProfileEditorView: View {
           set: { $store.profile.extraArguments.wrappedValue = $0 ?? "" }
         )
       )
+      environmentOverridesHeader
+      ForEach($store.profile.environmentOverrides) { $override in
+        environmentOverrideRow($override)
+      }
       Toggle("Use Dedicated Home", isOn: $store.profile.bindsDedicatedHome)
         .help("Keep a separate login, usage, and configuration for this profile")
       if store.profile.bindsDedicatedHome {
@@ -145,9 +149,62 @@ struct AgentProfileEditorView: View {
     }
   }
 
+  private var environmentOverridesHeader: some View {
+    LabeledContent {
+      Button {
+        store.send(.addEnvironmentOverride)
+      } label: {
+        Label("Add Variable", systemImage: "plus")
+      }
+      .help("Add an environment variable override for this profile's launches")
+    } label: {
+      Text("Environment Variables")
+      Text("Applied to the launched process, on top of the shell's environment.")
+    }
+  }
+
+  private func environmentOverrideRow(
+    _ override: Binding<AgentProfileEnvironmentOverride>
+  ) -> some View {
+    HStack(spacing: 8) {
+      TextField("NAME", text: override.name)
+        .font(.body.monospaced())
+        .frame(width: 180)
+        .accessibilityLabel("Variable name")
+      TextField("value", text: override.value)
+        .font(.body.monospaced())
+        .accessibilityLabel("Variable value")
+      if let issue = AgentProfileEnvironmentPolicy.issue(for: override.wrappedValue) {
+        Image(systemName: "exclamationmark.triangle.fill")
+          .foregroundStyle(.yellow)
+          .help(issueDescription(issue))
+          .accessibilityLabel(issueDescription(issue))
+      }
+      Button {
+        store.send(.removeEnvironmentOverride(override.wrappedValue.id))
+      } label: {
+        Label("Remove Variable", systemImage: "minus.circle")
+          .labelStyle(.iconOnly)
+      }
+      .buttonStyle(.plain)
+      .help("Remove this environment variable")
+    }
+  }
+
+  private func issueDescription(_ issue: AgentProfileEnvironmentPolicy.RowIssue) -> String {
+    switch issue {
+    case .invalidName:
+      "Not a valid environment variable name — this row is ignored at launch."
+    case .reservedName:
+      "Reserved by Prowl — this row is ignored at launch."
+    case .invalidValue:
+      "The value contains an unsupported character — this row is ignored at launch."
+    }
+  }
+
   private var launchPreviewSection: some View {
     Section("Launch Preview") {
-      Text("Prowl will execute this exact command.")
+      Text("Prowl will execute this command. Secret-looking values are hidden here.")
         .font(.caption)
         .foregroundStyle(.secondary)
       Text(previewText)

--- a/supacodeTests/AgentProfileEditorFeatureTests.swift
+++ b/supacodeTests/AgentProfileEditorFeatureTests.swift
@@ -27,6 +27,9 @@ struct AgentProfileEditorFeatureTests {
     profile.model = "gpt-5.6-sol"
     profile.reasoningEffort = "xhigh"
     profile.extraArguments = "--search"
+    profile.environmentOverrides = [
+      AgentProfileEnvironmentOverride(name: "OPENAI_BASE_URL", value: "https://api.deepseek.com/v1")
+    ]
     profile.executionMode = .unrestricted
     profile.icon = "wand.and.stars"
     profile.placement = .split
@@ -41,6 +44,7 @@ struct AgentProfileEditorFeatureTests {
       $0.profile.model = nil
       $0.profile.reasoningEffort = nil
       $0.profile.extraArguments = ""
+      $0.profile.environmentOverrides = []
       $0.profile.executionMode = .standard
       $0.profile.icon = "wand.and.stars"
       $0.profile.placement = .split
@@ -74,6 +78,26 @@ struct AgentProfileEditorFeatureTests {
 
     await store.send(.setIcon(nil)) {
       $0.profile.icon = nil
+    }
+    await store.receive(\.delegate.profileEdited)
+  }
+
+  @Test(.dependencies) func addingAndRemovingEnvironmentOverrideRowsDelegates() async {
+    let profile = AgentProfile(name: "Codex", runtime: .codex)
+    let store = TestStore(initialState: AgentProfileEditorFeature.State(profile: profile)) {
+      AgentProfileEditorFeature()
+    } withDependencies: {
+      $0.uuid = .incrementing
+    }
+
+    let rowID = UUID(0)
+    await store.send(.addEnvironmentOverride) {
+      $0.profile.environmentOverrides = [AgentProfileEnvironmentOverride(id: rowID)]
+    }
+    await store.receive(\.delegate.profileEdited)
+
+    await store.send(.removeEnvironmentOverride(rowID)) {
+      $0.profile.environmentOverrides = []
     }
     await store.receive(\.delegate.profileEdited)
   }

--- a/supacodeTests/AgentProfileTests.swift
+++ b/supacodeTests/AgentProfileTests.swift
@@ -47,7 +47,19 @@ struct AgentProfileTests {
     #expect(decoded.placement == .tab)
     #expect(decoded.splitDirection == .right)
     #expect(decoded.extraArguments.isEmpty)
+    #expect(decoded.environmentOverrides.isEmpty)
     #expect(!decoded.bindsDedicatedHome)
+  }
+
+  @Test func encodingRoundTripPreservesEnvironmentOverrides() throws {
+    var profile = profile(name: "Codex · DeepSeek")
+    profile.environmentOverrides = [
+      AgentProfileEnvironmentOverride(name: "OPENAI_BASE_URL", value: "https://api.deepseek.com/v1")
+    ]
+
+    let decoded = try JSONDecoder().decode(AgentProfile.self, from: JSONEncoder().encode(profile))
+
+    #expect(decoded.environmentOverrides == profile.environmentOverrides)
   }
 
   @Test func encodingRoundTripPreservesProfileIcon() throws {
@@ -182,7 +194,7 @@ struct AgentProfileTests {
       AgentProfileLaunchPlanner.pathString(home) == "/base/agent-profiles/\(bound.id.uuidString)"
     )
     #expect(plan.environment == ["CODEX_HOME": "/base/agent-profiles/\(bound.id.uuidString)"])
-    #expect(plan.previewText.hasPrefix("CODEX_HOME=/base/agent-profiles/"))
+    #expect(plan.previewText.hasPrefix("CODEX_HOME='/base/agent-profiles/"))
     #expect(AgentProfileLaunchPlanner.isContained(home, in: base))
   }
 
@@ -196,6 +208,113 @@ struct AgentProfileTests {
     )
 
     #expect(plan.environment.keys.contains("CLAUDE_CONFIG_DIR"))
+  }
+
+  // MARK: - Environment overrides
+
+  @Test func planAppliesOverridesWithTrimmedNamesAndLastDuplicateWins() throws {
+    var preset = profile(name: "Codex · DeepSeek")
+    preset.environmentOverrides = [
+      AgentProfileEnvironmentOverride(name: "  OPENAI_BASE_URL ", value: "https://api.deepseek.com/v1"),
+      AgentProfileEnvironmentOverride(name: "OPENAI_BASE_URL", value: "https://api.deepseek.com/beta"),
+      AgentProfileEnvironmentOverride(name: "EMPTY_VALUE", value: ""),
+    ]
+
+    let plan = try AgentProfileLaunchPlanner.plan(
+      for: preset,
+      homeBaseDirectory: URL(fileURLWithPath: "/base", isDirectory: true)
+    )
+
+    #expect(
+      plan.environment == [
+        "OPENAI_BASE_URL": "https://api.deepseek.com/beta",
+        "EMPTY_VALUE": "",
+      ]
+    )
+  }
+
+  @Test func planDropsInvalidReservedAndInProgressOverrideRows() throws {
+    var preset = profile(name: "Codex · Broken rows")
+    preset.environmentOverrides = [
+      AgentProfileEnvironmentOverride(name: "   ", value: "in-progress row"),
+      AgentProfileEnvironmentOverride(name: "9LEADING_DIGIT", value: "x"),
+      AgentProfileEnvironmentOverride(name: "BAD-NAME", value: "x"),
+      AgentProfileEnvironmentOverride(name: "PROWL_WORKTREE_PATH", value: "/forged"),
+      AgentProfileEnvironmentOverride(name: "CODEX_HOME", value: "/elsewhere"),
+      AgentProfileEnvironmentOverride(name: "CLAUDE_CONFIG_DIR", value: "/elsewhere"),
+      AgentProfileEnvironmentOverride(name: "NUL_VALUE", value: "trunc\0ated"),
+    ]
+
+    let plan = try AgentProfileLaunchPlanner.plan(
+      for: preset,
+      homeBaseDirectory: URL(fileURLWithPath: "/base", isDirectory: true)
+    )
+
+    #expect(plan.environment.isEmpty)
+  }
+
+  @Test func dedicatedHomeBindingBeatsSameNamedUserOverride() throws {
+    var bound = profile(name: "Codex · Work")
+    bound.bindsDedicatedHome = true
+    bound.environmentOverrides = [
+      AgentProfileEnvironmentOverride(name: "CODEX_HOME", value: "/attacker/home")
+    ]
+    let base = URL(fileURLWithPath: "/base/agent-profiles", isDirectory: true)
+
+    let plan = try AgentProfileLaunchPlanner.plan(for: bound, homeBaseDirectory: base)
+
+    #expect(plan.environment == ["CODEX_HOME": "/base/agent-profiles/\(bound.id.uuidString)"])
+  }
+
+  @Test func previewQuotesOverrideValuesAndMasksSecretLookingNames() throws {
+    var preset = profile(name: "Codex · DeepSeek")
+    preset.environmentOverrides = [
+      AgentProfileEnvironmentOverride(name: "OPENAI_BASE_URL", value: "https://a.example/v1 beta"),
+      AgentProfileEnvironmentOverride(name: "OPENAI_API_KEY", value: "sk-secret-123"),
+    ]
+
+    let plan = try AgentProfileLaunchPlanner.plan(
+      for: preset,
+      homeBaseDirectory: URL(fileURLWithPath: "/base", isDirectory: true)
+    )
+
+    #expect(plan.previewText.contains("OPENAI_BASE_URL='https://a.example/v1 beta'"))
+    #expect(plan.previewText.contains("OPENAI_API_KEY=•••"))
+    #expect(!plan.previewText.contains("sk-secret-123"))
+    #expect(plan.environment["OPENAI_API_KEY"] == "sk-secret-123")
+  }
+
+  @Test func environmentPolicyReportsRowIssuesForEditorDiagnostics() {
+    #expect(
+      AgentProfileEnvironmentPolicy.issue(
+        for: AgentProfileEnvironmentOverride(name: "OPENAI_BASE_URL", value: "x")
+      ) == nil
+    )
+    #expect(
+      AgentProfileEnvironmentPolicy.issue(
+        for: AgentProfileEnvironmentOverride(name: "", value: "typing…")
+      ) == nil
+    )
+    #expect(
+      AgentProfileEnvironmentPolicy.issue(
+        for: AgentProfileEnvironmentOverride(name: "BAD NAME", value: "x")
+      ) == .invalidName
+    )
+    #expect(
+      AgentProfileEnvironmentPolicy.issue(
+        for: AgentProfileEnvironmentOverride(name: "PROWL_ROOT_PATH", value: "x")
+      ) == .reservedName
+    )
+    #expect(
+      AgentProfileEnvironmentPolicy.issue(
+        for: AgentProfileEnvironmentOverride(name: "CLAUDE_CONFIG_DIR", value: "x")
+      ) == .reservedName
+    )
+    #expect(
+      AgentProfileEnvironmentPolicy.issue(
+        for: AgentProfileEnvironmentOverride(name: "OK", value: "bad\0value")
+      ) == .invalidValue
+    )
   }
 
   @Test func containmentRejectsBaseItselfAndOutsidePaths() {

--- a/supacodeTests/SymlinkPreservingFileWriterTests.swift
+++ b/supacodeTests/SymlinkPreservingFileWriterTests.swift
@@ -29,6 +29,17 @@ struct SymlinkPreservingFileWriterTests {
     #expect(!isSymlink(url))
   }
 
+  @Test func writesOwnerOnlyPermissions() throws {
+    let dir = try makeTempDir()
+    defer { try? fileManager.removeItem(at: dir) }
+    let url = dir.appending(path: "settings.json", directoryHint: .notDirectory)
+
+    try SymlinkPreservingFileWriter.write(Data("{}".utf8), to: url)
+
+    let attributes = try fileManager.attributesOfItem(atPath: url.path(percentEncoded: false))
+    #expect(attributes[.posixPermissions] as? Int == 0o600)
+  }
+
   @Test func createsMissingParentDirectories() throws {
     let dir = try makeTempDir()
     defer { try? fileManager.removeItem(at: dir) }


### PR DESCRIPTION
## Summary
- Agent profiles gain an **Environment Variables** table (Advanced, below Extra Arguments): ordered key-value rows applied to the launched surface on top of the shell environment. This enables profiles like "Codex but using DeepSeek" via `OPENAI_BASE_URL` + `OPENAI_API_KEY`.
- `AgentProfileEnvironmentPolicy` is shared by the planner and the editor: POSIX name validation, reserved names ignored (`PROWL_*` and adapter account-home variables `CLAUDE_CONFIG_DIR`/`CODEX_HOME`), last duplicate wins, NUL values refused. Invalid rows are flagged inline in the editor and never launch.
- The dedicated-home binding is written after user rows, so **Use Dedicated Home always beats a same-named row** — an env row can never bypass home provisioning, deletion protection, or rooted session detection.
- Launch Preview now renders `NAME='quoted value'` and masks secret-looking values (`KEY`/`TOKEN`/`SECRET`/`PASSWORD`).
- Settings files are written owner-only (`0600`) since overrides may carry API keys (previously `0644`).
- `runtimeChanged` clears overrides, consistent with Extra Arguments (runtime-scoped semantics).

## Design
- docs-ai record: `docs-ai/053-agent-profiles/004-environment-overrides.md` (amendment to 053), including the consciously relaxed plaintext-key boundary from `000-plan.md:56`.
- The design doc was reviewed by a parallel codex session; its four findings (plaintext-key P0, name validation, reserved-variable hole, preview quoting precision) are incorporated — Keychain references remain a follow-up.

## Known limitations (pre-existing, documented)
- Resume/handoff and layout-restored panes do not re-apply the env patch — same deferral as `dedicatedHome` (053/001-action deviation 2).

## Testing
- New unit tests: decode defaults + round-trip, planner merge (trim/last-wins/empty value), invalid+reserved row filtering, dedicated-home precedence, preview quoting/masking, policy diagnostics, editor add/remove rows, runtime-change clearing, writer 0600 permissions.
- 68 tests green across the five affected classes; `make check` and `make build-app` clean.

https://claude.ai/code/session_01EiT5G1tAXpq2m3BpBCEmfD
