### PR TITLE
Stabilize async TestClock synchronization

### DIFF
--- a/supacodeTests/DebouncerTests.swift
+++ b/supacodeTests/DebouncerTests.swift
@@ -1,10 +1,12 @@
 import Clocks
+import ConcurrencyExtras
 import Foundation
 import Testing
 
 @testable import supacode
 
 @MainActor
+@Suite(.serialized)
 struct DebouncerTests {
   @Test func actionFiresAfterInterval() async {
     let clock = TestClock()
@@ -74,6 +76,7 @@ struct DebouncerTests {
 }
 
 @MainActor
+@Suite(.serialized)
 struct KeyedDebouncerTests {
   @Test func keysDebounceIndependently() async {
     let clock = TestClock()
@@ -159,17 +162,14 @@ private func advance(_ clock: TestClock<Duration>, by duration: Duration) async 
   }
 }
 
-// Yields the main actor until `condition` holds. A fixed yield count is not
-// enough for positive assertions: when parallel suites contend for the main
-// actor, a resumed debounce task can need arbitrarily many hops before it runs
-// (the `isIdleTracksThePendingWindow` CI flake). The budget only bounds a
+// Yields the executor until `condition` holds. Plain `Task.yield()` can keep
+// rescheduling the test ahead of the debouncer task under full-suite load, so
+// use detached mega-yields to break that priority tie. The bound only guards a
 // genuine regression, which then fails the following `#expect` instead of
 // hanging the test.
 @MainActor
 private func settle(until condition: () -> Bool) async {
-  var budget = 10_000
-  while budget > 0, !condition() {
-    await Task.yield()
-    budget -= 1
+  for _ in 0..<50 where !condition() {
+    await Task.megaYield()
   }
 }

--- a/supacodeTests/GhosttySurfaceBridgeTests.swift
+++ b/supacodeTests/GhosttySurfaceBridgeTests.swift
@@ -1,4 +1,5 @@
 import Clocks
+import ConcurrencyExtras
 import GhosttyKit
 import Testing
 
@@ -97,7 +98,9 @@ struct GhosttySurfaceBridgeTests {
     #expect(bridge.state.progressState == GHOSTTY_PROGRESS_STATE_INDETERMINATE)
 
     // No further reports: the driver synthesizes a REMOVE once the window lapses.
-    await advanceProgressClock(clock, by: .milliseconds(200))
+    await advanceProgressClock(clock, by: .milliseconds(200)) {
+      bridge.state.progressState == nil
+    }
     #expect(bridge.state.progressState == nil)
     #expect(lastState == GHOSTTY_PROGRESS_STATE_REMOVE)
   }
@@ -218,5 +221,18 @@ struct GhosttySurfaceBridgeTests {
     await Task.yield()
     await clock.advance(by: duration)
     await Task.yield()
+  }
+
+  private func advanceProgressClock(
+    _ clock: TestClock<Duration>,
+    by duration: Duration,
+    until condition: () -> Bool
+  ) async {
+    // A freshly spawned task can register its sleep after the first advance under load.
+    // Keep advancing until the observable effect lands; the bound guards regressions.
+    for _ in 0..<50 where !condition() {
+      await Task.megaYield()
+      await clock.advance(by: duration)
+    }
   }
 }

--- a/supacodeTests/PullRequestRefreshCoordinatorTests.swift
+++ b/supacodeTests/PullRequestRefreshCoordinatorTests.swift
@@ -125,8 +125,8 @@ struct PullRequestRefreshCoordinatorTests {
     coordinator.enqueue(request(repo: "beta"))
 
     await advanceCoordinatorClock(clock, by: .milliseconds(250))
-    await Task.yield()
-    await Task.yield()
+    await waitUntil { await probe.legacyCalls().count == 1 }
+    await waitUntil { await outcomes.refreshedRepositories().count == 2 }
 
     let legacyCalls = await probe.legacyCalls()
     #expect(legacyCalls.count == 1)
@@ -672,7 +672,7 @@ private func makeCoordinator(
 @MainActor
 private func waitUntil(
   _ condition: @MainActor @escaping () async -> Bool,
-  maxIterations: Int = 500
+  maxIterations: Int = 10_000
 ) async {
   for _ in 0..<maxIterations {
     if await condition() {


### PR DESCRIPTION
## Summary

- wait for observable per-repository fallback completion instead of relying on a fixed number of executor yields
- advance the progress stale clock until the expected removal effect lands, with a bounded regression guard
- serialize the debouncer suites and use bounded detached mega-yields for positive completion assertions
- keep the repair test-only; production behavior is unchanged

## Root cause

Under full-suite CI load, background tasks can register their `TestClock` sleeps or finish nested task-group work after a fixed yield or clock advance. Plain `Task.yield()` loops can also repeatedly reschedule the test ahead of the main-actor debouncer task; the failed rerun exhausted all 10,000 iterations after roughly 33 seconds without observing completion.

The bounded progress advancement follows the synchronization pattern validated in supabitapp/supacode#723.

## Validation

- original two failures with `-test-iterations 100`
- three debouncer rerun failures with `-test-iterations 100`
- complete affected test classes: 40 passed
- `make test`: 2253 passed, 0 failed
- `make check`
- `make build-app`

Addresses the unrelated CI failures observed across both attempts of #674.
