### PR TITLE
Optimize build and test throughput

### DIFF
--- a/.github/actions/setup-macos/action.yml
+++ b/.github/actions/setup-macos/action.yml
@@ -18,6 +18,27 @@ runs:
     - run: mise install
       shell: bash
 
+    - name: Xcode cache identity
+      shell: bash
+      run: |
+        set -euo pipefail
+        XCODE_CACHE_ID="$(xcodebuild -version | awk '/Build version/ { print $3 }')"
+        if [[ -z "$XCODE_CACHE_ID" ]]; then
+          echo "error: failed to resolve Xcode build version" >&2
+          exit 1
+        fi
+        printf '%s\n' "XCODE_CACHE_ID=$XCODE_CACHE_ID" >> "$GITHUB_ENV"
+        echo "Xcode cache identity: $XCODE_CACHE_ID"
+
+    - name: CLI SwiftPM build cache
+      uses: actions/cache@v4
+      with:
+        path: .build
+        key: ${{ runner.os }}-${{ runner.arch }}-cli-spm-v1-${{ env.XCODE_CACHE_ID }}-${{ hashFiles('Package.swift', 'Package.resolved') }}-${{ hashFiles('ProwlCLI/**/*.swift', 'ProwlCLITests/**/*.swift', 'supacode/CLIService/Shared/**/*.swift') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ runner.arch }}-cli-spm-v1-${{ env.XCODE_CACHE_ID }}-${{ hashFiles('Package.swift', 'Package.resolved') }}-
+          ${{ runner.os }}-${{ runner.arch }}-cli-spm-v1-${{ env.XCODE_CACHE_ID }}-
+
     - name: Ghostty cache key
       shell: bash
       run: |
@@ -60,12 +81,11 @@ runs:
       uses: actions/cache@v4
       with:
         path: ~/Library/Developer/Xcode/DerivedData/CompilationCache.noindex
-        # Rotate when SPM deps or the Xcode project itself changes (target add/remove,
-        # build setting tweaks). Day-to-day .swift edits keep the same primary key, so
-        # `actions/cache` restores without re-uploading — the cache is content-addressed
-        # by file hash, so unchanged files still hit; changed files miss and recompile
-        # locally without invalidating the saved snapshot.
-        key: ${{ runner.os }}-${{ runner.arch }}-xcode-compilation-cache-v1-${{ hashFiles('Package.resolved', 'supacode.xcodeproj/project.pbxproj') }}
+        # GitHub cache entries are immutable. A source-state suffix guarantees that a
+        # successful changed build saves newly compiled objects; restore-keys select the
+        # newest compatible CAS. Never restore across Xcode builds because compiler cache
+        # keys and storage formats are toolchain-specific.
+        key: ${{ runner.os }}-${{ runner.arch }}-xcode-compilation-cache-v2-${{ env.XCODE_CACHE_ID }}-${{ hashFiles('Package.resolved', 'supacode.xcodeproj/project.pbxproj') }}-${{ hashFiles('supacode/**/*.swift', 'supacodeTests/**/*.swift') }}
         restore-keys: |
-          ${{ runner.os }}-${{ runner.arch }}-xcode-compilation-cache-v1-
-          ${{ runner.os }}-${{ runner.arch }}-xcode-compilation-cache-
+          ${{ runner.os }}-${{ runner.arch }}-xcode-compilation-cache-v2-${{ env.XCODE_CACHE_ID }}-${{ hashFiles('Package.resolved', 'supacode.xcodeproj/project.pbxproj') }}-
+          ${{ runner.os }}-${{ runner.arch }}-xcode-compilation-cache-v2-${{ env.XCODE_CACHE_ID }}-

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,8 +25,9 @@ jobs:
           submodules: recursive
       - uses: ./.github/actions/setup-macos
       - run: make lint
-      - run: make build-app
-      - name: Run tests in parallel
+      - name: Stage debug app resources
+        run: make embed-cli-debug embed-docs
+      - name: Build app and run tests in parallel
         shell: bash
         run: |
           set -euo pipefail

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ make format                      # Run full-tree swift-format cleanup
 make lint                        # Run swiftlint only
 make check                       # Run changed-file format, swift-format lint, and swiftlint
 make test                        # Run all tests
+make benchmark-build             # Benchmark CI-like clean/warm-CAS build and test time
 make bench                       # Run performance benchmarks with -O; append absolute medians to ~/Library/Logs/Prowl/measurements/bench/
 make measure-cpu                 # Steady-state CPU + per-symbol attribution of the running Prowl Debug app
 make capture-spike               # Sample the running Prowl Debug app when CPU crosses a threshold

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,8 @@ CLI_SOURCE_INPUTS := \
 VERSION ?=
 BUILD ?=
 XCODEBUILD_FLAGS ?=
+BUILD_BENCHMARK_SCENARIO ?= ci
+BUILD_BENCHMARK_SAMPLES ?= 1
 FORMAT_BASE_REF ?= origin/main
 BUILD_SETTINGS_CACHE := $(CURRENT_MAKEFILE_DIR)/.build_settings_cache.json
 PBXPROJ_PATH := $(CURRENT_MAKEFILE_DIR)/supacode.xcodeproj/project.pbxproj
