### PR TITLE
Add a performance benchmark suite pinning the #644–#665 hot paths

### DIFF
--- a/.claude/skills/run-benchmark/SKILL.md
+++ b/.claude/skills/run-benchmark/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: run-benchmark
+description: Run Prowl's performance benchmark layers for the current branch or a release, compare against recorded baselines, and write a persistent local report. Use only when the user explicitly invokes run-benchmark or explicitly asks to run performance benchmarks / verify performance impact. Do not invoke automatically after implementation work. Classify the user's intent first (hot-path change, new optimization, or release-level sweep), confirm it with the user, then run the matching layers.
+---
+
+# Run Benchmark
+
+## Invocation contract
+
+Run this skill only after an explicit user request. Implementing, fixing, or reviewing
+performance-adjacent code does not by itself authorize a benchmark run.
+
+All timing in this workflow assumes **one dedicated, quiet local machine** accumulating a
+series over time. Numbers from CI runners, other machines, or a loaded host are not
+comparable and must not enter the baseline series. Never run other builds, tests, or
+heavy agents concurrently with a timed run.
+
+Background and design decisions live in `docs-ai/057-performance-benchmark-suite/`; the
+measurement methodology (why workload context matters, why load kills comparability) in
+`docs-ai/032-performance-hardening/004-agent-detection-steady-state.md`.
+
+## Step 0 — Preflight
+
+1. `git status --short` — an A/B run switches the checkout to the baseline commit, so the
+   tree must be clean and HEAD committed. If dirty, tell the user what is blocked and ask
+   whether to commit/stash or fall back to a branch-only run.
+2. Quiet-host check: compare `uptime` load1 against `sysctl -n hw.ncpu`. Above roughly
+   half the cores, warn that starvation inflates numbers unevenly and ask whether to wait
+   or proceed; above one runnable process per core, refuse the timed run and say why.
+3. Note what is available for the live layer: is a Prowl instance running
+   (`prowl list --json`), and are any agents working (animating titles)?
+
+## Step 1 — Classify intent, then always confirm
+
+Gather evidence before guessing:
+
+- The user's own words in the invocation — these override everything below.
+- `git branch --show-current`; `BASE=$(git merge-base HEAD origin/main)`;
+  `git diff --name-only $BASE` and `git log --oneline $BASE..HEAD`.
+- Map changed files through the table in **Reference** to see which benchmark suites the
+  branch can plausibly affect.
+
+Classify into one of three modes:
+
+| Mode | Signal | What runs |
+| --- | --- | --- |
+| **hot-path** | Branch touches files mapped to existing suites; user wants to know whether the change regressed them | A/B `make bench`: merge-base baseline vs branch |
+| **new-optimization** | Branch introduces a performance improvement no suite pins yet | Add a benchmark first (057 pattern), then the hot-path A/B |
+| **release** | Pre-release or "how is performance overall" with no specific change in question | `make test` + `make bench` vs trailing series + live layer |
+
+Then **confirm with the user before running anything**, even when the evidence is clear:
+present the guessed mode with its one-line evidence and the alternatives (AskUserQuestion
+with the recommended option first). If the evidence is contradictory or absent, do not
+guess — ask. Benchmark runs take minutes and switch the checkout; a wrong mode wastes
+both.
+
+## Step 2 — Run the confirmed mode
+
+Every `make bench` appends records to `~/Library/Logs/Prowl/measurements/bench/bench.jsonl`
+keyed by `git rev-parse --short HEAD`. Record the exact SHA before each run so the
+comparison step can find its rows.
+
+### hot-path — A/B against the merge-base
+
+1. Check whether the baseline already exists on this machine:
+   `jq -c "select(.gitSHA == \"<base-short-sha>\")" bench.jsonl`. Reuse it if present.
+2. If absent: `git switch --detach $BASE` → `make bench` → `git switch -`. The first
+   optimized build after a switch takes minutes; later ones are incremental.
+3. `make bench` on the branch HEAD.
+4. Compare per Step 3.
+
+### new-optimization — pin the claim before measuring it
+
+1. Check the **Reference** inventory: does any suite already cover the optimized path?
+2. If not, the primary deliverable is a new benchmark following the 057 pattern, in the
+   same PR as the optimization:
+   - dig the replaced implementation out of git history and keep it **verbatim** as the
+     reference;
+   - assert output equivalence before timing;
+   - assert a floor ratio 2–4x below the measured Release ratio;
+   - gate Swift-vs-Swift ratios on optimized builds
+     (`BenchmarkMeasurement.isOptimizedBuild`); C-call/filesystem ratios assert everywhere.
+3. Then run the hot-path A/B: the new suite quantifies the win, the existing suites catch
+   collateral damage.
+4. The measured ratio goes into the report as the claim's durable evidence — this is
+   exactly what the #644–#665 wave lacked.
+
+### release — full sweep plus series
+
+1. `make test` — the behavioral + ratio layer (Debug).
+2. `make bench` — compare against the trailing series (last ~5 records per case across
+   recent SHAs), not a single baseline.
+3. Live layer, best-effort, report each as run/inconclusive/skipped:
+   - `make measure-titles` — needs a running app with at least one animating agent tab;
+     exit 3 means nothing was animating (inconclusive, not a pass).
+   - `make measure-cpu` — needs a running Prowl Debug instance; set `PROWL_PID` when
+     several run. Records agent mix and load next to the attribution, so quote them
+     together.
+4. `make capture-spike` is a standing watch for long-running instances, not a step here;
+   mention it if the user is chasing an intermittent spike.
+
+## Step 3 — Compare and judge
+
+Extract both sides:
+
+```bash
+jq -r 'select(.gitSHA == "SHA") | [.suite, .name, .referenceMilliseconds, .shippedMilliseconds, .ratio] | @tsv' \
+  ~/Library/Logs/Prowl/measurements/bench/bench.jsonl
+```
+
+Judgment rubric (single machine, warm cache, medians of 15):
+
+- A ratio below its asserted floor already failed the test — confirmed regression, no
+  further interpretation needed.
+- `shippedMilliseconds` against baseline: within ±20% is noise; 1.2–1.5x growth is a
+  **watch** — rerun `make bench` once to confirm before claiming anything; above 1.5x
+  sustained is a **regression**; above 2x is **major**. Name suspect commits via the
+  file→suite map.
+- Use `referenceMilliseconds` as the built-in host canary: the reference workload never
+  changes, so if it moved by a similar factor the *host* moved, not the code; if shipped
+  moved alone, the code moved.
+- Never average across load regimes. If load was elevated during a run, discard the run
+  and redo it — do not "correct" the numbers.
+
+## Step 4 — Persistent report
+
+Write a markdown report to
+`~/Library/Logs/Prowl/measurements/reports/$(date +%Y%m%d-%H%M)-<branch-or-tag>.md`
+(`mkdir -p` the directory; it lives with the rest of the measurement home, survives
+reboots, and is never cleaned by the system). Reports are append-only history — never
+overwrite or delete earlier ones.
+
+Required sections:
+
+- **Intent** — the mode the user confirmed, in one line.
+- **Context** — date, branch, baseline and branch SHAs, load average and core count at
+  run time, app/agent state if the live layer ran.
+- **Results** — one table per layer: case, baseline shipped ms, branch shipped ms, delta,
+  ratio vs floor.
+- **Verdict** — `no-regression` / `watch` / `regression` / `major`, with suspect commits
+  for anything above noise, and the host-canary observation.
+- **Not run** — layers skipped or inconclusive, and why.
+- **Raw refs** — the bench.jsonl SHAs and any script run directories.
+
+Reply to the user with the verdict and the report path. The report, not the chat, is the
+durable record.
+
+## Reference
+
+Benchmark inventory (all under `supacodeTests/`, suite root `PerformanceBenchmarks`):
+
+| Suite / check | Pins | Floor | Asserts in |
+| --- | --- | --- | --- |
+| `LineCountScanBenchmarks` sparse | #644/#652 memchr scan vs `Data.reduce` | 3x | all builds |
+| `LineCountScanBenchmarks` all-newline | #652 hybrid dense fallback | 2x | optimized only |
+| `FingerprintNormalizeBenchmarks` | #650/#657 escape-absence guard | 1.3x | optimized only |
+| `WorktreeDirectoryIndexBenchmarks` | #648/#655 index vs per-row scan | 2x | all builds |
+| `SessionScoringBenchmarks` | #650/#657 warm fragment cache | 3x | all builds |
+| `make measure-titles` (live) | #649/#656 title coalescing ≤ ~1/s | 1.25/s | running app |
+
+File → suite map for intent classification and suspect naming:
+
+| Changed path | Affected check |
+| --- | --- |
+| `supacode/Clients/Git/GitClient.swift`, `UntrackedLineCountCache.swift` | LineCountScan |
+| `supacode/Infrastructure/AgentDetection/AgentSessionResolver.swift` | FingerprintNormalize, SessionScoring |
+| `supacode/Domain/WorktreeDirectoryIndex.swift`, `supacode/Support/PathPolicy.swift` | WorktreeDirectoryIndex |
+| `supacode/Features/Terminal/Models/TerminalTabManager.swift`, `WorktreeTerminalState+AgentDetection.swift` | measure-titles, coalescing/dedup unit tests |
+| Sidebar / Active Agents views and reducers | counting tests only (no timing suite) |
+
+Caveats:
+
+- `referenceMilliseconds` values measured inside the Release test bundle are not
+  comparable to standalone `-O` binaries (~10x apart for `Data.reduce`); ratios are
+  unaffected. Compare bench.jsonl rows only with other bench.jsonl rows.
+- The suite is `.serialized` and `make bench` disables parallel testing and pins the
+  destination arch deliberately — do not "speed it up" by removing either.
+- `bench.jsonl` is append-only; the same SHA can have several rows (reruns). Prefer the
+  newest row per (suite, name, SHA) and note reruns in the report.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,10 @@ make format                      # Run full-tree swift-format cleanup
 make lint                        # Run swiftlint only
 make check                       # Run changed-file format, swift-format lint, and swiftlint
 make test                        # Run all tests
