### PR TITLE
Add semantic Prowl UI verification

### DIFF
--- a/.claude/skills/prowl-ui/SKILL.md
+++ b/.claude/skills/prowl-ui/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: prowl-ui
-description: Explicitly inspect and operate the native Prowl Debug UI with agent-ctrl on macOS. Use only when the user asks to verify or drive Prowl UI behavior, especially Settings, sheets, menus, popovers, view switching, repository selection, and Active Agents. Do not invoke automatically after implementation, and use prowl-cli instead for tabs, panes, terminal content, command routing, or agent sessions.
+description: Explicitly inspect, operate, and iteratively improve the native Prowl Debug UI verification surface with agent-ctrl on macOS. Use only when the user asks to verify or drive Prowl UI behavior, especially Settings, sheets, menus, popovers, view switching, repository selection, and Active Agents. When a run exposes a high-confidence Prowl accessibility metadata gap, make a narrow repair and report the before-and-after evidence; report lower-confidence or backend limitations without speculative changes. Do not invoke automatically after implementation, and use prowl-cli instead for tabs, panes, terminal content, command routing, or agent sessions.
 ---
 
 # Prowl UI
@@ -101,12 +101,10 @@ agent-ctrl scroll --ref "$ref" --session "$session" -- 0 -600
 
 ### View Modes
 
-The top-level `Default`, `Canvas`, and `Shelf` controls are buttons. `Canvas` has distinctive semantic descendants such as
-`Canvas navigation help`, `Arrange`, `Organize`, and `Tile`, so assert those after switching.
-
-SwiftUI currently does not expose a selected AX state for `Default` or `Shelf`. Their button press and visual highlight are
-not enough for a semantic `PASS`. Prove a mode through distinctive content or behavior when available; otherwise declare a
-visual assertion and use a pinned screenshot, or report the semantic assertion as `INCONCLUSIVE`.
+The top-level `Default`, `Canvas`, and `Shelf` controls are buttons with identifiers `sidebar-view-mode-default`,
+`sidebar-view-mode-canvas`, and `sidebar-view-mode-shelf`. The active button exposes selected state. After switching, assert
+that exactly one of the three is selected and that it is the requested mode. `Canvas` also has distinctive descendants such
+as `Canvas navigation help`, `Arrange`, `Organize`, and `Tile`; use those as secondary evidence when relevant.
 
 ### Active Agents
 
@@ -136,8 +134,8 @@ Never hardcode repository names, worktree labels, refs, or screen coordinates.
 ### Toolbar, Popovers, and Menus
 
 The Agents toolbar menu has accessibility identifier `agents-toolbar-menu`; the adjacent quick-launch control uses
-`agents-toolbar-quick-launch`. Opening Agents produces a nested dialog with `Manage Agent Profiles…`; it may not appear as
-a sibling in `window-list`. Do not activate a profile merely to test the popover.
+`agents-toolbar-quick-launch`. Opening Agents produces a named container with identifier `agents-toolbar-popover` inside a
+nested dialog; it may not appear as a sibling in `window-list`. Do not activate a profile merely to test the popover.
 
 Menus can appear more than once in the AX tree even though only one menu is visible. Treat duplicate menu-item nodes as one
 surface. Close a menu with its toggle when that changes state; otherwise use one safe outside click and verify the expected
@@ -171,9 +169,9 @@ of treating a focus failure as proof that the window is inaccessible.
 
 ## Sheets and Editable Controls
 
-`Add...` opens the in-window `Add to Prowl` dialog. `Browse…` opens an `NSOpenPanel` sheet that remains embedded in the
-main window's AX tree; it may not appear as another entry in `window-list`. Inspect the pinned tree for `dialog`, `Cancel`,
-and `Open` before searching for a sibling window.
+`Add...` opens a named container with identifier `add-to-prowl-popover` inside the in-window `Add to Prowl` dialog.
+`Browse…` opens an `NSOpenPanel` sheet that remains embedded in the main window's AX tree; it may not appear as another
+entry in `window-list`. Inspect the pinned tree for `dialog`, `Cancel`, and `Open` before searching for a sibling window.
 
 Prefer `fill` on a fresh editable ref for safe text-entry checks. Keyboard `press` can fail with `AXRaise` on sheets or
 Settings. Native search fields can temporarily replace the snapshot root with a suggestions menu and may never become
