### PR TITLE
Guarantee efficient terminal title updates

### DIFF
--- a/docs-ai/056-performance-optimization-2026-08/000-plan.md
+++ b/docs-ai/056-performance-optimization-2026-08/000-plan.md
@@ -4,7 +4,7 @@
 | --- | --- |
 | **Status** | Implemented |
 | **Anchor date** | 2026-08-01 |
-| **Primary PRs** | #644–#646, #649, #652, #653; review queue #647, #648, #650 |
+| **Primary PRs** | #644–#646, #649, #652, #653, #656; review queue #647, #648, #650 |
 | **Related** | [030-agent-status-detection](../030-agent-status-detection/000-plan.md), [032-performance-hardening](../032-performance-hardening/000-plan.md), [037-line-diff-tracking](../037-line-diff-tracking/000-plan.md), `docs/components/diff-view.md` |
 
 ## Background

--- a/docs-ai/056-performance-optimization-2026-08/000-plan.md
+++ b/docs-ai/056-performance-optimization-2026-08/000-plan.md
@@ -4,7 +4,7 @@
 | --- | --- |
 | **Status** | Implemented |
 | **Anchor date** | 2026-08-01 |
-| **Primary PRs** | #644–#646, #652, #653; review queue #647–#650 |
+| **Primary PRs** | #644–#646, #649, #652, #653; review queue #647, #648, #650 |
 | **Related** | [030-agent-status-detection](../030-agent-status-detection/000-plan.md), [032-performance-hardening](../032-performance-hardening/000-plan.md), [037-line-diff-tracking](../037-line-diff-tracking/000-plan.md), `docs/components/diff-view.md` |
 
 ## Background
@@ -137,7 +137,7 @@ pending independent code-path and test review.
 | #646 | Memoize per-surface agent screen parsing when agent and visible text are unchanged | Merged: exact agent/text cache identity preserves raw-state semantics; stabilization still runs per tick; cache lifetime follows detection/surface cleanup | `b2ac2936` |
 | #647 | Deduplicate raw-state-only agent emissions and narrow sidebar invalidation | Decide whether stale CLI `raw_state` is acceptable; trace UI/CLI ownership before merge | `e77ba660` |
 | #648 | Replace per-agent worktree scans/path resolution with a cached directory index | Verify deepest-match and symlink semantics, cache invalidation, render-path purity, and current CI | `08773383` |
-| #649 | Coalesce animated terminal-title writes and remove quadratic tab lookup | Verify final-title delivery, close/prune lifecycle, custom/locked titles, and clock boundaries | `b77888f3` |
+| #649 | Coalesce animated terminal-title writes and remove quadratic tab lookup | Reviewed for fork integration: per-tab coalescing now has clock-driven trailing delivery independent of agent detection, stale pending frames are discarded, and the optimized tab map is rebuilt after every structural mutation | `5c7e2a35` |
 | #650 | Cache parsed transcript tails and fast-path fingerprint normalization | Verify append/mtime invalidation, cache pruning, Unicode equivalence, collision behavior, and current CI | `c97cbb4` |
 
 ## Alternatives & decisions
@@ -173,3 +173,6 @@ pending independent code-path and test review.
   [002-opt-in-debug-tca-action-logging.md](002-opt-in-debug-tca-action-logging.md).
 - Updated 2026-08-02: Merged per-surface agent screen-scan memoization from #646 — see
   [003-agent-screen-scan-memoization.md](003-agent-screen-scan-memoization.md).
+- Updated 2026-08-02: Reviewed animated terminal-title coalescing from #649 and prepared
+  fork integration with guaranteed trailing delivery — see
+  [006-tab-title-coalescing.md](006-tab-title-coalescing.md).

--- a/docs-ai/056-performance-optimization-2026-08/006-tab-title-coalescing.md
+++ b/docs-ai/056-performance-optimization-2026-08/006-tab-title-coalescing.md
@@ -1,0 +1,63 @@
+# 056.006 — Terminal Tab Title Coalescing
+
+## Context
+
+Agent TUIs commonly animate a spinner in the terminal title through OSC 2 updates at roughly
+10 Hz. `TerminalTabManager.tabs` is observed as one array, so every visible title write rebuilds
+all tab views and drives AppKit layout and Core Animation work across the window. The original
+implementation also resolved each row's tab with a linear search, making one tab-bar rebuild
+quadratic in the number of tabs.
+
+The author sampled a 300-second workload with 32 tabs and attributed 82.5% of one main-thread
+core to SwiftUI graph work, Core Animation commits, and AppKit layout. The review verified the
+structural invalidation path and the resulting behavior; it did not independently reproduce that
+exact profile.
+
+## Change
+
+- #649 builds one tab lookup dictionary for each tab-bar render instead of scanning the tab
+  array for every row.
+- Live terminal-title writes are coalesced independently per tab, with at most one visible write
+  per second. Only the newest withheld title is retained, so bursts do not create queues.
+- A clock-driven trailing task flushes the newest withheld title at its deadline even when agent
+  detection is absent or has moved to its cold schedule. The first implementation tied delivery
+  to the detection poll and could leave the final title stale indefinitely for a non-agent
+  program.
+- If a title sequence returns to its currently visible value, the obsolete withheld frame is
+  discarded. This prevents `A -> B (held) -> A` from later flashing the stale `B` value.
+- Closing or pruning a tab removes its coalescing bookkeeping. Custom titles continue to mask
+  live values while preserving the newest underlying title, and title-locked tabs remain
+  immutable.
+- A trailing flush refreshes Active Agents through the same title-change path as an immediate
+  write. User-facing terminal documentation records the one-second maximum visible lag.
+
+## Refs
+
+- Original PR #649
+- Fork integration PR pending
+- Original implementation commits `14a6c1d8` and `b77888f3`
+- Fork follow-up commit `5c7e2a35`
+
+## Current state
+
+Animated live titles no longer mutate the observed tab array on every frame. Each tab has an
+independent deadline, and the scheduled task always arms the earliest one, flushes all entries
+that are due, then re-arms for the next later deadline. Cancellation and a stored-deadline guard
+prevent a replaced or reverted task from applying stale state.
+
+The coalescing boundary is intentionally limited to the shared tab title. An individual pane's
+raw title remains available to split-pane and CLI consumers, preserving the existing semantic
+distinction between a tab title and a surface title.
+
+## Verification
+
+- The original title-coalescing, flush-refresh, and pane-title suites passed 21 tests before the
+  follow-up.
+- Regression tests were added first for stale `A -> B -> A` delivery and trailing delivery with
+  no agent-detection task; each failed against the original implementation before its fix.
+- A clock-driven two-tab test covers re-arming after the first deadline so a later pending title
+  cannot be stranded.
+- The affected title, Active Agents, and terminal-manager suites passed 45 tests before the final
+  multi-tab addition; the new test also passed independently.
+- `make check` passed before integrating the latest `main`.
+- `make build-app` completed with no errors or warnings before integrating the latest `main`.