@@ -39,7 +41,7 @@ PROWL_POSTHOG_API_KEY ?=
 PROWL_POSTHOG_HOST ?=
 
 .DEFAULT_GOAL := help
-.PHONY: build-ghostty-xcframework ensure-ghostty sync-ghostty _record-ghostty-hash build-app build-cli build-cli-release embed-cli-debug embed-cli embed-docs run-app install-dev-build install-release archive export-archive format format-changed format-lint lint check test test-app test-cli-smoke test-cli-integration bump-version log-stream
+.PHONY: build-ghostty-xcframework ensure-ghostty sync-ghostty _record-ghostty-hash build-app build-cli build-cli-release embed-cli-debug embed-cli embed-docs run-app install-dev-build install-release archive export-archive format format-changed format-lint lint check test test-app test-cli-smoke test-cli-integration benchmark-build bump-version log-stream
 
 help:  # Display this help.
 	@-+echo "Run make with one of the following targets:"
@@ -350,6 +352,12 @@ test-cli-smoke: build-cli # Smoke test CLI executable
 
 test-cli-integration: # Run CLI integration tests via SwiftPM
 	swift test --filter ProwlCLIIntegrationTests
+
+benchmark-build: ensure-ghostty embed-cli-debug embed-docs # Benchmark clean and compilation-cache build/test time
+	@BUILD_BENCHMARK_ROOT="$(CURRENT_MAKEFILE_DIR)/.build-benchmark/build-time" \
+		SPM_CACHE_DIR="$(SPM_CACHE_DIR)" \
+		bash "$(CURRENT_MAKEFILE_DIR)/scripts/benchmark-build.sh" \
+		"$(BUILD_BENCHMARK_SCENARIO)" "$(BUILD_BENCHMARK_SAMPLES)"
 
 bench: ensure-ghostty embed-cli-debug embed-docs # Run performance benchmarks optimized (-O); append absolute medians to the bench log
 	@set -euo pipefail; \

--- a/Makefile
+++ b/Makefile
@@ -344,13 +344,17 @@ test-app: ensure-ghostty # Run app/unit tests via xcodebuild
 test-cli-smoke: build-cli # Smoke test CLI executable
 	@set -euo pipefail; \
 	bin="$$(swift build --show-bin-path)/prowl"; \
+	tmp_root="$${TMPDIR:-/tmp}"; \
+	tmp_dir="$$(mktemp -d "$${tmp_root%/}/prowl-smoke.XXXXXX")"; \
+	trap 'rm -rf "$$tmp_dir"' EXIT; \
 	help_output="$$("$$bin" --help)"; \
 	version_output="$$("$$bin" --version)"; \
 	echo "$$help_output" | grep -q "USAGE:"; \
 	echo "$$version_output" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?$$'; \
-	socket="/tmp/prowl-cli-smoke-$$RANDOM.sock"; \
-	PROWL_CLI_SOCKET="$$socket" "$$bin" list --json >/tmp/prowl-cli-smoke.json || true; \
-	jq -e '.error.code == "APP_NOT_RUNNING"' /tmp/prowl-cli-smoke.json >/dev/null
+	socket="$$tmp_dir/cli.sock"; \
+	response="$$tmp_dir/response.json"; \
+	PROWL_CLI_SOCKET="$$socket" "$$bin" list --json >"$$response" || true; \
+	jq -e '.error.code == "APP_NOT_RUNNING"' "$$response" >/dev/null
 
 test-cli-integration: # Run CLI integration tests via SwiftPM
 	@test_list="$$(swift test list)"; \

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ BUILD ?=
 XCODEBUILD_FLAGS ?=
 BUILD_BENCHMARK_SCENARIO ?= ci
 BUILD_BENCHMARK_SAMPLES ?= 1
+CLI_INTEGRATION_TEST_FILTER ?= ProwlCLIIntegrationTests
 FORMAT_BASE_REF ?= origin/main
 BUILD_SETTINGS_CACHE := $(CURRENT_MAKEFILE_DIR)/.build_settings_cache.json
 PBXPROJ_PATH := $(CURRENT_MAKEFILE_DIR)/supacode.xcodeproj/project.pbxproj
@@ -336,8 +337,9 @@ test-app: ensure-ghostty # Run app/unit tests via xcodebuild
 	set -e; \
 	if [ "$$xcodebuild_status" -ne 0 ]; then \
 		bash "$(CURRENT_MAKEFILE_DIR)/scripts/print-xcresult-failures.sh" "$$result_bundle" || true; \
+		exit "$$xcodebuild_status"; \
 	fi; \
-	exit "$$xcodebuild_status"
+	bash "$(CURRENT_MAKEFILE_DIR)/scripts/assert-xcresult-tests.sh" "$$result_bundle"
 
 test-cli-smoke: build-cli # Smoke test CLI executable
 	@set -euo pipefail; \
