### PR TITLE
Record the agent-detection profiling wave and add the measurement scripts

### DIFF
--- a/docs-ai/032-performance-hardening/000-plan.md
+++ b/docs-ai/032-performance-hardening/000-plan.md
@@ -98,3 +98,9 @@ Wave-1 fixes, each independent:
   `isMainWorktree` failure mode and added blocking filesystem calls to it; replaced with a
   cached `WorktreeDirectoryIndex` — see
   [003-sidebar-agent-row-resolution.md](003-sidebar-agent-row-resolution.md)
+- Updated 2026-07-25: wave 4 — with the sidebar fixed, the remaining steady-state CPU split
+  between agent detection and SwiftUI graph invalidation. Six fixes: emission dedup on
+  `rawState`, isolating the Active Agents panel's `entries` read, caching parsed transcript
+  fragments, short-circuiting escape stripping, coalescing emissions driven by animated pane
+  titles, and sharing transcript directory walks across panes — see
+  [004-agent-detection-steady-state.md](004-agent-detection-steady-state.md)

--- a/docs-ai/032-performance-hardening/000-plan.md
+++ b/docs-ai/032-performance-hardening/000-plan.md
@@ -104,3 +104,10 @@ Wave-1 fixes, each independent:
   fragments, short-circuiting escape stripping, coalescing emissions driven by animated pane
   titles, and sharing transcript directory walks across panes — see
   [004-agent-detection-steady-state.md](004-agent-detection-steady-state.md)
+- Updated 2026-07-27: wave 4 continued — sampling a several-hundred-percent spike while it
+  was happening named the invalidation source the steady-state profile could not. Two further
+  fixes: coalescing animated *tab* titles, which were invalidating the whole `@Observable`
+  `tabs` array 20–30 times per second and rebuilding all 32 tabs through a quadratic lookup,
+  and memoizing agent working-directory resolution across renders. Main-thread cost fell from
+  82.5% of a core to 11.7% — see
+  [004-agent-detection-steady-state.md](004-agent-detection-steady-state.md)

--- a/docs-ai/032-performance-hardening/004-agent-detection-steady-state.md
+++ b/docs-ai/032-performance-hardening/004-agent-detection-steady-state.md
@@ -7,11 +7,15 @@ filesystem work from `SidebarListView.activeAgentRowDisplays` and dropped proces
 94–134% to 29–70%. A long-running instance still burned 45–66% of a core with agents
 attached, so profiling continued against the same workload.
 
-This amendment records six fixes and, as much as the fixes themselves, the method that
+This amendment records eight fixes and, as much as the fixes themselves, the method that
 found them: at each step the largest remaining cost was measured, attributed to a specific
-symbol, and the fix aimed at that symbol only. Four of the six were only visible after an
-earlier one had shifted the profile, and two of them turned out to be the same defect
+symbol, and the fix aimed at that symbol only. Six of the eight were only visible after an
+earlier one had shifted the profile, and three of them turned out to be the same defect
 arriving through a different field.