@@ -182,6 +180,52 @@ structurally stable, so wait for a concrete control or value instead of relying 
 Never add a repository, clone, launch an agent profile, archive a worktree, run a command, or persist a setting unless the
 scenario explicitly requires that mutation and defines cleanup. Opening and cancelling a surface is sufficient for generic
 control verification.
+
+## Evolve the Verification Surface
+
+Treat friction during a real run as feedback to classify after first restoring the scenario to a known state. Distinguish:
+
+1. A Prowl accessibility metadata gap.
+2. An `agent-ctrl` discovery, scoping, or delivery limitation.
+3. A macOS permission, focus, timing, or framework limitation.
+
+Treat an explicit invocation of this skill as permission for a narrow Prowl-local accessibility metadata repair unless the
+parent request is read-only or explicitly forbids edits. Do not infer permission for functional UI changes, dependency
+installation, commits, pushes, or external reports.
+
+Make a Prowl repair autonomously only when all of these are true:
+
+- Fresh snapshots from the exact Debug PID reproduce the missing or incorrect semantic state.
+- The source makes the intended label, value, selection, role, or control identity unambiguous.
+- The fix is limited to stable `accessibilityIdentifier`, label, value, trait, action, or container metadata.
+- The fix does not change layout, control type, focus behavior, window lifecycle, persisted data, or the user-visible action.
+- The same scenario can prove the improvement directly after a rebuild and relaunch.
+
+Use stable, nonlocalized identifiers based on product meaning, not display text, indexes, repository names, refs, or runtime
+data. Keep VoiceOver semantics truthful: do not mark a semitransient popover as modal, add selected state to a momentary
+button, or collapse useful children merely to make an automation tree smaller.
+
+For a high-confidence gap:
+
+1. Preserve the before snapshot or exact failed assertion.
+2. Make the smallest metadata-only source change.
+3. Build and relaunch the isolated Debug app.
+4. Repeat the same interaction and capture after evidence.
+5. Re-check VoiceOver-oriented structure as well as `agent-ctrl` output.
+6. Update this skill only when the new behavior or workaround is durable, Prowl-specific, and verified. Edit the relevant
+   rule instead of appending a chronological field note, then validate the skill.
+
+If ownership or semantics remain uncertain, do not patch. Finish the requested verification, reduce the affected assertion
+to `INCONCLUSIVE` when necessary, and report the evidence plus the smallest recommended Prowl or upstream experiment.
+
+Always add a concise `UI Evolution` section to the final report:
+
+- `Friction` — what was difficult, or `None`.
+- `Ownership` — `Prowl`, `agent-ctrl`, `macOS`, or `Unclear`.
+- `Confidence` — `High`, `Medium`, or `Low`, with the decisive evidence.
+- `Change` — source and skill edits made, or `None`.
+- `Before / After` — direct semantic evidence when a repair was made.
+- `Follow-up` — unresolved recommendation, or `None`.
 
 ## Evidence and Outcome
 

