### PR TITLE
Fix agent profile environment row binding crash

### DIFF
--- a/supacode/Features/Settings/Views/AgentProfileEditorView.swift
+++ b/supacode/Features/Settings/Views/AgentProfileEditorView.swift
@@ -113,8 +113,11 @@ struct AgentProfileEditorView: View {
         )
       )
       environmentOverridesHeader
-      ForEach($store.profile.environmentOverrides) { $override in
-        environmentOverrideRow($override)
+      ForEach(store.profile.environmentOverrides) { override in
+        environmentOverrideRow(
+          environmentOverrideBinding(for: override),
+          id: override.id
+        )
       }
       Toggle("Use Dedicated Home", isOn: $store.profile.bindsDedicatedHome)
         .help("Keep a separate login, usage, and configuration for this profile")
@@ -164,7 +167,8 @@ struct AgentProfileEditorView: View {
   }
 
   private func environmentOverrideRow(
-    _ override: Binding<AgentProfileEnvironmentOverride>
+    _ override: Binding<AgentProfileEnvironmentOverride>,
+    id: AgentProfileEnvironmentOverride.ID
   ) -> some View {
     HStack(spacing: 8) {
       TextField("NAME", text: override.name)
@@ -181,7 +185,7 @@ struct AgentProfileEditorView: View {
           .accessibilityLabel(issueDescription(issue))
       }
       Button {
-        store.send(.removeEnvironmentOverride(override.wrappedValue.id))
+        store.send(.removeEnvironmentOverride(id))
       } label: {
         Label("Remove Variable", systemImage: "minus.circle")
           .labelStyle(.iconOnly)
@@ -189,6 +193,22 @@ struct AgentProfileEditorView: View {
       .buttonStyle(.plain)
       .help("Remove this environment variable")
     }
+  }
+
+  private func environmentOverrideBinding(
+    for override: AgentProfileEnvironmentOverride
+  ) -> Binding<AgentProfileEnvironmentOverride> {
+    Binding(
+      get: {
+        store.profile.environmentOverrides.first { $0.id == override.id } ?? override
+      },
+      set: { updatedOverride in
+        var overrides = store.profile.environmentOverrides
+        guard let index = overrides.firstIndex(where: { $0.id == override.id }) else { return }
+        overrides[index] = updatedOverride
+        $store.profile.environmentOverrides.wrappedValue = overrides
+      }
+    )
   }
 
   private func issueDescription(_ issue: AgentProfileEnvironmentPolicy.RowIssue) -> String {


### PR DESCRIPTION
## Summary

- iterate environment override rows as values instead of retaining array-index bindings
- resolve field bindings by stable row UUID on every read and write
- keep removed-row reads safe during SwiftUI teardown and ignore stale writes
- capture the row UUID directly for the remove action

## Root cause

`ForEach($store.profile.environmentOverrides)` produced element bindings backed by array indices. After removing a row, a `SystemTextField` could read one of those stale bindings during the next display-cycle layout and trap in `Array.subscript` with `Index out of range`.

This matches Sentry issue [PROWL-MACOS-FK](https://onevs-den.sentry.io/issues/7644519339/) and the local macOS crash report stack (`SystemTextField` → `Binding.subscript` → `Array.subscript`).

## Testing

- focused `AgentProfileEditorFeatureTests/addingAndRemovingEnvironmentOverrideRowsDelegates()`
- `make check`
- `make build-app`

The underlying stale `Binding<Array>[index]` failure was reproduced independently. A hosted SwiftUI crash fixture was not retained because it could not reproduce the production display-cycle path without introducing unrelated AppKit window-lifecycle failures.
