### PR TITLE
Agent Profile V1 audit and boundary hardening

### DIFF
--- a/docs-ai/053-agent-profiles/000-plan.md
+++ b/docs-ai/053-agent-profiles/000-plan.md
@@ -331,6 +331,13 @@ agent 列表不变。
 
 ## Amendments
 
+- Updated 2026-07-31: **环境补丁语义从 surface-scoped 改为 launch-scoped** — onevcat
+  定位出"Agents 启动 → agent 退出 → 手动 codex 继承 profile env"的串号链,环境补丁
+  改为随 `env` 前缀只作用于 launched 进程(home 内联、override 值经 `PROWL_ENV_*`
+  carrier 引用,不进 history),launch identity 随 launched 进程退出而清除;本文
+  「账号绑定与 runtime home」节的 surface 附加语义由此作废 — see
+  [006-launch-scoped-environment.md](006-launch-scoped-environment.md).
+
 - Updated 2026-07-31: V1 综合审计(双评审交叉核对)与首轮边界补强 — see
   [005-v1-audit.md](005-v1-audit.md)。修复:`HOME` 入 env 保留名单、launch 结果
   事件化(记忆后置 + 失败 toast)、profile 名按 runtime 门控、可用性判定共享且

--- a/docs-ai/053-agent-profiles/000-plan.md
+++ b/docs-ai/053-agent-profiles/000-plan.md
@@ -55,7 +55,8 @@ Profile 的本体是 **preset**(对已知 runtime 的一组命名预置配置);�
 - 不改动现有 Hand Off UI、`prowl handoff` 契约或继承配置行为。
 - 不把 API key、OAuth token、`auth.json` 内容放进 Prowl JSON、日志、分析或 SwiftUI 状态;
   V1 只使用 CLI 自管认证。裸 API key 输入(需 Keychain 引用 + agent-only 启动边界)整体
-  推迟。
+  推迟。(2026-07-31 显式放宽:env overrides 的值可含 API key、明文存储,配套 0600 与
+  预览脱敏,见 [004](004-environment-overrides.md)。)
 - 不接受任意可执行文件路径或 shell 片段。自定义附加参数(Advanced)是**字面 argv
   token**:按 shell-words 规则切分后逐个追加,永不经过 shell 解释(无变量展开、命令
   替换或重定向)。
@@ -329,6 +330,11 @@ agent 列表不变。
   方式(名称/UUID)与 handoff 迁移波次的结构化请求一起定,避免过早固化 CLI 契约。
 
 ## Amendments
+
+- Updated 2026-07-31: V1 综合审计(双评审交叉核对)与首轮边界补强 — see
+  [005-v1-audit.md](005-v1-audit.md)。修复:`HOME` 入 env 保留名单、launch 结果
+  事件化(记忆后置 + 失败 toast)、profile 名按 runtime 门控、可用性判定共享且
+  不阻断、settings 权限加载迁移与 0600 temp。
 
 - Updated 2026-07-31: 新增用户可配置的 per-profile 环境变量覆盖(base url / api key
   临时改写,如 "Codex but using DeepSeek")— see

--- a/docs-ai/053-agent-profiles/001-action.md
+++ b/docs-ai/053-agent-profiles/001-action.md
@@ -55,6 +55,7 @@ command-palette / active-agents / handoff 与 `docs/README.md` 索引。
 
 1. **model 建议列表未实现**:model 为纯自由文本,只有 effort 有 adapter 建议列表。
    原因:没有可靠的已验证 model 目录,硬编码会立即过时;后续可与 effort 同构补上。
+   (2026-07-31 追记:已按同构方式补上,adapter 现声明 `modelSuggestions`;本偏差关闭。)
 2. **resume 携带环境补丁推迟到 handoff 波次**:检测层的 config root 已实现,但
    `AgentResumeRequest` 未增加环境字段——填充它需要 handoff 的结构化请求改造
    (正是计划明确推迟的双路径工程)。当前从绑定 pane 发起 handoff 时,briefing