--- a/.claude/skills/prowl-ui/SKILL.md
+++ b/.claude/skills/prowl-ui/SKILL.md
@@ -1,0 +1,193 @@
+---
+name: prowl-ui
+description: Explicitly inspect and operate the native Prowl Debug UI with agent-ctrl on macOS. Use only when the user asks to verify or drive Prowl UI behavior, especially Settings, sheets, menus, popovers, view switching, repository selection, and Active Agents. Do not invoke automatically after implementation, and use prowl-cli instead for tabs, panes, terminal content, command routing, or agent sessions.
+---
+
+# Prowl UI
+
+## Scope
+
+Use `agent-ctrl` as the semantic macOS UI surface for an exact Prowl Debug process. Keep the workflow exploratory: choose
+the shortest interaction that proves the declared behavior, while applying the Prowl-specific constraints below.
+
+This skill is explicit-only. Do not run it merely because Prowl code changed. When called from `self-verify-prowl`, run the
+preflight before loading this file so a missing tool or permission becomes a cheap `SKIPPED` result.
+
+Split responsibility by surface:
+
+- Use `prowl-cli` for repositories and worktrees as data, tabs, panes, terminal input and output, task state, and agent
+  sessions. Read its skill before writing commands.
+- Use `agent-ctrl` for native windows, Settings, sheets, menus, popovers, sidebar disclosure, and other AppKit or SwiftUI
+  controls.
+- Use a PID-scoped screenshot only for visual assertions such as selection appearance, geometry, clipping, or hierarchy.
+
+Do not use Accessibility to type into Ghostty terminal surfaces or infer terminal state from pixels.
+
+## Preflight Without Prompting
+
+Run the bundled script before opening an AX session:
+
+```bash
+.claude/skills/prowl-ui/scripts/preflight.sh
+```
+
+It checks `command -v agent-ctrl`, requires version 0.1.3 or newer, inspects `info --json`, and runs
+`doctor --json --quick`. Its contract is:
+
+- Exit `0` with `{"status":"READY",...}` when the macOS AX surface and Accessibility permission are ready.
+- Exit `2` with `{"status":"SKIPPED",...}` when the binary, compatible version, JSON parser, AX surface, or permission is
+  unavailable.
+
+On `SKIPPED`, stop this UI scenario immediately. Do not install the tool, open System Settings, or enter an LLM-driven UI
+loop. Installation is a separate user-authorized action.
+
+## Pin the Debug Process
+
+Never target Prowl by process name or appearance. The installed and Debug apps are both named `ProwlApp` and share user
+data. When using this skill with `self-verify-prowl`, source its helpers and resolve the DerivedData Debug PID:
+
+```bash
+. .claude/skills/self-verify-prowl/scripts/helpers.sh
+pid="$(debug_pid_with_window)"
+test -n "$pid"
+
+session="prowl-ui-$$"
+agent-ctrl open ax --session "$session"
+agent-ctrl snapshot --target-pid "$pid" --session "$session"
+```
+
+Keep one session for one scenario and always close it:
+
+```bash
+agent-ctrl close --session "$session"
+```
+
+Window IDs and element refs are ephemeral. Re-run `window-list` or a PID-scoped snapshot after opening or closing a
+window. Do not assume `window:0`, `@e0`, or any previous ref still identifies the same object.
+
+## Observe, Act, Re-observe
+
+For every action:
+
+1. Take a fresh snapshot pinned to the Debug PID or its already-discovered window.
+2. Resolve the narrowest semantic target with `find`, or inspect the tree when the useful target is a parent cell.
+3. Perform exactly one action.
+4. Wait for a concrete result or disappearance when possible.
+5. Take another snapshot and assert the resulting label, role, state, value, title, or CLI state.
+
+Typical commands use this argument order:
+
+```bash
+ref="$(agent-ctrl find "Canvas" --role button --exact --first --session "$session")"
+agent-ctrl click "$ref" --session "$session"
+agent-ctrl wait-for "Arrange" --role button --session "$session"
+agent-ctrl snapshot --session "$session"
+arrange_ref="$(agent-ctrl find "Arrange" --role button --exact --first --session "$session")"
+agent-ctrl get name "$arrange_ref" --session "$session"
+```
+
+An action response such as `ok method=ax-press`, `ax-value`, or `cg-event` is delivery telemetry, not evidence that Prowl
+changed state. Never report `PASS` from the action response alone. If delivery is uncertain, observe before considering a
+retry.
+
+Use refs only from the latest snapshot. `find` searches the cached snapshot; it does not walk the UI itself. For negative
+scroll deltas, terminate option parsing explicitly, for example:
+
+```bash
+agent-ctrl scroll --ref "$ref" --session "$session" -- 0 -600
+```
+
+## Prowl Main Window Knowledge
+
+### View Modes
+
+The top-level `Default`, `Canvas`, and `Shelf` controls are buttons. `Canvas` has distinctive semantic descendants such as
+`Canvas navigation help`, `Arrange`, `Organize`, and `Tile`, so assert those after switching.
+
+SwiftUI currently does not expose a selected AX state for `Default` or `Shelf`. Their button press and visual highlight are
+not enough for a semantic `PASS`. Prove a mode through distinctive content or behavior when available; otherwise declare a
+visual assertion and use a pinned screenshot, or report the semantic assertion as `INCONCLUSIVE`.
+
+### Active Agents
+
+Collapse and expansion are reliably observable through the footer control:
+
+- Expanded state exposes `Hide Active Agents`.
+- Collapsed state exposes `Show Active Agents`.
+
+Assert the label flip after each click. Do not infer collapse solely from the continued presence or absence of the
+`Active Agents` region.
+
+### Repository and Worktree Selection
+
+Repository and worktree text regions can return a successful AX press without changing selection. After a selection
+attempt, query the dedicated Debug socket with `prowl list --json` and compare the focused worktree or pane.
+
+If semantic delivery did not change the CLI state:
+
+1. Re-snapshot and prefer the containing row or cell over its text region when one exists.
+2. Check the target bounds against the root window bounds. Nodes below or above the viewport may still claim
+   `visible=true`.
+3. If the row is on-screen and has no actionable semantic parent, use one physical click at the center of its fresh bounds.
+4. Query `prowl list --json` again. Do not repeat the click if the result is still ambiguous.
+
+Never hardcode repository names, worktree labels, refs, or screen coordinates.
+
+### Toolbar, Popovers, and Menus
+
+The Agents toolbar menu has accessibility identifier `agents-toolbar-menu`; the adjacent quick-launch control uses
+`agents-toolbar-quick-launch`. Opening Agents produces a nested dialog with `Manage Agent Profiles…`; it may not appear as
+a sibling in `window-list`. Do not activate a profile merely to test the popover.
+
+Menus can appear more than once in the AX tree even though only one menu is visible. Treat duplicate menu-item nodes as one
+surface. Close a menu with its toggle when that changes state; otherwise use one safe outside click and verify the expected
+menu item is gone.
+
+## Prowl Settings Knowledge
+
+Settings uses a SwiftUI `List(selection:)` exposed as `tree "Sidebar"`. Each navigation item is typically shaped like:
+
+```text
+cell
+  region "Notifications"
+```
+
+Click the `cell`, not the named text or region. `find "Notifications"` usually returns the region, so inspect its parent in
+the fresh snapshot and click that cell ref. The cell action may legitimately fall back from AXPress to a physical event.
+
+After navigation, assert both the selected row and a detail-specific heading or window title. Important title differences
+include:
+
+- The `Commands` row opens a window titled `Global Commands`.
+- Repository rows open repository-specific settings whose headings include `Display`, `Worktree`, `Agents`, and scripts.
+
+Repository rows can be present in the AX tree while outside the window. Before clicking one, compare its bounds to the
+Settings window, scroll over a currently visible sidebar cell, then re-snapshot. Use a bounded scroll, observe its direction,
+and adjust once rather than assuming `visible=true` or trusting a scroll success response.
+
+Opening Settings can reorder or replace the session's top-level window IDs, and `AXRaise` may be unsupported even when the
+correct window is already readable. Re-discover the window, verify its title and PID, and continue from the snapshot instead
+of treating a focus failure as proof that the window is inaccessible.
+
+## Sheets and Editable Controls
+
+`Add...` opens the in-window `Add to Prowl` dialog. `Browse…` opens an `NSOpenPanel` sheet that remains embedded in the
+main window's AX tree; it may not appear as another entry in `window-list`. Inspect the pinned tree for `dialog`, `Cancel`,
+and `Open` before searching for a sibling window.
+
+Prefer `fill` on a fresh editable ref for safe text-entry checks. Keyboard `press` can fail with `AXRaise` on sheets or
+Settings. Native search fields can temporarily replace the snapshot root with a suggestions menu and may never become
+structurally stable, so wait for a concrete control or value instead of relying on `wait-for --stable`.
+
+Never add a repository, clone, launch an agent profile, archive a worktree, run a command, or persist a setting unless the
+scenario explicitly requires that mutation and defines cleanup. Opening and cancelling a surface is sufficient for generic
+control verification.
+
+## Evidence and Outcome
+
+Prefer direct semantic evidence: a fresh tree fragment, a field value, a window title, or matching `prowl` JSON before and
+after. Use `agent-ctrl screenshot --session "$session"` only when pixels are part of the declared assertion.
+
+Classify each scenario as `PASS`, `FAIL`, `SKIPPED`, or `INCONCLUSIVE`. Include the exact Debug PID, agent-ctrl version,
+assertions and evidence, any physical fallback, restored state, and session cleanup. A partial semantic surface must reduce
+confidence; it must not silently become a visual pass.

