### PR TITLE
fix: show the runtime icon on a profile-launched tab

### DIFF
--- a/docs/components/terminal.md
+++ b/docs/components/terminal.md
@@ -90,6 +90,11 @@ Tabs get an auto-detected icon based on what's running (e.g. an agent's icon),
 which you can override (Change Tab Icon) or which a script can set. Icon
 precedence is `auto < script < user`.
 
+A tab opened by an Agent Profile launch starts with that runtime's brand icon
+instead of waiting for detection, because the launch command is prefixed with
+`env` and auto-detection reads the first token of the command. The slot stays
+claimable, so a later command in the same tab still takes it over.
+
 ## Shell integration & status (OSC sequences)
 
 Ghostty's shell integration drives several Prowl features via terminal escape

--- a/docs/components/terminal.md
+++ b/docs/components/terminal.md
@@ -90,10 +90,12 @@ Tabs get an auto-detected icon based on what's running (e.g. an agent's icon),
 which you can override (Change Tab Icon) or which a script can set. Icon
 precedence is `auto < script < user`.
 
-A tab opened by an Agent Profile launch starts with that runtime's brand icon
-instead of waiting for detection, because the launch command is prefixed with
-`env` and auto-detection reads the first token of the command. The slot stays
-claimable, so a later command in the same tab still takes it over.
+An Agent Profile launch applies that runtime's brand icon itself instead of
+waiting for detection — to the new tab, or to the containing tab when the
+profile opens in a split. Auto-detection reads the first token of the command,
+and a profile that sets launch-scoped environment variables runs as
+`env VAR=… claude`, whose first token is `env`. The slot stays claimable, so a
+later recognised command in the same tab still takes it over.
 
 ## Shell integration & status (OSC sequences)
 

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -495,7 +495,7 @@ final class WorktreeTerminalState {
     let tabId = createTab(
       TabCreation(
         title: plan.profileName,
-        icon: "terminal",
+        icon: Self.launchTabIcon(for: plan.runtime),
         isTitleLocked: false,
         initialInput: runScriptInput(plan.terminalInput),
         focusing: true,
@@ -508,6 +508,16 @@ final class WorktreeTerminalState {
     guard let tabId, let surfaceID = trees[tabId]?.root?.leftmostLeaf().id else { return nil }
     launchProfilesBySurface[surfaceID] = identity
     return surfaceID
+  }
+
+  /// Icon for a profile-launched tab. The launch path knows its runtime, so it
+  /// resolves the brand icon directly instead of waiting for `CommandIconMap`
+  /// to recognise the shell title: the launch command is `env VAR=… claude`,
+  /// whose first token is `env`, and an unmatched token leaves the icon
+  /// untouched. The lock stays `.auto`, so a later command in the same tab can
+  /// still take the slot, exactly as it does for a hand-typed agent.
+  static func launchTabIcon(for runtime: AgentProfileRuntime) -> String {
+    CommandIconMap.iconForFirstToken(runtime.agent.iconLookupToken)?.storageString ?? "terminal"
   }
 
   @discardableResult

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -490,12 +490,15 @@ final class WorktreeTerminalState {
       )
     {
       launchProfilesBySurface[surfaceID] = identity
+      if let icon = Self.launchTabIcon(for: plan.runtime), let tabID = tabID(containing: surfaceID) {
+        applyResolvedIcon(icon, surfaceId: surfaceID, tabId: tabID)
+      }
       return surfaceID
     }
     let tabId = createTab(
       TabCreation(
         title: plan.profileName,
-        icon: Self.launchTabIcon(for: plan.runtime),
+        icon: Self.launchTabIcon(for: plan.runtime)?.storageString ?? "terminal",
         isTitleLocked: false,
         initialInput: runScriptInput(plan.terminalInput),
         focusing: true,
@@ -510,14 +513,16 @@ final class WorktreeTerminalState {
     return surfaceID
   }
 
-  /// Icon for a profile-launched tab. The launch path knows its runtime, so it
+  /// Icon for a profile launch. The launch path knows its runtime, so it
   /// resolves the brand icon directly instead of waiting for `CommandIconMap`
-  /// to recognise the shell title: the launch command is `env VAR=… claude`,
-  /// whose first token is `env`, and an unmatched token leaves the icon
-  /// untouched. The lock stays `.auto`, so a later command in the same tab can
-  /// still take the slot, exactly as it does for a hand-typed agent.
-  static func launchTabIcon(for runtime: AgentProfileRuntime) -> String {
-    CommandIconMap.iconForFirstToken(runtime.agent.iconLookupToken)?.storageString ?? "terminal"
+  /// to recognise the shell title: a profile that sets launch-scoped
+  /// environment variables runs as `env VAR=… claude`, whose first token is
+  /// `env`, and an unmatched token leaves the icon untouched. The lock stays
+  /// `.auto`, so a later recognised command in the same tab can still take the
+  /// slot, exactly as it does for a hand-typed agent. `nil` means the runtime
+  /// has no mapping, in which case the tab keeps whatever icon it has.
+  static func launchTabIcon(for runtime: AgentProfileRuntime) -> TabIconSource? {
+    CommandIconMap.iconForFirstToken(runtime.agent.iconLookupToken)
   }
 
   @discardableResult

--- a/supacodeTests/WorktreeTerminalStateAgentProfileTests.swift
+++ b/supacodeTests/WorktreeTerminalStateAgentProfileTests.swift
@@ -57,6 +57,33 @@ struct WorktreeTerminalStateAgentProfileTests {
     #expect(state.launchProfilesBySurface[surfaceID] == nil)
   }
 
+  @Test func launchTabWearsTheRuntimeIconInsteadOfTheTerminalGlyph() {
+    #expect(
+      WorktreeTerminalState.launchTabIcon(for: .claude)
+        == CommandIconMap.iconForFirstToken("claude")?.storageString
+    )
+    #expect(WorktreeTerminalState.launchTabIcon(for: .claude) != "terminal")
+    #expect(WorktreeTerminalState.launchTabIcon(for: .codex) != "terminal")
+    #expect(
+      WorktreeTerminalState.launchTabIcon(for: .claude)
+        != WorktreeTerminalState.launchTabIcon(for: .codex)
+    )
+  }
+
+  @Test func launchCreatesTheTabWithTheRuntimeIcon() {
+    let state = makeState()
+
+    _ = state.launchAgentProfile(makePlan(dedicatedHome: nil))
+
+    // Guards the call site, not just the helper: a hardcoded glyph here is the
+    // original bug, and it survives a helper-only assertion.
+    #expect(state.tabManager.tabs.count == 1)
+    #expect(state.tabManager.tabs.first?.icon == WorktreeTerminalState.launchTabIcon(for: .codex))
+    #expect(state.tabManager.tabs.first?.icon != "terminal")
+    // Left claimable, so a later command in the same tab still wins the slot.
+    #expect(state.tabManager.tabs.first?.iconLock == .auto)
+  }
+
   private func makeState() -> WorktreeTerminalState {
     WorktreeTerminalState(
       runtime: GhosttyRuntime(),

--- a/supacodeTests/WorktreeTerminalStateAgentProfileTests.swift
+++ b/supacodeTests/WorktreeTerminalStateAgentProfileTests.swift
@@ -58,15 +58,16 @@ struct WorktreeTerminalStateAgentProfileTests {
   }
 
   @Test func launchTabWearsTheRuntimeIconInsteadOfTheTerminalGlyph() {
+    // No runtime falls back to the generic glyph: a new case added without a
+    // `CommandIconMap` entry would otherwise launch unbranded and silently.
+    for runtime in AgentProfileRuntime.allCases {
+      #expect(WorktreeTerminalState.launchTabIcon(for: runtime) != nil, "\(runtime) has no icon")
+    }
+    #expect(WorktreeTerminalState.launchTabIcon(for: .claude)?.storageString != "terminal")
+    #expect(WorktreeTerminalState.launchTabIcon(for: .codex)?.storageString != "terminal")
     #expect(
-      WorktreeTerminalState.launchTabIcon(for: .claude)
-        == CommandIconMap.iconForFirstToken("claude")?.storageString
-    )
-    #expect(WorktreeTerminalState.launchTabIcon(for: .claude) != "terminal")
-    #expect(WorktreeTerminalState.launchTabIcon(for: .codex) != "terminal")
-    #expect(
-      WorktreeTerminalState.launchTabIcon(for: .claude)
-        != WorktreeTerminalState.launchTabIcon(for: .codex)
+      WorktreeTerminalState.launchTabIcon(for: .claude)?.storageString
+        != WorktreeTerminalState.launchTabIcon(for: .codex)?.storageString
     )
   }
 
@@ -78,10 +79,64 @@ struct WorktreeTerminalStateAgentProfileTests {
     // Guards the call site, not just the helper: a hardcoded glyph here is the
     // original bug, and it survives a helper-only assertion.
     #expect(state.tabManager.tabs.count == 1)
-    #expect(state.tabManager.tabs.first?.icon == WorktreeTerminalState.launchTabIcon(for: .codex))
+    #expect(
+      state.tabManager.tabs.first?.icon
+        == WorktreeTerminalState.launchTabIcon(for: .codex)?.storageString
+    )
     #expect(state.tabManager.tabs.first?.icon != "terminal")
     // Left claimable, so a later command in the same tab still wins the slot.
     #expect(state.tabManager.tabs.first?.iconLock == .auto)
+  }
+
+  @Test func splitLaunchRebrandsTheContainingTab() throws {
+    let state = makeState()
+    _ = state.launchAgentProfile(makePlan(dedicatedHome: nil))
+    let tabID = try #require(state.tabManager.tabs.first?.id)
+    state.tabManager.updateIcon(tabID, icon: "@asset:Git")
+
+    let surfaceID = state.launchAgentProfile(
+      makePlan(dedicatedHome: nil, runtime: .claude, placement: .split)
+    )
+
+    // The split becomes the focused surface, so its runtime owns the tab icon;
+    // its `env …` title never reaches `CommandIconMap`.
+    #expect(state.tabID(containing: try #require(surfaceID)) == tabID)
+    #expect(state.tabManager.tabs.count == 1)
+    #expect(
+      state.tabManager.tabs.first?.icon
+        == WorktreeTerminalState.launchTabIcon(for: .claude)?.storageString
+    )
+    #expect(state.tabManager.tabs.first?.iconLock == .auto)
+  }
+
+  @Test func splitLaunchLeavesAClaimedIconAlone() throws {
+    let state = makeState()
+    _ = state.launchAgentProfile(makePlan(dedicatedHome: nil))
+    let tabID = try #require(state.tabManager.tabs.first?.id)
+    state.tabManager.overrideIcon(tabID, icon: "@asset:Git")
+
+    _ = state.launchAgentProfile(
+      makePlan(dedicatedHome: nil, runtime: .claude, placement: .split)
+    )
+
+    #expect(state.tabManager.tabs.first?.icon == "@asset:Git")
+    #expect(state.tabManager.tabs.first?.iconLock == .user)
+  }
+
+  @Test func splitLaunchLeavesAScriptIconAlone() throws {
+    let state = makeState()
+    _ = state.launchAgentProfile(makePlan(dedicatedHome: nil))
+    let tabID = try #require(state.tabManager.tabs.first?.id)
+    state.tabManager.setScriptIcon(tabID, icon: "@asset:Git")
+
+    _ = state.launchAgentProfile(
+      makePlan(dedicatedHome: nil, runtime: .claude, placement: .split)
+    )
+
+    // A launch is auto-detection's peer, not a script: it yields to `.script`
+    // just as `CommandIconMap` does.
+    #expect(state.tabManager.tabs.first?.icon == "@asset:Git")
+    #expect(state.tabManager.tabs.first?.iconLock == .script)
   }
 
   private func makeState() -> WorktreeTerminalState {
@@ -97,14 +152,18 @@ struct WorktreeTerminalStateAgentProfileTests {
     )
   }
 
-  private func makePlan(dedicatedHome: URL?) -> AgentProfileLaunchPlan {
+  private func makePlan(
+    dedicatedHome: URL?,
+    runtime: AgentProfileRuntime = .codex,
+    placement: AgentProfilePlacement = .tab
+  ) -> AgentProfileLaunchPlan {
     AgentProfileLaunchPlan(
       profileID: UUID(),
       profileName: "Codex · Bound",
-      runtime: .codex,
-      invocation: AgentInvocation(executable: "codex", arguments: []),
+      runtime: runtime,
+      invocation: AgentInvocation(executable: runtime.agent.iconLookupToken, arguments: []),
       commandEnvironmentTokens: [],
-      placement: .tab,
+      placement: placement,
       splitDirection: .right,
       surfaceEnvironment: [:],
       dedicatedHome: dedicatedHome


### PR DESCRIPTION
Launching an agent from the **Agents** menu leaves the tab wearing the generic terminal glyph, while typing `claude` by hand in the same worktree shows the Claude Code brand icon.

`launchAgentProfile` creates the tab with a hardcoded `icon: "terminal"` and leaves the rest to `CommandIconMap`, which resolves an icon from the first whitespace token of the command in the OSC 2 title. Since 053/006 the launch command is `env CLAUDE_CONFIG_DIR='…' claude`, so that token is `env`. It matches nothing, and per `CommandIconMap`'s contract an unmatched token deliberately leaves the existing icon untouched — so the placeholder stays for the life of the tab.

The launch path already knows its runtime, so it resolves the brand icon directly instead of round-tripping through the shell title. `iconLock` stays `.auto`, so a later command in the same tab still claims the slot, exactly as it does for a hand-typed agent.

A profile's custom SF Symbol is deliberately out of scope: it isn't part of `AgentProfileLaunchPlan`, and `docs/components/agent-profiles.md` already states that live panes show the icon of the process Prowl actually detects.

## Test plan

- `make build-app` — 0 errors, 0 warnings
- `WorktreeTerminalStateAgentProfileTests` — 5/5; reverting the one-line change fails `launchCreatesTheTabWithTheRuntimeIcon()`
- `make check` — clean
- Manually: launch a profile from the Agents menu → the tab shows the runtime icon; run another recognised command in that tab → the icon follows it

## Notes

- Conflicts with #651, which restructures the same `createTab` call (and keeps the hardcoded glyph). Happy to rebase whenever it lands.
- Possible follow-up, deliberately left out to keep this at one line: `CommandIconMap` could skip a leading `env VAR=…` prefix, so a hand-typed `env FOO=1 claude` resolves too.
