### PR TITLE
Fix flaky positive assertions in DebouncerTests

### DIFF
--- a/supacodeTests/DebouncerTests.swift
+++ b/supacodeTests/DebouncerTests.swift
@@ -16,6 +16,7 @@ struct DebouncerTests {
     #expect(!fired)
 
     await advance(clock, by: .milliseconds(1))
+    await settle { fired }
     #expect(fired)
   }
 
@@ -33,6 +34,7 @@ struct DebouncerTests {
     #expect(!secondFired)
 
     await advance(clock, by: .milliseconds(40))
+    await settle { secondFired }
     #expect(!firstFired)
     #expect(secondFired)
   }
@@ -62,6 +64,7 @@ struct DebouncerTests {
     #expect(!debouncer.isIdle)
 
     await advance(clock, by: .milliseconds(100))
+    await settle { debouncer.isIdle }
     #expect(debouncer.isIdle)
 
     debouncer.schedule {}
@@ -84,6 +87,7 @@ struct KeyedDebouncerTests {
     debouncer.schedule("a") { fired.append("a2") }
 
     await advance(clock, by: .milliseconds(100))
+    await settle { fired.count == 2 }
     #expect(fired.sorted() == ["a2", "b"])
   }
 
@@ -94,6 +98,7 @@ struct KeyedDebouncerTests {
 
     debouncer.schedule("a", after: .milliseconds(100)) { fired = true }
     await advance(clock, by: .milliseconds(100))
+    await settle { fired }
 
     #expect(fired)
   }
@@ -107,6 +112,7 @@ struct KeyedDebouncerTests {
     debouncer.schedule("b") { fired.append("b") }
     debouncer.cancel("a")
     await advance(clock, by: .milliseconds(100))
+    await settle { !fired.isEmpty }
 
     #expect(fired == ["b"])
   }
@@ -121,6 +127,7 @@ struct KeyedDebouncerTests {
     debouncer.schedule("drop-2") { fired.append("drop-2") }
     debouncer.cancelAll { $0.hasPrefix("drop") }
     await advance(clock, by: .milliseconds(100))
+    await settle { !fired.isEmpty }
 
     #expect(fired == ["keep"])
   }
@@ -144,9 +151,25 @@ private func advance(_ clock: TestClock<Duration>, by duration: Duration) async 
   await clock.advance(by: duration)
   // Deadlines are anchored at `schedule` time, so a debounce task that starts
   // after the advance still resumes immediately — but it needs a few executor
-  // hops to run its continuation on a loaded machine. A short yield burst
-  // keeps that deterministic without real-time sleeping.
+  // hops to run its continuation. The short burst gives "never fires"
+  // assertions a fair window without real-time sleeping; positive assertions
+  // must not rely on it and wait via `settle` instead.
   for _ in 0..<10 {
     await Task.yield()
+  }
+}
+
+// Yields the main actor until `condition` holds. A fixed yield count is not
+// enough for positive assertions: when parallel suites contend for the main
+// actor, a resumed debounce task can need arbitrarily many hops before it runs
+// (the `isIdleTracksThePendingWindow` CI flake). The budget only bounds a
+// genuine regression, which then fails the following `#expect` instead of
+// hanging the test.
+@MainActor
+private func settle(until condition: () -> Bool) async {
+  var budget = 10_000
+  while budget > 0, !condition() {
+    await Task.yield()
+    budget -= 1
   }
 }


### PR DESCRIPTION
## Problem

`DebouncerTests/isIdleTracksThePendingWindow()` failed in a full `make test-app` run:

```
Expectation failed: (debouncer → supacode.Debouncer).isIdle → false
```

The failing expectation is the one after `advance(clock, by: .milliseconds(100))`. The shared `advance` helper waits a **fixed 10 `Task.yield()` hops** for the debounce task to resume from its TestClock sleep and clear `task`. Under a loaded main actor — parallel suites contending during a full-suite run — the resumed task can need arbitrarily many hops before it executes, so the fixed burst is a race. This is the residue of the earlier CI flake that `anchoredSleep` fixed (see the comment in `Debouncer.swift`): deadline anchoring removed the "sleep never armed" hang, but the bounded-yield wait remained heuristic.

`Debouncer` itself is correct (no suspension point between the cancellation guard and `task = nil`; a superseded task never touches the replaced `task`) — this is purely test infrastructure.

## Fix

Test-only. Positive assertions now wait via a new `settle(until:)` helper that yields until the observed condition holds, bounded by a 10k budget so a genuine regression fails the following `#expect` with a clear message instead of hanging the test. Every positive post-advance assertion in the file had the same exposure and now settles on its condition. Negative "never fires" assertions keep the short fixed burst — their failure direction is a missed detection, never a red build, and absence cannot be awaited.

## Verification

- `DebouncerTests` + `KeyedDebouncerTests`: 100 consecutive iterations with `-test-iterations 100 -run-tests-until-failure`, all green.
- Full `make test-app`: 2248 tests passed, 0 failures (the environment where the original flake occurred).
- `make check` clean.

https://claude.ai/code/session_01PfhFwzeWZtuxLMpteY8UqB
