### PR TITLE
Cut the cost of counting untracked lines: memchr scan plus a size guard

### DIFF
--- a/supacode/Clients/Git/GitClient.swift
+++ b/supacode/Clients/Git/GitClient.swift
@@ -471,7 +471,29 @@ struct GitClient {
     data[offset..<(offset + 4)].reduce(UInt32(0)) { ($0 << 8) | UInt32($1) }
   }
 
+  /// Untracked files at or above this size contribute nothing to the diff badge.
+  ///
+  /// The badge counts the lines you are adding, and a file this large is not
+  /// something anyone typed. Profiling captures are the case that prompted it:
+  /// a single `sample(1)` output runs to tens of megabytes, and every byte of it
+  /// was being read on each refresh to produce a number no one wants. Source
+  /// files sit orders of magnitude below the threshold, so nothing a reader would
+  /// call a change is affected.
+  ///
+  /// Chosen over a `.gitignore` pattern deliberately. A pattern has to name the
+  /// file, so it fixes one repository for one spelling and misses the next
+  /// capture that lands under a different name.
+  nonisolated static let untrackedLineCountByteLimit = 2 * 1_024 * 1_024
+
   nonisolated private static func countLines(in fileURL: URL) -> Int? {
+    // Checked before opening the file, so an oversized one costs a stat rather
+    // than a full read. `nil` already means "not worth counting" here; binary
+    // files reach the same answer through the NUL probe below.
+    if let fileSize = try? fileURL.resourceValues(forKeys: [.fileSizeKey]).fileSize,
+      fileSize >= untrackedLineCountByteLimit
+    {
+      return nil
+    }
     guard let handle = try? FileHandle(forReadingFrom: fileURL) else { return nil }
     defer { try? handle.close() }
 

--- a/supacode/Clients/Git/GitClient.swift
+++ b/supacode/Clients/Git/GitClient.swift
@@ -496,10 +496,10 @@ struct GitClient {
       if probedByteCount < binaryProbeByteCount {
         let remainingProbeCount = binaryProbeByteCount - probedByteCount
         let probe = chunk.prefix(remainingProbeCount)
-        if probe.contains(0x00) { return nil }
+        if probe.containsByte(0x00) { return nil }
         probedByteCount += probe.count
       }
-      lineCount += chunk.reduce(0) { $0 + ($1 == 0x0A ? 1 : 0) }
+      lineCount += chunk.countOccurrences(of: 0x0A)
       lastByte = chunk.last
     }
 
@@ -1406,4 +1406,40 @@ struct GitClient {
     return GithubRemoteInfo(host: remoteWebInfo.host, owner: owner, repo: repo)
   }
 
+}
+
+/// Byte scans over `Data`'s contiguous storage.
+///
+/// `Data` conforms to `Sequence`, so `reduce` and `contains` walk it through
+/// `Data.Iterator` with a value-witness call per byte. Sampling a running instance
+/// for 300 s attributed roughly one whole core to exactly that path inside
+/// `countLines` — 31% in `Sequence.reduce`, 30% in `Data.Iterator.next`, 22% in
+/// value witnesses — about 72% of everything the process was burning, while
+/// counting lines in untracked files. `memchr` covers the same bytes in one
+/// vectorized pass over contiguous memory.
+extension Data {
+  /// Occurrences of `byte` in the whole buffer.
+  fileprivate nonisolated func countOccurrences(of byte: UInt8) -> Int {
+    withUnsafeBytes { raw -> Int in
+      guard let base = raw.baseAddress, !raw.isEmpty else { return 0 }
+      var count = 0
+      var scanned = 0
+      while scanned < raw.count,
+        let hit = memchr(base + scanned, Int32(byte), raw.count - scanned)
+      {
+        // memchr returns the hit itself, so resume one byte past it.
+        scanned = base.distance(to: UnsafeRawPointer(hit)) + 1
+        count += 1
+      }
+      return count
+    }
+  }
+
+  /// Whether `byte` occurs anywhere in the buffer. Stops at the first hit.
+  fileprivate nonisolated func containsByte(_ byte: UInt8) -> Bool {
+    withUnsafeBytes { raw -> Bool in
+      guard let base = raw.baseAddress, !raw.isEmpty else { return false }
+      return memchr(base, Int32(byte), raw.count) != nil
+    }
+  }
 }

