### PR TITLE
Detect an in-progress turn by its elapsed counter

### DIFF
--- a/supacode/Infrastructure/AgentDetection/ScreenHeuristics.swift
+++ b/supacode/Infrastructure/AgentDetection/ScreenHeuristics.swift
@@ -126,6 +126,9 @@ nonisolated private func detectClaude(_ content: String) -> AgentRawState {
   if hasSpinnerActivity(above) {
     return .working
   }
+  if hasElapsedStatusLine(above) {
+    return .working
+  }
   if hasClaudeBackgroundWork(content) {
     return .working
   }
@@ -143,7 +146,7 @@ nonisolated private func detectCodex(_ content: String) -> AgentRawState {
   {
     return .blocked
   }
-  if hasInterruptPattern(lower) || hasCodexWorkingHeader(content) {
+  if hasInterruptPattern(lower) || hasCodexWorkingHeader(content) || hasElapsedStatusLine(content) {
     return .working
   }
   return .idle
@@ -491,6 +494,35 @@ nonisolated private func hasSpinnerActivity(_ content: String) -> Bool {
       && rest.hasPrefix(" ")
       && rest.contains("…")
       && rest.contains(where: \.isLetter)
+  }
+}
+
+/// Matches an in-progress status line shaped `<glyph> <word> (<elapsed>`, such as
+/// `● Forging… (10s · thinking with high effort)` or `• Working (12s · esc to interrupt)`.
+///
+/// The word is randomized between renders, so no fixed vocabulary can track it and
+/// matching on one goes stale the moment a runtime reworks its wording. The elapsed
+/// counter carries the signal instead: it is rendered only while a turn is in flight.
+///
+/// Anchoring on that counter is also what keeps the check honest. Ordinary message
+/// bullets share the leading glyph and routinely end a clause with an ellipsis, so a
+/// glyph-and-ellipsis match alone would read a finished turn as a running one.
+nonisolated private func hasElapsedStatusLine(_ content: String) -> Bool {
+  let statusGlyphs: Set<UnicodeScalar> = ["●", "•"]
+  return content.split(separator: "\n").contains { line in
+    let trimmed = line.trimmingCharacters(in: .whitespaces)
+    guard let first = trimmed.unicodeScalars.first, statusGlyphs.contains(first) else {
+      return false
+    }
+    let body = trimmed.dropFirst()
+    guard body.hasPrefix(" "), let open = body.firstIndex(of: "(") else { return false }
+    // A single token, so a sentence that merely happens to reach a parenthesis cannot match.
+    let label = body[body.startIndex..<open].trimmingCharacters(in: .whitespaces)
+    guard !label.isEmpty, !label.contains(" ") else { return false }
+    let elapsed = body[body.index(after: open)...]
+    let digits = elapsed.prefix(while: \.isNumber)
+    guard !digits.isEmpty, let unit = elapsed.dropFirst(digits.count).first else { return false }
+    return unit == "s" || unit == "m" || unit == "h"
   }
 }
 

--- a/supacodeTests/ScreenHeuristicsTests.swift
+++ b/supacodeTests/ScreenHeuristicsTests.swift
@@ -342,6 +342,58 @@ struct ScreenHeuristicsTests {
     )
   }
 
+  /// Live captures. The word after the glyph is randomized between renders, so the
+  /// elapsed counter following it is the part that marks a turn as still in flight.
+  @Test func statusLineWithElapsedCounterIsWorking() {
+    let lines = [
+      "● Forging… (10s · thinking with high effort)",
+      "● Forming… (8s · ↓ 330 tokens · thinking with high effort)",
+      "● Grooving… (2s · thinking with high effort)",
+    ]
+    for line in lines {
+      #expect(
+        DetectedAgent.claude.detectState(
+          in: """
+            \(line)
+            ─────────
+            ❯
+            ─────────
+            """
+        ) == .working
+      )
+    }
+  }
+
+  /// Message bullets share the leading glyph and routinely end a clause with an
+  /// ellipsis, so the counter is the only thing separating a finished turn from a
+  /// running one. Without it these must stay idle.
+  @Test func bulletedMessageWithoutElapsedCounterIsIdle() {
+    let lines = [
+      "● I checked the file… it looks fine to me",
+      "● Done… (see above)",
+    ]
+    for line in lines {
+      #expect(
+        DetectedAgent.claude.detectState(
+          in: """
+            \(line)
+            ─────────
+            ❯
+            ─────────
+            """
+        ) == .idle
+      )
+    }
+  }
+
+  /// The existing header check matches the literal verb `Working`, so a reworded
+  /// status line only registers through the shared elapsed-counter shape.
+  @Test func codexStatusLineWithRewordedVerbIsWorking() {
+    #expect(DetectedAgent.codex.detectState(in: "• Exploring… (12s · 4 tool calls)") == .working)
+    #expect(DetectedAgent.codex.detectState(in: "• Reticulating (3m · 12 files)") == .working)
+    #expect(DetectedAgent.codex.detectState(in: "• Ready for your input") == .idle)
+  }
+
   @Test func codexDetection() {
     #expect(DetectedAgent.codex.detectState(in: "press enter to confirm or esc to cancel") == .blocked)
     #expect(DetectedAgent.codex.detectState(in: "• Working (12s)\nesc to interrupt") == .working)


### PR DESCRIPTION
A running agent currently shows as idle in Active Agents, because 2 of the 3 signals that marked a turn as in flight have gone stale. The interrupt hint the detector matches is no longer printed, and the glyph set behind `hasSpinnerActivity` carries U+25C9, U+25CE and U+25CD but not U+25CF, the filled circle the status line actually uses.

This matches the structure of the line rather than its vocabulary. A status line is a glyph, a single word, then a parenthetical whose first field is an elapsed time, as in `● Forging… (10s · thinking with high effort)`. The word is randomized between renders, so no fixed list can track it. The 3 captures in the test came from 3 consecutive runs and read `Forging`, `Forming` and `Grooving`. The counter is the part that carries meaning, since it is rendered only while a turn is in flight.

The counter is also what keeps the check honest. Message bullets share the leading glyph and routinely end a clause with an ellipsis, so matching on a glyph and an ellipsis alone would report a finished turn as a running one. There is a test for that case, and it fails if the counter requirement is dropped.

`hasSpinnerActivity` is also called from `hasGrokWorkingSignal`, so adding U+25CF to that shared set would have changed Grok detection as a side effect. The new predicate is separate for that reason, and nothing that passes today stops passing.

The same shape covers Codex, whose current check matches the literal verb in `• Working (`. Routing the Codex path through the shared predicate is additive, so the existing header and interrupt matches still stand while a reworded verb also registers. One caveat worth your judgment: I did not capture live Codex chrome for this, so the reworded-verb cases in that test are constructed rather than observed. If you know the current wording I am happy to replace them with a real capture, or to drop the Codex half into its own change.

Color would be a more durable signal still, since this styling has held for a year, and it was my first choice. It is not reachable from here. `ghostty_text_s` returns text, byte offsets and pixel coordinates, and the C API exposes no per-cell foreground read, so keying on it would mean adding a cell-style API in Zig and rebuilding the framework. The glyph and the counter carry the same information in characters the existing API already hands us.

This restores the working state only. Blocked still comes from `hasClaudeBlockedPrompt` matching prompt text, which has the same brittleness one layer down.

Verified with `make check` clean, the full suite at 0 failures, and a clean build at 0 errors and 0 warnings. Both new behaviors are mutation-checked: removing the detector call fails only the status-line test, and dropping the counter requirement fails only the message-bullet test.
