### PR TITLE
Memoize agent working-directory resolution across renders

### DIFF
--- a/supacode/Domain/WorktreeDirectoryIndex.swift
+++ b/supacode/Domain/WorktreeDirectoryIndex.swift
@@ -85,6 +85,15 @@ enum WorktreeDirectoryIndexCache {
   private static var cachedIndex = WorktreeDirectoryIndex()
   private static var nextCanonicalRevalidation: ContinuousClock.Instant?
 
+  /// Resolutions already computed against `cachedIndex`, keyed by the directory as asked for.
+  /// A resolution normalizes that directory, so it carries the same symlink assumption the index
+  /// does and is dropped on the same cadence.
+  private static var cachedResolutions: [URL: Worktree.ID?] = [:]
+
+  /// An agent's working directory is stable for the life of its pane, but a pane can `cd`
+  /// anywhere, so the memo is capped rather than assumed bounded by pane count.
+  private static let resolutionMemoLimit = 256
+
   private struct Entry: Equatable {
     let id: Worktree.ID
     let directory: URL
@@ -106,6 +115,11 @@ enum WorktreeDirectoryIndexCache {
     }
     cachedSignature = signature
     nextCanonicalRevalidation = now.advanced(by: canonicalRevalidationInterval)
+    // Resolutions normalize the directory they are asked about, so a symlink retarget can make one
+    // stale exactly as it can make the index stale. Clearing here rather than only when the index
+    // is rebuilt gives them the same staleness bound the revalidation interval already sets, which
+    // still collapses every lookup within an interval down to one.
+    cachedResolutions.removeAll(keepingCapacity: true)
     guard canonicalSignature != cachedCanonicalSignature else {
       return cachedIndex
     }
@@ -115,6 +129,32 @@ enum WorktreeDirectoryIndexCache {
       normalizedDirectories: canonicalSignature.map { (id: $0.id, directory: $0.directory) }
     )
     return cachedIndex
+  }
+
+  /// Resolves a working directory against the cached index, remembering the answer.
+  ///
+  /// `WorktreeDirectoryIndex.worktreeID(forWorkingDirectory:)` normalizes the directory it is
+  /// asked about, and `PathPolicy.normalizeURL` touches the filesystem — a `stat` plus a symlink
+  /// walk. The sidebar resolves every agent row on every render, so without this memo a window
+  /// with N agents pays N filesystem round-trips per frame on the main thread, for paths that
+  /// almost never change.
+  static func worktreeID(
+    forWorkingDirectory directory: URL,
+    in repositories: IdentifiedArrayOf<Repository>,
+    now: ContinuousClock.Instant = ContinuousClock.now
+  ) -> Worktree.ID? {
+    // Ordered first: a repository-set change or a due revalidation clears the memo, so a stale
+    // resolution can never be returned for an index that has moved on.
+    let index = index(for: repositories, now: now)
+    if let memoized = cachedResolutions[directory] {
+      return memoized
+    }
+    let resolved = index.worktreeID(forWorkingDirectory: directory)
+    if cachedResolutions.count >= resolutionMemoLimit {
+      cachedResolutions.removeAll(keepingCapacity: true)
+    }
+    cachedResolutions[directory] = resolved
+    return resolved
   }
 
   /// The id/directory pairs the index is built from, in build order. Comparing these avoids
@@ -140,5 +180,6 @@ enum WorktreeDirectoryIndexCache {
     cachedCanonicalSignature = []
     cachedIndex = WorktreeDirectoryIndex()
     nextCanonicalRevalidation = nil
+    cachedResolutions.removeAll()
   }
 }

