### PR TITLE
Resolve agent rows through a cached worktree directory index

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@ make bump-version                # Bump version (date-based YYYY.M.DD) and creat
 ```
 
 Run a single test class or method:
+
 ```bash
 xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" \
   -only-testing:supacodeTests/TerminalTabManagerTests \
@@ -28,6 +29,7 @@ xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platf
 ```
 
 **Swift Testing vs XCTest `-only-testing` format**: Swift Testing (`@Test`) requires trailing `()` in the test identifier. Without it, `xcodebuild` silently matches nothing and reports `TEST SUCCEEDED` with zero tests run.
+
 ```bash
 # XCTest (func testFoo)
 -only-testing:supacodeTests/FooTests/testBar
@@ -112,6 +114,14 @@ Reducer ← .terminalEvent(Event) ← AsyncStream<Event>
 - SwiftLint runs in strict mode; never disable lint rules without permission
 - Custom SwiftLint rule: `store_state_mutation_in_views` — do not mutate `store.*` directly in view files; send actions instead
 - Before creating a PR, run `make check`. Use `make format` only for intentional full-tree formatting cleanup.
+- If `make check` fails with `swift-format: command not found`, the Xcode toolchain is not on `PATH`. The Makefile invokes `swift-format` unqualified, and the binary ships inside Xcode rather than in a standard bin directory. Prepend it for the invocation:
+
+  ```bash
+  export PATH="$(dirname "$(xcrun --find swift-format)"):$PATH"
+  make check
+  ```
+
+  `make lint` is unaffected — it already runs SwiftLint through `mise exec`.
 
 ## UX Standards
 

--- a/docs-ai/032-performance-hardening/000-plan.md
+++ b/docs-ai/032-performance-hardening/000-plan.md
@@ -1,13 +1,13 @@
 # 032 — Performance Hardening: Plan
 
-| | |
-| --- | --- |
-| **Status** | Implemented (retrospective) |
-| **Anchor date** | 2026-05-21 |
-| **Documented** | 2026-07-12 (backfilled) |
-| **Primary PRs** | #231, #367, #371, #398 (wave 1); #414, #415, #416, #417 (wave 2, see amendment) |
-| **Sources** | PR descriptions, Sentry App Hang evidence quoted in #231, `docs-ai/017-upstream-sync-process/upstream-ledger.md` (2026-06-09 batch) |
-| **Related** | [020-observability](../020-observability/000-plan.md), [017-upstream-sync-process](../017-upstream-sync-process/000-plan.md), [028-pr-status-tracking](../028-pr-status-tracking/000-plan.md), [030-agent-status-detection](../030-agent-status-detection/000-plan.md) |
+|                 |                                                                                                                                                                                                                                                                        |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Status**      | Implemented (retrospective)                                                                                                                                                                                                                                            |
+| **Anchor date** | 2026-05-21                                                                                                                                                                                                                                                             |
+| **Documented**  | 2026-07-12 (backfilled)                                                                                                                                                                                                                                                |
+| **Primary PRs** | #231, #367, #371, #398 (wave 1); #414, #415, #416, #417 (wave 2, see amendment)                                                                                                                                                                                        |
+| **Sources**     | PR descriptions, Sentry App Hang evidence quoted in #231, `docs-ai/017-upstream-sync-process/upstream-ledger.md` (2026-06-09 batch)                                                                                                                                    |
+| **Related**     | [020-observability](../020-observability/000-plan.md), [017-upstream-sync-process](../017-upstream-sync-process/000-plan.md), [028-pr-status-tracking](../028-pr-status-tracking/000-plan.md), [030-agent-status-detection](../030-agent-status-detection/000-plan.md) |
 
 ## Background
 