@@ -351,7 +353,14 @@ test-cli-smoke: build-cli # Smoke test CLI executable
 	jq -e '.error.code == "APP_NOT_RUNNING"' /tmp/prowl-cli-smoke.json >/dev/null
 
 test-cli-integration: # Run CLI integration tests via SwiftPM
-	swift test --filter ProwlCLIIntegrationTests
+	@test_list="$$(swift test list)"; \
+	matching_test_count="$$(printf '%s\n' "$$test_list" | grep -Ec '$(CLI_INTEGRATION_TEST_FILTER)' || true)"; \
+	if [ "$$matching_test_count" -eq 0 ]; then \
+		echo "error: CLI integration filter matched zero tests: $(CLI_INTEGRATION_TEST_FILTER)" >&2; \
+		exit 1; \
+	fi; \
+	echo "CLI integration filter matched $$matching_test_count test(s)."; \
+	swift test --skip-build --filter '$(CLI_INTEGRATION_TEST_FILTER)'
 
 benchmark-build: ensure-ghostty embed-cli-debug embed-docs # Benchmark clean and compilation-cache build/test time
 	@BUILD_BENCHMARK_ROOT="$(CURRENT_MAKEFILE_DIR)/.build-benchmark/build-time" \

--- a/docs-ai/016-dev-build-and-ci-workflow/000-plan.md
+++ b/docs-ai/016-dev-build-and-ci-workflow/000-plan.md
@@ -91,3 +91,6 @@ Anchor wave, all landed 2026-04-04/05:
 - Updated 2026-06-20: Debug app identity at project level + local dev-loop acceleration
   (`run-app` guard removal, content-aware build inputs, build-settings cache, incremental
   compilation) — see [004-debug-identity-and-dev-loop.md](004-debug-identity-and-dev-loop.md)
+- Updated 2026-08-05: fixed-path build benchmarks, rotating toolchain-scoped caches, an
+  integrated CI build/test graph, and measured type-checker hotspot cleanup — see
+  [005-build-test-time-optimization.md](005-build-test-time-optimization.md)

--- a/docs-ai/016-dev-build-and-ci-workflow/005-build-test-time-optimization.md
+++ b/docs-ai/016-dev-build-and-ci-workflow/005-build-test-time-optimization.md
@@ -136,7 +136,9 @@ PR #678 implemented the planned build graph and cache changes:
   inference outside `#expect`; rerunning the 500 ms diagnostics reported neither hotspot.
 - `test-app` validates the successful `.xcresult` contains a passing, non-empty test run;
   `test-cli-integration` lists tests first and rejects a filter matching zero tests. These
-  guards close SwiftPM/Xcode's otherwise-successful empty-test false-negative path.
+  guards close SwiftPM/Xcode's otherwise-successful empty-test false-negative path. CLI
+  smoke output uses a unique temporary directory so parallel integration cleanup cannot
+  remove its response file.
 
 Local M2 Pro / Xcode 26.6 verification after implementation:
 

--- a/docs-ai/016-dev-build-and-ci-workflow/005-build-test-time-optimization.md
+++ b/docs-ai/016-dev-build-and-ci-workflow/005-build-test-time-optimization.md
@@ -2,8 +2,8 @@
 
 | | |
 | --- | --- |
-| **Status** | Planned |
-| **Primary PRs** | TBD |
+| **Status** | Implemented |
+| **Primary PRs** | #678 |
 | **Related** | [003-ci-throughput-and-caching.md](003-ci-throughput-and-caching.md), [004-debug-identity-and-dev-loop.md](004-debug-identity-and-dev-loop.md) |
 
 ## Context
@@ -120,13 +120,54 @@ do not split files or add modules based on line count alone.
 - Disabling compiler features, tests, lint rules, or signing/release checks to manufacture
   a faster result.
 
-## Verification plan
+## Outcome
 