--- a/.claude/skills/prowl-ui/agents/openai.yaml
+++ b/.claude/skills/prowl-ui/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Prowl UI"
+  short_description: "Verify Prowl Debug UI with agent-ctrl"
+  default_prompt: "Use $prowl-ui to verify this behavior in Prowl Debug."
+policy:
+  allow_implicit_invocation: false

--- a/.claude/skills/prowl-ui/agents/openai.yaml
+++ b/.claude/skills/prowl-ui/agents/openai.yaml
@@ -1,6 +1,6 @@
 interface:
   display_name: "Prowl UI"
-  short_description: "Verify Prowl Debug UI with agent-ctrl"
+  short_description: "Verify and improve Prowl Debug UI with agent-ctrl"
   default_prompt: "Use $prowl-ui to verify this behavior in Prowl Debug."
 policy:
   allow_implicit_invocation: false

--- a/.claude/skills/prowl-ui/scripts/preflight.sh
+++ b/.claude/skills/prowl-ui/scripts/preflight.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+
+set -u
+set -o pipefail
+
+minimum_version="0.1.3"
+
+skip() {
+  local reason="$1"
+  local version="${2:-}"
+
+  if command -v jq >/dev/null 2>&1; then
+    jq -cn \
+      --arg reason "$reason" \
+      --arg version "$version" \
+      --arg minimum_version "$minimum_version" \
+      '{status: "SKIPPED", reason: $reason}
+       + (if $version == "" then {} else {version: $version} end)
+       + (if $reason == "unsupported_version" then {minimum_version: $minimum_version} else {} end)'
+  else
+    printf '{"status":"SKIPPED","reason":"%s"}\n' "$reason"
+  fi
+  exit 2
+}
+
+version_is_supported() {
+  local candidate="$1"
+  local minimum="$2"
+  local candidate_major candidate_minor candidate_patch
+  local minimum_major minimum_minor minimum_patch
+
+  candidate="${candidate%%-*}"
+  candidate="${candidate%%+*}"
+  IFS=. read -r candidate_major candidate_minor candidate_patch <<<"$candidate"
+  IFS=. read -r minimum_major minimum_minor minimum_patch <<<"$minimum"
+
+  [[ "$candidate_major" =~ ^[0-9]+$ && "$candidate_minor" =~ ^[0-9]+$ && "$candidate_patch" =~ ^[0-9]+$ ]] ||
+    return 1
+
+  ((candidate_major > minimum_major)) && return 0
+  ((candidate_major < minimum_major)) && return 1
+  ((candidate_minor > minimum_minor)) && return 0
+  ((candidate_minor < minimum_minor)) && return 1
+  ((candidate_patch >= minimum_patch))
+}
+
+if ! command -v jq >/dev/null 2>&1; then
+  skip "json_parser_not_installed"
+fi
+
+if [[ -n "${AGENT_CTRL_BIN:-}" ]]; then
+  agent_ctrl="$AGENT_CTRL_BIN"
+  [[ -x "$agent_ctrl" ]] || skip "agent_ctrl_not_installed"
+else
+  agent_ctrl="$(command -v agent-ctrl 2>/dev/null || true)"
+  [[ -n "$agent_ctrl" && -x "$agent_ctrl" ]] || skip "agent_ctrl_not_installed"
+fi
+
+version_output="$("$agent_ctrl" --version 2>/dev/null || true)"
+if [[ "$version_output" =~ ([0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)?) ]]; then
+  version="${BASH_REMATCH[1]}"
+else
+  skip "version_unavailable"
+fi
+
+version_is_supported "$version" "$minimum_version" || skip "unsupported_version" "$version"
+
+info_json="$("$agent_ctrl" info --json 2>/dev/null || true)"
+doctor_json="$("$agent_ctrl" doctor --json --quick 2>/dev/null || true)"
+
+if ! jq -e . >/dev/null 2>&1 <<<"$info_json" || ! jq -e . >/dev/null 2>&1 <<<"$doctor_json"; then
+  skip "diagnostics_unavailable" "$version"
+fi
+
+info_ready="$(
+  jq -r '
+    .os == "macos"
+      and .recommended_surface == "ax"
+      and .macos_accessibility == "trusted"
+      and any(.surfaces[]?; .kind == "ax" and .status == "ready")
+  ' <<<"$info_json"
+)"
+doctor_ready="$(
+  jq -r '
+    .success == true
+      and any(.checks[]?; .id == "env.surface.ax" and .status == "pass")
+      and any(.checks[]?; .id == "perm.accessibility" and .status == "pass")
+  ' <<<"$doctor_json"
+)"
+
+if [[ "$info_ready" != "true" || "$doctor_ready" != "true" ]]; then
+  skip "accessibility_not_ready" "$version"
+fi
+
+jq -cn \
+  --arg binary "$agent_ctrl" \
+  --arg version "$version" \
+  '{status: "READY", binary: $binary, version: $version, surface: "ax"}'

