### PR TITLE
Bound transcript fingerprint reuse

### DIFF
--- a/docs-ai/056-performance-optimization-2026-08/000-plan.md
+++ b/docs-ai/056-performance-optimization-2026-08/000-plan.md
@@ -4,7 +4,7 @@
 | --- | --- |
 | **Status** | Implemented |
 | **Anchor date** | 2026-08-01 |
-| **Primary PRs** | #644–#646, #652, #653; review queue #647–#650 |
+| **Primary PRs** | #644–#646, #650, #652, #653; review queue #647–#649 |
 | **Related** | [030-agent-status-detection](../030-agent-status-detection/000-plan.md), [032-performance-hardening](../032-performance-hardening/000-plan.md), [037-line-diff-tracking](../037-line-diff-tracking/000-plan.md), `docs/components/diff-view.md` |
 
 ## Background
@@ -138,7 +138,7 @@ pending independent code-path and test review.
 | #647 | Deduplicate raw-state-only agent emissions and narrow sidebar invalidation | Decide whether stale CLI `raw_state` is acceptable; trace UI/CLI ownership before merge | `e77ba660` |
 | #648 | Replace per-agent worktree scans/path resolution with a cached directory index | Verify deepest-match and symlink semantics, cache invalidation, render-path purity, and current CI | `08773383` |
 | #649 | Coalesce animated terminal-title writes and remove quadratic tab lookup | Verify final-title delivery, close/prune lifecycle, custom/locked titles, and clock boundaries | `b77888f3` |
-| #650 | Cache parsed transcript tails and fast-path fingerprint normalization | Verify append/mtime invalidation, cache pruning, Unicode equivalence, collision behavior, and current CI | `c97cbb4` |
+| #650 | Cache parsed transcript tails and fast-path fingerprint normalization | Reviewed for fork integration: normalized fragments use one resolver-wide, entry- and payload-bounded LRU; the ASCII and escape-absence paths are pinned to the original Unicode-aware formulation | `c97cbb4` |
 
 ## Alternatives & decisions
 
@@ -173,3 +173,6 @@ pending independent code-path and test review.
   [002-opt-in-debug-tca-action-logging.md](002-opt-in-debug-tca-action-logging.md).
 - Updated 2026-08-02: Merged per-surface agent screen-scan memoization from #646 — see
   [003-agent-screen-scan-memoization.md](003-agent-screen-scan-memoization.md).
+- Updated 2026-08-02: Reviewed transcript-fragment reuse and fingerprint normalization from
+  #650 and bounded cache lifetime independently of process cleanup — see
+  [007-transcript-fragment-cache.md](007-transcript-fragment-cache.md).

--- a/docs-ai/056-performance-optimization-2026-08/000-plan.md
+++ b/docs-ai/056-performance-optimization-2026-08/000-plan.md
@@ -4,7 +4,7 @@
 | --- | --- |
 | **Status** | Implemented |
 | **Anchor date** | 2026-08-01 |
-| **Primary PRs** | #644–#646, #650, #652, #653; review queue #647–#649 |
+| **Primary PRs** | #644–#646, #650, #652, #653, #657; review queue #647–#649 |
 | **Related** | [030-agent-status-detection](../030-agent-status-detection/000-plan.md), [032-performance-hardening](../032-performance-hardening/000-plan.md), [037-line-diff-tracking](../037-line-diff-tracking/000-plan.md), `docs/components/diff-view.md` |
 
 ## Background

--- a/docs-ai/056-performance-optimization-2026-08/007-transcript-fragment-cache.md
+++ b/docs-ai/056-performance-optimization-2026-08/007-transcript-fragment-cache.md
@@ -36,7 +36,7 @@ reproduce those exact percentages.
 ## Refs
 
 - Original PR #650
-- Fork integration PR pending
+- Fork integration PR #657
 - Original implementation commits `1e8933cb` and `c97cbb4`
 - Fork follow-up commit `2c2eeddf`
 

--- a/docs-ai/056-performance-optimization-2026-08/007-transcript-fragment-cache.md
+++ b/docs-ai/056-performance-optimization-2026-08/007-transcript-fragment-cache.md
@@ -1,0 +1,72 @@
+# 056.007 — Transcript Fragment Cache and Fingerprint Normalization
+
+## Context
+
+Agent session resolution periodically compares visible terminal text with recent transcript
+tails. Before #650, every fresh resolution reread, parsed, normalized, and filtered the same
+candidate tails even when their bytes had not changed. The tails were normally already in the
+filesystem page cache, so repeated JSON parsing, ANSI stripping, Unicode case folding, and
+whitespace normalization dominated the matching cost rather than file I/O.
+
+The author sampled a 20-pane instance and attributed 15.9% of one core to agent detection,
+13.0% to `AgentSessionResolver.resolve`, 11.4% to fingerprint matching, and 6.7% to normalization.
+The review verified the repeated computation and cache boundaries but did not independently
+reproduce those exact percentages.
+
+## Change
+
+- #650 caches normalized, length-filtered fragments by transcript path and modification date.
+  An unchanged file reuses the exact values that the matcher would otherwise recompute; an
+  appended file receives a new key, and an unreadable tail is never cached as a failure.
+- The fork follow-up replaces per-process fragment caches with one resolver-wide LRU. Fragment
+  parsing is a pure function of transcript bytes and does not depend on the consulting process,
+  agent profile, config root, candidate set, or active screen, so sharing removes duplicate tails
+  across panes without changing scoring.
+- The shared cache retains at most 128 transcript entries and 8 MiB of normalized UTF-8 payload.
+  Both limits are independent of process-cache cleanup, so ordinary process churn cannot retain
+  one multi-megabyte cache per dead process. A single entry larger than the payload budget is
+  returned to the current match but not retained.
+- Observing a new modification date removes older cached versions of the same path immediately,
+  including when the new tail is temporarily unreadable. Entry and byte-budget pressure evict
+  the least recently used value.
+- Fingerprint normalization skips the ANSI regex when the input contains no ESC byte. Fully ASCII
+  strings use a byte scanner for CSI removal, ASCII case folding, and whitespace collapse; any
+  non-ASCII byte falls back to the original Unicode-aware formulation.
+
+## Refs
+
+- Original PR #650
+- Fork integration PR pending
+- Original implementation commits `1e8933cb` and `c97cbb4`
+- Fork follow-up commit `2c2eeddf`
+
+## Current state
+
+The resolver result cache still controls how often each process performs a fresh match. On a
+fresh match, candidates consult the shared fragment LRU, so several panes scanning the same
+history reuse one normalized value instead of retaining duplicates. Cache eviction can reduce the
+optimization to the pre-cache computation cost under an unusually broad, disjoint candidate set,
+but it cannot alter which candidate wins.
+
+The 8 MiB limit measures normalized UTF-8 payload plus path bytes, not total allocator RSS. The
+128-entry limit separately bounds array and string-object overhead. Transcript paths normally
+reside on APFS, whose modification-time precision makes same-path/same-time content collisions
+impractical for the append-only transcript workflow; deliberately preserving timestamps while
+rewriting content is outside this cache contract.
+
+## Verification
+
+- The original normalization, fragment-cache, profile, and resolver suites passed 54 tests before
+  the follow-up.
+- Entry-count and byte-budget tests were added first and failed to compile until the cache exposed
+  bounded construction. A new-version load-failure test then failed against the first LRU draft
+  until superseded versions were removed before loading.
+- Tests cover unchanged-file reuse, modification-date invalidation, unreadable-tail recovery,
+  immediate same-path replacement, entry-count LRU, cumulative byte-budget LRU, oversized values,
+  and matcher replay after the source files disappear.
+- The normalization fast path is compared with a pristine copy of the original implementation
+  across a hand-built Unicode/CSI corpus, 2,000 deterministic random ASCII strings, and every
+  one- and two-byte ASCII combination.
+- The final four focused suites passed 59 tests with no failures or warnings.
+- `make check` passed before integrating the latest `main`.
+- `make build-app` completed with no errors or warnings before integrating the latest `main`.