+
+Fixes 7 and 8 were added after the first six were verified. Fix 7 addresses the invalidation
+source that the original "Still open" section could not name — it was found by sampling a
+several-100% spike while it was happening, rather than by profiling steady state.
 
 Measurements come from `sample(1)` over a Debug build. Sample counts are reported as a
 percentage of one core (a 20-second window at 1 ms produces roughly 15,000 samples per
@@ -185,6 +189,65 @@ canonically equivalent, so byte matching would miss text differing only in NFC/N
 composition and would silently fail to resolve those sessions — a correctness hazard for
 roughly 1% of a core.
 
+## Fix 7 — Animated tab titles rebuilding the tab bar
+
+The six fixes above left the profile in the shape the original "Still open" section
+described: graph revalidation outweighing every app-owned `body`, plus a comparable AppKit
+layout cost, with no named requester for either. Steady-state sampling could not close it.
+
+What closed it was catching the failure at full size. A long-running instance reached several
+100% of a core, and a 300-second `sample(1)` taken while it was happening produced
+an attribution that a 20-second steady-state window had never shown:
+
+| main thread (300 s window, 32 tabs) | %core  |
+| ----------------------------------- | ------ |
+| busy (non-idle leaves)              | 82.50% |
+| `GraphHost.flushTransactions`       | 47.78% |
+| `CA::Transaction::commit`           | 32.33% |
+| ↳ AppKit view-tree layout           | 18.96% |
+| `detectAgentState`                  | 2.39%  |
+
+Detection — the subject of Fixes 1–6 — was 2.4% against 80% for invalidation and layout.
+
+**Root cause.** `TerminalTabItem.title` is a `var` inside `TerminalTabManager.tabs`, an array
+on an `@Observable` class. Observation granularity is per-property, not per-element: writing
+one element's title invalidates every view that read `tabs`. The same spinner animation
+behind Fix 5 therefore had a second consumer nobody had accounted for. At roughly 10 Hz per
+working pane, the tab bar rebuilt every tab 20–30 times per second, and each rebuild also
+marked the hosting view tree as needing layout — which is exactly the "most likely the same
+defect" hypothesis the previous section recorded, confirmed.
+
+`updateTitle` now drops no-op writes outright and holds a changed title that arrives inside a
+one-second window, newest-wins. As with Fix 5, a spinner that stops animating would strand its
+final frame, so `flushPendingTitles` lands it from the detection poll — no timer, because the
+poll is already running for precisely the panes that animate. `@ObservationIgnored` on both
+bookkeeping dictionaries keeps the coalescing from defeating itself.
+
+**A second defect in the same view.** `TerminalTabsRowView` looked each row up with
+`manager.tabs.first(where:)` *inside* a `ForEach` over that same array — 1,024 comparisons per
+rebuild at 32 tabs. It now reads `tabs` once and indexes it into a dictionary. This was
+harmless at the rebuild rate the tab bar was designed for and quadratic at the rate the
+spinner produced.
+
+## Fix 8 — Working-directory resolution repeated per render
+
+[003](003-sidebar-agent-row-resolution.md) made index *construction* cheap and cached the
+index against the repository set. The query side stayed hot: every lookup still normalized the
+directory being asked about, and `PathPolicy.normalizeURL` is a `fileExists` check plus
+`resolvingSymlinksInPath()` — one `getattrlist` per path component. The sidebar re-runs
+whenever any agent's state changes, so unchanged directories were re-normalized every frame.
+
+`WorktreeDirectoryIndexCache` now memoizes resolutions keyed by the directory as asked for. A
+resolution is a pure function of that directory and the index, so it stays valid until the
+index is rebuilt; rebuilding clears it in the same step, ordered so a stale answer cannot
+outlive its index. A pane can `cd` anywhere, so the memo is capped at 256 entries rather than
+assumed bounded by pane count.
+
+Measured at 0.11–0.16% of a core before the fix and 1.13% in the post-fix sample — the figure
+went *up* in absolute terms because the sample that produced it carried a far heavier
+workload. This fix is small, and an earlier commit message overstated it by quoting a
+14-millisecond window; the amended message records the real figures.
+
 ## Verification
 
 Structural results are load-independent and hold regardless of agent count:
@@ -227,49 +290,106 @@ the number independently. `scripts/measure-agent-detection-cpu.sh` records the a
 average, and per-symbol attribution together for this reason — a CPU percentage without its
 workload is not a measurement.
 
+## Verification of Fixes 7 and 8
+
+Measured on a live instance after installing the fixed build, against 28 tabs with 6 agents
+working and 1 blocked. A 20-second `sample(1)`, 13,138 samples at 1 ms:
+
+| main thread                   | spike (32 tabs) | after (28 tabs) | change |
+| ----------------------------- | --------------- | --------------- | ------ |
+| busy (non-idle leaves)        | 82.50%          | 11.70%          | −86%   |
+| `GraphHost.flushTransactions` | 47.78%          | 3.86%           | −92%   |
+| `CA::Transaction::commit`     | 32.33%          | 2.09%           | −94%   |
+| ↳ AppKit `_layoutViewTree`    | 18.96%          | 1.54%           | −92%   |
+| `detectAgentState`            | 2.39%           | 3.82%           | —      |
+| directory resolution          | —               | 1.13%           | —      |
+
+The main thread is 88.30% idle. `detectAgentState` did not grow; it stopped being buried, and
+is now the largest named main-thread cost.
+
+Unlike Fix 5, Fix 7 **is** observable from outside the app. `prowl list` reports `tab.title`
+from the live snapshot, which reads the same `tabs` array the tab bar observes. Polling it
+7.9 times per second for 30 seconds across 28 tabs:
+
+| animating tab                | changes/s |
+| ---------------------------- | --------- |
+| `[ . ] Action Required \| …` | 0.96      |
+| `[ ! ] Action Required \| …` | 0.96      |
+| `⠴ plugins-d`                | 0.93      |
+| `⠹ spx-j`                    | 0.93      |
+| three further panes          | 0.73      |
+
+Every animating tab sits at or below the one-second interval, against a measured source rate
+of 9.79 changes/second per working pane. Seven animating tabs produced 6.01 writes/second
+where the source would have produced roughly 68. Blocked panes animate too — their
+`[ . ]`/`[ ! ]` alternation was among the fastest — so a mostly-blocked roster is not a quiet
+one.
+
+Sustained process CPU, differenced from `ps -o time=` over awake time only:
+
+| window                 | agent mix             | %core |
+| ---------------------- | --------------------- | ----- |
+| 25.6 min               | 6 working, 1 blocked  | 18.3% |
+| 63 min (sleep-excised) | 1 working, 10 blocked | 24.5% |
+
+**Caveats.** The comparison run carried 28 tabs against the spike's 32, and the post-fix
+sample is a 20-second window against the spike's 300. Dividing CPU time by wall-clock
+understates cost whenever the host sleeps — two clamshell sleeps occurred during this session
+and the figures above exclude them. `scripts/capture-cpu-spike.sh` was written to catch a
+recurrence unattended; across four runs it never fired, but its coverage was thin enough
+(sleep, plus runs terminated early) that this is not evidence of absence.
+
 ## Still open
 
-With detection reduced by roughly a third, the SwiftUI flush is again the larger of the two
-paths, and the ratio that motivated Fixes 1, 2 and 5 has not changed shape:
+The invalidation source that the previous revision could not name was Fix 7, and the AppKit
+layout cost fell with it — confirming that the two were one defect billed to two subsystems,
+as hypothesized. What remains is smaller and differently shaped:
 
-| under `flushTransactions` (5.74% total) | %core |
-| --------------------------------------- | ----- |
-| `AG::Subgraph::update`                  | 0.81% |
-| `AG::Graph::propagate_dirty`            | 0.58% |
-| `AG::Graph::UpdateStack::update`        | 0.41% |
-| largest single app view body            | 0.30% |
+- `detectAgentState` at 3.82% is now the largest named main-thread cost. Fixes 3, 4 and 6
+  reduced it 34–48% per pane; the remainder is the 300 ms poll cadence itself, which every
+  agent pane runs regardless of state.
+- A residual `flushTransactions` at 3.86% with `propagate_dirty` at 0.33%. Far below the
+  ratio that motivated Fixes 1, 2, 5 and 7, and no longer the dominant path.
 
-Graph revalidation still outweighs every app-owned `body`, so something continues to dirty the
-graph more often than user-visible state changes. The remaining emission source is not
-identified: titles and `rawState` are both accounted for, and no view is slow enough to matter.
-Narrowing it further needs in-app instrumentation (`Self._printChanges()` or an emission
-counter), not `sample(1)`, because the profile can show that invalidation happens but not what
-requested it.
+Neither is worth attacking without first establishing that the current cost is a problem.
 
-A second cost sits entirely outside the SwiftUI path: `CA::Transaction::flush_as_runloop_observer`
-measured 6.70% of a core here and 11.77% on a starved host. Despite the CoreAnimation symbol
-names it is not layer rendering. The commit runs AppKit's display-cycle observer, which
-performs constraint-based layout of the whole window:
+## Refs
 
-```
-CA::Transaction::commit                        4.27%
-  run_commit_handlers → NSDisplayCycleFlush     4.19%
-    -[NSWindow layoutIfNeeded]                  3.85%
-      -[NSWindow _layoutViewTree]               3.77%
-        -[NSView _layoutSubtreeWithOldSize:]    ×33 nested frames
-```
+All branches are off `main` and unmerged at time of writing. The fixes do not map one-to-one
+onto branches: two pairs share a commit, and the branches form three stacks.
 
-The recursion is 33 `NSView` levels deep and still carries 18% of its root cost at the deepest
-frame, over a window holding 32 tabs across 29 worktrees. Almost no app-owned frame appears
-anywhere inside it — the cost is tree traversal, not any view's own layout. Two candidates were
-ruled out by measurement: `NSProgressIndicator`, the sidebar's per-worktree spinner, at 0.01%
-(12 were animating), and terminal surface rendering, which does not appear on the path.
+**Stack A** — `perf/agent-entry-churn`, then `perf/agent-title-coalescing` on top of it:
 
-This is most likely the same defect as the graph invalidation above rather than a second one.
-An invalidation that dirties the SwiftUI graph also marks the hosting view tree as needing
-layout, and the two costs then bill separately — roughly 5.7% in graph revalidation plus 3.8%
-in AppKit layout, together larger than agent detection. Finding the single invalidation source
-would address both; optimizing either subtree in isolation would not.
+| commit     | subject                                                          | fix   |
+| ---------- | ---------------------------------------------------------------- | ----- |
+| `eee5a988` | Stop agent-state churn from re-rendering the whole sidebar       | 1 + 2 |
+| `ad6e10e2` | Drop dead try/throws from the emission dedup fixture             | —     |
+| `4c7725ad` | Space out Active Agents emissions driven by animated pane titles | 5     |
+
+**Stack B** — `perf/session-fingerprint-cache`, then `perf/session-scan-cache`:
+
+| commit     | subject                                                                 | fix   |
+| ---------- | ----------------------------------------------------------------------- | ----- |
+| `2d33d2e3` | Cut agent session resolution CPU by reusing parsed transcript tails     | 3 + 4 |
+| `a06a0b31` | Skip escape stripping when a fragment holds no escape byte              | 4     |
+| `eae28144` | Share transcript directory walks across panes and cut redundant scoring | 6     |
+
+**Stack C** — `perf/sidebar-worktree-resolution`, then `perf/worktree-directory-query-memo`.
+`3420844c` is [003](003-sidebar-agent-row-resolution.md)'s fix rather than one of these eight;
+`c1c0b1d0` and `1aa1096a` are its documentation:
+
+| commit     | subject                                                      | fix |
+| ---------- | ------------------------------------------------------------ | --- |
+| `3420844c` | Resolve agent rows through a cached worktree directory index | 003 |
+| `2a7090cb` | Memoize agent working-directory resolution across renders    | 8   |
+
+**Standalone:** `perf/tab-title-coalescing` (`8662264d`) carries fix 7.
+`perf/agent-detection-scan-cache` (`9648f2ea`, "Memoize agent screen scans to skip re-parsing
+unchanged terminals") is part of this wave but is not one of the numbered fixes — it is covered
+only by `AgentScreenScanCacheTests` below. `perf/tca-action-log-gating` (`51cdab5b`) gates
+per-action TCA logging behind `PROWL_LOG_TCA_ACTIONS` and is a logging change, not a fix.
+
+`perf/combined-verify` stacks everything for local verification and is not a PR candidate.
 
 ## Tests
 
@@ -283,6 +403,19 @@ would address both; optimizing either subtree in isolation would not.
   shared across differing thresholds, and kept separate per root.
 - `AgentSessionFingerprintNormalizeTests` — both optimized paths reproduce the original
   formulation over a corpus and 2,000 seeded random inputs.
+- `TerminalTabTitleCoalescingTests` — 11 tests: frames inside the interval never reach `tabs`,
+  the flush lands only the most recent suppressed title, coalescing is per-tab rather than
+  global, a locked title is neither written nor held, a custom title masks a flushed live one,
+  and closing a tab drops its coalescing state.
+- `WorktreeDirectoryIndexTests` — the memo is proven by revoking the symlink a first lookup
+  resolved through: an answer that survives that can only have been memoized. Plus
+  invalidation on a repository-set change and eviction past the 256-entry cap.
+
+`TerminalTabManager` and `WorktreeTerminalState` coalesce on separate clocks, so
+`AgentEntryTitleCoalescingTests` stamps its titles through a fixture clock spaced past the tab
+interval. Without it the tab layer withholds a title the entry test expects to see, and the
+two mechanisms cannot be exercised independently. Whichever of the two coalescing branches
+merges second needs this fixture change.
 
 ## Lessons
 
@@ -292,8 +425,20 @@ profile; each became the top cost only after the one before it landed.
 **A cheap check that proves an expensive one unnecessary beats optimizing the expensive one.**
 The ESC-absence guard outperformed the hand-written ASCII scanner it was meant to support.
 
-**Fixing one volatile field does not fix the class.** `rawState` and `paneTitle` were the
-same defect. A field's presence in an equatable identity is what matters, not what it means.
+**Fixing one volatile field does not fix the class.** `rawState`, `paneTitle`, and
+`TerminalTabItem.title` were one defect found three times, each through a different consumer.
+A field's presence in an equatable identity — or in an observed collection — is what matters,
+not what it means. After closing two of them the third was still costing 80% of a core.
+
+**Sample the failure, not the steady state.** Six fixes of steady-state profiling could not
+name the invalidation source; one 300-second sample taken *while* the spike was happening
+named it immediately, at 47.78%. A cost that is intermittent is invisible in a window that
+averages over its absence, which is what `scripts/capture-cpu-spike.sh` exists to avoid.
+
+**Observation granularity is per-property, not per-element.** Mutating one element of an
+`@Observable` array invalidates every reader of that array. A 10 Hz write to one tab's title
+rebuilt all 32 — and a `first(where:)` lookup that was harmless at the designed rebuild rate
+became quadratic at the spinner's.
 
 **Attribute the flush before optimizing views.** 76% `AttributeGraph` internals against 13%
 app view bodies said "dirtied too often", not "views too slow".

--- a/docs-ai/032-performance-hardening/004-agent-detection-steady-state.md
+++ b/docs-ai/032-performance-hardening/004-agent-detection-steady-state.md
@@ -246,11 +246,30 @@ Narrowing it further needs in-app instrumentation (`Self._printChanges()` or an 
 counter), not `sample(1)`, because the profile can show that invalidation happens but not what
 requested it.
 
-A second cost sits entirely outside both paths and has never been examined:
-`CA::Transaction::flush_as_runloop_observer` — CoreAnimation layer commit — measured 6.70% of a
-core here and 11.77% on a starved host. Terminal surface rendering and the sidebar's
-per-worktree `ProgressView` spinners (12 running simultaneously in the sampled fleet) are both
-plausible contributors; they have not been separated.
+A second cost sits entirely outside the SwiftUI path: `CA::Transaction::flush_as_runloop_observer`
+measured 6.70% of a core here and 11.77% on a starved host. Despite the CoreAnimation symbol
+names it is not layer rendering. The commit runs AppKit's display-cycle observer, which
+performs constraint-based layout of the whole window:
+
+```
+CA::Transaction::commit                        4.27%
+  run_commit_handlers → NSDisplayCycleFlush     4.19%
+    -[NSWindow layoutIfNeeded]                  3.85%
+      -[NSWindow _layoutViewTree]               3.77%
+        -[NSView _layoutSubtreeWithOldSize:]    ×33 nested frames
+```
+
+The recursion is 33 `NSView` levels deep and still carries 18% of its root cost at the deepest
+frame, over a window holding 32 tabs across 29 worktrees. Almost no app-owned frame appears
+anywhere inside it — the cost is tree traversal, not any view's own layout. Two candidates were
+ruled out by measurement: `NSProgressIndicator`, the sidebar's per-worktree spinner, at 0.01%
+(12 were animating), and terminal surface rendering, which does not appear on the path.
+
+This is most likely the same defect as the graph invalidation above rather than a second one.
+An invalidation that dirties the SwiftUI graph also marks the hosting view tree as needing
+layout, and the two costs then bill separately — roughly 5.7% in graph revalidation plus 3.8%
+in AppKit layout, together larger than agent detection. Finding the single invalidation source
+would address both; optimizing either subtree in isolation would not.
 
 ## Tests
 

--- a/docs-ai/032-performance-hardening/004-agent-detection-steady-state.md
+++ b/docs-ai/032-performance-hardening/004-agent-detection-steady-state.md
@@ -1,0 +1,232 @@
+# 032.004 — Agent Detection Steady-State CPU
+
+## Context
+
+[003-sidebar-agent-row-resolution](003-sidebar-agent-row-resolution.md) removed the
+filesystem work from `SidebarListView.activeAgentRowDisplays` and dropped process CPU from
+94–134% to 29–70%. A long-running instance still burned 45–66% of a core with agents
+attached, so profiling continued against the same workload.
+
+This amendment records five fixes and, as much as the fixes themselves, the method that
+found them: at each step the largest remaining cost was measured, attributed to a specific
+symbol, and the fix aimed at that symbol only. Three of the five were only visible after an
+earlier one had shifted the profile, and two of them turned out to be the same defect
+arriving through a different field.
+
+Measurements come from `sample(1)` over a Debug build. Sample counts are reported as a
+percentage of one core (a 20-second window at 1 ms produces roughly 15,000 samples per
+thread), and inclusive subtree costs are summed from the shallowest occurrence of a symbol
+in each thread so nested frames are not double counted.
+
+**A note on load.** Several intermediate samples were taken while the host ran at load
+averages of 35–49 on 12 cores, and they are not usable: every number inflates under
+starvation, and one such sample showed detection *above* its pre-fix baseline. Only samples
+taken below roughly one runnable process per core are quoted here. Within-sample
+composition ratios stayed consistent across both regimes, which is what made the elevated
+samples worth keeping as a cross-check rather than discarding outright.
+
+## What the profile showed
+
+With the sidebar fixed, the steady-state cost split into two paths:
+
+| path                                     | share                |
+| ---------------------------------------- | -------------------- |
+| `WorktreeTerminalState.detectAgentState` | 15.9% of a core      |
+| `GraphHost.flushTransactions` (SwiftUI)  | 12.9–16.1% of a core |
+
+Under the flush, only about 13% of the subtree was app-owned view bodies; the remaining 76%
+was `AttributeGraph` revalidation. That ratio is the finding: the graph was being dirtied
+too often, and no view was slow. Optimizing a `body` would have bought nothing.
+
+## Fix 1 — Emissions driven by `rawState`
+
+`ActiveAgentEntry.rawState` is the un-stabilized per-poll detection result. It oscillates on
+every 300 ms poll while an agent animates, and it is surfaced only by `prowl agents`
+(`AgentsCommandHandler.swift`); no view renders it. Because emission dedup compared whole
+entries, each flicker pushed a new entry into `ActiveAgentsFeature.State.entries` and re-ran
+`SidebarListView.body`, which recreated every `RepositorySectionView`.
+
+`equalsIgnoringRawState` now gates emission. Measured with `Self._printChanges()` on a
+working agent: `RepositorySectionView` re-evaluations over 8 seconds went from 99 to 0.
+
+## Fix 2 — Sidebar re-render scope
+
+Even with emissions reduced, `SidebarListView.body` read `state.activeAgents.entries`, so
+any real entry change still re-ran the entire sidebar. The `entries` read moved into a new
+`SidebarActiveAgentsOverlay`, which owns the panel and its row-display computation. An
+entries change now re-evaluates that overlay alone.
+
+After both fixes `RepositorySectionView` does not appear in the profile at all (0.01–0.10%).
+
+## Fix 3 — Re-parsing unchanged transcript tails
+
+Session fingerprint matching dominated detection:
+
+```
+detectAgentState                    15.9%
+  AgentSessionResolver.resolve      13.0%
+    resolveUncached                 13.0%
+      bestMatch                     11.4%
+        normalize                    6.7%
+        transcriptStrings            2.5%
+      recentCandidates               1.6%
+      tailData (file I/O)            0.01%
+```
+
+I/O at 0.01% against 11.4% of comparison work is the whole story: the tails sat in the page
+cache and the cost was recomputation. Every pane re-read, re-parsed, and re-normalized the
+same bytes each time its 5-second session cache expired.
+
+`TranscriptFragmentCache` keys parsed, normalized fragments on the transcript's path and
+modification date. Entries not consulted in a round are pruned, which bounds a cache whose
+keys would otherwise grow with every append. Matching behavior is unchanged: identical
+fragments produce identical scores.
+
+## Fix 4 — Normalization cost
+
+`AgentSessionFingerprintMatcher.normalize` strips ANSI escapes, folds case, and collapses
+whitespace. Component timing over 12 real transcript tails:
+
+| component                        | cost     |
+| -------------------------------- | -------- |
+| grapheme split + join            | 102.5 ms |
+| escape-stripping regex           | 49.9 ms  |
+| lowercase                        | 10.4 ms  |
+| byte scan proving no ESC present | 11.5 ms  |
+
+**238 of 240 fragments contained no ESC byte at all**, yet the regex engine walked every one
+of them to conclude nothing. A pattern anchored on ESC cannot match a string without one, so
+an `utf8.contains(0x1B)` guard short-circuits it:
+
+| implementation         | ms/round | vs original |
+| ---------------------- | -------- | ----------- |
+| original               | 101.6    | 1.00x       |
+| + escape-absence guard | 64.1     | 1.58x       |
+| + ASCII fast path      | 57.9     | 1.75x       |
+
+The escape guard was the larger win and applies to all input. The ASCII fast path — a single
+byte scan replacing Swift Regex and grapheme-level splitting — adds only 1.11x on top,
+because 79% of transcript *bytes* are non-ASCII and defer to the general path. An initial
+estimate of "detection 15.9% → ~5%" was too optimistic for exactly that reason.
+
+Both paths are tested against a pristine copy of the original formulation over a hand-built
+corpus and 2,000 seeded random ASCII inputs, so neither can drift from the semantics the
+matcher was built on.
+
+## Fix 5 — Animated pane titles
+
+With detection reduced, the SwiftUI flush became the largest single cost. Three `prowl
+agents` snapshots three seconds apart identified the trigger: **titles changed on 6 of 24
+panes while agent status changed on none.**
+
+```
+"⠂ Read-only review of worktree and branch" → "⠐ Read-only review of worktree and branch"
+"⠦ spx-h"                                   → "⠧ spx-h"
+"[ . ] Action Required | spx-b"             → "[ ! ] Action Required | spx-b"
+```
+
+Agent TUIs animate a spinner glyph into the terminal title at roughly 10 Hz. `paneTitle` is
+part of `ActiveAgentEntry`, so every frame failed the dedup from Fix 1, mutated `entries`,
+and dirtied the graph — roughly 60 invalidations per second, none of them a state change.
+
+This is the same defect as Fix 1 arriving through a different field. Closing one volatile
+field did not close the class.
+
+Title-only differences now emit at most once per second. Any user-visible change
+(`displayState`, session, working directory) still emits immediately and carries the pending
+title along, so a state transition is never delayed.
+
+Coalescing alone would strand the final frame of a spinner that stops animating, since no
+further title change would arrive to carry it. A suppressed entry is therefore retained and
+flushed by the next detection poll once the interval elapses — no timer, and the stale
+window is bounded to one poll.
+
+**Rejected:** stripping the glyphs instead. It would require maintaining a list of every
+agent's spinner alphabet, and an unrecognized style would silently regress to per-frame
+emission.
+
+## Fix 6 — Directory walks repeated per pane
+
+A 26-pane sample on a quiet machine (load average 3.93) showed where the fragment cache had
+and had not helped. Normalizing by pane, because all agent panes poll at 300 ms regardless
+of state:
+
+| per pane            | before | after  |          |
+| ------------------- | ------ | ------ | -------- |
+| `transcriptStrings` | 0.124% | 0.000% | −100%    |
+| `normalize`         | 0.335% | 0.099% | −70%     |
+| `bestMatch`         | 0.569% | 0.322% | −43%     |
+| `recentCandidates`  | 0.079% | 0.151% | **+92%** |
+| detection total     | 0.794% | 0.676% | −15%     |
+
+The fragment cache worked exactly as designed — `transcriptStrings` and `tailData` both hit
+0.00% — but the total moved only 15% because the filesystem walk nearly doubled per pane and
+swallowed the gains. The walk scales with files on disk, not pane count: this host held
+5,483 transcripts totalling 3.9 GB, and that number grows as the agents work.
+
+Panes resolve independently but overwhelmingly share roots — every agent in one project
+enumerates that project's transcript directory. One walk per root is now retained for two
+seconds and replayed for whatever panes arrive inside that window. The stored list is
+unfiltered so callers keep applying their own process-start threshold, which lets panes with
+unrelated start times share a single enumeration.
+
+The visit limit is part of the cache key. A walk made under a looser limit may hold entries a
+stricter caller would refuse to trust, so it must not answer for one; the existing
+`truncatedScansYieldNoCandidates` test caught this when the key was the root alone.
+
+The scoring loop also recomputed `String(normalized.suffix(80))` and walked graphemes for
+`normalized.count` on every fragment of every match, for text that never changes. Both now
+ride along in the cached fragment. That exposed a redundant search: for a fragment of 80
+characters or fewer the suffix *is* the fragment, so the second `contains` reran the first
+verbatim. Those fragments now skip it.
+
+**Rejected:** replacing `String.contains` with a UTF8 byte search. String comparison is
+canonically equivalent, so byte matching would miss text differing only in NFC/NFD
+composition and would silently fail to resolve those sessions — a correctness hazard for
+roughly 1% of a core.
+
+## Verification
+
+Structural results are load-independent and hold regardless of agent count:
+
+- `RepositorySectionView` absent from the profile (0.01–0.10%), against 99 re-evaluations
+  per 8 seconds before Fix 1.
+- Session resolution fell from 82% to 58–65% of `detectAgentState`; `normalize` from 42% to
+  10–14%.
+- `transcriptStrings` and `tailData` at 0.00%.
+
+Absolute CPU comparisons proved harder to state honestly than expected. Agent count, the
+working/blocked mix, host load, and files on disk all moved between runs, and each shifts
+the number independently. `scripts/measure-agent-detection-cpu.sh` records the agent mix, load
+average, and per-symbol attribution together for this reason — a CPU percentage without its
+workload is not a measurement.
+
+## Tests
+
+- `AgentEntryEmissionDedupTests` — `rawState` and bookkeeping churn do not re-emit.
+- `AgentEntryTitleCoalescingTests` — spinner frames coalesce, visible changes bypass the
+  interval, a settled title is flushed by the next poll.
+- `AgentScreenScanCacheTests` — unchanged screens are not re-scanned.
+- `TranscriptFragmentCacheTests` — reuse, invalidation on append, unreadable tails are not
+  cached, pruning is bounded, precomputed count and suffix.
+- `AgentSessionRootScanCacheTests` — walks are shared within the window, redone after it,
+  shared across differing thresholds, and kept separate per root.
+- `AgentSessionFingerprintNormalizeTests` — both optimized paths reproduce the original
+  formulation over a corpus and 2,000 seeded random inputs.
+
+## Lessons
+
+**Measure after each fix, not once at the start.** Fixes 3–6 were invisible in the original
+profile; each became the top cost only after the one before it landed.
+
+**A cheap check that proves an expensive one unnecessary beats optimizing the expensive one.**
+The ESC-absence guard outperformed the hand-written ASCII scanner it was meant to support.
+
+**Fixing one volatile field does not fix the class.** `rawState` and `paneTitle` were the
+same defect. A field's presence in an equatable identity is what matters, not what it means.
+
+**Attribute the flush before optimizing views.** 76% `AttributeGraph` internals against 13%
+app view bodies said "dirtied too often", not "views too slow".
+
+**Estimates from composition can mislead.** "15.9% → ~5%" assumed the ASCII fast path would
+carry most inputs; measuring showed 79% of bytes were non-ASCII.

--- a/docs-ai/032-performance-hardening/004-agent-detection-steady-state.md
+++ b/docs-ai/032-performance-hardening/004-agent-detection-steady-state.md
@@ -7,9 +7,9 @@ filesystem work from `SidebarListView.activeAgentRowDisplays` and dropped proces
 94–134% to 29–70%. A long-running instance still burned 45–66% of a core with agents
 attached, so profiling continued against the same workload.
 
-This amendment records five fixes and, as much as the fixes themselves, the method that
+This amendment records six fixes and, as much as the fixes themselves, the method that
 found them: at each step the largest remaining cost was measured, attributed to a specific
-symbol, and the fix aimed at that symbol only. Three of the five were only visible after an
+symbol, and the fix aimed at that symbol only. Four of the six were only visible after an
 earlier one had shifted the profile, and two of them turned out to be the same defect
 arriving through a different field.
 
@@ -189,17 +189,68 @@ roughly 1% of a core.
 
 Structural results are load-independent and hold regardless of agent count:
 
-- `RepositorySectionView` absent from the profile (0.01–0.10%), against 99 re-evaluations
-  per 8 seconds before Fix 1.
-- Session resolution fell from 82% to 58–65% of `detectAgentState`; `normalize` from 42% to
-  10–14%.
-- `transcriptStrings` and `tailData` at 0.00%.
+- `RepositorySectionView` effectively absent from the profile (0.09–0.20%), against 99
+  re-evaluations per 8 seconds before Fix 1.
+- Session resolution fell from 82% to 61–71% of `detectAgentState`; `normalize` from 42% to
+  9–17%; `bestMatch` from 72% to 24–37%.
+- `transcriptStrings` and `tailData` at 0.00–0.03%.
+
+Three samples taken after the fixes were rebased onto v2026.7.25 bracket the absolute cost.
+Per-pane figures divide by pane count, because every agent pane polls at 300 ms regardless of
+state; the baseline column is a 25-pane run at load average 4.38 carrying Fixes 1–4 only.
+
+| per pane           | baseline (load 4.4) | 26 panes (load 16.9) | change |
+| ------------------ | ------------------- | -------------------- | ------ |
+| `detectAgentState` | 0.368%              | 0.241%               | −34%   |
+| `resolve`          | 0.286%              | 0.160%               | −44%   |
+| `bestMatch`        | 0.172%              | 0.090%               | −48%   |
+| `normalize`        | 0.054%              | 0.030%               | −43%   |
+| `recentCandidates` | 0.110%              | 0.066%               | −40%   |
+
+The comparison run carried four times the host load and three working agents against the
+baseline's one, both of which raise detection cost, so these are lower bounds rather than
+estimates. `recentCandidates` at −40% is the figure Fix 6 was written for: it had regressed
++92% per pane when the fragment cache landed, and the shared walk put it below its
+pre-regression level.
+
+**Fix 5 is not observable from outside the app.** `prowl agents` reports `tab.title` and
+`pane.title` from the live `ListRuntimeSnapshot`, and the payload never exposes
+`ActiveAgentEntry.paneTitle`, so CLI polling measures the spinner's source rate — confirmed at
+9.8 changes/second per working pane, and ~1/second on idle and blocked panes — not the
+emission rate coalescing governs. `AgentEntryTitleCoalescingTests` is the verification;
+the live profile is only consistent with it, showing every app-owned view body at or below
+0.30% of a core beneath a 5.74% flush.
 
 Absolute CPU comparisons proved harder to state honestly than expected. Agent count, the
 working/blocked mix, host load, and files on disk all moved between runs, and each shifts
 the number independently. `scripts/measure-agent-detection-cpu.sh` records the agent mix, load
 average, and per-symbol attribution together for this reason — a CPU percentage without its
 workload is not a measurement.
+
+## Still open
+
+With detection reduced by roughly a third, the SwiftUI flush is again the larger of the two
+paths, and the ratio that motivated Fixes 1, 2 and 5 has not changed shape:
+
+| under `flushTransactions` (5.74% total) | %core |
+| --------------------------------------- | ----- |
+| `AG::Subgraph::update`                  | 0.81% |
+| `AG::Graph::propagate_dirty`            | 0.58% |
+| `AG::Graph::UpdateStack::update`        | 0.41% |
+| largest single app view body            | 0.30% |
+
+Graph revalidation still outweighs every app-owned `body`, so something continues to dirty the
+graph more often than user-visible state changes. The remaining emission source is not
+identified: titles and `rawState` are both accounted for, and no view is slow enough to matter.
+Narrowing it further needs in-app instrumentation (`Self._printChanges()` or an emission
+counter), not `sample(1)`, because the profile can show that invalidation happens but not what
+requested it.
+
+A second cost sits entirely outside both paths and has never been examined:
+`CA::Transaction::flush_as_runloop_observer` — CoreAnimation layer commit — measured 6.70% of a
+core here and 11.77% on a starved host. Terminal surface rendering and the sidebar's
+per-worktree `ProgressView` spinners (12 running simultaneously in the sampled fleet) are both
+plausible contributors; they have not been separated.
 
 ## Tests
 

--- a/scripts/capture-cpu-spike.sh
+++ b/scripts/capture-cpu-spike.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+# Capture a stack sample of Prowl at the moment its CPU crosses a threshold.
+#
+# `sample(1)` only sees its own window, so a runaway that has already passed is
+# invisible no matter how long the sample runs — averaging a spike over a long
+# window is what hides it. This watches until the spike is happening and samples
+# then, unattended.
+#
+# Usage:  bash scripts/capture-cpu-spike.sh [threshold_percent] [sample_seconds]
+#         bash scripts/capture-cpu-spike.sh 150 10      # default
+#
+# Environment:
+#   PROWL_SPIKE_INTERVAL   seconds between CPU checks (default 2)
+#   PROWL_SPIKE_MAX_WAIT   give up after this many seconds (default 7200)
+#   PROWL_SPIKE_CONSECUTIVE  readings above threshold before firing (default 2)
+#   PROWL_MEASURE_DIR      where runs are written
+#                          (default ~/Library/Logs/Prowl/measurements)
+set -uo pipefail
+
+THRESHOLD=${1:-150}
+SAMPLE_SECONDS=${2:-10}
+INTERVAL=${PROWL_SPIKE_INTERVAL:-2}
+MAX_WAIT=${PROWL_SPIKE_MAX_WAIT:-7200}
+NEEDED=${PROWL_SPIKE_CONSECUTIVE:-2}
+
+# ~/Library/Logs is where macOS keeps user-visible diagnostics, so a captured
+# spike survives a reboot and Console.app can see it. $TMPDIR is wrong for this:
+# it is cleared periodically and on reboot, and a spike capture is worth keeping
+# precisely because the spike is hard to catch a second time.
+OUT="${PROWL_MEASURE_DIR:-$HOME/Library/Logs/Prowl/measurements}/spikes/$(date +%Y%m%d-%H%M%S)"
+mkdir -p "$OUT"
+
+PID=$(ps -Ao pid,comm | grep "Prowl Debug.app/Contents/MacOS/ProwlApp" | grep -v grep | awk '{print $1}' | head -1)
+if [ -z "$PID" ]; then
+  echo "Prowl Debug is not running." >&2
+  exit 1
+fi
+
+# `ps -o %cpu` is a decayed average since launch, which lags a sudden spike by
+# far too much to trigger on. Differencing consumed CPU time over a known
+# interval gives the real instantaneous figure instead.
+cpu_seconds() {
+  ps -o time= -p "$1" 2>/dev/null | tr -d ' ' |
+    awk -F: '{ total = 0; for (i = 1; i <= NF; i++) total = total * 60 + $i; print total }'
+}
+
+echo "watching pid $PID for >= ${THRESHOLD}% of one core"
+echo "  checking every ${INTERVAL}s, need ${NEEDED} consecutive, giving up after ${MAX_WAIT}s"
+echo "  output: $OUT"
+echo
+
+PREV=$(cpu_seconds "$PID")
+[ -z "$PREV" ] && { echo "Could not read CPU time for pid $PID." >&2; exit 1; }
+
+STREAK=0
+# A bounded loop rather than `while true`, so the watcher always terminates.
+ITERATIONS=$((MAX_WAIT / INTERVAL))
+for _ in $(seq 1 "$ITERATIONS"); do
+  sleep "$INTERVAL"
+  NOW=$(cpu_seconds "$PID")
+  if [ -z "$NOW" ]; then
+    echo "pid $PID exited before a spike was seen." >&2
+    exit 1
+  fi
+  PCT=$(awk -v a="$PREV" -v b="$NOW" -v t="$INTERVAL" 'BEGIN { printf "%.0f", (b - a) / t * 100 }')
+  PREV=$NOW
+
+  if [ "$PCT" -ge "$THRESHOLD" ]; then
+    STREAK=$((STREAK + 1))
+    echo "$(date +%H:%M:%S)  ${PCT}%  (${STREAK}/${NEEDED})"
+  else
+    [ "$STREAK" -gt 0 ] && echo "$(date +%H:%M:%S)  ${PCT}%  (reset)"
+    STREAK=0
+    continue
+  fi
+
+  [ "$STREAK" -ge "$NEEDED" ] || continue
+
+  echo
+  echo "=== spike: sampling for ${SAMPLE_SECONDS}s ==="
+  # Context first: a spike figure without its workload cannot be compared to any
+  # other run, and the host may simply be overcommitted.
+  {
+    echo "triggered_at: $(date -Iseconds)"
+    echo "observed:     ${PCT}% of one core (threshold ${THRESHOLD}%)"
+    echo "pid:          $PID  (up $(ps -o etime= -p "$PID" | tr -d ' '))"
+    echo "load:         $(uptime | sed 's/.*load averages*: //')   cores: $(sysctl -n hw.ncpu)"
+    echo
+    echo "top host processes:"
+    ps -Ao pid,%cpu,comm -r | head -8
+  } > "$OUT/context.txt"
+  cat "$OUT/context.txt"
+
+  prowl agents --json 2>/dev/null > "$OUT/agents.json" || true
+  jq -r 'if .ok then "agent mix: total=\(.data.agents|length)   "
+      + (.data.agents|group_by(.status)|map("\(.[0].status)=\(length)")|join("  "))
+    else "CLI unavailable" end' < "$OUT/agents.json" 2>/dev/null || true
+
+  # Keep the header: it carries the window size every later attribution needs.
+  sample "$PID" "$SAMPLE_SECONDS" -f "$OUT/sample.txt" >/dev/null 2>&1
+  echo
+  echo "captured: $OUT/sample.txt  ($(wc -l < "$OUT/sample.txt" | tr -d ' ') lines)"
+  echo "          $OUT/context.txt  $OUT/agents.json"
+  exit 0
+done
+
+echo "no spike >= ${THRESHOLD}% seen within ${MAX_WAIT}s." >&2
+exit 2

--- a/scripts/measure-agent-detection-cpu.sh
+++ b/scripts/measure-agent-detection-cpu.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+# Measure Prowl's steady-state CPU and attribute it to the agent-detection and
+# SwiftUI-flush paths, alongside the baseline recorded in
+# docs-ai/032-performance-hardening/004-agent-detection-steady-state.md.
+#
+# A CPU percentage means nothing without its workload, so every run records the
+# agent mix and the host load average next to the per-symbol attribution. Treat
+# a sample taken above roughly one runnable process per core as unusable:
+# starvation inflates every number, and it inflates them unevenly.
+set -uo pipefail
+
+# Each run gets its own directory so earlier samples stay comparable.
+# ~/Library/Logs is where macOS keeps user-visible diagnostics, so runs survive a
+# reboot and Console.app can see them. $TMPDIR is wrong for this: it is cleared
+# periodically and on reboot, which silently discards the baseline a later run is
+# meant to be compared against. ~/Library/Caches would be worse still, since the
+# system may evict it under disk pressure.
+RUN_ID=$(date +%Y%m%d-%H%M%S)
+OUT="${PROWL_MEASURE_DIR:-$HOME/Library/Logs/Prowl/measurements}/$RUN_ID"
+mkdir -p "$OUT"
+
+# Keep the console output and the on-disk record identical.
+exec > >(tee "$OUT/summary.txt") 2>&1
+
+PID=$(ps -Ao pid,comm | grep "Prowl Debug.app/Contents/MacOS/ProwlApp" | grep -v grep | awk '{print $1}' | head -1)
+if [ -z "$PID" ]; then
+  echo "Prowl Debug is not running." >&2
+  exit 1
+fi
+
+echo "pid: $PID  (up $(ps -o etime= -p "$PID" | tr -d ' '))"
+echo "load: $(uptime | sed 's/.*load averages*: //')   cores: $(sysctl -n hw.ncpu)"
+echo
+
+echo "=== agent mix ==="
+# Working agents drive the expensive detection path, so the mix is needed to
+# compare two runs honestly.
+prowl agents --json 2>/dev/null > "$OUT/agents.json" || true
+jq -r 'if .ok then "total=\(.data.agents|length)   " + (.data.agents|group_by(.status)|map("\(.[0].status)=\(length)")|join("  ")) else "CLI unavailable" end' \
+  < "$OUT/agents.json" 2>/dev/null || echo "CLI unavailable"
+echo
+
+echo "=== process CPU (20 s) ==="
+top -l 21 -s 1 -pid "$PID" -stats pid,cpu 2>/dev/null \
+  | grep -E "^ *$PID" | awk '{print $2}' | tail -20 > "$OUT/cpu.txt"
+python3 - "$OUT/cpu.txt" <<'PY'
+import statistics as s, sys
+v = [float(x) for x in open(sys.argv[1]).read().split()]
+if v:
+    print(f"mean={s.mean(v):.1f}%  median={s.median(v):.1f}%  min={min(v):.1f}%  max={max(v):.1f}%")
+PY
+echo
+
+echo "=== stack sample (20 s) ==="
+sample "$PID" 20 -f "$OUT/sample.txt" >/dev/null 2>&1
+python3 - "$OUT/sample.txt" <<'PY'
+import re, sys
+
+lines = open(sys.argv[1]).read().splitlines()
+hdr = []
+for i, l in enumerate(lines):
+    m = re.match(r'^\s+(\d+) (Thread_\w+.*)$', l)
+    if m:
+        hdr.append((i, int(m.group(1)), m.group(2).strip()))
+if not hdr:
+    print("no thread blocks parsed")
+    raise SystemExit
+
+# (symbol, pre-fix % of one core) — baseline was 20 agents: 1 working, 2 blocked.
+syms = [
+    ('detectAgentState',             15.88),
+    ('AgentSessionResolver.resolve(', 13.02),
+    ('resolveUncached',              12.98),
+    ('bestMatch',                    11.38),
+    ('normalize(',                    6.70),
+    ('transcriptStrings',             2.47),
+    ('recentCandidates',              1.57),
+    ('flushTransactions',              None),
+    ('RepositorySectionView',          None),
+    ('SidebarActiveAgentsOverlay',     None),
+]
+tot = {s: 0 for s, _ in syms}
+
+for idx, (i, _t, _desc) in enumerate(hdr):
+    end = hdr[idx + 1][0] if idx + 1 < len(hdr) else len(lines)
+    ent = []
+    for l in lines[i + 1:end]:
+        m = re.search(r'(\d+) (\S.*)$', l)
+        if m:
+            ent.append((m.start(1), int(m.group(1)), m.group(2)))
+    # Sum only the shallowest occurrences so nested frames are not double counted.
+    for s, _ in syms:
+        counted, mind = [], None
+        for d, c, sym in ent:
+            if s in sym:
+                if mind is None or d <= mind:
+                    counted.append(c)
+                    mind = d
+        tot[s] += sum(counted)
+
+W = hdr[0][1]
+print(f"window={W} samples/thread;  1 core = {W} samples\n")
+print(f"{'%core':>7}  {'was':>7}   symbol")
+for s, base in syms:
+    pct = 100 * tot[s] / W
+    was = f"{base:.2f}%" if base is not None else "  -  "
+    print(f"{pct:6.2f}%  {was:>7}   {s}")
+
+det = 100 * tot['detectAgentState'] / W
+if det > 0:
+    print("\ncomposition of detectAgentState (load-independent):")
+    for s, base in [('AgentSessionResolver.resolve(', 82), ('bestMatch', 72), ('normalize(', 42)]:
+        share = 100 * tot[s] / max(tot['detectAgentState'], 1)
+        print(f"  {s:32s} {share:5.1f}%  (was {base}%)")
+PY
+
+echo
+echo "run dir: $OUT"
+echo "  sample.txt / cpu.txt / summary.txt"


### PR DESCRIPTION
A reported several-100% CPU spike was invisible to ordinary sampling, so this change adds tooling that catches it and records what it turned out to be.

`sample(1)` only sees its own window, so a burst that has already passed leaves no trace however long the sample runs, and averaging a spike across a long window is exactly what hides it. Four samples of the reported burst all landed after it and showed 18 to 32% of a single core, with no thread above 9.7%. The new sampler watches for the spike and triggers on it.

A 300-second sample taken while a spike was in progress put 47.78% of a core in `flushTransactions` and 32.33% in the CoreAnimation commit, against 2.39% for agent detection. The cause is that `TerminalTabItem.title` is a `var` inside an `@Observable` array, so a single pane's 10 Hz spinner invalidated every reader of `tabs` and rebuilt all 32 through a `first(where:)` lookup that was quadratic at that rate.

The entry records the post-fix measurements, where the main thread fell from 82.5% to 11.7%, `flushTransactions` dropped 92%, and tab titles were capped at 0.96 per second against a 9.79 per second source. It also states the coverage limits plainly:

- 28 tabs against the spike's 32
- a 20-second window against 300
- a spike watcher that never fired across 4 runs, whose coverage was too thin to mean anything

Both scripts write to `${PROWL_MEASURE_DIR:-$HOME/Library/Logs/Prowl/measurements}`. `~/Library/Logs` is where macOS keeps user-visible diagnostics, so a run survives a reboot and Console.app can see it. `$TMPDIR` is the wrong home for output whose entire purpose is comparison against a later run, since it is cleared periodically and on reboot, and `~/Library/Caches` would be worse because the system may evict it under disk pressure.

Captures left in a working tree are handled separately, by the size guard merged in #644, rather than by a `.gitignore` pattern here. A pattern has to name the file, so it would fix one repository for one spelling and miss the next capture that lands under a different name.