--- a/.claude/skills/prowl-ui/scripts/preflight_test.sh
+++ b/.claude/skills/prowl-ui/scripts/preflight_test.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+
+set -u
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+preflight="$script_dir/preflight.sh"
+scratch="$(mktemp -d "${TMPDIR:-/tmp}/prowl-ui-preflight.XXXXXX")"
+mock="$scratch/agent-ctrl"
+
+cleanup() {
+  /usr/bin/trash "$scratch" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+cat >"$mock" <<'EOF'
+#!/bin/bash
+case "${1:-}" in
+  --version)
+    printf 'agent-ctrl %s\n' "${MOCK_VERSION:-0.1.3}"
+    ;;
+  info)
+    printf '%s\n' "${MOCK_INFO_JSON:-}"
+    ;;
+  doctor)
+    printf '%s\n' "${MOCK_DOCTOR_JSON:-}"
+    ;;
+  *)
+    exit 64
+    ;;
+esac
+EOF
+chmod +x "$mock"
+
+failures=0
+output=""
+status=0
+
+run_preflight() {
+  set +e
+  output="$(
+    AGENT_CTRL_BIN="${AGENT_CTRL_BIN_OVERRIDE:-$mock}" \
+      MOCK_VERSION="${MOCK_VERSION_OVERRIDE:-0.1.3}" \
+      MOCK_INFO_JSON="${MOCK_INFO_OVERRIDE:-}" \
+      MOCK_DOCTOR_JSON="${MOCK_DOCTOR_OVERRIDE:-}" \
+      /bin/bash "$preflight" 2>&1
+  )"
+  status=$?
+  set -e
+}
+
+assert_status() {
+  local expected="$1"
+  local name="$2"
+  if [[ "$status" -ne "$expected" ]]; then
+    printf 'FAIL %s: expected exit %s, got %s\n%s\n' "$name" "$expected" "$status" "$output"
+    failures=$((failures + 1))
+  fi
+}
+
+assert_json() {
+  local filter="$1"
+  local name="$2"
+  if ! printf '%s\n' "$output" | jq -e "$filter" >/dev/null; then
+    printf 'FAIL %s: output did not match %s\n%s\n' "$name" "$filter" "$output"
+    failures=$((failures + 1))
+  fi
+}
+
+AGENT_CTRL_BIN_OVERRIDE="$scratch/missing"
+run_preflight
+assert_status 2 "missing binary"
+assert_json '.status == "SKIPPED" and .reason == "agent_ctrl_not_installed"' "missing binary"
+
+AGENT_CTRL_BIN_OVERRIDE="$mock"
+MOCK_VERSION_OVERRIDE="0.1.2"
+run_preflight
+assert_status 2 "old version"
+assert_json '.status == "SKIPPED" and .reason == "unsupported_version" and .minimum_version == "0.1.3"' \
+  "old version"
+
+MOCK_VERSION_OVERRIDE="0.1.3"
+MOCK_INFO_OVERRIDE='{"os":"macos","recommended_surface":"ax","surfaces":[{"kind":"ax","status":"ready"}],"macos_accessibility":"denied"}'
+MOCK_DOCTOR_OVERRIDE='{"success":false,"checks":[{"id":"env.surface.ax","status":"pass"},{"id":"perm.accessibility","status":"fail"}]}'
+run_preflight
+assert_status 2 "accessibility denied"
+assert_json '.status == "SKIPPED" and .reason == "accessibility_not_ready"' "accessibility denied"
+
+MOCK_INFO_OVERRIDE='{"os":"macos","recommended_surface":"ax","surfaces":[{"kind":"ax","status":"ready"}],"macos_accessibility":"trusted"}'
+MOCK_DOCTOR_OVERRIDE='{"success":true,"checks":[{"id":"env.surface.ax","status":"pass"},{"id":"perm.accessibility","status":"pass"}]}'
+run_preflight
+assert_status 0 "ready"
+assert_json '.status == "READY" and .version == "0.1.3" and .surface == "ax"' "ready"
+
+MOCK_VERSION_OVERRIDE="0.1.3+local"
+run_preflight
+assert_status 0 "build metadata version"
+assert_json '.status == "READY" and .version == "0.1.3+local"' "build metadata version"
+
+MOCK_DOCTOR_OVERRIDE='not-json'
+run_preflight
+assert_status 2 "invalid diagnostics"
+assert_json '.status == "SKIPPED" and .reason == "diagnostics_unavailable"' "invalid diagnostics"
+
+if [[ "$failures" -ne 0 ]]; then
+  printf '%s preflight test(s) failed\n' "$failures"
+  exit 1
+fi
+
+printf 'All prowl-ui preflight tests passed\n'

