### PR TITLE
fix: surface the dedicated-home badge tooltip in the profile list

### DIFF
--- a/supacode/Features/Settings/Views/AgentProfilesSettingsView.swift
+++ b/supacode/Features/Settings/Views/AgentProfilesSettingsView.swift
@@ -68,7 +68,6 @@ struct AgentProfilesSettingsView: View {
       NavigationLink(state: AgentProfileEditorFeature.State(profile: profile)) {
         profileLabel(profile)
       }
-      .help("Edit this profile")
     }
     .contextMenu {
       Button("Move Up") { move(profile.id, by: -1) }
@@ -78,11 +77,16 @@ struct AgentProfilesSettingsView: View {
     }
   }
 
+  // `.help` on the NavigationLink itself would shadow the badge's own tooltip,
+  // so the edit hint is scoped to the regions around the badge instead.
   private func profileLabel(_ profile: AgentProfile) -> some View {
     HStack(spacing: 8) {
-      AgentProfileIconImage(source: profile.iconSource, pointSize: 16)
-        .frame(width: 16, height: 16)
-      Text(profile.name)
+      HStack(spacing: 8) {
+        AgentProfileIconImage(source: profile.iconSource, pointSize: 16)
+          .frame(width: 16, height: 16)
+        Text(profile.name)
+      }
+      .help("Edit this profile")
       if profile.bindsDedicatedHome {
         Image(systemName: "person.crop.circle.badge.checkmark")
           .foregroundStyle(.secondary)
@@ -92,6 +96,7 @@ struct AgentProfilesSettingsView: View {
       Spacer()
       Text(AgentRuntimeAdapterRegistry.displayName(for: profile.runtime.agent))
         .foregroundStyle(.secondary)
+        .help("Edit this profile")
     }
   }
 


### PR DESCRIPTION
## Problem

In Settings → Agents, profiles with a dedicated home show a `person.crop.circle.badge.checkmark` badge after the name, but hovering it never showed its explanation. The code had `.help("Uses a dedicated home with its own account")` on the badge all along — it just never fired.

## Root cause

The row's `NavigationLink` carried `.help("Edit this profile")`, and on macOS an ancestor `.help` shadows any `.help` nested inside the link label. Verified with a standalone SwiftUI repro driven by synthetic hover events:

- badge help inside link label + outer help on link → hovering the badge shows **"Edit this profile"**, the badge text never appears
- badge help inside link label, no outer help → badge tooltip works
- sibling non-overlapping helps inside the label → all show correctly

## Fix

Drop the link-level `.help` and scope "Edit this profile" to the icon+name group and the runtime text, so the badge's own tooltip surfaces on hover.

## Verification

- Repro app confirms the target structure shows all three tooltips (name area / badge / runtime area) correctly
- `make check` passes
- `make build-app` succeeds

https://claude.ai/code/session_01VZsCaJFCUz5pMeREZfs1uY
