### PR TITLE
Add guard rails to release.sh version handling

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -14,6 +14,7 @@
 #   SPARKLE_PRIVATE_KEY_FILE        Path to EdDSA private key file (default: ~/.prowl-sparkle-private-key)
 #   NETLIFY_BUILD_HOOK              Netlify Build Hook URL for Prowl-Site rebuild
 #   SKIP_SENTRY                     Set to 1 to skip dSYM upload and Sentry release tracking
+#   FORCE_RERELEASE                 Set to 1 to replace a version that already has a GitHub Release
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -59,6 +60,32 @@ signing_identity_sha() {
 log() { echo "[release] $*"; }
 die() { echo "error: $*" >&2; exit 1; }
 
+version_date_compact() {
+  # Print the YYYYMMDD date encoded in a YYYY.M.DD[.N] version string.
+  # Fails when the components do not form a real calendar date (BSD date
+  # either rejects the input or normalizes it, so a round-trip mismatch
+  # catches rollovers like 2026.2.30 -> 2026-03-02).
+  local year month day compact roundtrip
+  IFS='.' read -r year month day _ <<<"$1"
+  compact="$(printf '%04d%02d%02d' "$((10#$year))" "$((10#$month))" "$((10#$day))")"
+  roundtrip="$(date -j -f '%Y%m%d' "$compact" +%Y%m%d 2>/dev/null)" || return 1
+  [[ "$roundtrip" == "$compact" ]] || return 1
+  echo "$compact"
+}
+
+ensure_release_not_published() {
+  # A GitHub Release for this tag means the version already shipped. Re-running
+  # would delete and re-create the release and force-move the published tag, so
+  # a mistyped old version must not silently clobber a live release.
+  local repo="$1" tag="$2"
+  if gh release view "$tag" --repo "$repo" >/dev/null 2>&1; then
+    if [[ "${FORCE_RERELEASE:-}" != "1" ]]; then
+      die "GitHub Release $tag already exists on $repo — refusing to overwrite a published release (set FORCE_RERELEASE=1 to replace it intentionally)"
+    fi
+    log "FORCE_RERELEASE=1 — existing release $tag will be replaced"
+  fi
+}
+
 # ── Preflight ────────────────────────────────────────────────────────────────
 
 log "preflight checks..."
@@ -82,6 +109,16 @@ fi
 
 if [[ -n "$(git status --porcelain)" ]]; then
   die "working tree is not clean — commit or stash changes first"
+fi
+
+# Releasing from a stale checkout starts the build-number monotonicity guard
+# from an outdated CURRENT_PROJECT_VERSION and merges outdated appcast history,
+# which can publish a Sparkle item that sorts below the live latest build.
+log "checking checkout freshness against origin/main..."
+git fetch --quiet origin || die "cannot fetch origin — network is required for a release"
+git rev-parse --verify --quiet origin/main >/dev/null || die "origin/main not found — cannot verify checkout freshness"
+if ! git merge-base --is-ancestor origin/main HEAD; then
+  die "HEAD does not contain origin/main — sync your checkout (git pull) before releasing"
 fi
 
 REPO="${GH_REPO:-$(origin_repo_from_remote || true)}"
@@ -125,6 +162,15 @@ if [[ -n "${1:-}" ]]; then
   if ! echo "$VERSION" | grep -qE '^[0-9]{4}\.[0-9]{1,2}\.[0-9]{1,2}(\.[0-9]+)?$'; then
     die "VERSION must be in YYYY.M.DD or YYYY.M.DD.N format"
   fi
+  VERSION_DATE="$(version_date_compact "$VERSION")" \
+    || die "VERSION $VERSION does not encode a real calendar date"
+  TODAY_COMPACT="$(date +%Y%m%d)"
+  if (( VERSION_DATE > TODAY_COMPACT )); then
+    die "VERSION $VERSION is dated in the future (today is $(date +%Y.%-m.%-d)) — refusing to publish a future-dated release"
+  fi
+  if (( VERSION_DATE < TODAY_COMPACT )); then
+    log "note: VERSION $VERSION is dated before today ($(date +%Y.%-m.%-d))"
+  fi
 else
   VERSION="$(date +%Y.%-m.%-d)"
   suffix=1
@@ -135,6 +181,8 @@ else
 fi
 
 TAG="v$VERSION"
+
+ensure_release_not_published "$REPO" "$TAG"
 
 BUILD="$(date +%Y%m%d)"
 CURRENT_BUILD="$(/usr/bin/awk -F' = ' '/CURRENT_PROJECT_VERSION = [0-9]+;/{gsub(/;/,""); print $2; exit}' "$PROJECT_DIR/supacode.xcodeproj/project.pbxproj")"


### PR DESCRIPTION
## Why

The Tolaria `v2027-07-31` incident: a hand-typed future-dated tag passed a format-only check, shipped as the release version, and stranded updater clients behind a "future" installed version. Prowl is naturally immune to the worst outcome (Sparkle compares the clock-derived, monotonic build number, never the hand-typed marketing version), but `release.sh` had three adjacent gaps.

## What

1. **Future/invalid date rejection** — a manually passed `VERSION` must encode a real calendar date no later than today. `2027.8.2` and `2026.2.30` now die before anything runs; past-dated versions stay allowed (legitimate for resuming an interrupted release) with a logged notice.
2. **Published-release protection** — if the tag already has a GitHub Release, the script refuses to proceed instead of silently `gh release delete` + re-creating and force-moving the published tag. `FORCE_RERELEASE=1` overrides for intentional re-releases.
3. **Checkout freshness** — HEAD must contain `origin/main`, so a stale checkout cannot restart the build-number monotonicity guard from an outdated `CURRENT_PROJECT_VERSION` or merge outdated appcast history.

## Verification

- Unit tests on the extracted real functions (13 cases): calendar validation incl. leading-zero/octal and BSD `date` rollover edge cases; published-tag guard verified read-only against this repo's real `v2026.8.1` release (blocked), `FORCE_RERELEASE=1` (allowed), nonexistent tag (silent pass), unreachable repo (treated as not published).
- Sandboxed end-to-end run of the real script (8 cases): future/invalid versions rejected at the guard; valid/past versions pass all guards and stop at `make bump-version` (sandbox has no Makefile); stale checkout rejected; ahead-of-origin checkout allowed; no tags or remote state created anywhere.
- `bash -n` and `shellcheck` clean (only the two pre-existing warnings remain untouched).

No real release flow was executed.

https://claude.ai/code/session_01PfhFwzeWZtuxLMpteY8UqB