+make bench                       # Run performance benchmarks with -O; append absolute medians to ~/Library/Logs/Prowl/measurements/bench/
+make measure-cpu                 # Steady-state CPU + per-symbol attribution of the running Prowl Debug app
+make capture-spike               # Sample the running Prowl Debug app when CPU crosses a threshold
+make measure-titles              # Black-box check that animated tab titles stay coalesced (~1 change/s)
 make log-stream                  # Stream app logs (subsystem: com.onevcat.prowl)
 make build-cli                   # Build CLI (prowl) via SwiftPM
 make test-cli-smoke              # Run CLI smoke tests (unit-level)

--- a/Makefile
+++ b/Makefile
@@ -351,6 +351,37 @@ test-cli-smoke: build-cli # Smoke test CLI executable
 test-cli-integration: # Run CLI integration tests via SwiftPM
 	swift test --filter ProwlCLIIntegrationTests
 
+bench: ensure-ghostty embed-cli-debug embed-docs # Run performance benchmarks optimized (-O); append absolute medians to the bench log
+	@set -euo pipefail; \
+	bench_log_dir="$$HOME/Library/Logs/Prowl/measurements/bench"; \
+	mkdir -p "$$bench_log_dir"; \
+	bench_log="$$bench_log_dir/bench.jsonl"; \
+	touch "$$bench_log"; \
+	lines_before="$$(wc -l < "$$bench_log")"; \
+	TEST_RUNNER_PROWL_BENCH_REPORT=1 \
+	TEST_RUNNER_PROWL_BENCH_GIT_SHA="$$(git rev-parse --short HEAD)" \
+	TEST_RUNNER_PROWL_BENCH_LOG_DIR="$$bench_log_dir" \
+	xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS,arch=$$(uname -m)" \
+		-configuration Release \
+		-only-testing:supacodeTests/PerformanceBenchmarks \
+		-parallel-testing-enabled NO \
+		-derivedDataPath "$(CURRENT_MAKEFILE_DIR)/build/bench-derived-data" \
+		CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation \
+		-clonedSourcePackagesDirPath $(SPM_CACHE_DIR) \
+		ENABLE_TESTABILITY=YES 2>&1 | mise exec -- xcsift -w --format toon; \
+	echo; \
+	echo "new bench records ($$bench_log):"; \
+	tail -n "+$$((lines_before + 1))" "$$bench_log" | jq -c .
+
+measure-cpu: # Steady-state CPU + per-symbol attribution of the running Prowl Debug app (PROWL_PID=... to target)
+	@bash scripts/measure-agent-detection-cpu.sh
+
+capture-spike: # Sample the running Prowl Debug app the moment CPU crosses a threshold (THRESHOLD=150 DURATION=10)
+	@bash scripts/capture-cpu-spike.sh $(or $(THRESHOLD),150) $(or $(DURATION),10)
+
+measure-titles: # Black-box check that animated tab titles stay coalesced to ~1 change/s (works on Release builds)
+	@bash scripts/measure-title-coalescing.sh
+
 format: # Format all Swift code with swift-format (full-tree cleanup)
 	swift-format -p --in-place --recursive --configuration ./.swift-format.json supacode supacodeTests
 

--- a/docs-ai/057-performance-benchmark-suite/000-plan.md
+++ b/docs-ai/057-performance-benchmark-suite/000-plan.md
@@ -4,7 +4,7 @@
 | --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Status**      | Implemented                                                                                                                                              |
 | **Anchor date** | 2026-08-02                                                                                                                                               |
-| **Primary PRs** | (fill in as they merge)                                                                                                                                  |
+| **Primary PRs** | #668                                                                                                                                                     |
 | **Related**     | [056-performance-optimization-2026-08](../056-performance-optimization-2026-08/000-plan.md), [032-performance-hardening](../032-performance-hardening/000-plan.md) |
 
 ## Background

--- a/docs-ai/057-performance-benchmark-suite/000-plan.md
+++ b/docs-ai/057-performance-benchmark-suite/000-plan.md
@@ -103,4 +103,6 @@ optimized settings.)
 
 ## Amendments
 
-(append `- Updated 2026-MM-DD: ... — see [00N-topic.md](00N-topic.md)` lines here)
+- Updated 2026-08-02: added the explicit-invocation `run-benchmark` skill so agents can
+  run the layers with the right comparison and a persistent report — see
+  [002-benchmark-runbook-skill.md](002-benchmark-runbook-skill.md)