-- Repeat fixed-path local clean and warm-CAS scenarios after each material change.
-- Confirm type-checker diagnostics no longer report the targeted expressions.
-- Run `make check`, `make build-app`, all App tests, `make build-cli`,
-  `make test-cli-smoke`, and `make test-cli-integration`.
-- Push the branch and collect at least three GitHub Actions samples where practical;
-  compare phase medians and cache hit/save behavior against the 60-run baseline.
-- Record runner image and Xcode build identity so infrastructure changes are not mistaken
-  for source regressions.
+PR #678 implemented the planned build graph and cache changes:
+
+- `.github/workflows/test.yml` stages the CLI/docs once, then runs the integrated App
+  build/test alongside CLI smoke and integration tests. The separate `make build-app` CI
+  step is gone; `xcodebuild test` remains a complete App build correctness check.
+- `.github/actions/setup-macos/action.yml` records the Xcode build identity, restores/saves
+  the compilation CAS by toolchain/project/source state, and caches CLI SwiftPM products
+  by their complete source inputs.
+- `scripts/benchmark-build.sh` and `make benchmark-build` provide fixed-path clean/warm-CAS
+  scenarios with JSONL history and retained raw/xcsift logs.
+- `ShellClientStreamingTests.swift` and `AgentProfileTests.swift` move expensive collection
+  inference outside `#expect`; rerunning the 500 ms diagnostics reported neither hotspot.
+
+Local M2 Pro / Xcode 26.6 verification after implementation:
+
+| Scenario | Result |
+| --- | ---: |
+| Integrated test, cold CAS | 99.472 s |
+| Integrated test, warm CAS sample 1 | 48.424 s |
+| Integrated test, warm CAS sample 2 | 48.443 s |
+
+All three benchmark runs passed 2,263 App tests. `make check`, `make build-app`, `make test`,
+`make build-cli`, `make test-cli-smoke`, and `make test-cli-integration` also passed.
+
+GitHub Actions run `30925147131` supplied one cache-population and two warm samples on the
+same Xcode 26.6 runner image family:
+
+| Sample | Setup | Resource staging | Integrated build/tests | Whole job |
+| --- | ---: | ---: | ---: | ---: |
+| Empty new cache namespace | 60 s | 52 s | 510 s | 11m44s |
+| Warm attempt 2 | 37 s | 21 s | 140 s | 3m46s |
+| Warm attempt 3 | 77 s | 28 s | 167 s | 5m08s |
+
+The cold sample spent another 49 s uploading the initial Xcode/CLI caches after tests. Its
+integrated build/test step was still 3m19s faster than PR #677's separate 7m13s build plus
+4m36s test steps. The two warm whole-job samples had a 4m27s median, 56% below the 608 s
+pre-change median, and both were below the requested five-to-six-minute steady-state goal.
+
+## Current state and caveats
+
+- A new Xcode build version intentionally starts a new compilation-cache namespace. The
+  first successful `main` run for that toolchain populates the default-branch cache; later
+  PRs can restore it, and changed PR source states save updated entries.
+- An exact-source rerun is the upper-bound cache case. Ordinary source changes restore the
+  newest compatible CAS through the toolchain/project prefix, then compile affected files.
+- GitHub runner/network variance remains visible: the two equivalent warm jobs differed by
+  82 s. Trend decisions should continue to use multiple samples and step-level timings.
+- Full DerivedData remains uncached; only compiler CAS and deterministic dependency/build
+  inputs are persisted.