--- a/.claude/skills/self-verify-prowl/SKILL.md
+++ b/.claude/skills/self-verify-prowl/SKILL.md
@@ -39,8 +39,8 @@ Keep scenarios narrow. “The app launched” or “the UI looks correct” is n
 Use the smallest surface that can prove the assertion:
 
 1. Use `prowl` for worktrees, tabs, panes, terminal contents, command routing, task state, and agent sessions.
-2. Use a semantic macOS accessibility tool for UI labels, roles, enabled or selected state, navigation, sheets, menus,
-   popovers, and buttons. Load that tool's own skill before using it.
+2. Use the repository's `prowl-ui` skill for native UI labels, roles, enabled or selected state, navigation, sheets, menus,
+   popovers, and buttons, but only after its deterministic preflight returns `READY`.
 3. Use a PID-scoped screenshot only for geometry, clipping, visual hierarchy, or other pixel-level assertions.
 4. Use targeted `SupaLogger` markers only when neither public CLI state nor accessibility state exposes the behavior.
 
@@ -50,6 +50,18 @@ AppleScript coordinate loops are not an acceptable fallback. If no suitable cont
 
 Before writing any `prowl` command, load and read the `prowl-cli` skill. It is authoritative for JSON fields, selectors,
 quoting, argument semantics, and error codes.