--- a/supacode/Infrastructure/AgentDetection/AgentSessionResolver.swift
+++ b/supacode/Infrastructure/AgentDetection/AgentSessionResolver.swift
@@ -640,8 +640,16 @@ nonisolated enum AgentSessionFingerprintMatcher {
   /// Reference implementation. `normalize` must agree with it for every input;
   /// `AgentSessionFingerprintNormalizeTests` asserts that over a corpus.
   static func normalizeGeneral(_ value: String) -> String {
-    value
-      .replacing(#/\u{001B}\[[0-?]*[ -\/]*[@-~]/#, with: " ")
+    // A pattern anchored on ESC cannot match a string with no ESC byte, and
+    // nearly every transcript fragment has none. Proving absence with a byte
+    // scan is several times cheaper than letting the regex engine walk the
+    // whole string to reach the same conclusion.
+    let stripped =
+      value.utf8.contains(0x1B)
+      ? value.replacing(#/\u{001B}\[[0-?]*[ -\/]*[@-~]/#, with: " ")
+      : value
+    return
+      stripped
       .lowercased()
       .split(whereSeparator: \Character.isWhitespace)
       .joined(separator: " ")

--- a/supacode/Infrastructure/AgentDetection/AgentSessionResolver.swift
+++ b/supacode/Infrastructure/AgentDetection/AgentSessionResolver.swift
@@ -70,6 +70,46 @@ nonisolated struct AgentSessionResolution: Sendable {
   let isFresh: Bool
 }
 
+/// Parsed, normalized transcript fragments reused across resolver polls.
+///
+/// Fingerprint matching re-reads the same transcript tails every time a pane's
+/// session cache expires (5 s while a session stays resolved). The bytes are
+/// almost always identical and the tails sit in the page cache, so the cost is
+/// re-parsing JSON and re-normalizing text rather than I/O. Keying the parsed
+/// result on the file's modification time replays it for unchanged transcripts
+/// without altering which candidate wins.
+nonisolated struct TranscriptFragmentCache: Sendable {
+  struct Key: Hashable, Sendable {
+    let path: String
+    let modifiedAt: Date
+  }
+
+  private var entries: [Key: [String]] = [:]
+  private var consulted: Set<Key> = []
+
+  var count: Int { entries.count }
+
+  /// Returns the cached fragments for `key`, otherwise stores and returns
+  /// `load()`. A nil `load()` is deliberately not cached: an unreadable tail is
+  /// transient, and caching the failure would keep a recovered file excluded.
+  mutating func fragments(for key: Key, load: () -> [String]?) -> [String]? {
+    consulted.insert(key)
+    if let cached = entries[key] { return cached }
+    guard let loaded = load() else { return nil }
+    entries[key] = loaded
+    return loaded
+  }
+
+  /// Drops every entry not consulted since the previous prune: superseded
+  /// versions of an appended transcript, and files that left the candidate set.
+  /// Because the key carries a modification date, an actively written transcript
+  /// mints a new entry per poll; without this the cache would grow without bound.
+  mutating func pruneUnconsulted() {
+    entries = entries.filter { consulted.contains($0.key) }
+    consulted.removeAll(keepingCapacity: true)
+  }
+}
+
 /// Compatibility shim over the per-agent profiles; the actual rules live in
 /// `AgentSessionProfile`.
 nonisolated enum AgentSessionPathParser {
@@ -92,6 +132,20 @@ actor AgentSessionResolver {
     let usedWideScan: Bool
     var unresolvedStreak: Int = 0
     var provisionalSoleID: String?
+  }
+
+  /// The immutable inputs of one uncached resolution, grouped so the scan and
+  /// match steps take a single subject rather than a long parameter list.
+  private struct ResolveRequest {
+    let identified: IdentifiedAgentProcess
+    let processStartedAt: Date
+    let workingDirectory: URL?
+    let activeText: String
+    /// A relocated agent config root, when the runtime supports one. Selects the
+    /// rooted path parser and candidate roots, and suppresses the pid-keyed
+    /// lookup, whose artifacts only ever live in the default home.
+    let configRoot: URL?
+    let now: Date
   }
 
   /// Unresolved lookups retry quickly while the narrow scan stays cheap, then
@@ -132,6 +186,9 @@ actor AgentSessionResolver {
   }
 
   private var cache: [CacheKey: CachedResult] = [:]
+  /// Per-pane transcript fragment reuse, kept beside `cache` so both are evicted
+  /// on the same liveness check.
+  private var fragmentCaches: [CacheKey: TranscriptFragmentCache] = [:]
   private let fileManager: FileManager
   private let homeDirectory: URL
 
@@ -169,14 +226,20 @@ actor AgentSessionResolver {
       }
     }
 
+    var fragments = fragmentCaches[key] ?? TranscriptFragmentCache()
     let (resolved, usedWideScan) = resolveUncached(
-      identified: identified,
-      processStartedAt: startedAt,
-      workingDirectory: workingDirectory,
-      activeText: activeText,
-      configRoot: configRoot,
-      now: now
+      ResolveRequest(
+        identified: identified,
+        processStartedAt: startedAt,
+        workingDirectory: workingDirectory,
+        activeText: activeText,
+        configRoot: configRoot,
+        now: now
+      ),
+      fragments: &fragments
     )
+    fragments.pruneUnconsulted()
+    fragmentCaches[key] = fragments
     var session = resolved
     var provisionalID: String?
     if let candidate = session, candidate.confidence == .medium {
@@ -202,6 +265,7 @@ actor AgentSessionResolver {
       cache = cache.filter { entry in
         ProcessDetection.processStartDate(pid: entry.key.pid) == entry.key.startedAt
       }
+      fragmentCaches = fragmentCaches.filter { cache[$0.key] != nil }
     }
     return AgentSessionResolution(session: session, isFresh: true)
   }
@@ -229,15 +293,12 @@ actor AgentSessionResolver {
   }
 
   private func resolveUncached(
-    identified: IdentifiedAgentProcess,
-    processStartedAt: Date,
-    workingDirectory: URL?,
-    activeText: String,
-    configRoot: URL? = nil,
-    now: Date
+    _ request: ResolveRequest,
+    fragments cache: inout TranscriptFragmentCache
   ) -> (session: AgentSession?, usedWideScan: Bool) {
+    let identified = request.identified
     let profile = AgentSessionProfile.profile(for: identified.agent)
-    let parsePath = Self.pathParser(profile: profile, configRoot: configRoot)
+    let parsePath = Self.pathParser(profile: profile, configRoot: request.configRoot)
 
     let openSessions = ProcessDetection.openFilePaths(pid: identified.process.pid)
       .compactMap { parsePath($0) }
@@ -261,8 +322,8 @@ actor AgentSessionResolver {
 
     // pid-keyed artifacts live in the default home; a relocated config root
     // has no equivalent (no bound-capable runtime defines one).
-    if configRoot == nil,
-      let session = profile.pidKeyedSession?(homeDirectory, identified.process.pid, processStartedAt)
+    if request.configRoot == nil,
+      let session = profile.pidKeyedSession?(homeDirectory, identified.process.pid, request.processStartedAt)
     {
       return (session, false)
     }
@@ -275,8 +336,9 @@ actor AgentSessionResolver {
       return AgentSessionCandidate(session: session, modifiedAt: modifiedAt)
     }
     if let matched = AgentSessionFingerprintMatcher.bestMatch(
-      activeText: activeText,
-      candidates: openCandidates
+      activeText: request.activeText,
+      candidates: openCandidates,
+      fragments: &cache
     ) {
       let resolved = AgentSession(
         id: matched.session.id,
@@ -289,12 +351,16 @@ actor AgentSessionResolver {
 
     let (candidates, usedWideScan) = recentCandidates(
       profile: profile,
-      processStartedAt: processStartedAt,
-      workingDirectory: workingDirectory,
-      configRoot: configRoot,
-      now: now
+      processStartedAt: request.processStartedAt,
+      workingDirectory: request.workingDirectory,
+      configRoot: request.configRoot,
+      now: request.now
     )
-    if let matched = AgentSessionFingerprintMatcher.bestMatch(activeText: activeText, candidates: candidates) {
+    if let matched = AgentSessionFingerprintMatcher.bestMatch(
+      activeText: request.activeText,
+      candidates: candidates,
+      fragments: &cache
+    ) {
       let resolved = AgentSession(
         id: matched.session.id,
         transcriptPath: matched.session.transcriptPath,
@@ -303,7 +369,8 @@ actor AgentSessionResolver {
       )
       return (resolved, usedWideScan)
     }
-    let sole = AgentSessionCandidate.uniqueActiveCandidate(candidates, processStartedAt: processStartedAt)?.session
+    let sole = AgentSessionCandidate.uniqueActiveCandidate(candidates, processStartedAt: request.processStartedAt)?
+      .session
     return (sole, usedWideScan)
   }
 
@@ -478,9 +545,19 @@ actor AgentSessionResolver {
 }
 
 nonisolated enum AgentSessionFingerprintMatcher {
+  /// Convenience for call sites with no cache to reuse (tests, one-shot lookups).
   static func bestMatch(
     activeText: String,
     candidates: [AgentSessionCandidate]
+  ) -> AgentSessionCandidate? {
+    var scratch = TranscriptFragmentCache()
+    return bestMatch(activeText: activeText, candidates: candidates, fragments: &scratch)
+  }
+
+  static func bestMatch(
+    activeText: String,
+    candidates: [AgentSessionCandidate],
+    fragments cache: inout TranscriptFragmentCache
   ) -> AgentSessionCandidate? {
     let screen = normalize(activeText)
     guard screen.count >= 12 else { return nil }
@@ -494,16 +571,12 @@ nonisolated enum AgentSessionFingerprintMatcher {
     for group in bySession.values {
       var sessionScoreable = false
       for candidate in group.sorted(by: { $0.modifiedAt > $1.modifiedAt }).prefix(2) {
-        guard let path = candidate.session.transcriptPath, let data = tailData(at: path) else { continue }
-        // Lossy decoding is deliberate: the tail window can start mid-character
-        // in a multi-byte transcript, and a failable conversion would void the
-        // whole tail instead of just the cut first line.
-        // swiftlint:disable:next optional_data_string_conversion
-        let fragments = transcriptStrings(String(decoding: data, as: UTF8.self))
         // Scoreable means the session produced at least one fragment long
         // enough to actually enter the comparison — fragments below the floor
         // ("OK") are no testimony at all.
-        let comparable = fragments.map(normalize).filter { $0.count >= 12 }
+        guard let path = candidate.session.transcriptPath,
+          let comparable = comparableFragments(at: path, modifiedAt: candidate.modifiedAt, cache: &cache)
+        else { continue }
         if !comparable.isEmpty { sessionScoreable = true }
         let score = comparable.reduce(0) { best, normalized in
           if screen.contains(normalized) { return max(best, min(200, normalized.count + 80)) }
@@ -532,12 +605,104 @@ nonisolated enum AgentSessionFingerprintMatcher {
     return winner.best.0
   }
 
+  /// Normalized, length-filtered fragments for one transcript tail, served from
+  /// `cache` whenever the file has not been appended to since the last poll.
+  private static func comparableFragments(
+    at path: URL,
+    modifiedAt: Date,
+    cache: inout TranscriptFragmentCache
+  ) -> [String]? {
+    cache.fragments(for: TranscriptFragmentCache.Key(path: path.path, modifiedAt: modifiedAt)) {
+      guard let data = tailData(at: path) else { return nil }
+      // Lossy decoding is deliberate: the tail window can start mid-character
+      // in a multi-byte transcript, and a failable conversion would void the
+      // whole tail instead of just the cut first line.
+      // swiftlint:disable:next optional_data_string_conversion
+      return transcriptStrings(String(decoding: data, as: UTF8.self))
+        .map(normalize)
+        .filter { $0.count >= 12 }
+    }
+  }
+
+  /// Strips ANSI escapes, folds case, and collapses whitespace runs so screen
+  /// text and transcript text compare on content alone.
+  ///
+  /// The ASCII fast path exists because this runs over every transcript fragment
+  /// of every fingerprint match and dominated the resolver's CPU: Swift Regex
+  /// and grapheme-level whitespace splitting are both far more expensive than a
+  /// single byte scan. Any non-ASCII byte defers to `normalizeGeneral`, so
+  /// Unicode case folding and the full Unicode whitespace set keep their exact
+  /// semantics rather than being approximated.
   static func normalize(_ value: String) -> String {
+    normalizeASCII(value) ?? normalizeGeneral(value)
+  }
+
+  /// Reference implementation. `normalize` must agree with it for every input;
+  /// `AgentSessionFingerprintNormalizeTests` asserts that over a corpus.
+  static func normalizeGeneral(_ value: String) -> String {
     value
       .replacing(#/\u{001B}\[[0-?]*[ -\/]*[@-~]/#, with: " ")
       .lowercased()
       .split(whereSeparator: \Character.isWhitespace)
       .joined(separator: " ")
+  }
+
+  /// Returns nil when `value` holds any non-ASCII byte, leaving those inputs to
+  /// the general path.
+  private static func normalizeASCII(_ value: String) -> String? {
+    let utf8 = value.utf8
+    // Built as scalars rather than bytes: every byte kept here is ASCII, so the
+    // conversion is exact and needs no decoding pass over the result.
+    var output = String.UnicodeScalarView()
+    output.reserveCapacity(utf8.count)
+    var pendingSeparator = false
+    var index = utf8.startIndex
+
+    while index < utf8.endIndex {
+      let byte = utf8[index]
+      guard byte < 0x80 else { return nil }
+      // A well-formed CSI sequence becomes a space, which is itself a separator;
+      // a bare ESC matches no sequence and survives as ordinary text.
+      if byte == 0x1B, let end = csiEnd(utf8, from: index) {
+        pendingSeparator = true
+        index = end
+        continue
+      }
+      if isASCIIWhitespace(byte) {
+        pendingSeparator = true
+      } else {
+        // Leading whitespace produces no separator because nothing precedes it,
+        // and a trailing run is simply never flushed — matching the trim that
+        // `split` + `joined` performs.
+        if pendingSeparator {
+          if !output.isEmpty { output.append(Unicode.Scalar(UInt8(0x20))) }
+          pendingSeparator = false
+        }
+        output.append(Unicode.Scalar(byte >= 0x41 && byte <= 0x5A ? byte + 0x20 : byte))
+      }
+      index = utf8.index(after: index)
+    }
+    return String(output)
+  }
+
+  /// The Unicode `White_Space` members that fall in the ASCII range.
+  private static func isASCIIWhitespace(_ byte: UInt8) -> Bool {
+    byte == 0x20 || (0x09...0x0D).contains(byte)
+  }
+
+  /// Index just past a CSI sequence starting at `start`, or nil if the bytes
+  /// there do not form one: `ESC [` , parameters, intermediates, then a final byte.
+  private static func csiEnd(
+    _ utf8: String.UTF8View,
+    from start: String.UTF8View.Index
+  ) -> String.UTF8View.Index? {
+    var index = utf8.index(after: start)
+    guard index < utf8.endIndex, utf8[index] == 0x5B else { return nil }
+    index = utf8.index(after: index)
+    while index < utf8.endIndex, (0x30...0x3F).contains(utf8[index]) { index = utf8.index(after: index) }
+    while index < utf8.endIndex, (0x20...0x2F).contains(utf8[index]) { index = utf8.index(after: index) }
+    guard index < utf8.endIndex, (0x40...0x7E).contains(utf8[index]) else { return nil }
+    return utf8.index(after: index)
   }
 
   private static func tailData(at url: URL, byteLimit: UInt64 = 131_072) -> Data? {

--- a/supacode/Infrastructure/AgentDetection/AgentSessionResolver.swift
+++ b/supacode/Infrastructure/AgentDetection/AgentSessionResolver.swift
@@ -70,22 +70,40 @@ nonisolated struct AgentSessionResolution: Sendable {
   let isFresh: Bool
 }
 
-/// Parsed, normalized transcript fragments reused across resolver polls.
+/// Parsed, normalized transcript fragments reused across resolver polls and panes.
 ///
 /// Fingerprint matching re-reads the same transcript tails every time a pane's
 /// session cache expires (5 s while a session stays resolved). The bytes are
 /// almost always identical and the tails sit in the page cache, so the cost is
 /// re-parsing JSON and re-normalizing text rather than I/O. Keying the parsed
 /// result on the file's modification time replays it for unchanged transcripts
-/// without altering which candidate wins.
+/// without altering which candidate wins. Entry-count and retained-payload limits
+/// bound process churn and candidate-set churn independently of process cleanup.
 nonisolated struct TranscriptFragmentCache: Sendable {
   struct Key: Hashable, Sendable {
     let path: String
     let modifiedAt: Date
   }
 
-  private var entries: [Key: [String]] = [:]
-  private var consulted: Set<Key> = []
+  private struct Entry: Sendable {
+    let fragments: [String]
+    let retainedUTF8Bytes: Int
+    var lastAccess: UInt64
+  }
+
+  private var entries: [Key: Entry] = [:]
+  private var retainedUTF8Bytes = 0
+  private var accessCounter: UInt64 = 0
+  private let maxEntryCount: Int
+  private let maxRetainedUTF8Bytes: Int
+
+  init(
+    maxEntryCount: Int = 128,
+    maxRetainedUTF8Bytes: Int = 8 * 1_024 * 1_024
+  ) {
+    self.maxEntryCount = max(0, maxEntryCount)
+    self.maxRetainedUTF8Bytes = max(0, maxRetainedUTF8Bytes)
+  }
 
   var count: Int { entries.count }
 
@@ -93,20 +111,49 @@ nonisolated struct TranscriptFragmentCache: Sendable {
   /// `load()`. A nil `load()` is deliberately not cached: an unreadable tail is
   /// transient, and caching the failure would keep a recovered file excluded.
   mutating func fragments(for key: Key, load: () -> [String]?) -> [String]? {
-    consulted.insert(key)
-    if let cached = entries[key] { return cached }
+    accessCounter &+= 1
+    if var cached = entries[key] {
+      cached.lastAccess = accessCounter
+      entries[key] = cached
+      return cached.fragments
+    }
+    // Only the newest observed version of a path can be useful. Removing older
+    // modification-time keys immediately avoids spending the shared budget on
+    // append history until LRU pressure happens to arrive. Do this even when
+    // the new version is temporarily unreadable: an old key cannot answer a
+    // request for the new file contents.
+    for superseded in entries.keys.filter({ $0.path == key.path }) {
+      remove(superseded)
+    }
     guard let loaded = load() else { return nil }
-    entries[key] = loaded
+
+    let byteCount =
+      key.path.utf8.count
+      + loaded.reduce(into: 0) { count, fragment in
+        count += fragment.utf8.count
+      }
+    guard maxEntryCount > 0, byteCount <= maxRetainedUTF8Bytes else { return loaded }
+    entries[key] = Entry(
+      fragments: loaded,
+      retainedUTF8Bytes: byteCount,
+      lastAccess: accessCounter
+    )
+    retainedUTF8Bytes += byteCount
+    evictIfNeeded()
     return loaded
   }
 
-  /// Drops every entry not consulted since the previous prune: superseded
-  /// versions of an appended transcript, and files that left the candidate set.
-  /// Because the key carries a modification date, an actively written transcript
-  /// mints a new entry per poll; without this the cache would grow without bound.
-  mutating func pruneUnconsulted() {
-    entries = entries.filter { consulted.contains($0.key) }
-    consulted.removeAll(keepingCapacity: true)
+  private mutating func evictIfNeeded() {
+    while entries.count > maxEntryCount || retainedUTF8Bytes > maxRetainedUTF8Bytes {
+      guard let leastRecentlyUsed = entries.min(by: { $0.value.lastAccess < $1.value.lastAccess })?.key
+      else { return }
+      remove(leastRecentlyUsed)
+    }
+  }
+
+  private mutating func remove(_ key: Key) {
+    guard let removed = entries.removeValue(forKey: key) else { return }
+    retainedUTF8Bytes -= removed.retainedUTF8Bytes
   }
 }
 
@@ -186,9 +233,10 @@ actor AgentSessionResolver {
   }
 
   private var cache: [CacheKey: CachedResult] = [:]
-  /// Per-pane transcript fragment reuse, kept beside `cache` so both are evicted
-  /// on the same liveness check.
-  private var fragmentCaches: [CacheKey: TranscriptFragmentCache] = [:]
+  /// Transcript parsing depends only on file identity, not on the process doing
+  /// the match. Sharing one bounded cache avoids retaining duplicate 128 KiB
+  /// tails for every pane that consults the same candidate set.
+  private var fragmentCache = TranscriptFragmentCache()
   private let fileManager: FileManager
   private let homeDirectory: URL
 
@@ -226,7 +274,6 @@ actor AgentSessionResolver {
       }
     }
 
-    var fragments = fragmentCaches[key] ?? TranscriptFragmentCache()
     let (resolved, usedWideScan) = resolveUncached(
       ResolveRequest(
         identified: identified,
@@ -236,10 +283,8 @@ actor AgentSessionResolver {
         configRoot: configRoot,
         now: now
       ),
-      fragments: &fragments
+      fragments: &fragmentCache
     )
-    fragments.pruneUnconsulted()
-    fragmentCaches[key] = fragments
     var session = resolved
     var provisionalID: String?
     if let candidate = session, candidate.confidence == .medium {
@@ -265,7 +310,6 @@ actor AgentSessionResolver {
       cache = cache.filter { entry in
         ProcessDetection.processStartDate(pid: entry.key.pid) == entry.key.startedAt
       }
-      fragmentCaches = fragmentCaches.filter { cache[$0.key] != nil }
     }
     return AgentSessionResolution(session: session, isFresh: true)
   }

--- a/supacodeTests/AgentSessionFingerprintNormalizeTests.swift
+++ b/supacodeTests/AgentSessionFingerprintNormalizeTests.swift
@@ -47,12 +47,26 @@ struct AgentSessionFingerprintNormalizeTests {
     "mixed ascii and ünicode with  spacing",
   ]
 
-  @Test func fastPathMatchesReferenceForEveryCorpusInput() {
+  /// The original formulation, before either the ASCII fast path or the
+  /// escape-absence guard. Both shipped paths must reproduce it exactly.
+  private static func pristine(_ value: String) -> String {
+    value
+      .replacing(#/\u{001B}\[[0-?]*[ -\/]*[@-~]/#, with: " ")
+      .lowercased()
+      .split(whereSeparator: \Character.isWhitespace)
+      .joined(separator: " ")
+  }
+
+  @Test func bothPathsMatchTheOriginalForEveryCorpusInput() {
     for input in Self.corpus {
+      let expected = Self.pristine(input)
       #expect(
-        AgentSessionFingerprintMatcher.normalize(input)
-          == AgentSessionFingerprintMatcher.normalizeGeneral(input),
-        "normalize diverged from the reference for \(String(reflecting: input))"
+        AgentSessionFingerprintMatcher.normalize(input) == expected,
+        "normalize diverged for \(String(reflecting: input))"
+      )
+      #expect(
+        AgentSessionFingerprintMatcher.normalizeGeneral(input) == expected,
+        "normalizeGeneral diverged for \(String(reflecting: input))"
       )
     }
   }
@@ -65,10 +79,14 @@ struct AgentSessionFingerprintNormalizeTests {
     for _ in 0..<2000 {
       let length = Int.random(in: 0...40, using: &generator)
       let input = String((0..<length).map { _ in alphabet.randomElement(using: &generator)! })
+      let expected = Self.pristine(input)
       #expect(
-        AgentSessionFingerprintMatcher.normalize(input)
-          == AgentSessionFingerprintMatcher.normalizeGeneral(input),
-        "normalize diverged from the reference for \(String(reflecting: input))"
+        AgentSessionFingerprintMatcher.normalize(input) == expected,
+        "normalize diverged for \(String(reflecting: input))"
+      )
+      #expect(
+        AgentSessionFingerprintMatcher.normalizeGeneral(input) == expected,
+        "normalizeGeneral diverged for \(String(reflecting: input))"
       )
     }
   }

--- a/supacodeTests/AgentSessionFingerprintNormalizeTests.swift
+++ b/supacodeTests/AgentSessionFingerprintNormalizeTests.swift
@@ -91,6 +91,20 @@ struct AgentSessionFingerprintNormalizeTests {
     }
   }
 
+  @Test func fastPathMatchesReferenceForEveryASCIIByteAndPair() {
+    let scalars = (UInt8.min...UInt8.max).prefix(128).map { String(Unicode.Scalar($0)) }
+    for first in scalars {
+      #expect(AgentSessionFingerprintMatcher.normalize(first) == Self.pristine(first))
+      for second in scalars {
+        let input = first + second
+        #expect(
+          AgentSessionFingerprintMatcher.normalize(input) == Self.pristine(input),
+          "normalize diverged for \(String(reflecting: input))"
+        )
+      }
+    }
+  }
+
   @Test func normalizesToExpectedText() {
     #expect(AgentSessionFingerprintMatcher.normalize("  \u{001B}[1;31mHello\t\tWORLD  ") == "hello world")
     #expect(AgentSessionFingerprintMatcher.normalize("") == "")

--- a/supacodeTests/AgentSessionFingerprintNormalizeTests.swift
+++ b/supacodeTests/AgentSessionFingerprintNormalizeTests.swift
@@ -1,0 +1,97 @@
+import Foundation
+import Testing
+
+@testable import supacode
+
+/// `normalize` runs an ASCII byte-scan fast path in place of the Swift Regex +
+/// grapheme-split reference. It must be indistinguishable from that reference
+/// for every input, or fingerprint matching would silently change which
+/// transcript wins.
+struct AgentSessionFingerprintNormalizeTests {
+  /// Inputs chosen to exercise every branch of the fast path and every reason it
+  /// bails out to the general path.
+  private static let corpus: [String] = [
+    "",
+    " ",
+    "\t\n \r\n",
+    "plain text",
+    "  leading and trailing  ",
+    "MiXeD CaSe TEXT",
+    "collapse\t\tmultiple\n\nwhitespace\u{000B}runs\u{000C}here",
+    "windows\r\nline\r\nendings",
+    // ANSI: reset, params, private-mode param byte, an intermediate byte.
+    "\u{001B}[0mreset",
+    "\u{001B}[1;31mred\u{001B}[0m normal",
+    "\u{001B}[?25hcursor shown",
+    "\u{001B}[ qbar cursor",
+    "adjacent\u{001B}[0m\u{001B}[1msequences",
+    "\u{001B}[2Jleading sequence",
+    "trailing sequence\u{001B}[0m",
+    // Malformed: these must survive as ordinary text, not be swallowed.
+    "bare \u{001B} escape",
+    "truncated \u{001B}[",
+    "no final byte \u{001B}[1;2",
+    "escape at end \u{001B}",
+    "\u{001B}",
+    "\u{001B}[",
+    // Non-ASCII must defer to the general path.
+    "héllo wörld",
+    "CAFÉ AU LAIT",
+    "日本語のテキストです",
+    "emoji 🎉 mixed with ascii",
+    "non-breaking\u{00A0}space",
+    "next\u{0085}line",
+    "İstanbul uppercase dotted i",
+    "ﬁ ligature",
+    "\u{001B}[31mré\u{001B}[0m d",
+    "mixed ascii and ünicode with  spacing",
+  ]
+
+  @Test func fastPathMatchesReferenceForEveryCorpusInput() {
+    for input in Self.corpus {
+      #expect(
+        AgentSessionFingerprintMatcher.normalize(input)
+          == AgentSessionFingerprintMatcher.normalizeGeneral(input),
+        "normalize diverged from the reference for \(String(reflecting: input))"
+      )
+    }
+  }
+
+  @Test func fastPathMatchesReferenceForRandomASCII() {
+    // Random byte soup over the interesting ASCII range catches sequence shapes
+    // the hand-written corpus does not enumerate.
+    var generator = SeededGenerator(seed: 0x5EED_1234)
+    let alphabet: [Character] = Array("abzAZ019 \t\n\r\u{000B}\u{000C}[;?@~\u{001B}mJq/ ")
+    for _ in 0..<2000 {
+      let length = Int.random(in: 0...40, using: &generator)
+      let input = String((0..<length).map { _ in alphabet.randomElement(using: &generator)! })
+      #expect(
+        AgentSessionFingerprintMatcher.normalize(input)
+          == AgentSessionFingerprintMatcher.normalizeGeneral(input),
+        "normalize diverged from the reference for \(String(reflecting: input))"
+      )
+    }
+  }
+
+  @Test func normalizesToExpectedText() {
+    #expect(AgentSessionFingerprintMatcher.normalize("  \u{001B}[1;31mHello\t\tWORLD  ") == "hello world")
+    #expect(AgentSessionFingerprintMatcher.normalize("") == "")
+    #expect(AgentSessionFingerprintMatcher.normalize("   ") == "")
+  }
+}
+
+/// Deterministic generator so a divergence is reproducible from the seed.
+private struct SeededGenerator: RandomNumberGenerator {
+  private var state: UInt64
+
+  init(seed: UInt64) {
+    state = seed
+  }
+
+  mutating func next() -> UInt64 {
+    state ^= state << 13
+    state ^= state >> 7
+    state ^= state << 17
+    return state
+  }
+}

--- a/supacodeTests/TranscriptFragmentCacheTests.swift
+++ b/supacodeTests/TranscriptFragmentCacheTests.swift
@@ -1,0 +1,147 @@
+import Foundation
+import Testing
+
+@testable import supacode
+
+/// Fingerprint matching re-reads the same transcript tails every time a pane's
+/// session cache expires. `TranscriptFragmentCache` replays the parsed result
+/// for unchanged files; these tests pin both the reuse and the bounding.
+struct TranscriptFragmentCacheTests {
+  private func key(_ path: String, _ secondsSinceEpoch: TimeInterval) -> TranscriptFragmentCache.Key {
+    TranscriptFragmentCache.Key(path: path, modifiedAt: Date(timeIntervalSince1970: secondsSinceEpoch))
+  }
+
+  @Test func reusesFragmentsForAnUnchangedFile() {
+    var cache = TranscriptFragmentCache()
+    var loads = 0
+    let target = key("/tmp/a.jsonl", 100)
+
+    let first = cache.fragments(for: target) {
+      loads += 1
+      return ["parsed fragment"]
+    }
+    let second = cache.fragments(for: target) {
+      loads += 1
+      return ["should not be reached"]
+    }
+
+    #expect(loads == 1)
+    #expect(first == ["parsed fragment"])
+    #expect(second == ["parsed fragment"])
+  }
+
+  @Test func reloadsWhenTheFileIsAppendedTo() {
+    var cache = TranscriptFragmentCache()
+    var loads = 0
+
+    _ = cache.fragments(for: key("/tmp/a.jsonl", 100)) {
+      loads += 1
+      return ["old"]
+    }
+    let updated = cache.fragments(for: key("/tmp/a.jsonl", 101)) {
+      loads += 1
+      return ["new"]
+    }
+
+    #expect(loads == 2)
+    #expect(updated == ["new"])
+  }
+
+  @Test func doesNotCacheAnUnreadableTail() {
+    var cache = TranscriptFragmentCache()
+    var loads = 0
+    let target = key("/tmp/gone.jsonl", 100)
+
+    let missing = cache.fragments(for: target) {
+      loads += 1
+      return nil
+    }
+    let recovered = cache.fragments(for: target) {
+      loads += 1
+      return ["now readable"]
+    }
+
+    // Caching the failure would keep a briefly unreadable transcript excluded
+    // from every later match.
+    #expect(loads == 2)
+    #expect(missing == nil)
+    #expect(recovered == ["now readable"])
+  }
+
+  @Test func pruneDropsOnlyEntriesNotConsultedSinceTheLastPrune() {
+    var cache = TranscriptFragmentCache()
+    let stable = key("/tmp/stable.jsonl", 100)
+    let superseded = key("/tmp/busy.jsonl", 100)
+    _ = cache.fragments(for: stable) { ["stable"] }
+    _ = cache.fragments(for: superseded) { ["v1"] }
+    #expect(cache.count == 2)
+
+    cache.pruneUnconsulted()
+    #expect(cache.count == 2, "Both were consulted in this round, so both survive")
+
+    // Next round: the busy transcript is appended to, so its old key is never
+    // consulted again and must not accumulate.
+    _ = cache.fragments(for: stable) { ["stable"] }
+    _ = cache.fragments(for: key("/tmp/busy.jsonl", 101)) { ["v2"] }
+    cache.pruneUnconsulted()
+
+    #expect(cache.count == 2)
+    var loads = 0
+    _ = cache.fragments(for: superseded) {
+      loads += 1
+      return ["v1 again"]
+    }
+    #expect(loads == 1, "The superseded entry was evicted, so it must reload")
+  }
+
+  @Test func bestMatchServesASecondCallFromTheCache() throws {
+    let root = FileManager.default.temporaryDirectory
+      .appending(path: "prowl-fragment-cache-\(UUID().uuidString)", directoryHint: .isDirectory)
+    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let firstURL = root.appending(path: "first.jsonl")
+    let secondURL = root.appending(path: "second.jsonl")
+    try #"{"type":"user","message":{"content":"Refactor authentication middleware without changing its API."}}"#
+      .write(to: firstURL, atomically: true, encoding: .utf8)
+    try #"{"type":"user","message":{"content":"Investigate the unrelated rendering regression."}}"#
+      .write(to: secondURL, atomically: true, encoding: .utf8)
+
+    let modifiedAt = Date(timeIntervalSince1970: 1_000)
+    let candidates = [
+      AgentSessionCandidate(
+        session: AgentSession(id: "first", transcriptPath: firstURL, source: .recentFile),
+        modifiedAt: modifiedAt
+      ),
+      AgentSessionCandidate(
+        session: AgentSession(id: "second", transcriptPath: secondURL, source: .recentFile),
+        modifiedAt: modifiedAt
+      ),
+    ]
+    let activeText = "❯ Refactor authentication middleware without changing its API."
+
+    var cache = TranscriptFragmentCache()
+    let first = AgentSessionFingerprintMatcher.bestMatch(
+      activeText: activeText,
+      candidates: candidates,
+      fragments: &cache
+    )
+    #expect(first?.session.id == "first")
+
+    // Deleting the transcripts makes a re-read impossible, so a second match on
+    // the same keys can only succeed by replaying the cached fragments.
+    try FileManager.default.removeItem(at: firstURL)
+    try FileManager.default.removeItem(at: secondURL)
+
+    let cached = AgentSessionFingerprintMatcher.bestMatch(
+      activeText: activeText,
+      candidates: candidates,
+      fragments: &cache
+    )
+    #expect(cached?.session.id == "first")
+
+    // A cacheless call over the same candidates now has nothing to read, which
+    // confirms the previous call really was served from the cache.
+    #expect(AgentSessionFingerprintMatcher.bestMatch(activeText: activeText, candidates: candidates) == nil)
+  }
+}

--- a/supacodeTests/TranscriptFragmentCacheTests.swift
+++ b/supacodeTests/TranscriptFragmentCacheTests.swift
@@ -68,30 +68,86 @@ struct TranscriptFragmentCacheTests {
     #expect(recovered == ["now readable"])
   }
 
-  @Test func pruneDropsOnlyEntriesNotConsultedSinceTheLastPrune() {
+  @Test func replacesAnOlderVersionOfTheSamePathImmediately() {
     var cache = TranscriptFragmentCache()
-    let stable = key("/tmp/stable.jsonl", 100)
-    let superseded = key("/tmp/busy.jsonl", 100)
-    _ = cache.fragments(for: stable) { ["stable"] }
-    _ = cache.fragments(for: superseded) { ["v1"] }
-    #expect(cache.count == 2)
-
-    cache.pruneUnconsulted()
-    #expect(cache.count == 2, "Both were consulted in this round, so both survive")
-
-    // Next round: the busy transcript is appended to, so its old key is never
-    // consulted again and must not accumulate.
-    _ = cache.fragments(for: stable) { ["stable"] }
+    _ = cache.fragments(for: key("/tmp/busy.jsonl", 100)) { ["v1"] }
     _ = cache.fragments(for: key("/tmp/busy.jsonl", 101)) { ["v2"] }
-    cache.pruneUnconsulted()
 
-    #expect(cache.count == 2)
-    var loads = 0
-    _ = cache.fragments(for: superseded) {
-      loads += 1
-      return ["v1 again"]
+    #expect(cache.count == 1)
+  }
+
+  @Test func dropsAnOlderVersionWhenLoadingTheNewVersionFails() {
+    var cache = TranscriptFragmentCache()
+    _ = cache.fragments(for: key("/tmp/busy.jsonl", 100)) { ["v1"] }
+
+    #expect(cache.fragments(for: key("/tmp/busy.jsonl", 101)) { nil } == nil)
+    #expect(cache.count == 0)
+  }
+
+  @Test func evictsTheLeastRecentlyUsedEntryAtCapacity() {
+    var cache = TranscriptFragmentCache(maxEntryCount: 2, maxRetainedUTF8Bytes: .max)
+    let first = key("/tmp/first.jsonl", 100)
+    let second = key("/tmp/second.jsonl", 100)
+    let third = key("/tmp/third.jsonl", 100)
+    _ = cache.fragments(for: first) { ["first"] }
+    _ = cache.fragments(for: second) { ["second"] }
+    _ = cache.fragments(for: first) { ["not reached"] }
+    _ = cache.fragments(for: third) { ["third"] }
+
+    var firstReloads = 0
+    _ = cache.fragments(for: first) {
+      firstReloads += 1
+      return ["first reloaded"]
     }
-    #expect(loads == 1, "The superseded entry was evicted, so it must reload")
+    var secondReloads = 0
+    _ = cache.fragments(for: second) {
+      secondReloads += 1
+      return ["second reloaded"]
+    }
+
+    #expect(firstReloads == 0, "A cache hit must make the entry most recently used")
+    #expect(secondReloads == 1, "The least recently used entry must be evicted first")
+  }
+
+  @Test func doesNotRetainAnEntryLargerThanTheByteBudget() {
+    var cache = TranscriptFragmentCache(maxEntryCount: 10, maxRetainedUTF8Bytes: 3)
+    let target = key("/tmp/large.jsonl", 100)
+    var loads = 0
+
+    for _ in 0..<2 {
+      _ = cache.fragments(for: target) {
+        loads += 1
+        return ["four"]
+      }
+    }
+
+    #expect(loads == 2)
+    #expect(cache.count == 0)
+  }
+
+  @Test func byteBudgetEvictsTheLeastRecentlyUsedEntry() {
+    var cache = TranscriptFragmentCache(maxEntryCount: 10, maxRetainedUTF8Bytes: 10)
+    let first = key("a", 100)
+    let second = key("b", 100)
+    let third = key("c", 100)
+    _ = cache.fragments(for: first) { ["1234"] }
+    _ = cache.fragments(for: second) { ["1234"] }
+    _ = cache.fragments(for: first) { ["not reached"] }
+    _ = cache.fragments(for: third) { ["1234"] }
+
+    var firstReloads = 0
+    _ = cache.fragments(for: first) {
+      firstReloads += 1
+      return ["1234"]
+    }
+    var secondReloads = 0
+    _ = cache.fragments(for: second) {
+      secondReloads += 1
+      return ["1234"]
+    }
+
+    #expect(firstReloads == 0)
+    #expect(secondReloads == 1)
   }
 
   @Test func bestMatchServesASecondCallFromTheCache() throws {


### PR DESCRIPTION
## Summary

- preserve both original commits from #650 and their author attribution
- reuse parsed and normalized transcript fragments across resolver polls and panes
- replace per-process retention with one 128-entry / 8 MiB payload-bounded LRU
- remove superseded path versions immediately and cover entry/byte eviction boundaries
- retain the original Unicode normalization semantics while fast-pathing common ASCII and no-ESC inputs

## Review follow-up

The original optimization addresses a real repeated-computation hot path and its normalization fast paths match the previous formulation. Its fragment caches were attached to process cache keys, however, and dead processes below the existing 129-process cleanup threshold could retain many normalized 128 KiB transcript tails indefinitely.

The follow-up makes fragment reuse resolver-wide because the cached value depends only on transcript bytes, not the process, agent profile, config root, candidate set, or active screen. One LRU now bounds all retained values independently of process cleanup. It also removes older versions of a path as soon as a new modification date is observed, including when the new version is temporarily unreadable.

## Validation

- 63 focused resolver/profile/cache/screen-scan tests passed after merging the latest `main`
- cache tests cover entry-count and cumulative-byte LRU, oversized values, unreadable loads, same-path replacement, and source-file deletion
- normalization tests compare with the pristine implementation over a Unicode/CSI corpus, deterministic fuzz, and every ASCII byte pair
- `make check`
- `make build-app` (0 errors, 0 warnings)

Closes #650 after integration.