--- a/docs-ai/016-dev-build-and-ci-workflow/005-build-test-time-optimization.md
+++ b/docs-ai/016-dev-build-and-ci-workflow/005-build-test-time-optimization.md
@@ -1,0 +1,132 @@
+# 016 — Amendment: Build/Test Time Optimization Wave (2026-08-05)
+
+| | |
+| --- | --- |
+| **Status** | Planned |
+| **Primary PRs** | TBD |
+| **Related** | [003-ci-throughput-and-caching.md](003-ci-throughput-and-caching.md), [004-debug-identity-and-dev-loop.md](004-debug-identity-and-dev-loop.md) |
+
+## Context
+
+By August 2026, successful PR test jobs routinely exceeded ten minutes. The 60 successful
+PR runs immediately preceding this work had these median step durations:
+
+| Phase | Median |
+| --- | ---: |
+| Whole `build` job | 608 s |
+| `setup-macos` | 91 s |
+| `make lint` | 13 s |
+| `make build-app` | 316 s |
+| Parallel tests | 167 s |
+
+Run `30919601917` (PR #677) was a high-tail sample at 866 s: setup took 122 s, the build
+433 s, and tests 276 s. Test execution itself was not the dominant cost. The App test step
+built the 210-file test target after the standalone App build; it then ran 2,264 tests.
+
+The repository had also grown substantially since the first CI throughput wave:
+
+| Snapshot | App Swift files / lines | Test Swift files / lines |
+| --- | ---: | ---: |
+| 2026-04-01 | 197 / 35,879 | 67 / 14,633 |
+| 2026-08-05 | 419 / 85,169 | 210 / 56,768 |
+
+## Baseline method
+
+Use isolated, disposable DerivedData under `.build-benchmark/`, a fixed absolute path per
+scenario, the existing pinned `SourcePackages`, and `-showBuildTimingSummary`. Report wall
+time separately from summed task time. The core scenarios are:
+
+1. clean App build with compilation caching disabled, to expose compiler/type-checker cost;
+2. clean integrated App test, which proves both App compilation and test correctness;
+3. a second clean-DerivedData run against a populated Xcode compilation CAS at the same
+   path, modeling a correctly restored CI compilation cache;
+4. no-change `make build-app`, modeling the local edit/build/install loop.
+
+Initial local results on an M2 Pro / 12 logical CPUs / Xcode 26.6:
+
+| Scenario | Wall time |
+| --- | ---: |
+| Clean App, no CAS | 47.7 s |
+| Existing separate clean App + follow-up test | 114.8 s |
+| Integrated clean App test, no CAS | 98.8 s |
+| Integrated clean App test, fully warm same-path CAS | 50.9 s |
+
+The separate-build comparison is the sum of a 47.7 s clean App build and a 67.1 s test
+that reused its DerivedData. The integrated command was 14% faster locally while retaining
+the same build and test coverage.
+
+## Root causes and design decisions
+
+### 1. The CI compilation cache is immutable but its key is effectively static
+
+The `xcode-compilation-cache-v1` primary key includes `Package.resolved` and
+`project.pbxproj`, but not the toolchain or a rotating save suffix. Ordinary Swift changes
+therefore hit the same immutable `actions/cache` entry and never save newly compiled
+objects. Run `30919601917` explicitly logged “primary key ... not saving cache”. The same
+entry was also restored after the runner image moved from Xcode 26.5 to 26.6. That run
+spent 66 s downloading/restoring a 1.90 GB CAS which could not contain compatible 26.6
+compiler outputs.
+
+The replacement key will:
+
+- isolate exact Xcode build versions;
+- use an immutable App/test source-state suffix so successful changed builds save their
+  updated CAS without uploading duplicates for docs-only commits;
+- restore the newest cache sharing the toolchain/project prefix;
+- never fall back across Xcode build versions.
+
+A similar rotating cache will preserve SwiftPM CLI build products. The current App build
+spends about 33 s building the embedded CLI on a clean runner, and the parallel CLI tests
+then contend for the same uncached `.build` directory.
+
+### 2. CI performs two App build graphs
+
+`make build-app` compiles the App, then `make test-app` invokes `xcodebuild test`, which
+constructs another build graph to compile/link the test bundle and relink the host as
+needed. A single integrated `xcodebuild test` is already a build correctness check and also
+runs every App test. CI will stage the embedded CLI/docs once and use the integrated path,
+while local `make build-app` remains an explicit standalone verification command.
+
+CLI smoke and integration tests remain required. Their execution may stay parallel with
+App tests when that reduces wall time without corrupting the shared SwiftPM build.
+
+### 3. One Swift Testing assertion is a test-compilation hotspot
+
+`-warn-long-function-bodies=500` and
+`-warn-long-expression-type-checking=500` found only two App reducer bodies above 500 ms
+(about 0.9 s and 0.6 s), but found a more material test hotspot:
+`runStreamThrowsShellClientErrorOnNonZeroExit()` took 5.8 s to type-check, almost entirely
+in two `#expect(collection.contains(where:))` macro expressions (3.1 s and 2.6 s).
+Preserve the assertions while moving closure-heavy inference outside the macro expansion.
+Apply the same treatment only to other measured expressions where a rerun proves a win;
+do not split files or add modules based on line count alone.
+
+## Goals
+
+- Preserve the exact App build, all App tests, CLI smoke tests, and CLI integration tests.
+- Reduce median PR wall time toward five to six minutes on `macos-26` runners.
+- Improve clean and no-change local `make build-app` / `make test` time without weakening
+  Debug correctness.
+- Make regressions diagnosable from retained phase summaries rather than ad-hoc local logs.
+
+## Non-goals
+
+- GhosttyKit source build performance; CI and normal local builds use the pinned binary
+  artifact/cache path.
+- Test sharding that increases total compute before the single-job build graph and cache
+  strategy have been exhausted.
+- Full DerivedData caching; it is larger and more path-sensitive than Xcode's compilation
+  CAS.
+- Disabling compiler features, tests, lint rules, or signing/release checks to manufacture
+  a faster result.
+
+## Verification plan
+
+- Repeat fixed-path local clean and warm-CAS scenarios after each material change.
+- Confirm type-checker diagnostics no longer report the targeted expressions.
+- Run `make check`, `make build-app`, all App tests, `make build-cli`,
+  `make test-cli-smoke`, and `make test-cli-integration`.
+- Push the branch and collect at least three GitHub Actions samples where practical;
+  compare phase medians and cache hit/save behavior against the 60-run baseline.
+- Record runner image and Xcode build identity so infrastructure changes are not mistaken
+  for source regressions.

--- a/docs-ai/016-dev-build-and-ci-workflow/005-build-test-time-optimization.md
+++ b/docs-ai/016-dev-build-and-ci-workflow/005-build-test-time-optimization.md
@@ -134,6 +134,9 @@ PR #678 implemented the planned build graph and cache changes:
   scenarios with JSONL history and retained raw/xcsift logs.
 - `ShellClientStreamingTests.swift` and `AgentProfileTests.swift` move expensive collection
   inference outside `#expect`; rerunning the 500 ms diagnostics reported neither hotspot.
+- `test-app` validates the successful `.xcresult` contains a passing, non-empty test run;
+  `test-cli-integration` lists tests first and rejects a filter matching zero tests. These
+  guards close SwiftPM/Xcode's otherwise-successful empty-test false-negative path.
 
 Local M2 Pro / Xcode 26.6 verification after implementation:
 
@@ -144,7 +147,9 @@ Local M2 Pro / Xcode 26.6 verification after implementation:
 | Integrated test, warm CAS sample 2 | 48.443 s |
 
 All three benchmark runs passed 2,263 App tests. `make check`, `make build-app`, `make test`,
-`make build-cli`, `make test-cli-smoke`, and `make test-cli-integration` also passed.
+`make build-cli`, `make test-cli-smoke`, and `make test-cli-integration` also passed. Negative-path
+checks injected exit 23 from both `xcodebuild` and `swift test`, and used a zero-match CLI filter;
+all three made their Make target fail, while the workflow's parallel wait harness returned 1.
 
 GitHub Actions run `30925147131` supplied one cache-population and two warm samples on the
 same Xcode 26.6 runner image family:

--- a/scripts/assert-xcresult-tests.sh
+++ b/scripts/assert-xcresult-tests.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ "$#" -ne 1 ]]; then
+  echo "usage: $0 <xcresult-path>" >&2
+  exit 2
+fi
+
+result_bundle="$1"
+
+if [[ ! -d "$result_bundle" ]]; then
+  echo "error: xcresult bundle not found: $result_bundle" >&2
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "error: jq is required to validate xcresult test counts" >&2
+  exit 1
+fi
+
+summary_json="$(mktemp)"
+cleanup() {
+  rm -f "$summary_json"
+}
+trap cleanup EXIT
+
+if ! xcrun xcresulttool get test-results summary --path "$result_bundle" --compact >"$summary_json"; then
+  echo "error: failed to parse xcresult test summary: $result_bundle" >&2
+  exit 1
+fi
+
+read -r result total_tests failed_tests < <(
+  jq -er '
+    def numeric:
+      if type == "number" then .
+      elif type == "string" then tonumber
+      else error("expected numeric test count")
+      end;
+    [
+      (.result // "Unknown"),
+      ((.totalTestCount // 0) | numeric),
+      ((.failedTests // 0) | numeric)
+    ] | @tsv
+  ' "$summary_json"
+)
+
+if [[ "$result" != "Passed" ]]; then
+  echo "error: xcresult test result is $result, expected Passed" >&2
+  exit 1
+fi
+
+if (( failed_tests != 0 )); then
+  echo "error: xcresult reports $failed_tests failed test(s)" >&2
+  exit 1
+fi
+
+if (( total_tests <= 0 )); then
+  echo "error: xcresult reports zero tests; refusing a false-success test run" >&2
+  exit 1
+fi
+
+echo "Verified xcresult: $total_tests test(s), zero failures."

--- a/scripts/benchmark-build.sh
+++ b/scripts/benchmark-build.sh
@@ -1,0 +1,261 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+SCENARIO="${1:-ci}"
+SAMPLES="${2:-1}"
+BENCHMARK_ROOT="${BUILD_BENCHMARK_ROOT:-$ROOT/.build-benchmark/build-time}"
+SOURCE_PACKAGES="${SPM_CACHE_DIR:-$HOME/Library/Caches/supacode-spm-cache/SourcePackages}"
+CAS_PATH="$BENCHMARK_ROOT/ci/CompilationCache.noindex"
+DERIVED_DATA_PATH="$BENCHMARK_ROOT/ci/DerivedData"
+RESULT_BUNDLE_PATH="$BENCHMARK_ROOT/ci/TestResults.xcresult"
+RESULTS_PATH="$BENCHMARK_ROOT/results.jsonl"
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/benchmark-build.sh [scenario] [samples]
+
+Scenarios:
+  app-clean       Clean App build with compilation caching disabled.
+  test-clean      Clean integrated App build/test with caching disabled.
+  test-cas-cold   Clean integrated test with an empty compilation cache.
+  test-cas-warm   Clean DerivedData, preserve and reuse the compilation cache.
+  ci              Run test-cas-cold once, then test-cas-warm samples (default).
+  all             Run app-clean, test-clean, then the ci sequence.
+
+Environment:
+  BUILD_BENCHMARK_ROOT  Stable artifact root (default: .build-benchmark/build-time).
+  SPM_CACHE_DIR         SourcePackages path used by xcodebuild.
+  BUILD_DIAGNOSTICS=1   Enable 500 ms type-checker diagnostics.
+EOF
+}
+
+if [[ "$SCENARIO" == "-h" || "$SCENARIO" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+if [[ ! "$SAMPLES" =~ ^[1-9][0-9]*$ ]]; then
+  echo "error: samples must be a positive integer" >&2
+  exit 2
+fi
+
+case "$SCENARIO" in
+  app-clean | test-clean | test-cas-cold | test-cas-warm | ci | all) ;;
+  *)
+    echo "error: unknown scenario: $SCENARIO" >&2
+    usage >&2
+    exit 2
+    ;;
+esac
+
+for command in git jq mise python3 xcodebuild; do
+  if ! command -v "$command" >/dev/null 2>&1; then
+    echo "error: required command not found: $command" >&2
+    exit 127
+  fi
+done
+
+if [[ ! -d "$SOURCE_PACKAGES" ]]; then
+  echo "error: SourcePackages not found: $SOURCE_PACKAGES" >&2
+  echo "Run make build-app once to resolve packages before benchmarking." >&2
+  exit 1
+fi
+
+mkdir -p "$BENCHMARK_ROOT"
+touch "$RESULTS_PATH"
+
+GIT_SHA="$(git -C "$ROOT" rev-parse HEAD)"
+XCODE_VERSION="$(xcodebuild -version | tr '\n' ' ' | sed 's/[[:space:]]*$//')"
+HARDWARE="$(sysctl -n machdep.cpu.brand_string)"
+LOGICAL_CPUS="$(sysctl -n hw.logicalcpu)"
+RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)-$$"
+RUN_RESULTS="$BENCHMARK_ROOT/$RUN_ID.jsonl"
+
+run_case() {
+  local name="$1"
+  local action="$2"
+  local cache_mode="$3"
+  local reset_cache="$4"
+  local sample="$5"
+  local case_dir="$BENCHMARK_ROOT/$RUN_ID/$name-$sample"
+  local raw_log="$case_dir/xcodebuild.log"
+  local toon_log="$case_dir/xcodebuild.toon"
+  local status start end wall cas_bytes
+
+  rm -rf "$DERIVED_DATA_PATH" "$RESULT_BUNDLE_PATH"
+  if [[ "$reset_cache" == "yes" ]]; then
+    rm -rf "$CAS_PATH"
+  elif [[ "$cache_mode" == "warm" && ! -d "$CAS_PATH" ]]; then
+    echo "error: warm CAS not found: $CAS_PATH" >&2
+    echo "Run the test-cas-cold or ci scenario first." >&2
+    return 1
+  fi
+  mkdir -p "$case_dir"
+
+  local -a command=(
+    xcodebuild
+    -project "$ROOT/supacode.xcodeproj"
+    -scheme supacode
+    -configuration Debug
+    -destination "platform=macOS,arch=$(uname -m)"
+    -derivedDataPath "$DERIVED_DATA_PATH"
+    -skipMacroValidation
+    -clonedSourcePackagesDirPath "$SOURCE_PACKAGES"
+    -showBuildTimingSummary
+    SWIFT_COMPILATION_MODE=incremental
+  )
+
+  if [[ "$action" == "test" ]]; then
+    command+=(
+      -resultBundlePath "$RESULT_BUNDLE_PATH"
+      CODE_SIGNING_ALLOWED=NO
+      CODE_SIGNING_REQUIRED=NO
+      CODE_SIGN_IDENTITY=
+    )
+  fi
+
+  if [[ "$cache_mode" == "disabled" ]]; then
+    command+=(COMPILATION_CACHE_ENABLE_CACHING=NO)
+  else
+    command+=(
+      COMPILATION_CACHE_ENABLE_CACHING=YES
+      COMPILATION_CACHE_CAS_PATH="$CAS_PATH"
+    )
+  fi
+
+  if [[ "${BUILD_DIAGNOSTICS:-0}" == "1" ]]; then
+    command+=(
+      'OTHER_SWIFT_FLAGS=$(inherited) -Xfrontend -warn-long-function-bodies=500 -Xfrontend -warn-long-expression-type-checking=500'
+    )
+  fi
+
+  command+=("$action")
+
+  echo
+  echo "==> $name sample $sample"
+  echo "DerivedData: $DERIVED_DATA_PATH"
+  echo "Compilation cache: $cache_mode"
+  printf 'Command:'
+  printf ' %q' "${command[@]}"
+  echo
+
+  start="$(python3 -c 'import time; print(time.time())')"
+  set +e
+  (
+    cd "$ROOT"
+    "${command[@]}" 2>&1 | tee "$raw_log" | mise exec -- xcsift -w --build-info --format toon | tee "$toon_log"
+  )
+  status=${PIPESTATUS[0]}
+  set -e
+  end="$(python3 -c 'import time; print(time.time())')"
+  wall="$(python3 - "$start" "$end" <<'PY'
+import sys
+print(f"{float(sys.argv[2]) - float(sys.argv[1]):.3f}")
+PY
+)"
+
+  cas_bytes=0
+  if [[ -d "$CAS_PATH" ]]; then
+    cas_bytes="$(( $(du -sk "$CAS_PATH" | awk '{print $1}') * 1024 ))"
+  fi
+
+  jq -cn \
+    --arg runID "$RUN_ID" \
+    --arg scenario "$name" \
+    --argjson sample "$sample" \
+    --arg gitSHA "$GIT_SHA" \
+    --arg xcode "$XCODE_VERSION" \
+    --arg hardware "$HARDWARE" \
+    --argjson logicalCPUs "$LOGICAL_CPUS" \
+    --argjson wallSeconds "$wall" \
+    --argjson status "$status" \
+    --argjson casBytes "$cas_bytes" \
+    --arg rawLog "${raw_log#$ROOT/}" \
+    --arg resultBundle "${RESULT_BUNDLE_PATH#$ROOT/}" \
+    '{
+      run_id: $runID,
+      scenario: $scenario,
+      sample: $sample,
+      git_sha: $gitSHA,
+      xcode: $xcode,
+      hardware: $hardware,
+      logical_cpus: $logicalCPUs,
+      wall_seconds: $wallSeconds,
+      status: $status,
+      compilation_cache_bytes: $casBytes,
+      raw_log: $rawLog,
+      result_bundle: $resultBundle
+    }' | tee -a "$RUN_RESULTS" >> "$RESULTS_PATH"
+
+  echo "Result: $name sample $sample = ${wall}s (status $status)"
+  if [[ "$status" -ne 0 ]]; then
+    return "$status"
+  fi
+}
+
+run_samples() {
+  local name="$1"
+  local action="$2"
+  local cache_mode="$3"
+  local reset_first="$4"
+  local sample
+
+  for ((sample = 1; sample <= SAMPLES; sample++)); do
+    local reset="no"
+    if [[ "$reset_first" == "each" || ( "$reset_first" == "yes" && "$sample" -eq 1 ) ]]; then
+      reset="yes"
+    fi
+    run_case "$name" "$action" "$cache_mode" "$reset" "$sample"
+  done
+}
+
+case "$SCENARIO" in
+  app-clean)
+    run_samples app-clean build disabled no
+    ;;
+  test-clean)
+    run_samples test-clean test disabled no
+    ;;
+  test-cas-cold)
+    run_samples test-cas-cold test cold each
+    ;;
+  test-cas-warm)
+    run_samples test-cas-warm test warm no
+    ;;
+  ci)
+    run_case test-cas-cold test cold yes 1
+    run_samples test-cas-warm test warm no
+    ;;
+  all)
+    run_samples app-clean build disabled no
+    run_samples test-clean test disabled no
+    run_case test-cas-cold test cold yes 1
+    run_samples test-cas-warm test warm no
+    ;;
+esac
+
+python3 - "$RUN_RESULTS" <<'PY'
+import json
+import statistics
+import sys
+from collections import defaultdict
+
+values = defaultdict(list)
+with open(sys.argv[1]) as stream:
+    for line in stream:
+        record = json.loads(line)
+        values[record["scenario"]].append(record["wall_seconds"])
+
+print("\nSummary:")
+for scenario, samples in values.items():
+    print(
+        f"  {scenario}: n={len(samples)} "
+        f"median={statistics.median(samples):.3f}s "
+        f"min={min(samples):.3f}s max={max(samples):.3f}s"
+    )
+PY
+
+echo "Results: $RUN_RESULTS"
+echo "History: $RESULTS_PATH"

