### PR TITLE
Stop animated tab titles from rebuilding the whole tab bar

### DIFF
--- a/supacode/Features/Terminal/Models/TerminalTabManager.swift
+++ b/supacode/Features/Terminal/Models/TerminalTabManager.swift
@@ -6,12 +6,34 @@ import Observation
 final class TerminalTabManager {
   var tabs: [TerminalTabItem] = [] {
     didSet {
+      // Only when tabs actually went away: this fires on every title write too,
+      // and the prune is O(n) where the guard is O(1).
+      if tabs.count < oldValue.count {
+        pruneTitleCoalescingState()
+      }
       guard let editingTabID, !tabs.contains(where: { $0.id == editingTabID }) else { return }
       self.editingTabID = nil
     }
   }
   var selectedTabId: TerminalTabID?
   private(set) var editingTabID: TerminalTabID?
+
+  /// Shortest gap between two live title writes for one tab.
+  ///
+  /// An agent TUI animates a spinner glyph inside its terminal title at roughly
+  /// 10 Hz. `tabs` is observed as a whole, so one tab's frame invalidates every
+  /// view reading the array — the tab bar then rebuilds every tab and AppKit
+  /// re-lays the window's view tree. Sampling a spike measured that at 47% of a
+  /// core in `flushTransactions` plus 32% in the CoreAnimation commit, against
+  /// 2% for agent detection.
+  static let liveTitleCoalescingInterval: TimeInterval = 1
+
+  /// Bookkeeping only — a write here must never invalidate the tab bar, which is
+  /// the whole point of the coalescing.
+  @ObservationIgnored private var lastLiveTitleWriteAt: [TerminalTabID: Date] = [:]
+  /// The most recent title held back by coalescing. A spinner that stops leaves
+  /// no further change to carry it, so `flushPendingTitles` lands it instead.
+  @ObservationIgnored private var pendingLiveTitles: [TerminalTabID: String] = [:]
 
   /// Creates a tab next to the current selection. With `select: false` the
   /// selection is left untouched (background creation, e.g. a headless handoff
@@ -45,15 +67,68 @@ final class TerminalTabManager {
   /// `displayTitle` actually changed (a custom title masks live updates),
   /// so callers can refresh derived UI like the Active Agents subtitle.
   @discardableResult
-  func updateTitle(_ id: TerminalTabID, title: String) -> Bool {
+  func updateTitle(_ id: TerminalTabID, title: String, now: Date = Date()) -> Bool {
     guard let index = tabs.firstIndex(where: { $0.id == id }) else { return false }
     guard !tabs[index].isTitleLocked else { return false }
     // A TUI re-emits the same title constantly; skip the no-op write so it
     // doesn't invalidate the tab bar while an agent streams output.
     guard tabs[index].title != title else { return false }
+    // A changed title arriving inside the interval is almost always the next
+    // frame of an animation. Hold it rather than rebuilding the tab bar for it;
+    // the newest one wins, so nothing queues up.
+    if let lastWriteAt = lastLiveTitleWriteAt[id],
+      now.timeIntervalSince(lastWriteAt) < Self.liveTitleCoalescingInterval
+    {
+      pendingLiveTitles[id] = title
+      return false
+    }
+    return writeLiveTitle(title, toTabAt: index, id: id, now: now)
+  }
+
+  /// Lands any held-back title whose interval has elapsed. Returns the tabs whose
+  /// visible `displayTitle` moved, so callers can refresh derived UI exactly as
+  /// they would after `updateTitle`.
+  ///
+  /// Driven by the agent-detection poll rather than a timer: the only way a
+  /// pending title is left stranded is that the writes stopped, and the poll is
+  /// already running for precisely the panes that animate.
+  @discardableResult
+  func flushPendingTitles(now: Date = Date()) -> [TerminalTabID] {
+    guard !pendingLiveTitles.isEmpty else { return [] }
+    var changed: [TerminalTabID] = []
+    for (id, title) in pendingLiveTitles {
+      guard let lastWriteAt = lastLiveTitleWriteAt[id],
+        now.timeIntervalSince(lastWriteAt) >= Self.liveTitleCoalescingInterval
+      else { continue }
+      pendingLiveTitles.removeValue(forKey: id)
+      guard let index = tabs.firstIndex(where: { $0.id == id }),
+        !tabs[index].isTitleLocked,
+        tabs[index].title != title
+      else { continue }
+      if writeLiveTitle(title, toTabAt: index, id: id, now: now) {
+        changed.append(id)
+      }
+    }
+    return changed
+  }
+
+  private func writeLiveTitle(
+    _ title: String,
+    toTabAt index: Int,
+    id: TerminalTabID,
+    now: Date
+  ) -> Bool {
+    pendingLiveTitles.removeValue(forKey: id)
+    lastLiveTitleWriteAt[id] = now
     let previousDisplayTitle = tabs[index].displayTitle
     tabs[index].title = title
     return tabs[index].displayTitle != previousDisplayTitle
+  }
+
+  private func pruneTitleCoalescingState() {
+    let liveIDs = Set(tabs.map(\.id))
+    lastLiveTitleWriteAt = lastLiveTitleWriteAt.filter { liveIDs.contains($0.key) }
+    pendingLiveTitles = pendingLiveTitles.filter { liveIDs.contains($0.key) }
   }
 
   /// Sets (or clears, when blank) the user-defined title. Returns `true` when

--- a/supacode/Features/Terminal/Models/TerminalTabManager.swift
+++ b/supacode/Features/Terminal/Models/TerminalTabManager.swift
@@ -131,6 +131,18 @@ final class TerminalTabManager {
     pendingLiveTitles = pendingLiveTitles.filter { liveIDs.contains($0.key) }
   }
 
+  /// Every tab the coalescing bookkeeping still holds an entry for.
+  ///
+  /// The dictionaries are private so a title write is only ever observable through
+  /// `tabs`, which is what keeps them from invalidating the tab bar. That also hides
+  /// whether closing a tab pruned them: `flushPendingTitles` skips an absent tab on
+  /// its own existence guard, so it returns the same empty result either way. Without
+  /// this seam a test cannot tell a working prune from a leak that grows with every
+  /// tab ever closed.
+  var coalescedTabIDsForTesting: Set<TerminalTabID> {
+    Set(lastLiveTitleWriteAt.keys).union(pendingLiveTitles.keys)
+  }
+
   /// Sets (or clears, when blank) the user-defined title. Returns `true` when
   /// the visible `displayTitle` actually changed.
   @discardableResult

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState+AgentDetection.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState+AgentDetection.swift
@@ -26,6 +26,11 @@ extension WorktreeTerminalState {
         guard let self, let view, self.surfaces[view.id] != nil else { return }
         let hasAgent = await self.detectAgentState(for: view, tabId: tabId)
         let now = Date()
+        // Lands the last frame of a spinner that stopped animating. Cheap when
+        // nothing is pending, which is the common case.
+        for flushedTabID in self.tabManager.flushPendingTitles(now: now) {
+          self.refreshAgentEntriesForTitleChange(in: flushedTabID)
+        }
         let schedule = self.agentDetectionSchedules[view.id] ?? .cold
         self.agentDetectionSchedules[view.id] =
           hasAgent ? schedule.observedAgent(now: now) : schedule.observedNoAgent(now: now)

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState+AgentDetection.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState+AgentDetection.swift
@@ -26,11 +26,7 @@ extension WorktreeTerminalState {
         guard let self, let view, self.surfaces[view.id] != nil else { return }
         let hasAgent = await self.detectAgentState(for: view, tabId: tabId)
         let now = Date()
-        // Lands the last frame of a spinner that stopped animating. Cheap when
-        // nothing is pending, which is the common case.
-        for flushedTabID in self.tabManager.flushPendingTitles(now: now) {
-          self.refreshAgentEntriesForTitleChange(in: flushedTabID)
-        }
+        self.flushCoalescedTabTitles(now: now)
         let schedule = self.agentDetectionSchedules[view.id] ?? .cold
         self.agentDetectionSchedules[view.id] =
           hasAgent ? schedule.observedAgent(now: now) : schedule.observedNoAgent(now: now)
@@ -268,6 +264,23 @@ extension WorktreeTerminalState {
     for surfaceID in surfaceIDs {
       refreshAgentEntryForTitleChange(surfaceID: surfaceID, in: tabId)
     }
+  }
+
+  /// Lands tab titles held back by coalescing and refreshes the Active Agents
+  /// entries that follow them — the same refresh a title written directly through
+  /// `updateTitle` triggers, so the two paths cannot drift.
+  ///
+  /// Driven by the detection poll: a spinner that stops animating leaves no further
+  /// title change to carry its last frame, and the poll is already running for
+  /// exactly the panes that animate. Split out of that `Task` loop because the loop
+  /// offers no synchronous seam a test can drive.
+  @discardableResult
+  func flushCoalescedTabTitles(now: Date = Date()) -> [TerminalTabID] {
+    let flushed = tabManager.flushPendingTitles(now: now)
+    for tabID in flushed {
+      refreshAgentEntriesForTitleChange(in: tabID)
+    }
+    return flushed
   }
 
   /// Single-pane variant for a surface whose own title changed without moving

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabsRowView.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabsRowView.swift
@@ -21,10 +21,16 @@ struct TerminalTabsRowView: View {
   @State private var rowFrame: CGRect = .zero
 
   var body: some View {
+    // Read `tabs` once and index it: the lookup below runs inside a `ForEach`
+    // over the same collection, so scanning it per row made each rebuild
+    // quadratic — and a rebuild happens whenever any one tab's title changes.
+    let tabs = manager.tabs
+    let tabsByID = Dictionary(tabs.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
+
     ZStack(alignment: .topLeading) {
       HStack(alignment: .center, spacing: TerminalTabBarMetrics.tabSpacing) {
         ForEach(Array(openedTabs.enumerated()), id: \.element) { index, id in
-          if let item = manager.tabs.first(where: { $0.id == id }) {
+          if let item = tabsByID[id] {
             TerminalTabView(
               tab: item,
               isActive: manager.selectedTabId == id,
@@ -65,7 +71,7 @@ struct TerminalTabsRowView: View {
             .simultaneousGesture(makeTabDragGesture(id: id))
             .terminalTabContextMenu(
               tabId: id,
-              tabs: manager.tabs,
+              tabs: tabs,
               actions: TerminalTabContextMenuActions(
                 renameTab: renameTab,
                 changeIcon: changeIcon,

--- a/supacodeTests/TabTitleFlushRefreshTests.swift
+++ b/supacodeTests/TabTitleFlushRefreshTests.swift
@@ -1,0 +1,99 @@
+import AppKit
+import Foundation
+import GhosttyKit
+import Testing
+
+@testable import supacode
+
+/// A tab title held back by coalescing must refresh the Active Agents subtitle the
+/// same way a title written straight through `updateTitle` does. Those are two
+/// separate call sites into `refreshAgentEntriesForTitleChange`, and nothing but a
+/// test keeps them from drifting — the withheld title is invisible until the flush
+/// lands it, so a flush that forgot to refresh would show a stale subtitle
+/// indefinitely rather than for one poll.
+@MainActor
+struct TabTitleFlushRefreshTests {
+  private let start = Date(timeIntervalSince1970: 1_000)
+
+  @Test func flushingAWithheldTitleRefreshesTheAgentEntry() {
+    let fixture = makeFixture()
+    var received: [ActiveAgentEntry] = []
+    fixture.state.onAgentEntryChanged = { received.append($0) }
+
+    #expect(fixture.state.tabManager.updateTitle(fixture.tabId, title: "⠋ building", now: start))
+    received.removeAll()
+
+    // Inside the interval, so the tab bar never sees it and no refresh fires yet.
+    #expect(
+      fixture.state.tabManager.updateTitle(
+        fixture.tabId, title: "⠙ building", now: start.addingTimeInterval(0.2)) == false
+    )
+    #expect(received.isEmpty, "A withheld title must not reach the entry either")
+
+    let flushed = fixture.state.flushCoalescedTabTitles(now: start.addingTimeInterval(1.5))
+
+    #expect(flushed == [fixture.tabId])
+    #expect(received.count == 1, "The flush must refresh the entry, not just the tab")
+    #expect(received.last?.paneTitle == "⠙ building")
+  }
+
+  /// The flush is called on every detection tick, so the common case — nothing held
+  /// back — must not emit. Otherwise the coalescing would trade one source of entry
+  /// churn for another.
+  @Test func flushingWithNothingWithheldEmitsNothing() {
+    let fixture = makeFixture()
+    _ = fixture.state.tabManager.updateTitle(fixture.tabId, title: "⠋ building", now: start)
+    var received: [ActiveAgentEntry] = []
+    fixture.state.onAgentEntryChanged = { received.append($0) }
+
+    #expect(fixture.state.flushCoalescedTabTitles(now: start.addingTimeInterval(5)).isEmpty)
+    #expect(received.isEmpty)
+  }
+
+  /// A flush inside the interval must leave the title held, so the one-second spacing
+  /// is not quietly bypassed by the poll running more often than that.
+  @Test func aFlushInsideTheIntervalHoldsTheTitle() {
+    let fixture = makeFixture()
+    _ = fixture.state.tabManager.updateTitle(fixture.tabId, title: "⠋ building", now: start)
+    _ = fixture.state.tabManager.updateTitle(fixture.tabId, title: "⠙ building", now: start.addingTimeInterval(0.2))
+    var received: [ActiveAgentEntry] = []
+    fixture.state.onAgentEntryChanged = { received.append($0) }
+
+    #expect(fixture.state.flushCoalescedTabTitles(now: start.addingTimeInterval(0.5)).isEmpty)
+    #expect(received.isEmpty)
+    #expect(fixture.state.tabManager.tabs.first?.title == "⠋ building")
+  }
+
+  private struct Fixture {
+    let state: WorktreeTerminalState
+    let tabId: TerminalTabID
+    let pane: GhosttySurfaceView
+  }
+
+  private func makeFixture() -> Fixture {
+    let state = WorktreeTerminalState(
+      runtime: GhosttyRuntime(),
+      worktree: Worktree(
+        id: "/tmp/repo/worktree",
+        name: "worktree",
+        detail: "",
+        workingDirectory: URL(fileURLWithPath: "/tmp/repo/worktree"),
+        repositoryRootURL: URL(fileURLWithPath: "/tmp/repo")
+      )
+    )
+    let pane = GhosttySurfaceView(
+      runtime: state.runtime,
+      workingDirectory: URL(fileURLWithPath: "/tmp/repo/worktree", isDirectory: true),
+      fontSize: nil,
+      context: GHOSTTY_SURFACE_CONTEXT_TAB,
+      skipsSurfaceCreationForTesting: true
+    )
+    let tabId = state.tabManager.createTab(title: "worktree 1", icon: "terminal")
+    state.surfaces[pane.id] = pane
+    state.trees[tabId] = SplitTree<GhosttySurfaceView>(view: pane)
+    state.focusedSurfaceIdByTab[tabId] = pane.id
+    // An entry is only produced for a pane with a detected agent in a known state.
+    state.surfaceAgentStates[pane.id] = PaneAgentState(detectedAgent: .claude, state: .working)
+    return Fixture(state: state, tabId: tabId, pane: pane)
+  }
+}

--- a/supacodeTests/TerminalTabTitleCoalescingTests.swift
+++ b/supacodeTests/TerminalTabTitleCoalescingTests.swift
@@ -127,13 +127,56 @@ struct TerminalTabTitleCoalescingTests {
     #expect(manager.tabs.first(where: { $0.id == id })?.displayTitle == "my tab")
   }
 
+  /// Asserts the bookkeeping itself, not `flushPendingTitles`'s return value: that
+  /// value is empty for a closed tab whether or not the prune ran, because the flush
+  /// skips any id missing from `tabs`. Reading the retained ids is the only way to
+  /// tell a working prune from a leak that grows with every tab ever closed.
   @Test func closingATabDropsItsCoalescingState() {
     let (manager, id) = makeManager()
     _ = manager.updateTitle(id, title: "⠋ working", now: start)
     _ = manager.updateTitle(id, title: "⠙ working", now: start.addingTimeInterval(0.2))
+    #expect(manager.coalescedTabIDsForTesting == [id], "Both a last-write stamp and a pending title are held")
+
     manager.closeTab(id)
 
+    #expect(manager.coalescedTabIDsForTesting.isEmpty, "Closing the tab must drop its bookkeeping, not leak it")
     #expect(manager.flushPendingTitles(now: start.addingTimeInterval(5)).isEmpty)
     #expect(manager.tabs.isEmpty)
+  }
+
+  /// A surviving tab must keep its state when a sibling closes, so the prune cannot
+  /// be "fixed" by clearing everything.
+  @Test func closingOneTabKeepsAnotherTabsCoalescingState() {
+    let (manager, kept) = makeManager()
+    let closed = manager.createTab(title: "second", icon: nil)
+    _ = manager.updateTitle(kept, title: "⠋ kept", now: start)
+    _ = manager.updateTitle(closed, title: "⠋ closed", now: start)
+
+    manager.closeTab(closed)
+
+    #expect(manager.coalescedTabIDsForTesting == [kept])
+  }
+
+  /// Pins the comparison at `TerminalTabManager.swift`'s `<` against the interval.
+  /// Without a case landing exactly on the boundary, changing it to `<=` — which
+  /// would withhold a title that has waited the full interval — passes every other
+  /// test in this file.
+  @Test func aTitleArrivingExactlyOnTheIntervalIsWritten() {
+    let (manager, id) = makeManager()
+    _ = manager.updateTitle(id, title: "⠋ working", now: start)
+    let boundary = start.addingTimeInterval(TerminalTabManager.liveTitleCoalescingInterval)
+
+    #expect(manager.updateTitle(id, title: "⠙ working", now: boundary))
+    #expect(title(of: manager, id) == "⠙ working")
+  }
+
+  /// The other side of the same boundary: one instant earlier must still be withheld.
+  @Test func aTitleArrivingJustInsideTheIntervalIsWithheld() {
+    let (manager, id) = makeManager()
+    _ = manager.updateTitle(id, title: "⠋ working", now: start)
+    let justInside = start.addingTimeInterval(TerminalTabManager.liveTitleCoalescingInterval - 0.001)
+
+    #expect(manager.updateTitle(id, title: "⠙ working", now: justInside) == false)
+    #expect(title(of: manager, id) == "⠋ working")
   }
 }

--- a/supacodeTests/TerminalTabTitleCoalescingTests.swift
+++ b/supacodeTests/TerminalTabTitleCoalescingTests.swift
@@ -1,0 +1,139 @@
+import Foundation
+import Testing
+
+@testable import supacode
+
+/// `TerminalTabManager.tabs` is observed as a whole, so one tab's title write
+/// rebuilds the entire tab bar. Agent TUIs animate a spinner glyph into the
+/// title at roughly 10 Hz, so live title writes are spaced out; these tests pin
+/// both the spacing and the trailing flush that keeps a settled title from
+/// being stranded.
+@MainActor
+struct TerminalTabTitleCoalescingTests {
+  private let start = Date(timeIntervalSince1970: 1_000)
+
+  private func makeManager() -> (TerminalTabManager, TerminalTabID) {
+    let manager = TerminalTabManager()
+    let id = manager.createTab(title: "initial", icon: nil)
+    return (manager, id)
+  }
+
+  private func title(of manager: TerminalTabManager, _ id: TerminalTabID) -> String? {
+    manager.tabs.first(where: { $0.id == id })?.title
+  }
+
+  @Test func theFirstTitleAfterAQuietPeriodIsWrittenImmediately() {
+    let (manager, id) = makeManager()
+
+    #expect(manager.updateTitle(id, title: "building", now: start))
+    #expect(title(of: manager, id) == "building")
+  }
+
+  @Test func framesArrivingInsideTheIntervalDoNotReachTheTabs() {
+    let (manager, id) = makeManager()
+    _ = manager.updateTitle(id, title: "⠋ working", now: start)
+
+    #expect(manager.updateTitle(id, title: "⠙ working", now: start.addingTimeInterval(0.1)) == false)
+    #expect(manager.updateTitle(id, title: "⠹ working", now: start.addingTimeInterval(0.2)) == false)
+
+    #expect(
+      title(of: manager, id) == "⠋ working",
+      "Animation frames must not mutate the observed array"
+    )
+  }
+
+  @Test func aTitleArrivingAfterTheIntervalIsWrittenAgain() {
+    let (manager, id) = makeManager()
+    _ = manager.updateTitle(id, title: "⠋ working", now: start)
+    _ = manager.updateTitle(id, title: "⠙ working", now: start.addingTimeInterval(0.5))
+
+    #expect(manager.updateTitle(id, title: "⠸ working", now: start.addingTimeInterval(1.1)))
+    #expect(title(of: manager, id) == "⠸ working")
+  }
+
+  /// Only the newest held-back title survives, so a burst never queues up.
+  @Test func flushLandsTheMostRecentSuppressedTitle() {
+    let (manager, id) = makeManager()
+    _ = manager.updateTitle(id, title: "⠋ working", now: start)
+    _ = manager.updateTitle(id, title: "⠙ working", now: start.addingTimeInterval(0.2))
+    _ = manager.updateTitle(id, title: "⠸ working", now: start.addingTimeInterval(0.4))
+
+    #expect(manager.flushPendingTitles(now: start.addingTimeInterval(1.5)) == [id])
+    #expect(title(of: manager, id) == "⠸ working")
+  }
+
+  @Test func flushDoesNothingBeforeTheIntervalElapses() {
+    let (manager, id) = makeManager()
+    _ = manager.updateTitle(id, title: "⠋ working", now: start)
+    _ = manager.updateTitle(id, title: "⠙ working", now: start.addingTimeInterval(0.2))
+
+    #expect(manager.flushPendingTitles(now: start.addingTimeInterval(0.5)).isEmpty)
+    #expect(title(of: manager, id) == "⠋ working")
+  }
+
+  @Test func flushIsANoOpWhenNothingWasSuppressed() {
+    let (manager, id) = makeManager()
+    _ = manager.updateTitle(id, title: "done", now: start)
+
+    #expect(manager.flushPendingTitles(now: start.addingTimeInterval(5)).isEmpty)
+    #expect(title(of: manager, id) == "done")
+  }
+
+  /// A suppressed frame must not resurface after a later title has been written,
+  /// or the tab would flick back to a stale animation frame.
+  @Test func aSuppressedTitleIsDiscardedOnceANewerOneIsWritten() {
+    let (manager, id) = makeManager()
+    _ = manager.updateTitle(id, title: "⠋ working", now: start)
+    _ = manager.updateTitle(id, title: "⠙ working", now: start.addingTimeInterval(0.2))
+    _ = manager.updateTitle(id, title: "finished", now: start.addingTimeInterval(1.1))
+
+    #expect(manager.flushPendingTitles(now: start.addingTimeInterval(9)).isEmpty)
+    #expect(title(of: manager, id) == "finished")
+  }
+
+  @Test func coalescingIsPerTabNotGlobal() {
+    let manager = TerminalTabManager()
+    let first = manager.createTab(title: "first", icon: nil)
+    let second = manager.createTab(title: "second", icon: nil)
+
+    #expect(manager.updateTitle(first, title: "⠋ one", now: start))
+    // The second tab has its own history, so its first write is not held back.
+    #expect(manager.updateTitle(second, title: "⠋ two", now: start.addingTimeInterval(0.1)))
+
+    #expect(title(of: manager, first) == "⠋ one")
+    #expect(title(of: manager, second) == "⠋ two")
+  }
+
+  @Test func aLockedTitleIsNeverWrittenOrHeld() {
+    let manager = TerminalTabManager()
+    let id = manager.createTab(title: "pinned", icon: nil, isTitleLocked: true)
+
+    #expect(manager.updateTitle(id, title: "⠋ working", now: start) == false)
+    #expect(manager.updateTitle(id, title: "⠙ working", now: start.addingTimeInterval(0.2)) == false)
+    #expect(manager.flushPendingTitles(now: start.addingTimeInterval(5)).isEmpty)
+    #expect(title(of: manager, id) == "pinned")
+  }
+
+  /// A custom title masks the live one, so the visible title never moves — the
+  /// live value still updates underneath so clearing the custom title reveals it.
+  @Test func aCustomTitleMasksTheFlushedLiveTitle() {
+    let (manager, id) = makeManager()
+    _ = manager.setCustomTitle(id, title: "my tab")
+    _ = manager.updateTitle(id, title: "⠋ working", now: start)
+    _ = manager.updateTitle(id, title: "⠙ working", now: start.addingTimeInterval(0.2))
+
+    #expect(manager.flushPendingTitles(now: start.addingTimeInterval(1.5)).isEmpty)
+    #expect(title(of: manager, id) == "⠙ working")
+    #expect(manager.tabs.first(where: { $0.id == id })?.displayTitle == "my tab")
+  }
+
+  @Test func closingATabDropsItsCoalescingState() {
+    let (manager, id) = makeManager()
+    _ = manager.updateTitle(id, title: "⠋ working", now: start)
+    _ = manager.updateTitle(id, title: "⠙ working", now: start.addingTimeInterval(0.2))
+    manager.closeTab(id)
+
+    #expect(manager.flushPendingTitles(now: start.addingTimeInterval(5)).isEmpty)
+    #expect(manager.tabs.isEmpty)
+  }
+}


### PR DESCRIPTION
One pane's animated title rebuilt every tab in the window many times a second, so this change coalesces title writes and adds the tests that can catch a regression in them.

A 300-second sample of a window with 32 tabs caught the main thread at 82.5 percent of a core: 47.8 percent in `GraphHost.flushTransactions` and 32.3 percent in the CoreAnimation commit, of which 18.9 percent was AppKit view-tree layout, against 2.4 percent for agent detection. `TerminalTabItem.title` is a `var` inside `TerminalTabManager.tabs`, so one pane's 10 Hz spinner invalidated every reader of `tabs`.

A test-evidence audit found that `closingATabDropsItsCoalescingState` proved nothing. It asserted that `flushPendingTitles` returns empty after a close, but `flushPendingTitles` already skips any id missing from `tabs` on its own guard. Deleting `pruneTitleCoalescingState` outright, which would leave bookkeeping that grows with every tab ever closed, left the test green. The dictionaries are private precisely so that a title write cannot invalidate the tab bar, which also leaves the prune unobservable, so this adds a narrow read-only seam over the retained ids and asserts those instead, along with a sibling case proving a surviving tab keeps its state.

The same audit named two further gaps, both now closed:

1. The one-second interval was only ever exercised at convenient distances, so changing its `<` to `<=` passed all eleven tests. Both sides of the boundary are now pinned.
2. The flush call site refreshed Active Agents entries inline in the detection `Task`, which no test could reach. It is extracted as `flushCoalescedTabTitles` and covered, so a withheld title refreshes the entry when it lands, an empty flush emits nothing, and a flush inside the interval keeps holding.