--- a/supacode/Features/Repositories/Views/SidebarListView.swift
+++ b/supacode/Features/Repositories/Views/SidebarListView.swift
@@ -585,16 +585,21 @@ struct SidebarListView: View {
     repositories: IdentifiedArrayOf<Repository>,
     metadata: ActiveAgentWorktreeMetadata
   ) -> [ActiveAgentEntry.ID: ActiveAgentRowDisplay] {
-    // Built (or reused) once for the whole batch: resolving each row against every worktree
-    // individually put a filesystem round-trip per row/worktree pair on the main thread.
-    let directoryIndex = WorktreeDirectoryIndexCache.index(for: repositories)
+    // Resolutions are memoized across renders, not just shared within this batch. The index made
+    // the *build* side cheap; the lookup still normalizes the queried directory, and that
+    // normalization is a filesystem round-trip. This view re-runs whenever an agent's state
+    // changes, so re-resolving unchanged directories put N `stat`s plus N symlink walks on the
+    // main thread per frame.
     var displays: [ActiveAgentEntry.ID: ActiveAgentRowDisplay] = [:]
     for entry in entries {
+      let resolvedWorktreeID = entry.workingDirectory.flatMap {
+        WorktreeDirectoryIndexCache.worktreeID(forWorkingDirectory: $0, in: repositories)
+      }
       displays[entry.id] = activeAgentRowDisplay(
         for: entry,
         repositories: repositories,
         metadata: metadata,
-        directoryIndex: directoryIndex
+        resolvedWorktreeID: resolvedWorktreeID
       )
     }
     return displays
@@ -606,17 +611,37 @@ struct SidebarListView: View {
   /// 2. `workingDirectory` is known but outside every repo → derive a name from its last path
   ///    component (same logic as adding a repository).
   /// 3. `workingDirectory` is unknown → fall back to the surface's owning worktree (legacy behavior).
-  /// `directoryIndex` is supplied by `activeAgentRowDisplays` so a batch shares one index; passing
-  /// `nil` builds a throwaway one for a single lookup.
+  /// `directoryIndex` resolves the entry's working directory; passing `nil` builds a throwaway
+  /// index for the single lookup. `activeAgentRowDisplays` does not come through here — it resolves
+  /// through the memo in `WorktreeDirectoryIndexCache` and calls the `resolvedWorktreeID` overload.
   static func activeAgentRowDisplay(
     for entry: ActiveAgentEntry,
     repositories: IdentifiedArrayOf<Repository>,
     metadata: ActiveAgentWorktreeMetadata,
     directoryIndex: WorktreeDirectoryIndex? = nil
   ) -> ActiveAgentRowDisplay {
+    let resolvedWorktreeID = entry.workingDirectory.flatMap { workingDirectory in
+      (directoryIndex ?? WorktreeDirectoryIndex(repositories: repositories))
+        .worktreeID(forWorkingDirectory: workingDirectory)
+    }
+    return activeAgentRowDisplay(
+      for: entry,
+      repositories: repositories,
+      metadata: metadata,
+      resolvedWorktreeID: resolvedWorktreeID
+    )
+  }
+
+  /// Builds the display from an already-resolved owning worktree, so a caller that resolves in
+  /// bulk pays the directory normalization once per directory instead of once per row.
+  static func activeAgentRowDisplay(
+    for entry: ActiveAgentEntry,
+    repositories: IdentifiedArrayOf<Repository>,
+    metadata: ActiveAgentWorktreeMetadata,
+    resolvedWorktreeID: Worktree.ID?
+  ) -> ActiveAgentRowDisplay {
     if let workingDirectory = entry.workingDirectory {
-      let index = directoryIndex ?? WorktreeDirectoryIndex(repositories: repositories)
-      if let key = index.worktreeID(forWorkingDirectory: workingDirectory) {
+      if let key = resolvedWorktreeID {
         let fallbackName = workingDirectory.lastPathComponent
         return ActiveAgentRowDisplay(
           repositoryName: metadata.repositoryNamesByWorktreeID[key] ?? fallbackName,
@@ -649,8 +674,7 @@ struct SidebarListView: View {
     forWorkingDirectory workingDirectory: URL,
     in repositories: IdentifiedArrayOf<Repository>
   ) -> Worktree.ID? {
-    WorktreeDirectoryIndexCache.index(for: repositories)
-      .worktreeID(forWorkingDirectory: workingDirectory)
+    WorktreeDirectoryIndexCache.worktreeID(forWorkingDirectory: workingDirectory, in: repositories)
   }
 
   /// Directory of the surface's owning worktree, used when the agent hasn't

--- a/supacodeTests/WorktreeDirectoryIndexTests.swift
+++ b/supacodeTests/WorktreeDirectoryIndexTests.swift
@@ -148,7 +148,183 @@ struct WorktreeDirectoryIndexTests {
     #expect(revalidated.worktreeID(forWorkingDirectory: firstTarget) == nil)
   }
 
+  // MARK: - Resolution memo
+
+  /// Proves the memo by making recomputation impossible to reproduce: the symlink the first
+  /// lookup resolved through is deleted, so a fresh resolution would no longer reach the worktree.
+  /// An answer that survives that can only have come from the memo.
+  @Test func repeatedLookupIsServedFromTheMemo() throws {
+    let fixture = try SymlinkedWorktreeFixture()
+    defer { fixture.cleanUp() }
+    WorktreeDirectoryIndexCache.reset()
+    // Both lookups sit inside one revalidation interval, which is where the memo applies.
+    let start = ContinuousClock.now
+
+    #expect(
+      WorktreeDirectoryIndexCache.worktreeID(
+        forWorkingDirectory: fixture.queryThroughSymlink,
+        in: fixture.repositories,
+        now: start
+      ) == fixture.worktreeID
+    )
+
+    try fixture.removeSymlink()
+
+    #expect(
+      WorktreeDirectoryIndexCache.worktreeID(
+        forWorkingDirectory: fixture.queryThroughSymlink,
+        in: fixture.repositories,
+        now: start.advanced(by: .milliseconds(16))
+      ) == fixture.worktreeID,
+      "The symlink is gone, so only a memoized answer can still resolve"
+    )
+
+    // And the memo is the only reason: dropping it must recompute, which now finds nothing.
+    WorktreeDirectoryIndexCache.reset()
+    #expect(
+      WorktreeDirectoryIndexCache.worktreeID(
+        forWorkingDirectory: fixture.queryThroughSymlink,
+        in: fixture.repositories,
+        now: start.advanced(by: .milliseconds(32))
+      ) == nil
+    )
+  }
+
+  /// A resolution is only valid against the index that produced it, so changing the repository
+  /// set must not leave an answer computed against the previous one.
+  @Test func memoIsDroppedWhenTheRepositorySetChanges() {
+    WorktreeDirectoryIndexCache.reset()
+    let mainWorktree = makeWorktree(repoRoot: "/tmp/repo", path: "/tmp/repo", branch: "main")
+    let nested = makeWorktree(repoRoot: "/tmp/repo", path: "/tmp/repo/worktrees/feature", branch: "feature")
+    let directory = URL(fileURLWithPath: "/tmp/repo/worktrees/feature/lib")
+    let start = ContinuousClock.now
+
+    #expect(
+      WorktreeDirectoryIndexCache.worktreeID(
+        forWorkingDirectory: directory,
+        in: [makeRepository(id: "/tmp/repo", worktrees: [mainWorktree])],
+        now: start
+      ) == mainWorktree.id
+    )
+    #expect(
+      WorktreeDirectoryIndexCache.worktreeID(
+        forWorkingDirectory: directory,
+        in: [makeRepository(id: "/tmp/repo", worktrees: [mainWorktree, nested])],
+        now: start.advanced(by: .milliseconds(16))
+      ) == nested.id,
+      "A stale memo would still report the main worktree"
+    )
+  }
+
+  /// A memoized resolution normalizes the directory it was asked about, so it can go stale the same
+  /// way the index can. It must not outlive the revalidation that exists to catch exactly that.
+  @Test func memoIsDroppedWhenCanonicalPathsAreRevalidated() throws {
+    let fixture = try SymlinkedWorktreeFixture()
+    defer { fixture.cleanUp() }
+    WorktreeDirectoryIndexCache.reset()
+    let start = ContinuousClock.now
+
+    #expect(
+      WorktreeDirectoryIndexCache.worktreeID(
+        forWorkingDirectory: fixture.queryThroughSymlink,
+        in: fixture.repositories,
+        now: start
+      ) == fixture.worktreeID
+    )
+
+    try fixture.removeSymlink()
+
+    #expect(
+      WorktreeDirectoryIndexCache.worktreeID(
+        forWorkingDirectory: fixture.queryThroughSymlink,
+        in: fixture.repositories,
+        now: start.advanced(by: .seconds(1))
+      ) == nil,
+      "Past the revalidation interval the answer must be recomputed, and it no longer resolves"
+    )
+  }
+
+  /// A pane can `cd` anywhere, so the memo must not grow without bound.
+  @Test func memoIsBoundedAndEvictsOldEntries() throws {
+    let fixture = try SymlinkedWorktreeFixture()
+    defer { fixture.cleanUp() }
+    WorktreeDirectoryIndexCache.reset()
+    // Held at one instant so revalidation never fires, leaving the cap as the only thing that can
+    // drop the entry.
+    let start = ContinuousClock.now
+
+    #expect(
+      WorktreeDirectoryIndexCache.worktreeID(
+        forWorkingDirectory: fixture.queryThroughSymlink,
+        in: fixture.repositories,
+        now: start
+      ) == fixture.worktreeID
+    )
+    try fixture.removeSymlink()
+
+    // Flood past the cap with directories that resolve to nothing.
+    for offset in 0..<300 {
+      _ = WorktreeDirectoryIndexCache.worktreeID(
+        forWorkingDirectory: URL(fileURLWithPath: "/tmp/flood-\(offset)"),
+        in: fixture.repositories,
+        now: start
+      )
+    }
+
+    #expect(
+      WorktreeDirectoryIndexCache.worktreeID(
+        forWorkingDirectory: fixture.queryThroughSymlink,
+        in: fixture.repositories,
+        now: start
+      ) == nil,
+      "The original entry should have been evicted and recomputed"
+    )
+  }
+
   // MARK: - Helpers
