### PR TITLE
Bound screen status detection to live UI regions

### DIFF
--- a/docs-ai/030-agent-status-detection/000-plan.md
+++ b/docs-ai/030-agent-status-detection/000-plan.md
@@ -116,3 +116,6 @@ the failed attempt to extend the first signal to plain commands is
 - Updated 2026-08-03: Codex and Claude screen evidence was bounded to live UI regions
   so transcript prose no longer impersonates confirmation or working chrome — see
   [004-live-region-evidence.md](004-live-region-evidence.md)
+- Updated 2026-08-04: confirmation live regions were anchored to numbered selections so
+  ordinary prompts and short completed responses cannot impersonate blocked UI — see
+  [005-confirmation-live-structure.md](005-confirmation-live-structure.md)

--- a/docs-ai/030-agent-status-detection/000-plan.md
+++ b/docs-ai/030-agent-status-detection/000-plan.md
@@ -113,3 +113,6 @@ the failed attempt to extend the first signal to plain commands is
 - Updated 2026-06-23: plain-command running-indicator fallback (#484) merged, then
   reverted; successor design tracked in issue #495 — see
   [003-plain-command-running-indicator.md](003-plain-command-running-indicator.md)
+- Updated 2026-08-03: Codex and Claude screen evidence was bounded to live UI regions
+  so transcript prose no longer impersonates confirmation or working chrome — see
+  [004-live-region-evidence.md](004-live-region-evidence.md)

--- a/docs-ai/030-agent-status-detection/004-live-region-evidence.md
+++ b/docs-ai/030-agent-status-detection/004-live-region-evidence.md
@@ -31,9 +31,9 @@ as equally live:
 3. Claude working evidence is limited to the status rows immediately above its prompt box.
    Current spinner glyphs remain supported; PR #673's `● <word>… (<elapsed> · …)` shape is
    accepted only there and only with a complete elapsed token.
-4. Codex confirmation evidence comes from strong current-interaction footer text or an
-   explicit Yes/No choice structure. The generic `hasConfirmationPrompt` transcript search
-   is no longer used for Codex.
+4. Codex confirmation evidence comes from strong footer text after a recognized prompt line
+   or an explicit Yes/No choice structure around that prompt. If the prompt boundary is absent,
+   confirmation vocabulary fails closed instead of falling back to a transcript-wide search.
 5. Codex screen fallback accepts only the current `•`/`◦ Working (... esc to interrupt)`
    footer in the bottom three non-empty lines. Arbitrary reworded elapsed bullets are not a
    Codex signal.

--- a/docs-ai/030-agent-status-detection/004-live-region-evidence.md
+++ b/docs-ai/030-agent-status-detection/004-live-region-evidence.md
@@ -1,0 +1,63 @@
+# 030.004 — Live-region evidence for Codex and Claude
+
+## Context
+
+PR #673 proposed recognizing a generic `glyph + word + elapsed counter` line anywhere in
+the recent screen. Live testing on 2026-08-03 found a more fundamental issue: Prowl treated
+ordinary retained transcript text as current UI state.
+
+- Codex CLI 0.146.0 rendered `• Working (Ns • esc to interrupt)` while active. After an
+  answer or user prompt mentioned `do you want` and later `yes`, the idle pane was reported
+  as blocked. The same weak confirmation match also outranked a real working footer.
+- Claude Code 2.1.220 rendered animated glyph status rows such as
+  `✶ Philosophising… (6s · thinking with xhigh effort)`. An idle answer that quoted
+  `esc to interrupt` remained classified as working because the detector searched all
+  response prose above the prompt box.
+- Real Codex and Claude permission prompts carried structured, current-interaction chrome:
+  numbered choices plus an explicit confirmation/cancel footer. Both were cancelled during
+  the reproduction; neither temporary probe file was created.
+
+The screen-scan memoization introduced later was not causal. Its cache key includes the
+detected agent and full active-screen text, so changed terminal content is reclassified.
+
+## Change
+
+Screen evidence is now selected and ranked per agent instead of treating every recent line
+as equally live:
+
+1. Claude viewer/overlay detection remains the strongest no-signal state.
+2. Structured confirmation UI in the current interaction region remains blocked and
+   outranks working evidence.
+3. Claude working evidence is limited to the status rows immediately above its prompt box.
+   Current spinner glyphs remain supported; PR #673's `● <word>… (<elapsed> · …)` shape is
+   accepted only there and only with a complete elapsed token.
+4. Codex confirmation evidence comes from strong current-interaction footer text or an
+   explicit Yes/No choice structure. The generic `hasConfirmationPrompt` transcript search
+   is no longer used for Codex.
+5. Codex screen fallback accepts only the current `•`/`◦ Working (... esc to interrupt)`
+   footer in the bottom three non-empty lines. Arbitrary reworded elapsed bullets are not a
+   Codex signal.
+
+Pure fixtures in `supacodeTests/ScreenHeuristicsTests.swift` cover live working rows, idle
+prose quoting detector vocabulary, real permission dialogs, blocker/working conflicts,
+strict elapsed-token boundaries, and status-shaped transcript text outside the live region.
+Current behavior is documented in `docs/components/agent-detection.md`.
+
+## Decisions and follow-ups
+
+- A full declarative rule engine was not needed for this repair. Small agent-specific region
+  helpers preserve the existing pure `String -> AgentRawState` API and minimize blast radius.
+- Prowl already receives OSC titles in `GhosttySurfaceState.title`, and the current hierarchy gives
+  title evidence higher priority than screen fallbacks. Passing that signal through detector
+  input and cache identity remains a separate enhancement because it changes more than the
+  screen classifier.
+- Screen-only evidence cannot prove liveness when transcript prose exactly reproduces live
+  chrome in the same terminal position. The repair deliberately narrows that residual
+  ambiguity instead of claiming authoritative state.
+
+## Refs
+
+- PR #673 (reviewed source proposal; not merged unchanged)
+- `supacode/Infrastructure/AgentDetection/ScreenHeuristics.swift`
+- `supacodeTests/ScreenHeuristicsTests.swift`
+- `docs/components/agent-detection.md`

--- a/docs-ai/030-agent-status-detection/004-live-region-evidence.md
+++ b/docs-ai/030-agent-status-detection/004-live-region-evidence.md
@@ -26,22 +26,24 @@ Screen evidence is now selected and ranked per agent instead of treating every r
 as equally live:
 
 1. Claude viewer/overlay detection remains the strongest no-signal state.
-2. Structured confirmation UI in the current interaction region remains blocked and
-   outranks working evidence.
+2. Structured confirmation UI remains blocked and outranks working evidence. For Claude,
+   only a current numbered selection row opens the surrounding confirmation region; a bare
+   input prompt severs the completed transcript above it.
 3. Claude working evidence is limited to the status rows immediately above its prompt box.
    Current spinner glyphs remain supported; PR #673's `● <word>… (<elapsed> · …)` shape is
    accepted only there and only with a complete elapsed token.
-4. Codex confirmation evidence comes from strong footer text after a recognized prompt line
-   or an explicit Yes/No choice structure around that prompt. If the prompt boundary is absent,
-   confirmation vocabulary fails closed instead of falling back to a transcript-wide search.
+4. Codex confirmation evidence comes from strong footer text after a numbered selected row,
+   while that footer is still in the bottom live region, or from an explicit Yes/No choice
+   structure around the selected row. Ordinary user prompts are not confirmation boundaries.
 5. Codex screen fallback accepts only the current `•`/`◦ Working (... esc to interrupt)`
    footer in the bottom three non-empty lines. Arbitrary reworded elapsed bullets are not a
    Codex signal.
 
 Pure fixtures in `supacodeTests/ScreenHeuristicsTests.swift` cover live working rows, idle
-prose quoting detector vocabulary, real permission dialogs, blocker/working conflicts,
-strict elapsed-token boundaries, and status-shaped transcript text outside the live region.
-Current behavior is documented in `docs/components/agent-detection.md`.
+prose quoting detector vocabulary, refresh gaps before the next prompt appears, real
+permission dialogs, blocker/working conflicts, strict elapsed-token boundaries, and
+status-shaped transcript text outside the live region. Current behavior is documented in
+`docs/components/agent-detection.md`.
 
 ## Decisions and follow-ups
 

--- a/docs-ai/030-agent-status-detection/005-confirmation-live-structure.md
+++ b/docs-ai/030-agent-status-detection/005-confirmation-live-structure.md
@@ -1,0 +1,38 @@
+# 030.005 — Structured confirmation live regions
+
+## Context
+
+Review probes on PR #674 found that confirmation evidence was still wider than the live
+UI it represented:
+
+- Codex treated the last ordinary `›` prompt as a confirmation boundary. Confirmation
+  vocabulary in that user input, or in a completed response before the next prompt was
+  painted, therefore reported blocked and could outrank a real working footer.
+- Claude looked ten lines above a bare idle `❯` prompt. A short completed response that
+  mentioned a confirmation question therefore remained blocked after the input box returned.
+
+Both transitions are observable between 300 ms screen polls, so waiting for the next paint
+does not make the false state harmless.
+
+## Change
+
+- Codex strong confirmation footers now require a current numbered selected row and must
+  remain in the bottom live footer region. Explicit Yes/No choice structure remains a
+  separate positive signal.
+- Claude only opens its surrounding confirmation region when the current `❯` row is a
+  numbered selection. A bare or ordinary input prompt cuts off preceding transcript prose.
+- Regression fixtures cover confirmation vocabulary in a Codex user prompt, in a completed
+  Codex response before the next prompt paint, and in a short Claude response above an idle
+  prompt. Existing real confirmation fixtures remain positive controls.
+
+The implementation remains private pure `String -> AgentRawState` classification in
+`supacode/Infrastructure/AgentDetection/ScreenHeuristics.swift`; polling, caching, and state
+stabilization are unchanged. Current behavior is described in
+`docs/components/agent-detection.md`.
+
+## Refs
+
+- PR #674
+- `supacode/Infrastructure/AgentDetection/ScreenHeuristics.swift`
+- `supacodeTests/ScreenHeuristicsTests.swift`
+- `docs/components/agent-detection.md`

--- a/docs/components/agent-detection.md
+++ b/docs/components/agent-detection.md
@@ -36,10 +36,12 @@ at a `~/.grok/` install (so Cursor's own `agent` entrypoint stays Cursor).
    agent-specific live UI regions rather than treating every transcript line as current
    state. Structured confirmation/permission chrome is **Blocked**; status rows and
    spinners are **Working**. Claude working rows are scoped to the lines immediately above
-   its prompt box. Codex uses an exact bottom-of-screen `•`/`◦ Working (... esc to
-   interrupt)` footer fallback, while its confirmation detector requires a recognized prompt
-   line followed by strong footer text or explicit Yes/No choice structure. Without that prompt
-   boundary, confirmation-like text is treated as transcript prose rather than current state.
+   its prompt box, while confirmation text is consulted only around a current numbered
+   selection row such as `❯ 1. Yes`; a bare input prompt cuts off the preceding transcript.
+   Codex uses an exact bottom-of-screen `•`/`◦ Working (... esc to interrupt)` footer
+   fallback. Its confirmation detector requires a numbered selected row such as `› 1. Yes`
+   paired with a live bottom footer or an explicit Yes/No choice structure. Ordinary prompt
+   text and completed responses are not confirmation boundaries.
    Other agent families keep their own patterns (including Oh My Pi's
    `Working… ⟦esc⟧` loader, braille frames, symbol cycles, Cursor's
    hexagons, Kimi's moon phases, etc.).

--- a/docs/components/agent-detection.md
+++ b/docs/components/agent-detection.md
@@ -32,12 +32,16 @@ at a `~/.grok/` install (so Cursor's own `agent` entrypoint stays Cursor).
 1. **Process probe.** Prowl reads the pane's foreground process group and matches
    process names / argv against known agent executables, scoring argv[0] highest,
    then process name, then command-line tokens.
-2. **Screen heuristics.** It scans the last ~24 non-blank lines of the pane for
-   agent-specific UI cues — e.g. "Esc to interrupt", Oh My Pi's
-   `Working… ⟦esc⟧` loader or braille spinner status line (working), its
-   interactive `Ask` choice prompt (blocked), confirmation/permission prompts
-   (blocked), idle prompts. Each agent family has its own patterns (including spinner
-   glyphs: braille frames, symbol cycles, Cursor's hexagons, Kimi's moon phases, etc.).
+2. **Screen heuristics.** It starts from the last ~24 non-blank lines, then selects
+   agent-specific live UI regions rather than treating every transcript line as current
+   state. Structured confirmation/permission chrome is **Blocked**; status rows and
+   spinners are **Working**. Claude working rows are scoped to the lines immediately above
+   its prompt box. Codex uses an exact bottom-of-screen `•`/`◦ Working (... esc to
+   interrupt)` footer fallback, while its confirmation detector requires current strong
+   footer text or explicit Yes/No choice structure. Ordinary response prose that merely
+   quotes those phrases is not state evidence. Other agent families keep their own patterns
+   (including Oh My Pi's `Working… ⟦esc⟧` loader, braille frames, symbol cycles, Cursor's
+   hexagons, Kimi's moon phases, etc.).
    For Claude, a running **background workflow** keeps a status line *below* the
    input box (e.g. `3/5 agents done · 7m 29s · ↓ 288.5k tokens`) after the turn has
    ended; Prowl reads that footer as **Working**, so a churning workflow isn't

--- a/docs/components/agent-detection.md
+++ b/docs/components/agent-detection.md
@@ -37,10 +37,11 @@ at a `~/.grok/` install (so Cursor's own `agent` entrypoint stays Cursor).
    state. Structured confirmation/permission chrome is **Blocked**; status rows and
    spinners are **Working**. Claude working rows are scoped to the lines immediately above
    its prompt box. Codex uses an exact bottom-of-screen `•`/`◦ Working (... esc to
-   interrupt)` footer fallback, while its confirmation detector requires current strong
-   footer text or explicit Yes/No choice structure. Ordinary response prose that merely
-   quotes those phrases is not state evidence. Other agent families keep their own patterns
-   (including Oh My Pi's `Working… ⟦esc⟧` loader, braille frames, symbol cycles, Cursor's
+   interrupt)` footer fallback, while its confirmation detector requires a recognized prompt
+   line followed by strong footer text or explicit Yes/No choice structure. Without that prompt
+   boundary, confirmation-like text is treated as transcript prose rather than current state.
+   Other agent families keep their own patterns (including Oh My Pi's
+   `Working… ⟦esc⟧` loader, braille frames, symbol cycles, Cursor's
    hexagons, Kimi's moon phases, etc.).
    For Claude, a running **background workflow** keeps a status line *below* the
    input box (e.g. `3/5 agents done · 7m 29s · ↓ 288.5k tokens`) after the turn has

--- a/supacode/Infrastructure/AgentDetection/ScreenHeuristics.swift
+++ b/supacode/Infrastructure/AgentDetection/ScreenHeuristics.swift
@@ -118,12 +118,8 @@ nonisolated private func detectClaude(_ content: String) -> AgentRawState {
     return .blocked
   }
 
-  let above = contentAbovePromptBox(content)
-  let aboveLower = above.lowercased()
-  if aboveLower.contains("esc to interrupt") || aboveLower.contains("ctrl+c to interrupt") {
-    return .working
-  }
-  if hasSpinnerActivity(above) {
+  let liveStatus = recentLines(contentAbovePromptBox(content), limit: 3)
+  if hasSpinnerActivity(liveStatus) || hasClaudeElapsedStatusLine(liveStatus) {
     return .working
   }
   if hasClaudeBackgroundWork(content) {
@@ -133,17 +129,10 @@ nonisolated private func detectClaude(_ content: String) -> AgentRawState {
 }
 
 nonisolated private func detectCodex(_ content: String) -> AgentRawState {
-  let lower = content.lowercased()
-  if lower.contains("press enter to confirm or esc to cancel")
-    || lower.contains("enter to submit answer")
-    || lower.contains("allow command?")
-    || lower.contains("[y/n]")
-    || lower.contains("yes (y)")
-    || hasConfirmationPrompt(lower)
-  {
+  if hasCodexBlockedPrompt(content) {
     return .blocked
   }
-  if hasInterruptPattern(lower) || hasCodexWorkingHeader(content) {
+  if hasCodexWorkingFooter(content) {
     return .working
   }
   return .idle
@@ -357,6 +346,75 @@ nonisolated private func claudeCurrentInteractionRegion(_ content: String) -> St
   return lines[lowerBound..<lines.endIndex].joined(separator: "\n")
 }
 
+nonisolated private func codexCurrentInteractionRegion(_ content: String) -> String {
+  let lines = content.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+  guard let promptIndex = lines.lastIndex(where: isCodexPromptLine) else {
+    return content
+  }
+  return lines[promptIndex..<lines.endIndex].joined(separator: "\n")
+}
+
+nonisolated private func isCodexPromptLine(_ line: String) -> Bool {
+  let trimmed = line.trimmingCharacters(in: .whitespaces)
+  guard trimmed.first == "›" else { return false }
+  let remainder = trimmed.dropFirst()
+  return remainder.isEmpty || remainder.first?.isWhitespace == true
+}
+
+nonisolated private func hasCodexBlockedPrompt(_ content: String) -> Bool {
+  let currentLower = codexCurrentInteractionRegion(content).lowercased()
+  if currentLower.contains("press enter to confirm or esc to cancel")
+    || currentLower.contains("enter to submit answer")
+    || currentLower.contains("allow command?")
+    || currentLower.contains("[y/n]")
+    || currentLower.contains("yes (y)")
+  {
+    return true
+  }
+  return hasCodexConfirmationChoices(content)
+}
+
+nonisolated private func hasCodexConfirmationChoices(_ content: String) -> Bool {
+  let lines = content.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+  guard let promptIndex = lines.lastIndex(where: isCodexPromptLine) else {
+    return false
+  }
+  let selectedChoice = normalizedCodexChoice(lines[promptIndex])
+  guard isNumberedCodexChoice(selectedChoice) else { return false }
+
+  let lowerBound = max(lines.startIndex, promptIndex - 6)
+  let interactionLines = lines[lowerBound..<lines.endIndex]
+  let lower = interactionLines.joined(separator: "\n").lowercased()
+  guard lower.contains("do you want") || lower.contains("would you like") else {
+    return false
+  }
+
+  let options = interactionLines.map(normalizedCodexChoice)
+  let hasYes = options.contains { option in
+    option == "yes" || option.hasPrefix("1. yes") || option.hasPrefix("2. yes")
+  }
+  let hasNo = options.contains { option in
+    option == "no" || option.hasPrefix("2. no") || option.hasPrefix("3. no")
+  }
+  return hasYes && hasNo
+}
+
+nonisolated private func normalizedCodexChoice(_ line: String) -> String {
+  let trimmed = line.trimmingCharacters(in: .whitespaces).lowercased()
+  let withoutSelection = trimmed.hasPrefix("›") ? trimmed.dropFirst() : trimmed[...]
+  return withoutSelection.trimmingCharacters(in: .whitespaces)
+}
+
+nonisolated private func isNumberedCodexChoice(_ option: String) -> Bool {
+  guard let firstToken = option.split(whereSeparator: { $0.isWhitespace }).first,
+    firstToken.last == "."
+  else {
+    return false
+  }
+  let number = firstToken.dropLast()
+  return !number.isEmpty && number.allSatisfy(\.isNumber)
+}
+
 nonisolated private func hasClaudeBlockedPrompt(content: String, lower: String) -> Bool {
   if lower.contains("do you want to proceed?")
     || lower.contains("would you like to proceed?")
@@ -471,9 +529,15 @@ nonisolated private func hasInterruptPattern(_ lower: String) -> Bool {
     || (lower.contains("esc") && lower.contains("interrupt"))
 }
 
-nonisolated private func hasCodexWorkingHeader(_ content: String) -> Bool {
-  content.split(separator: "\n").contains { line in
-    line.trimmingCharacters(in: .whitespaces).hasPrefix("• Working (")
+nonisolated private func hasCodexWorkingFooter(_ content: String) -> Bool {
+  recentLines(content, limit: 3).split(separator: "\n").contains { line in
+    let trimmed = line.trimmingCharacters(in: .whitespaces)
+    guard trimmed.first == "•" || trimmed.first == "◦" else { return false }
+    let body = trimmed.dropFirst()
+    guard body.hasPrefix(" Working (") else { return false }
+    guard let hint = body.range(of: "esc to interrupt)") else { return false }
+    let trailing = body[hint.upperBound...]
+    return trailing.isEmpty || trailing.hasPrefix(" · ")
   }
 }
 
@@ -491,6 +555,30 @@ nonisolated private func hasSpinnerActivity(_ content: String) -> Bool {
       && rest.hasPrefix(" ")
       && rest.contains("…")
       && rest.contains(where: \.isLetter)
+  }
+}
+
+nonisolated private func hasClaudeElapsedStatusLine(_ content: String) -> Bool {
+  content.split(separator: "\n").contains { line in
+    let trimmed = line.trimmingCharacters(in: .whitespaces)
+    guard trimmed.first == "●" else { return false }
+    let body = trimmed.dropFirst().trimmingCharacters(in: .whitespaces)
+    guard let open = body.firstIndex(of: "(") else { return false }
+
+    let label = body[..<open].trimmingCharacters(in: .whitespaces)
+    guard label.hasSuffix("…"), label.split(whereSeparator: { $0.isWhitespace }).count == 1 else {
+      return false
+    }
+
+    let elapsed = body[body.index(after: open)...]
+    let digits = elapsed.prefix(while: \.isNumber)
+    guard !digits.isEmpty else { return false }
+    let afterDigits = elapsed.dropFirst(digits.count)
+    guard let unit = afterDigits.first, unit == "s" || unit == "m" || unit == "h" else {
+      return false
+    }
+    let trailing = afterDigits.dropFirst()
+    return trailing.hasPrefix(")") || trailing.hasPrefix(" · ")
   }
 }
 

--- a/supacode/Infrastructure/AgentDetection/ScreenHeuristics.swift
+++ b/supacode/Infrastructure/AgentDetection/ScreenHeuristics.swift
@@ -341,17 +341,19 @@ nonisolated private func claudeCurrentInteractionRegion(_ content: String) -> St
   guard let promptIndex = lines.lastIndex(where: { $0.contains("❯") }) else {
     return lines.suffix(18).joined(separator: "\n")
   }
+  guard isClaudeNumberedSelectionLine(lines[promptIndex]) else {
+    return ""
+  }
 
   let lowerBound = max(lines.startIndex, promptIndex - 10)
   return lines[lowerBound..<lines.endIndex].joined(separator: "\n")
 }
 
-nonisolated private func codexCurrentInteractionRegion(_ content: String) -> String {
-  let lines = content.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
-  guard let promptIndex = lines.lastIndex(where: isCodexPromptLine) else {
-    return ""
-  }
-  return lines[promptIndex..<lines.endIndex].joined(separator: "\n")
+nonisolated private func isClaudeNumberedSelectionLine(_ line: String) -> Bool {
+  let trimmed = line.trimmingCharacters(in: .whitespaces)
+  guard trimmed.first == "❯" else { return false }
+  let option = trimmed.dropFirst().trimmingCharacters(in: .whitespaces)
+  return isNumberedChoice(option)
 }
 
 nonisolated private func isCodexPromptLine(_ line: String) -> Bool {
@@ -362,16 +364,25 @@ nonisolated private func isCodexPromptLine(_ line: String) -> Bool {
 }
 
 nonisolated private func hasCodexBlockedPrompt(_ content: String) -> Bool {
-  let currentLower = codexCurrentInteractionRegion(content).lowercased()
-  if currentLower.contains("press enter to confirm or esc to cancel")
-    || currentLower.contains("enter to submit answer")
-    || currentLower.contains("allow command?")
-    || currentLower.contains("[y/n]")
-    || currentLower.contains("yes (y)")
-  {
-    return true
+  hasCodexConfirmationFooter(content) || hasCodexConfirmationChoices(content)
+}
+
+nonisolated private func hasCodexConfirmationFooter(_ content: String) -> Bool {
+  let lines = content.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+  guard let promptIndex = lines.lastIndex(where: isCodexPromptLine) else {
+    return false
   }
-  return hasCodexConfirmationChoices(content)
+  let selectedChoice = normalizedCodexChoice(lines[promptIndex])
+  guard isNumberedChoice(selectedChoice) else { return false }
+
+  let footerStart = lines.index(after: promptIndex)
+  guard footerStart < lines.endIndex else { return false }
+  let footerLower = recentLines(lines[footerStart...].joined(separator: "\n"), limit: 3).lowercased()
+  return footerLower.contains("press enter to confirm or esc to cancel")
+    || footerLower.contains("enter to submit answer")
+    || footerLower.contains("allow command?")
+    || footerLower.contains("[y/n]")
+    || footerLower.contains("yes (y)")
 }
 
 nonisolated private func hasCodexConfirmationChoices(_ content: String) -> Bool {
@@ -380,7 +391,7 @@ nonisolated private func hasCodexConfirmationChoices(_ content: String) -> Bool 
     return false
   }
   let selectedChoice = normalizedCodexChoice(lines[promptIndex])
-  guard isNumberedCodexChoice(selectedChoice) else { return false }
+  guard isNumberedChoice(selectedChoice) else { return false }
 
   let lowerBound = max(lines.startIndex, promptIndex - 6)
   let interactionLines = lines[lowerBound..<lines.endIndex]
@@ -405,7 +416,7 @@ nonisolated private func normalizedCodexChoice(_ line: String) -> String {
   return withoutSelection.trimmingCharacters(in: .whitespaces)
 }
 
-nonisolated private func isNumberedCodexChoice(_ option: String) -> Bool {
+nonisolated private func isNumberedChoice(_ option: String) -> Bool {
   guard let firstToken = option.split(whereSeparator: { $0.isWhitespace }).first,
     firstToken.last == "."
   else {
@@ -433,12 +444,7 @@ nonisolated private func hasClaudeBlockedPrompt(content: String, lower: String) 
 }
 
 nonisolated private func hasClaudeSelectionPrompt(_ content: String) -> Bool {
-  content.split(separator: "\n").contains { line in
-    let trimmed = line.trimmingCharacters(in: .whitespaces)
-    return trimmed.hasPrefix("❯")
-      && trimmed.contains(".")
-      && trimmed.contains(where: \.isNumber)
-  }
+  content.split(separator: "\n").contains { isClaudeNumberedSelectionLine(String($0)) }
 }
 
 nonisolated private func hasClaudeYesNoChoice(_ content: String) -> Bool {

--- a/supacode/Infrastructure/AgentDetection/ScreenHeuristics.swift
+++ b/supacode/Infrastructure/AgentDetection/ScreenHeuristics.swift
@@ -349,7 +349,7 @@ nonisolated private func claudeCurrentInteractionRegion(_ content: String) -> St
 nonisolated private func codexCurrentInteractionRegion(_ content: String) -> String {
   let lines = content.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
   guard let promptIndex = lines.lastIndex(where: isCodexPromptLine) else {
-    return content
+    return ""
   }
   return lines[promptIndex..<lines.endIndex].joined(separator: "\n")
 }

--- a/supacodeTests/ScreenHeuristicsTests.swift
+++ b/supacodeTests/ScreenHeuristicsTests.swift
@@ -422,7 +422,14 @@ struct ScreenHeuristicsTests {
   }
 
   @Test func codexDetection() {
-    #expect(DetectedAgent.codex.detectState(in: "press enter to confirm or esc to cancel") == .blocked)
+    #expect(
+      DetectedAgent.codex.detectState(
+        in: """
+          › 1. Yes, proceed (y)
+          Press enter to confirm or esc to cancel
+          """
+      ) == .blocked
+    )
     #expect(DetectedAgent.codex.detectState(in: "• Working (12s • esc to interrupt)") == .working)
     #expect(DetectedAgent.codex.detectState(in: "Ready for input") == .idle)
   }
@@ -458,6 +465,17 @@ struct ScreenHeuristicsTests {
             2. No
           › Run /review on my current changes
           gpt-5.6-terra xhigh · Context 5% used
+          """
+      ) == .idle
+    )
+  }
+
+  @Test func codexConfirmationVocabularyWithoutPromptIsIdle() {
+    #expect(
+      DetectedAgent.codex.detectState(
+        in: """
+          • The previous prompt said: press enter to confirm or esc to cancel.
+            It also mentioned allow command? and [y/n].
           """
       ) == .idle
     )

--- a/supacodeTests/ScreenHeuristicsTests.swift
+++ b/supacodeTests/ScreenHeuristicsTests.swift
@@ -157,6 +157,28 @@ struct ScreenHeuristicsTests {
     )
   }
 
+  @Test func claudeShortCompletedResponseQuestionBeforeIdlePromptIsIdle() {
+    #expect(
+      DetectedAgent.claude.detectState(
+        in: """
+          ⏺ The completed response explains: Do you want to proceed?
+          ─────────
+          ❯
+          ─────────
+          ? for shortcuts
+          """
+      ) == .idle
+    )
+    #expect(
+      DetectedAgent.claude.detectState(
+        in: """
+          ❯ Quote the phrase Do you want to proceed?
+          ─────────
+          """
+      ) == .idle
+    )
+  }
+
   @Test func claudeIgnoresStalePermissionPromptOutsideRecentTail() {
     #expect(
       DetectedAgent.claude.detectState(
@@ -476,6 +498,49 @@ struct ScreenHeuristicsTests {
         in: """
           • The previous prompt said: press enter to confirm or esc to cancel.
             It also mentioned allow command? and [y/n].
+          """
+      ) == .idle
+    )
+  }
+
+  @Test func codexUserPromptConfirmationVocabularyIsIdle() {
+    #expect(
+      DetectedAgent.codex.detectState(
+        in: """
+          › Explain why the UI says press enter to confirm or esc to cancel.
+          gpt-5.6-terra xhigh · Context 5% used
+          """
+      ) == .idle
+    )
+    #expect(
+      DetectedAgent.codex.detectState(
+        in: """
+          Press enter to confirm or esc to cancel
+          › 1. Explain this footer ordering.
+          """
+      ) == .idle
+    )
+  }
+
+  @Test func codexCompletedResponseConfirmationVocabularyBeforeNextPromptIsIdle() {
+    let completedResponse = """
+      › Describe the confirmation footer.
+      • The footer says: Press enter to confirm or esc to cancel.
+      """
+    #expect(DetectedAgent.codex.detectState(in: completedResponse) == .idle)
+    #expect(
+      DetectedAgent.codex.detectState(
+        in: """
+          \(completedResponse)
+          • Working (2s • esc to interrupt)
+          """
+      ) == .working
+    )
+    #expect(
+      DetectedAgent.codex.detectState(
+        in: """
+          \(completedResponse)
+          ›
           """
       ) == .idle
     )

--- a/supacodeTests/ScreenHeuristicsTests.swift
+++ b/supacodeTests/ScreenHeuristicsTests.swift
@@ -300,6 +300,85 @@ struct ScreenHeuristicsTests {
     )
   }
 
+  @Test func claudeCurrentStatusRowsAreWorking() {
+    let statusRows = [
+      "· Vibing…",
+      "✻ Vibing…",
+      "✽ Tinkering… (4s · ↓ 157 tokens · thought for 1s)",
+      "✶ Philosophising… (6s · thinking with xhigh effort)",
+    ]
+    for statusRow in statusRows {
+      #expect(
+        DetectedAgent.claude.detectState(
+          in: """
+            \(statusRow)
+            ─────────
+            ❯
+            ─────────
+            """
+        ) == .working
+      )
+    }
+  }
+
+  @Test func claudeQuotedInterruptHintInIdleResponseIsIdle() {
+    #expect(
+      DetectedAgent.claude.detectState(
+        in: """
+          ⏺ The live status row includes the phrase "esc to interrupt".
+          ─────────
+          ❯
+          ─────────
+          [Fable 5 | Max] Prowl git:(main)
+          """
+      ) == .idle
+    )
+  }
+
+  @Test func claudeElapsedStatusLineIsScopedAndRequiresACompleteToken() {
+    #expect(
+      DetectedAgent.claude.detectState(
+        in: """
+          ● Forging… (10s · thinking with high effort)
+          ─────────
+          ❯
+          ─────────
+          """
+      ) == .working
+    )
+
+    let invalidRows = [
+      "● Retry… (1st attempt)",
+      "● Retry… (10seconds)",
+    ]
+    for statusRow in invalidRows {
+      #expect(
+        DetectedAgent.claude.detectState(
+          in: """
+            \(statusRow)
+            ─────────
+            ❯
+            ─────────
+            """
+        ) == .idle
+      )
+    }
+
+    #expect(
+      DetectedAgent.claude.detectState(
+        in: """
+          ● Retrying… (10s · thinking with high effort)
+          Completed line 1
+          Completed line 2
+          Completed line 3
+          ─────────
+          ❯
+          ─────────
+          """
+      ) == .idle
+    )
+  }
+
   @Test func claudeDetectsRunningWorkflowFooterBelowPrompt() {
     // A running background workflow: the turn has ended (no spinner / "esc to
     // interrupt" above the prompt), but Claude keeps a status line BELOW the
@@ -344,8 +423,82 @@ struct ScreenHeuristicsTests {
 
   @Test func codexDetection() {
     #expect(DetectedAgent.codex.detectState(in: "press enter to confirm or esc to cancel") == .blocked)
-    #expect(DetectedAgent.codex.detectState(in: "• Working (12s)\nesc to interrupt") == .working)
+    #expect(DetectedAgent.codex.detectState(in: "• Working (12s • esc to interrupt)") == .working)
     #expect(DetectedAgent.codex.detectState(in: "Ready for input") == .idle)
+  }
+
+  @Test func codexTranscriptConfirmationVocabularyDoesNotOverrideLiveState() {
+    #expect(
+      DetectedAgent.codex.detectState(
+        in: """
+          › Reply with two lines containing do you want and yes.
+          • Working (2s • esc to interrupt)
+          › Improve documentation in @filename
+          gpt-5.6-terra xhigh · Context 5% used
+          """
+      ) == .working
+    )
+    #expect(
+      DetectedAgent.codex.detectState(
+        in: """
+          › Reply with two lines containing do you want and yes.
+          • The parser looks for do you want.
+            The parser later accepts yes.
+          › Improve documentation in @filename
+          gpt-5.6-terra xhigh · Context 5% used
+          """
+      ) == .idle
+    )
+    #expect(
+      DetectedAgent.codex.detectState(
+        in: """
+          › Explain a confirmation dialog without opening one.
+          • A dialog might say: Would you like to run the command?
+            1. Yes
+            2. No
+          › Run /review on my current changes
+          gpt-5.6-terra xhigh · Context 5% used
+          """
+      ) == .idle
+    )
+  }
+
+  @Test func codexCurrentConfirmationOutranksRetainedWorkingFooter() {
+    #expect(
+      DetectedAgent.codex.detectState(
+        in: """
+          • Working (4s • esc to interrupt)
+          Would you like to run the following command?
+          › 1. Yes, proceed (y)
+            2. No, and tell Codex what to do differently (esc)
+          Press enter to confirm or esc to cancel
+          """
+      ) == .blocked
+    )
+  }
+
+  @Test func codexWorkingFooterMustBeInTheLiveBottomRegion() {
+    #expect(
+      DetectedAgent.codex.detectState(
+        in: """
+          • Working (4s • esc to interrupt)
+          • Completed line 1
+            Completed line 2
+            Completed line 3
+          › Improve documentation in @filename
+          gpt-5.6-terra xhigh · Context 5% used
+          """
+      ) == .idle
+    )
+
+    let transcriptBullets = [
+      "• Retry (1st attempt)",
+      "• Retrying… (10seconds)",
+      "• Retrying… (10s)",
+    ]
+    for bullet in transcriptBullets {
+      #expect(DetectedAgent.codex.detectState(in: bullet) == .idle)
+    }
   }
 
   @Test func geminiDetection() {


### PR DESCRIPTION
## Summary

- scope status evidence to runtime-specific live UI regions
- keep structured confirmation chrome ahead of working fallbacks
- add regression fixtures and update detection documentation

## Root cause

The classifier treated broad recent terminal text as live UI, so historical response prose could impersonate working or confirmation state. The proposed elapsed-status fallback also lacked sufficient location and token boundaries.

## Validation

- `ScreenHeuristicsTests`: 33 passed
- `make check`
- `make build-app`
- Debug app live verification of working, idle, and blocked transitions
- sidebar and toolbar accessibility descriptions verified for idle and blocked states

Follow-up to #673.
