### PR TITLE
Preserve live CLI state while reducing sidebar churn

### DIFF
--- a/docs-ai/056-performance-optimization-2026-08/000-plan.md
+++ b/docs-ai/056-performance-optimization-2026-08/000-plan.md
@@ -4,7 +4,7 @@
 | --- | --- |
 | **Status** | Implemented |
 | **Anchor date** | 2026-08-01 |
-| **Primary PRs** | #644–#646, #652, #653; review queue #647–#650 |
+| **Primary PRs** | #644–#647, #652, #653; review queue #648–#650 |
 | **Related** | [030-agent-status-detection](../030-agent-status-detection/000-plan.md), [032-performance-hardening](../032-performance-hardening/000-plan.md), [037-line-diff-tracking](../037-line-diff-tracking/000-plan.md), `docs/components/diff-view.md` |
 
 ## Background
@@ -135,7 +135,7 @@ pending independent code-path and test review.
 | #644 | Replace `Data.Iterator` line scans and avoid repeated large untracked-file work | Integrated through #652 with exact cached counts, a refresh-wide budget, and explicit incomplete state | `978b7b59` |
 | #645 | Gate Debug TCA action reflection/state-diff logging behind `PROWL_LOG_TCA_ACTIONS` | Reviewed and integrated through #653: default Debug launches bypass the expensive diagnostics; the opt-in path remains available and Release behavior is unchanged | `616bbf4b` |
 | #646 | Memoize per-surface agent screen parsing when agent and visible text are unchanged | Merged: exact agent/text cache identity preserves raw-state semantics; stabilization still runs per tick; cache lifetime follows detection/surface cleanup | `b2ac2936` |
-| #647 | Deduplicate raw-state-only agent emissions and narrow sidebar invalidation | Decide whether stale CLI `raw_state` is acceptable; trace UI/CLI ownership before merge | `e77ba660` |
+| #647 | Deduplicate raw-state-only agent emissions and narrow sidebar invalidation | Reviewed with follow-up: UI emission ignores raw-only churn while `prowl agents` reads live terminal raw state; full-field guard includes Profile attribution | `e77ba660` |
 | #648 | Replace per-agent worktree scans/path resolution with a cached directory index | Verify deepest-match and symlink semantics, cache invalidation, render-path purity, and current CI | `08773383` |
 | #649 | Coalesce animated terminal-title writes and remove quadratic tab lookup | Verify final-title delivery, close/prune lifecycle, custom/locked titles, and clock boundaries | `b77888f3` |
 | #650 | Cache parsed transcript tails and fast-path fingerprint normalization | Verify append/mtime invalidation, cache pruning, Unicode equivalence, collision behavior, and current CI | `c97cbb4` |
@@ -173,3 +173,6 @@ pending independent code-path and test review.
   [002-opt-in-debug-tca-action-logging.md](002-opt-in-debug-tca-action-logging.md).
 - Updated 2026-08-02: Merged per-surface agent screen-scan memoization from #646 — see
   [003-agent-screen-scan-memoization.md](003-agent-screen-scan-memoization.md).
+- Updated 2026-08-02: Reviewed agent-entry emission deduplication from #647 and preserved the
+  live CLI raw-state contract in the fork follow-up — see
+  [004-agent-entry-emission-dedup.md](004-agent-entry-emission-dedup.md).

--- a/docs-ai/056-performance-optimization-2026-08/000-plan.md
+++ b/docs-ai/056-performance-optimization-2026-08/000-plan.md
@@ -4,7 +4,7 @@
 | --- | --- |
 | **Status** | Implemented |
 | **Anchor date** | 2026-08-01 |
-| **Primary PRs** | #644–#647, #652, #653; review queue #648–#650 |
+| **Primary PRs** | #644–#647, #652–#654; review queue #648–#650 |
 | **Related** | [030-agent-status-detection](../030-agent-status-detection/000-plan.md), [032-performance-hardening](../032-performance-hardening/000-plan.md), [037-line-diff-tracking](../037-line-diff-tracking/000-plan.md), `docs/components/diff-view.md` |
 
 ## Background
