### PR TITLE
Gate per-action TCA logging behind a launch flag

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@ make bump-version                # Bump version (date-based YYYY.M.DD) and creat
 ```
 
 Run a single test class or method:
+
 ```bash
 xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" \
   -only-testing:supacodeTests/TerminalTabManagerTests \
@@ -28,6 +29,7 @@ xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platf
 ```
 
 **Swift Testing vs XCTest `-only-testing` format**: Swift Testing (`@Test`) requires trailing `()` in the test identifier. Without it, `xcodebuild` silently matches nothing and reports `TEST SUCCEEDED` with zero tests run.
+
 ```bash
 # XCTest (func testFoo)
 -only-testing:supacodeTests/FooTests/testBar
@@ -36,6 +38,8 @@ xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platf
 ```
 
 Requires [mise](https://mise.jdx.dev/) for zig, swiftlint, and xcsift tooling.
+
+`make log-stream` shows no `TCA` action lines by default: per-action logging — the action label plus a full app-state snapshot and diff — is gated off because it runs on every action and shows up as steady main-thread cost. Launch with `PROWL_LOG_TCA_ACTIONS=1` (scheme env var, or exported before `open`) to trace the action stream through the unified log.
 
 ## Architecture
 

--- a/docs-ai/056-performance-optimization-2026-08/000-plan.md
+++ b/docs-ai/056-performance-optimization-2026-08/000-plan.md
@@ -4,7 +4,7 @@
 | --- | --- |
 | **Status** | Implemented |
 | **Anchor date** | 2026-08-01 |
-| **Primary PRs** | #644, #645, #652; review queue #646–#650 |
+| **Primary PRs** | #644, #645, #652, #653; review queue #646–#650 |
 | **Related** | [032-performance-hardening](../032-performance-hardening/000-plan.md), [037-line-diff-tracking](../037-line-diff-tracking/000-plan.md), `docs/components/diff-view.md` |
 
 ## Background
@@ -30,9 +30,9 @@ The first application was #644. Its `memchr` scan removes the dominant per-byte
 untracked text file to zero added lines. If that is the only change, the worktree badge
 disappears even though Show Diff still includes the file.
 
-The second application is #645. The root reducer remains wrapped for opt-in diagnostics,
-but a normal Debug launch now bypasses action reflection, state snapshots and equality
-checks, and `CustomDump` diff generation. See
+The second application originated in #645 and is integrated through #653. The root reducer
+remains wrapped for opt-in diagnostics, but a normal Debug launch now bypasses action
+reflection, state snapshots and equality checks, and `CustomDump` diff generation. See
 [056.002](002-opt-in-debug-tca-action-logging.md) for the reviewed behavior and scope.
 
 ## Measured baseline for #644
@@ -128,7 +128,7 @@ pending independent code-path and test review.
 | PR | Confirmed scope | Review focus / placeholder | Head |
 | --- | --- | --- | --- |
 | #644 | Replace `Data.Iterator` line scans and avoid repeated large untracked-file work | Integrated through #652 with exact cached counts, a refresh-wide budget, and explicit incomplete state | `978b7b59` |
-| #645 | Gate Debug TCA action reflection/state-diff logging behind `PROWL_LOG_TCA_ACTIONS` | Reviewed: default Debug launches bypass the expensive diagnostics; the opt-in path remains available and Release behavior is unchanged | `616bbf4b` |
+| #645 | Gate Debug TCA action reflection/state-diff logging behind `PROWL_LOG_TCA_ACTIONS` | Reviewed and integrated through #653: default Debug launches bypass the expensive diagnostics; the opt-in path remains available and Release behavior is unchanged | `616bbf4b` |
 | #646 | Memoize per-surface agent screen parsing when agent and visible text are unchanged | Verify cache invalidation, stabilization timing, observation isolation, and surface teardown | `b2ac2936` |
 | #647 | Deduplicate raw-state-only agent emissions and narrow sidebar invalidation | Decide whether stale CLI `raw_state` is acceptable; trace UI/CLI ownership before merge | `e77ba660` |
 | #648 | Replace per-agent worktree scans/path resolution with a cached directory index | Verify deepest-match and symlink semantics, cache invalidation, render-path purity, and current CI | `08773383` |
@@ -163,5 +163,6 @@ pending independent code-path and test review.
 
 ## Amendments
 
-- Updated 2026-08-02: Reviewed and integrated opt-in Debug TCA action logging from #645 — see
+- Updated 2026-08-02: Reviewed opt-in Debug TCA action logging from #645 and moved integration
+  to fork-owned PR #653 — see
   [002-opt-in-debug-tca-action-logging.md](002-opt-in-debug-tca-action-logging.md).

--- a/docs-ai/056-performance-optimization-2026-08/000-plan.md
+++ b/docs-ai/056-performance-optimization-2026-08/000-plan.md
@@ -4,7 +4,7 @@
 | --- | --- |
 | **Status** | Implemented |
 | **Anchor date** | 2026-08-01 |
-| **Primary PRs** | #644, #652; review queue #645–#650 |
+| **Primary PRs** | #644, #645, #652; review queue #646–#650 |
 | **Related** | [032-performance-hardening](../032-performance-hardening/000-plan.md), [037-line-diff-tracking](../037-line-diff-tracking/000-plan.md), `docs/components/diff-view.md` |
 
 ## Background
@@ -25,10 +25,15 @@ This entry records the cross-cutting standard used to review and integrate that 
 - require tests that can fail when the optimized path stops being equivalent;
 - keep each PR independently reviewable instead of combining unrelated hot paths.
 
-The first application is #644. Its `memchr` scan removes the dominant per-byte
+The first application was #644. Its `memchr` scan removes the dominant per-byte
 `Data.Iterator` overhead, but its per-file 2 MiB cutoff silently maps a present, readable
 untracked text file to zero added lines. If that is the only change, the worktree badge
 disappears even though Show Diff still includes the file.
+
+The second application is #645. The root reducer remains wrapped for opt-in diagnostics,
+but a normal Debug launch now bypasses action reflection, state snapshots and equality
+checks, and `CustomDump` diff generation. See
+[056.002](002-opt-in-debug-tca-action-logging.md) for the reviewed behavior and scope.
 
 ## Measured baseline for #644
 
@@ -71,10 +76,10 @@ bounding this dense-match case.
 
 - No user-facing setting for byte budgets or cache policy in this wave.
 - No replacement of `git diff HEAD --shortstat` or the FSEvents scheduling pipeline.
-- No combined implementation of #645–#650; each remains an independent review and merge
+- No combined implementation of #646–#650; each remains an independent review and merge
   decision.
-- No claim that author-reported sampling numbers are independently verified until that PR
-  receives its own review.
+- No author-reported sampling number is treated as independently verified without a
+  same-path reproduction.
 
 ## Design / Approach
 
@@ -117,13 +122,13 @@ input while preserving exact counts.
 
 ## Performance PR review queue
 
-The descriptions and heads below were confirmed on 2026-08-01. All claims remain pending
-independent code-path and test review except #644, which is the active implementation wave.
+The descriptions and heads below were confirmed on 2026-08-02. Claims for #646–#650 remain
+pending independent code-path and test review.
 
 | PR | Confirmed scope | Review focus / placeholder | Head |
 | --- | --- | --- | --- |
-| #644 | Replace `Data.Iterator` line scans and avoid repeated large untracked-file work | Active: preserve exact badge semantics with cache, aggregate budget, and explicit incomplete state | `978b7b59` |
-| #645 | Gate Debug TCA action reflection/state-diff logging behind `PROWL_LOG_TCA_ACTIONS` | Verify flag parsing, logging contract, Debug-only scope, and pass-through reducer semantics | `616bbf4b` |
+| #644 | Replace `Data.Iterator` line scans and avoid repeated large untracked-file work | Integrated through #652 with exact cached counts, a refresh-wide budget, and explicit incomplete state | `978b7b59` |
+| #645 | Gate Debug TCA action reflection/state-diff logging behind `PROWL_LOG_TCA_ACTIONS` | Reviewed: default Debug launches bypass the expensive diagnostics; the opt-in path remains available and Release behavior is unchanged | `616bbf4b` |
 | #646 | Memoize per-surface agent screen parsing when agent and visible text are unchanged | Verify cache invalidation, stabilization timing, observation isolation, and surface teardown | `b2ac2936` |
 | #647 | Deduplicate raw-state-only agent emissions and narrow sidebar invalidation | Decide whether stale CLI `raw_state` is acceptable; trace UI/CLI ownership before merge | `e77ba660` |
 | #648 | Replace per-agent worktree scans/path resolution with a cached directory index | Verify deepest-match and symlink semantics, cache invalidation, render-path purity, and current CI | `08773383` |
@@ -157,3 +162,6 @@ independent code-path and test review except #644, which is the active implement
   hybrid scanner change.
 
 ## Amendments
+
+- Updated 2026-08-02: Reviewed and integrated opt-in Debug TCA action logging from #645 — see
+  [002-opt-in-debug-tca-action-logging.md](002-opt-in-debug-tca-action-logging.md).

--- a/docs-ai/056-performance-optimization-2026-08/002-opt-in-debug-tca-action-logging.md
+++ b/docs-ai/056-performance-optimization-2026-08/002-opt-in-debug-tca-action-logging.md
@@ -1,0 +1,55 @@
+# 056.002 — Opt-in Debug TCA Action Logging
+
+## Context
+
+The root `AppFeature` reducer is wrapped by `LogActionsReducer` in
+`supacode/App/supacodeApp.swift`. Before #645, every action in a Debug build paid for
+`debugCaseOutput` reflection, a pre-reduction state snapshot, full-state equality, and a
+`CustomDump` diff when state changed. That diagnostic path ran even when its stdout was not
+observable from a Finder- or launchd-launched app.
+
+The author reported that a sampled idle workload with 24 terminal surfaces attributed about
+5% of main-thread time to this path, with the wrapper accounting for 93% of sampled
+main-thread reducer time. Those percentages are author measurements; the review verified
+the code path and resulting bypass, not the original capture.
+
+## Change
+
+- PR #645 adds the launch-scoped `PROWL_LOG_TCA_ACTIONS=1` gate in
+  `supacode/Support/DebugCaseOutput.swift`.
+- With the flag absent or set to any other value, the Debug wrapper immediately calls
+  `base.reduce` and skips action reflection, state snapshotting and comparison, and diff
+  generation.
+- With the flag set, action labels use `SupaLogger.notice` so they reach the unified log and
+  `make log-stream`; state diffs remain on stdout through `print`.
+- `supacode/Support/SupaLogger.swift` now owns an `OSLog.Logger` in Debug as well as Release
+  and exposes `notice` for diagnostics that must reach the unified log in both configurations.
+- The Release branch is unchanged: it still emits the existing compact action label,
+  Sentry log entry, and breadcrumb before reducing the action.
+- `AGENTS.md` documents the opt-in flag and its default-off behavior.
+
+## Refs
+
+- PR #645
+- Original implementation commit `616bbf4b`
+
+## Current state
+
+The default Debug hot path now adds only the flag branch and the direct call to the wrapped
+reducer; the measured reflection, state-copy/equality, and diff costs are not reachable. The
+diagnostic behavior remains intentionally expensive when explicitly enabled.
+
+The focused tests in `supacodeTests/LogActionsReducerTests.swift` cover state mutation through
+the wrapper, but they do not distinguish enabled from disabled flag evaluation and their
+test reducer returns no effects. The implementation's pass-through is direct and low risk,
+but future changes to the gate should use an injectable configuration seam if deterministic
+branch and effect-forwarding coverage becomes important.
+
+## Verification
+
+- `LogActionsReducerTests` passed 2 tests with `PROWL_LOG_TCA_ACTIONS` absent.
+- The same focused suite passed 2 tests with `PROWL_LOG_TCA_ACTIONS=1`.
+- `make check` passed.
+- `make build-app` completed with no errors or warnings.
+- The author-reported sampled percentages were not independently reproduced during this
+  review.

--- a/docs-ai/056-performance-optimization-2026-08/002-opt-in-debug-tca-action-logging.md
+++ b/docs-ai/056-performance-optimization-2026-08/002-opt-in-debug-tca-action-logging.md
@@ -30,7 +30,8 @@ the code path and resulting bypass, not the original capture.
 
 ## Refs
 
-- PR #645
+- Original PR #645
+- Fork integration PR #653
 - Original implementation commit `616bbf4b`
 
 ## Current state

--- a/docs-ai/README.md
+++ b/docs-ai/README.md
@@ -106,4 +106,4 @@ agent-facing manual for that).
 | 052 | [sidebar-context-menus](052-sidebar-context-menus/000-plan.md) | 2026-07-27 | Sidebar context menu overhaul: worktree terminal actions, header/workspace path actions, PR click-through |
 | 053 | [agent-profiles](053-agent-profiles/000-plan.md) | 2026-07-29 | Agent Profile V1: preset-first Claude Code/Codex launch profiles, opt-in account isolation, path routing, and future handoff seam |
 | 054 | [native-settings-navigation](054-native-settings-navigation/000-plan.md) | 2026-07-30 | SwiftUI-owned singleton Settings window, native sidebar/detail navigation, and Agent Profile drill-ins |
-| 056 | [performance-optimization-2026-08](056-performance-optimization-2026-08/000-plan.md) | 2026-08-01 | Review and integration standard for the August performance series; exact cached and bounded untracked-line counts |
+| 056 | [performance-optimization-2026-08](056-performance-optimization-2026-08/000-plan.md) | 2026-08-01 | August performance review series: exact cached line counts and opt-in Debug TCA action logging |

--- a/supacode/Support/DebugCaseOutput.swift
+++ b/supacode/Support/DebugCaseOutput.swift
@@ -10,6 +10,18 @@ extension Reducer where State: Equatable {
   }
 }
 
+/// When set, `LogActionsReducer` labels every action and logs it to the unified
+/// log, plus prints a `CustomDump` state diff. Off by default: the label
+/// reflection (`debugCaseOutput`) together with a full app-state snapshot and a
+/// deep `==` compare run on *every* action, which stack sampling measured as a
+/// steady main-thread cost under heavy action throughput. Enable per launch with
+/// `PROWL_LOG_TCA_ACTIONS=1` (Xcode scheme env var, or `open` with the variable
+/// exported) to trace the stream via `make log-stream`.
+#if DEBUG
+  private let tcaActionLoggingEnabled =
+    ProcessInfo.processInfo.environment["PROWL_LOG_TCA_ACTIONS"] == "1"
+#endif
+
 struct LogActionsReducer<Base: Reducer>: Reducer where Base.State: Equatable {
   let base: Base
 
@@ -17,8 +29,14 @@ struct LogActionsReducer<Base: Reducer>: Reducer where Base.State: Equatable {
 
   func reduce(into state: inout Base.State, action: Base.Action) -> Effect<Base.Action> {
     #if DEBUG
+      guard tcaActionLoggingEnabled else {
+        return base.reduce(into: &state, action: action)
+      }
       let actionLabel = debugCaseOutput(action)
-      logger.debug("Action: \(actionLabel)")
+      // `notice`, not `debug`: in DEBUG `SupaLogger.debug` prints to a stdout
+      // that a Finder/launchd-launched app discards, so `make log-stream` would
+      // never see it. `notice` routes to the unified log in all configs.
+      logger.notice("Action: \(actionLabel)")
       let previousState = state
       let effects = base.reduce(into: &state, action: action)
       if previousState != state, let diff = CustomDump.diff(previousState, state) {

--- a/supacode/Support/SupaLogger.swift
+++ b/supacode/Support/SupaLogger.swift
@@ -2,9 +2,7 @@ import OSLog
 
 nonisolated struct SupaLogger: Sendable {
   private let category: String
-  #if !DEBUG
-    private let logger: Logger
-  #endif
+  private let logger: Logger
   /// Signposter for emitting `os_signpost` intervals/events visible in
   /// Instruments. Signposts are essentially zero-cost when no Instruments
   /// session is attached (a single TLS read), so they are always live —
@@ -23,9 +21,7 @@ nonisolated struct SupaLogger: Sendable {
   init(_ category: String) {
     self.category = category
     let subsystem = Bundle.main.bundleIdentifier ?? "com.onevcat.prowl"
-    #if !DEBUG
-      self.logger = Logger(subsystem: subsystem, category: category)
-    #endif
+    self.logger = Logger(subsystem: subsystem, category: category)
     self.signposter = OSSignposter(subsystem: subsystem, category: "PointsOfInterest")
   }
 
@@ -51,6 +47,16 @@ nonisolated struct SupaLogger: Sendable {
     #else
       logger.warning("\(message, privacy: .public)")
     #endif
+  }
+
+  /// Emits to the unified log (`log stream`, Console, `make log-stream`) in
+  /// every build configuration. Unlike `debug`/`info`, which `print` in DEBUG
+  /// so they surface in the Xcode console, `notice` is for opt-in diagnostics
+  /// that must be greppable from the unified log even during local development
+  /// — e.g. the gated TCA action stream, which a `print` to a discarded stdout
+  /// would never reach.
+  func notice(_ message: String) {
+    logger.notice("\(message, privacy: .public)")
   }
 
   /// Wraps `body` in an `os_signpost` interval named `name`. The

--- a/supacodeTests/LogActionsReducerTests.swift
+++ b/supacodeTests/LogActionsReducerTests.swift
@@ -1,0 +1,55 @@
+import ComposableArchitecture
+import Testing
+
+@testable import supacode
+
+private struct Counter: Reducer {
+  struct State: Equatable {
+    var count = 0
+    var label = ""
+  }
+
+  enum Action: Equatable {
+    case increment
+    case setLabel(String)
+  }
+
+  func reduce(into state: inout State, action: Action) -> Effect<Action> {
+    switch action {
+    case .increment:
+      state.count += 1
+      return .none
+    case .setLabel(let value):
+      state.label = value
+      return .none
+    }
+  }
+}
+
+@MainActor
+struct LogActionsReducerTests {
+  /// With action logging off (the default), the wrapper must reduce exactly like
+  /// its base — same state mutation, no diverging behavior from the gated path.
+  @Test func passesActionsThroughToBaseWhenLoggingDisabled() {
+    let reducer = LogActionsReducer(base: Counter())
+    var state = Counter.State()
+
+    _ = reducer.reduce(into: &state, action: .increment)
+    _ = reducer.reduce(into: &state, action: .setLabel("repo"))
+
+    #expect(state.count == 1)
+    #expect(state.label == "repo")
+  }
+
+  /// A no-op action leaves state untouched, so the diff branch has nothing to
+  /// print; the reducer must still return the base's effect and state.
+  @Test func leavesStateUnchangedForActionsThatDoNotMutate() {
+    let reducer = LogActionsReducer(base: Counter())
+    var state = Counter.State(count: 5, label: "keep")
+
+    _ = reducer.reduce(into: &state, action: .setLabel("keep"))
+
+    #expect(state.count == 5)
+    #expect(state.label == "keep")
+  }
+}


### PR DESCRIPTION
## Summary

- carry the original #645 implementation commit onto a fork-owned integration branch
- merge the latest `main`, including the August performance-series overview
- gate expensive Debug TCA action reflection, state comparison, and diff generation behind `PROWL_LOG_TCA_ACTIONS=1`
- keep opt-in action labels available through the unified log
- update `docs-ai/056-performance-optimization-2026-08` with the reviewed scope, current state, and validation

## Why

The root reducer previously paid for Debug action labeling and full-state diff work on every action even when nobody could observe the output. The default Debug path now reduces directly through the wrapped reducer, while the diagnostic path remains explicitly available.

The original implementation came from #645. This PR provides a branch owned by `onevcat/Prowl` because the source organization fork does not allow the base-repository maintainer to push the merge and documentation commits.

## Review notes

The code-path review confirms that the default Debug branch bypasses the reported expensive operations and that Release behavior is unchanged. The author-reported sampling percentages were not independently reproduced. The focused tests verify state mutation through the wrapper but do not deterministically distinguish the flag branches or exercise effect forwarding; this is a non-blocking test-coverage gap.

## Validation

- `LogActionsReducerTests`: 2 tests passed with `PROWL_LOG_TCA_ACTIONS` absent
- `LogActionsReducerTests`: 2 tests passed with `PROWL_LOG_TCA_ACTIONS=1`
- `make check`
- `make build-app` — 0 errors, 0 warnings