--- a/docs-ai/056-performance-optimization-2026-08/006-tab-title-coalescing.md
+++ b/docs-ai/056-performance-optimization-2026-08/006-tab-title-coalescing.md
@@ -34,7 +34,7 @@ exact profile.
 ## Refs
 
 - Original PR #649
-- Fork integration PR pending
+- Fork integration PR #656
 - Original implementation commits `14a6c1d8` and `b77888f3`
 - Fork follow-up commit `5c7e2a35`
 

--- a/docs/components/terminal.md
+++ b/docs/components/terminal.md
@@ -68,6 +68,12 @@ A tab's displayed title is, in order of precedence:
 2. the **live shell title** the running program emits (OSC 2), else
 3. an auto-generated default like `project 1`, `project 2`.
 
+Rapid live-title animation is coalesced per tab to at most one visible update
+per second so one spinner frame does not rebuild the entire tab bar. The newest
+withheld title is applied at the end of that interval even when no agent is
+running, so a live title may visibly lag by up to one second but its final value
+is not left behind.
+
 The Run Script tab is labeled **RUN SCRIPT** and is **title-locked** for its
 lifetime. Prowl also "learns" your shell's idle prompt so it doesn't mistake it
 for a meaningful title.

--- a/supacode/Features/Terminal/Models/TerminalTabManager.swift
+++ b/supacode/Features/Terminal/Models/TerminalTabManager.swift
@@ -6,12 +6,34 @@ import Observation
 final class TerminalTabManager {
   var tabs: [TerminalTabItem] = [] {
     didSet {
+      // Only when tabs actually went away: this fires on every title write too,
+      // and the prune is O(n) where the guard is O(1).
+      if tabs.count < oldValue.count {
+        pruneTitleCoalescingState()
+      }
       guard let editingTabID, !tabs.contains(where: { $0.id == editingTabID }) else { return }
       self.editingTabID = nil
     }
   }
   var selectedTabId: TerminalTabID?
   private(set) var editingTabID: TerminalTabID?
+
+  /// Shortest gap between two live title writes for one tab.
+  ///
+  /// An agent TUI animates a spinner glyph inside its terminal title at roughly
+  /// 10 Hz. `tabs` is observed as a whole, so one tab's frame invalidates every
+  /// view reading the array — the tab bar then rebuilds every tab and AppKit
+  /// re-lays the window's view tree. Sampling a spike measured that at 47% of a
+  /// core in `flushTransactions` plus 32% in the CoreAnimation commit, against
+  /// 2% for agent detection.
+  static let liveTitleCoalescingInterval: TimeInterval = 1
+
+  /// Bookkeeping only — a write here must never invalidate the tab bar, which is
+  /// the whole point of the coalescing.
+  @ObservationIgnored private var lastLiveTitleWriteAt: [TerminalTabID: Date] = [:]
+  /// The most recent title held back by coalescing. A spinner that stops leaves
+  /// no further change to carry it, so `flushPendingTitles` lands it instead.
+  @ObservationIgnored private var pendingLiveTitles: [TerminalTabID: String] = [:]
 
   /// Creates a tab next to the current selection. With `select: false` the
   /// selection is left untouched (background creation, e.g. a headless handoff
@@ -45,15 +67,68 @@ final class TerminalTabManager {
   /// `displayTitle` actually changed (a custom title masks live updates),
   /// so callers can refresh derived UI like the Active Agents subtitle.
   @discardableResult
-  func updateTitle(_ id: TerminalTabID, title: String) -> Bool {
+  func updateTitle(_ id: TerminalTabID, title: String, now: Date = Date()) -> Bool {
     guard let index = tabs.firstIndex(where: { $0.id == id }) else { return false }
     guard !tabs[index].isTitleLocked else { return false }
     // A TUI re-emits the same title constantly; skip the no-op write so it
     // doesn't invalidate the tab bar while an agent streams output.
     guard tabs[index].title != title else { return false }
+    // A changed title arriving inside the interval is almost always the next
+    // frame of an animation. Hold it rather than rebuilding the tab bar for it;
+    // the newest one wins, so nothing queues up.
+    if let lastWriteAt = lastLiveTitleWriteAt[id],
+      now.timeIntervalSince(lastWriteAt) < Self.liveTitleCoalescingInterval
+    {
+      pendingLiveTitles[id] = title
+      return false
+    }
+    return writeLiveTitle(title, toTabAt: index, id: id, now: now)
+  }
+
+  /// Lands any held-back title whose interval has elapsed. Returns the tabs whose
+  /// visible `displayTitle` moved, so callers can refresh derived UI exactly as
+  /// they would after `updateTitle`.
+  ///
+  /// Driven by the agent-detection poll rather than a timer: the only way a
+  /// pending title is left stranded is that the writes stopped, and the poll is
+  /// already running for precisely the panes that animate.
+  @discardableResult
+  func flushPendingTitles(now: Date = Date()) -> [TerminalTabID] {
+    guard !pendingLiveTitles.isEmpty else { return [] }
+    var changed: [TerminalTabID] = []
+    for (id, title) in pendingLiveTitles {
+      guard let lastWriteAt = lastLiveTitleWriteAt[id],
+        now.timeIntervalSince(lastWriteAt) >= Self.liveTitleCoalescingInterval
+      else { continue }
+      pendingLiveTitles.removeValue(forKey: id)
+      guard let index = tabs.firstIndex(where: { $0.id == id }),
+        !tabs[index].isTitleLocked,
+        tabs[index].title != title
+      else { continue }
+      if writeLiveTitle(title, toTabAt: index, id: id, now: now) {
+        changed.append(id)
+      }
+    }
+    return changed
+  }
+
+  private func writeLiveTitle(
+    _ title: String,
+    toTabAt index: Int,
+    id: TerminalTabID,
+    now: Date
+  ) -> Bool {
+    pendingLiveTitles.removeValue(forKey: id)
+    lastLiveTitleWriteAt[id] = now
     let previousDisplayTitle = tabs[index].displayTitle
     tabs[index].title = title
     return tabs[index].displayTitle != previousDisplayTitle
+  }
+
+  private func pruneTitleCoalescingState() {
+    let liveIDs = Set(tabs.map(\.id))
+    lastLiveTitleWriteAt = lastLiveTitleWriteAt.filter { liveIDs.contains($0.key) }
+    pendingLiveTitles = pendingLiveTitles.filter { liveIDs.contains($0.key) }
   }
 
   /// Sets (or clears, when blank) the user-defined title. Returns `true` when

--- a/supacode/Features/Terminal/Models/TerminalTabManager.swift
+++ b/supacode/Features/Terminal/Models/TerminalTabManager.swift
@@ -34,6 +34,14 @@ final class TerminalTabManager {
   /// The most recent title held back by coalescing. A spinner that stops leaves
   /// no further change to carry it, so `flushPendingTitles` lands it instead.
   @ObservationIgnored private var pendingLiveTitles: [TerminalTabID: String] = [:]
+  @ObservationIgnored private let titleFlushClock: any Clock<Duration>
+  @ObservationIgnored private var pendingTitleFlushTask: Task<Void, Never>?
+  @ObservationIgnored private var scheduledPendingTitleFlushDate: Date?
+  @ObservationIgnored var onCoalescedTitlesFlushed: (([TerminalTabID]) -> Void)?
+
+  init(titleFlushClock: any Clock<Duration> = ContinuousClock()) {
+    self.titleFlushClock = titleFlushClock
+  }
 
   /// Creates a tab next to the current selection. With `select: false` the
   /// selection is left untouched (background creation, e.g. a headless handoff
@@ -71,8 +79,14 @@ final class TerminalTabManager {
     guard let index = tabs.firstIndex(where: { $0.id == id }) else { return false }
     guard !tabs[index].isTitleLocked else { return false }
     // A TUI re-emits the same title constantly; skip the no-op write so it
-    // doesn't invalidate the tab bar while an agent streams output.
-    guard tabs[index].title != title else { return false }
+    // doesn't invalidate the tab bar while an agent streams output. The latest
+    // title still supersedes a held frame: A → B (held) → A must not flush B.
+    guard tabs[index].title != title else {
+      if pendingLiveTitles.removeValue(forKey: id) != nil {
+        scheduleNextPendingTitleFlush(referenceDate: now)
+      }
+      return false
+    }
     // A changed title arriving inside the interval is almost always the next
     // frame of an animation. Hold it rather than rebuilding the tab bar for it;
     // the newest one wins, so nothing queues up.
@@ -80,23 +94,26 @@ final class TerminalTabManager {
       now.timeIntervalSince(lastWriteAt) < Self.liveTitleCoalescingInterval
     {
       pendingLiveTitles[id] = title
+      scheduleNextPendingTitleFlush(referenceDate: now)
       return false
     }
-    return writeLiveTitle(title, toTabAt: index, id: id, now: now)
+    let changed = writeLiveTitle(title, toTabAt: index, id: id, now: now)
+    scheduleNextPendingTitleFlush(referenceDate: now)
+    return changed
   }
 
   /// Lands any held-back title whose interval has elapsed. Returns the tabs whose
   /// visible `displayTitle` moved, so callers can refresh derived UI exactly as
   /// they would after `updateTitle`.
   ///
-  /// Driven by the agent-detection poll rather than a timer: the only way a
-  /// pending title is left stranded is that the writes stopped, and the poll is
-  /// already running for precisely the panes that animate.
+  /// A clock-driven trailing task calls this at the earliest pending deadline,
+  /// independently of agent detection, so non-agent programs cannot strand a
+  /// final title after the detection schedule goes cold.
   @discardableResult
   func flushPendingTitles(now: Date = Date()) -> [TerminalTabID] {
     guard !pendingLiveTitles.isEmpty else { return [] }
     var changed: [TerminalTabID] = []
-    for (id, title) in pendingLiveTitles {
+    for (id, title) in Array(pendingLiveTitles) {
       guard let lastWriteAt = lastLiveTitleWriteAt[id],
         now.timeIntervalSince(lastWriteAt) >= Self.liveTitleCoalescingInterval
       else { continue }
@@ -109,6 +126,7 @@ final class TerminalTabManager {
         changed.append(id)
       }
     }
+    scheduleNextPendingTitleFlush(referenceDate: now)
     return changed
   }
 
@@ -129,6 +147,39 @@ final class TerminalTabManager {
     let liveIDs = Set(tabs.map(\.id))
     lastLiveTitleWriteAt = lastLiveTitleWriteAt.filter { liveIDs.contains($0.key) }
     pendingLiveTitles = pendingLiveTitles.filter { liveIDs.contains($0.key) }
+    scheduleNextPendingTitleFlush(referenceDate: Date())
+  }
+
+  private func scheduleNextPendingTitleFlush(referenceDate: Date) {
+    let nextFlushDate = pendingLiveTitles.keys.compactMap { id in
+      lastLiveTitleWriteAt[id]?.addingTimeInterval(Self.liveTitleCoalescingInterval)
+    }.min()
+    guard let nextFlushDate else {
+      pendingTitleFlushTask?.cancel()
+      pendingTitleFlushTask = nil
+      scheduledPendingTitleFlushDate = nil
+      return
+    }
+    guard nextFlushDate != scheduledPendingTitleFlushDate else { return }
+
+    pendingTitleFlushTask?.cancel()
+    scheduledPendingTitleFlushDate = nextFlushDate
+    let delay = max(0, nextFlushDate.timeIntervalSince(referenceDate))
+    let sleep = titleFlushClock.anchoredSleep(for: .seconds(delay))
+    pendingTitleFlushTask = Task { @MainActor [weak self] in
+      do {
+        try await sleep()
+      } catch {
+        return
+      }
+      guard let self, self.scheduledPendingTitleFlushDate == nextFlushDate else { return }
+      self.pendingTitleFlushTask = nil
+      self.scheduledPendingTitleFlushDate = nil
+      let changed = self.flushPendingTitles(now: nextFlushDate)
+      if !changed.isEmpty {
+        self.onCoalescedTitlesFlushed?(changed)
+      }
+    }
   }
 
   /// Every tab the coalescing bookkeeping still holds an entry for.

--- a/supacode/Features/Terminal/Models/TerminalTabManager.swift
+++ b/supacode/Features/Terminal/Models/TerminalTabManager.swift
@@ -131,6 +131,18 @@ final class TerminalTabManager {
     pendingLiveTitles = pendingLiveTitles.filter { liveIDs.contains($0.key) }
   }
 
+  /// Every tab the coalescing bookkeeping still holds an entry for.
+  ///
+  /// The dictionaries are private so a title write is only ever observable through
+  /// `tabs`, which is what keeps them from invalidating the tab bar. That also hides
+  /// whether closing a tab pruned them: `flushPendingTitles` skips an absent tab on
+  /// its own existence guard, so it returns the same empty result either way. Without
+  /// this seam a test cannot tell a working prune from a leak that grows with every
+  /// tab ever closed.
+  var coalescedTabIDsForTesting: Set<TerminalTabID> {
+    Set(lastLiveTitleWriteAt.keys).union(pendingLiveTitles.keys)
+  }
+
   /// Sets (or clears, when blank) the user-defined title. Returns `true` when
   /// the visible `displayTitle` actually changed.
   @discardableResult

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState+AgentDetection.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState+AgentDetection.swift
@@ -26,7 +26,6 @@ extension WorktreeTerminalState {
         guard let self, let view, self.surfaces[view.id] != nil else { return }
         let hasAgent = await self.detectAgentState(for: view, tabId: tabId)
         let now = Date()
-        self.flushCoalescedTabTitles(now: now)
         let schedule = self.agentDetectionSchedules[view.id] ?? .cold
         self.agentDetectionSchedules[view.id] =
           hasAgent ? schedule.observedAgent(now: now) : schedule.observedNoAgent(now: now)
@@ -270,10 +269,8 @@ extension WorktreeTerminalState {
   /// entries that follow them — the same refresh a title written directly through
   /// `updateTitle` triggers, so the two paths cannot drift.
   ///
-  /// Driven by the detection poll: a spinner that stops animating leaves no further
-  /// title change to carry its last frame, and the poll is already running for
-  /// exactly the panes that animate. Split out of that `Task` loop because the loop
-  /// offers no synchronous seam a test can drive.
+  /// The manager's clock-driven trailing flush uses the same refresh path. This
+  /// synchronous seam lets callers and tests force a flush at an explicit date.
   @discardableResult
   func flushCoalescedTabTitles(now: Date = Date()) -> [TerminalTabID] {
     let flushed = tabManager.flushPendingTitles(now: now)

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState+AgentDetection.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState+AgentDetection.swift
@@ -26,6 +26,11 @@ extension WorktreeTerminalState {
         guard let self, let view, self.surfaces[view.id] != nil else { return }
         let hasAgent = await self.detectAgentState(for: view, tabId: tabId)
         let now = Date()
+        // Lands the last frame of a spinner that stopped animating. Cheap when
+        // nothing is pending, which is the common case.
+        for flushedTabID in self.tabManager.flushPendingTitles(now: now) {
+          self.refreshAgentEntriesForTitleChange(in: flushedTabID)
+        }
         let schedule = self.agentDetectionSchedules[view.id] ?? .cold
         self.agentDetectionSchedules[view.id] =
           hasAgent ? schedule.observedAgent(now: now) : schedule.observedNoAgent(now: now)

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState+AgentDetection.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState+AgentDetection.swift
@@ -26,11 +26,7 @@ extension WorktreeTerminalState {
         guard let self, let view, self.surfaces[view.id] != nil else { return }
         let hasAgent = await self.detectAgentState(for: view, tabId: tabId)
         let now = Date()
-        // Lands the last frame of a spinner that stopped animating. Cheap when
-        // nothing is pending, which is the common case.
-        for flushedTabID in self.tabManager.flushPendingTitles(now: now) {
-          self.refreshAgentEntriesForTitleChange(in: flushedTabID)
-        }
+        self.flushCoalescedTabTitles(now: now)
         let schedule = self.agentDetectionSchedules[view.id] ?? .cold
         self.agentDetectionSchedules[view.id] =
           hasAgent ? schedule.observedAgent(now: now) : schedule.observedNoAgent(now: now)
@@ -268,6 +264,23 @@ extension WorktreeTerminalState {
     for surfaceID in surfaceIDs {
       refreshAgentEntryForTitleChange(surfaceID: surfaceID, in: tabId)
     }
+  }
+
+  /// Lands tab titles held back by coalescing and refreshes the Active Agents
+  /// entries that follow them — the same refresh a title written directly through
+  /// `updateTitle` triggers, so the two paths cannot drift.
+  ///
+  /// Driven by the detection poll: a spinner that stops animating leaves no further
+  /// title change to carry its last frame, and the poll is already running for
+  /// exactly the panes that animate. Split out of that `Task` loop because the loop
+  /// offers no synchronous seam a test can drive.
+  @discardableResult
+  func flushCoalescedTabTitles(now: Date = Date()) -> [TerminalTabID] {
+    let flushed = tabManager.flushPendingTitles(now: now)
+    for tabID in flushed {
+      refreshAgentEntriesForTitleChange(in: tabID)
+    }
+    return flushed
   }
 
   /// Single-pane variant for a surface whose own title changed without moving

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -215,18 +215,24 @@ final class WorktreeTerminalState {
     worktree: Worktree,
     runSetupScript: Bool = false,
     defaultFontSize: Float32? = nil,
-    targetHandleRegistry: TerminalTargetHandleRegistry? = nil
+    targetHandleRegistry: TerminalTargetHandleRegistry? = nil,
+    titleFlushClock: any Clock<Duration> = ContinuousClock()
   ) {
     self.runtime = runtime
     self.worktree = worktree
     self.targetHandleRegistry = targetHandleRegistry ?? TerminalTargetHandleRegistry()
     self.pendingSetupScript = runSetupScript
     self.defaultFontSize = defaultFontSize
-    self.tabManager = TerminalTabManager()
+    self.tabManager = TerminalTabManager(titleFlushClock: titleFlushClock)
     _repositorySettings = SharedReader(
       wrappedValue: RepositorySettings.default,
       .repositorySettings(worktree.repositoryRootURL)
     )
+    self.tabManager.onCoalescedTitlesFlushed = { [weak self] tabIDs in
+      for tabID in tabIDs {
+        self?.refreshAgentEntriesForTitleChange(in: tabID)
+      }
+    }
   }
 
   var worktreeID: Worktree.ID { worktree.id }

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabsRowView.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabsRowView.swift
@@ -21,10 +21,16 @@ struct TerminalTabsRowView: View {
   @State private var rowFrame: CGRect = .zero
 
   var body: some View {
+    // Read `tabs` once and index it: the lookup below runs inside a `ForEach`
+    // over the same collection, so scanning it per row made each rebuild
+    // quadratic — and a rebuild happens whenever any one tab's title changes.
+    let tabs = manager.tabs
+    let tabsByID = Dictionary(tabs.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
+
     ZStack(alignment: .topLeading) {
       HStack(alignment: .center, spacing: TerminalTabBarMetrics.tabSpacing) {
         ForEach(Array(openedTabs.enumerated()), id: \.element) { index, id in
-          if let item = manager.tabs.first(where: { $0.id == id }) {
+          if let item = tabsByID[id] {
             TerminalTabView(
               tab: item,
               isActive: manager.selectedTabId == id,
@@ -65,7 +71,7 @@ struct TerminalTabsRowView: View {
             .simultaneousGesture(makeTabDragGesture(id: id))
             .terminalTabContextMenu(
               tabId: id,
-              tabs: manager.tabs,
+              tabs: tabs,
               actions: TerminalTabContextMenuActions(
                 renameTab: renameTab,
                 changeIcon: changeIcon,

--- a/supacode/Support/Debouncer.swift
+++ b/supacode/Support/Debouncer.swift
@@ -51,7 +51,7 @@ final class Debouncer {
 /// `TestClock`, let the test advance past a deadline that was never armed,
 /// hanging the sleep forever (the CI-only `DebouncerTests` flake).
 extension Clock where Duration == Swift.Duration {
-  fileprivate func anchoredSleep(for interval: Duration) -> @Sendable () async throws -> Void {
+  func anchoredSleep(for interval: Duration) -> @Sendable () async throws -> Void {
     let deadline = now.advanced(by: interval)
     return { try await self.sleep(until: deadline, tolerance: nil) }
   }

--- a/supacodeTests/TabTitleFlushRefreshTests.swift
+++ b/supacodeTests/TabTitleFlushRefreshTests.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Clocks
 import Foundation
 import GhosttyKit
 import Testing
@@ -64,13 +65,36 @@ struct TabTitleFlushRefreshTests {
     #expect(fixture.state.tabManager.tabs.first?.title == "⠋ building")
   }
 
+  @Test func aWithheldTitleFlushesWithoutAnAgentDetectionTask() async {
+    let clock = TestClock()
+    let fixture = makeFixture(titleFlushClock: clock)
+    var received: [ActiveAgentEntry] = []
+    fixture.state.onAgentEntryChanged = { received.append($0) }
+
+    _ = fixture.state.tabManager.updateTitle(fixture.tabId, title: "A", now: start)
+    _ = fixture.state.tabManager.updateTitle(
+      fixture.tabId,
+      title: "B",
+      now: start.addingTimeInterval(0.2)
+    )
+    #expect(fixture.state.agentDetectionTasks.isEmpty)
+
+    await clock.advance(by: .seconds(1))
+    for _ in 0..<10 { await Task.yield() }
+
+    #expect(fixture.state.tabManager.tabs.first?.title == "B")
+    #expect(received.map(\.paneTitle) == ["B"])
+  }
+
   private struct Fixture {
     let state: WorktreeTerminalState
     let tabId: TerminalTabID
     let pane: GhosttySurfaceView
   }
 
-  private func makeFixture() -> Fixture {
+  private func makeFixture(
+    titleFlushClock: any Clock<Duration> = ContinuousClock()
+  ) -> Fixture {
     let state = WorktreeTerminalState(
       runtime: GhosttyRuntime(),
       worktree: Worktree(
@@ -79,7 +103,8 @@ struct TabTitleFlushRefreshTests {
         detail: "",
         workingDirectory: URL(fileURLWithPath: "/tmp/repo/worktree"),
         repositoryRootURL: URL(fileURLWithPath: "/tmp/repo")
-      )
+      ),
+      titleFlushClock: titleFlushClock
     )
     let pane = GhosttySurfaceView(
       runtime: state.runtime,

--- a/supacodeTests/TabTitleFlushRefreshTests.swift
+++ b/supacodeTests/TabTitleFlushRefreshTests.swift
@@ -1,0 +1,99 @@
+import AppKit
+import Foundation
+import GhosttyKit
+import Testing
+
+@testable import supacode
+
+/// A tab title held back by coalescing must refresh the Active Agents subtitle the
+/// same way a title written straight through `updateTitle` does. Those are two
+/// separate call sites into `refreshAgentEntriesForTitleChange`, and nothing but a
+/// test keeps them from drifting — the withheld title is invisible until the flush
+/// lands it, so a flush that forgot to refresh would show a stale subtitle
+/// indefinitely rather than for one poll.
+@MainActor
+struct TabTitleFlushRefreshTests {
+  private let start = Date(timeIntervalSince1970: 1_000)
+
+  @Test func flushingAWithheldTitleRefreshesTheAgentEntry() {
+    let fixture = makeFixture()
+    var received: [ActiveAgentEntry] = []
+    fixture.state.onAgentEntryChanged = { received.append($0) }
+
+    #expect(fixture.state.tabManager.updateTitle(fixture.tabId, title: "⠋ building", now: start))
+    received.removeAll()
+
+    // Inside the interval, so the tab bar never sees it and no refresh fires yet.
+    #expect(
+      fixture.state.tabManager.updateTitle(
+        fixture.tabId, title: "⠙ building", now: start.addingTimeInterval(0.2)) == false
+    )
+    #expect(received.isEmpty, "A withheld title must not reach the entry either")
+
+    let flushed = fixture.state.flushCoalescedTabTitles(now: start.addingTimeInterval(1.5))
+
+    #expect(flushed == [fixture.tabId])
+    #expect(received.count == 1, "The flush must refresh the entry, not just the tab")
+    #expect(received.last?.paneTitle == "⠙ building")
+  }
+
+  /// The flush is called on every detection tick, so the common case — nothing held
+  /// back — must not emit. Otherwise the coalescing would trade one source of entry
+  /// churn for another.
+  @Test func flushingWithNothingWithheldEmitsNothing() {
+    let fixture = makeFixture()
+    _ = fixture.state.tabManager.updateTitle(fixture.tabId, title: "⠋ building", now: start)
+    var received: [ActiveAgentEntry] = []
+    fixture.state.onAgentEntryChanged = { received.append($0) }
+
+    #expect(fixture.state.flushCoalescedTabTitles(now: start.addingTimeInterval(5)).isEmpty)
+    #expect(received.isEmpty)
+  }
+
+  /// A flush inside the interval must leave the title held, so the one-second spacing
+  /// is not quietly bypassed by the poll running more often than that.
+  @Test func aFlushInsideTheIntervalHoldsTheTitle() {
+    let fixture = makeFixture()
+    _ = fixture.state.tabManager.updateTitle(fixture.tabId, title: "⠋ building", now: start)
+    _ = fixture.state.tabManager.updateTitle(fixture.tabId, title: "⠙ building", now: start.addingTimeInterval(0.2))
+    var received: [ActiveAgentEntry] = []
+    fixture.state.onAgentEntryChanged = { received.append($0) }
+
+    #expect(fixture.state.flushCoalescedTabTitles(now: start.addingTimeInterval(0.5)).isEmpty)
+    #expect(received.isEmpty)
+    #expect(fixture.state.tabManager.tabs.first?.title == "⠋ building")
+  }
+
+  private struct Fixture {
+    let state: WorktreeTerminalState
+    let tabId: TerminalTabID
+    let pane: GhosttySurfaceView
+  }
+
+  private func makeFixture() -> Fixture {
+    let state = WorktreeTerminalState(
+      runtime: GhosttyRuntime(),
+      worktree: Worktree(
+        id: "/tmp/repo/worktree",
+        name: "worktree",
+        detail: "",
+        workingDirectory: URL(fileURLWithPath: "/tmp/repo/worktree"),
+        repositoryRootURL: URL(fileURLWithPath: "/tmp/repo")
+      )
+    )
+    let pane = GhosttySurfaceView(
+      runtime: state.runtime,
+      workingDirectory: URL(fileURLWithPath: "/tmp/repo/worktree", isDirectory: true),
+      fontSize: nil,
+      context: GHOSTTY_SURFACE_CONTEXT_TAB,
+      skipsSurfaceCreationForTesting: true
+    )
+    let tabId = state.tabManager.createTab(title: "worktree 1", icon: "terminal")
+    state.surfaces[pane.id] = pane
+    state.trees[tabId] = SplitTree<GhosttySurfaceView>(view: pane)
+    state.focusedSurfaceIdByTab[tabId] = pane.id
+    // An entry is only produced for a pane with a detected agent in a known state.
+    state.surfaceAgentStates[pane.id] = PaneAgentState(detectedAgent: .claude, state: .working)
+    return Fixture(state: state, tabId: tabId, pane: pane)
+  }
+}

--- a/supacodeTests/TerminalTabTitleCoalescingTests.swift
+++ b/supacodeTests/TerminalTabTitleCoalescingTests.swift
@@ -127,13 +127,56 @@ struct TerminalTabTitleCoalescingTests {
     #expect(manager.tabs.first(where: { $0.id == id })?.displayTitle == "my tab")
   }
 
+  /// Asserts the bookkeeping itself, not `flushPendingTitles`'s return value: that
+  /// value is empty for a closed tab whether or not the prune ran, because the flush
+  /// skips any id missing from `tabs`. Reading the retained ids is the only way to
+  /// tell a working prune from a leak that grows with every tab ever closed.
   @Test func closingATabDropsItsCoalescingState() {
     let (manager, id) = makeManager()
     _ = manager.updateTitle(id, title: "⠋ working", now: start)
     _ = manager.updateTitle(id, title: "⠙ working", now: start.addingTimeInterval(0.2))
+    #expect(manager.coalescedTabIDsForTesting == [id], "Both a last-write stamp and a pending title are held")
+
     manager.closeTab(id)
 
+    #expect(manager.coalescedTabIDsForTesting.isEmpty, "Closing the tab must drop its bookkeeping, not leak it")
     #expect(manager.flushPendingTitles(now: start.addingTimeInterval(5)).isEmpty)
     #expect(manager.tabs.isEmpty)
+  }
+
+  /// A surviving tab must keep its state when a sibling closes, so the prune cannot
+  /// be "fixed" by clearing everything.
+  @Test func closingOneTabKeepsAnotherTabsCoalescingState() {
+    let (manager, kept) = makeManager()
+    let closed = manager.createTab(title: "second", icon: nil)
+    _ = manager.updateTitle(kept, title: "⠋ kept", now: start)
+    _ = manager.updateTitle(closed, title: "⠋ closed", now: start)
+
+    manager.closeTab(closed)
+
+    #expect(manager.coalescedTabIDsForTesting == [kept])
+  }
+
+  /// Pins the comparison at `TerminalTabManager.swift`'s `<` against the interval.
+  /// Without a case landing exactly on the boundary, changing it to `<=` — which
+  /// would withhold a title that has waited the full interval — passes every other
+  /// test in this file.
+  @Test func aTitleArrivingExactlyOnTheIntervalIsWritten() {
+    let (manager, id) = makeManager()
+    _ = manager.updateTitle(id, title: "⠋ working", now: start)
+    let boundary = start.addingTimeInterval(TerminalTabManager.liveTitleCoalescingInterval)
+
+    #expect(manager.updateTitle(id, title: "⠙ working", now: boundary))
+    #expect(title(of: manager, id) == "⠙ working")
+  }
+
+  /// The other side of the same boundary: one instant earlier must still be withheld.
+  @Test func aTitleArrivingJustInsideTheIntervalIsWithheld() {
+    let (manager, id) = makeManager()
+    _ = manager.updateTitle(id, title: "⠋ working", now: start)
+    let justInside = start.addingTimeInterval(TerminalTabManager.liveTitleCoalescingInterval - 0.001)
+
+    #expect(manager.updateTitle(id, title: "⠙ working", now: justInside) == false)
+    #expect(title(of: manager, id) == "⠋ working")
   }
 }

--- a/supacodeTests/TerminalTabTitleCoalescingTests.swift
+++ b/supacodeTests/TerminalTabTitleCoalescingTests.swift
@@ -1,0 +1,139 @@
+import Foundation
+import Testing
+
+@testable import supacode
+
+/// `TerminalTabManager.tabs` is observed as a whole, so one tab's title write
+/// rebuilds the entire tab bar. Agent TUIs animate a spinner glyph into the
+/// title at roughly 10 Hz, so live title writes are spaced out; these tests pin
+/// both the spacing and the trailing flush that keeps a settled title from
+/// being stranded.
+@MainActor
+struct TerminalTabTitleCoalescingTests {
+  private let start = Date(timeIntervalSince1970: 1_000)
+
+  private func makeManager() -> (TerminalTabManager, TerminalTabID) {
+    let manager = TerminalTabManager()
+    let id = manager.createTab(title: "initial", icon: nil)
+    return (manager, id)
+  }
+
+  private func title(of manager: TerminalTabManager, _ id: TerminalTabID) -> String? {
+    manager.tabs.first(where: { $0.id == id })?.title
+  }
+
+  @Test func theFirstTitleAfterAQuietPeriodIsWrittenImmediately() {
+    let (manager, id) = makeManager()
+
+    #expect(manager.updateTitle(id, title: "building", now: start))
+    #expect(title(of: manager, id) == "building")
+  }
+
+  @Test func framesArrivingInsideTheIntervalDoNotReachTheTabs() {
+    let (manager, id) = makeManager()
+    _ = manager.updateTitle(id, title: "⠋ working", now: start)
+
+    #expect(manager.updateTitle(id, title: "⠙ working", now: start.addingTimeInterval(0.1)) == false)
+    #expect(manager.updateTitle(id, title: "⠹ working", now: start.addingTimeInterval(0.2)) == false)
+
+    #expect(
+      title(of: manager, id) == "⠋ working",
+      "Animation frames must not mutate the observed array"
+    )
+  }
+
+  @Test func aTitleArrivingAfterTheIntervalIsWrittenAgain() {
+    let (manager, id) = makeManager()
+    _ = manager.updateTitle(id, title: "⠋ working", now: start)
+    _ = manager.updateTitle(id, title: "⠙ working", now: start.addingTimeInterval(0.5))
+
+    #expect(manager.updateTitle(id, title: "⠸ working", now: start.addingTimeInterval(1.1)))
+    #expect(title(of: manager, id) == "⠸ working")
+  }
+
+  /// Only the newest held-back title survives, so a burst never queues up.
+  @Test func flushLandsTheMostRecentSuppressedTitle() {
+    let (manager, id) = makeManager()
+    _ = manager.updateTitle(id, title: "⠋ working", now: start)
+    _ = manager.updateTitle(id, title: "⠙ working", now: start.addingTimeInterval(0.2))
+    _ = manager.updateTitle(id, title: "⠸ working", now: start.addingTimeInterval(0.4))
+
+    #expect(manager.flushPendingTitles(now: start.addingTimeInterval(1.5)) == [id])
+    #expect(title(of: manager, id) == "⠸ working")
+  }
+
+  @Test func flushDoesNothingBeforeTheIntervalElapses() {
+    let (manager, id) = makeManager()
+    _ = manager.updateTitle(id, title: "⠋ working", now: start)
+    _ = manager.updateTitle(id, title: "⠙ working", now: start.addingTimeInterval(0.2))
+
+    #expect(manager.flushPendingTitles(now: start.addingTimeInterval(0.5)).isEmpty)
+    #expect(title(of: manager, id) == "⠋ working")
+  }
+
+  @Test func flushIsANoOpWhenNothingWasSuppressed() {
+    let (manager, id) = makeManager()
+    _ = manager.updateTitle(id, title: "done", now: start)
+
+    #expect(manager.flushPendingTitles(now: start.addingTimeInterval(5)).isEmpty)
+    #expect(title(of: manager, id) == "done")
+  }
+
+  /// A suppressed frame must not resurface after a later title has been written,
+  /// or the tab would flick back to a stale animation frame.
+  @Test func aSuppressedTitleIsDiscardedOnceANewerOneIsWritten() {
+    let (manager, id) = makeManager()
+    _ = manager.updateTitle(id, title: "⠋ working", now: start)
+    _ = manager.updateTitle(id, title: "⠙ working", now: start.addingTimeInterval(0.2))
+    _ = manager.updateTitle(id, title: "finished", now: start.addingTimeInterval(1.1))
+
+    #expect(manager.flushPendingTitles(now: start.addingTimeInterval(9)).isEmpty)
+    #expect(title(of: manager, id) == "finished")
+  }
+
+  @Test func coalescingIsPerTabNotGlobal() {
+    let manager = TerminalTabManager()
+    let first = manager.createTab(title: "first", icon: nil)
+    let second = manager.createTab(title: "second", icon: nil)
+
+    #expect(manager.updateTitle(first, title: "⠋ one", now: start))
+    // The second tab has its own history, so its first write is not held back.
+    #expect(manager.updateTitle(second, title: "⠋ two", now: start.addingTimeInterval(0.1)))
+
+    #expect(title(of: manager, first) == "⠋ one")
+    #expect(title(of: manager, second) == "⠋ two")
+  }
+
+  @Test func aLockedTitleIsNeverWrittenOrHeld() {
+    let manager = TerminalTabManager()
+    let id = manager.createTab(title: "pinned", icon: nil, isTitleLocked: true)
+
+    #expect(manager.updateTitle(id, title: "⠋ working", now: start) == false)
+    #expect(manager.updateTitle(id, title: "⠙ working", now: start.addingTimeInterval(0.2)) == false)
+    #expect(manager.flushPendingTitles(now: start.addingTimeInterval(5)).isEmpty)
+    #expect(title(of: manager, id) == "pinned")
+  }
+
+  /// A custom title masks the live one, so the visible title never moves — the
+  /// live value still updates underneath so clearing the custom title reveals it.
+  @Test func aCustomTitleMasksTheFlushedLiveTitle() {
+    let (manager, id) = makeManager()
+    _ = manager.setCustomTitle(id, title: "my tab")
+    _ = manager.updateTitle(id, title: "⠋ working", now: start)
+    _ = manager.updateTitle(id, title: "⠙ working", now: start.addingTimeInterval(0.2))
+
+    #expect(manager.flushPendingTitles(now: start.addingTimeInterval(1.5)).isEmpty)
+    #expect(title(of: manager, id) == "⠙ working")
+    #expect(manager.tabs.first(where: { $0.id == id })?.displayTitle == "my tab")
+  }
+
+  @Test func closingATabDropsItsCoalescingState() {
+    let (manager, id) = makeManager()
+    _ = manager.updateTitle(id, title: "⠋ working", now: start)
+    _ = manager.updateTitle(id, title: "⠙ working", now: start.addingTimeInterval(0.2))
+    manager.closeTab(id)
+
+    #expect(manager.flushPendingTitles(now: start.addingTimeInterval(5)).isEmpty)
+    #expect(manager.tabs.isEmpty)
+  }
+}

--- a/supacodeTests/TerminalTabTitleCoalescingTests.swift
+++ b/supacodeTests/TerminalTabTitleCoalescingTests.swift
@@ -1,3 +1,4 @@
+import Clocks
 import Foundation
 import Testing
 
@@ -91,6 +92,16 @@ struct TerminalTabTitleCoalescingTests {
     #expect(title(of: manager, id) == "finished")
   }
 
+  @Test func aSuppressedTitleIsDiscardedWhenTheLatestTitleRevertsToTheVisibleValue() {
+    let (manager, id) = makeManager()
+    _ = manager.updateTitle(id, title: "A", now: start)
+    _ = manager.updateTitle(id, title: "B", now: start.addingTimeInterval(0.2))
+
+    #expect(manager.updateTitle(id, title: "A", now: start.addingTimeInterval(0.4)) == false)
+    #expect(manager.flushPendingTitles(now: start.addingTimeInterval(1.5)).isEmpty)
+    #expect(title(of: manager, id) == "A")
+  }
+
   @Test func coalescingIsPerTabNotGlobal() {
     let manager = TerminalTabManager()
     let first = manager.createTab(title: "first", icon: nil)
@@ -102,6 +113,33 @@ struct TerminalTabTitleCoalescingTests {
 
     #expect(title(of: manager, first) == "⠋ one")
     #expect(title(of: manager, second) == "⠋ two")
+  }
+
+  @Test func automaticFlushRearmsForTheNextTabsLaterDeadline() async {
+    let clock = TestClock()
+    let manager = TerminalTabManager(titleFlushClock: clock)
+    let first = manager.createTab(title: "first", icon: nil)
+    let second = manager.createTab(title: "second", icon: nil)
+    var flushed: [[TerminalTabID]] = []
+    manager.onCoalescedTitlesFlushed = { flushed.append($0) }
+
+    _ = manager.updateTitle(first, title: "first A", now: start)
+    _ = manager.updateTitle(first, title: "first B", now: start.addingTimeInterval(0.1))
+    _ = manager.updateTitle(second, title: "second A", now: start.addingTimeInterval(0.4))
+    _ = manager.updateTitle(second, title: "second B", now: start.addingTimeInterval(0.5))
+
+    await clock.advance(by: .seconds(0.9))
+    for _ in 0..<10 { await Task.yield() }
+
+    #expect(title(of: manager, first) == "first B")
+    #expect(title(of: manager, second) == "second A")
+    #expect(flushed == [[first]])
+
+    await clock.advance(by: .seconds(0.4))
+    for _ in 0..<10 { await Task.yield() }
+
+    #expect(title(of: manager, second) == "second B")
+    #expect(flushed == [[first], [second]])
   }
 
   @Test func aLockedTitleIsNeverWrittenOrHeld() {


### PR DESCRIPTION
## Summary

- preserve both original commits from #649 and their author attribution
- coalesce animated live terminal titles independently per tab and remove repeated linear tab lookup
- guarantee trailing delivery with a clock-driven task even when agent detection is absent or cold
- discard stale pending frames when the latest title returns to the visible value
- document the one-second live-title coalescing contract and record the performance review

## Review follow-up

The original implementation correctly addresses a real SwiftUI/AppKit invalidation hot path, but its trailing flush depended on the agent-detection poll. A non-agent program, or a pane whose detection schedule became cold, could therefore leave the newest withheld title behind indefinitely. The follow-up gives title delivery its own clock, keeps one task per manager, and re-arms it for later per-tab deadlines.

It also closes the `A -> B (held) -> A` stale-frame case and uses a snapshot while removing flushed dictionary entries. Custom and locked titles keep their existing semantics, and Active Agents is refreshed through the same path as an immediate visible title update.

## Validation

- 46 focused tests passed after merging the latest `main`
- the automatic trailing-delivery test runs with no agent-detection task
- a two-tab `TestClock` test verifies re-arming for a later deadline
- `make check`
- `make build-app` (0 errors, 0 warnings)

Closes #649 after integration.