@@ -135,7 +135,7 @@ pending independent code-path and test review.
 | #644 | Replace `Data.Iterator` line scans and avoid repeated large untracked-file work | Integrated through #652 with exact cached counts, a refresh-wide budget, and explicit incomplete state | `978b7b59` |
 | #645 | Gate Debug TCA action reflection/state-diff logging behind `PROWL_LOG_TCA_ACTIONS` | Reviewed and integrated through #653: default Debug launches bypass the expensive diagnostics; the opt-in path remains available and Release behavior is unchanged | `616bbf4b` |
 | #646 | Memoize per-surface agent screen parsing when agent and visible text are unchanged | Merged: exact agent/text cache identity preserves raw-state semantics; stabilization still runs per tick; cache lifetime follows detection/surface cleanup | `b2ac2936` |
-| #647 | Deduplicate raw-state-only agent emissions and narrow sidebar invalidation | Reviewed with follow-up: UI emission ignores raw-only churn while `prowl agents` reads live terminal raw state; full-field guard includes Profile attribution | `e77ba660` |
+| #647 | Deduplicate raw-state-only agent emissions and narrow sidebar invalidation | Reviewed and integrated through #654: UI emission ignores raw-only churn while `prowl agents` reads live terminal raw state; full-field guard includes Profile attribution | `e77ba660` |
 | #648 | Replace per-agent worktree scans/path resolution with a cached directory index | Verify deepest-match and symlink semantics, cache invalidation, render-path purity, and current CI | `08773383` |
 | #649 | Coalesce animated terminal-title writes and remove quadratic tab lookup | Verify final-title delivery, close/prune lifecycle, custom/locked titles, and clock boundaries | `b77888f3` |
 | #650 | Cache parsed transcript tails and fast-path fingerprint normalization | Verify append/mtime invalidation, cache pruning, Unicode equivalence, collision behavior, and current CI | `c97cbb4` |

--- a/docs-ai/056-performance-optimization-2026-08/004-agent-entry-emission-dedup.md
+++ b/docs-ai/056-performance-optimization-2026-08/004-agent-entry-emission-dedup.md
@@ -33,6 +33,7 @@ the review verified the emission and observation path, not the original instrume
 ## Refs
 
 - Original PR #647
+- Fork integration PR #654
 - Original implementation commits `7903375c` and `e77ba660`
 - Fork follow-up commit `d209df96`
 

--- a/docs-ai/056-performance-optimization-2026-08/004-agent-entry-emission-dedup.md
+++ b/docs-ai/056-performance-optimization-2026-08/004-agent-entry-emission-dedup.md
@@ -1,0 +1,58 @@
+# 056.004 — Agent Entry Emission Deduplication
+
+## Context
+
+Agent detection polls active surfaces as frequently as every 300 ms. The raw detector state
+can oscillate with an agent's animated terminal output even when the stabilized display state,
+session, working directory, and every other consumer-visible field remain unchanged. Before
+#647, each raw-only change emitted a new `ActiveAgentEntry`, traversed the terminal event stream,
+updated `ActiveAgentsFeature.State.entries`, and invalidated the sidebar view that read the
+entries while constructing the repository list.
+
+The author measured nine `SidebarListView.body` evaluations and 99 repository-section
+evaluations over an eight-second working-agent capture. Those counts are author measurements;
+the review verified the emission and observation path, not the original instrumented capture.
+
+## Change
+
+- #647 adds `ActiveAgentEntry.equalsIgnoringRawState(_:)` and uses it in
+  `WorktreeTerminalState.emitAgentEntry`. A raw-state-only change remains in the terminal-owned
+  `surfaceAgentStates` snapshot but no longer emits through TCA.
+- `SidebarActiveAgentsOverlay` owns the `activeAgents.entries` read and row-display computation.
+  Entry changes therefore invalidate the overlay rather than the parent
+  `SidebarListView.body` that constructs every repository section.
+- The original PR would also have made `prowl agents` report the raw state from the most recent
+  visible entry change. The fork follow-up keeps the existing point-in-time CLI contract:
+  `AgentsRuntimeSnapshot` captures live `PaneAgentState.fallbackState` values from
+  `WorktreeTerminalManager`, and `AgentsCommandHandler` uses that value when available while
+  retaining the reducer entry as a defensive fallback.
+- The emission-equivalence regression test changes every stored `ActiveAgentEntry` field one at
+  a time. The follow-up adds the previously omitted `launchProfileName`, which affects the agent
+  display name and must force a new entry.
+
+## Refs
+
+- Original PR #647
+- Original implementation commits `7903375c` and `e77ba660`
+- Fork follow-up commit `d209df96`
+
+## Current state
+
+Raw detector flicker no longer crosses the terminal-to-TCA event boundary or invalidates the
+sidebar. Stabilized status, session, title, working-directory, Profile attribution, and other
+entry changes still emit normally. CLI requests read the latest terminal-owned raw state on the
+main actor, so the optimization does not turn `raw_state` into a delayed value.
+
+The follow-up deliberately does not add another raw-state stream or dependency client. CLI
+snapshot construction already receives `WorktreeTerminalManager`, and the live state is copied
+only when a CLI request arrives.
+
+## Verification
+
+- The original focused `AgentEntryEmissionDedupTests` and `CLIAgentsCommandHandlerTests` passed
+  seven tests before the follow-up.
+- A CLI test was changed first to require a live raw state different from the reducer entry; it
+  failed to compile until the live-state snapshot input existed.
+- The focused suites then passed seven tests, including raw-only deduplication, visible-state
+  emission, removal/re-attachment, full-field equality protection, and live CLI raw-state
+  precedence.

