### PR TITLE
Space out Active Agents emissions driven by animated pane titles

### DIFF
--- a/supacode/Features/ActiveAgents/Models/ActiveAgentEntry.swift
+++ b/supacode/Features/ActiveAgents/Models/ActiveAgentEntry.swift
@@ -16,7 +16,8 @@ struct ActiveAgentEntry: Identifiable, Equatable, Sendable {
   /// The title of the agent's own pane: the surface's live title when it has one,
   /// falling back to the tab's display title. Kept per-pane so agents in different
   /// splits of one tab don't all mirror the focused pane's title.
-  let paneTitle: String
+  /// A `var` so `equalsIgnoringRawStateAndPaneTitle` can normalize it.
+  var paneTitle: String
   let surfaceID: UUID
   let paneIndex: Int
   /// Command/process token used for row icon lookup. This can be more specific than
@@ -47,6 +48,18 @@ struct ActiveAgentEntry: Identifiable, Equatable, Sendable {
   func equalsIgnoringRawState(_ other: ActiveAgentEntry) -> Bool {
     var normalized = self
     normalized.rawState = other.rawState
+    return normalized == other
+  }
+
+  /// Equality ignoring `rawState` and `paneTitle`. Agent TUIs animate a spinner
+  /// glyph inside the terminal title (`⠦ spx-h` → `⠧ spx-h`), so the title
+  /// changes several times a second while nothing a user would call a change has
+  /// happened. Callers use this to recognize a title-only difference and space
+  /// those emissions out instead of forwarding every animation frame.
+  func equalsIgnoringRawStateAndPaneTitle(_ other: ActiveAgentEntry) -> Bool {
+    var normalized = self
+    normalized.rawState = other.rawState
+    normalized.paneTitle = other.paneTitle
     return normalized == other
   }
 

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState+AgentDetection.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState+AgentDetection.swift
@@ -26,6 +26,12 @@ extension WorktreeTerminalState {
         guard let self, let view, self.surfaces[view.id] != nil else { return }
         let hasAgent = await self.detectAgentState(for: view, tabId: tabId)
         let now = Date()
+        // Titles land on the manager's own clock now, because a non-agent program
+        // can strand one after this schedule goes cold. An entry cannot be
+        // stranded that way: it exists only while a pane has a detected agent,
+        // and that is exactly the condition keeping this loop warm. So the poll
+        // stays the trailing flush here, and no second timer is needed.
+        self.flushPendingAgentEntry(surfaceID: view.id, now: now)
         let schedule = self.agentDetectionSchedules[view.id] ?? .cold
         self.agentDetectionSchedules[view.id] =
           hasAgent ? schedule.observedAgent(now: now) : schedule.observedNoAgent(now: now)
@@ -264,6 +270,8 @@ extension WorktreeTerminalState {
     // started agent is the user's own — default home, default account — and
     // must not wear the profile's name or config root.
     launchProfilesBySurface.removeValue(forKey: surfaceID)
+    lastAgentEntryEmitAtBySurface.removeValue(forKey: surfaceID)
+    pendingAgentEntryBySurface.removeValue(forKey: surfaceID)
     onAgentEntryRemoved?(surfaceID)
     if let tabId = tabId(containing: surfaceID) {
       updateTabAgentBusyState(for: tabId)
@@ -321,18 +329,59 @@ extension WorktreeTerminalState {
     emitAgentEntry(surfaceID: surfaceID, tabId: tabId, state: state)
   }
 
-  func emitAgentEntry(surfaceID: UUID, tabId: TerminalTabID, state: PaneAgentState) {
+  /// Minimum spacing between emissions whose only difference is the pane title.
+  /// Agent TUIs animate a spinner glyph into the terminal title at roughly 10 Hz;
+  /// forwarding each frame mutates `ActiveAgentsFeature.State.entries` and dirties
+  /// the SwiftUI graph for a change no one can perceive. One second keeps titles
+  /// feeling live while cutting those invalidations by an order of magnitude.
+  static let agentEntryTitleCoalescingInterval: TimeInterval = 1
+
+  func emitAgentEntry(
+    surfaceID: UUID,
+    tabId: TerminalTabID,
+    state: PaneAgentState,
+    now: Date = Date()
+  ) {
     guard let entry = activeAgentEntry(surfaceID: surfaceID, tabId: tabId, state: state) else {
       lastEmittedAgentEntriesBySurface.removeValue(forKey: surfaceID)
+      lastAgentEntryEmitAtBySurface.removeValue(forKey: surfaceID)
+      pendingAgentEntryBySurface.removeValue(forKey: surfaceID)
       onAgentEntryRemoved?(surfaceID)
       return
     }
-    // Dedup ignoring `rawState`: it flickers every poll while an agent animates
-    // and drives no UI, so emitting on it alone would re-render the sidebar
-    // continuously. Visible changes (displayState, title, session, …) still emit.
-    guard lastEmittedAgentEntriesBySurface[surfaceID]?.equalsIgnoringRawState(entry) != true else { return }
+    if let previous = lastEmittedAgentEntriesBySurface[surfaceID] {
+      // `rawState` flickers every poll while an agent animates and drives no UI,
+      // so it never justifies an emission on its own.
+      if previous.equalsIgnoringRawState(entry) { return }
+      // Only the animated title moved. Hold it back until the interval elapses;
+      // the suppressed entry is not recorded, so the next emission carries the
+      // title as of that moment rather than a stale frame.
+      if previous.equalsIgnoringRawStateAndPaneTitle(entry),
+        let lastEmitAt = lastAgentEntryEmitAtBySurface[surfaceID],
+        now.timeIntervalSince(lastEmitAt) < Self.agentEntryTitleCoalescingInterval
+      {
+        pendingAgentEntryBySurface[surfaceID] = entry
+        return
+      }
+    }
+    pendingAgentEntryBySurface.removeValue(forKey: surfaceID)
     lastEmittedAgentEntriesBySurface[surfaceID] = entry
+    lastAgentEntryEmitAtBySurface[surfaceID] = now
     onAgentEntryChanged?(entry)
+  }
+
+  /// Emits a title-only entry that coalescing held back, once the interval has
+  /// passed. Driven by the detection poll rather than a timer, so a spinner that
+  /// stops mid-window still settles on its final title within one poll.
+  func flushPendingAgentEntry(surfaceID: UUID, now: Date = Date()) {
+    guard let pending = pendingAgentEntryBySurface[surfaceID],
+      let lastEmitAt = lastAgentEntryEmitAtBySurface[surfaceID],
+      now.timeIntervalSince(lastEmitAt) >= Self.agentEntryTitleCoalescingInterval
+    else { return }
+    pendingAgentEntryBySurface.removeValue(forKey: surfaceID)
+    lastEmittedAgentEntriesBySurface[surfaceID] = pending
+    lastAgentEntryEmitAtBySurface[surfaceID] = now
+    onAgentEntryChanged?(pending)
   }
 
   func activeAgentEntry(surfaceID: UUID, tabId: TerminalTabID, state: PaneAgentState) -> ActiveAgentEntry? {
@@ -392,6 +441,8 @@ extension WorktreeTerminalState {
     lastAgentDetectionDiagnosticsBySurface.removeValue(forKey: surfaceId)
     lastAgentScreenScanBySurface.removeValue(forKey: surfaceId)
     lastEmittedAgentEntriesBySurface.removeValue(forKey: surfaceId)
+    lastAgentEntryEmitAtBySurface.removeValue(forKey: surfaceId)
+    pendingAgentEntryBySurface.removeValue(forKey: surfaceId)
     onAgentEntryRemoved?(surfaceId)
   }
 
@@ -408,6 +459,8 @@ extension WorktreeTerminalState {
     lastAgentDetectionDiagnosticsBySurface.removeAll()
     lastAgentScreenScanBySurface.removeAll()
     lastEmittedAgentEntriesBySurface.removeAll()
+    lastAgentEntryEmitAtBySurface.removeAll()
+    pendingAgentEntryBySurface.removeAll()
     for id in removedIDs {
       onAgentEntryRemoved?(id)
     }

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -125,6 +125,14 @@ final class WorktreeTerminalState {
   /// holds); comparing against the consumer-visible entry here keeps that
   /// churn out of the terminal event stream and the TCA action log.
   var lastEmittedAgentEntriesBySurface: [UUID: ActiveAgentEntry] = [:]
+  /// When each surface last emitted, used to space out title-only emissions.
+  /// Pure bookkeeping for `emitAgentEntry`; no view reads it.
+  @ObservationIgnored var lastAgentEntryEmitAtBySurface: [UUID: Date] = [:]
+  /// The most recent title-only entry held back by coalescing. A spinner that
+  /// stops animating produces no further title change, so without a trailing
+  /// flush the last frame would stay on screen until some unrelated state
+  /// change happened to carry the current title along.
+  @ObservationIgnored var pendingAgentEntryBySurface: [UUID: ActiveAgentEntry] = [:]
   var tabIsRunningById: [TerminalTabID: Bool] = [:]
   /// Per-tab aggregate of agent busy-state: `true` when at least one surface in
   /// the tab has a detected agent whose stabilized `displayState` is `.working`

--- a/supacodeTests/AgentEntryTitleCoalescingTests.swift
+++ b/supacodeTests/AgentEntryTitleCoalescingTests.swift
@@ -115,32 +115,99 @@ struct AgentEntryTitleCoalescingTests {
     #expect(!base.equalsIgnoringRawState(spinnerMoved))
   }
 
+  /// The test above pins one field this comparison must still notice. It
+  /// normalizes two, and nothing structural stops a later edit from normalizing
+  /// a third — the failure would be silent: it compiles, every test in this file
+  /// still passes, and the only symptom is a real change that never reaches the
+  /// sidebar. Walk the remaining fields so widening the normalization fails here
+  /// instead of in the UI.
+  @Test func everyOtherFieldStillBreaksTheTitleComparison() {
+    let base = makeEntry()
+    let variants: [(field: String, entry: ActiveAgentEntry)] = [
+      ("id", makeEntry(id: Self.otherEntryID)),
+      ("worktreeID", makeEntry(worktreeID: "/tmp/repo/other")),
+      ("worktreeName", makeEntry(worktreeName: "other")),
+      // Resolves the repository and branch the row displays, so a suppressed
+      // change leaves the sidebar naming the directory the agent has left.
+      ("workingDirectory", makeEntry(workingDirectory: URL(fileURLWithPath: "/tmp/repo/other"))),
+      ("workingDirectory=nil", makeEntry(workingDirectory: nil)),
+      ("tabID", makeEntry(tabID: Self.otherEntryTabID)),
+      ("surfaceID", makeEntry(surfaceID: Self.otherEntryID)),
+      ("paneIndex", makeEntry(paneIndex: 2)),
+      ("iconLookupToken", makeEntry(iconLookupToken: "codex")),
+      ("agent", makeEntry(agent: .codex)),
+      // Carries the resume target `prowl agents` reports; a suppressed change
+      // would keep pointing at the previous session's transcript.
+      ("session", makeEntry(session: Self.otherSession)),
+      ("session=nil", makeEntry(session: nil)),
+      ("displayState", makeEntry(displayState: .blocked)),
+      ("lastChangedAt", makeEntry(lastChangedAt: Date(timeIntervalSince1970: 5_000))),
+    ]
+
+    for variant in variants {
+      #expect(
+        !base.equalsIgnoringRawStateAndPaneTitle(variant.entry),
+        "A change to \(variant.field) must still emit; normalizing it would hide the change from the sidebar"
+      )
+    }
+
+    // The two fields the comparison exists to ignore, moving together.
+    #expect(base.equalsIgnoringRawStateAndPaneTitle(makeEntry(paneTitle: "⠧ spx-h", rawState: .idle)))
+  }
+
+  /// Defaults spell out every field so a case can override exactly one and the
+  /// assertion stays about that field alone.
   private func makeEntry(
-    paneTitle: String,
-    rawState: AgentRawState,
-    displayState: AgentDisplayState
+    id: UUID = entryID,
+    worktreeID: Worktree.ID = "/tmp/repo/worktree",
+    worktreeName: String = "worktree",
+    workingDirectory: URL? = URL(fileURLWithPath: "/tmp/repo/worktree"),
+    tabID: TerminalTabID = entryTabID,
+    paneTitle: String = "⠦ spx-h",
+    surfaceID: UUID = entryID,
+    paneIndex: Int = 1,
+    iconLookupToken: String = "claude",
+    agent: DetectedAgent = .claude,
+    session: AgentSession? = baseSession,
+    rawState: AgentRawState = .working,
+    displayState: AgentDisplayState = .working,
+    lastChangedAt: Date = Date(timeIntervalSince1970: 0)
   ) -> ActiveAgentEntry {
     ActiveAgentEntry(
-      id: Self.entryID,
-      worktreeID: "/tmp/repo/worktree",
-      worktreeName: "worktree",
-      workingDirectory: nil,
-      tabID: Self.entryTabID,
+      id: id,
+      worktreeID: worktreeID,
+      worktreeName: worktreeName,
+      workingDirectory: workingDirectory,
+      tabID: tabID,
       paneTitle: paneTitle,
-      surfaceID: Self.entryID,
-      paneIndex: 1,
-      iconLookupToken: "claude",
-      agent: .claude,
-      session: nil,
+      surfaceID: surfaceID,
+      paneIndex: paneIndex,
+      iconLookupToken: iconLookupToken,
+      agent: agent,
+      session: session,
       rawState: rawState,
       displayState: displayState,
-      lastChangedAt: Date(timeIntervalSince1970: 0)
+      lastChangedAt: lastChangedAt
     )
   }
 
   private static let entryID = UUID(uuidString: "00000000-0000-0000-0000-0000000000FF")!
+  private static let otherEntryID = UUID(uuidString: "00000000-0000-0000-0000-0000000000FE")!
   /// Shared so two entries under comparison differ only in the field under test.
   private static let entryTabID = TerminalTabID()
+  private static let otherEntryTabID = TerminalTabID()
+  private static let baseSession = AgentSession(
+    id: "session-1",
+    transcriptPath: URL(fileURLWithPath: "/tmp/transcripts/session-1.jsonl"),
+    source: .openFile,
+    confidence: .exact
+  )
+  private static let otherSession = AgentSession(
+    id: "session-2",
+    transcriptPath: URL(fileURLWithPath: "/tmp/transcripts/session-2.jsonl"),
+    source: .openFile,
+    confidence: .exact
+  )
 
   private struct Fixture {
     let state: WorktreeTerminalState

--- a/supacodeTests/AgentEntryTitleCoalescingTests.swift
+++ b/supacodeTests/AgentEntryTitleCoalescingTests.swift
@@ -1,0 +1,188 @@
+import AppKit
+import Foundation
+import GhosttyKit
+import Testing
+
+@testable import supacode
+
+/// Agent TUIs animate a spinner glyph inside the terminal title (`⠦ spx-h` →
+/// `⠧ spx-h`) at roughly 10 Hz. Each frame reaches `emitAgentEntry` as a new
+/// `ActiveAgentEntry`, and forwarding all of them mutates the Active Agents
+/// state — and dirties the SwiftUI graph — for a change no one perceives.
+/// `emitAgentEntry` must space title-only emissions out while still forwarding
+/// real state changes immediately.
+@MainActor
+struct AgentEntryTitleCoalescingTests {
+  private let start = Date(timeIntervalSince1970: 1_000)
+
+  @Test func spinnerFramesWithinTheIntervalAreCoalesced() {
+    let fixture = makeFixture()
+    var received: [ActiveAgentEntry] = []
+    fixture.state.onAgentEntryChanged = { received.append($0) }
+    let working = PaneAgentState(detectedAgent: .claude, state: .working)
+
+    fixture.emit(working, at: start)
+    // Four spinner frames over 400 ms, as a real agent would produce.
+    for frame in ["⠦ spx-h", "⠧ spx-h", "⠇ spx-h", "⠏ spx-h"].enumerated() {
+      fixture.setTitle(frame.element)
+      fixture.emit(working, at: start.addingTimeInterval(0.1 * Double(frame.offset + 1)))
+    }
+
+    #expect(received.count == 1, "Only the initial emission should reach the consumer")
+  }
+
+  @Test func aTitleChangeEmitsOnceTheIntervalElapses() {
+    let fixture = makeFixture()
+    var received: [ActiveAgentEntry] = []
+    fixture.state.onAgentEntryChanged = { received.append($0) }
+    let working = PaneAgentState(detectedAgent: .claude, state: .working)
+
+    fixture.emit(working, at: start)
+    fixture.setTitle("⠦ spx-h")
+    fixture.emit(working, at: start.addingTimeInterval(0.5))
+    // Past the interval, so the newest title is forwarded.
+    fixture.setTitle("⠧ spx-h")
+    fixture.emit(working, at: start.addingTimeInterval(1.5))
+
+    #expect(received.count == 2)
+    // The suppressed frame is never recorded, so the emission that follows
+    // carries the title as of that moment rather than the stale frame.
+    #expect(received.last?.paneTitle == "⠧ spx-h")
+  }
+
+  @Test func aVisibleStateChangeEmitsImmediatelyDespiteTheInterval() {
+    let fixture = makeFixture()
+    var received: [ActiveAgentEntry] = []
+    fixture.state.onAgentEntryChanged = { received.append($0) }
+
+    fixture.emit(PaneAgentState(detectedAgent: .claude, state: .working), at: start)
+    // Well inside the coalescing window, but `displayState` is user-visible and
+    // must never be delayed.
+    fixture.setTitle("⠧ spx-h")
+    fixture.emit(PaneAgentState(detectedAgent: .claude, state: .blocked), at: start.addingTimeInterval(0.05))
+
+    #expect(received.map(\.displayState) == [.working, .blocked])
+    #expect(received.last?.paneTitle == "⠧ spx-h", "The pending title rides along on the real change")
+  }
+
+  @Test func identicalTitlesNeverEmitEvenAfterTheInterval() {
+    let fixture = makeFixture()
+    var received: [ActiveAgentEntry] = []
+    fixture.state.onAgentEntryChanged = { received.append($0) }
+    let working = PaneAgentState(detectedAgent: .claude, state: .working)
+
+    fixture.emit(working, at: start)
+    fixture.emit(working, at: start.addingTimeInterval(5))
+    fixture.emit(working, at: start.addingTimeInterval(10))
+
+    #expect(received.count == 1, "Coalescing must not turn into a periodic re-emit")
+  }
+
+  @Test func aSettledTitleIsFlushedByTheNextPoll() {
+    let fixture = makeFixture()
+    var received: [ActiveAgentEntry] = []
+    fixture.state.onAgentEntryChanged = { received.append($0) }
+    let working = PaneAgentState(detectedAgent: .claude, state: .working)
+
+    fixture.emit(working, at: start)
+    // The spinner's final frame is suppressed, then the agent stops animating,
+    // so no further title change will ever arrive to carry it.
+    fixture.setTitle("spx-h")
+    fixture.emit(working, at: start.addingTimeInterval(0.2))
+    #expect(received.count == 1)
+
+    // A poll inside the window must not release it early.
+    fixture.flush(at: start.addingTimeInterval(0.5))
+    #expect(received.count == 1)
+
+    fixture.flush(at: start.addingTimeInterval(1.2))
+    #expect(received.count == 2)
+    #expect(received.last?.paneTitle == "spx-h")
+
+    // Nothing is left pending, so later polls stay quiet.
+    fixture.flush(at: start.addingTimeInterval(5))
+    #expect(received.count == 2)
+  }
+
+  @Test func comparisonIgnoresOnlyRawStateAndPaneTitle() {
+    let base = makeEntry(paneTitle: "⠦ spx-h", rawState: .working, displayState: .working)
+    let spinnerMoved = makeEntry(paneTitle: "⠧ spx-h", rawState: .idle, displayState: .working)
+    let stateMoved = makeEntry(paneTitle: "⠦ spx-h", rawState: .working, displayState: .blocked)
+
+    #expect(base.equalsIgnoringRawStateAndPaneTitle(spinnerMoved))
+    #expect(!base.equalsIgnoringRawStateAndPaneTitle(stateMoved))
+    // The narrower comparison still treats a title move as a difference.
+    #expect(!base.equalsIgnoringRawState(spinnerMoved))
+  }
+
+  private func makeEntry(
+    paneTitle: String,
+    rawState: AgentRawState,
+    displayState: AgentDisplayState
+  ) -> ActiveAgentEntry {
+    ActiveAgentEntry(
+      id: Self.entryID,
+      worktreeID: "/tmp/repo/worktree",
+      worktreeName: "worktree",
+      workingDirectory: nil,
+      tabID: Self.entryTabID,
+      paneTitle: paneTitle,
+      surfaceID: Self.entryID,
+      paneIndex: 1,
+      iconLookupToken: "claude",
+      agent: .claude,
+      session: nil,
+      rawState: rawState,
+      displayState: displayState,
+      lastChangedAt: Date(timeIntervalSince1970: 0)
+    )
+  }
+
+  private static let entryID = UUID(uuidString: "00000000-0000-0000-0000-0000000000FF")!
+  /// Shared so two entries under comparison differ only in the field under test.
+  private static let entryTabID = TerminalTabID()
+
+  private struct Fixture {
+    let state: WorktreeTerminalState
+    let tabId: TerminalTabID
+    let pane: GhosttySurfaceView
+
+    func setTitle(_ title: String) {
+      state.tabManager.updateTitle(tabId, title: title)
+    }
+
+    func emit(_ paneState: PaneAgentState, at now: Date) {
+      state.emitAgentEntry(surfaceID: pane.id, tabId: tabId, state: paneState, now: now)
+    }
+
+    /// Stands in for one turn of the detection poll, which drives the flush.
+    func flush(at now: Date) {
+      state.flushPendingAgentEntry(surfaceID: pane.id, now: now)
+    }
+  }
+
+  private func makeFixture() -> Fixture {
+    let state = WorktreeTerminalState(
+      runtime: GhosttyRuntime(),
+      worktree: Worktree(
+        id: "/tmp/repo/worktree",
+        name: "worktree",
+        detail: "",
+        workingDirectory: URL(fileURLWithPath: "/tmp/repo/worktree"),
+        repositoryRootURL: URL(fileURLWithPath: "/tmp/repo")
+      )
+    )
+    let pane = GhosttySurfaceView(
+      runtime: state.runtime,
+      workingDirectory: URL(fileURLWithPath: "/tmp/repo/worktree", isDirectory: true),
+      fontSize: nil,
+      context: GHOSTTY_SURFACE_CONTEXT_TAB,
+      skipsSurfaceCreationForTesting: true
+    )
+    let tabId = state.tabManager.createTab(title: "worktree 1", icon: "terminal")
+    state.surfaces[pane.id] = pane
+    state.trees[tabId] = SplitTree<GhosttySurfaceView>(view: pane)
+    state.focusedSurfaceIdByTab[tabId] = pane.id
+    return Fixture(state: state, tabId: tabId, pane: pane)
+  }
+}

--- a/supacodeTests/AgentEntryTitleCoalescingTests.swift
+++ b/supacodeTests/AgentEntryTitleCoalescingTests.swift
@@ -209,13 +209,27 @@ struct AgentEntryTitleCoalescingTests {
     confidence: .exact
   )
 
+  /// `TerminalTabManager` spaces out its own live title writes on a separate
+  /// clock. These tests exercise the entry-level coalescing, so each title is
+  /// stamped far enough apart that the tab layer never withholds one and the
+  /// two mechanisms stay independently testable.
+  private final class TitleClock {
+    private var now = Date(timeIntervalSince1970: 0)
+
+    func next() -> Date {
+      now = now.addingTimeInterval(TerminalTabManager.liveTitleCoalescingInterval * 2)
+      return now
+    }
+  }
+
   private struct Fixture {
     let state: WorktreeTerminalState
     let tabId: TerminalTabID
     let pane: GhosttySurfaceView
+    let titleClock = TitleClock()
 
     func setTitle(_ title: String) {
-      state.tabManager.updateTitle(tabId, title: title)
+      state.tabManager.updateTitle(tabId, title: title, now: titleClock.next())
     }
 
     func emit(_ paneState: PaneAgentState, at now: Date) {


### PR DESCRIPTION
Agent spinner frames reached the Active Agents panel at roughly 10 Hz, so this change spaces out emissions whose only difference is the animated title while letting real state changes through immediately.

Emissions that differ only in `paneTitle` are held for 1 second. The suppressed entry is not recorded, so the emission that follows carries the title as of that moment rather than a stale frame. A change to `displayState` bypasses the interval and emits at once. A title that settles inside the window is flushed by the next detection poll, so a spinner that stops mid-window still lands its final frame instead of waiting for a change that will never come.

That trailing flush is the part to question, because #656 moved tab titles off the detection poll and onto their own clock for what looks like the same problem. What differs is whether the poll can go cold underneath a held frame. A tab title belongs to any program, so a non-agent one can strand a pending title once the schedule goes cold, which is what your clock-driven task fixes. An agent entry exists only while a pane has a detected agent, and that is the same condition keeping the poll warm, so a pending entry cannot be stranded that way. I kept it poll-driven for that reason and put the reasoning in a comment at the call site. If you would rather have a single mechanism, I am happy to move it onto `onCoalescedTitlesFlushed` or its own clock.

`equalsIgnoringRawStateAndPaneTitle` normalizes 2 fields, and only `displayState` was pinned as a field it must still notice. Nothing structural stops a later edit from normalizing a third, and the failure would be silent, since it compiles and every test in the file still passes while a real change never reaches the sidebar. A test walks the remaining 12 fields, asserting that each one alone breaks equality, plus the positive case that `rawState` and `paneTitle` moving together do not. It is mutation-checked: normalizing `session` fails only this test while the 6 tests already in the file pass either way.

`TerminalTabManager` and `WorktreeTerminalState` coalesce on separate clocks that share the same 1-second interval, so the entry tests stamp each title far enough apart that the tab layer never withholds one. That keeps the two mechanisms independently testable.