+
+For a native UI scenario, run the cheap dependency gate before loading the full `prowl-ui` skill:
+
+```bash
+ui_status=0
+ui_preflight="$(.claude/skills/prowl-ui/scripts/preflight.sh)" || ui_status=$?
+printf '%s\n' "$ui_preflight"
+```
+
+Exit `0` means `READY`: load `.claude/skills/prowl-ui/SKILL.md` and continue. Exit `2` means `SKIPPED`: record its JSON
+reason and stop that UI scenario without entering an LLM-driven interaction loop. Do not install or authorize a dependency
+during self-verification.
 
 ## Preconditions
 
@@ -141,14 +153,14 @@ Agents.
 
 ## Verify UI Semantics
 
-When an accessibility-capable desktop tool is available:
+After the `prowl-ui` preflight is `READY`, follow that skill's Prowl-specific workflow. At minimum:
 
-1. Preflight its installation and Accessibility permission without prompting.
-2. Resolve the debug PID with `debug_pid_with_window`, then select the exact window belonging to that PID.
-3. Start with a compact or skeleton accessibility snapshot and drill into the relevant region.
-4. Act through a fresh semantic element reference rather than coordinates.
-5. Re-snapshot the affected region or surface and assert the resulting label, value, role, state, or window.
-6. Treat sheets, alerts, menus, and popovers as separate surfaces.
+1. Resolve the debug PID with `debug_pid_with_window`, then pin the AX session to that PID.
+2. Start with a compact accessibility snapshot and drill into the relevant region.
+3. Act once through a fresh semantic element reference.
+4. Re-snapshot the affected region or surface and assert the resulting label, value, role, state, window, or matching
+   `prowl` JSON.
+5. Close the AX session and restore any UI state changed by the scenario.
 
 Do not identify the debug app by appearance: it shares data with the installed app and may look identical. If a tool cannot
 pin reads and actions to the debug PID or exact window, do not use it while both instances are running.

--- a/supacode/Features/Repositories/Views/AddToProwlView.swift
+++ b/supacode/Features/Repositories/Views/AddToProwlView.swift
@@ -58,6 +58,9 @@ struct AddToProwlView: View {
     }
     .padding(EdgeInsets(top: 26, leading: 26, bottom: 20, trailing: 26))
     .frame(width: 400)