--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -541,12 +541,19 @@ struct SupacodeApp: App {
       )
     }
     let agentsHandler = AgentsCommandHandler {
-      AgentsRuntimeSnapshot(
+      var rawStatesBySurfaceID: [UUID: AgentRawState] = [:]
+      for terminalState in terminalManager.activeWorktreeStates {
+        for (surfaceID, agentState) in terminalState.surfaceAgentStates {
+          rawStatesBySurfaceID[surfaceID] = agentState.fallbackState
+        }
+      }
+      return AgentsRuntimeSnapshot(
         repositoriesState: appStore.state.repositories,
         listSnapshot: ListRuntimeSnapshotBuilder.makeSnapshot(
           repositoriesState: appStore.state.repositories,
           terminalManager: terminalManager
-        )
+        ),
+        rawStatesBySurfaceID: rawStatesBySurfaceID
       )
     }
     let sendHandler = SendCommandHandler(

--- a/supacode/CLIService/AgentsCommandHandler.swift
+++ b/supacode/CLIService/AgentsCommandHandler.swift
@@ -3,6 +3,10 @@ import Foundation
 struct AgentsRuntimeSnapshot {
   let repositoriesState: RepositoriesFeature.State
   let listSnapshot: ListRuntimeSnapshot
+  /// Live detector output keyed by pane. Reducer entries intentionally skip
+  /// raw-state-only changes to avoid invalidating the sidebar, so CLI snapshots
+  /// must source this field from terminal state instead.
+  let rawStatesBySurfaceID: [UUID: AgentRawState]
 }
 
 final class AgentsCommandHandler: CommandHandler {
@@ -83,7 +87,7 @@ final class AgentsCommandHandler: CommandHandler {
         type: entry.agent.rawValue,
         name: entry.displayName,
         status: AgentsCommandStatus(rawValue: entry.displayState.rawValue) ?? .idle,
-        rawState: entry.rawState.rawValue,
+        rawState: (snapshot.rawStatesBySurfaceID[entry.surfaceID] ?? entry.rawState).rawValue,
         lastChangedAt: dateFormatter.string(from: entry.lastChangedAt),
         project: AgentsCommandProject(
           name: display.repositoryName,

--- a/supacode/Features/ActiveAgents/Models/ActiveAgentEntry.swift
+++ b/supacode/Features/ActiveAgents/Models/ActiveAgentEntry.swift
@@ -24,7 +24,10 @@ struct ActiveAgentEntry: Identifiable, Equatable, Sendable {
   let iconLookupToken: String
   let agent: DetectedAgent
   var session: AgentSession?
-  let rawState: AgentRawState
+  /// Un-stabilized per-poll detection result. Surfaced only by `prowl agents`
+  /// (`raw_state`); no SwiftUI view renders it (they show `displayState`). A
+  /// `var` so `equalsIgnoringRawState` can normalize it for emission dedup.
+  var rawState: AgentRawState
   let displayState: AgentDisplayState
   let lastChangedAt: Date
   /// Profile display name recorded at launch for Prowl-launched surfaces
@@ -33,6 +36,18 @@ struct ActiveAgentEntry: Identifiable, Equatable, Sendable {
   var launchProfileName: String?
   var displayName: String {
     launchProfileName ?? Self.displayName(iconLookupToken: iconLookupToken, agent: agent)
+  }
+
+  /// Equality for emission purposes, excluding `rawState`. `rawState` oscillates
+  /// on every 300 ms poll while an agent animates its spinner; if it gated
+  /// emission, each flicker would push a new entry into `ActiveAgentsFeature`
+  /// state and re-render the whole sidebar for a value no view displays.
+  /// `rawState` still rides along on entries that emit for a visible reason, so
+  /// `prowl agents` reports the raw state as of the last visible change.
+  func equalsIgnoringRawState(_ other: ActiveAgentEntry) -> Bool {
+    var normalized = self
+    normalized.rawState = other.rawState
+    return normalized == other
   }
 
   /// The user-facing agent name: the launch command token (e.g. `omp`) when it

--- a/supacode/Features/Repositories/Views/SidebarActiveAgentsOverlay.swift
+++ b/supacode/Features/Repositories/Views/SidebarActiveAgentsOverlay.swift
@@ -1,0 +1,71 @@
+import ComposableArchitecture
+import Sharing
+import SwiftUI
+
+/// The Active Agents panel plus the `entries → row-display` computation that
+/// feeds it, split out of `SidebarListView`.
+///
+/// `ActiveAgentsFeature.State.entries` is re-emitted whenever an agent's state
+/// changes — frequently while agents work. When the read of `entries` lived in
+/// `SidebarListView.body`, every such change re-ran the entire sidebar body and
+/// recreated every `RepositorySectionView` (measured at ~11 child re-evals per
+/// parent re-eval). Isolating the `entries` read here means an entries change
+/// re-evaluates only this overlay; the repository list is untouched. See
+/// `docs-ai/032-performance-hardening`.
+struct SidebarActiveAgentsOverlay: View {
+  @Bindable var store: StoreOf<RepositoriesFeature>
+  let terminalManager: WorktreeTerminalManager
+  let panelHeight: Double
+  let maximumPanelHeight: Double
+  let panelOffset: Double
+  let isPanelHidden: Bool
+  let sidebarFooterHeight: Double
+  let onHeightChanged: (Double) -> Void
+  let onHeightChangeEnded: (Double) -> Void
+
+  @Environment(\.resolvedKeybindings) private var resolvedKeybindings
+  @Environment(CommandKeyObserver.self) private var commandKeyObserver
+  @Shared(.repositoryAppearances) private var repositoryAppearances
+
+  var body: some View {
+    let state = store.state
+    let metadata = SidebarListView.activeAgentWorktreeMetadata(
+      repositories: state.repositories,
+      customTitles: state.repositoryCustomTitles,
+      repositoryAppearances: repositoryAppearances
+    )
+    let rowDisplays = SidebarListView.activeAgentRowDisplays(
+      entries: state.activeAgents.entries,
+      repositories: state.repositories,
+      metadata: metadata
+    )
+    let selectedSurfaceID = state.selectedWorktreeID.flatMap { worktreeID in
+      terminalManager.stateIfExists(for: worktreeID)?.activeSurfaceID
+    }
+    // Only surface the hint while Cmd is held and the bindings are still at their
+    // defaults; a customized binding makes the merged "⌥⌃↑↓" glyph inaccurate.
+    let shortcutHint =
+      commandKeyObserver.isPressed
+      ? AppShortcuts.activeAgentsNavigationDisplay(in: resolvedKeybindings)
+      : nil
+
+    ActiveAgentsPanel(
+      store: store.scope(state: \.activeAgents, action: \.activeAgents),
+      rowDisplays: rowDisplays,
+      selectedSurfaceID: selectedSurfaceID,
+      navigationShortcutHint: shortcutHint,
+      showTabTitles: state.showActiveAgentTabTitles,
+      height: panelHeight,
+      maximumHeight: maximumPanelHeight,
+      onHeightChanged: onHeightChanged,
+      onHeightChangeEnded: onHeightChangeEnded
+    )
+    .padding(6)
+    .frame(height: panelHeight)
+    .offset(y: panelOffset)
+    .clipped()
+    .padding(.bottom, sidebarFooterHeight)
+    .allowsHitTesting(!isPanelHidden)
+    .animation(.easeOut(duration: 0.18), value: isPanelHidden)
+  }
+}

--- a/supacode/Features/Repositories/Views/SidebarListView.swift
+++ b/supacode/Features/Repositories/Views/SidebarListView.swift
@@ -62,7 +62,6 @@ struct SidebarListView: View {
   @State private var isAddChoicePresented = false
   @Namespace private var topSegmentNamespace
   @Environment(\.resolvedKeybindings) private var resolvedKeybindings
-  @Shared(.repositoryAppearances) private var repositoryAppearances
 
   var body: some View {
     let state = store.state

--- a/supacode/Features/Repositories/Views/SidebarListView.swift
+++ b/supacode/Features/Repositories/Views/SidebarListView.swift
@@ -62,7 +62,6 @@ struct SidebarListView: View {
   @State private var isAddChoicePresented = false
   @Namespace private var topSegmentNamespace
   @Environment(\.resolvedKeybindings) private var resolvedKeybindings
-  @Environment(CommandKeyObserver.self) private var commandKeyObserver
   @Shared(.repositoryAppearances) private var repositoryAppearances
 
   var body: some View {
@@ -72,31 +71,16 @@ struct SidebarListView: View {
     let expandableRepositoryIDs = Self.expandableRepositoryIDs(in: state.repositories)
     let repositoryItems = presentation.items.filter(\.isRepositoryOrderItem)
     let selectedWorktreeIDs = Self.selectedWorktreeIDs(in: state)
-    let selectedSurfaceID = state.selectedWorktreeID.flatMap { worktreeID in
-      terminalManager.stateIfExists(for: worktreeID)?.activeSurfaceID
-    }
-    // Only surface the hint while Cmd is held and the bindings are still at their
-    // defaults; a customized binding makes the merged "⌥⌃↑↓" glyph inaccurate.
-    let activeAgentsShortcutHint =
-      commandKeyObserver.isPressed
-      ? AppShortcuts.activeAgentsNavigationDisplay(in: resolvedKeybindings)
-      : nil
     let pendingSidebarReveal = state.pendingSidebarReveal
 
     let maximumPanelHeight =
       sidebarHeight > 0
       ? ActiveAgentsFeature.maximumPanelHeight(forContainerHeight: sidebarHeight)
       : ActiveAgentsFeature.maximumPanelHeight
-    let agentWorktreeMetadata = Self.activeAgentWorktreeMetadata(
-      repositories: state.repositories,
-      customTitles: state.repositoryCustomTitles,
-      repositoryAppearances: repositoryAppearances
-    )
-    let agentRowDisplays = Self.activeAgentRowDisplays(
-      entries: state.activeAgents.entries,
-      repositories: state.repositories,
-      metadata: agentWorktreeMetadata
-    )
+    // The Active Agents panel and its `entries` read live in
+    // `SidebarActiveAgentsOverlay` so that agent-state churn re-evaluates only
+    // that overlay, not this body and the repository list. This body must not
+    // read `state.activeAgents.entries`.
     let panelHeight = min(resizingPanelHeight ?? state.activeAgents.panelHeight, maximumPanelHeight)
     let panelOffset = state.activeAgents.isPanelHidden ? panelHeight : 0
     let activeAgentsPanelTopGap = 4.0
@@ -171,14 +155,14 @@ struct SidebarListView: View {
         }
       }
       .overlay(alignment: .bottom) {
-        ActiveAgentsPanel(
-          store: store.scope(state: \.activeAgents, action: \.activeAgents),
-          rowDisplays: agentRowDisplays,
-          selectedSurfaceID: selectedSurfaceID,
-          navigationShortcutHint: activeAgentsShortcutHint,
-          showTabTitles: state.showActiveAgentTabTitles,
-          height: panelHeight,
-          maximumHeight: maximumPanelHeight,
+        SidebarActiveAgentsOverlay(
+          store: store,
+          terminalManager: terminalManager,
+          panelHeight: panelHeight,
+          maximumPanelHeight: maximumPanelHeight,
+          panelOffset: panelOffset,
+          isPanelHidden: state.activeAgents.isPanelHidden,
+          sidebarFooterHeight: sidebarFooterHeight,
           onHeightChanged: { height in
             resizingPanelHeight = height
           },
@@ -187,13 +171,6 @@ struct SidebarListView: View {
             store.send(.activeAgents(.panelHeightChanged(height)))
           }
         )
-        .padding(6)
-        .frame(height: panelHeight)
-        .offset(y: panelOffset)
-        .clipped()
-        .padding(.bottom, sidebarFooterHeight)
-        .allowsHitTesting(!state.activeAgents.isPanelHidden)
-        .animation(.easeOut(duration: 0.18), value: state.activeAgents.isPanelHidden)
       }
       .dropDestination(for: URL.self) { urls, _ in
         let fileURLs = urls.filter(\.isFileURL)

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState+AgentDetection.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState+AgentDetection.swift
@@ -281,7 +281,10 @@ extension WorktreeTerminalState {
       onAgentEntryRemoved?(surfaceID)
       return
     }
-    guard entry != lastEmittedAgentEntriesBySurface[surfaceID] else { return }
+    // Dedup ignoring `rawState`: it flickers every poll while an agent animates
+    // and drives no UI, so emitting on it alone would re-render the sidebar
+    // continuously. Visible changes (displayState, title, session, …) still emit.
+    guard lastEmittedAgentEntriesBySurface[surfaceID]?.equalsIgnoringRawState(entry) != true else { return }
     lastEmittedAgentEntriesBySurface[surfaceID] = entry
     onAgentEntryChanged?(entry)
   }

--- a/supacodeTests/AgentEntryEmissionDedupTests.swift
+++ b/supacodeTests/AgentEntryEmissionDedupTests.swift
@@ -67,6 +67,103 @@ struct AgentEntryEmissionDedupTests {
     #expect(removed == [fixture.pane.id])
   }
 
+  /// `equalsIgnoringRawState` normalizes one field and compares the rest through
+  /// the synthesized `==`. Nothing structural stops a later edit from
+  /// normalizing a second field, and the damage would be silent: the helper
+  /// still compiles, every test above still passes, and the only symptom is a
+  /// real change to that field never reaching the sidebar. `emitAgentEntry`
+  /// promises "displayState, title, session, …" still emit, so pin the whole
+  /// promise — one differing field must always be enough to break equality.
+  @Test func everyFieldExceptRawStateBreaksEmissionEquality() {
+    let base = Self.entry()
+    let variants: [(field: String, entry: ActiveAgentEntry)] = [
+      ("id", Self.entry(id: Self.otherID)),
+      ("worktreeID", Self.entry(worktreeID: "/tmp/repo/other")),
+      ("worktreeName", Self.entry(worktreeName: "other")),
+      // Resolves the repository and branch the row displays, so a suppressed
+      // change leaves the sidebar naming the directory the agent has left.
+      ("workingDirectory", Self.entry(workingDirectory: URL(fileURLWithPath: "/tmp/repo/other"))),
+      ("workingDirectory=nil", Self.entry(workingDirectory: nil)),
+      ("tabID", Self.entry(tabID: Self.otherTabID)),
+      ("paneTitle", Self.entry(paneTitle: "other title")),
+      ("surfaceID", Self.entry(surfaceID: Self.otherID)),
+      ("paneIndex", Self.entry(paneIndex: 2)),
+      ("iconLookupToken", Self.entry(iconLookupToken: "codex")),
+      ("agent", Self.entry(agent: .codex)),
+      // Carries the resume target `prowl agents` reports; a suppressed change
+      // would keep pointing at the previous session's transcript.
+      ("session", Self.entry(session: Self.otherSession)),
+      ("session=nil", Self.entry(session: nil)),
+      ("displayState", Self.entry(displayState: .blocked)),
+      ("lastChangedAt", Self.entry(lastChangedAt: Date(timeIntervalSince1970: 5_000))),
+    ]
+
+    for variant in variants {
+      #expect(
+        !base.equalsIgnoringRawState(variant.entry),
+        "A change to \(variant.field) must still emit; normalizing it would hide the change from the sidebar"
+      )
+    }
+
+    // The single field the helper exists to ignore.
+    #expect(base.equalsIgnoringRawState(Self.entry(rawState: .idle)))
+  }
+
+  private static let baseID = UUID(uuidString: "00000000-0000-0000-0000-0000000000A1")!
+  private static let otherID = UUID(uuidString: "00000000-0000-0000-0000-0000000000A2")!
+  /// Fixed rather than freshly generated, so two entries under comparison differ
+  /// only in the field the case is about.
+  private static let baseTabID = TerminalTabID(rawValue: UUID(uuidString: "00000000-0000-0000-0000-0000000000B1")!)
+  private static let otherTabID = TerminalTabID(rawValue: UUID(uuidString: "00000000-0000-0000-0000-0000000000B2")!)
+  private static let baseSession = AgentSession(
+    id: "session-1",
+    transcriptPath: URL(fileURLWithPath: "/tmp/transcripts/session-1.jsonl"),
+    source: .openFile,
+    confidence: .exact
+  )
+  private static let otherSession = AgentSession(
+    id: "session-2",
+    transcriptPath: URL(fileURLWithPath: "/tmp/transcripts/session-2.jsonl"),
+    source: .openFile,
+    confidence: .exact
+  )
+
+  /// Defaults spell out every field so a case can override exactly one and the
+  /// assertion stays about that field alone.
+  private static func entry(
+    id: UUID = baseID,
+    worktreeID: Worktree.ID = "/tmp/repo/worktree",
+    worktreeName: String = "worktree",
+    workingDirectory: URL? = URL(fileURLWithPath: "/tmp/repo/worktree"),
+    tabID: TerminalTabID = baseTabID,
+    paneTitle: String = "spx-h",
+    surfaceID: UUID = baseID,
+    paneIndex: Int = 1,
+    iconLookupToken: String = "claude",
+    agent: DetectedAgent = .claude,
+    session: AgentSession? = baseSession,
+    rawState: AgentRawState = .working,
+    displayState: AgentDisplayState = .working,
+    lastChangedAt: Date = Date(timeIntervalSince1970: 1_000)
+  ) -> ActiveAgentEntry {
+    ActiveAgentEntry(
+      id: id,
+      worktreeID: worktreeID,
+      worktreeName: worktreeName,
+      workingDirectory: workingDirectory,
+      tabID: tabID,
+      paneTitle: paneTitle,
+      surfaceID: surfaceID,
+      paneIndex: paneIndex,
+      iconLookupToken: iconLookupToken,
+      agent: agent,
+      session: session,
+      rawState: rawState,
+      displayState: displayState,
+      lastChangedAt: lastChangedAt
+    )
+  }
+
   private struct Fixture {
     let state: WorktreeTerminalState
     let tabId: TerminalTabID

--- a/supacodeTests/AgentEntryEmissionDedupTests.swift
+++ b/supacodeTests/AgentEntryEmissionDedupTests.swift
@@ -90,6 +90,7 @@ struct AgentEntryEmissionDedupTests {
       ("paneIndex", Self.entry(paneIndex: 2)),
       ("iconLookupToken", Self.entry(iconLookupToken: "codex")),
       ("agent", Self.entry(agent: .codex)),
+      ("launchProfileName", Self.entry(launchProfileName: "Review Profile")),
       // Carries the resume target `prowl agents` reports; a suppressed change
       // would keep pointing at the previous session's transcript.
       ("session", Self.entry(session: Self.otherSession)),
@@ -141,6 +142,7 @@ struct AgentEntryEmissionDedupTests {
     paneIndex: Int = 1,
     iconLookupToken: String = "claude",
     agent: DetectedAgent = .claude,
+    launchProfileName: String? = nil,
     session: AgentSession? = baseSession,
     rawState: AgentRawState = .working,
     displayState: AgentDisplayState = .working,
@@ -160,7 +162,8 @@ struct AgentEntryEmissionDedupTests {
       session: session,
       rawState: rawState,
       displayState: displayState,
-      lastChangedAt: lastChangedAt
+      lastChangedAt: lastChangedAt,
+      launchProfileName: launchProfileName
     )
   }
 

--- a/supacodeTests/AgentEntryEmissionDedupTests.swift
+++ b/supacodeTests/AgentEntryEmissionDedupTests.swift
@@ -11,25 +11,25 @@ import Testing
 /// changes so that churn never floods the terminal event stream.
 @MainActor
 struct AgentEntryEmissionDedupTests {
-  @Test func identicalEntryIsEmittedOnce() {
+  @Test func rawStateAndBookkeepingChangesDoNotReEmit() {
     let fixture = makeFixture()
     var received: [ActiveAgentEntry] = []
     fixture.state.onAgentEntryChanged = { received.append($0) }
 
-    // Same visible entry, differing only in internal bookkeeping.
+    // Same visible entry; only rawState (fallbackState) and internal bookkeeping
+    // differ across the three emits.
     var paneState = PaneAgentState(detectedAgent: .claude, fallbackState: .working, state: .working)
     fixture.state.emitAgentEntry(surfaceID: fixture.pane.id, tabId: fixture.tabId, state: paneState)
     paneState.sessionMissStreak = 1
     paneState.fallbackState = .idle
     fixture.state.emitAgentEntry(surfaceID: fixture.pane.id, tabId: fixture.tabId, state: paneState)
-
-    // fallbackState is part of the visible entry (CLI raw_state); the streak
-    // alone must not re-emit.
     paneState.sessionMissStreak = 2
     fixture.state.emitAgentEntry(surfaceID: fixture.pane.id, tabId: fixture.tabId, state: paneState)
 
-    #expect(received.count == 2)
-    #expect(received.map(\.rawState) == [.working, .idle])
+    // rawState never renders in the sidebar, so a raw-only flicker must not
+    // re-emit; only the first (visible) entry is forwarded.
+    #expect(received.count == 1)
+    #expect(received.map(\.rawState) == [.working])
   }
 
   @Test func visibleChangeStillEmits() {

--- a/supacodeTests/CLIAgentsCommandHandlerTests.swift
+++ b/supacodeTests/CLIAgentsCommandHandlerTests.swift
@@ -29,7 +29,10 @@ struct CLIAgentsCommandHandlerTests {
     #expect(agent.type == "pi")
     #expect(agent.name == "omp")
     #expect(agent.status == .blocked)
-    #expect(agent.rawState == "blocked")
+    // The reducer entry may intentionally lag raw-state-only terminal polls so
+    // the sidebar does not re-render. CLI snapshots must use the live terminal
+    // raw state instead of that UI-deduplicated value.
+    #expect(agent.rawState == "working")
     #expect(agent.lastChangedAt == "2026-09-21T14:00:00Z")
     #expect(agent.project.name == "Prowl")
     #expect(agent.project.branch == "feature/agents")
@@ -179,7 +182,8 @@ struct CLIAgentsCommandHandlerTests {
           otherPaneID: otherPaneID,
           tabID: tabID,
           tabWorktree: tabWorktree
-        )
+        ),
+        rawStatesBySurfaceID: [tabPaneID: .working]
       )
     )
   }


### PR DESCRIPTION
## Summary

- preserve both original commits from #647 and its raw-state emission deduplication
- isolate Active Agents entry observation from the repository-list body
- keep `prowl agents` point-in-time `raw_state` semantics by reading live terminal state when the CLI snapshot is built
- cover Profile display attribution in the full-field emission-equivalence regression test
- record the reviewed contract and validation under `docs-ai/056-performance-optimization-2026-08`

## Why this follow-up

The original optimization correctly prevents raw detector flicker from crossing the terminal event stream and invalidating the sidebar. However, the same deduplication left the reducer entry's `rawState` stale, and the CLI generated its payload from that reducer entry. This follow-up separates the two ownership paths: UI state remains deduplicated, while an on-demand CLI snapshot reads the latest terminal-owned `PaneAgentState.fallbackState`.

The original field-by-field guard also omitted `launchProfileName`, which changes the displayed identity and must continue to force an emission.

## Attribution

The complete commits from #647 by Simon Heimlicher are retained in this branch:

- `7903375c` — Stop agent-state churn from re-rendering the whole sidebar
- `e77ba660` — Pin every field the emission dedup must not ignore

## Validation

- focused baseline suites: 7 tests passed on the original head
- live CLI raw-state requirement: observed failing compile before the snapshot input was implemented
- focused follow-up suites: 7 tests passed
- post-main-merge emission, CLI, and screen-scan suites: 11 tests passed
- `make check`
- `make build-app` — 0 errors, 0 warnings