--- a/docs-ai/053-agent-profiles/005-v1-audit.md
+++ b/docs-ai/053-agent-profiles/005-v1-audit.md
@@ -5,7 +5,7 @@
 | **日期** | 2026-07-31 |
 | **基线** | `main` == `origin/main`,`b698a23f`(含 PR #632 env overrides) |
 | **来源** | 两份独立评审(Claude Code 全链路调研 × 并行 agent 审计)的交叉核对与仲裁 |
-| **修复** | 本轮边界补强见文末「本次修复」(PR 见分支 `agent-profile-boundary-hardening`) |
+| **修复** | 本轮边界补强见文末「本次修复」([PR #634](https://github.com/onevcat/Prowl/pull/634)) |
 
 ## 综合结论
 

--- a/docs-ai/053-agent-profiles/005-v1-audit.md
+++ b/docs-ai/053-agent-profiles/005-v1-audit.md
@@ -1,0 +1,107 @@
+# 053.005 — Agent Profile V1 综合审计
+
+| | |
+| --- | --- |
+| **日期** | 2026-07-31 |
+| **基线** | `main` == `origin/main`,`b698a23f`(含 PR #632 env overrides) |
+| **来源** | 两份独立评审(Claude Code 全链路调研 × 并行 agent 审计)的交叉核对与仲裁 |
+| **修复** | 本轮边界补强见文末「本次修复」(PR 见分支 `agent-profile-boundary-hardening`) |
+
+## 综合结论
+
+V1 主体设计成立:preset 与账号绑定正交、纯函数 launch planner(预览与启动同渲染)、
+UUID 派生 home 的双重包含闸、单一 launch action、三层推荐、rooted session 检测,
+均按 000-plan 落地且文档与实现高度一致。不存在需要推倒重来的结构问题。
+
+| 方面 | 判断 |
+| --- | --- |
+| 功能与配置 | V1 基本齐全;Canvas 无 capsule 入口、播种一次性、palette 无 Manage 项为已知小缺口 |
+| 安全性 | 本机使用达标;env 作用域文案与保留名单需补强(本轮已修) |
+| 架构 | 无致命缺陷;「profile 身份只在创建瞬间存在」是系统性隐患(split/handoff/restore 三路丢失) |
+| 代码质量 | domain/reducer 测试密集且对抗性强(~57 专属测试);终端层(`launchAgentProfile` 以下)零测试 |
+| 产品完整性 | 启动闭环完整;handoff/resume、布局恢复、CLI、profile 生命周期管理仍有明显缺口 |
+
+## 双方一致的确认发现
+
+按严重度排列,均经代码定位核实:
+
+1. **启动失败静默 + 推荐记忆提前写入**。plan 失败与 home provision 失败只落日志
+   (`AppFeature+AgentProfiles.swift`、`WorktreeTerminalState.launchAgentProfile`),
+   用户点击后无任何反馈;且 `lastLaunchedAgentProfileID` 在 `terminalClient.send`
+   之前写入——实际未启动也会改变 Recommended。【本轮已修:launch 结果事件化】
+2. **可用性判定的误判与入口分叉**。「已安装」= `~/.claude`/`~/.codex` 存在:
+   CLI 已装未跑、或用户只打算经 dedicated home 首登时误判为不可用且 popover
+   硬禁用;palette 完全不检查,同一 profile 两个入口行为相反。【本轮已修:
+   启发式降级为警示不阻断,双入口共享同一判定】
+3. **旧 profile 名张冠李戴**。`launchProfileName`(`+AgentDetection.swift:305`)
+   未按 runtime 门控——launched agent 退出后在同 pane 手动启动其他家 agent,
+   Active Agents 仍显示旧 profile 名;`configRoot` 已门控(:130),显示名漏了。
+   【本轮已修】
+4. **终端层零测试**。env merge 优先级、split→tab 回退、provision 失败中止、
+   身份记录/清理均无测试锁定;测试金字塔在 `TerminalClient.Command` 边界断层。
+   【本轮部分补齐:provision 失败中止路径】
+5. **保留名单可绕行**。`HOME` 未保留:未绑定 profile 设 `HOME=…` 即间接搬迁
+   `.claude`/`.codex`,绕过 provision、删除保护与 rooted 检测——正是
+   「custom home 不从 env 表格后门进入」要防的事。【本轮已修:`HOME` 入保留名单】
+6. **settings 权限迁移缺口**。0600 只在写入时施加,存量 0644 文件要等下次保存;
+   atomic 写的 temp 文件在 rename 前为默认权限。【本轮已修:加载时迁移 +
+   0600 temp 后 rename】
+7. **文档/注释漂移**。`AgentProfileLaunchPlan.environment` 注释仍称
+   "Non-empty only for account-bound profiles"(env overrides 后已失真);
+   编辑器与 docs 称 env "applied to the launched process",实际作用于整个
+   surface;001-action 偏差 1(model suggestions 未实现)已被后续实现追平但
+   未回写。【本轮已修】
+8. **Profile 身份不随生命周期传播**(架构性,双方均定位):
+   - 手动 split 绑定 pane → 新 surface 无 env 无身份,pane 内手敲 agent 落到默认账号;
+   - handoff 接收端走无 `additionalEnvironment` 的 `createTab` overload;
+   - 布局恢复不重放 env、不恢复 `launchProfilesBySurface`,重启后绑定 pane 检测回落默认 home;
+   - resume(`AgentResumeRequest`/`ShellClient.runLogin`)无 env 缝(001-action 已知推迟)。
+9. **Profile home 生命周期不完整**:绑定 agent 仍在运行时可 "Remove and Trash
+   Files",无活跃 surface 检查;删除保留文件后 UUID 永久悬空,无 orphan home
+   管理入口。
+10. 次级:播种一次性全局 flag(装新 CLI 不补种)、Repo Settings picker 对
+    disabled/悬空 default 显示空白而非 None、推荐排序依赖未保证的 `sorted(by:)`
+    稳定性、`★` 与 "Recommended · " 两种标记不统一、CLI 检查在 view body 同步
+    stat 文件系统、profile 启动创建 worktree 首个 tab 不消费 setup script。
+
+## 分歧仲裁
+
+两份报告仅在以下判断上不一致,仲裁如下:
+
+- **「env 存 API key 时不能评为本机无忧」**:事实部分成立(surface 级作用域、
+  shell rc 可见、agent 退出后残留、后续进程继承),但**严重度维持「本机达标」**:
+  同用户进程本就可读 0600 的 JSON 文件,surface env 不扩大信任边界;真正的缺陷
+  是文案承诺(process-only)与实际(surface-wide)不符。
+- **「改为 `env KEY=value codex …` 前缀注入」的修法被否决**:typed input 会进入
+  shell history 与终端 scrollback,secret 暴露面比 spawn env 更大,属于倒退。
+  正确方向是文案如实 + 保留名单补强(本轮),以及远期的 Keychain 引用。
+- **「硬禁用不可用 profile」**:000-plan 的原意是"灰显示因、不静默改推",但
+  启发式存在已证实的 false negative(dedicated-home-only 用户被锁死)。仲裁为
+  **启发式不得阻断**:灰显 + 警示保留,行保持可点,启动失败在新 surface 内可见。
+
+## 本次修复(边界补强与实现正确性)
+
+范围刻意排除 handoff 贯通与新 runtime 接入(各有独立波次):
+
+1. `AgentProfileEnvironmentPolicy` 保留 `HOME`;编辑器/文档文案改为如实的
+   surface 级作用域表述;`AgentProfileLaunchPlan.environment` 注释修正。
+2. Launch 结果事件化:新增 `agentProfileLaunched` / `agentProfileLaunchFailed`
+   终端事件;`lastLaunchedAgentProfileID` 改为成功事件后写入;失败(plan 或
+   provision)以 toast 呈现。
+3. `launchProfileName` 与 capsule 显示名按 runtime 门控,与 `configRoot` 同规。
+4. 可用性判定收敛到单一 helper,popover 与 palette 共享;灰显警示不阻断。
+5. settings 文件权限:加载时迁移 0600;写入改为 0600 temp + rename,消除
+   默认权限窗口。
+6. 测试:上述各项 + provision 失败中止(不建 tab、不记身份)。
+
+## 遗留 follow-up(按优先级)
+
+1. **Handoff × Profile 贯通**(既定方向):resume/`runLogin` env 缝、HUD 目标
+   列表 profile 化,双路径同改。
+2. **身份生命周期传播**:split 继承、布局恢复以 profileID 重新 plan 派生 env
+   (env 值含 secret,不得入 snapshot)。
+3. **可用性真探测**:可注入、缓存的 executable probe(login-shell PATH 解析)
+   替代 home 目录启发式;launcher query 统一为单一 resolved-option 类型。
+4. **Profile 生命周期**:Trash 前活跃 surface 检查、orphan home 管理、
+   per-runtime 补种、Duplicate、repo picker 悬空显示、`prowl` CLI profile 感知。
+5. **Secret 治理**:Keychain 引用型 env value、编辑器遮盖输入。

--- a/docs-ai/053-agent-profiles/005-v1-audit.md
+++ b/docs-ai/053-agent-profiles/005-v1-audit.md
@@ -93,6 +93,13 @@ UUID 派生 home 的双重包含闸、单一 launch action、三层推荐、root
 5. settings 文件权限:加载时迁移 0600;写入改为 0600 temp + rename,消除
    默认权限窗口。
 6. 测试:上述各项 + provision 失败中止(不建 tab、不记身份)。
+7. (同日追加)**login-shell executable probe**(follow-up 3 的探测部分提前落地):
+   `AgentRuntimeAvailabilityProbe` 经 `ShellClient.runLogin` 在用户 login shell 内
+   `command -v`,与启动共用同一条 PATH 解析,结果按 session 缓存于
+   `@Shared(.inMemory)`;阳性终局、阴性/未知在每次打开 Agents popover 时后台重测。
+   判定两级:probe 已应答即 ground truth("not on your shell's PATH"),未应答回退
+   home 启发式("may not be installed")。播种保持 home 启发式(信号语义是"用户在用
+   这家",而非"二进制存在")。launcher query 的 resolved-option 统一仍留在 follow-up。
 
 ## 遗留 follow-up(按优先级)
 

--- a/docs-ai/053-agent-profiles/006-launch-scoped-environment.md
+++ b/docs-ai/053-agent-profiles/006-launch-scoped-environment.md
@@ -1,0 +1,80 @@
+# 053.006 — 环境补丁改为 launch-scoped
+
+| | |
+| --- | --- |
+| **日期** | 2026-07-31 |
+| **状态** | Implemented(与 005 同分支/PR) |
+| **关联** | [000-plan](000-plan.md) · [004-environment-overrides](004-environment-overrides.md) · [005-v1-audit](005-v1-audit.md) |
+
+## 背景:onevcat 发现的串 env
+
+原设计把环境补丁(dedicated home 变量 + 用户 env overrides)在 **surface spawn 时注入
+shell 环境**(000-plan「环境 patch 是叠加而非替换」)。onevcat 在 005 审计讨论中指出
+这与产品语义冲突,并定位出具体串号链:
+
+```
+Agents button → shell 带 CODEX_HOME/OPENAI_API_KEY 出生 → agent 退出(Ctrl+C)
+→ env 残留在 shell → 用户手动敲 codex → 继承 profile 的 home/key
+→ 手动启动跑在了 profile 账号 / override 端点上
+```
+
+产品承诺被澄清为:**profile 属于启动动作,不属于 pane**。经 Prowl 的 Agent Profile
+入口(Agents 菜单、Command Palette)拉起的 agent 带 profile;用户手动启动的
+agent 必须走自己的默认环境与账号。surface-scoped 注入违反该承诺,且 pane 里后续
+任何进程(npm script、curl…)都会静默继承 API key。
+
+## 决策:全部 launch-scoped
+
+三个候选(全 launch-scoped / home 留 surface 的混合 / 维持现状 + 可见化)中,
+onevcat 选定**全部 launch-scoped**。已知且接受的行为代价:绑定 pane 内 agent 退出后,
+手动 `codex` / `codex resume` 走用户默认账号,profile home 里的 session 手动恢复不到
+——回到 profile 上下文的唯一方式是再经 Agents 入口启动。这正是所选语义的直接推论。
+
+## 机制
+
+打入 pane 的命令从 `'codex' …` 变为:
+
+```
+env CODEX_HOME='/Users/x/.prowl/agent-profiles/<uuid>' OPENAI_API_KEY="$PROWL_ENV_OPENAI_API_KEY" 'codex' …
+```
+
+- **home 路径内联**:非 secret,UUID 派生无空格,经既有 `AgentInvocation.shellQuote`
+  单引号渲染;preview 里可见即自文档。
+- **override 值经 `PROWL_ENV_<NAME>` carrier 间接引用**:真实值仍走 Ghostty spawn env,
+  但顶着 Prowl 保留前缀——没有工具会读它;命令文本、shell history、scrollback 里只有
+  引用,永不出现值。name 经 POSIX 校验,引用 token 不含任何用户 shell 文本,注入安全
+  不变。`PROWL_` 保留名单保证用户行无法与 carrier 碰撞。
+- `env(1)` 是外部二进制,zsh/bash/fish 语法一致(fish 不可靠支持 `VAR=x cmd` 裸前缀,
+  故不用裸前缀);`"$VAR"` 展开三家皆同。
+- **launch identity 与 launched 进程同生命周期**:`removeAgentEntryIfNeeded`(detection
+  层感知 agent 退出的缝)同时清除 `launchProfilesBySurface`——之后手动启动的同 runtime
+  agent 不再顶着 profile 名,rooted session 检测的 config root 一并复原。
+- Launch Preview 即 `terminalInput` 本身(所打即所见);004 的名字启发式脱敏机制删除
+  ——secret 已不在预览里,无需脱敏。
+
+## 连带简化
+
+- 005 曾把「split 继承 / layout restore 重放 env」列为下一步推荐;launch-scoped 语义下
+  这两条**不再需要**(surface 上只剩 carrier 变量,不继承恰是正确行为),从 follow-up
+  中撤销。
+- restore/手动启动"不重放 override"从 known limitation 升格为规则本身。
+- resume(handoff 波次)携带环境的缺口不变:结构化 resume 需要把同一组
+  token/carrier 语义带过去,仍归 handoff 波次。
+
+## 已知边界
+
+- agent 退出与手动重启发生在同一 detection tick 内时,identity 存在极短的残留窗口
+  (presence hold 粒度);可接受,detection 按进程存亡收敛。
+- 用户可 `echo $PROWL_ENV_X` 查看 carrier 值:同用户主动检视,与 0600 JSON 同级,
+  非泄露面。
+- 从 shell history 重放 launch 命令会得到空的 carrier 展开(auth 显式失败,可见),
+  这与"手动启动不带 profile env"的语义一致。
+
+## 验证
+
+- Planner 测试:home token 内联渲染、override 排序 token + carrier 映射、reserved 行
+  (含 `CODEX_HOME` 伪造)零 token、preview == terminalInput 且不含任何 override 值、
+  空值 override 语义保留。
+- 终端层测试:agent 退出清除 launch identity。
+- `make check` / 全量 `make test` / `make build-app` 全绿;文案与 docs
+  (`docs/components/agent-profiles.md`)同步改写为 launch-scoped 语义。

--- a/docs/components/agent-profiles.md
+++ b/docs/components/agent-profiles.md
@@ -39,8 +39,10 @@ A launch creates a **new** tab (or split, per placement) in the current
 worktree, running the agent interactively with no initial prompt. Prowl never
 types into an existing shell. The new pane records its profile identity at
 creation: the Active Agents rows and the capsule show the profile's display
-name (frozen at launch — later renames don't relabel live panes; a *different*
-agent started manually in the same pane shows its own name, not the profile's).
+name (frozen at launch — later renames don't relabel live panes). The identity
+lives exactly as long as the launched agent: once it exits, any agent started
+manually in that pane shows its own name and runs with your default
+environment and account.
 A launch that fails before its surface exists (e.g. home provisioning) shows a
 warning toast, and only a successful launch updates the per-repo "last
 launched" memory behind the Recommended resolution.
@@ -72,11 +74,15 @@ existing, enabled profile.
 ## Environment variables
 
 The **Environment Variables** table (Advanced, below Extra Arguments) adds
-per-profile environment overrides to the launched surface — they are applied
-at spawn, so the new pane's shell and everything started in it (the agent, its
-subprocesses, later manual commands in that pane) see them, on top of the
-shell's normal environment — e.g. `OPENAI_BASE_URL` + `OPENAI_API_KEY` to get
-a "Codex but using DeepSeek" profile. Rules:
+per-profile environment overrides — e.g. `OPENAI_BASE_URL` + `OPENAI_API_KEY`
+to get a "Codex but using DeepSeek" profile. The whole patch is
+**launch-scoped**: it applies to the launched agent process (and its
+subprocesses) only. The pane's shell keeps your normal environment, so after
+the agent exits, a manual `codex` / `claude` — or any other command — in that
+pane runs with your own account and environment. Mechanically, the launch
+command carries `env NAME="$PROWL_ENV_NAME" …` references while the values
+ride in hidden `PROWL_ENV_*` surface variables, so no override value ever
+appears in the typed command, shell history, or scrollback. Rules:
 
 - Names must be valid POSIX names (`[A-Za-z_][A-Za-z0-9_]*`). An empty value
   legitimately sets the variable to the empty string.
@@ -87,21 +93,26 @@ a "Codex but using DeepSeek" profile. Rules:
   through **Use Dedicated Home**, which always wins over a same-named row.
 - Later duplicate names win (shell-export semantics).
 - Values are stored in plaintext in `~/.prowl/global.onevcat.json` (kept
-  owner-only, `0600`). The Launch Preview masks secret-looking values
-  (names containing `KEY`/`TOKEN`/`SECRET`/`PASSWORD`).
-- Overrides apply to profile launches only; resumed or restored panes do not
-  re-apply them (same limitation as dedicated homes).
+  owner-only, `0600`); the Launch Preview shows only the `$PROWL_ENV_*`
+  references, never the values.
+- Launch-scoped by design: manual launches, resumed sessions, and restored
+  panes intentionally run with your default environment. Re-launch through
+  the Agents menu to get the profile's environment again.
 
 ## Dedicated home (separate account)
 
 Toggling **Use Dedicated Home** (Advanced) gives the profile its own runtime
-home under `~/.prowl/agent-profiles/<uuid>/`, attached to the new surface via
-`CLAUDE_CONFIG_DIR` / `CODEX_HOME`. That relocates the runtime's *entire*
-home: separate login and usage, but also separate skills, global instructions
+home under `~/.prowl/agent-profiles/<uuid>/`, attached to the launched agent
+via a `CLAUDE_CONFIG_DIR` / `CODEX_HOME` assignment on the launch command
+(launch-scoped, like overrides). That relocates the runtime's *entire* home:
+separate login and usage, but also separate skills, global instructions
 (`CLAUDE.md` / `AGENTS.md`), and session history. The first launch is the
 sign-in moment — the agent's own TUI walks through login and the credentials
 land inside the profile home. Prowl never reads or copies them; use **Reveal
-Profile Files** to manage skills and instruction files there yourself.
+Profile Files** to manage skills and instruction files there yourself. After
+the launched agent exits, a manually started agent in the same pane uses your
+default home and account — re-enter the profile's account by launching from
+the Agents menu again.
 
 Removing any profile asks first. Pure presets have no file operations. A bound
 profile offers **Remove Profile** to keep its folder on disk and **Remove and
@@ -134,10 +145,12 @@ effort, execution mode, placement).
 
 ## Gotchas for agents
 
-- Session detection follows the relocated home for Prowl-launched bound panes
-  (resume and handoff artifacts resolve against the profile's config root).
-  An agent you start manually with your own `CLAUDE_CONFIG_DIR`/`CODEX_HOME`
-  is still detected, but without session identity.
+- Session detection follows the relocated home while the launched bound agent
+  is running (resume and handoff artifacts resolve against the profile's
+  config root); once it exits, the pane's config root reverts with the
+  identity. An agent you start manually with your own
+  `CLAUDE_CONFIG_DIR`/`CODEX_HOME` is still detected, but without session
+  identity.
 - Availability is judged in two tiers. Ground truth is a background
   login-shell probe (`command -v`, the same PATH resolution a launch uses):
   once it answers, "not found" warns "… is not on your shell's PATH" and

--- a/docs/components/agent-profiles.md
+++ b/docs/components/agent-profiles.md
@@ -28,10 +28,10 @@ respawn.
 
 - **Toolbar Agents capsule** — always opens a popover. With a detected agent it
   leads with Hand Off; launch rows follow, the current worktree's
-  **Recommended** profile first. Rows for runtimes that look uninstalled are
-  dimmed with a warning ("… may not be installed") but stay clickable — the
-  heuristic has false negatives, so it never blocks a launch. "Manage Agent
-  Profiles…" opens Settings → Agents.
+  **Recommended** profile first. Rows for runtimes that look unavailable are
+  dimmed with a warning but stay clickable — availability signals can be
+  wrong, so they never block a launch. "Manage Agent Profiles…" opens
+  Settings → Agents.
 - **Command Palette** (`⌘P`) — "Launch Agent: <name>" rows dispatch the exact
   same action, and carry the same availability warning in their subtitle.
 
@@ -138,10 +138,15 @@ effort, execution mode, placement).
   (resume and handoff artifacts resolve against the profile's config root).
   An agent you start manually with your own `CLAUDE_CONFIG_DIR`/`CODEX_HOME`
   is still detected, but without session identity.
-- Availability warnings use a heuristic: the runtime's default home
-  (`~/.claude` / `~/.codex`) exists iff the CLI has ever run. It can be wrong
-  in both directions (installed but never run; binary removed but home kept),
-  which is why it dims rows instead of disabling them.
+- Availability is judged in two tiers. Ground truth is a background
+  login-shell probe (`command -v`, the same PATH resolution a launch uses):
+  once it answers, "not found" warns "… is not on your shell's PATH" and
+  "found" clears any warning. Until it answers, the fallback heuristic — the
+  runtime's default home (`~/.claude` / `~/.codex`) exists iff the CLI has
+  ever run — warns "… may not be installed". A positive probe is cached for
+  the session; negatives re-probe each time the Agents popover opens, so
+  installing a CLI mid-session clears its warning without a relaunch. Both
+  signals only dim rows, never disable them.
 - Prowl provides no directory sharing between a bound home and the default
   one. Symlinking read-mostly directories (e.g. `skills/`) yourself works, but
   never link files the CLI rewrites (`settings.json`, `config.toml`,

--- a/docs/components/agent-profiles.md
+++ b/docs/components/agent-profiles.md
@@ -28,16 +28,22 @@ respawn.
 
 - **Toolbar Agents capsule** — always opens a popover. With a detected agent it
   leads with Hand Off; launch rows follow, the current worktree's
-  **Recommended** profile first. Rows for runtimes that are not installed are
-  grayed with the reason. "Manage Agent Profiles…" opens Settings → Agents.
+  **Recommended** profile first. Rows for runtimes that look uninstalled are
+  dimmed with a warning ("… may not be installed") but stay clickable — the
+  heuristic has false negatives, so it never blocks a launch. "Manage Agent
+  Profiles…" opens Settings → Agents.
 - **Command Palette** (`⌘P`) — "Launch Agent: <name>" rows dispatch the exact
-  same action.
+  same action, and carry the same availability warning in their subtitle.
 
 A launch creates a **new** tab (or split, per placement) in the current
 worktree, running the agent interactively with no initial prompt. Prowl never
 types into an existing shell. The new pane records its profile identity at
 creation: the Active Agents rows and the capsule show the profile's display
-name (frozen at launch — later renames don't relabel live panes).
+name (frozen at launch — later renames don't relabel live panes; a *different*
+agent started manually in the same pane shows its own name, not the profile's).
+A launch that fails before its surface exists (e.g. home provisioning) shows a
+warning toast, and only a successful launch updates the per-repo "last
+launched" memory behind the Recommended resolution.
 
 ## Managing profiles
 
@@ -66,16 +72,19 @@ existing, enabled profile.
 ## Environment variables
 
 The **Environment Variables** table (Advanced, below Extra Arguments) adds
-per-profile environment overrides to the launched process, on top of the
+per-profile environment overrides to the launched surface — they are applied
+at spawn, so the new pane's shell and everything started in it (the agent, its
+subprocesses, later manual commands in that pane) see them, on top of the
 shell's normal environment — e.g. `OPENAI_BASE_URL` + `OPENAI_API_KEY` to get
 a "Codex but using DeepSeek" profile. Rules:
 
 - Names must be valid POSIX names (`[A-Za-z_][A-Za-z0-9_]*`). An empty value
   legitimately sets the variable to the empty string.
 - Reserved names are ignored at launch and flagged inline: anything starting
-  with `PROWL_`, plus the account-home variables (`CLAUDE_CONFIG_DIR`,
-  `CODEX_HOME`) — a custom home must go through **Use Dedicated Home**, which
-  always wins over a same-named row.
+  with `PROWL_`, `HOME` (relocating it would move every runtime's default home
+  past Prowl's provisioning and deletion safeguards), plus the account-home
+  variables (`CLAUDE_CONFIG_DIR`, `CODEX_HOME`) — a custom home must go
+  through **Use Dedicated Home**, which always wins over a same-named row.
 - Later duplicate names win (shell-export semantics).
 - Values are stored in plaintext in `~/.prowl/global.onevcat.json` (kept
   owner-only, `0600`). The Launch Preview masks secret-looking values
@@ -129,8 +138,10 @@ effort, execution mode, placement).
   (resume and handoff artifacts resolve against the profile's config root).
   An agent you start manually with your own `CLAUDE_CONFIG_DIR`/`CODEX_HOME`
   is still detected, but without session identity.
-- Availability graying uses a heuristic: the runtime's default home
-  (`~/.claude` / `~/.codex`) exists iff the CLI has ever run.
+- Availability warnings use a heuristic: the runtime's default home
+  (`~/.claude` / `~/.codex`) exists iff the CLI has ever run. It can be wrong
+  in both directions (installed but never run; binary removed but home kept),
+  which is why it dims rows instead of disabling them.
 - Prowl provides no directory sharing between a bound home and the default
   one. Symlinking read-mostly directories (e.g. `skills/`) yourself works, but
   never link files the CLI rewrites (`settings.json`, `config.toml`,

--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -55,6 +55,7 @@ final class SupacodeAppDelegate: NSObject, NSApplicationDelegate {
       "ApplePressAndHoldEnabled": false
     ])
     AgentProfileSeeder.seedIfNeeded()
+    Task { await AgentRuntimeAvailabilityProbe.refresh() }
     appStore?.send(.appLaunched)
   }
 

--- a/supacode/Clients/AgentProfile/AgentRuntimeAvailabilityProbe.swift
+++ b/supacode/Clients/AgentProfile/AgentRuntimeAvailabilityProbe.swift
@@ -1,0 +1,74 @@
+import Dependencies
+import Foundation
+import Sharing
+
+extension SharedReaderKey where Self == InMemoryKey<[AgentProfileRuntime: Bool]>.Default {
+  /// Session cache of the login-shell executable probe. A missing entry means
+  /// the probe has not answered for that runtime yet this session.
+  static var agentRuntimeProbedAvailability: Self {
+    Self[.inMemory("agentRuntimeProbedAvailability"), default: [:]]
+  }
+}
+
+extension AgentProfileAvailability {
+  /// The launcher surfaces' judgment: the session probe cache first, the
+  /// home-directory heuristic while a runtime is unanswered.
+  @MainActor
+  static func launchWarning(for profile: AgentProfile) -> String? {
+    @Shared(.agentRuntimeProbedAvailability) var probed
+    return launchWarning(for: profile, probedAvailable: probed[profile.runtime])
+  }
+}
+
+/// Resolves each runtime's executable through the user's login shell — the
+/// same resolution a profile launch uses, so a positive answer means the
+/// launch will find the binary (docs-ai 053/005). A GUI app's own PATH is the
+/// launchd default and useless for this; the login shell's rc-built PATH is
+/// the truth. Results cache for the session: a positive is final, while a
+/// negative or unanswered runtime re-probes on the next refresh (opening the
+/// Agents popover), so installing a CLI mid-session clears its warning
+/// without a relaunch.
+@MainActor
+enum AgentRuntimeAvailabilityProbe {
+  static func refresh() async {
+    @Shared(.agentRuntimeProbedAvailability) var probed
+    let pending = AgentProfileRuntime.allCases.filter { probed[$0] != true }
+    guard !pending.isEmpty else { return }
+    await withTaskGroup(of: (AgentProfileRuntime, Bool?).self) { group in
+      for runtime in pending {
+        group.addTask { (runtime, await probeAvailability(of: runtime)) }
+      }
+      for await (runtime, availability) in group {
+        guard let availability else { continue }
+        $probed.withLock { $0[runtime] = availability }
+      }
+    }
+  }
+
+  /// true/false when the login shell answered; nil when the probe itself
+  /// could not run (spawn failure) — an unanswered probe must not masquerade
+  /// as "not installed".
+  private static func probeAvailability(of runtime: AgentProfileRuntime) async -> Bool? {
+    guard
+      let executable = try? AgentRuntimeAdapterRegistry.makeStartInvocation(
+        AgentStartRequest(agent: runtime.agent, intent: .interactive)
+      ).executable
+    else { return nil }
+    @Dependency(ShellClient.self) var shell
+    do {
+      // `command -v` is a shell builtin, so it runs in an inner /bin/sh that
+      // inherits the PATH the outer login shell built from the user's rc.
+      _ = try await shell.runLogin(
+        URL(fileURLWithPath: "/bin/sh"),
+        ["-c", "command -v -- '\(executable)'"],
+        nil,
+        log: false
+      )
+      return true
+    } catch let error as ShellClientError {
+      return error.exitCode > 0 ? false : nil
+    } catch {
+      return nil
+    }
+  }
+}

--- a/supacode/Clients/Terminal/TerminalClient.swift
+++ b/supacode/Clients/Terminal/TerminalClient.swift
@@ -83,6 +83,11 @@ struct TerminalClient {
     case taskStatusChanged(worktreeID: Worktree.ID, status: WorktreeTaskStatus)
     case agentEntryChanged(ActiveAgentEntry)
     case agentEntryRemoved(ActiveAgentEntry.ID)
+    /// A profile launch created its surface. The reducer records the per-repo
+    /// launch memory on this event — not at dispatch — so a failed launch
+    /// never shifts the Recommended resolution (docs-ai 053/005).
+    case agentProfileLaunched(worktreeID: Worktree.ID, profileID: AgentProfile.ID)
+    case agentProfileLaunchFailed(worktreeID: Worktree.ID, profileName: String)
     case runScriptStatusChanged(worktreeID: Worktree.ID, isRunning: Bool)
     case commandPaletteToggleRequested(worktreeID: Worktree.ID)
     case setupScriptConsumed(worktreeID: Worktree.ID)

--- a/supacode/Domain/AgentProfile/AgentProfileAvailability.swift
+++ b/supacode/Domain/AgentProfile/AgentProfileAvailability.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// One shared availability judgment for every profile launcher surface
+/// (Agents popover, Command Palette), so entry points can never disagree
+/// (docs-ai 053/005). The installation heuristic is deliberately soft — the
+/// runtime's default home exists iff the CLI has ever run — so a non-nil
+/// warning must gray a row, never block the launch: a false negative
+/// (installed but never run, or a dedicated-home-only login) would otherwise
+/// lock out a perfectly launchable profile.
+nonisolated enum AgentProfileAvailability {
+  static func launchWarning(
+    for profile: AgentProfile,
+    isRuntimeInstalled: (AgentProfileRuntime) -> Bool = isRuntimeInstalled
+  ) -> String? {
+    guard !isRuntimeInstalled(profile.runtime) else { return nil }
+    let name = AgentRuntimeAdapterRegistry.displayName(for: profile.runtime.agent)
+    return "\(name) may not be installed"
+  }
+
+  /// The runtime's default home exists iff the CLI has ever run; PATH lookups
+  /// from a GUI app are unreliable (docs-ai 053). Also the seeding heuristic.
+  static func isRuntimeInstalled(_ runtime: AgentProfileRuntime) -> Bool {
+    let home = FileManager.default.homeDirectoryForCurrentUser
+      .appending(path: runtime.defaultHomeDirectoryName, directoryHint: .isDirectory)
+    return FileManager.default.fileExists(atPath: home.path(percentEncoded: false))
+  }
+}

--- a/supacode/Domain/AgentProfile/AgentProfileAvailability.swift
+++ b/supacode/Domain/AgentProfile/AgentProfileAvailability.swift
@@ -8,13 +8,25 @@ import Foundation
 /// (installed but never run, or a dedicated-home-only login) would otherwise
 /// lock out a perfectly launchable profile.
 nonisolated enum AgentProfileAvailability {
+  /// Two-tier judgment. The login-shell probe is ground truth once it has
+  /// answered — it resolves the executable exactly the way a launch will, in
+  /// both directions (installed-but-never-run stops warning; uninstalled with
+  /// a leftover home starts warning). Until it answers, the home-directory
+  /// heuristic fills in.
   static func launchWarning(
     for profile: AgentProfile,
+    probedAvailable: Bool?,
     isRuntimeInstalled: (AgentProfileRuntime) -> Bool = isRuntimeInstalled
   ) -> String? {
-    guard !isRuntimeInstalled(profile.runtime) else { return nil }
     let name = AgentRuntimeAdapterRegistry.displayName(for: profile.runtime.agent)
-    return "\(name) may not be installed"
+    switch probedAvailable {
+    case true?:
+      return nil
+    case false?:
+      return "\(name) is not on your shell's PATH"
+    case nil:
+      return isRuntimeInstalled(profile.runtime) ? nil : "\(name) may not be installed"
+    }
   }
 
   /// The runtime's default home exists iff the CLI has ever run; PATH lookups

--- a/supacode/Domain/AgentProfile/AgentProfileLaunchPlan.swift
+++ b/supacode/Domain/AgentProfile/AgentProfileLaunchPlan.swift
@@ -10,8 +10,10 @@ nonisolated struct AgentProfileLaunchPlan: Equatable, Sendable {
   let invocation: AgentInvocation
   let placement: AgentProfilePlacement
   let splitDirection: UserCustomSplitDirection
-  /// Environment patch for the new surface. Non-empty only for account-bound
-  /// profiles; additive over the shell's normal environment, never a scrub.
+  /// Environment patch for the new surface: the profile's user overrides
+  /// plus, for account-bound profiles, the dedicated-home variable. Applied at
+  /// surface spawn, so the shell and everything started in it see it; additive
+  /// over the shell's normal environment, never a scrub.
   let environment: [String: String]
   /// Dedicated home to provision before launch; nil for pure presets.
   let dedicatedHome: URL?
@@ -72,8 +74,12 @@ nonisolated enum AgentProfileEnvironmentPolicy {
     }
   }
 
+  /// `HOME` is reserved for the same reason as the account-home variables:
+  /// relocating it moves every runtime's *default* home (`$HOME/.claude`,
+  /// `$HOME/.codex`), bypassing home provisioning, deletion protection, and
+  /// rooted session detection without ever flipping the binding toggle.
   static func isReserved(_ name: String) -> Bool {
-    name.hasPrefix("PROWL_") || reservedNames.contains(name)
+    name.hasPrefix("PROWL_") || name == "HOME" || reservedNames.contains(name)
   }
 
   /// A NUL would be silently truncated at the C-string boundary; refuse the

--- a/supacode/Domain/AgentProfile/AgentProfileLaunchPlan.swift
+++ b/supacode/Domain/AgentProfile/AgentProfileLaunchPlan.swift
@@ -8,39 +8,31 @@ nonisolated struct AgentProfileLaunchPlan: Equatable, Sendable {
   let profileName: String
   let runtime: AgentProfileRuntime
   let invocation: AgentInvocation
+  /// `env(1)` assignment tokens typed ahead of the invocation. The whole
+  /// environment patch is launch-scoped (docs-ai 053/006): it exists for the
+  /// launched agent process only — the pane's shell keeps the user's normal
+  /// environment, so a manual `codex`/`claude` after the agent exits runs
+  /// with the user's own account. Home paths are inlined (not secret);
+  /// override values are referenced as `"$PROWL_ENV_<NAME>"` so no user
+  /// value ever appears in the typed command, shell history, or scrollback.
+  let commandEnvironmentTokens: [String]
   let placement: AgentProfilePlacement
   let splitDirection: UserCustomSplitDirection
-  /// Environment patch for the new surface: the profile's user overrides
-  /// plus, for account-bound profiles, the dedicated-home variable. Applied at
-  /// surface spawn, so the shell and everything started in it see it; additive
-  /// over the shell's normal environment, never a scrub.
-  let environment: [String: String]
+  /// Carrier variables for the reference tokens, injected at surface spawn:
+  /// `PROWL_ENV_<NAME>` → verbatim value. The namespace is Prowl-reserved, so
+  /// nothing but the launch command reads them, and the real variable names
+  /// never exist in the pane's shell.
+  let surfaceEnvironment: [String: String]
   /// Dedicated home to provision before launch; nil for pure presets.
   let dedicatedHome: URL?
 
-  var terminalInput: String { invocation.terminalInput }
-
-  /// Human-readable launch preview: env prefix plus the exact rendered
-  /// invocation. The prefix is an equivalent shell rendering — the real patch
-  /// goes through Ghostty's spawn env array, never a shell — so values are
-  /// quoted for faithfulness and secret-looking values are masked rather than
-  /// displayed (docs-ai 053/004).
-  var previewText: String {
-    let prefix = environment.sorted { $0.key < $1.key }.map { pair in
-      "\(pair.key)=\(Self.previewValue(name: pair.key, value: pair.value))"
-    }
-    return (prefix + [invocation.terminalInput]).joined(separator: " ")
+  /// The exact line typed into the new pane; doubles as the launch preview.
+  var terminalInput: String {
+    guard !commandEnvironmentTokens.isEmpty else { return invocation.terminalInput }
+    return (["env"] + commandEnvironmentTokens + [invocation.terminalInput]).joined(separator: " ")
   }
 
-  private static let secretNameFragments = ["KEY", "TOKEN", "SECRET", "PASSWORD"]
-
-  private static func previewValue(name: String, value: String) -> String {
-    let upper = name.uppercased()
-    if secretNameFragments.contains(where: { upper.contains($0) }) {
-      return "•••"
-    }
-    return "'" + value.replacing("'", with: "'\"'\"'") + "'"
-  }
+  var previewText: String { terminalInput }
 }
 
 /// Which env variable names a profile override may set, shared by the planner
@@ -97,6 +89,14 @@ nonisolated enum AgentProfileEnvironmentPolicy {
     if isReserved(name) { return .reservedName }
     if !isValidValue(override.value) { return .invalidValue }
     return nil
+  }
+
+  /// Carrier variable in the surface environment holding an override's value.
+  /// The `PROWL_` namespace is already reserved, so user rows can't collide
+  /// with a carrier, and the validated POSIX name keeps the reference token
+  /// (`NAME="$PROWL_ENV_NAME"`) free of any user-authored shell text.
+  static func carrierName(for name: String) -> String {
+    "PROWL_ENV_\(name)"
   }
 
   /// The applied subset: trimmed names, invalid/reserved rows dropped, later
@@ -178,10 +178,12 @@ nonisolated enum AgentProfileLaunchPlanner {
       AgentStartRequest(agent: profile.runtime.agent, intent: .interactive, configuration: configuration)
     )
 
-    // User overrides first; the dedicated-home variable is written after, so
-    // an account binding always beats a same-named user row — the account
-    // isolation reasoning must stay provable (docs-ai 053/004).
-    var environment = AgentProfileEnvironmentPolicy.effectiveOverrides(profile.environmentOverrides)
+    // The whole patch renders as launch-scoped `env` tokens (docs-ai
+    // 053/006). The home token leads: it is the launch's identity, and the
+    // reserved-name policy already guarantees no user row can carry the same
+    // name — the account isolation reasoning stays provable.
+    var tokens: [String] = []
+    var surfaceEnvironment: [String: String] = [:]
     var dedicatedHome: URL?
     if profile.bindsDedicatedHome {
       guard let variable = adapter.accountHomeEnvironmentVariable else {
@@ -191,8 +193,16 @@ nonisolated enum AgentProfileLaunchPlanner {
       guard isContained(home, in: homeBaseDirectory) else {
         throw AgentProfileLaunchPlanError.homeEscapesBase(home)
       }
-      environment[variable] = pathString(home)
+      // Inlined literal: the UUID-derived path is not a secret, and seeing it
+      // in the preview documents which home the launch binds.
+      tokens.append("\(variable)=\(AgentInvocation.shellQuote(pathString(home)))")
       dedicatedHome = home
+    }
+    let overrides = AgentProfileEnvironmentPolicy.effectiveOverrides(profile.environmentOverrides)
+    for name in overrides.keys.sorted() {
+      let carrier = AgentProfileEnvironmentPolicy.carrierName(for: name)
+      tokens.append("\(name)=\"$\(carrier)\"")
+      surfaceEnvironment[carrier] = overrides[name]
     }
 
     return AgentProfileLaunchPlan(
@@ -200,9 +210,10 @@ nonisolated enum AgentProfileLaunchPlanner {
       profileName: profile.name,
       runtime: profile.runtime,
       invocation: invocation,
+      commandEnvironmentTokens: tokens,
       placement: profile.placement,
       splitDirection: profile.splitDirection,
-      environment: environment,
+      surfaceEnvironment: surfaceEnvironment,
       dedicatedHome: dedicatedHome
     )
   }

--- a/supacode/Domain/AgentRuntime/AgentRuntimeAdapter.swift
+++ b/supacode/Domain/AgentRuntime/AgentRuntimeAdapter.swift
@@ -152,7 +152,9 @@ nonisolated struct AgentInvocation: Equatable, Sendable {
     ([executable] + arguments).map(Self.shellQuote).joined(separator: " ")
   }
 
-  private static func shellQuote(_ argument: String) -> String {
+  /// The single reviewed quoting rule for anything typed into a pane's shell;
+  /// the profile launch planner reuses it for inlined `env` assignments.
+  static func shellQuote(_ argument: String) -> String {
     "'" + argument.replacing("'", with: "'\"'\"'") + "'"
   }
 }

--- a/supacode/Features/App/Reducer/AppFeature+AgentProfiles.swift
+++ b/supacode/Features/App/Reducer/AppFeature+AgentProfiles.swift
@@ -5,8 +5,10 @@ import Sharing
 extension AppFeature {
   /// The single profile-launch path (docs-ai 053): every entry point (Agents
   /// menu, Command Palette) dispatches here, so placement, identity recording,
-  /// and the environment patch always agree. Launching also records the
-  /// per-repo launch memory that backs the Recommended resolution.
+  /// and the environment patch always agree. The per-repo launch memory that
+  /// backs the Recommended resolution is recorded on the terminal's
+  /// `agentProfileLaunched` event — never here, so a launch that fails to
+  /// create a surface cannot shift the recommendation (docs-ai 053/005).
   func launchAgentProfile(_ profileID: AgentProfile.ID, state: inout State) -> Effect<Action> {
     @Shared(.userGlobalSettings) var userGlobalSettings
     guard
@@ -23,11 +25,8 @@ extension AppFeature {
       )
     } catch {
       appLogger.warning("Agent profile launch planning failed: \(error)")
-      return .none
+      return .send(.repositories(.showToast(.warning("Couldn't launch “\(profile.name)”"))))
     }
-
-    @Shared(.userRepositorySettings(worktree.repositoryRootURL)) var userRepositorySettings
-    $userRepositorySettings.withLock { $0.lastLaunchedAgentProfileID = profile.id }
 
     return .run { _ in
       await terminalClient.send(.launchAgentProfile(worktree, plan: plan))
@@ -41,7 +40,7 @@ extension AppFeature {
 @MainActor
 enum AgentProfileSeeder {
   static func seedIfNeeded(
-    isRuntimeInstalled: (AgentProfileRuntime) -> Bool = defaultInstallationCheck
+    isRuntimeInstalled: (AgentProfileRuntime) -> Bool = AgentProfileAvailability.isRuntimeInstalled
   ) {
     @Shared(.userGlobalSettings) var settings
     guard !settings.didSeedAgentProfiles else { return }
@@ -58,9 +57,4 @@ enum AgentProfileSeeder {
     }
   }
 
-  nonisolated static func defaultInstallationCheck(_ runtime: AgentProfileRuntime) -> Bool {
-    let home = FileManager.default.homeDirectoryForCurrentUser
-      .appending(path: runtime.defaultHomeDirectoryName, directoryHint: .isDirectory)
-    return FileManager.default.fileExists(atPath: home.path(percentEncoded: false))
-  }
 }

--- a/supacode/Features/App/Reducer/AppFeature+TerminalEvents.swift
+++ b/supacode/Features/App/Reducer/AppFeature+TerminalEvents.swift
@@ -1,5 +1,6 @@
 import ComposableArchitecture
 import Foundation
+import Sharing
 
 extension AppFeature {
   func reduceTerminalEvent(
@@ -154,6 +155,17 @@ extension AppFeature {
 
     case .agentEntryRemoved(let id):
       return .send(.repositories(.activeAgents(.agentEntryRemoved(id))))
+
+    case .agentProfileLaunched(let worktreeID, let profileID):
+      // Launch memory is recorded only once a surface actually exists, so a
+      // failed provision or surface creation never shifts Recommended.
+      guard let worktree = state.repositories.terminalWorktree(for: worktreeID) else { return .none }
+      @Shared(.userRepositorySettings(worktree.repositoryRootURL)) var userRepositorySettings
+      $userRepositorySettings.withLock { $0.lastLaunchedAgentProfileID = profileID }
+      return .none
+
+    case .agentProfileLaunchFailed(_, let profileName):
+      return .send(.repositories(.showToast(.warning("Couldn't launch “\(profileName)”"))))
 
     default:
       return nil

--- a/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
+++ b/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
@@ -545,7 +545,8 @@ private func customCommandItems(_ commands: [EffectiveCustomCommand]) -> [Comman
 /// Canvas card otherwise. Internal for tests.
 func agentProfileLaunchItems(
   _ repositories: RepositoriesFeature.State,
-  actionTargetWorktreeID: Worktree.ID? = nil
+  actionTargetWorktreeID: Worktree.ID? = nil,
+  isRuntimeInstalled: (AgentProfileRuntime) -> Bool = AgentProfileAvailability.isRuntimeInstalled
 ) -> [CommandPaletteItem] {
   guard
     let worktree = repositories.actionTargetTerminalWorktree(
@@ -568,10 +569,17 @@ func agentProfileLaunchItems(
   return ordered.map { profile in
     let runtimeName = AgentRuntimeAdapterRegistry.displayName(for: profile.runtime.agent)
     let placement = profile.id == recommendedID ? "Recommended · " : ""
+    // Same soft availability judgment as the Agents popover — surfaced in the
+    // subtitle, never blocking activation (docs-ai 053/005).
+    let warning = AgentProfileAvailability.launchWarning(
+      for: profile,
+      isRuntimeInstalled: isRuntimeInstalled
+    )
+    let detail = warning.map { "\($0) · \(worktree.name)" } ?? "New \(runtimeName) in \(worktree.name)"
     return CommandPaletteItem(
       id: CommandPaletteItemID.launchAgentProfile(profile.id),
       title: "Launch Agent: \(profile.name)",
-      subtitle: "\(placement)New \(runtimeName) in \(worktree.name)",
+      subtitle: "\(placement)\(detail)",
       kind: .launchAgentProfile(profile.id),
       category: .terminal,
       defaultSuggestion: false,

--- a/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
+++ b/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
@@ -546,7 +546,7 @@ private func customCommandItems(_ commands: [EffectiveCustomCommand]) -> [Comman
 func agentProfileLaunchItems(
   _ repositories: RepositoriesFeature.State,
   actionTargetWorktreeID: Worktree.ID? = nil,
-  isRuntimeInstalled: (AgentProfileRuntime) -> Bool = AgentProfileAvailability.isRuntimeInstalled
+  launchWarning: @MainActor (AgentProfile) -> String? = AgentProfileAvailability.launchWarning(for:)
 ) -> [CommandPaletteItem] {
   guard
     let worktree = repositories.actionTargetTerminalWorktree(
@@ -571,10 +571,7 @@ func agentProfileLaunchItems(
     let placement = profile.id == recommendedID ? "Recommended · " : ""
     // Same soft availability judgment as the Agents popover — surfaced in the
     // subtitle, never blocking activation (docs-ai 053/005).
-    let warning = AgentProfileAvailability.launchWarning(
-      for: profile,
-      isRuntimeInstalled: isRuntimeInstalled
-    )
+    let warning = launchWarning(profile)
     let detail = warning.map { "\($0) · \(worktree.name)" } ?? "New \(runtimeName) in \(worktree.name)"
     return CommandPaletteItem(
       id: CommandPaletteItemID.launchAgentProfile(profile.id),

--- a/supacode/Features/Repositories/Views/AgentsToolbarButton.swift
+++ b/supacode/Features/Repositories/Views/AgentsToolbarButton.swift
@@ -182,6 +182,9 @@ private struct AgentsPopoverContent: View {
     }
     .padding(6)
     .frame(width: 280, alignment: .leading)
+    // Runtimes still warned about (or unanswered) re-probe on every open, so
+    // a CLI installed mid-session clears its warning without a relaunch.
+    .task { await AgentRuntimeAvailabilityProbe.refresh() }
   }
 }
 

--- a/supacode/Features/Repositories/Views/AgentsToolbarButton.swift
+++ b/supacode/Features/Repositories/Views/AgentsToolbarButton.swift
@@ -21,8 +21,11 @@ struct AgentsLauncherItem: Equatable, Identifiable {
   let runtimeName: String
   let iconSource: AgentProfileIconSource
   let isRecommended: Bool
-  /// Why the row is disabled ("Claude Code is not installed"); nil = launchable.
-  let unavailableReason: String?
+  /// Soft availability warning ("Claude Code may not be installed"); nil = no
+  /// concern. A warning dims the row but never disables it — the heuristic has
+  /// false negatives (installed but never run, dedicated-home-only logins),
+  /// and a wrong launch fails visibly in the new surface (docs-ai 053/005).
+  let availabilityWarning: String?
 }
 
 /// Toolbar entry point for agent-scoped actions, left of the branch title.
@@ -161,11 +164,11 @@ private struct AgentsPopoverContent: View {
       ForEach(launcherItems) { item in
         AgentsPopoverRow(
           title: item.isRecommended ? "Launch \(item.name) ★" : "Launch \(item.name)",
-          subtitle: item.unavailableReason
+          subtitle: item.availabilityWarning.map { "\($0) · \(item.runtimeName)" }
             ?? "New agent in this worktree · \(item.runtimeName)",
           systemImage: "play.circle",
           iconSource: item.iconSource,
-          isEnabled: item.unavailableReason == nil,
+          isDimmed: item.availabilityWarning != nil,
           action: { onLaunchProfile(item.id) }
         )
       }
@@ -187,7 +190,9 @@ private struct AgentsPopoverRow: View {
   let subtitle: String
   let systemImage: String
   var iconSource: AgentProfileIconSource?
-  var isEnabled: Bool = true
+  /// Dimmed rows carry an availability warning but stay fully clickable — the
+  /// warning heuristic must never block a launch (docs-ai 053/005).
+  var isDimmed: Bool = false
   let action: () -> Void
   @State private var isHovered = false
 
@@ -218,11 +223,10 @@ private struct AgentsPopoverRow: View {
       .contentShape(.rect)
     }
     .buttonStyle(.plain)
-    .disabled(!isEnabled)
-    .opacity(isEnabled ? 1 : 0.5)
+    .opacity(isDimmed ? 0.5 : 1)
     .background(
       RoundedRectangle(cornerRadius: 6)
-        .fill(isHovered && isEnabled ? Color.accentColor.opacity(0.2) : Color.clear)
+        .fill(isHovered ? Color.accentColor.opacity(0.2) : Color.clear)
     )
     .onHover { isHovered = $0 }
   }

--- a/supacode/Features/Repositories/Views/WorktreeDetailView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailView.swift
@@ -399,8 +399,11 @@ struct WorktreeDetailView: View {
     // Same naming rule as the Active Agents rows: the launch profile name
     // recorded at surface creation wins for Prowl-launched panes; launch
     // aliases such as `omp` show their own name, not the semantic agent's.
+    // Runtime-gated like `configRoot`: a *different* agent started manually
+    // in the same pane must not wear the old profile's name (docs-ai 053/005).
+    let launchProfile = state.launchProfilesBySurface[surfaceID]
     let displayName =
-      state.launchProfilesBySurface[surfaceID]?.name
+      (launchProfile?.runtime.agent == agent ? launchProfile?.name : nil)
       ?? ActiveAgentEntry.displayName(
         iconLookupToken: paneState.iconLookupToken ?? agent.iconLookupToken,
         agent: agent
@@ -437,15 +440,13 @@ struct WorktreeDetailView: View {
       (lhs.id == recommendedID ? 0 : 1) < (rhs.id == recommendedID ? 0 : 1)
     }
     return ordered.map { profile in
-      let runtimeName = AgentRuntimeAdapterRegistry.displayName(for: profile.runtime.agent)
-      let installed = AgentProfileSeeder.defaultInstallationCheck(profile.runtime)
-      return AgentsLauncherItem(
+      AgentsLauncherItem(
         id: profile.id,
         name: profile.name,
-        runtimeName: runtimeName,
+        runtimeName: AgentRuntimeAdapterRegistry.displayName(for: profile.runtime.agent),
         iconSource: profile.iconSource,
         isRecommended: profile.id == recommendedID,
-        unavailableReason: installed ? nil : "\(runtimeName) is not installed"
+        availabilityWarning: AgentProfileAvailability.launchWarning(for: profile)
       )
     }
   }

--- a/supacode/Features/Settings/BusinessLogic/RepositoryLocalSettingsPersistence.swift
+++ b/supacode/Features/Settings/BusinessLogic/RepositoryLocalSettingsPersistence.swift
@@ -9,7 +9,13 @@ nonisolated struct RepositoryLocalSettingsStorage: Sendable {
 nonisolated enum RepositoryLocalSettingsStorageKey: DependencyKey {
   static var liveValue: RepositoryLocalSettingsStorage {
     RepositoryLocalSettingsStorage(
-      load: { try Data(contentsOf: $0) },
+      load: { url in
+        let data = try Data(contentsOf: url)
+        // Files written before saves enforced 0600 migrate on first read
+        // (docs-ai 053/005), not on their next save.
+        SymlinkPreservingFileWriter.restrictToOwnerOnly(url)
+        return data
+      },
       // Per-repo settings live under `~/.prowl/repo/<name>/` (not inside the
       // cloned repo), so they are user-owned config a dotfiles user may symlink
       // — follow the link on write to preserve it (#478). Upstream keeps a

--- a/supacode/Features/Settings/BusinessLogic/SettingsFilePersistence.swift
+++ b/supacode/Features/Settings/BusinessLogic/SettingsFilePersistence.swift
@@ -10,7 +10,13 @@ nonisolated struct SettingsFileStorage: Sendable {
 nonisolated enum SettingsFileStorageKey: DependencyKey {
   static var liveValue: SettingsFileStorage {
     SettingsFileStorage(
-      load: { try Data(contentsOf: $0) },
+      load: { url in
+        let data = try Data(contentsOf: url)
+        // Files written before saves enforced 0600 migrate on first read
+        // (docs-ai 053/005), not on their next save.
+        SymlinkPreservingFileWriter.restrictToOwnerOnly(url)
+        return data
+      },
       // Follows a symlinked destination to its real file so a user who links
       // `~/.prowl/settings.json` (and the repository-entries / appearances
       // files that share this closure) into a dotfiles repo keeps the link

--- a/supacode/Features/Settings/BusinessLogic/SymlinkPreservingFileWriter.swift
+++ b/supacode/Features/Settings/BusinessLogic/SymlinkPreservingFileWriter.swift
@@ -7,6 +7,11 @@ nonisolated enum SymlinkPreservingFileWriterError: Error, Equatable {
   /// The chain exceeds the kernel's symlink-resolution limit, so the loader
   /// could never follow it; refuse rather than write a file it can't read back.
   case symbolicLinkChainTooDeep(URL)
+  /// The owner-only temporary file could not be created in the target's
+  /// directory, so there is nothing safe to rename into place.
+  case temporaryFileCreationFailed(URL)
+  /// `rename(2)` of the temporary file onto the target failed with this errno.
+  case renameFailed(URL, code: Int32)
 }
 
 /// Atomic file writes that survive a symlinked destination. When the target is a
@@ -21,20 +26,50 @@ nonisolated enum SymlinkPreservingFileWriter {
   /// the write rather than fabricating a phantom tree there).
   static func write(_ data: Data, to url: URL) throws {
     let target = try resolvedTarget(for: url)
-    try FileManager.default.createDirectory(
+    let fileManager = FileManager.default
+    try fileManager.createDirectory(
       at: url.deletingLastPathComponent(),
       withIntermediateDirectories: true
     )
-    // The atomic temp+rename happens in the target's directory, so a symlink at
-    // `url` is written through and preserved instead of replaced.
-    try data.write(to: target, options: [.atomic])
     // Settings may carry secrets (agent profile env overrides can hold API
-    // keys, docs-ai 053/004); keep every settings file owner-only instead of
-    // the default 0644.
-    try FileManager.default.setAttributes(
-      [.posixPermissions: 0o600],
-      ofItemAtPath: target.path(percentEncoded: false)
-    )
+    // keys, docs-ai 053/004): the temporary file is born 0600, and the
+    // same-directory rename(2) both replaces the target atomically — through a
+    // symlink at `url`, preserving the link — and carries those owner-only
+    // permissions with it, so the content is never readable by other users,
+    // not even between write and rename.
+    let temporary =
+      target
+      .deletingLastPathComponent()
+      .appending(path: ".\(target.lastPathComponent).tmp-\(UUID().uuidString)", directoryHint: .notDirectory)
+    let temporaryPath = temporary.path(percentEncoded: false)
+    guard
+      fileManager.createFile(
+        atPath: temporaryPath,
+        contents: data,
+        attributes: [.posixPermissions: 0o600]
+      )
+    else {
+      throw SymlinkPreservingFileWriterError.temporaryFileCreationFailed(target)
+    }
+    guard rename(temporaryPath, target.path(percentEncoded: false)) == 0 else {
+      let code = errno
+      try? fileManager.removeItem(at: temporary)
+      throw SymlinkPreservingFileWriterError.renameFailed(target, code: code)
+    }
+  }
+
+  /// Best-effort owner-only migration for files written before saves enforced
+  /// 0600 (docs-ai 053/004). Runs on load so a legacy 0644 settings file stops
+  /// being world-readable the first time it is touched, not on its next save.
+  static func restrictToOwnerOnly(_ url: URL) {
+    guard let target = try? resolvedTarget(for: url) else { return }
+    let path = target.path(percentEncoded: false)
+    let fileManager = FileManager.default
+    guard
+      let permissions = (try? fileManager.attributesOfItem(atPath: path))?[.posixPermissions] as? Int,
+      permissions != 0o600
+    else { return }
+    try? fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: path)
   }
 
   /// macOS resolves at most MAXSYMLINKS (32) links before ELOOP, so a deeper

--- a/supacode/Features/Settings/Views/AgentProfileEditorView.swift
+++ b/supacode/Features/Settings/Views/AgentProfileEditorView.swift
@@ -159,7 +159,7 @@ struct AgentProfileEditorView: View {
       .help("Add an environment variable override for this profile's launches")
     } label: {
       Text("Environment Variables")
-      Text("Applied to the new terminal surface — its shell and everything started in it.")
+      Text("Applied only to the launched agent — the pane's shell keeps your normal environment.")
     }
   }
 
@@ -204,9 +204,12 @@ struct AgentProfileEditorView: View {
 
   private var launchPreviewSection: some View {
     Section("Launch Preview") {
-      Text("Prowl will execute this command. Secret-looking values are hidden here.")
-        .font(.caption)
-        .foregroundStyle(.secondary)
+      Text(
+        "Prowl types this command into the new pane. "
+          + "Override values travel in hidden PROWL_ENV variables, never in the command text."
+      )
+      .font(.caption)
+      .foregroundStyle(.secondary)
       Text(previewText)
         .font(.callout.monospaced())
         .foregroundStyle(.secondary)

--- a/supacode/Features/Settings/Views/AgentProfileEditorView.swift
+++ b/supacode/Features/Settings/Views/AgentProfileEditorView.swift
@@ -159,7 +159,7 @@ struct AgentProfileEditorView: View {
       .help("Add an environment variable override for this profile's launches")
     } label: {
       Text("Environment Variables")
-      Text("Applied to the launched process, on top of the shell's environment.")
+      Text("Applied to the new terminal surface — its shell and everything started in it.")
     }
   }
 

--- a/supacode/Features/Terminal/BusinessLogic/TerminalEventCoalescer.swift
+++ b/supacode/Features/Terminal/BusinessLogic/TerminalEventCoalescer.swift
@@ -36,7 +36,8 @@ struct TerminalEventCoalescer {
       return .agentEntry(entry.id)
     case .customCommandSucceeded, .notificationReceived, .notificationIndicatorChanged,
       .tabCreated, .tabClosed, .agentEntryRemoved, .commandPaletteToggleRequested,
-      .setupScriptConsumed, .layoutRestored, .layoutRestoreFailed:
+      .setupScriptConsumed, .layoutRestored, .layoutRestoreFailed,
+      .agentProfileLaunched, .agentProfileLaunchFailed:
       return nil
     }
   }

--- a/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
+++ b/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
@@ -60,6 +60,17 @@ final class WorktreeTerminalManager {
     createTabAsync(in: worktree, runSetupScriptIfNew: false, workingDirectory: directory)
   }
 
+  /// The launch outcome is reported as an event either way: the reducer
+  /// records the per-repo launch memory only on success and surfaces the
+  /// failure as a toast (docs-ai 053/005).
+  private func launchAgentProfile(_ plan: AgentProfileLaunchPlan, in worktree: Worktree) {
+    if state(for: worktree).launchAgentProfile(plan) != nil {
+      emit(.agentProfileLaunched(worktreeID: worktree.id, profileID: plan.profileID))
+    } else {
+      emit(.agentProfileLaunchFailed(worktreeID: worktree.id, profileName: plan.profileName))
+    }
+  }
+
   private func handleTabCommand(_ command: TerminalClient.Command) -> Bool {
     switch command {
     case .createTab(let worktree, let runSetupScriptIfNew):
@@ -91,7 +102,7 @@ final class WorktreeTerminalManager {
         )
       }
     case .launchAgentProfile(let worktree, let plan):
-      state(for: worktree).launchAgentProfile(plan)
+      launchAgentProfile(plan, in: worktree)
     case .createTabInDirectory(let worktree, let directory):
       Task {
         createTabAsync(in: worktree, runSetupScriptIfNew: false, workingDirectory: directory)

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState+AgentDetection.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState+AgentDetection.swift
@@ -302,8 +302,18 @@ extension WorktreeTerminalState {
       rawState: state.fallbackState,
       displayState: state.displayState,
       lastChangedAt: state.lastChangedAt,
-      launchProfileName: launchProfilesBySurface[surfaceID]?.name
+      launchProfileName: launchProfileName(surfaceID: surfaceID, detected: agent)
     )
+  }
+
+  /// Runtime-gated like `SurfaceLaunchProfile.configRoot(forDetected:)`: after
+  /// the launched agent exits, a manually started *different* agent in the
+  /// same pane must not wear the old profile's name (docs-ai 053/005).
+  func launchProfileName(surfaceID: UUID, detected agent: DetectedAgent) -> String? {
+    guard let profile = launchProfilesBySurface[surfaceID], profile.runtime.agent == agent else {
+      return nil
+    }
+    return profile.name
   }
 
   func activeAgentWorkingDirectory(surfaceID: UUID) -> URL? {

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState+AgentDetection.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState+AgentDetection.swift
@@ -228,6 +228,11 @@ extension WorktreeTerminalState {
     surfaceAgentStates[surfaceID] = PaneAgentState(lastChangedAt: Date())
     lastWorkingAtBySurface.removeValue(forKey: surfaceID)
     lastEmittedAgentEntriesBySurface.removeValue(forKey: surfaceID)
+    // The launch identity lives exactly as long as the launched agent
+    // (docs-ai 053/006): once the pane is a bare shell again, a manually
+    // started agent is the user's own — default home, default account — and
+    // must not wear the profile's name or config root.
+    launchProfilesBySurface.removeValue(forKey: surfaceID)
     onAgentEntryRemoved?(surfaceID)
     if let tabId = tabId(containing: surfaceID) {
       updateTabAgentBusyState(for: tabId)

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -436,7 +436,7 @@ final class WorktreeTerminalState {
       let surfaceID = createSplitOnFocusedSurface(
         direction: plan.splitDirection,
         initialInput: plan.terminalInput,
-        additionalEnvironment: plan.environment
+        additionalEnvironment: plan.surfaceEnvironment
       )
     {
       launchProfilesBySurface[surfaceID] = identity
@@ -452,7 +452,7 @@ final class WorktreeTerminalState {
         inheritingFromSurfaceId: currentFocusedSurfaceId(),
         context: GHOSTTY_SURFACE_CONTEXT_TAB,
         workingDirectoryOverride: nil,
-        additionalEnvironment: plan.environment
+        additionalEnvironment: plan.surfaceEnvironment
       )
     )
     guard let tabId, let surfaceID = trees[tabId]?.root?.leftmostLeaf().id else { return nil }

--- a/supacodeTests/AgentProfileTests.swift
+++ b/supacodeTests/AgentProfileTests.swift
@@ -169,7 +169,8 @@ struct AgentProfileTests {
       homeBaseDirectory: URL(fileURLWithPath: "/base", isDirectory: true)
     )
 
-    #expect(plan.environment.isEmpty)
+    #expect(plan.surfaceEnvironment.isEmpty)
+    #expect(plan.commandEnvironmentTokens.isEmpty)
     #expect(plan.dedicatedHome == nil)
     #expect(plan.invocation.executable == "codex")
     #expect(
@@ -193,8 +194,13 @@ struct AgentProfileTests {
     #expect(
       AgentProfileLaunchPlanner.pathString(home) == "/base/agent-profiles/\(bound.id.uuidString)"
     )
-    #expect(plan.environment == ["CODEX_HOME": "/base/agent-profiles/\(bound.id.uuidString)"])
-    #expect(plan.previewText.hasPrefix("CODEX_HOME='/base/agent-profiles/"))
+    // The home rides the launch command, not the pane's shell environment: a
+    // manual launch after the agent exits uses the default account.
+    #expect(
+      plan.commandEnvironmentTokens == ["CODEX_HOME='/base/agent-profiles/\(bound.id.uuidString)'"]
+    )
+    #expect(plan.surfaceEnvironment.isEmpty)
+    #expect(plan.previewText.hasPrefix("env CODEX_HOME='/base/agent-profiles/"))
     #expect(AgentProfileLaunchPlanner.isContained(home, in: base))
   }
 
@@ -207,7 +213,7 @@ struct AgentProfileTests {
       homeBaseDirectory: URL(fileURLWithPath: "/base", isDirectory: true)
     )
 
-    #expect(plan.environment.keys.contains("CLAUDE_CONFIG_DIR"))
+    #expect(plan.commandEnvironmentTokens.first?.hasPrefix("CLAUDE_CONFIG_DIR=") == true)
   }
 
   // MARK: - Environment overrides
@@ -225,12 +231,20 @@ struct AgentProfileTests {
       homeBaseDirectory: URL(fileURLWithPath: "/base", isDirectory: true)
     )
 
+    // Values ride in namespaced carriers; the command only references them.
     #expect(
-      plan.environment == [
-        "OPENAI_BASE_URL": "https://api.deepseek.com/beta",
-        "EMPTY_VALUE": "",
+      plan.surfaceEnvironment == [
+        "PROWL_ENV_OPENAI_BASE_URL": "https://api.deepseek.com/beta",
+        "PROWL_ENV_EMPTY_VALUE": "",
       ]
     )
+    #expect(
+      plan.commandEnvironmentTokens == [
+        "EMPTY_VALUE=\"$PROWL_ENV_EMPTY_VALUE\"",
+        "OPENAI_BASE_URL=\"$PROWL_ENV_OPENAI_BASE_URL\"",
+      ]
+    )
+    #expect(plan.terminalInput.hasPrefix("env EMPTY_VALUE="))
   }
 
   @Test func planDropsInvalidReservedAndInProgressOverrideRows() throws {
@@ -251,7 +265,8 @@ struct AgentProfileTests {
       homeBaseDirectory: URL(fileURLWithPath: "/base", isDirectory: true)
     )
 
-    #expect(plan.environment.isEmpty)
+    #expect(plan.surfaceEnvironment.isEmpty)
+    #expect(plan.commandEnvironmentTokens.isEmpty)
   }
 
   @Test func dedicatedHomeBindingBeatsSameNamedUserOverride() throws {
@@ -264,10 +279,15 @@ struct AgentProfileTests {
 
     let plan = try AgentProfileLaunchPlanner.plan(for: bound, homeBaseDirectory: base)
 
-    #expect(plan.environment == ["CODEX_HOME": "/base/agent-profiles/\(bound.id.uuidString)"])
+    // The reserved-name policy drops the user row, so the launch command
+    // carries exactly one CODEX_HOME assignment — the derived home.
+    #expect(
+      plan.commandEnvironmentTokens == ["CODEX_HOME='/base/agent-profiles/\(bound.id.uuidString)'"]
+    )
+    #expect(plan.surfaceEnvironment.isEmpty)
   }
 
-  @Test func previewQuotesOverrideValuesAndMasksSecretLookingNames() throws {
+  @Test func commandAndPreviewCarryReferencesButNeverOverrideValues() throws {
     var preset = profile(name: "Codex · DeepSeek")
     preset.environmentOverrides = [
       AgentProfileEnvironmentOverride(name: "OPENAI_BASE_URL", value: "https://a.example/v1 beta"),
@@ -279,10 +299,14 @@ struct AgentProfileTests {
       homeBaseDirectory: URL(fileURLWithPath: "/base", isDirectory: true)
     )
 
-    #expect(plan.previewText.contains("OPENAI_BASE_URL='https://a.example/v1 beta'"))
-    #expect(plan.previewText.contains("OPENAI_API_KEY=•••"))
+    // The typed command (== preview) references the carriers; the values ride
+    // the spawn environment only — never shell history or scrollback.
+    #expect(plan.previewText == plan.terminalInput)
+    #expect(plan.previewText.contains("OPENAI_API_KEY=\"$PROWL_ENV_OPENAI_API_KEY\""))
+    #expect(plan.previewText.contains("OPENAI_BASE_URL=\"$PROWL_ENV_OPENAI_BASE_URL\""))
     #expect(!plan.previewText.contains("sk-secret-123"))
-    #expect(plan.environment["OPENAI_API_KEY"] == "sk-secret-123")
+    #expect(!plan.previewText.contains("a.example"))
+    #expect(plan.surfaceEnvironment["PROWL_ENV_OPENAI_API_KEY"] == "sk-secret-123")
   }
 
   @Test func environmentPolicyReportsRowIssuesForEditorDiagnostics() {

--- a/supacodeTests/AgentProfileTests.swift
+++ b/supacodeTests/AgentProfileTests.swift
@@ -326,6 +326,34 @@ struct AgentProfileTests {
     )
   }
 
+  @Test func launchWarningPrefersTheProbeAnswerOverTheHomeHeuristic() {
+    let codex = profile(name: "Codex")
+
+    // Probe answered: ground truth in both directions, home is irrelevant.
+    #expect(
+      AgentProfileAvailability.launchWarning(
+        for: codex, probedAvailable: true, isRuntimeInstalled: { _ in false }
+      ) == nil
+    )
+    #expect(
+      AgentProfileAvailability.launchWarning(
+        for: codex, probedAvailable: false, isRuntimeInstalled: { _ in true }
+      ) == "Codex is not on your shell's PATH"
+    )
+
+    // Probe unanswered: the home-directory heuristic fills in.
+    #expect(
+      AgentProfileAvailability.launchWarning(
+        for: codex, probedAvailable: nil, isRuntimeInstalled: { _ in true }
+      ) == nil
+    )
+    #expect(
+      AgentProfileAvailability.launchWarning(
+        for: codex, probedAvailable: nil, isRuntimeInstalled: { _ in false }
+      ) == "Codex may not be installed"
+    )
+  }
+
   @Test func containmentRejectsBaseItselfAndOutsidePaths() {
     let base = URL(fileURLWithPath: "/base/agent-profiles", isDirectory: true)
     #expect(!AgentProfileLaunchPlanner.isContained(base, in: base))

--- a/supacodeTests/AgentProfileTests.swift
+++ b/supacodeTests/AgentProfileTests.swift
@@ -242,6 +242,7 @@ struct AgentProfileTests {
       AgentProfileEnvironmentOverride(name: "PROWL_WORKTREE_PATH", value: "/forged"),
       AgentProfileEnvironmentOverride(name: "CODEX_HOME", value: "/elsewhere"),
       AgentProfileEnvironmentOverride(name: "CLAUDE_CONFIG_DIR", value: "/elsewhere"),
+      AgentProfileEnvironmentOverride(name: "HOME", value: "/relocated"),
       AgentProfileEnvironmentOverride(name: "NUL_VALUE", value: "trunc\0ated"),
     ]
 
@@ -308,6 +309,14 @@ struct AgentProfileTests {
     #expect(
       AgentProfileEnvironmentPolicy.issue(
         for: AgentProfileEnvironmentOverride(name: "CLAUDE_CONFIG_DIR", value: "x")
+      ) == .reservedName
+    )
+    // Relocating `HOME` would move every runtime's default home past the
+    // dedicated-home safeguards, so it is reserved alongside the account-home
+    // variables (docs-ai 053/005).
+    #expect(
+      AgentProfileEnvironmentPolicy.issue(
+        for: AgentProfileEnvironmentOverride(name: "HOME", value: "/relocated")
       ) == .reservedName
     )
     #expect(

--- a/supacodeTests/AgentRuntimeAvailabilityProbeTests.swift
+++ b/supacodeTests/AgentRuntimeAvailabilityProbeTests.swift
@@ -1,0 +1,58 @@
+import Dependencies
+import DependenciesTestSupport
+import Foundation
+import Sharing
+import Testing
+
+@testable import supacode
+
+@MainActor
+struct AgentRuntimeAvailabilityProbeTests {
+  @Test(.dependencies) func refreshRecordsShellAnswersPerRuntime() async {
+    await withDependencies {
+      $0.shellClient = ShellClient(
+        run: { _, _, _ in ShellOutput(stdout: "", stderr: "", exitCode: 0) },
+        runLoginImpl: { _, arguments, _, _ in
+          let command = arguments.joined(separator: " ")
+          if command.contains("'codex'") {
+            return ShellOutput(stdout: "/opt/homebrew/bin/codex", stderr: "", exitCode: 0)
+          }
+          // `command -v` answers "not found" with a non-zero exit, which the
+          // shell client surfaces as a thrown error.
+          throw ShellClientError(command: command, stdout: "", stderr: "", exitCode: 1)
+        }
+      )
+    } operation: {
+      await AgentRuntimeAvailabilityProbe.refresh()
+
+      @Shared(.agentRuntimeProbedAvailability) var probed
+      #expect(probed[.codex] == true)
+      #expect(probed[.claude] == false)
+    }
+  }
+
+  @Test(.dependencies) func refreshLeavesFailedProbesUnansweredAndSkipsPositives() async {
+    let probeCalls = LockIsolated(0)
+    await withDependencies {
+      $0.shellClient = ShellClient(
+        run: { _, _, _ in ShellOutput(stdout: "", stderr: "", exitCode: 0) },
+        runLoginImpl: { _, _, _, _ in
+          probeCalls.withValue { $0 += 1 }
+          // A spawn-level failure (not a shell answer) must not masquerade as
+          // "not installed".
+          throw CocoaError(.fileNoSuchFile)
+        }
+      )
+    } operation: {
+      @Shared(.agentRuntimeProbedAvailability) var probed
+      // A positive answer is final for the session: no re-probe.
+      $probed.withLock { $0[.codex] = true }
+
+      await AgentRuntimeAvailabilityProbe.refresh()
+
+      #expect(probeCalls.value == 1)
+      #expect(probed[.codex] == true)
+      #expect(probed[.claude] == nil)
+    }
+  }
+}

--- a/supacodeTests/AppFeatureAgentProfileTests.swift
+++ b/supacodeTests/AppFeatureAgentProfileTests.swift
@@ -8,7 +8,7 @@ import Testing
 
 @MainActor
 struct AppFeatureAgentProfileTests {
-  @Test(.dependencies) func launchSendsPlanAndRecordsPerRepoMemory() async throws {
+  @Test(.dependencies) func launchSendsPlanAndDefersMemoryToTheLaunchedEvent() async throws {
     let worktree = makeWorktree()
     let repositories = makeRepositoriesState(worktree: worktree)
     let profile = AgentProfile(name: "Codex · Work", runtime: .codex, model: "gpt-5.4")
@@ -44,7 +44,43 @@ struct AppFeatureAgentProfileTests {
       homeBaseDirectory: SupacodePaths.agentProfileHomesDirectory
     )
     #expect(sent.value == [.launchAgentProfile(worktree, plan: expectedPlan)])
+    // Dispatch must not record launch memory: a launch that fails to create a
+    // surface would otherwise shift Recommended (docs-ai 053/005).
+    #expect(repoSettings.wrappedValue.lastLaunchedAgentProfileID == nil)
+
+    await store.send(.terminalEvent(.agentProfileLaunched(worktreeID: worktree.id, profileID: profile.id)))
     #expect(repoSettings.wrappedValue.lastLaunchedAgentProfileID == profile.id)
+  }
+
+  @Test(.dependencies) func launchFailedEventShowsWarningToastWithoutRecordingMemory() async {
+    let worktree = makeWorktree()
+    let repositories = makeRepositoriesState(worktree: worktree)
+    let storage = SettingsTestStorage()
+
+    let (store, repoSettings) = withDependencies {
+      $0.settingsFileStorage = storage.storage
+    } operation: {
+      @Shared(.userRepositorySettings(worktree.repositoryRootURL)) var repoSettings
+      let store = TestStore(
+        initialState: AppFeature.State(
+          repositories: repositories,
+          settings: SettingsFeature.State()
+        )
+      ) {
+        AppFeature()
+      }
+      return (store, $repoSettings)
+    }
+    // The toast auto-dismiss effect sleeps a real clock; non-exhaustive mode
+    // lets the test end without draining it.
+    store.exhaustivity = .off
+
+    await store.send(
+      .terminalEvent(.agentProfileLaunchFailed(worktreeID: worktree.id, profileName: "Broken"))
+    )
+    await store.receive(\.repositories.showToast)
+    #expect(store.state.repositories.statusToast == .warning("Couldn't launch “Broken”"))
+    #expect(repoSettings.wrappedValue.lastLaunchedAgentProfileID == nil)
   }
 
   @Test(.dependencies) func launchIgnoresDisabledOrUnknownProfiles() async {
@@ -115,7 +151,7 @@ struct AppFeatureAgentProfileTests {
       @Shared(.userRepositorySettings(worktree.repositoryRootURL)) var repoSettings
       $repoSettings.withLock { $0.defaultAgentProfileID = second.id }
 
-      let items = agentProfileLaunchItems(repositories)
+      let items = agentProfileLaunchItems(repositories, isRuntimeInstalled: { _ in true })
 
       #expect(items.map(\.title) == ["Launch Agent: Second", "Launch Agent: First"])
       #expect(items.first?.kind == .launchAgentProfile(second.id))
@@ -123,6 +159,29 @@ struct AppFeatureAgentProfileTests {
       #expect(items.last?.subtitle?.hasPrefix("Recommended") == false)
       #expect(items.first?.agentProfileIconSource == second.iconSource)
       #expect(items.last?.agentProfileIconSource == first.iconSource)
+    }
+  }
+
+  @Test(.dependencies) func paletteAnnotatesButNeverBlocksUnavailableRuntimes() {
+    let worktree = makeWorktree()
+    let repositories = makeRepositoriesState(worktree: worktree)
+    let storage = SettingsTestStorage()
+    let localStorage = RepositoryLocalSettingsTestStorage()
+    withDependencies {
+      $0.settingsFileStorage = storage.storage
+      $0.repositoryLocalSettingsStorage = localStorage.storage
+    } operation: {
+      let profile = AgentProfile(name: "Codex", runtime: .codex)
+      @Shared(.userGlobalSettings) var settings
+      $settings.withLock { $0.agentProfiles = [profile] }
+
+      let items = agentProfileLaunchItems(repositories, isRuntimeInstalled: { _ in false })
+
+      // The soft heuristic surfaces as a subtitle warning; the row stays a
+      // normal, activatable launch item (docs-ai 053/005).
+      #expect(items.map(\.title) == ["Launch Agent: Codex"])
+      #expect(items.first?.subtitle?.contains("may not be installed") == true)
+      #expect(items.first?.kind == .launchAgentProfile(profile.id))
     }
   }
 
@@ -142,8 +201,12 @@ struct AppFeatureAgentProfileTests {
       @Shared(.userGlobalSettings) var settings
       $settings.withLock { $0.agentProfiles = [profile] }
 
-      #expect(agentProfileLaunchItems(repositories).isEmpty)
-      let items = agentProfileLaunchItems(repositories, actionTargetWorktreeID: worktree.id)
+      #expect(agentProfileLaunchItems(repositories, isRuntimeInstalled: { _ in true }).isEmpty)
+      let items = agentProfileLaunchItems(
+        repositories,
+        actionTargetWorktreeID: worktree.id,
+        isRuntimeInstalled: { _ in true }
+      )
       #expect(items.map(\.title) == ["Launch Agent: Codex"])
       #expect(items.first?.subtitle?.contains(worktree.name) == true)
     }
@@ -205,7 +268,11 @@ struct AppFeatureAgentProfileTests {
       @Shared(.userGlobalSettings) var settings
       $settings.withLock { $0.agentProfiles = [profile] }
 
-      let items = agentProfileLaunchItems(repositories, actionTargetWorktreeID: plain.id)
+      let items = agentProfileLaunchItems(
+        repositories,
+        actionTargetWorktreeID: plain.id,
+        isRuntimeInstalled: { _ in true }
+      )
       #expect(items.map(\.title) == ["Launch Agent: Codex"])
       #expect(items.first?.subtitle?.contains("plain-folder") == true)
     }

--- a/supacodeTests/AppFeatureAgentProfileTests.swift
+++ b/supacodeTests/AppFeatureAgentProfileTests.swift
@@ -151,7 +151,7 @@ struct AppFeatureAgentProfileTests {
       @Shared(.userRepositorySettings(worktree.repositoryRootURL)) var repoSettings
       $repoSettings.withLock { $0.defaultAgentProfileID = second.id }
 
-      let items = agentProfileLaunchItems(repositories, isRuntimeInstalled: { _ in true })
+      let items = agentProfileLaunchItems(repositories, launchWarning: { _ in nil })
 
       #expect(items.map(\.title) == ["Launch Agent: Second", "Launch Agent: First"])
       #expect(items.first?.kind == .launchAgentProfile(second.id))
@@ -175,7 +175,7 @@ struct AppFeatureAgentProfileTests {
       @Shared(.userGlobalSettings) var settings
       $settings.withLock { $0.agentProfiles = [profile] }
 
-      let items = agentProfileLaunchItems(repositories, isRuntimeInstalled: { _ in false })
+      let items = agentProfileLaunchItems(repositories, launchWarning: { _ in "Codex may not be installed" })
 
       // The soft heuristic surfaces as a subtitle warning; the row stays a
       // normal, activatable launch item (docs-ai 053/005).
@@ -201,11 +201,11 @@ struct AppFeatureAgentProfileTests {
       @Shared(.userGlobalSettings) var settings
       $settings.withLock { $0.agentProfiles = [profile] }
 
-      #expect(agentProfileLaunchItems(repositories, isRuntimeInstalled: { _ in true }).isEmpty)
+      #expect(agentProfileLaunchItems(repositories, launchWarning: { _ in nil }).isEmpty)
       let items = agentProfileLaunchItems(
         repositories,
         actionTargetWorktreeID: worktree.id,
-        isRuntimeInstalled: { _ in true }
+        launchWarning: { _ in nil }
       )
       #expect(items.map(\.title) == ["Launch Agent: Codex"])
       #expect(items.first?.subtitle?.contains(worktree.name) == true)
@@ -271,7 +271,7 @@ struct AppFeatureAgentProfileTests {
       let items = agentProfileLaunchItems(
         repositories,
         actionTargetWorktreeID: plain.id,
-        isRuntimeInstalled: { _ in true }
+        launchWarning: { _ in nil }
       )
       #expect(items.map(\.title) == ["Launch Agent: Codex"])
       #expect(items.first?.subtitle?.contains("plain-folder") == true)

--- a/supacodeTests/SymlinkPreservingFileWriterTests.swift
+++ b/supacodeTests/SymlinkPreservingFileWriterTests.swift
@@ -194,4 +194,48 @@ struct SymlinkPreservingFileWriterTests {
     #expect(try Data(contentsOf: url) == payload)
     #expect(!isSymlink(url))
   }
+
+  @Test func writeLeavesNoTemporaryFilesBehind() throws {
+    let dir = try makeTempDir()
+    defer { try? fileManager.removeItem(at: dir) }
+    let url = dir.appending(path: "settings.json", directoryHint: .notDirectory)
+
+    try SymlinkPreservingFileWriter.write(Data("{}".utf8), to: url)
+
+    let contents = try fileManager.contentsOfDirectory(atPath: dir.path(percentEncoded: false))
+    #expect(contents == ["settings.json"])
+  }
+
+  @Test func overwritingLegacyPermissionsEndsOwnerOnly() throws {
+    let dir = try makeTempDir()
+    defer { try? fileManager.removeItem(at: dir) }
+    let url = dir.appending(path: "settings.json", directoryHint: .notDirectory)
+    try Data("old".utf8).write(to: url)
+    try fileManager.setAttributes(
+      [.posixPermissions: 0o644], ofItemAtPath: url.path(percentEncoded: false)
+    )
+
+    try SymlinkPreservingFileWriter.write(Data("new".utf8), to: url)
+
+    let attributes = try fileManager.attributesOfItem(atPath: url.path(percentEncoded: false))
+    #expect(attributes[.posixPermissions] as? Int == 0o600)
+  }
+
+  @Test func restrictToOwnerOnlyMigratesLegacyFileThroughSymlink() throws {
+    let dir = try makeTempDir()
+    defer { try? fileManager.removeItem(at: dir) }
+    let target = dir.appending(path: "target.json", directoryHint: .notDirectory)
+    let link = dir.appending(path: "settings.json", directoryHint: .notDirectory)
+    try Data("{}".utf8).write(to: target)
+    try fileManager.setAttributes(
+      [.posixPermissions: 0o644], ofItemAtPath: target.path(percentEncoded: false)
+    )
+    try fileManager.createSymbolicLink(at: link, withDestinationURL: target)
+
+    SymlinkPreservingFileWriter.restrictToOwnerOnly(link)
+
+    let attributes = try fileManager.attributesOfItem(atPath: target.path(percentEncoded: false))
+    #expect(attributes[.posixPermissions] as? Int == 0o600)
+    #expect(isSymlink(link))
+  }
 }

--- a/supacodeTests/WorktreeTerminalStateAgentProfileTests.swift
+++ b/supacodeTests/WorktreeTerminalStateAgentProfileTests.swift
@@ -1,0 +1,67 @@
+import Foundation
+import Testing
+
+@testable import supacode
+
+/// Terminal-layer behavior of `launchAgentProfile` that is testable without a
+/// live Ghostty surface (docs-ai 053/005).
+@MainActor
+struct WorktreeTerminalStateAgentProfileTests {
+  @Test func provisionFailureAbortsTheLaunchEntirely() {
+    let state = makeState()
+    // A dedicated home outside the profile-home base fails the containment
+    // gate before any surface is created.
+    let plan = makePlan(
+      dedicatedHome: URL(filePath: "/tmp/prowl-test-outside-base/home", directoryHint: .isDirectory)
+    )
+
+    let surfaceID = state.launchAgentProfile(plan)
+
+    #expect(surfaceID == nil)
+    #expect(state.tabManager.tabs.isEmpty)
+    #expect(state.launchProfilesBySurface.isEmpty)
+  }
+
+  @Test func launchProfileNameOnlyAppliesToTheLaunchedRuntime() {
+    let state = makeState()
+    let surfaceID = UUID()
+    state.launchProfilesBySurface[surfaceID] = WorktreeTerminalState.SurfaceLaunchProfile(
+      profileID: UUID(),
+      name: "Codex · Work",
+      runtime: .codex,
+      dedicatedHome: nil
+    )
+
+    #expect(state.launchProfileName(surfaceID: surfaceID, detected: .codex) == "Codex · Work")
+    // A *different* agent started manually in the same pane must not wear the
+    // old profile's name — same gating rule as `configRoot(forDetected:)`.
+    #expect(state.launchProfileName(surfaceID: surfaceID, detected: .claude) == nil)
+    #expect(state.launchProfileName(surfaceID: UUID(), detected: .codex) == nil)
+  }
+
+  private func makeState() -> WorktreeTerminalState {
+    WorktreeTerminalState(
+      runtime: GhosttyRuntime(),
+      worktree: Worktree(
+        id: "/tmp/repo/wt-1",
+        name: "wt-1",
+        detail: "",
+        workingDirectory: URL(fileURLWithPath: "/tmp/repo/wt-1"),
+        repositoryRootURL: URL(fileURLWithPath: "/tmp/repo")
+      )
+    )
+  }
+
+  private func makePlan(dedicatedHome: URL?) -> AgentProfileLaunchPlan {
+    AgentProfileLaunchPlan(
+      profileID: UUID(),
+      profileName: "Codex · Bound",
+      runtime: .codex,
+      invocation: AgentInvocation(executable: "codex", arguments: []),
+      placement: .tab,
+      splitDirection: .right,
+      environment: [:],
+      dedicatedHome: dedicatedHome
+    )
+  }
+}

--- a/supacodeTests/WorktreeTerminalStateAgentProfileTests.swift
+++ b/supacodeTests/WorktreeTerminalStateAgentProfileTests.swift
@@ -39,6 +39,24 @@ struct WorktreeTerminalStateAgentProfileTests {
     #expect(state.launchProfileName(surfaceID: UUID(), detected: .codex) == nil)
   }
 
+  @Test func launchIdentityClearsWhenTheLaunchedAgentExits() {
+    let state = makeState()
+    let surfaceID = UUID()
+    state.launchProfilesBySurface[surfaceID] = WorktreeTerminalState.SurfaceLaunchProfile(
+      profileID: UUID(),
+      name: "Codex · Work",
+      runtime: .codex,
+      dedicatedHome: nil
+    )
+    state.surfaceAgentStates[surfaceID] = PaneAgentState(detectedAgent: .codex)
+
+    state.removeAgentEntryIfNeeded(surfaceID: surfaceID)
+
+    // The identity lives exactly as long as the launched agent: a manually
+    // started agent afterwards is the user's own (docs-ai 053/006).
+    #expect(state.launchProfilesBySurface[surfaceID] == nil)
+  }
+
   private func makeState() -> WorktreeTerminalState {
     WorktreeTerminalState(
       runtime: GhosttyRuntime(),
@@ -58,9 +76,10 @@ struct WorktreeTerminalStateAgentProfileTests {
       profileName: "Codex · Bound",
       runtime: .codex,
       invocation: AgentInvocation(executable: "codex", arguments: []),
+      commandEnvironmentTokens: [],
       placement: .tab,
       splitDirection: .right,
-      environment: [:],
+      surfaceEnvironment: [:],
       dedicatedHome: dedicatedHome
     )
   }


### PR DESCRIPTION
## Summary

Consolidated audit of the Agent Profile V1 feature (cross-checking two independent reviews, recorded as `docs-ai/053-agent-profiles/005-v1-audit.md`), plus fixes scoped to boundary hardening and implementation correctness, an availability probe, and a semantic redesign of the environment patch (`docs-ai/053-agent-profiles/006-launch-scoped-environment.md`). Handoff integration and additional runtimes are deliberately left to their own waves.

## Fixes

**Env / settings boundaries**
- `HOME` joins the reserved environment-override names: relocating it would move every runtime's default home past home provisioning, deletion protection, and rooted session detection.
- Settings files hold `0600` for their whole lifetime: the writer creates an owner-only temp and `rename(2)`s it into place (no default-permission window), and legacy `0644` files migrate on first read.

**Launch correctness**
- New `agentProfileLaunched` / `agentProfileLaunchFailed` terminal events. Per-repo launch memory (the Recommended resolution's second tier) is recorded only on success; a failed provision no longer shifts the recommendation. Failures surface as a warning toast instead of only a log line.
- `launchProfileName` is runtime-gated like `configRoot`: a different agent started manually in the same pane no longer wears the old profile's name in Active Agents or the capsule.

**Availability probe**
- `AgentRuntimeAvailabilityProbe` resolves each runtime's executable with `command -v` inside the user's login shell — the exact PATH resolution a launch uses. Session-cached: positives are final; negatives re-probe when the Agents popover opens, so a CLI installed mid-session clears its warning without a relaunch. Two-tier judgment: the probe is ground truth once it answers ("not on your shell's PATH"); the home-directory heuristic only fills in until then ("may not be installed"). Warnings dim rows but never block a launch. Popover and Command Palette share the same judgment.

**Launch-scoped environment (semantic redesign, docs-ai 053/006)**
- The environment patch (dedicated home + user overrides) no longer lives in the pane's shell — it rides the launch command as `env(1)` assignments and exists for the launched agent process only. Previously, exiting the agent and manually typing `codex`/`claude` in the same pane silently inherited the profile's account/home/API keys; now manual launches always run with the user's own environment.
- Override values are referenced as `"$PROWL_ENV_<NAME>"` with values carried in namespaced spawn variables, so secrets never enter the typed command, shell history, or scrollback. The launch preview is the typed command verbatim.
- The launch identity (profile name, session-detection config root) lives exactly as long as the launched agent and clears when detection sees it exit.

## Tests

- `make check` clean; full `make test` green; `make build-app` zero errors/warnings.
- New/extended: `HOME` reservation, writer temp-permission/no-leftover/migration, launch-memory deferral + failure toast, palette availability annotation, provision-failure abort, launch-profile-name runtime gating, probe orchestration (answer mapping, positive-skip, spawn-failure-as-unknown), launch-scoped token rendering (home inline, carrier references, reserved rows, preview never contains values), identity cleared on agent exit.

https://claude.ai/code/session_01VGdVh6A5eK5CxJXo33bv5c