+    .accessibilityElement(children: .contain)
+    .accessibilityLabel("Add to Prowl")
+    .accessibilityIdentifier("add-to-prowl-popover")
   }
 
   private var dropZone: some View {

--- a/supacode/Features/Repositories/Views/AgentsToolbarButton.swift
+++ b/supacode/Features/Repositories/Views/AgentsToolbarButton.swift
@@ -203,6 +203,9 @@ private struct AgentsPopoverContent: View {
     }
     .padding(6)
     .frame(width: 280, alignment: .leading)
+    .accessibilityElement(children: .contain)
+    .accessibilityLabel("Agents")
+    .accessibilityIdentifier("agents-toolbar-popover")
     // Runtimes still warned about (or unanswered) re-probe on every open, so
     // a CLI installed mid-session clears its warning without a relaunch.
     .task { await AgentRuntimeAvailabilityProbe.refresh() }

--- a/supacode/Features/Repositories/Views/SidebarListView.swift
+++ b/supacode/Features/Repositories/Views/SidebarListView.swift
@@ -245,11 +245,17 @@ struct SidebarListView: View {
   // the macOS 26 look while truly filling the width.
   private var topSegmentBar: some View {
     HStack(spacing: 4) {
-      topSegmentButton(.tabbed, systemImage: "checklist.unchecked", title: "Default")
+      topSegmentButton(
+        .tabbed,
+        systemImage: "checklist.unchecked",
+        title: "Default",
+        accessibilityIdentifier: "sidebar-view-mode-default"
+      )
       topSegmentButton(
         .canvas,
         systemImage: "square.grid.2x2",
         title: "Canvas",
+        accessibilityIdentifier: "sidebar-view-mode-canvas",
         shortcutCommandID: AppShortcuts.CommandID.toggleCanvas,
         requiresRepository: true
       )
@@ -257,6 +263,7 @@ struct SidebarListView: View {
         .shelf,
         systemImage: "distribute.horizontal.fill",
         title: "Shelf",
+        accessibilityIdentifier: "sidebar-view-mode-shelf",
         shortcutCommandID: AppShortcuts.CommandID.toggleShelf,
         requiresRepository: true
       )
@@ -277,6 +284,7 @@ struct SidebarListView: View {
     _ segment: TopSegment,
     systemImage: String,
     title: String,
+    accessibilityIdentifier: String,
     shortcutCommandID: String? = nil,
     requiresRepository: Bool = false
   ) -> some View {
@@ -312,6 +320,8 @@ struct SidebarListView: View {
     .disabled(isDisabled)
     .help(helpText)
     .accessibilityLabel(Text(title))
+    .accessibilityIdentifier(accessibilityIdentifier)
+    .accessibilityAddTraits(isSelected ? [.isSelected, .isButton] : .isButton)
   }
 
   private func focusTerminalAfterSidebarSelection(worktreeID: Worktree.ID?) {


### PR DESCRIPTION
## Summary

- add an explicit-only `prowl-ui` skill for semantic Prowl Debug UI verification with `agent-ctrl`
- add a deterministic preflight that returns structured `READY` or `SKIPPED` results before any UI interaction loop
- document Prowl-specific AX behavior for view modes, Active Agents, worktree selection, Settings cells, sheets, menus, and popovers
- make `self-verify-prowl` conditionally load the UI skill only after preflight succeeds
- expose stable identifiers and truthful selected state for the Default, Canvas, and Shelf controls
- expose named, identifiable content containers for the Add to Prowl and Agents popovers
- let explicit UI verification runs make narrow, high-confidence accessibility metadata repairs and require a structured UI Evolution report

## Runtime findings captured by the skill

- Settings navigation requires clicking the sidebar cell rather than its named region
- successful AX delivery does not prove worktree selection; focused state must be checked through `prowl list --json`
- view-mode verification can assert exactly one selected button through stable identifiers
- native sheets and popovers often remain nested in the pinned window tree instead of appearing as sibling windows
- structural dialog nodes can still be visible but unaddressable; tracked upstream in https://github.com/k4cper-g/agent-ctrl/issues/1

## Verification

- `bash .claude/skills/prowl-ui/scripts/preflight_test.sh`
- `bash .claude/skills/self-verify-prowl/scripts/helpers_test.sh`
- skill schema validation
- ShellCheck for both skill scripts
- RED/GREEN verification against an isolated Prowl Debug process:
  - Default, Canvas, and Shelf each become the unique selected mode
  - Add to Prowl exposes `add-to-prowl-popover`
  - Agents exposes `agents-toolbar-popover`
- `make check`
- `make build-app` (0 warnings, 0 errors)