@@ -94,3 +94,7 @@ Wave-1 fixes, each independent:
 - Updated 2026-06-08: wave 2 — four upstream-ported performance fixes for agent-hot paths
   (#414–#417, from the 2026-06-09 upstream review batch) — see
   [002-june-upstream-ports.md](002-june-upstream-ports.md)
+- Updated 2026-07-22: wave 3 — the Active Agents row resolution repeated wave 1's
+  `isMainWorktree` failure mode and added blocking filesystem calls to it; replaced with a
+  cached `WorktreeDirectoryIndex` — see
+  [003-sidebar-agent-row-resolution.md](003-sidebar-agent-row-resolution.md)

--- a/docs-ai/032-performance-hardening/003-sidebar-agent-row-resolution.md
+++ b/docs-ai/032-performance-hardening/003-sidebar-agent-row-resolution.md
@@ -1,0 +1,88 @@
+# 032.003 — Sidebar Agent Row Resolution
+
+## Context
+
+Wave 1 of this entry fixed `RepositoriesFeature.State.isMainWorktree(_:)`, where
+`URL.standardizedFileURL` ran `O(repos × worktrees²)` times per sidebar render on the main
+thread (#231). The Active Agents panel later grew its own resolution path with the same
+shape, and it went further by touching the filesystem rather than only decoding strings.
+
+A 10-second `sample(1)` of a running Debug build with 6 Codex sessions and 34 terminal
+surfaces attributed 2253 of 4711 samples — roughly half of all process CPU — to
+`SidebarListView.resolveWorktreeID(forWorkingDirectory:in:)`. The main thread was on-CPU for
+4203 of those samples. `stat` and `__getattrlist` ranked among the top non-blocking leaf
+frames, alongside Foundation's URL path-normalization internals
+(`String._removingDotSegments`, `_hasDotDotComponent`, `_compressingSlashes`).
+
+The reported symptom was twofold: sustained high CPU whenever agents streamed output, and a
+roughly one-second delay between creating a worktree and its row appearing in the sidebar.
+
+## Root cause
+
+`SidebarListView.activeAgentRowDisplays(entries:repositories:metadata:)` called
+`resolveWorktreeID` once per agent row, and each call scanned every worktree of every
+repository. Per candidate pair it invoked `PathPolicy.normalizeURL` three times — twice
+inside `PathPolicy.contains(_:in:)` and once for the depth comparison.
+
+`PathPolicy.normalizeURL` (`supacode/Support/PathPolicy.swift`) performs a
+`FileManager.fileExists` check followed by `resolvingSymlinksInPath()`, which issues one
+`getattrlist` per path component. So every `(row, worktree)` pair cost two blocking
+filesystem round-trips, inside a SwiftUI `body` getter that re-runs on every agent output
+tick.
+
+The worktree-creation lag had the same origin rather than a slow `wt` subprocess.
+`insertWorktree` mutates `state.repositories` synchronously
+(`supacode/Features/Repositories/Reducer/RepositoriesFeature+WorktreeState.swift`), and the
+same reducer case also fires `.reloadRepositories(animated:)`
+(`supacode/Features/Repositories/Reducer/RepositoriesFeature+WorktreeCreation.swift`). Both
+invalidations forced a full rescan before the sidebar could paint, and the new worktree
+permanently lengthened the inner loop.
+
+## Change
+
+`supacode/Domain/WorktreeDirectoryIndex.swift` introduces two types:
+
+- `WorktreeDirectoryIndex` normalizes each candidate directory once into a dictionary keyed
+  by joined path components. A lookup normalizes the queried directory once, then walks it
+  upward one component at a time and returns the first hit, so the deepest containing
+  directory still wins. Keys compare whole components rather than raw string prefixes, which
+  keeps `/tmp/repo` from matching a sibling `/tmp/repo2`.
+- `WorktreeDirectoryIndexCache` memoizes the index against the `(id, directory)` pairs it was
+  built from. Render passes that change only branch names, colors, or icons reuse it.
+
+`SidebarListView.activeAgentRowDisplays` now resolves the index once for the whole batch.
+`resolveWorktreeID` is kept as the public entry point and delegates to the cache.
+
+Per sidebar render the cost drops from `agents × worktrees × 3` calls to `normalizeURL` — two
+filesystem round-trips each — to zero filesystem calls while the repository set is unchanged,
+and `worktrees + 1` on the render after it changes.
+
+Resolution semantics are unchanged, including the pre-existing asymmetry where a
+non-existent path skips symlink resolution while an existing one does not. The 13 sidebar
+tests in `supacodeTests/RepositorySectionViewTests.swift` pass unmodified.
+
+## Refs
+
+Commit `ddb203e6` on branch `perf/sidebar-worktree-resolution`. PR pending — the branch was
+held for local verification before opening one.
+
+## Current state
+
+`supacode/Domain/WorktreeDirectoryIndex.swift` owns the resolution. Eight tests in
+`supacodeTests/WorktreeDirectoryIndexTests.swift` cover nested resolution, deepest-match
+preference, the sibling-prefix trap, plain-folder repositories, unmatched paths, the empty
+index, `..` normalization, and both cache paths.
+
+`make build-app` reported 0 errors and 0 warnings, `make test` reported 1943 passing tests
+and 0 failures, and `make check` (swift-format strict lint plus SwiftLint) was clean.
+
+The measured CPU reduction on a live instance is unverified: confirming it requires restarting
+Prowl, which was deferred to avoid interrupting running agent sessions.
+
+## Recurrence note
+
+This is the third instance in this entry of the same failure mode: path normalization
+performed per-item inside a sidebar render pass. `standardizedFileURL` and
+`resolvingSymlinksInPath()` are not cheap accessors — the latter is a syscall per path
+component. New sidebar-render code should resolve paths through a precomputed index rather
+than normalizing inside a loop.

--- a/docs-ai/032-performance-hardening/003-sidebar-agent-row-resolution.md
+++ b/docs-ai/032-performance-hardening/003-sidebar-agent-row-resolution.md
@@ -76,8 +76,21 @@ index, `..` normalization, and both cache paths.
 `make build-app` reported 0 errors and 0 warnings, `make test` reported 1943 passing tests
 and 0 failures, and `make check` (swift-format strict lint plus SwiftLint) was clean.
 
-The measured CPU reduction on a live instance is unverified: confirming it requires restarting
-Prowl, which was deferred to avoid interrupting running agent sessions.
+The reduction was measured on a live instance after swapping in the fixed build. Two 10-second
+`sample(1)` runs, before and after, on comparable workloads:
+
+| Main-thread measure           |     Before |      After |
+| ----------------------------- | ---------: | ---------: |
+| `resolveWorktreeID` samples   | 2253 (48%) | 0 (absent) |
+| `SidebarListView.body`        | 2382 (51%) | 183 (2.4%) |
+| `GraphHost.flushTransactions` | 3774 (80%) | 1530 (20%) |
+| Idle in `mach_msg2_trap`      |       ~11% |        53% |
+
+Process CPU fell from 94–134% to 29–70%. The workloads were not identical — 34 surfaces and 6
+sessions before versus 23 surfaces and 8 sessions after — so the percentages are indicative
+rather than a controlled comparison; the disappearance of `resolveWorktreeID` from the profile
+is not. The only residual frames are 24 samples (0.3%) in `WorktreeDirectoryIndex.worktreeID`,
+which is the by-design single normalization of the queried directory per lookup.
 
 ## Recurrence note
 

--- a/supacode/Domain/WorktreeDirectoryIndex.swift
+++ b/supacode/Domain/WorktreeDirectoryIndex.swift
@@ -1,0 +1,111 @@
+import Foundation
+import IdentifiedCollections
+
+/// Maps a directory an agent runs in to the deepest repository or worktree that contains it.
+///
+/// Normalizing a path to its canonical form touches the filesystem (a `stat` plus a symlink walk
+/// per path component), so every candidate directory is normalized once when the index is built and
+/// never again per lookup. A lookup then costs one normalization of the queried directory plus a
+/// handful of dictionary probes, instead of re-scanning and re-normalizing every worktree.
+nonisolated struct WorktreeDirectoryIndex: Equatable {
+  /// Keyed by normalized path components joined back together, so a probe compares whole components
+  /// rather than raw string prefixes — `/tmp/repo` must not match a sibling `/tmp/repo2`.
+  private var idsByNormalizedPath: [String: Worktree.ID] = [:]
+  private var deepestComponentCount = 0
+
+  init() {}
+
+  init(repositories: some Sequence<Repository>) {
+    for repository in repositories {
+      if repository.capabilities.supportsRunnableFolderActions,
+        !repository.capabilities.supportsWorktrees
+      {
+        insert(id: repository.id, directory: repository.rootURL)
+      }
+      for worktree in repository.worktrees {
+        insert(id: worktree.id, directory: worktree.workingDirectory)
+      }
+    }
+  }
+
+  private mutating func insert(id: Worktree.ID, directory: URL) {
+    let components = PathPolicy.normalizeURL(directory).pathComponents
+    let key = Self.key(for: components)
+    // The first entry registered for a directory wins. This preserves the previous behavior when a
+    // plain-folder repository root and its main worktree resolve to the same path.
+    guard idsByNormalizedPath[key] == nil else { return }
+    idsByNormalizedPath[key] = id
+    deepestComponentCount = max(deepestComponentCount, components.count)
+  }
+
+  /// Finds the most specific indexed directory containing `workingDirectory`. The walk starts at the
+  /// full path and shortens one component at a time, so the deepest match is the first hit.
+  func worktreeID(forWorkingDirectory workingDirectory: URL) -> Worktree.ID? {
+    guard !idsByNormalizedPath.isEmpty else { return nil }
+    var components = PathPolicy.normalizeURL(workingDirectory).pathComponents
+    // No indexed directory is deeper than this, so longer prefixes cannot match.
+    if components.count > deepestComponentCount {
+      components.removeLast(components.count - deepestComponentCount)
+    }
+    while !components.isEmpty {
+      if let id = idsByNormalizedPath[Self.key(for: components)] {
+        return id
+      }
+      components.removeLast()
+    }
+    return nil
+  }
+
+  private static func key(for components: [String]) -> String {
+    components.joined(separator: "/")
+  }
+}
+
+/// Memoizes the index across SwiftUI render passes.
+///
+/// `SidebarListView.body` re-runs on every agent output tick, and rebuilding the index each time
+/// would put one filesystem round-trip per worktree back on the main thread. The index is a pure
+/// function of the repository set, so a cached copy stays valid until that set changes.
+@MainActor
+enum WorktreeDirectoryIndexCache {
+  private static var cachedSignature: [Entry] = []
+  private static var cachedIndex = WorktreeDirectoryIndex()
+
+  private struct Entry: Equatable {
+    let id: Worktree.ID
+    let directory: URL
+  }
+
+  static func index(for repositories: IdentifiedArrayOf<Repository>) -> WorktreeDirectoryIndex {
+    let signature = signature(for: repositories)
+    guard signature == cachedSignature else {
+      cachedSignature = signature
+      cachedIndex = WorktreeDirectoryIndex(repositories: repositories)
+      return cachedIndex
+    }
+    return cachedIndex
+  }
+
+  /// The id/directory pairs the index is built from, in build order. Comparing these avoids
+  /// rebuilding when an unrelated part of a repository changes (a branch rename, a color, an icon).
+  private static func signature(for repositories: IdentifiedArrayOf<Repository>) -> [Entry] {
+    var entries: [Entry] = []
+    for repository in repositories {
+      if repository.capabilities.supportsRunnableFolderActions,
+        !repository.capabilities.supportsWorktrees
+      {
+        entries.append(Entry(id: repository.id, directory: repository.rootURL))
+      }
+      for worktree in repository.worktrees {
+        entries.append(Entry(id: worktree.id, directory: worktree.workingDirectory))
+      }
+    }
+    return entries
+  }
+
+  /// Drops the memo so a test starts from a known state.
+  static func reset() {
+    cachedSignature = []
+    cachedIndex = WorktreeDirectoryIndex()
+  }
+}

--- a/supacode/Features/Repositories/Views/SidebarListView.swift
+++ b/supacode/Features/Repositories/Views/SidebarListView.swift
@@ -609,12 +609,16 @@ struct SidebarListView: View {
     repositories: IdentifiedArrayOf<Repository>,
     metadata: ActiveAgentWorktreeMetadata
   ) -> [ActiveAgentEntry.ID: ActiveAgentRowDisplay] {
+    // Built (or reused) once for the whole batch: resolving each row against every worktree
+    // individually put a filesystem round-trip per row/worktree pair on the main thread.
+    let directoryIndex = WorktreeDirectoryIndexCache.index(for: repositories)
     var displays: [ActiveAgentEntry.ID: ActiveAgentRowDisplay] = [:]
     for entry in entries {
       displays[entry.id] = activeAgentRowDisplay(
         for: entry,
         repositories: repositories,
-        metadata: metadata
+        metadata: metadata,
+        directoryIndex: directoryIndex
       )
     }
     return displays
@@ -626,13 +630,17 @@ struct SidebarListView: View {
   /// 2. `workingDirectory` is known but outside every repo → derive a name from its last path
   ///    component (same logic as adding a repository).
   /// 3. `workingDirectory` is unknown → fall back to the surface's owning worktree (legacy behavior).
+  /// `directoryIndex` is supplied by `activeAgentRowDisplays` so a batch shares one index; passing
+  /// `nil` builds a throwaway one for a single lookup.
   static func activeAgentRowDisplay(
     for entry: ActiveAgentEntry,
     repositories: IdentifiedArrayOf<Repository>,
-    metadata: ActiveAgentWorktreeMetadata
+    metadata: ActiveAgentWorktreeMetadata,
+    directoryIndex: WorktreeDirectoryIndex? = nil
   ) -> ActiveAgentRowDisplay {
     if let workingDirectory = entry.workingDirectory {
-      if let key = resolveWorktreeID(forWorkingDirectory: workingDirectory, in: repositories) {
+      let index = directoryIndex ?? WorktreeDirectoryIndex(repositories: repositories)
+      if let key = index.worktreeID(forWorkingDirectory: workingDirectory) {
         let fallbackName = workingDirectory.lastPathComponent
         return ActiveAgentRowDisplay(
           repositoryName: metadata.repositoryNamesByWorktreeID[key] ?? fallbackName,
@@ -665,24 +673,8 @@ struct SidebarListView: View {
     forWorkingDirectory workingDirectory: URL,
     in repositories: IdentifiedArrayOf<Repository>
   ) -> Worktree.ID? {
-    var best: (id: Worktree.ID, depth: Int)?
-    func consider(id: Worktree.ID, directory: URL) {
-      guard PathPolicy.contains(workingDirectory, in: directory) else { return }
-      let depth = PathPolicy.normalizeURL(directory).pathComponents.count
-      if let current = best, current.depth >= depth { return }
-      best = (id, depth)
-    }
-    for repository in repositories {
-      if repository.capabilities.supportsRunnableFolderActions,
-        !repository.capabilities.supportsWorktrees
-      {
-        consider(id: repository.id, directory: repository.rootURL)
-      }
-      for worktree in repository.worktrees {
-        consider(id: worktree.id, directory: worktree.workingDirectory)
-      }
-    }
-    return best?.id
+    WorktreeDirectoryIndexCache.index(for: repositories)
+      .worktreeID(forWorkingDirectory: workingDirectory)
   }
 
   /// Directory of the surface's owning worktree, used when the agent hasn't

--- a/supacodeTests/WorktreeDirectoryIndexTests.swift
+++ b/supacodeTests/WorktreeDirectoryIndexTests.swift
@@ -1,0 +1,144 @@
+import Foundation
+import IdentifiedCollections
+import Testing
+
+@testable import supacode
+
+@MainActor
+struct WorktreeDirectoryIndexTests {
+  @Test func resolvesNestedDirectoryToItsEnclosingWorktree() {
+    let worktree = makeWorktree(repoRoot: "/tmp/repo", path: "/tmp/repo", branch: "main")
+    let index = WorktreeDirectoryIndex(repositories: [makeRepository(id: "/tmp/repo", worktrees: [worktree])])
+
+    #expect(
+      index.worktreeID(forWorkingDirectory: URL(fileURLWithPath: "/tmp/repo/src/lib")) == worktree.id
+    )
+  }
+
+  @Test func prefersTheDeepestContainingWorktree() {
+    let mainWorktree = makeWorktree(repoRoot: "/tmp/repo", path: "/tmp/repo", branch: "main")
+    let nestedWorktree = makeWorktree(
+      repoRoot: "/tmp/repo",
+      path: "/tmp/repo/worktrees/feature",
+      branch: "feature"
+    )
+    let index = WorktreeDirectoryIndex(
+      repositories: [makeRepository(id: "/tmp/repo", worktrees: [mainWorktree, nestedWorktree])]
+    )
+
+    #expect(
+      index.worktreeID(forWorkingDirectory: URL(fileURLWithPath: "/tmp/repo/worktrees/feature/lib"))
+        == nestedWorktree.id
+    )
+    #expect(
+      index.worktreeID(forWorkingDirectory: URL(fileURLWithPath: "/tmp/repo/src")) == mainWorktree.id
+    )
+  }
+
+  /// A sibling whose name merely starts with an indexed directory's name must not match. This is why
+  /// the index compares whole path components rather than raw string prefixes.
+  @Test func doesNotMatchSiblingDirectoryWithSharedNamePrefix() {
+    let worktree = makeWorktree(repoRoot: "/tmp/repo", path: "/tmp/repo", branch: "main")
+    let index = WorktreeDirectoryIndex(repositories: [makeRepository(id: "/tmp/repo", worktrees: [worktree])])
+
+    #expect(index.worktreeID(forWorkingDirectory: URL(fileURLWithPath: "/tmp/repo2/src")) == nil)
+    #expect(index.worktreeID(forWorkingDirectory: URL(fileURLWithPath: "/tmp/repo-backup")) == nil)
+  }
+
+  @Test func resolvesPlainFolderRepositoryByItsRootURL() {
+    let repository = makeRepository(id: "/tmp/notes", kind: .plain, worktrees: [])
+    let index = WorktreeDirectoryIndex(repositories: [repository])
+
+    #expect(
+      index.worktreeID(forWorkingDirectory: URL(fileURLWithPath: "/tmp/notes/inbox")) == repository.id
+    )
+  }
+
+  @Test func returnsNilForDirectoryOutsideEveryRepository() {
+    let worktree = makeWorktree(repoRoot: "/tmp/repo", path: "/tmp/repo", branch: "main")
+    let index = WorktreeDirectoryIndex(repositories: [makeRepository(id: "/tmp/repo", worktrees: [worktree])])
+
+    #expect(index.worktreeID(forWorkingDirectory: URL(fileURLWithPath: "/tmp/scratch")) == nil)
+  }
+
+  @Test func emptyIndexResolvesNothing() {
+    let index = WorktreeDirectoryIndex()
+
+    #expect(index.worktreeID(forWorkingDirectory: URL(fileURLWithPath: "/tmp/repo")) == nil)
+  }
+
+  /// Trailing slashes and `.` / `..` segments must normalize to the same lookup.
+  @Test func normalizesRelativeSegmentsBeforeMatching() {
+    let worktree = makeWorktree(repoRoot: "/tmp/repo", path: "/tmp/repo", branch: "main")
+    let index = WorktreeDirectoryIndex(repositories: [makeRepository(id: "/tmp/repo", worktrees: [worktree])])
+
+    #expect(
+      index.worktreeID(forWorkingDirectory: URL(fileURLWithPath: "/tmp/repo/src/../lib")) == worktree.id
+    )
+  }
+
+  // MARK: - Cache
+
+  @Test func cacheRebuildsWhenAWorktreeIsAdded() {
+    WorktreeDirectoryIndexCache.reset()
+    let mainWorktree = makeWorktree(repoRoot: "/tmp/repo", path: "/tmp/repo", branch: "main")
+    let before: IdentifiedArrayOf<Repository> = [makeRepository(id: "/tmp/repo", worktrees: [mainWorktree])]
+    #expect(
+      WorktreeDirectoryIndexCache.index(for: before)
+        .worktreeID(forWorkingDirectory: URL(fileURLWithPath: "/tmp/repo/worktrees/feature/lib"))
+        == mainWorktree.id
+    )
+
+    let nestedWorktree = makeWorktree(
+      repoRoot: "/tmp/repo",
+      path: "/tmp/repo/worktrees/feature",
+      branch: "feature"
+    )
+    let after: IdentifiedArrayOf<Repository> = [
+      makeRepository(id: "/tmp/repo", worktrees: [mainWorktree, nestedWorktree])
+    ]
+
+    #expect(
+      WorktreeDirectoryIndexCache.index(for: after)
+        .worktreeID(forWorkingDirectory: URL(fileURLWithPath: "/tmp/repo/worktrees/feature/lib"))
+        == nestedWorktree.id
+    )
+  }
+
+  /// A branch rename changes the worktree's name but not its directory, so the memo stays valid.
+  @Test func cacheReturnsAnEquivalentIndexWhenOnlyBranchNamesChange() {
+    WorktreeDirectoryIndexCache.reset()
+    let original = makeWorktree(repoRoot: "/tmp/repo", path: "/tmp/repo", branch: "main")
+    let renamed = makeWorktree(repoRoot: "/tmp/repo", path: "/tmp/repo", branch: "trunk")
+    let first = WorktreeDirectoryIndexCache.index(for: [makeRepository(id: "/tmp/repo", worktrees: [original])])
+    let second = WorktreeDirectoryIndexCache.index(for: [makeRepository(id: "/tmp/repo", worktrees: [renamed])])
+
+    #expect(first == second)
+  }
+
+  // MARK: - Helpers
+
+  private func makeWorktree(repoRoot: String, path: String, branch: String) -> Worktree {
+    Worktree(
+      id: path,
+      name: branch,
+      detail: branch,
+      workingDirectory: URL(fileURLWithPath: path),
+      repositoryRootURL: URL(fileURLWithPath: repoRoot)
+    )
+  }
+
+  private func makeRepository(
+    id: String,
+    kind: Repository.Kind = .git,
+    worktrees: IdentifiedArrayOf<Worktree>
+  ) -> Repository {
+    Repository(
+      id: id,
+      rootURL: URL(fileURLWithPath: id),
+      name: URL(fileURLWithPath: id).lastPathComponent,
+      kind: kind,
+      worktrees: worktrees
+    )
+  }
+}


### PR DESCRIPTION
The sidebar spent roughly half the app's CPU working out which worktree each agent row belonged to, so this change replaces the per-row scan with an index and returns that time to the rest of the app.

A 10-second sample of a running instance with 6 agents and 34 terminal surfaces put 2,253 of 4,711 samples in `SidebarListView.resolveWorktreeID`, with `stat` and `getattrlist` among the top leaf frames. The cost was structural. `activeAgentRowDisplays` called `resolveWorktreeID` for every agent row, and each call scanned every repository worktree while invoking `resolvingSymlinksInPath`, which costs a syscall per path component.

Measured again on a live instance after the fix, `resolveWorktreeID` is absent from the profile and `SidebarListView.body` fell from 51 percent to 2.4 percent of main-thread samples.

The design, the sampling evidence, and a recurrence note for future sidebar-render code are recorded in `docs-ai/032-performance-hardening/003-sidebar-agent-row-resolution.md`. `AGENTS.md` gains a note that `make check` fails with `swift-format: command not found` when the Xcode toolchain is not on `PATH`, along with the `xcrun --find` one-liner that resolves it.
