### PR TITLE
Stop agent-state churn from re-rendering the whole sidebar

### DIFF
--- a/supacode/Features/ActiveAgents/Models/ActiveAgentEntry.swift
+++ b/supacode/Features/ActiveAgents/Models/ActiveAgentEntry.swift
@@ -24,7 +24,10 @@ struct ActiveAgentEntry: Identifiable, Equatable, Sendable {
   let iconLookupToken: String
   let agent: DetectedAgent
   var session: AgentSession?
-  let rawState: AgentRawState
+  /// Un-stabilized per-poll detection result. Surfaced only by `prowl agents`
+  /// (`raw_state`); no SwiftUI view renders it (they show `displayState`). A
+  /// `var` so `equalsIgnoringRawState` can normalize it for emission dedup.
+  var rawState: AgentRawState
   let displayState: AgentDisplayState
   let lastChangedAt: Date
   /// Profile display name recorded at launch for Prowl-launched surfaces
@@ -33,6 +36,18 @@ struct ActiveAgentEntry: Identifiable, Equatable, Sendable {
   var launchProfileName: String?
   var displayName: String {
     launchProfileName ?? Self.displayName(iconLookupToken: iconLookupToken, agent: agent)
+  }
+
+  /// Equality for emission purposes, excluding `rawState`. `rawState` oscillates
+  /// on every 300 ms poll while an agent animates its spinner; if it gated
+  /// emission, each flicker would push a new entry into `ActiveAgentsFeature`
+  /// state and re-render the whole sidebar for a value no view displays.
+  /// `rawState` still rides along on entries that emit for a visible reason, so
+  /// `prowl agents` reports the raw state as of the last visible change.
+  func equalsIgnoringRawState(_ other: ActiveAgentEntry) -> Bool {
+    var normalized = self
+    normalized.rawState = other.rawState
+    return normalized == other
   }
 
   /// The user-facing agent name: the launch command token (e.g. `omp`) when it

--- a/supacode/Features/Repositories/Views/SidebarActiveAgentsOverlay.swift
+++ b/supacode/Features/Repositories/Views/SidebarActiveAgentsOverlay.swift
@@ -1,0 +1,71 @@
+import ComposableArchitecture
+import Sharing
+import SwiftUI
+
+/// The Active Agents panel plus the `entries → row-display` computation that
+/// feeds it, split out of `SidebarListView`.
+///
+/// `ActiveAgentsFeature.State.entries` is re-emitted whenever an agent's state
+/// changes — frequently while agents work. When the read of `entries` lived in
+/// `SidebarListView.body`, every such change re-ran the entire sidebar body and
+/// recreated every `RepositorySectionView` (measured at ~11 child re-evals per
+/// parent re-eval). Isolating the `entries` read here means an entries change
+/// re-evaluates only this overlay; the repository list is untouched. See
+/// `docs-ai/032-performance-hardening`.
+struct SidebarActiveAgentsOverlay: View {
+  @Bindable var store: StoreOf<RepositoriesFeature>
+  let terminalManager: WorktreeTerminalManager
+  let panelHeight: Double
+  let maximumPanelHeight: Double
+  let panelOffset: Double
+  let isPanelHidden: Bool
+  let sidebarFooterHeight: Double
+  let onHeightChanged: (Double) -> Void
+  let onHeightChangeEnded: (Double) -> Void
+
+  @Environment(\.resolvedKeybindings) private var resolvedKeybindings
+  @Environment(CommandKeyObserver.self) private var commandKeyObserver
+  @Shared(.repositoryAppearances) private var repositoryAppearances
+
+  var body: some View {
+    let state = store.state
+    let metadata = SidebarListView.activeAgentWorktreeMetadata(
+      repositories: state.repositories,
+      customTitles: state.repositoryCustomTitles,
+      repositoryAppearances: repositoryAppearances
+    )
+    let rowDisplays = SidebarListView.activeAgentRowDisplays(
+      entries: state.activeAgents.entries,
+      repositories: state.repositories,
+      metadata: metadata
+    )
+    let selectedSurfaceID = state.selectedWorktreeID.flatMap { worktreeID in
+      terminalManager.stateIfExists(for: worktreeID)?.activeSurfaceID
+    }
+    // Only surface the hint while Cmd is held and the bindings are still at their
+    // defaults; a customized binding makes the merged "⌥⌃↑↓" glyph inaccurate.
+    let shortcutHint =
+      commandKeyObserver.isPressed
+      ? AppShortcuts.activeAgentsNavigationDisplay(in: resolvedKeybindings)
+      : nil
+
+    ActiveAgentsPanel(
+      store: store.scope(state: \.activeAgents, action: \.activeAgents),
+      rowDisplays: rowDisplays,
+      selectedSurfaceID: selectedSurfaceID,
+      navigationShortcutHint: shortcutHint,
+      showTabTitles: state.showActiveAgentTabTitles,
+      height: panelHeight,
+      maximumHeight: maximumPanelHeight,
+      onHeightChanged: onHeightChanged,
+      onHeightChangeEnded: onHeightChangeEnded
+    )
+    .padding(6)
+    .frame(height: panelHeight)
+    .offset(y: panelOffset)
+    .clipped()
+    .padding(.bottom, sidebarFooterHeight)
+    .allowsHitTesting(!isPanelHidden)
+    .animation(.easeOut(duration: 0.18), value: isPanelHidden)
+  }
+}

--- a/supacode/Features/Repositories/Views/SidebarListView.swift
+++ b/supacode/Features/Repositories/Views/SidebarListView.swift
@@ -62,7 +62,6 @@ struct SidebarListView: View {
   @State private var isAddChoicePresented = false
   @Namespace private var topSegmentNamespace
   @Environment(\.resolvedKeybindings) private var resolvedKeybindings
-  @Environment(CommandKeyObserver.self) private var commandKeyObserver
   @Shared(.repositoryAppearances) private var repositoryAppearances
 
   var body: some View {
@@ -72,31 +71,16 @@ struct SidebarListView: View {
     let expandableRepositoryIDs = Self.expandableRepositoryIDs(in: state.repositories)
     let repositoryItems = presentation.items.filter(\.isRepositoryOrderItem)
     let selectedWorktreeIDs = Self.selectedWorktreeIDs(in: state)
-    let selectedSurfaceID = state.selectedWorktreeID.flatMap { worktreeID in
-      terminalManager.stateIfExists(for: worktreeID)?.activeSurfaceID
-    }
-    // Only surface the hint while Cmd is held and the bindings are still at their
-    // defaults; a customized binding makes the merged "⌥⌃↑↓" glyph inaccurate.
-    let activeAgentsShortcutHint =
-      commandKeyObserver.isPressed
-      ? AppShortcuts.activeAgentsNavigationDisplay(in: resolvedKeybindings)
-      : nil
     let pendingSidebarReveal = state.pendingSidebarReveal
 
     let maximumPanelHeight =
       sidebarHeight > 0
       ? ActiveAgentsFeature.maximumPanelHeight(forContainerHeight: sidebarHeight)
       : ActiveAgentsFeature.maximumPanelHeight
-    let agentWorktreeMetadata = Self.activeAgentWorktreeMetadata(
-      repositories: state.repositories,
-      customTitles: state.repositoryCustomTitles,
-      repositoryAppearances: repositoryAppearances
-    )
-    let agentRowDisplays = Self.activeAgentRowDisplays(
-      entries: state.activeAgents.entries,
-      repositories: state.repositories,
-      metadata: agentWorktreeMetadata
-    )
+    // The Active Agents panel and its `entries` read live in
+    // `SidebarActiveAgentsOverlay` so that agent-state churn re-evaluates only
+    // that overlay, not this body and the repository list. This body must not
+    // read `state.activeAgents.entries`.
     let panelHeight = min(resizingPanelHeight ?? state.activeAgents.panelHeight, maximumPanelHeight)
     let panelOffset = state.activeAgents.isPanelHidden ? panelHeight : 0
     let activeAgentsPanelTopGap = 4.0
@@ -171,14 +155,14 @@ struct SidebarListView: View {
         }
       }
       .overlay(alignment: .bottom) {
-        ActiveAgentsPanel(
-          store: store.scope(state: \.activeAgents, action: \.activeAgents),
-          rowDisplays: agentRowDisplays,
-          selectedSurfaceID: selectedSurfaceID,
-          navigationShortcutHint: activeAgentsShortcutHint,
-          showTabTitles: state.showActiveAgentTabTitles,
-          height: panelHeight,
-          maximumHeight: maximumPanelHeight,
+        SidebarActiveAgentsOverlay(
+          store: store,
+          terminalManager: terminalManager,
+          panelHeight: panelHeight,
+          maximumPanelHeight: maximumPanelHeight,
+          panelOffset: panelOffset,
+          isPanelHidden: state.activeAgents.isPanelHidden,
+          sidebarFooterHeight: sidebarFooterHeight,
           onHeightChanged: { height in
             resizingPanelHeight = height
           },
@@ -187,13 +171,6 @@ struct SidebarListView: View {
             store.send(.activeAgents(.panelHeightChanged(height)))
           }
         )
-        .padding(6)
-        .frame(height: panelHeight)
-        .offset(y: panelOffset)
-        .clipped()
-        .padding(.bottom, sidebarFooterHeight)
-        .allowsHitTesting(!state.activeAgents.isPanelHidden)
-        .animation(.easeOut(duration: 0.18), value: state.activeAgents.isPanelHidden)
       }
       .dropDestination(for: URL.self) { urls, _ in
         let fileURLs = urls.filter(\.isFileURL)

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState+AgentDetection.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState+AgentDetection.swift
@@ -281,7 +281,10 @@ extension WorktreeTerminalState {
       onAgentEntryRemoved?(surfaceID)
       return
     }
-    guard entry != lastEmittedAgentEntriesBySurface[surfaceID] else { return }
+    // Dedup ignoring `rawState`: it flickers every poll while an agent animates
+    // and drives no UI, so emitting on it alone would re-render the sidebar
+    // continuously. Visible changes (displayState, title, session, …) still emit.
+    guard lastEmittedAgentEntriesBySurface[surfaceID]?.equalsIgnoringRawState(entry) != true else { return }
     lastEmittedAgentEntriesBySurface[surfaceID] = entry
     onAgentEntryChanged?(entry)
   }

--- a/supacodeTests/AgentEntryEmissionDedupTests.swift
+++ b/supacodeTests/AgentEntryEmissionDedupTests.swift
@@ -67,6 +67,103 @@ struct AgentEntryEmissionDedupTests {
     #expect(removed == [fixture.pane.id])
   }
 
+  /// `equalsIgnoringRawState` normalizes one field and compares the rest through
+  /// the synthesized `==`. Nothing structural stops a later edit from
+  /// normalizing a second field, and the damage would be silent: the helper
+  /// still compiles, every test above still passes, and the only symptom is a
+  /// real change to that field never reaching the sidebar. `emitAgentEntry`
+  /// promises "displayState, title, session, …" still emit, so pin the whole
+  /// promise — one differing field must always be enough to break equality.
+  @Test func everyFieldExceptRawStateBreaksEmissionEquality() {
+    let base = Self.entry()
+    let variants: [(field: String, entry: ActiveAgentEntry)] = [
+      ("id", Self.entry(id: Self.otherID)),
+      ("worktreeID", Self.entry(worktreeID: "/tmp/repo/other")),
+      ("worktreeName", Self.entry(worktreeName: "other")),
+      // Resolves the repository and branch the row displays, so a suppressed
+      // change leaves the sidebar naming the directory the agent has left.
+      ("workingDirectory", Self.entry(workingDirectory: URL(fileURLWithPath: "/tmp/repo/other"))),
+      ("workingDirectory=nil", Self.entry(workingDirectory: nil)),
+      ("tabID", Self.entry(tabID: Self.otherTabID)),
+      ("paneTitle", Self.entry(paneTitle: "other title")),
+      ("surfaceID", Self.entry(surfaceID: Self.otherID)),
+      ("paneIndex", Self.entry(paneIndex: 2)),
+      ("iconLookupToken", Self.entry(iconLookupToken: "codex")),
+      ("agent", Self.entry(agent: .codex)),
+      // Carries the resume target `prowl agents` reports; a suppressed change
+      // would keep pointing at the previous session's transcript.
+      ("session", Self.entry(session: Self.otherSession)),
+      ("session=nil", Self.entry(session: nil)),
+      ("displayState", Self.entry(displayState: .blocked)),
+      ("lastChangedAt", Self.entry(lastChangedAt: Date(timeIntervalSince1970: 5_000))),
+    ]
+
+    for variant in variants {
+      #expect(
+        !base.equalsIgnoringRawState(variant.entry),
+        "A change to \(variant.field) must still emit; normalizing it would hide the change from the sidebar"
+      )
+    }
+
+    // The single field the helper exists to ignore.
+    #expect(base.equalsIgnoringRawState(Self.entry(rawState: .idle)))
+  }
+
+  private static let baseID = UUID(uuidString: "00000000-0000-0000-0000-0000000000A1")!
+  private static let otherID = UUID(uuidString: "00000000-0000-0000-0000-0000000000A2")!
+  /// Fixed rather than freshly generated, so two entries under comparison differ
+  /// only in the field the case is about.
+  private static let baseTabID = TerminalTabID(rawValue: UUID(uuidString: "00000000-0000-0000-0000-0000000000B1")!)
+  private static let otherTabID = TerminalTabID(rawValue: UUID(uuidString: "00000000-0000-0000-0000-0000000000B2")!)
+  private static let baseSession = AgentSession(
+    id: "session-1",
+    transcriptPath: URL(fileURLWithPath: "/tmp/transcripts/session-1.jsonl"),
+    source: .openFile,
+    confidence: .exact
+  )
+  private static let otherSession = AgentSession(
+    id: "session-2",
+    transcriptPath: URL(fileURLWithPath: "/tmp/transcripts/session-2.jsonl"),
+    source: .openFile,
+    confidence: .exact
+  )
+
+  /// Defaults spell out every field so a case can override exactly one and the
+  /// assertion stays about that field alone.
+  private static func entry(
+    id: UUID = baseID,
+    worktreeID: Worktree.ID = "/tmp/repo/worktree",
+    worktreeName: String = "worktree",
+    workingDirectory: URL? = URL(fileURLWithPath: "/tmp/repo/worktree"),
+    tabID: TerminalTabID = baseTabID,
+    paneTitle: String = "spx-h",
+    surfaceID: UUID = baseID,
+    paneIndex: Int = 1,
+    iconLookupToken: String = "claude",
+    agent: DetectedAgent = .claude,
+    session: AgentSession? = baseSession,
+    rawState: AgentRawState = .working,
+    displayState: AgentDisplayState = .working,
+    lastChangedAt: Date = Date(timeIntervalSince1970: 1_000)
+  ) -> ActiveAgentEntry {
+    ActiveAgentEntry(
+      id: id,
+      worktreeID: worktreeID,
+      worktreeName: worktreeName,
+      workingDirectory: workingDirectory,
+      tabID: tabID,
+      paneTitle: paneTitle,
+      surfaceID: surfaceID,
+      paneIndex: paneIndex,
+      iconLookupToken: iconLookupToken,
+      agent: agent,
+      session: session,
+      rawState: rawState,
+      displayState: displayState,
+      lastChangedAt: lastChangedAt
+    )
+  }
+
   private struct Fixture {
     let state: WorktreeTerminalState
     let tabId: TerminalTabID

--- a/supacodeTests/AgentEntryEmissionDedupTests.swift
+++ b/supacodeTests/AgentEntryEmissionDedupTests.swift
@@ -11,25 +11,25 @@ import Testing
 /// changes so that churn never floods the terminal event stream.
 @MainActor
 struct AgentEntryEmissionDedupTests {
-  @Test func identicalEntryIsEmittedOnce() {
+  @Test func rawStateAndBookkeepingChangesDoNotReEmit() {
     let fixture = makeFixture()
     var received: [ActiveAgentEntry] = []
     fixture.state.onAgentEntryChanged = { received.append($0) }
 
-    // Same visible entry, differing only in internal bookkeeping.
+    // Same visible entry; only rawState (fallbackState) and internal bookkeeping
+    // differ across the three emits.
     var paneState = PaneAgentState(detectedAgent: .claude, fallbackState: .working, state: .working)
     fixture.state.emitAgentEntry(surfaceID: fixture.pane.id, tabId: fixture.tabId, state: paneState)
     paneState.sessionMissStreak = 1
     paneState.fallbackState = .idle
     fixture.state.emitAgentEntry(surfaceID: fixture.pane.id, tabId: fixture.tabId, state: paneState)
-
-    // fallbackState is part of the visible entry (CLI raw_state); the streak
-    // alone must not re-emit.
     paneState.sessionMissStreak = 2
     fixture.state.emitAgentEntry(surfaceID: fixture.pane.id, tabId: fixture.tabId, state: paneState)
 
-    #expect(received.count == 2)
-    #expect(received.map(\.rawState) == [.working, .idle])
+    // rawState never renders in the sidebar, so a raw-only flicker must not
+    // re-emit; only the first (visible) entry is forwarded.
+    #expect(received.count == 1)
+    #expect(received.map(\.rawState) == [.working])
   }
 
   @Test func visibleChangeStillEmits() {


### PR DESCRIPTION
Agent state churn re-rendered the whole sidebar about once a second, so this change stops emissions that no view can display and pins the fields that must still emit.

The diagnosis came from an instrumented build driven through the CLI with a working agent over 8 seconds. `SidebarListView.body` re-ran 9 times and recreated every `RepositorySectionView`, giving 99 child re-evaluations, driven by `ActiveAgentsFeature.State.entries` changing about once per second. That churn comes from detection re-emitting an `ActiveAgentEntry` on every `rawState` flicker as an agent animates its spinner. No SwiftUI view renders `rawState`, since views show `displayState` and `rawState` is reported only by the CLI.

Agent entries are now deduplicated ignoring `rawState`, so a raw-only flicker no longer pushes a new entry into state or re-renders anything.

`equalsIgnoringRawState` normalizes one field and compares the rest through the synthesized `==`. Nothing structural stops a later edit from normalizing a second field, and the damage would be silent, since the helper still compiles and the existing dedup tests still pass while a real change to that field never reaches the sidebar. Two fields make that concrete. `session` carries the resume target `prowl agents` reports, and `workingDirectory` resolves the repository and branch the sidebar row displays. Suppressing either leaves the interface describing state the agent has already left.

A test walks all fourteen fields, asserting that each one alone breaks equality, plus the positive case that `rawState` is ignored. It is mutation-checked: normalizing `session`, and separately `workingDirectory`, each fails only this test while the three existing dedup tests pass either way.

One behavior change is deliberate, and it is the `raw_state` question you asked to discuss here.

`prowl agents` now reports `raw_state` as of the last visible change rather than live, which inverts the assertion in `identicalEntryIsEmittedOnce`. That test pins the opposite guarantee today, so it changes in this commit rather than simply continuing to pass.

The three options as I see them:

1. What this PR does. Deduplicate on every field except `raw_state`, so the CLI reports it as of the last visible change. Cheapest, and no view is affected, but a CLI consumer polling `raw_state` can see a value that lags by seconds.
2. Keep emitting whenever `raw_state` changes and remove the churn in the view layer instead. Correct for the CLI, but it leaves a new entry landing in `ActiveAgentsFeature.State` roughly once a second per working agent, which is the invalidation this branch exists to remove.
3. Split the two. Deduplicate the entry that feeds the sidebar, and have `prowl agents` read `raw_state` from `surfaceAgentStates` at request time, where it is always current. More code, and a second path into the same data, but nothing is given up.

I chose 1 because no SwiftUI view renders `raw_state` and the CLI is a point-in-time query, so a stale value looked like the cheapest thing to trade. If you would rather not weaken the CLI contract, 3 is the one I would build. Happy to go whichever way you prefer.