--- a/supacodeTests/GitClientLineChangesTests.swift
+++ b/supacodeTests/GitClientLineChangesTests.swift
@@ -312,6 +312,62 @@ struct GitClientLineChangesTests {
     #expect(count == 2)
   }
 
+  /// The reader works in 64 KiB chunks, so a scan that resumed from the wrong offset
+  /// after a hit — or restarted per chunk — would miscount only once a file is larger
+  /// than one chunk. Every other case in this file fits in a single chunk.
+  @Test func countLinesInFilesCountsAcrossChunkBoundaries() throws {
+    let fileManager = FileManager.default
+    let tempRoot = fileManager.temporaryDirectory.appending(path: UUID().uuidString)
+    defer { try? fileManager.removeItem(at: tempRoot) }
+    try fileManager.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+    // 40_000 lines of "line\n" is ~200 KB, spanning four chunks.
+    let content = String(repeating: "line\n", count: 40_000)
+    try content.write(to: tempRoot.appending(path: "big.txt"), atomically: true, encoding: .utf8)
+
+    #expect(GitClient.countLinesInFiles(["big.txt"], relativeTo: tempRoot) == 40_000)
+  }
+
+  /// A newline landing on the final byte of a chunk is the boundary case: the scan must
+  /// neither drop it nor double-count it against the next chunk's first byte.
+  @Test func countLinesInFilesCountsANewlineOnTheChunkBoundary() throws {
+    let fileManager = FileManager.default
+    let tempRoot = fileManager.temporaryDirectory.appending(path: UUID().uuidString)
+    defer { try? fileManager.removeItem(at: tempRoot) }
+    try fileManager.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+    let chunkByteCount = 64 * 1_024
+    var bytes = Data(repeating: UInt8(ascii: "a"), count: chunkByteCount - 1)
+    bytes.append(0x0A)  // exactly the last byte of chunk one
+    bytes.append(contentsOf: Data("second\n".utf8))
+    try bytes.write(to: tempRoot.appending(path: "boundary.txt"))
+
+    #expect(GitClient.countLinesInFiles(["boundary.txt"], relativeTo: tempRoot) == 2)
+  }
+
+  /// Binary detection probes only the first 8 KiB. A NUL past that window has always
+  /// been counted as text, and the faster scan must not widen the probe by accident.
+  @Test func countLinesInFilesTreatsALateNULAsText() throws {
+    let fileManager = FileManager.default
+    let tempRoot = fileManager.temporaryDirectory.appending(path: UUID().uuidString)
+    defer { try? fileManager.removeItem(at: tempRoot) }
+    try fileManager.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+    var bytes = Data(repeating: UInt8(ascii: "a"), count: 10_000)
+    bytes.append(0x00)  // beyond the 8 KiB probe
+    bytes.append(0x0A)
+    try bytes.write(to: tempRoot.appending(path: "late-nul.txt"))
+
+    #expect(GitClient.countLinesInFiles(["late-nul.txt"], relativeTo: tempRoot) == 1)
+  }
+
+  @Test func countLinesInFilesCountsAnEmptyFileAsZero() throws {
+    let fileManager = FileManager.default
+    let tempRoot = fileManager.temporaryDirectory.appending(path: UUID().uuidString)
+    defer { try? fileManager.removeItem(at: tempRoot) }
+    try fileManager.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+    try Data().write(to: tempRoot.appending(path: "empty.txt"))
+
+    #expect(GitClient.countLinesInFiles(["empty.txt"], relativeTo: tempRoot) == 0)
+  }
+
   private func writeGitIndexHeader(
     version: UInt32 = 2,
     entryCount: UInt32,

--- a/supacodeTests/GitClientLineChangesTests.swift
+++ b/supacodeTests/GitClientLineChangesTests.swift
@@ -301,6 +301,36 @@ struct GitClientLineChangesTests {
     #expect(count == 2)
   }
 
+  /// A capture-sized untracked file must not be read at all. The badge counts
+  /// lines you are adding, and nobody typed 2 MiB of `sample(1)` output.
+  @Test func countLinesInFilesSkipsFilesAtOrAboveTheByteLimit() throws {
+    let fileManager = FileManager.default
+    let tempRoot = fileManager.temporaryDirectory.appending(path: UUID().uuidString)
+    defer { try? fileManager.removeItem(at: tempRoot) }
+    try fileManager.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+    try "a\nb\n".write(to: tempRoot.appending(path: "small.txt"), atomically: true, encoding: .utf8)
+    // Text, not binary: the NUL probe would pass it and count every newline.
+    let oversized = Data(repeating: 0x0A, count: GitClient.untrackedLineCountByteLimit)
+    try oversized.write(to: tempRoot.appending(path: "sample.txt"))
+
+    let count = GitClient.countLinesInFiles(["small.txt", "sample.txt"], relativeTo: tempRoot)
+    #expect(count == 2, "Only the small file should contribute")
+  }
+
+  /// The boundary is the whole point of the guard, so pin the side that must
+  /// still count. One byte under the limit is an ordinary file.
+  @Test func countLinesInFilesStillCountsJustUnderTheByteLimit() throws {
+    let fileManager = FileManager.default
+    let tempRoot = fileManager.temporaryDirectory.appending(path: UUID().uuidString)
+    defer { try? fileManager.removeItem(at: tempRoot) }
+    try fileManager.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+    let justUnder = Data(repeating: 0x0A, count: GitClient.untrackedLineCountByteLimit - 1)
+    try justUnder.write(to: tempRoot.appending(path: "big.txt"))
+
+    let count = GitClient.countLinesInFiles(["big.txt"], relativeTo: tempRoot)
+    #expect(count == GitClient.untrackedLineCountByteLimit - 1)
+  }
+
   @Test func countLinesInFilesSkipsMissingFiles() throws {
     let fileManager = FileManager.default
     let tempRoot = fileManager.temporaryDirectory.appending(path: UUID().uuidString)


### PR DESCRIPTION
Sampling a running instance for 300 seconds put roughly 1 whole core inside `GitClient.countLines`, so this change makes the scan fast for files worth scanning and stops reading the ones that are not.

`countLines` feeds the sidebar diff badge by reading every untracked file end to end. Two things were wrong with it, and they are in the same function.

The scan itself was slow. `Data` conforms to `Sequence`, so `reduce` and `contains` walk it through `Data.Iterator` with a value-witness call for every byte, which comes to 65,536 calls per 64 KiB chunk. That path accounted for about 72% of everything the process burned, spread across 7 dispatch threads. `memchr` covers the same bytes in a single vectorized pass over contiguous memory. On a 66 MB file the time drops from 278.0 ms to 6.2 ms, a factor of 44.6, and both versions count 302,570 newlines.

The scan also ran on files nobody would ever want counted. The only early exit was a binary probe, so a file with no NUL byte in its first 8 KiB was read in full whatever its size. A 35 MB `sample(1)` capture left in a working tree therefore cost 35 MB of reads per refresh to produce a number that helps no one, because the badge reports the lines you are adding and nobody typed a profiling capture. Files at or above 2 MiB are now skipped, with the size read through `resourceValues` before the handle opens, so an oversized file costs a stat instead of a full read. Returning `nil` already means "not worth counting" here, which is how binary files reach the same result, and the call site already coalesces it to zero.

A `.gitignore` pattern was the alternative to the size guard, and it is worse. A pattern has to name the file, so it fixes one repository for one spelling and misses the next capture that lands under a different name.

The eight existing `countLinesInFiles` tests pass without modification. New tests cover what a rewrite could plausibly break and single-chunk cases could not catch:

- a file spanning four chunks
- a newline landing on an exact chunk boundary
- a NUL byte past the 8 KiB binary probe, which should still count as text
- an empty file
- a file at the size limit, which must contribute nothing
- a file one byte under the limit, which must still be counted in full

The last two are mutation-checked. Disabling the guard fails the oversized case and nothing else, and relaxing the comparison from `>=` to `>` fails it as well, which pins the boundary as inclusive.