+
+  /// A real worktree directory plus a symlink pointing at it, so a test can revoke the symlink and
+  /// observe whether a later lookup recomputed or replayed.
+  private struct SymlinkedWorktreeFixture {
+    let root: URL
+    let repositories: IdentifiedArrayOf<Repository>
+    let worktreeID: Worktree.ID
+    let queryThroughSymlink: URL
+
+    init() throws {
+      root = FileManager.default.temporaryDirectory
+        .appending(path: "prowl-directory-memo-\(UUID().uuidString)", directoryHint: .isDirectory)
+      let real = root.appending(path: "real", directoryHint: .isDirectory)
+      try FileManager.default.createDirectory(
+        at: real.appending(path: "sub", directoryHint: .isDirectory),
+        withIntermediateDirectories: true
+      )
+      try FileManager.default.createSymbolicLink(
+        at: root.appending(path: "link", directoryHint: .isDirectory),
+        withDestinationURL: real
+      )
+      let worktree = Worktree(
+        id: real.path,
+        name: "main",
+        detail: "main",
+        workingDirectory: real,
+        repositoryRootURL: real
+      )
+      worktreeID = worktree.id
+      repositories = [
+        Repository(id: real.path, rootURL: real, name: "real", kind: .git, worktrees: [worktree])
+      ]
+      queryThroughSymlink = root.appending(path: "link/sub", directoryHint: .isDirectory)
+    }
+
+    func removeSymlink() throws {
+      try FileManager.default.removeItem(at: root.appending(path: "link", directoryHint: .isDirectory))
+    }
+
+    func cleanUp() {
+      try? FileManager.default.removeItem(at: root)
+    }
+  }
 
   private func makeWorktree(repoRoot: String, path: String, branch: String) -> Worktree {
     Worktree(


### PR DESCRIPTION
The worktree directory index made building the index cheap but left every lookup normalizing paths against the filesystem, so this change memoizes the answers.

`PathPolicy.normalizeURL` performs a `stat` plus a symlink walk for each path component. The sidebar resolves every agent row on every render, so a window with N agents made N filesystem round-trips per frame on the main thread, for directories that almost never change.

Measured on a live instance with 26 to 29 agents attached, the path costs 0.11 to 0.16% of a core in `normalizeURL` and 0.21 to 0.26% in the enclosing `worktreeID` lookup, consistent across a 2-second window and a 177-second one. That is small. It is fixed anyway, because the work is filesystem I/O on a render path, where the cost depends on disk state rather than on anything the render controls, and it scales with agent count.

Resolutions are cached in `WorktreeDirectoryIndexCache` alongside the index. The memo is capped, since a pane can `cd` anywhere and its working directory is not bounded by the repository set. Only the batch path routes through the memo, so the CLI and single-lookup callers keep the throwaway-index behavior they had.

Your symlink revalidation in #655 changed what the memo lifetime should be, and that is the part worth a close look. A memoized resolution normalizes the directory it was asked about, so it can go stale exactly the way a cached index entry can. Dropping it only when the repository set changed would have let it outlive the revalidation that exists to catch that. Resolutions are therefore cleared whenever revalidation runs, which caps a memoized answer at one interval while still collapsing every lookup inside that interval down to a single normalization. `worktreeID(forWorkingDirectory:in:now:)` takes the same `now` your `index(for:now:)` does, so tests drive expiry from an explicit instant rather than from wall time.

Tests prove the memo observably rather than by counting calls. A lookup resolves through a symlink, the symlink is deleted, and the answer must still arrive, which only a memo can do. Companion tests cover invalidation on a repository-set change, expiry at the revalidation boundary, and eviction past the cap. The expiry behavior is mutation-checked: removing the clear fails that test and the repository-set test, and nothing else.
