### PR TITLE
Guard close-confirmation alert against re-entrant presentation

### DIFF
--- a/supacode/Features/Terminal/Models/TerminalCloseConfirmationGate.swift
+++ b/supacode/Features/Terminal/Models/TerminalCloseConfirmationGate.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// App-global guard against re-entrant close-confirmation alerts.
+///
+/// Close requests arrive from independent paths (TCA effects, Ghostty
+/// callbacks, the tab bar, the CLI socket), and `NSAlert.runModal()` keeps
+/// draining main-actor jobs while it spins, so a late request can try to
+/// present a second alert from inside the first one's run loop. AppKit may
+/// answer that nested modal with an uncaught NSException (SIGABRT, Sentry
+/// PROWL-MACOS-FP). While a confirmation is on screen, later ones are
+/// dropped and treated as cancelled.
+@MainActor
+enum TerminalCloseConfirmationGate {
+  private(set) static var isPresenting = false
+
+  /// Runs `present` unless a confirmation is already showing.
+  /// Returns `nil` when the gate is held; callers treat that as "cancelled".
+  static func run<T>(_ present: () -> T) -> T? {
+    guard !isPresenting else { return nil }
+    isPresenting = true
+    defer { isPresenting = false }
+    return present()
+  }
+}

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState+Surfaces.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState+Surfaces.swift
@@ -47,13 +47,16 @@ extension WorktreeTerminalState {
     target: TerminalCloseConfirmationTarget,
     decision: TerminalCloseConfirmationDecision
   ) -> Bool {
-    let alert = NSAlert()
-    alert.messageText = target.messageText
-    alert.informativeText = closeConfirmationMessage(for: decision)
-    alert.alertStyle = .warning
-    alert.addButton(withTitle: target.confirmButtonTitle)
-    alert.addButton(withTitle: "Cancel")
-    return alert.runModal() == .alertFirstButtonReturn
+    let confirmed = TerminalCloseConfirmationGate.run {
+      let alert = NSAlert()
+      alert.messageText = target.messageText
+      alert.informativeText = closeConfirmationMessage(for: decision)
+      alert.alertStyle = .warning
+      alert.addButton(withTitle: target.confirmButtonTitle)
+      alert.addButton(withTitle: "Cancel")
+      return alert.runModal() == .alertFirstButtonReturn
+    }
+    return confirmed ?? false
   }
 
   func closeConfirmationMessage(for decision: TerminalCloseConfirmationDecision) -> String {

--- a/supacodeTests/TerminalCloseConfirmationGateTests.swift
+++ b/supacodeTests/TerminalCloseConfirmationGateTests.swift
@@ -1,0 +1,29 @@
+import Testing
+
+@testable import supacode
+
+@MainActor
+struct TerminalCloseConfirmationGateTests {
+  @Test func runExecutesWhenGateIsFree() {
+    let result = TerminalCloseConfirmationGate.run { true }
+    #expect(result == true)
+    #expect(TerminalCloseConfirmationGate.isPresenting == false)
+  }
+
+  @Test func nestedRunIsDropped() {
+    var nestedResult: Bool? = false
+    let outer = TerminalCloseConfirmationGate.run { () -> Bool in
+      #expect(TerminalCloseConfirmationGate.isPresenting)
+      nestedResult = TerminalCloseConfirmationGate.run { true }
+      return true
+    }
+    #expect(outer == true)
+    #expect(nestedResult == nil)
+  }
+
+  @Test func gateIsReleasedAfterRun() {
+    _ = TerminalCloseConfirmationGate.run { true }
+    let second = TerminalCloseConfirmationGate.run { false }
+    #expect(second == false)
+  }
+}


### PR DESCRIPTION
## Summary

Fixes the SIGABRT crash in Sentry issue [PROWL-MACOS-FP](https://onevs-den.sentry.io/issues/7647246314/) (`SIGABRT: Close Terminal Tab? > terminating due to uncaught exception of type NSException`).

**Root cause**: close requests reach `presentCloseConfirmation` from independent paths (TCA effects, Ghostty callbacks, the tab bar, the CLI socket). `NSAlert.runModal()` keeps draining main-actor jobs while it spins (the modal loop runs in common modes), so a late close request could present a **second confirmation nested inside the first one's run loop**. On macOS 27 beta, AppKit answers that nested modal with an NSException that is rethrown out of `runModal` into Swift frames, which cannot catch ObjC exceptions → `std::terminate` → SIGABRT.

The crash report's OS crash-info showed the on-screen alert was "Close Terminal Tab?" (`.tab` target) while the crashing stack was presenting the `.pane` alert from `handleCloseRequest` — two different alerts, confirming the nesting.

## Fix

Add `TerminalCloseConfirmationGate`, an app-global `@MainActor` guard: while a close confirmation is on screen, later `presentCloseConfirmation` calls are dropped and treated as cancelled (return `false`). All close paths funnel through `presentCloseConfirmation`, so the gate covers TCA, Ghostty-callback, tab-bar, and CLI triggers alike.

## Testing

- New `TerminalCloseConfirmationGateTests` (3 tests, passing): free-gate execution, nested run dropped, gate released after run.
- `make check` passes.
- `make build-app` succeeds.

https://claude.ai/code/session_01TWSNesKV4dk8HLKmcNEJjS
