### PR TITLE
Fix Pi working state detection

### DIFF
--- a/docs/components/agent-detection.md
+++ b/docs/components/agent-detection.md
@@ -21,8 +21,9 @@ Kimi, Droid, Amp, Pi (`pi`), Oh My Pi (`omp`, `oh-my-pi`), Qoder CLI (`qodercli`
 Qwen Code (`qwen`), and Grok Build (`grok`).
 Detection covers
 common wrappers (node, python, bun, bash, etc.) so agents launched indirectly are
-still found. Pi and Oh My Pi are independent detected agents. Pi uses only its
-own minimal working/idle cues; Oh My Pi owns its richer spinner and interactive
+still found. Pi and Oh My Pi are independent detected agents. Pi recognizes its
+own minimal working/idle cues, including its built-in braille-prefixed `Working...`
+loader; Oh My Pi owns its richer spinner and interactive
 Ask-prompt heuristics, plus its own session layout and icon. Grok Build also
 ships an `agent` symlink; Prowl only treats that name as Grok when the path points
 at a `~/.grok/` install (so Cursor's own `agent` entrypoint stays Cursor).

--- a/supacode/Infrastructure/AgentDetection/ScreenHeuristics.swift
+++ b/supacode/Infrastructure/AgentDetection/ScreenHeuristics.swift
@@ -89,10 +89,6 @@ nonisolated private func hasOMPWorkingLine(_ content: String) -> Bool {
   }
 }
 
-nonisolated private let piSpinnerFrames: Set<UnicodeScalar> = [
-  "⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏",
-]
-
 nonisolated private let piWorkingMessages: Set<String> = ["Working...", "Working…", "Interrupting…"]
 
 nonisolated private func isPiWorkingText(_ line: String) -> Bool {
@@ -100,7 +96,9 @@ nonisolated private func isPiWorkingText(_ line: String) -> Bool {
     return true
   }
 
-  guard let spinner = line.unicodeScalars.first, piSpinnerFrames.contains(spinner) else {
+  guard let spinner = line.unicodeScalars.first,
+    (0x2800...0x28FF).contains(Int(spinner.value))
+  else {
     return false
   }
   let message = String(line.unicodeScalars.dropFirst()).trimmingCharacters(in: .whitespaces)

--- a/supacode/Infrastructure/AgentDetection/ScreenHeuristics.swift
+++ b/supacode/Infrastructure/AgentDetection/ScreenHeuristics.swift
@@ -89,8 +89,22 @@ nonisolated private func hasOMPWorkingLine(_ content: String) -> Bool {
   }
 }
 
+nonisolated private let piSpinnerFrames: Set<UnicodeScalar> = [
+  "⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏",
+]
+
+nonisolated private let piWorkingMessages: Set<String> = ["Working...", "Working…", "Interrupting…"]
+
 nonisolated private func isPiWorkingText(_ line: String) -> Bool {
-  line == "Working..." || line == "Working…" || line == "Interrupting…"
+  if piWorkingMessages.contains(line) {
+    return true
+  }
+
+  guard let spinner = line.unicodeScalars.first, piSpinnerFrames.contains(spinner) else {
+    return false
+  }
+  let message = String(line.unicodeScalars.dropFirst()).trimmingCharacters(in: .whitespaces)
+  return piWorkingMessages.contains(message)
 }
 
 nonisolated private func hasOMPInterruptHint(_ line: String) -> Bool {

--- a/supacodeTests/ScreenHeuristicsTests.swift
+++ b/supacodeTests/ScreenHeuristicsTests.swift
@@ -10,6 +10,7 @@ struct ScreenHeuristicsTests {
 
   @Test func piDetection() {
     #expect(DetectedAgent.pi.detectState(in: "Working...") == .working)
+    #expect(DetectedAgent.pi.detectState(in: "⠹ Working...") == .working)
     #expect(DetectedAgent.pi.detectState(in: "Interrupting…") == .working)
     #expect(DetectedAgent.pi.detectState(in: "Done") == .idle)
   }

--- a/supacodeTests/ScreenHeuristicsTests.swift
+++ b/supacodeTests/ScreenHeuristicsTests.swift
@@ -11,6 +11,7 @@ struct ScreenHeuristicsTests {
   @Test func piDetection() {
     #expect(DetectedAgent.pi.detectState(in: "Working...") == .working)
     #expect(DetectedAgent.pi.detectState(in: "⠹ Working...") == .working)
+    #expect(DetectedAgent.pi.detectState(in: "⣾ Working...") == .working)
     #expect(DetectedAgent.pi.detectState(in: "Interrupting…") == .working)
     #expect(DetectedAgent.pi.detectState(in: "Done") == .idle)
   }


### PR DESCRIPTION
## Summary
- Recognize Pi's built-in braille-prefixed `Working...` loader.
- Add regression coverage and document the supported cue.

## Validation
- `xcodebuild test -project supacode.xcodeproj -scheme supacode -destination 'platform=macOS' -only-testing:'supacodeTests/ScreenHeuristicsTests' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY='' -skipMacroValidation 2>&1 | xcsift -f toon`
- `make check`
- `make build-app`
