### PR TITLE
Anchor debounce deadlines at schedule time

### DIFF
--- a/supacode/Support/Debouncer.swift
+++ b/supacode/Support/Debouncer.swift
@@ -26,9 +26,10 @@ final class Debouncer {
   /// Schedules `action` to run after the interval, replacing any pending action.
   func schedule(_ action: @escaping @MainActor () async -> Void) {
     task?.cancel()
-    task = Task { [interval, clock] in
+    let sleep = clock.anchoredSleep(for: interval)
+    task = Task {
       do {
-        try await clock.sleep(for: interval)
+        try await sleep()
       } catch {
         return
       }
@@ -41,6 +42,18 @@ final class Debouncer {
   func cancel() {
     task?.cancel()
     task = nil
+  }
+}
+
+/// Captures the debounce deadline synchronously at `schedule` time instead of
+/// when the spawned task first runs. Under scheduler load the task can start
+/// measurably late, which would silently stretch the window — and, with a
+/// `TestClock`, let the test advance past a deadline that was never armed,
+/// hanging the sleep forever (the CI-only `DebouncerTests` flake).
+extension Clock where Duration == Swift.Duration {
+  fileprivate func anchoredSleep(for interval: Duration) -> @Sendable () async throws -> Void {
+    let deadline = now.advanced(by: interval)
+    return { try await self.sleep(until: deadline, tolerance: nil) }
   }
 }
 
@@ -61,10 +74,10 @@ final class KeyedDebouncer<Key: Hashable & Sendable> {
   /// interval), replacing any action already pending for the same key.
   func schedule(_ key: Key, after interval: Duration? = nil, _ action: @escaping @MainActor () async -> Void) {
     tasks[key]?.cancel()
-    let interval = interval ?? self.interval
-    tasks[key] = Task { [clock] in
+    let sleep = clock.anchoredSleep(for: interval ?? self.interval)
+    tasks[key] = Task {
       do {
-        try await clock.sleep(for: interval)
+        try await sleep()
       } catch {
         return
       }

--- a/supacodeTests/DebouncerTests.swift
+++ b/supacodeTests/DebouncerTests.swift
@@ -141,7 +141,12 @@ struct KeyedDebouncerTests {
 
 @MainActor
 private func advance(_ clock: TestClock<Duration>, by duration: Duration) async {
-  await Task.yield()
   await clock.advance(by: duration)
-  await Task.yield()
+  // Deadlines are anchored at `schedule` time, so a debounce task that starts
+  // after the advance still resumes immediately — but it needs a few executor
+  // hops to run its continuation on a loaded machine. A short yield burst
+  // keeps that deterministic without real-time sleeping.
+  for _ in 0..<10 {
+    await Task.yield()
+  }
 }


### PR DESCRIPTION
## Summary
Fixes the CI-only `DebouncerTests` flake (`actionFiresAfterInterval` / `isIdleTracksThePendingWindow` failing after ~20s on loaded runners, e.g. run 30625671664 — triggered by a docs-only commit on #632).

**Root cause**: `Debouncer`/`KeyedDebouncer` slept via `clock.sleep(for:)` *inside* the spawned task, so the deadline was measured from whenever the task happened to start. Under `TestClock` this is a race: if the test's `clock.advance` ran before the task armed its sleep, the deadline was computed against the already-advanced now and could never be reached — the action never fired. In production the same late start silently stretches the debounce window.

**Fix**: capture the deadline synchronously in `schedule()` (via a `Clock` extension that anchors `now + interval` and returns a `sleep(until:)` thunk) — a late-starting sleep against a past deadline now resumes immediately, making the tests deterministic regardless of task scheduling. The test `advance` helper swaps its single pre/post `Task.yield()` for a short post-advance yield burst.

## Testing
- `DebouncerTests` + `KeyedDebouncerTests`: 9/9 green locally.
- `make check` and `make build-app` clean.

https://claude.ai/code/session_01EiT5G1tAXpq2m3BpBCEmfD