--- a/supacodeTests/AgentProfileTests.swift
+++ b/supacodeTests/AgentProfileTests.swift
@@ -240,7 +240,8 @@ struct AgentProfileTests {
         }
         let suffix = managedArguments.map { $0.isEmpty ? AgentProfileLaunchPlanner.pathString(home) : $0 }
         let tuiCount = expectation.runtime == .cline ? 1 : 0
-        #expect(plan.invocation.arguments.dropLast(tuiCount).suffix(suffix.count) == suffix[...])
+        let invocationSuffix = Array(plan.invocation.arguments.dropLast(tuiCount).suffix(suffix.count))
+        #expect(invocationSuffix == suffix)
       }
     }
   }

--- a/supacodeTests/ShellClientStreamingTests.swift
+++ b/supacodeTests/ShellClientStreamingTests.swift
@@ -156,8 +156,10 @@ struct ShellClientStreamingTests {
       #expect(shellError.command.contains("/bin/sh"))
     }
 
-    #expect(streamedLines.contains(where: { $0.source == .stdout && $0.text == "out" }))
-    #expect(streamedLines.contains(where: { $0.source == .stderr && $0.text == "err" }))
+    let expectedStdoutLine = ShellStreamLine(source: .stdout, text: "out")
+    let expectedStderrLine = ShellStreamLine(source: .stderr, text: "err")
+    #expect(streamedLines.contains(expectedStdoutLine))
+    #expect(streamedLines.contains(expectedStderrLine))
   }
 
   @Test func cancellingRunStreamConsumerTerminatesProcessQuickly() async throws {


### PR DESCRIPTION
## Summary

- replace the duplicate CI App build + test graphs with one integrated App test build
- rotate Xcode compilation caches by toolchain and source state, and cache CLI SwiftPM products
- add a reproducible clean/warm-CAS build benchmark harness
- simplify measured Swift Testing expressions that took up to 5.8s to type-check

## Baseline and local results

Recent 60 successful PR runs had a 608s median job duration (setup 91s, App build 316s, tests 167s). Run 30919601917 took 866s.

On M2 Pro / Xcode 26.6:

- separate clean App build + follow-up tests: 114.8s
- integrated clean App test: 99.5s
- integrated clean App test with same-path warm CAS: 48.4s median (2 runs)
- all 2,263 App tests passed in the cold and warm benchmark runs

## Verification

- `make check`
- `make build-app`
- `make test`
- `make build-cli`
- `make test-cli-smoke`
- `make test-cli-integration`
- `make benchmark-build BUILD_BENCHMARK_SCENARIO=ci BUILD_BENCHMARK_SAMPLES=2`
