### PR TITLE
Agents toolbar: quick-launch split button and popover icon alignment

### DIFF
--- a/docs/components/agent-profiles.md
+++ b/docs/components/agent-profiles.md
@@ -32,7 +32,9 @@ respawn.
   row shows the profile name with the runtime name trailing. Rows for runtimes
   that look unavailable are dimmed with a warning but stay clickable —
   availability signals can be wrong, so they never block a launch. "Manage
-  Agent Profiles…" opens Settings → Agents.
+  Agent Profiles…" opens Settings → Agents. When launch rows exist the capsule
+  carries a trailing **quick-launch segment** (a `play.circle` split button):
+  one click launches the Recommended profile directly, skipping the popover.
 - **Command Palette** (`⌘P`) — "Launch Agent: <name>" rows dispatch the exact
   same action, and carry the same availability warning in their subtitle.
 

--- a/supacode/Features/Repositories/Views/AgentsToolbarButton.swift
+++ b/supacode/Features/Repositories/Views/AgentsToolbarButton.swift
@@ -39,13 +39,13 @@ struct AgentsLauncherItem: Equatable, Identifiable {
 /// toolbars flatten custom menu labels to their text, dropping the badge, so
 /// the popover is the durable container here.
 ///
-/// When launcher profiles exist, the capsule grows a trailing quick-launch
-/// segment (mirroring the Open In split button on the far side): one click
-/// starts the Recommended profile — the popover list's leader — without
-/// opening the popover. Both segments share a single glass capsule; the
-/// system split look can't be reused here because it requires separate
-/// toolbar items in one shared-background group, and this control already
-/// opts out of that group to stay clear of the branch title.
+/// The button carries no background of its own: it sits in a shared-glass
+/// toolbar group next to `AgentsQuickLaunchButton`, which renders the pair
+/// as one system split control — the same look as the trailing Open In +
+/// chevron pair. The branch title stays out of that capsule by opting out of
+/// the group background itself (see the toolbar site): a fixed
+/// `ToolbarSpacer` cannot split the navigation group, even with an explicit
+/// `.navigation` placement.
 struct AgentsToolbarButton: View {
   let capsule: AgentsCapsuleState?
   let launcherItems: [AgentsLauncherItem]
@@ -53,85 +53,33 @@ struct AgentsToolbarButton: View {
   let onLaunchProfile: (AgentProfile.ID) -> Void
   let onManageProfiles: () -> Void
   @State private var isPopoverPresented = false
-  @State private var isHovered = false
-  @State private var isQuickLaunchHovered = false
-
-  /// The popover list's leading row (Recommended first, docs-ai 053), so the
-  /// segment and the popover always agree on what one click launches.
-  private var quickLaunchItem: AgentsLauncherItem? { launcherItems.first }
 
   var body: some View {
-    HStack(spacing: 0) {
-      Button {
-        isPopoverPresented.toggle()
-      } label: {
-        label
-          .padding(.leading, 10)
-          .padding(.trailing, quickLaunchItem == nil ? 10 : 8)
-          .padding(.vertical, 8)
-          .contentShape(.rect)
-      }
-      .buttonStyle(.plain)
-      .help(helpText)
-      .accessibilityLabel(accessibilityText)
-      .popover(isPresented: $isPopoverPresented, arrowEdge: .bottom) {
-        AgentsPopoverContent(
-          capsule: capsule,
-          launcherItems: launcherItems,
-          onHandOff: {
-            isPopoverPresented = false
-            onHandOff()
-          },
-          onLaunchProfile: { id in
-            isPopoverPresented = false
-            onLaunchProfile(id)
-          },
-          onManageProfiles: {
-            isPopoverPresented = false
-            onManageProfiles()
-          }
-        )
-      }
-      if let quickLaunchItem {
-        Rectangle()
-          .fill(.separator)
-          .frame(width: 1)
-          .padding(.vertical, 8)
-        Button {
-          onLaunchProfile(quickLaunchItem.id)
-        } label: {
-          Image(systemName: "play.circle")
-            .font(.title3.weight(.medium))
-            .foregroundStyle(isQuickLaunchHovered ? .primary : .secondary)
-            .padding(.leading, 8)
-            .padding(.trailing, 10)
-            .padding(.vertical, 8)
-            .contentShape(.rect)
-        }
-        .buttonStyle(.plain)
-        .onHover { isQuickLaunchHovered = $0 }
-        .help("Launch \(quickLaunchItem.name) in this worktree")
-        .accessibilityLabel("Launch \(quickLaunchItem.name)")
-      }
+    Button {
+      isPopoverPresented.toggle()
+    } label: {
+      label
     }
-    // The item opts out of the navigation group's shared background
-    // (`sharedBackgroundVisibility(.hidden)`) to stay separate from the
-    // branch title, and draws its own glass capsule. `.plain` + an explicit
-    // glass background keeps the horizontal padding as tight as the other
-    // toolbar buttons; `.buttonStyle(.glass)` pads noticeably wider.
-    //
-    // Hover feedback must live in the glass material itself: a translucent
-    // fill layered under `glassEffect` gets swallowed by the material
-    // compositing, and `.interactive()` only adds press feedback on macOS.
-    // The material tints as one pill; the quick-launch segment signals its
-    // own hover by promoting its symbol from secondary to primary.
-    .glassEffect(
-      isHovered
-        ? .regular.tint(.primary.opacity(0.12)).interactive()
-        : .regular.interactive(),
-      in: Capsule()
-    )
-    .onHover { isHovered = $0 }
+    .help(helpText)
+    .accessibilityLabel(accessibilityText)
+    .popover(isPresented: $isPopoverPresented, arrowEdge: .bottom) {
+      AgentsPopoverContent(
+        capsule: capsule,
+        launcherItems: launcherItems,
+        onHandOff: {
+          isPopoverPresented = false
+          onHandOff()
+        },
+        onLaunchProfile: { id in
+          isPopoverPresented = false
+          onLaunchProfile(id)
+        },
+        onManageProfiles: {
+          isPopoverPresented = false
+          onManageProfiles()
+        }
+      )
+    }
   }
 
   /// Mirrors `WorktreeDetailTitleView`'s label metrics (title3 medium,
@@ -174,6 +122,29 @@ struct AgentsToolbarButton: View {
   private var accessibilityText: String {
     guard let capsule else { return "Agents" }
     return "Agents: \(capsule.displayName)"
+  }
+}
+
+/// Quick-launch half of the Agents split control: one click starts the
+/// Recommended profile — the launcher list's leading row (docs-ai 053) — so
+/// the segment and the popover always agree on what it launches. Lives as its
+/// own toolbar item in the Agents shared-glass group, which is what produces
+/// the system split-button look (and per-segment hover) next to
+/// `AgentsToolbarButton`.
+struct AgentsQuickLaunchButton: View {
+  let item: AgentsLauncherItem
+  let onLaunch: (AgentProfile.ID) -> Void
+
+  var body: some View {
+    Button {
+      onLaunch(item.id)
+    } label: {
+      Image(systemName: "play.circle")
+        .font(.title3.weight(.medium))
+        .foregroundStyle(.secondary)
+    }
+    .help("Launch \(item.name) in this worktree")
+    .accessibilityLabel("Launch \(item.name)")
   }
 }
 

--- a/supacode/Features/Repositories/Views/AgentsToolbarButton.swift
+++ b/supacode/Features/Repositories/Views/AgentsToolbarButton.swift
@@ -219,12 +219,10 @@ private struct AgentsPopoverRow: View {
         if let iconSource {
           AgentProfileIconImage(source: iconSource, pointSize: 16)
             .frame(width: 16)
-            .padding(.top, 2)
         } else {
           Image(systemName: systemImage)
             .frame(width: 16)
             .accessibilityHidden(true)
-            .padding(.top, 2)
         }
         VStack(alignment: .leading, spacing: 2) {
           HStack(alignment: .firstTextBaseline, spacing: 8) {

--- a/supacode/Features/Repositories/Views/AgentsToolbarButton.swift
+++ b/supacode/Features/Repositories/Views/AgentsToolbarButton.swift
@@ -38,6 +38,14 @@ struct AgentsLauncherItem: Equatable, Identifiable {
 /// carries no state indicator. A `Menu` cannot host this control: macOS
 /// toolbars flatten custom menu labels to their text, dropping the badge, so
 /// the popover is the durable container here.
+///
+/// When launcher profiles exist, the capsule grows a trailing quick-launch
+/// segment (mirroring the Open In split button on the far side): one click
+/// starts the Recommended profile — the popover list's leader — without
+/// opening the popover. Both segments share a single glass capsule; the
+/// system split look can't be reused here because it requires separate
+/// toolbar items in one shared-background group, and this control already
+/// opts out of that group to stay clear of the branch title.
 struct AgentsToolbarButton: View {
   let capsule: AgentsCapsuleState?
   let launcherItems: [AgentsLauncherItem]
@@ -46,25 +54,77 @@ struct AgentsToolbarButton: View {
   let onManageProfiles: () -> Void
   @State private var isPopoverPresented = false
   @State private var isHovered = false
+  @State private var isQuickLaunchHovered = false
+
+  /// The popover list's leading row (Recommended first, docs-ai 053), so the
+  /// segment and the popover always agree on what one click launches.
+  private var quickLaunchItem: AgentsLauncherItem? { launcherItems.first }
 
   var body: some View {
-    Button {
-      isPopoverPresented.toggle()
-    } label: {
-      label
-        .padding(.horizontal, 10)
-        .padding(.vertical, 8)
-        .contentShape(Capsule())
+    HStack(spacing: 0) {
+      Button {
+        isPopoverPresented.toggle()
+      } label: {
+        label
+          .padding(.leading, 10)
+          .padding(.trailing, quickLaunchItem == nil ? 10 : 8)
+          .padding(.vertical, 8)
+          .contentShape(.rect)
+      }
+      .buttonStyle(.plain)
+      .help(helpText)
+      .accessibilityLabel(accessibilityText)
+      .popover(isPresented: $isPopoverPresented, arrowEdge: .bottom) {
+        AgentsPopoverContent(
+          capsule: capsule,
+          launcherItems: launcherItems,
+          onHandOff: {
+            isPopoverPresented = false
+            onHandOff()
+          },
+          onLaunchProfile: { id in
+            isPopoverPresented = false
+            onLaunchProfile(id)
+          },
+          onManageProfiles: {
+            isPopoverPresented = false
+            onManageProfiles()
+          }
+        )
+      }
+      if let quickLaunchItem {
+        Rectangle()
+          .fill(.separator)
+          .frame(width: 1)
+          .padding(.vertical, 8)
+        Button {
+          onLaunchProfile(quickLaunchItem.id)
+        } label: {
+          Image(systemName: "play.circle")
+            .font(.title3.weight(.medium))
+            .foregroundStyle(isQuickLaunchHovered ? .primary : .secondary)
+            .padding(.leading, 8)
+            .padding(.trailing, 10)
+            .padding(.vertical, 8)
+            .contentShape(.rect)
+        }
+        .buttonStyle(.plain)
+        .onHover { isQuickLaunchHovered = $0 }
+        .help("Launch \(quickLaunchItem.name) in this worktree")
+        .accessibilityLabel("Launch \(quickLaunchItem.name)")
+      }
     }
     // The item opts out of the navigation group's shared background
     // (`sharedBackgroundVisibility(.hidden)`) to stay separate from the
     // branch title, and draws its own glass capsule. `.plain` + an explicit
     // glass background keeps the horizontal padding as tight as the other
     // toolbar buttons; `.buttonStyle(.glass)` pads noticeably wider.
-    .buttonStyle(.plain)
+    //
     // Hover feedback must live in the glass material itself: a translucent
     // fill layered under `glassEffect` gets swallowed by the material
     // compositing, and `.interactive()` only adds press feedback on macOS.
+    // The material tints as one pill; the quick-launch segment signals its
+    // own hover by promoting its symbol from secondary to primary.
     .glassEffect(
       isHovered
         ? .regular.tint(.primary.opacity(0.12)).interactive()
@@ -72,26 +132,6 @@ struct AgentsToolbarButton: View {
       in: Capsule()
     )
     .onHover { isHovered = $0 }
-    .help(helpText)
-    .accessibilityLabel(accessibilityText)
-    .popover(isPresented: $isPopoverPresented, arrowEdge: .bottom) {
-      AgentsPopoverContent(
-        capsule: capsule,
-        launcherItems: launcherItems,
-        onHandOff: {
-          isPopoverPresented = false
-          onHandOff()
-        },
-        onLaunchProfile: { id in
-          isPopoverPresented = false
-          onLaunchProfile(id)
-        },
-        onManageProfiles: {
-          isPopoverPresented = false
-          onManageProfiles()
-        }
-      )
-    }
   }
 
   /// Mirrors `WorktreeDetailTitleView`'s label metrics (title3 medium,

--- a/supacode/Features/Repositories/Views/WorktreeDetailTitleView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailTitleView.swift
@@ -13,6 +13,14 @@ struct WorktreeDetailTitleView: View {
 
   var body: some View {
     titleButton
+      // The item opts out of the navigation group's shared glass background
+      // (`sharedBackgroundVisibility(.hidden)` at the toolbar site) so the
+      // Agents pair can render as one system split control in that group,
+      // and draws its own capsule instead. Hover feedback must live in the
+      // glass material itself: translucent fills layered under `glassEffect`
+      // are swallowed by material compositing (docs-ai 049).
+      .buttonStyle(.plain)
+      .glassEffect(titleGlass, in: Capsule())
       .onHover { hovering in
         isHovered = hovering
       }
@@ -68,6 +76,15 @@ struct WorktreeDetailTitleView: View {
     isPresented = true
   }
 
+  /// Interactive glass (press feedback, hover tint) only when the title is a
+  /// real rename button; the folder/workspace variant stays a static pill.
+  private var titleGlass: Glass {
+    guard title.supportsRename else { return .regular }
+    return isHovered
+      ? .regular.tint(.primary.opacity(0.12)).interactive()
+      : .regular.interactive()
+  }
+
   private var labelContent: some View {
     HStack(spacing: 6) {
       Image(systemName: (title.supportsRename && isHovered) ? "pencil" : title.systemImage)
@@ -77,6 +94,9 @@ struct WorktreeDetailTitleView: View {
       Text(title.text)
     }
     .font(.title3.weight(.medium))
+    .padding(.horizontal, 10)
+    .padding(.vertical, 8)
+    .contentShape(Capsule())
   }
 }
 

--- a/supacode/Features/Repositories/Views/WorktreeDetailView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailView.swift
@@ -914,12 +914,14 @@ struct WorktreeDetailView: View {
     @Environment(\.resolvedKeybindings) private var resolvedKeybindings
 
     var body: some ToolbarContent {
-      // `.sharedBackgroundVisibility(.hidden)` keeps the capsule out of the
-      // navigation group's shared glass background — adjacent items in the
-      // same placement would otherwise merge with the branch title into one
-      // capsule-shaped control (a fixed ToolbarSpacer does not split the
-      // navigation group).
-      ToolbarItem(placement: .navigation) {
+      // The Agents button and its quick-launch segment share the navigation
+      // group's glass background, which renders them as one system split
+      // control (like the trailing Open In + chevron pair). Nothing can split
+      // that group — a fixed ToolbarSpacer is ignored even with an explicit
+      // `.navigation` placement (re-verified 2026-08; docs-ai 049) — so the
+      // branch title opts out via `.sharedBackgroundVisibility(.hidden)` and
+      // draws its own glass capsule instead.
+      ToolbarItemGroup(placement: .navigation) {
         AgentsToolbarButton(
           capsule: toolbarState.agentsCapsule,
           launcherItems: toolbarState.agentsLauncherItems,
@@ -927,8 +929,10 @@ struct WorktreeDetailView: View {
           onLaunchProfile: onLaunchProfile,
           onManageProfiles: onManageProfiles
         )
+        if let quickLaunchItem = toolbarState.agentsLauncherItems.first {
+          AgentsQuickLaunchButton(item: quickLaunchItem, onLaunch: onLaunchProfile)
+        }
       }
-      .sharedBackgroundVisibility(.hidden)
 
       ToolbarItem(placement: .navigation) {
         WorktreeDetailTitleView(
@@ -938,6 +942,7 @@ struct WorktreeDetailView: View {
           onConsumeExternalRenamePrompt: onConsumeExternalRenamePrompt
         )
       }
+      .sharedBackgroundVisibility(.hidden)
 
       ToolbarItem(placement: .principal) {
         ToolbarStatusView(


### PR DESCRIPTION
## Summary

- Remove the 2pt top padding on Agents popover row icons so they align with the title line instead of sitting visibly low.
- Grow the toolbar Agents entry into a split control (mirroring the Open In + chevron pair): the leading segment keeps the popover, and a new trailing `play.circle` segment launches the Recommended profile (the popover list's first row) with one click. The segment hides when no launchable profile exists.

## Design notes

- The split uses the standard mechanism: `AgentsToolbarButton` and the new `AgentsQuickLaunchButton` are separate items sharing the navigation group's glass background, so the pair gets the system split look, per-segment hover, and system chrome for free.
- A fixed `ToolbarSpacer` cannot split the navigation group even with an explicit `.navigation` placement (re-verified the docs-ai 049 finding empirically), so the opt-out moves to the branch title: it hides the shared background and draws its own glass capsule, reusing the hover-tint-in-material pattern the Agents capsule used before.
- `docs/components/agent-profiles.md` updated for the new segment.

## Verification

- `make check` and `make build-app` pass.
- Verified visually in a debug instance via self-verify-prowl: Agents + play render as one system capsule with per-segment hover and correct tooltip; the branch title sits in its own pill. Quick-launch confirmed working by onevcat in the debug build.

https://claude.ai/code/session_01UH3mgabxdTL5HCMWFYBg4G