--- a/docs-ai/057-performance-benchmark-suite/000-plan.md
+++ b/docs-ai/057-performance-benchmark-suite/000-plan.md
@@ -1,0 +1,106 @@
+# 057 — Performance Benchmark Suite: Plan
+
+|                 |                                                                                                                                                          |
+| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Status**      | Implemented                                                                                                                                              |
+| **Anchor date** | 2026-08-02                                                                                                                                               |
+| **Primary PRs** | (fill in as they merge)                                                                                                                                  |
+| **Related**     | [056-performance-optimization-2026-08](../056-performance-optimization-2026-08/000-plan.md), [032-performance-hardening](../032-performance-hardening/000-plan.md) |
+
+## Background
+
+The August 2026 performance wave (#644–#665) landed with strong behavioral test coverage
+but zero timed benchmarks. Its quantitative claims — the `memchr` scan removing 94–96% of
+untracked line-count CPU, the escape-absence guard cutting `normalize` by 1.58x, animated
+tab titles coalescing to at most one write per second — are author measurements;
+[056.011](../056-performance-optimization-2026-08/011-profiling-method-and-tools.md)
+records explicitly that review "verified the structural paths and the tools, not the
+original long captures". The Release microbenchmark that justified #652's scanner design
+was never committed, so its numbers cannot be re-run.
+
+An independent reproduction on 2026-08-02 confirmed the three headline claims (scan −94%
+on 2 MiB sparse text with the dense-tail regression bounded by the hybrid scanner;
+escape guard 1.53x on a 240-fragment 81%-non-ASCII corpus; a live Release instance's
+animating tab at 0.99 title changes/second against a ~10 Hz source). This entry turns that
+one-off reproduction into repo-owned infrastructure so future changes to these hot paths
+are measured, not remembered.
+
+## Goals
+
+- Pin the optimized hot paths against naive reference implementations with **ratio
+  assertions** that run in the normal test suite: machine-independent, load-tolerant
+  (both sides of a ratio see the same load), and conservative enough never to flake.
+- Provide `make bench` to run the same suite with `-O` and report **absolute medians**,
+  appended as JSON lines to `~/Library/Logs/Prowl/measurements/bench/` so one machine
+  accumulates a comparable time series keyed by git SHA.
+- Add a black-box title-coalescing check (`scripts/measure-title-coalescing.sh`) — the
+  only claim verifiable against a running Release build with no instrumentation.
+- Wrap the existing measurement scripts in `make measure-cpu` / `make capture-spike` so
+  the live-measurement layer is discoverable.
+
+### Non-goals
+
+- No CI timing gates. Absolute numbers are only meaningful on one quiet machine; the
+  ratio assertions are the portable regression net.
+- No automation of `sample(1)`-percentage claims (flush shares, spike profiles). Those
+  remain the domain of the 032.004 method and the two capture scripts.
+- No new benchmarks for paths whose protection is already deterministic (emission-count
+  tests, budget-proxy tests) — counting beats timing where counting is possible.
+
+## Design / Approach
+
+Four benchmark suites in `supacodeTests/`, Swift Testing, each pitting the shipped path
+against a pristine reference implementation kept inside the benchmark file:
+
+| Suite | Shipped path | Reference | Claim pinned |
+| --- | --- | --- | --- |
+| `LineCountScanBenchmarks` | `GitClient.countLinesInFiles` (fresh `UntrackedLineCountCache`) | pre-#644 `Data.reduce` reader | #644/#652 scan win; dense-input bound |
+| `FingerprintNormalizeBenchmarks` | `AgentSessionFingerprintMatcher.normalize` | pre-#650 regex-always formulation | #650/#657 escape-absence guard |
+| `WorktreeDirectoryIndexBenchmarks` | `WorktreeDirectoryIndex` build + lookups | pre-#648 per-row `PathPolicy.normalizeURL` scan | #648/#655 index win |
+| `SessionScoringBenchmarks` | `bestMatch` with warm `TranscriptFragmentCache` | same call with a cold cache per round | #650/#657 fragment reuse |
+
+Shared plumbing in `supacodeTests/BenchmarkMeasurement.swift`: median-of-N timing via
+`ContinuousClock`, input sizing (small in the default test run to keep Debug wall-clock
+low, full-size when `PROWL_BENCH_REPORT=1`), and the JSONL reporter (records suite, case,
+median, iterations, mode, git SHA from `PROWL_BENCH_GIT_SHA`).
+
+Every suite asserts output equivalence between the shipped and reference paths before
+timing, so a benchmark can never pass while the implementations diverge semantically.
+
+`make bench` runs `xcodebuild test` filtered to the four suites under
+`-configuration Release` with `ENABLE_TESTABILITY=YES` and a dedicated derived-data path
+so optimized builds do not thrash the normal test cache. (A global
+`SWIFT_OPTIMIZATION_LEVEL=-O` override was tried first and rejected: applied to every SPM
+package target it broke the `PackageFrameworks` product layout with cascading linker
+failures, while the Release configuration builds each target with its own verified
+optimized settings.)
+
+## Alternatives & decisions
+
+- **package-benchmark in a separate SwiftPM package** (rejected): the hot-path sources
+  live in the app target; a benchmark package would compile them by file path, which
+  breaks silently on file moves. Running inside `supacodeTests` keeps `@testable` access
+  and single-source truth.
+- **Absolute-time assertions with committed baselines** (rejected): baselines drift per
+  machine and Xcode version; ratios against an in-file reference are portable and
+  self-calibrating.
+- **Timing benchmarks opt-in only, outside `make test`** (rejected): an opt-in gate that
+  nobody runs protects nothing. Ratio margins are set 2–4x below measured Release ratios,
+  so the default-run cost is a few seconds without flake risk.
+- **Which ratios run in Debug**: a ratio whose slow side is a C call or filesystem I/O
+  (sparse scan vs `memchr`, per-row scan vs the index, cold vs warm fragment cache) holds
+  in any build mode and asserts everywhere. A ratio between two Swift-level formulations
+  does not: measured under `-Onone`, the escape-absence guard fell to 1.13x the regex it
+  guards and the hybrid scanner's raw-pointer fallback ran at 0.45x the `Data.reduce`
+  reader. Those two assertions gate on an optimized build, detected at runtime via an
+  `assert` side effect (`assert` bodies execute only under `-Onone`), and so fire in
+  `make bench` runs only.
+- **Threshold source**: measured Release ratios were scan 16x (sparse), 5x (dense),
+  normalize 1.53x; assertions use ≥3x, ≥2x, ≥1.3x respectively.
+- **Destination pinning**: a generic `platform=macOS` destination matched two run
+  destinations and executed every test twice; `make bench` pins
+  `platform=macOS,arch=$(uname -m)` so the log receives one record per case per run.
+
+## Amendments
+
+(append `- Updated 2026-MM-DD: ... — see [00N-topic.md](00N-topic.md)` lines here)

--- a/docs-ai/057-performance-benchmark-suite/001-action.md
+++ b/docs-ai/057-performance-benchmark-suite/001-action.md
@@ -1,0 +1,56 @@
+# 057 — Performance Benchmark Suite: Action Log
+
+## Timeline
+
+| Date | Change | Ref |
+| --- | --- | --- |
+| 2026-08-02 | Independent reproduction of the #644/#652 scan benchmark, the #650/#657 normalize ratios, and the #649/#656 title-coalescing rate (0.99 changes/s live) confirmed the wave's headline claims | (scratchpad, results recorded in 000-plan) |
+| 2026-08-02 | Four ratio-assertion benchmark suites plus shared measurement support added under `supacodeTests/` | PR TBD |
+| 2026-08-02 | `make bench` (Release + testability, pinned arch, serial), `make measure-cpu`, `make capture-spike`, `make measure-titles` added | PR TBD |
+| 2026-08-02 | `scripts/measure-title-coalescing.sh` added; verified live (animating tab 0.90/s, static tabs 0, exit 0) | PR TBD |
+
+## Outcome & current state (as of 2026-08-02)
+
+- `supacodeTests/BenchmarkMeasurement.swift` — serialized root suite `PerformanceBenchmarks`,
+  interleaved median timing, runtime `-O` detection via an `assert` side effect, and the
+  JSONL reporter (active only under `PROWL_BENCH_REPORT=1`).
+- `supacodeTests/LineCountScanBenchmarks.swift`, `FingerprintNormalizeBenchmarks.swift`,
+  `WorktreeDirectoryIndexBenchmarks.swift`, `SessionScoringBenchmarks.swift` — each pins a
+  shipped hot path against a verbatim pre-optimization reference implementation, asserting
+  output equivalence before timing.
+- `make bench` runs the suite under `-configuration Release` + `ENABLE_TESTABILITY=YES`
+  into `build/bench-derived-data`, appending records to
+  `~/Library/Logs/Prowl/measurements/bench/bench.jsonl` keyed by git SHA.
+- First optimized run (M-series, quiet host): sparse scan 115x, all-newline scan 37x,
+  normalize 1.55x, warm scoring 7.3x, directory index 24x — all far above the asserted
+  floors (3x / 2x / 1.3x / 3x / 2x).
+- Debug `make test` runs the three C-call/I/O-bound ratios (sparse scan, index, scoring)
+  and skips the two Swift-vs-Swift ratios, which assert only under `make bench`.
+
+## Deviations from plan
+
+- **`SWIFT_OPTIMIZATION_LEVEL=-O` override abandoned** for `make bench`: applied globally
+  it broke SPM `PackageFrameworks` linking. Replaced with the Release configuration plus
+  `ENABLE_TESTABILITY=YES` (already recorded in 000-plan's alternatives).
+- **Two existing test files needed `#if DEBUG` guards** (`CommandIconMapTests`,
+  `CLISocketServerTests`): they exercise Debug-only members (`debugAllEntries`,
+  `debugFileDescriptors`) and cannot compile in a Release test build.
+- **`GhosttyRuntime` gained an explicit `@MainActor`**: under Release whole-module builds,
+  the test target's deserialization of the app swiftmodule lost the default-isolation
+  inference for its `isolated deinit` and failed with "containing class is not isolated
+  to an actor". The explicit attribute is semantically identical and serializes correctly.
+- **Benchmarks must run with parallel testing disabled**: with the scheme's parallel
+  clones, every benchmark executed twice (two runner processes); `make bench` passes
+  `-parallel-testing-enabled NO` and pins `-destination platform=macOS,arch=$(uname -m)`.
+
+## Open questions
+
+- The reference `Data.reduce` reader measures ~84 ms per 2 MiB inside the Release test
+  bundle against ~8.5 ms in a standalone `-O` SwiftPM binary. The ratio direction is
+  unaffected, but absolute `reference*` values in the bench log are not comparable to the
+  docs-ai/056 standalone baselines; `shipped*` values are close (0.73 ms vs 0.36–0.54 ms,
+  which includes per-call metadata reads).
+- A generic `platform=macOS` destination ran every test twice in this project (observed
+  with two runner PIDs before pinning the arch and disabling parallel clones). Whether
+  `make test-app` pays the same duplication for the full suite is worth checking
+  separately; it is out of this entry's scope.

--- a/docs-ai/057-performance-benchmark-suite/001-action.md
+++ b/docs-ai/057-performance-benchmark-suite/001-action.md
@@ -5,9 +5,9 @@
 | Date | Change | Ref |
 | --- | --- | --- |
 | 2026-08-02 | Independent reproduction of the #644/#652 scan benchmark, the #650/#657 normalize ratios, and the #649/#656 title-coalescing rate (0.99 changes/s live) confirmed the wave's headline claims | (scratchpad, results recorded in 000-plan) |
-| 2026-08-02 | Four ratio-assertion benchmark suites plus shared measurement support added under `supacodeTests/` | PR TBD |
-| 2026-08-02 | `make bench` (Release + testability, pinned arch, serial), `make measure-cpu`, `make capture-spike`, `make measure-titles` added | PR TBD |
-| 2026-08-02 | `scripts/measure-title-coalescing.sh` added; verified live (animating tab 0.90/s, static tabs 0, exit 0) | PR TBD |
+| 2026-08-02 | Four ratio-assertion benchmark suites plus shared measurement support added under `supacodeTests/` | #668 |
+| 2026-08-02 | `make bench` (Release + testability, pinned arch, serial), `make measure-cpu`, `make capture-spike`, `make measure-titles` added | #668 |
+| 2026-08-02 | `scripts/measure-title-coalescing.sh` added; verified live (animating tab 0.90/s, static tabs 0, exit 0) | #668 |
 
 ## Outcome & current state (as of 2026-08-02)
 

--- a/docs-ai/057-performance-benchmark-suite/002-benchmark-runbook-skill.md
+++ b/docs-ai/057-performance-benchmark-suite/002-benchmark-runbook-skill.md
@@ -1,0 +1,28 @@
+# 057.002 — Benchmark Runbook Skill
+
+## Context
+
+The suite's value depends on being run at the right moments with the right comparison,
+and that judgment was living only in one conversation. Benchmark monitoring is planned to
+be delegated to agents, so the workflow needed a durable, explicitly-invoked home.
+
+## Change
+
+Added `.claude/skills/run-benchmark/SKILL.md`: an explicit-invocation-only runbook that
+
+- classifies the user's intent from the branch diff and their words into hot-path A/B,
+  new-optimization pinning, or a release-level sweep — and always confirms the guessed
+  mode with the user before running, since a run takes minutes and can switch the
+  checkout;
+- runs the matching layers (`make bench` A/B against the merge-base, the 057 benchmark
+  pattern for new optimizations, `make test` + trailing-series + live checks for
+  releases);
+- judges results with fixed noise bands (±20% noise, 1.5x regression, 2x major) and uses
+  the never-changing reference implementation as a host-noise canary;
+- writes an append-only markdown report to
+  `~/Library/Logs/Prowl/measurements/reports/` — local to the one quiet machine the
+  series assumes, but persistent across sessions.
+
+## Refs
+
+- PR #668

--- a/docs-ai/README.md
+++ b/docs-ai/README.md
@@ -108,3 +108,4 @@ agent-facing manual for that).
 | 054 | [native-settings-navigation](054-native-settings-navigation/000-plan.md) | 2026-07-30 | SwiftUI-owned singleton Settings window, native sidebar/detail navigation, and Agent Profile drill-ins |
 | 055 | [agent-profile-runtimes](055-agent-profile-runtimes/000-plan.md) | 2026-08-01 | Capability-based runtime adapters and Agent Profile support across Prowl's recognized agent catalog |
 | 056 | [performance-optimization-2026-08](056-performance-optimization-2026-08/000-plan.md) | 2026-08-01 | August performance review series: exact cached line counts, opt-in Debug TCA logging, and agent screen-scan memoization |
+| 057 | [performance-benchmark-suite](057-performance-benchmark-suite/000-plan.md) | 2026-08-02 | Ratio-assertion benchmarks pinning the #644–#665 hot paths, `make bench` absolute-number reporting, and live measurement wrappers |

--- a/scripts/measure-title-coalescing.sh
+++ b/scripts/measure-title-coalescing.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+# Verify that animated tab titles stay coalesced, from outside the app.
+#
+# `prowl list` reports `tab.title` from the same live snapshot the tab bar
+# observes, so polling it measures exactly the write rate that title coalescing
+# governs (docs-ai/032.004, Fix 7). Agent TUIs animate spinner glyphs into the
+# title at roughly 10 Hz; the shipped coalescing must hold every animating tab
+# at or near one visible change per second. This is the one claim from the
+# #644–#665 wave that a Release build can be checked against with no
+# instrumentation at all.
+#
+# Usage:  bash scripts/measure-title-coalescing.sh [duration_seconds] [max_changes_per_second]
+#         bash scripts/measure-title-coalescing.sh 30 1.25     # default
+#
+# The threshold leaves headroom over the exact 1/s contract because sampling
+# jitter can split one interval across two observation windows.
+#
+# Environment:
+#   PROWL_MEASURE_DIR   where runs are written
+#                       (default ~/Library/Logs/Prowl/measurements)
+#
+# Exit codes: 0 pass; 1 an animating tab exceeded the threshold; 2 CLI
+# unavailable; 3 inconclusive (no tab changed at all — nothing was animating);
+# 64 usage error.
+set -euo pipefail
+umask 077
+
+DURATION=${1:-30}
+MAX_RATE=${2:-1.25}
+
+usage_error() {
+  echo "$1" >&2
+  exit 64
+}
+
+case "$DURATION" in
+  '' | *[!0-9]*) usage_error "duration_seconds must be a positive integer." ;;
+esac
+[ "$DURATION" -gt 0 ] || usage_error "duration_seconds must be greater than zero."
+case "$MAX_RATE" in
+  '' | *[!0-9.]* | . | *.*.*) usage_error "max_changes_per_second must be a positive number." ;;
+esac
+
+command -v prowl >/dev/null || { echo "prowl CLI is not on PATH." >&2; exit 2; }
+prowl list --json >/dev/null 2>&1 || { echo "prowl CLI cannot reach a running app." >&2; exit 2; }
+
+OUT="${PROWL_MEASURE_DIR:-$HOME/Library/Logs/Prowl/measurements}/title-rates/$(date +%Y%m%d-%H%M%S)-$$"
+mkdir -p "$OUT"
+
+# Rates are computed against measured wall-clock, not the nominal poll count:
+# CLI latency stretches every polling loop, and dividing by the intended
+# duration would overstate each tab's change rate.
+status=0
+DURATION="$DURATION" MAX_RATE="$MAX_RATE" OUT="$OUT" python3 <<'PY' || status=$?
+import json
+import os
+import subprocess
+import sys
+import time
+
+duration = int(os.environ["DURATION"])
+max_rate = float(os.environ["MAX_RATE"])
+out = os.environ["OUT"]
+
+poll_interval = 0.125
+changes = {}
+titles = {}
+last = {}
+polls = 0
+
+start = time.monotonic()
+with open(os.path.join(out, "titles.jsonl"), "w") as log:
+    while time.monotonic() - start < duration:
+        result = subprocess.run(["prowl", "list", "--json"], capture_output=True, text=True)
+        now = time.monotonic() - start
+        try:
+            items = json.loads(result.stdout)["data"]["items"]
+        except (json.JSONDecodeError, KeyError):
+            continue
+        polls += 1
+        snapshot = {}
+        for item in items:
+            tab = item.get("tab") or {}
+            tab_id, title = tab.get("id"), tab.get("title")
+            if tab_id is None or title is None:
+                continue
+            snapshot[tab_id] = title
+            titles.setdefault(tab_id, title)
+            if tab_id in last and last[tab_id] != title:
+                changes[tab_id] = changes.get(tab_id, 0) + 1
+            last[tab_id] = title
+        log.write(json.dumps({"t": round(now, 3), "tabs": snapshot}) + "\n")
+        time.sleep(poll_interval)
+elapsed = time.monotonic() - start
+
+lines = [f"polls={polls}  elapsed={elapsed:.1f}s  threshold={max_rate}/s"]
+worst = 0.0
+for tab_id, title in titles.items():
+    count = changes.get(tab_id, 0)
+    rate = count / elapsed
+    worst = max(worst, rate)
+    flag = "  <-- OVER" if rate > max_rate else ""
+    lines.append(f"  {tab_id[:8]}  changes={count:3d}  rate={rate:.2f}/s  {title[:60]}{flag}")
+
+summary = "\n".join(lines)
+print(summary)
+with open(os.path.join(out, "summary.txt"), "w") as f:
+    f.write(summary + "\n")
+
+if polls == 0:
+    print("no successful polls; is the app responding?", file=sys.stderr)
+    sys.exit(2)
+if not changes:
+    print("\nno tab title changed at all — nothing was animating, run is inconclusive.", file=sys.stderr)
+    sys.exit(3)
+sys.exit(1 if worst > max_rate else 0)
+PY
+echo
+echo "run dir: $OUT"
+exit "$status"

--- a/supacode/Infrastructure/Ghostty/GhosttyRuntime.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttyRuntime.swift
@@ -5,6 +5,12 @@ import UniformTypeIdentifiers
 
 nonisolated let ghosttyLogger = SupaLogger("GhosttyRuntime")
 
+// Explicitly isolated rather than relying on the module's MainActor default:
+// when a Release (whole-module) build's swiftmodule is deserialized by the test
+// target, default-isolation inference is lost for the `isolated deinit` check
+// and compilation fails with "containing class is not isolated to an actor".
+// The explicit attribute is semantically identical and serializes correctly.
+@MainActor
 final class GhosttyRuntime {
   nonisolated static let ghosttyExecutableCandidates = [
     "/Applications/Ghostty.app/Contents/MacOS/ghostty",

--- a/supacodeTests/BenchmarkMeasurement.swift
+++ b/supacodeTests/BenchmarkMeasurement.swift
@@ -1,0 +1,131 @@
+import Foundation
+import Testing
+
+@testable import supacode
+
+/// Root suite for the timed benchmarks that pin the hot paths optimized in the
+/// #644–#665 performance wave against the naive implementations they replaced.
+///
+/// Assertions are ratios, never absolute times: reference and shipped bodies run
+/// interleaved in one process, so machine speed and background load cancel out.
+/// Thresholds sit far below the ratios measured in a Release build, which is
+/// what keeps the default Debug test run from flaking. Serialized recursively
+/// because two timing suites running concurrently would distort each other's
+/// medians in a way interleaving cannot compensate for.
+///
+/// `make bench` runs this suite alone with `-O` and `PROWL_BENCH_REPORT=1`,
+/// switching to full-size inputs and appending absolute medians to the bench
+/// log — the durable per-machine time series the ratio assertions never read.
+@Suite(.serialized)
+struct PerformanceBenchmarks {}
+
+nonisolated enum BenchmarkMeasurement {
+  /// Full mode uses input sizes comparable to the docs-ai/056 baselines and
+  /// reports absolute numbers; the default sizes keep the Debug-mode run short.
+  static var isFullMode: Bool {
+    ProcessInfo.processInfo.environment["PROWL_BENCH_REPORT"] == "1"
+  }
+
+  static var iterations: Int { isFullMode ? 15 : 5 }
+
+  /// True in `-O` builds: `assert` bodies execute only under `-Onone`. This is
+  /// what distinguishes `make bench` from the regular Debug test run — `DEBUG`
+  /// stays defined in both, so a compilation condition cannot tell them apart.
+  ///
+  /// Ratios whose slow side is a C call (`memchr`, filesystem I/O) hold in any
+  /// build mode; ratios between two Swift-level formulations only mean anything
+  /// once both sides are optimized, so those assertions gate on this. Measured
+  /// in Debug before gating: the escape-absence guard's own byte scan drops to
+  /// 1.13x the regex it guards, and the hybrid scanner's raw-pointer fallback
+  /// runs at 0.45x the `Data.reduce` reader it replaced.
+  static var isOptimizedBuild: Bool {
+    var optimized = true
+    assert(
+      {
+        optimized = false
+        return true
+      }()
+    )
+    return optimized
+  }
+
+  /// Medians for two bodies measured alternately, so a load spike lands on both
+  /// sides of the ratio instead of biasing whichever side it happened to hit.
+  static func interleavedMedians(
+    reference: () -> Void,
+    shipped: () -> Void
+  ) -> (reference: Duration, shipped: Duration) {
+    // One untimed round faults in file caches and lazy runtime state.
+    reference()
+    shipped()
+    var referenceTimes: [Duration] = []
+    var shippedTimes: [Duration] = []
+    for _ in 0..<iterations {
+      referenceTimes.append(time(reference))
+      shippedTimes.append(time(shipped))
+    }
+    return (median(referenceTimes), median(shippedTimes))
+  }
+
+  static func time(_ body: () -> Void) -> Duration {
+    let start = ContinuousClock.now
+    body()
+    return ContinuousClock.now - start
+  }
+
+  static func median(_ values: [Duration]) -> Duration {
+    values.sorted()[values.count / 2]
+  }
+
+  static func milliseconds(_ duration: Duration) -> Double {
+    Double(duration.components.seconds) * 1_000 + Double(duration.components.attoseconds) / 1e15
+  }
+
+  static func ratio(_ medians: (reference: Duration, shipped: Duration)) -> Double {
+    milliseconds(medians.reference) / milliseconds(medians.shipped)
+  }
+
+  /// Appends one measurement to the bench log when running under `make bench`.
+  /// JSON lines keyed by git SHA keep the series across commits comparable on
+  /// one machine; nothing in the test assertions ever reads this file back.
+  static func report(suite: String, name: String, medians: (reference: Duration, shipped: Duration)) {
+    guard isFullMode else { return }
+    let environment = ProcessInfo.processInfo.environment
+    let record = Record(
+      date: Date.now.ISO8601Format(),
+      suite: suite,
+      name: name,
+      referenceMilliseconds: milliseconds(medians.reference),
+      shippedMilliseconds: milliseconds(medians.shipped),
+      ratio: ratio(medians),
+      iterations: iterations,
+      gitSHA: environment["PROWL_BENCH_GIT_SHA"]
+    )
+    guard let line = try? JSONEncoder().encode(record) else { return }
+
+    let directory =
+      environment["PROWL_BENCH_LOG_DIR"].map { URL(fileURLWithPath: $0) }
+      ?? FileManager.default.homeDirectoryForCurrentUser
+      .appending(path: "Library/Logs/Prowl/measurements/bench")
+    let logURL = directory.appending(path: "bench.jsonl")
+    try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    if !FileManager.default.fileExists(atPath: logURL.path(percentEncoded: false)) {
+      FileManager.default.createFile(atPath: logURL.path(percentEncoded: false), contents: nil)
+    }
+    guard let handle = try? FileHandle(forWritingTo: logURL) else { return }
+    defer { try? handle.close() }
+    _ = try? handle.seekToEnd()
+    try? handle.write(contentsOf: line + Data("\n".utf8))
+  }
+
+  private struct Record: Encodable {
+    let date: String
+    let suite: String
+    let name: String
+    let referenceMilliseconds: Double
+    let shippedMilliseconds: Double
+    let ratio: Double
+    let iterations: Int
+    let gitSHA: String?
+  }
+}

--- a/supacodeTests/CLISocketServerTests.swift
+++ b/supacodeTests/CLISocketServerTests.swift
@@ -55,16 +55,20 @@ struct CLISocketServerTests {
     #expect(canConnect(to: socketPath))
   }
 
-  @Test func ownedDescriptorsAreClosedOnExec() throws {
-    let socketPath = temporarySocketPath(suffix: "cloexec")
-    let server = CLISocketServer(router: CLICommandRouter(), socketPath: socketPath)
-    try server.start()
-    defer { server.stop() }
+  // `debugFileDescriptors` exists only in Debug builds, and so does this test —
+  // `make bench` compiles this target under the Release configuration.
+  #if DEBUG
+    @Test func ownedDescriptorsAreClosedOnExec() throws {
+      let socketPath = temporarySocketPath(suffix: "cloexec")
+      let server = CLISocketServer(router: CLICommandRouter(), socketPath: socketPath)
+      try server.start()
+      defer { server.stop() }
 
-    let descriptors = server.debugFileDescriptors
-    #expect(isCloseOnExec(descriptors.server))
-    #expect(isCloseOnExec(descriptors.lock))
-  }
+      let descriptors = server.debugFileDescriptors
+      #expect(isCloseOnExec(descriptors.server))
+      #expect(isCloseOnExec(descriptors.lock))
+    }
+  #endif
 
   @Test func socketFilesAreOwnerOnly() throws {
     let socketPath = temporarySocketPath(suffix: "permissions")

--- a/supacodeTests/CommandIconMapTests.swift
+++ b/supacodeTests/CommandIconMapTests.swift
@@ -93,18 +93,22 @@ struct CommandIconMapTests {
 
   // MARK: - Debug catalog
 
-  @Test func debugAllEntriesIsSorted() {
-    let tokens = CommandIconMap.debugAllEntries.map(\.token)
-    #expect(tokens == tokens.sorted())
-  }
+  // `debugAllEntries` exists only in Debug builds, and so do these tests —
+  // `make bench` compiles this target under the Release configuration.
+  #if DEBUG
+    @Test func debugAllEntriesIsSorted() {
+      let tokens = CommandIconMap.debugAllEntries.map(\.token)
+      #expect(tokens == tokens.sorted())
+    }
 
-  @Test func debugAllEntriesCoversWellKnownTokens() {
-    let tokens = Set(CommandIconMap.debugAllEntries.map(\.token))
-    // Spot-check that the debug surface actually exposes the tokens
-    // a user is most likely to hunt for.
-    let mustHave: Set<String> = [
-      "git", "docker", "claude", "vim", "ssh", "npm", "swift",
-    ]
-    #expect(mustHave.isSubset(of: tokens))
-  }
+    @Test func debugAllEntriesCoversWellKnownTokens() {
+      let tokens = Set(CommandIconMap.debugAllEntries.map(\.token))
+      // Spot-check that the debug surface actually exposes the tokens
+      // a user is most likely to hunt for.
+      let mustHave: Set<String> = [
+        "git", "docker", "claude", "vim", "ssh", "npm", "swift",
+      ]
+      #expect(mustHave.isSubset(of: tokens))
+    }
+  #endif
 }

--- a/supacodeTests/FingerprintNormalizeBenchmarks.swift
+++ b/supacodeTests/FingerprintNormalizeBenchmarks.swift
@@ -1,0 +1,77 @@
+import Foundation
+import Testing
+
+@testable import supacode
+
+extension PerformanceBenchmarks {
+  /// Pins the #650/#657 escape-absence guard: nearly every transcript fragment
+  /// holds no ESC byte, so proving absence with a byte scan must stay cheaper
+  /// than letting the regex engine walk the whole string to conclude nothing.
+  ///
+  /// The corpus mirrors the measured workload shape from docs-ai/032.004 —
+  /// mostly non-ASCII bytes, a small minority of fragments carrying escapes —
+  /// which is also why no separate ASCII-fast-path ratio is asserted: on this
+  /// byte mix its measured gain is marginal, and the equivalence tests in
+  /// `AgentSessionFingerprintNormalizeTests` already pin its semantics.
+  @Suite
+  struct FingerprintNormalizeBenchmarks {
+    /// Optimized builds only: under `-Onone` the guard's own byte scan is an
+    /// unspecialized `Sequence.contains` and its advantage over the regex
+    /// collapses to ~1.13x — see `BenchmarkMeasurement.isOptimizedBuild`.
+    @Test(.enabled(if: BenchmarkMeasurement.isOptimizedBuild))
+    func escapeAbsenceGuardOutpacesTheRegexOnlyFormulation() {
+      let corpus = Self.corpus()
+
+      for fragment in corpus {
+        #expect(AgentSessionFingerprintMatcher.normalize(fragment) == Self.referenceNormalize(fragment))
+      }
+
+      let medians = BenchmarkMeasurement.interleavedMedians(
+        reference: {
+          for fragment in corpus { _ = Self.referenceNormalize(fragment) }
+        },
+        shipped: {
+          for fragment in corpus { _ = AgentSessionFingerprintMatcher.normalize(fragment) }
+        }
+      )
+      BenchmarkMeasurement.report(suite: "FingerprintNormalize", name: "mixed-corpus", medians: medians)
+      #expect(
+        BenchmarkMeasurement.ratio(medians) >= 1.3,
+        "shipped normalize was only \(BenchmarkMeasurement.ratio(medians))x the regex-only formulation"
+      )
+    }
+
+    /// The pre-#650 formulation: the escape-stripping regex runs whether or not
+    /// an ESC byte exists. Kept verbatim so the benchmark measures exactly the
+    /// path the guard replaced.
+    private static func referenceNormalize(_ value: String) -> String {
+      value
+        .replacing(#/\u{001B}\[[0-?]*[ -\/]*[@-~]/#, with: " ")
+        .lowercased()
+        .split(whereSeparator: \Character.isWhitespace)
+        .joined(separator: " ")
+    }
+
+    /// 240 fragments, ~80% non-ASCII bytes, 2 carrying real CSI sequences —
+    /// the "238 of 240 fragments contained no ESC" shape the guard was built
+    /// for. Deterministic so every run measures the same bytes.
+    private static func corpus() -> [String] {
+      let fragmentCount = BenchmarkMeasurement.isFullMode ? 240 : 60
+      let cjkLine = "エージェントが長い応答を生成しています。コードの説明と修正の提案を含む本文のテキストです。"
+      let asciiLine = "The agent produced MIXED Case output with    collapsing\twhitespace and code: let x = f(y)"
+      var fragments: [String] = []
+      for index in 0..<fragmentCount {
+        var fragment = ""
+        for line in 0..<20 {
+          fragment += (line % 4 == 3) ? asciiLine : cjkLine
+          fragment += "\n"
+        }
+        if index < 2 {
+          fragment = "\u{001B}[1;31m" + fragment + "\u{001B}[0m"
+        }
+        fragments.append(fragment)
+      }
+      return fragments
+    }
+  }
+}

--- a/supacodeTests/LineCountScanBenchmarks.swift
+++ b/supacodeTests/LineCountScanBenchmarks.swift
@@ -1,0 +1,121 @@
+import Foundation
+import Testing
+
+@testable import supacode
+
+extension PerformanceBenchmarks {
+  /// Pins the #644/#652 untracked line-count scanner against the pre-#644
+  /// `Data.reduce` reader it replaced. Two shapes matter: sparse text is where
+  /// `memchr` wins, and newline-dense input is where pure `memchr` regressed
+  /// past the original until the hybrid raw-pointer fallback bounded it.
+  @Suite
+  struct LineCountScanBenchmarks {
+    @Test func scannerOutpacesTheReduceReaderOnSparseText() throws {
+      try assertScannerBeatsReference(
+        data: Self.sparseText(byteCount: Self.inputByteCount),
+        name: "sparse",
+        minimumRatio: 3
+      )
+    }
+
+    /// Optimized builds only: the dense case is a race between two Swift-level
+    /// loops (the hybrid's raw-pointer fallback vs `Data.Iterator`), and under
+    /// `-Onone` the fallback loses — see `BenchmarkMeasurement.isOptimizedBuild`.
+    @Test(.enabled(if: BenchmarkMeasurement.isOptimizedBuild))
+    func scannerStaysAheadOfTheReduceReaderOnAllNewlineInput() throws {
+      try assertScannerBeatsReference(
+        data: Data(repeating: 0x0A, count: Self.inputByteCount),
+        name: "all-newline",
+        minimumRatio: 2
+      )
+    }
+
+    private func assertScannerBeatsReference(data: Data, name: String, minimumRatio: Double) throws {
+      let fileManager = FileManager.default
+      let tempRoot = fileManager.temporaryDirectory.appending(path: UUID().uuidString)
+      defer { try? fileManager.removeItem(at: tempRoot) }
+      try fileManager.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+      try data.write(to: tempRoot.appending(path: "input.txt"))
+
+      // Both implementations must agree before their speed is compared.
+      let shippedCount = GitClient.countLinesInFiles(
+        ["input.txt"],
+        relativeTo: tempRoot,
+        cache: UntrackedLineCountCache()
+      )
+      let referenceCount = Self.referenceCountLines(in: tempRoot.appending(path: "input.txt"))
+      #expect(shippedCount.skippedFileCount == 0)
+      #expect(shippedCount.lines == referenceCount)
+
+      let medians = BenchmarkMeasurement.interleavedMedians(
+        reference: {
+          _ = Self.referenceCountLines(in: tempRoot.appending(path: "input.txt"))
+        },
+        shipped: {
+          // A fresh cache each round keeps this a scan benchmark; the cached
+          // path is pinned separately by the byte-budget proxy tests.
+          _ = GitClient.countLinesInFiles(
+            ["input.txt"],
+            relativeTo: tempRoot,
+            cache: UntrackedLineCountCache()
+          )
+        }
+      )
+      BenchmarkMeasurement.report(suite: "LineCountScan", name: name, medians: medians)
+      #expect(
+        BenchmarkMeasurement.ratio(medians) >= minimumRatio,
+        "shipped scanner was only \(BenchmarkMeasurement.ratio(medians))x the reduce reader on \(name)"
+      )
+    }
+
+    private static var inputByteCount: Int {
+      (BenchmarkMeasurement.isFullMode ? 2_048 : 256) * 1_024
+    }
+
+    /// Text shaped like a `sample(1)` capture — the workload #644 was written
+    /// against: moderate lines, leading indentation, pure ASCII.
+    private static func sparseText(byteCount: Int) -> Data {
+      var out = Data(capacity: byteCount + 128)
+      var lineNumber = 0
+      while out.count < byteCount {
+        let indent = String(repeating: " ", count: 4 + (lineNumber % 5) * 2)
+        let line = "\(indent)\(1_200 + lineNumber % 800) Thread_\(90_000 + lineNumber)   com.apple.main-thread\n"
+        out.append(Data(line.utf8))
+        lineNumber += 1
+      }
+      return out.prefix(byteCount)
+    }
+
+    /// The pre-#644 reader, verbatim: 64 KiB chunks walked through
+    /// `Data.Iterator` with a value-witness call per byte.
+    private static func referenceCountLines(in fileURL: URL) -> Int? {
+      guard let handle = try? FileHandle(forReadingFrom: fileURL) else { return nil }
+      defer { try? handle.close() }
+
+      let binaryProbeByteCount = 8_192
+      let chunkByteCount = 64 * 1_024
+      var probedByteCount = 0
+      var lineCount = 0
+      var isEmpty = true
+      var lastByte: UInt8?
+
+      while true {
+        guard let chunk = try? handle.read(upToCount: chunkByteCount), !chunk.isEmpty else { break }
+        isEmpty = false
+        if probedByteCount < binaryProbeByteCount {
+          let remainingProbeCount = binaryProbeByteCount - probedByteCount
+          let probe = chunk.prefix(remainingProbeCount)
+          if probe.contains(0x00) { return nil }
+          probedByteCount += probe.count
+        }
+        lineCount += chunk.reduce(0) { $0 + ($1 == 0x0A ? 1 : 0) }
+        lastByte = chunk.last
+      }
+
+      if !isEmpty, lastByte != 0x0A {
+        lineCount += 1
+      }
+      return lineCount
+    }
+  }
+}

--- a/supacodeTests/SessionScoringBenchmarks.swift
+++ b/supacodeTests/SessionScoringBenchmarks.swift
@@ -1,0 +1,90 @@
+import Foundation
+import Testing
+
+@testable import supacode
+
+extension PerformanceBenchmarks {
+  /// Pins the #650/#657 fragment cache: a poll whose transcript tails are
+  /// unchanged must not pay tail reads, JSON parsing, and normalization again.
+  /// Cold rounds rebuild a fresh `TranscriptFragmentCache` per call — the
+  /// pre-#650 per-poll cost — while warm rounds reuse one cache the way
+  /// `AgentSessionResolver` does across its 300 ms polls.
+  @Suite
+  struct SessionScoringBenchmarks {
+    @Test func warmFragmentCacheOutpacesColdReparsingPerPoll() throws {
+      let fileManager = FileManager.default
+      let tempRoot = fileManager.temporaryDirectory.appending(path: UUID().uuidString)
+      defer { try? fileManager.removeItem(at: tempRoot) }
+      try fileManager.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+
+      let marker = "the quick brown benchmark fox jumps over the lazy resolver dog"
+      let sessionCount = 6
+      let linesPerTranscript = BenchmarkMeasurement.isFullMode ? 400 : 100
+      var candidates: [AgentSessionCandidate] = []
+      for sessionIndex in 0..<sessionCount {
+        let url = tempRoot.appending(path: "session\(sessionIndex).jsonl")
+        var lines: [String] = []
+        for lineIndex in 0..<linesPerTranscript {
+          lines.append(#"{"content": "セッション\#(sessionIndex)の本文テキスト行\#(lineIndex)、画面には現れない内容です。"}"#)
+        }
+        if sessionIndex == 0 {
+          lines.append(#"{"content": "\#(marker)"}"#)
+        }
+        try lines.joined(separator: "\n").write(to: url, atomically: true, encoding: .utf8)
+        let modifiedAt =
+          (try? url.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate) ?? .now
+        candidates.append(
+          AgentSessionCandidate(
+            session: AgentSession(id: "session\(sessionIndex)", transcriptPath: url, source: .recentFile),
+            modifiedAt: modifiedAt
+          )
+        )
+      }
+      let activeText = "  \(marker)  \n prompt>"
+
+      var coldCache = TranscriptFragmentCache()
+      let coldWinner = AgentSessionFingerprintMatcher.bestMatch(
+        activeText: activeText,
+        candidates: candidates,
+        fragments: &coldCache
+      )
+      let warmBox = FragmentCacheBox()
+      let warmWinner = AgentSessionFingerprintMatcher.bestMatch(
+        activeText: activeText,
+        candidates: candidates,
+        fragments: &warmBox.cache
+      )
+      #expect(coldWinner?.session.id == "session0")
+      #expect(warmWinner?.session.id == coldWinner?.session.id)
+
+      let medians = BenchmarkMeasurement.interleavedMedians(
+        reference: {
+          var cache = TranscriptFragmentCache()
+          _ = AgentSessionFingerprintMatcher.bestMatch(
+            activeText: activeText,
+            candidates: candidates,
+            fragments: &cache
+          )
+        },
+        shipped: {
+          _ = AgentSessionFingerprintMatcher.bestMatch(
+            activeText: activeText,
+            candidates: candidates,
+            fragments: &warmBox.cache
+          )
+        }
+      )
+      BenchmarkMeasurement.report(suite: "SessionScoring", name: "warm-vs-cold", medians: medians)
+      #expect(
+        BenchmarkMeasurement.ratio(medians) >= 3,
+        "warm fragment cache was only \(BenchmarkMeasurement.ratio(medians))x cold re-parsing"
+      )
+    }
+  }
+}
+
+/// `bestMatch` takes the cache `inout`; a closure cannot capture `inout` state,
+/// so the warm cache lives in a reference box instead.
+private final class FragmentCacheBox {
+  var cache = TranscriptFragmentCache()
+}

--- a/supacodeTests/WorktreeDirectoryIndexBenchmarks.swift
+++ b/supacodeTests/WorktreeDirectoryIndexBenchmarks.swift
@@ -1,0 +1,99 @@
+import Foundation
+import IdentifiedCollections
+import Testing
+
+@testable import supacode
+
+extension PerformanceBenchmarks {
+  /// Pins the #648/#655 directory index against the pre-#648 shape it replaced:
+  /// every agent row scanning every worktree, with `PathPolicy` normalizing both
+  /// sides of each containment test — filesystem round-trips per (row, worktree)
+  /// pair. The index normalizes each worktree once at build time and each query
+  /// once at lookup, so even the worst case (build plus a full query batch)
+  /// must beat one naive batch.
+  @Suite
+  struct WorktreeDirectoryIndexBenchmarks {
+    @Test func indexBuildPlusQueryBatchOutpacesThePerRowScan() throws {
+      let fileManager = FileManager.default
+      let tempRoot = fileManager.temporaryDirectory.appending(path: UUID().uuidString)
+      defer { try? fileManager.removeItem(at: tempRoot) }
+
+      let repositoryCount = BenchmarkMeasurement.isFullMode ? 6 : 3
+      let worktreesPerRepository = 4
+      var repositories: IdentifiedArrayOf<Repository> = []
+      var queries: [URL] = []
+      for repositoryIndex in 0..<repositoryCount {
+        let repoRoot = tempRoot.appending(path: "repo\(repositoryIndex)")
+        var worktrees: IdentifiedArrayOf<Worktree> = []
+        for worktreeIndex in 0..<worktreesPerRepository {
+          let directory = repoRoot.appending(path: "wt\(worktreeIndex)")
+          // Real directories, because `PathPolicy.normalizeURL` only pays its
+          // symlink walk for paths that exist — the cost being benchmarked.
+          let nested = directory.appending(path: "src/lib")
+          try fileManager.createDirectory(at: nested, withIntermediateDirectories: true)
+          worktrees.append(
+            Worktree(
+              id: directory.path,
+              name: "wt\(worktreeIndex)",
+              detail: "wt\(worktreeIndex)",
+              workingDirectory: directory,
+              repositoryRootURL: repoRoot
+            )
+          )
+          queries.append(nested)
+        }
+        repositories.append(
+          Repository(
+            id: repoRoot.path,
+            rootURL: repoRoot,
+            name: repoRoot.lastPathComponent,
+            kind: .git,
+            worktrees: worktrees
+          )
+        )
+      }
+      queries.append(tempRoot.appending(path: "outside"))
+
+      let allWorktrees = repositories.flatMap(\.worktrees)
+      let index = WorktreeDirectoryIndex(repositories: repositories)
+      for query in queries {
+        #expect(index.worktreeID(forWorkingDirectory: query) == Self.referenceResolve(query, in: allWorktrees))
+      }
+
+      let medians = BenchmarkMeasurement.interleavedMedians(
+        reference: {
+          for query in queries {
+            _ = Self.referenceResolve(query, in: allWorktrees)
+          }
+        },
+        shipped: {
+          // Rebuilding per round is the index's worst case; steady state reuses
+          // the built index through `WorktreeDirectoryIndexCache` and is
+          // strictly cheaper than what is measured here.
+          let index = WorktreeDirectoryIndex(repositories: repositories)
+          for query in queries {
+            _ = index.worktreeID(forWorkingDirectory: query)
+          }
+        }
+      )
+      BenchmarkMeasurement.report(suite: "WorktreeDirectoryIndex", name: "build-plus-batch", medians: medians)
+      #expect(
+        BenchmarkMeasurement.ratio(medians) >= 2,
+        "index build plus batch was only \(BenchmarkMeasurement.ratio(medians))x the per-row scan"
+      )
+    }
+
+    /// The pre-#648 resolution shape: every query walks every worktree, and each
+    /// containment test normalizes both sides again via `PathPolicy`.
+    private static func referenceResolve(_ query: URL, in worktrees: [Worktree]) -> Worktree.ID? {
+      var best: (id: Worktree.ID, depth: Int)?
+      for worktree in worktrees where PathPolicy.contains(query, in: worktree.workingDirectory) {
+        let depth = PathPolicy.normalizeURL(worktree.workingDirectory).pathComponents.count
+        if depth > (best?.depth ?? -1) {
+          best = (worktree.id, depth)
+        }
+      }
+      return best?.id
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Four serialized ratio-assertion benchmark suites in `supacodeTests/` pin the wave's optimized hot paths against verbatim copies of the implementations they replaced, asserting output equivalence before timing:
  - `LineCountScanBenchmarks` — #644/#652 scanner vs the `Data.reduce` reader (sparse ≥3x, all-newline ≥2x)
  - `FingerprintNormalizeBenchmarks` — #650/#657 escape-absence guard vs the regex-always formulation (≥1.3x)
  - `WorktreeDirectoryIndexBenchmarks` — #648/#655 index vs the per-row `PathPolicy` scan (≥2x)
  - `SessionScoringBenchmarks` — warm `TranscriptFragmentCache` vs cold re-parsing (≥3x)
- Ratios whose slow side is a C call or filesystem I/O assert in every build mode; the two Swift-vs-Swift ratios collapse under `-Onone` (measured 1.13x and 0.45x) and assert only in optimized builds, detected via an `assert` side effect.
- `make bench` runs the suite alone under `-configuration Release` + `ENABLE_TESTABILITY=YES`, serial and arch-pinned (parallel clones and a generic destination both execute every test twice), appending absolute medians as JSON lines keyed by git SHA to `~/Library/Logs/Prowl/measurements/bench/`.
- `scripts/measure-title-coalescing.sh` (+ `make measure-titles`) black-box-verifies the #649/#656 coalescing contract against a running app via `prowl list` polling; `make measure-cpu` / `make capture-spike` wrap the #665 scripts.
- Release test builds surfaced two pre-existing snags, fixed here: tests exercising Debug-only members now compile away outside Debug, and `GhosttyRuntime` declares `@MainActor` explicitly because whole-module swiftmodule deserialization loses default-isolation inference for its `isolated deinit`.
- `.claude/skills/run-benchmark` — the benchmark runbook as an explicit-invocation skill: classifies the request (hot-path A/B / new-optimization pinning / release sweep), confirms the mode, runs the matching layers, and writes an append-only report under `~/Library/Logs/Prowl/measurements/reports/`.
- docs-ai entry 057 records the design, decisions, and first optimized-run numbers.

## First optimized run (M-series, quiet host)

| suite/case | reference | shipped | ratio (floor) |
| --- | --- | --- | --- |
| LineCountScan/sparse | 84.40ms | 0.73ms | 115x (3x) |
| LineCountScan/all-newline | 83.14ms | 2.23ms | 37x (2x) |
| FingerprintNormalize/mixed-corpus | 39.05ms | 25.22ms | 1.55x (1.3x) |
| SessionScoring/warm-vs-cold | 7.85ms | 1.08ms | 7.3x (3x) |
| WorktreeDirectoryIndex/build-plus-batch | 32.10ms | 1.33ms | 24x (2x) |

## Validation

- `make bench` — 5 passed in 4.8s, first JSONL records written
- `make test` — 2,248 passed, 0 failures (gated benchmarks skip in Debug as designed)
- `make check`, `make build-app` — clean
- `bash -n` + ShellCheck clean on the new script; live run measured an animating tab at 0.90 changes/s (exit 0) and static tabs at 0

https://claude.ai/code/session_01TWSNesKV4dk8HLKmcNEJjS

