### PR TITLE
Fix Codex pre-session state detection

### DIFF
--- a/docs-ai/030-agent-status-detection/000-plan.md
+++ b/docs-ai/030-agent-status-detection/000-plan.md
@@ -119,3 +119,6 @@ the failed attempt to extend the first signal to plain commands is
 - Updated 2026-08-04: confirmation live regions were anchored to numbered selections so
   ordinary prompts and short completed responses cannot impersonate blocked UI — see
   [005-confirmation-live-structure.md](005-confirmation-live-structure.md)
+- Updated 2026-08-06: current Codex pre-session directory trust, hook review, and sign-in
+  dialogs are covered with screen-only rules — see
+  [006-current-cli-pre-session-blockers.md](006-current-cli-pre-session-blockers.md)

--- a/docs-ai/030-agent-status-detection/006-current-cli-pre-session-blockers.md
+++ b/docs-ai/030-agent-status-detection/006-current-cli-pre-session-blockers.md
@@ -1,0 +1,57 @@
+# 030.006 — Current CLI pre-session blockers
+
+## Context
+
+Issue #676 reported stale Claude Code and Codex state detection. Before changing the
+classifier, the current installed CLIs were exercised in isolated temporary workspaces:
+Claude Code 2.1.223 and Codex CLI 0.146.1.
+
+Claude's current workspace-trust dialog retains its numbered `❯ 1. Yes` selection
+structure, so the existing Claude detector already classifies it as `blocked`. Its
+subagent UI now keeps the parent spinner visible while listing the active subagent, so
+it is already classified as `working`; the historical `Waiting for 1 background agent`
+line was not observed.
+
+Codex 0.146.1 has three unclassified pre-session blockers, all currently falling back
+to `idle`:
+
+- directory trust;
+- hook review after a directory is trusted;
+- first-run sign-in selection.
+
+## Change
+
+Added narrowly scoped Codex screen rules for the three observed dialog structures.
+Directory trust and hook review require a current selected choice plus their adjacent
+options and footer. Sign-in requires Codex's startup heading and its complete three-way
+choice menu. This keeps transcript text from becoming a blocker merely by quoting a
+single confirmation phrase.
+
+Normalized excerpts from the live captures are inline regression fixtures in
+`supacodeTests/ScreenHeuristicsTests.swift`, following the existing test convention.
+The fixture also proves a stale directory-trust transcript followed by an ordinary input
+remains `idle`. `docs/components/agent-detection.md` documents the recognized Codex
+pre-session blockers.
+
+## Non-goals
+
+- Do not use hooks, process liveness, sockets, or agent-side integration as state
+  evidence.
+- Do not introduce a declarative rule engine or an external fixture corpus in this
+  repair.
+- Do not change Claude heuristics without a current failing capture.
+
+## Validation
+
+- The three new Codex fixtures failed against the pre-change detector because all fell
+  through to `idle`.
+- Focused and complete `ScreenHeuristicsTests` passed after the change.
+- `make check` passed.
+- `make build-app` passed with 0 errors and 0 warnings.
+
+## Refs
+
+- Issue #676
+- `supacode/Infrastructure/AgentDetection/ScreenHeuristics.swift`
+- `supacodeTests/ScreenHeuristicsTests.swift`
+- `docs/components/agent-detection.md`

--- a/docs-ai/030-agent-status-detection/006-current-cli-pre-session-blockers.md
+++ b/docs-ai/030-agent-status-detection/006-current-cli-pre-session-blockers.md
@@ -23,15 +23,18 @@ to `idle`:
 
 Added narrowly scoped Codex screen rules for the three observed dialog structures.
 Directory trust and hook review require a current selected choice plus their adjacent
-options and footer. Sign-in requires Codex's startup heading and its complete three-way
-choice menu. This keeps transcript text from becoming a blocker merely by quoting a
-single confirmation phrase.
+options and footer, anchored to the last `›` prompt line on screen. Sign-in requires
+Codex's startup heading, its complete three-way choice menu, and its selected option as
+the last `›`/`>` selection-marker line on screen — the live menu renders no composer
+below it, so a later marker line means the menu text is stale transcript or a
+quotation. This keeps transcript text from becoming a blocker merely by quoting a
+confirmation phrase or a full menu.
 
 Normalized excerpts from the live captures are inline regression fixtures in
 `supacodeTests/ScreenHeuristicsTests.swift`, following the existing test convention.
-The fixture also proves a stale directory-trust transcript followed by an ordinary input
-remains `idle`. `docs/components/agent-detection.md` documents the recognized Codex
-pre-session blockers.
+The fixtures also prove stale directory-trust and sign-in screens followed by an
+ordinary input remain `idle`. `docs/components/agent-detection.md` documents the
+recognized Codex pre-session blockers.
 
 ## Non-goals
 
@@ -45,6 +48,8 @@ pre-session blockers.
 
 - The three new Codex fixtures failed against the pre-change detector because all fell
   through to `idle`.
+- The stale sign-in fixture failed against the unanchored sign-in rule (classified
+  `blocked`) and passes with the last-marker anchor.
 - Focused and complete `ScreenHeuristicsTests` passed after the change.
 - `make check` passed.
 - `make build-app` passed with 0 errors and 0 warnings.

--- a/docs/components/agent-detection.md
+++ b/docs/components/agent-detection.md
@@ -41,8 +41,10 @@ at a `~/.grok/` install (so Cursor's own `agent` entrypoint stays Cursor).
    selection row such as `❯ 1. Yes`; a bare input prompt cuts off the preceding transcript.
    Codex uses an exact bottom-of-screen `•`/`◦ Working (... esc to interrupt)` footer
    fallback. Its confirmation detector requires a numbered selected row such as `› 1. Yes`
-   paired with a live bottom footer or an explicit Yes/No choice structure. Ordinary prompt
-   text and completed responses are not confirmation boundaries.
+   paired with a live bottom footer or an explicit Yes/No choice structure. It also recognizes
+   the current directory-trust, hook-review, and initial sign-in menus as **Blocked** from
+   their complete selected-choice and footer structures. Ordinary prompt text and completed
+   responses are not confirmation boundaries.
    Other agent families keep their own patterns (including Oh My Pi's
    `Working… ⟦esc⟧` loader, braille frames, symbol cycles, Cursor's
    hexagons, Kimi's moon phases, etc.).

--- a/supacode/Infrastructure/AgentDetection/ScreenHeuristics.swift
+++ b/supacode/Infrastructure/AgentDetection/ScreenHeuristics.swift
@@ -141,7 +141,7 @@ nonisolated private func detectClaude(_ content: String) -> AgentRawState {
 }
 
 nonisolated private func detectCodex(_ content: String) -> AgentRawState {
-  if hasCodexBlockedPrompt(content) {
+  if hasCodexPreSessionBlockedPrompt(content) || hasCodexBlockedPrompt(content) {
     return .blocked
   }
   if hasCodexWorkingFooter(content) {
@@ -373,6 +373,87 @@ nonisolated private func isCodexPromptLine(_ line: String) -> Bool {
   guard trimmed.first == "›" else { return false }
   let remainder = trimmed.dropFirst()
   return remainder.isEmpty || remainder.first?.isWhitespace == true
+}
+
+nonisolated private func hasCodexPreSessionBlockedPrompt(_ content: String) -> Bool {
+  hasCodexDirectoryTrustPrompt(content) || hasCodexHookReviewPrompt(content) || hasCodexSignInPrompt(content)
+}
+
+nonisolated private func hasCodexDirectoryTrustPrompt(_ content: String) -> Bool {
+  hasCodexSelectedChoice(
+    content,
+    matchingAnyOf: ["1. yes, continue", "2. no, quit"],
+    withBefore: ["do you trust the contents of this directory?"],
+    andAround: ["1. yes, continue", "2. no, quit"],
+    andAfter: ["press enter to continue"]
+  )
+}
+
+nonisolated private func hasCodexHookReviewPrompt(_ content: String) -> Bool {
+  hasCodexSelectedChoice(
+    content,
+    matchingAnyOf: [
+      "1. review hooks",
+      "2. trust all and continue",
+      "3. continue without trusting (hooks won't run)",
+    ],
+    withBefore: ["hooks need review"],
+    andAround: ["1. review hooks", "2. trust all and continue", "3. continue without trusting"],
+    andAfter: ["press enter to confirm or esc to go back"]
+  )
+}
+
+nonisolated private func hasCodexSelectedChoice(
+  _ content: String,
+  matchingAnyOf options: Set<String>,
+  withBefore beforeNeedles: [String],
+  andAround aroundNeedles: [String],
+  andAfter afterNeedles: [String]
+) -> Bool {
+  let lines = content.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+  guard let promptIndex = lines.lastIndex(where: isCodexPromptLine) else {
+    return false
+  }
+
+  let selectedChoice = normalizedCodexChoice(lines[promptIndex])
+  guard options.contains(selectedChoice) else {
+    return false
+  }
+
+  let lowerBound = max(lines.startIndex, promptIndex - 6)
+  let before = lines[lowerBound..<promptIndex].joined(separator: "\n").lowercased()
+  guard beforeNeedles.allSatisfy(before.contains) else {
+    return false
+  }
+
+  let afterStart = lines.index(after: promptIndex)
+  let afterEnd = min(lines.endIndex, afterStart + 6)
+  let around = lines[lowerBound..<afterEnd].joined(separator: "\n").lowercased()
+  guard aroundNeedles.allSatisfy(around.contains) else {
+    return false
+  }
+
+  let after = lines[afterStart..<afterEnd].joined(separator: "\n").lowercased()
+  return afterNeedles.allSatisfy(after.contains)
+}
+
+nonisolated private func hasCodexSignInPrompt(_ content: String) -> Bool {
+  let lines = content.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+  let recent = lines.suffix(18)
+  let lower = recent.joined(separator: "\n").lowercased()
+  let hasSelectedChoice = recent.contains { line in
+    let trimmed = line.trimmingCharacters(in: .whitespaces)
+    guard trimmed.first == "›" || trimmed.first == ">" else { return false }
+    let choice = trimmed.dropFirst().trimmingCharacters(in: .whitespaces).lowercased()
+    return choice.hasPrefix("1. sign in with chatgpt")
+      || choice.hasPrefix("2. sign in with device code")
+      || choice.hasPrefix("3. provide your own api key")
+  }
+  return hasSelectedChoice
+    && lower.contains("welcome to codex, openai's command-line coding agent")
+    && lower.contains("2. sign in with device code")
+    && lower.contains("3. provide your own api key")
+    && lower.contains("press enter to continue")
 }
 
 nonisolated private func hasCodexBlockedPrompt(_ content: String) -> Bool {

--- a/supacode/Infrastructure/AgentDetection/ScreenHeuristics.swift
+++ b/supacode/Infrastructure/AgentDetection/ScreenHeuristics.swift
@@ -440,17 +440,31 @@ nonisolated private func hasCodexSelectedChoice(
 nonisolated private func hasCodexSignInPrompt(_ content: String) -> Bool {
   let lines = content.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
   let recent = lines.suffix(18)
-  let lower = recent.joined(separator: "\n").lowercased()
-  let hasSelectedChoice = recent.contains { line in
-    let trimmed = line.trimmingCharacters(in: .whitespaces)
-    guard trimmed.first == "›" || trimmed.first == ">" else { return false }
-    let choice = trimmed.dropFirst().trimmingCharacters(in: .whitespaces).lowercased()
-    return choice.hasPrefix("1. sign in with chatgpt")
+  // The live sign-in menu renders no composer below it, so its selected option
+  // is the last `›`/`>` marker line on screen. A later marker line means the
+  // menu text above is stale transcript (or a quotation), not the current
+  // interaction.
+  guard
+    let selected = recent.last(where: { line in
+      let trimmed = line.trimmingCharacters(in: .whitespaces)
+      return trimmed.first == "›" || trimmed.first == ">"
+    })
+  else {
+    return false
+  }
+  let choice = selected.trimmingCharacters(in: .whitespaces)
+    .dropFirst()
+    .trimmingCharacters(in: .whitespaces)
+    .lowercased()
+  guard
+    choice.hasPrefix("1. sign in with chatgpt")
       || choice.hasPrefix("2. sign in with device code")
       || choice.hasPrefix("3. provide your own api key")
+  else {
+    return false
   }
-  return hasSelectedChoice
-    && lower.contains("welcome to codex, openai's command-line coding agent")
+  let lower = recent.joined(separator: "\n").lowercased()
+  return lower.contains("welcome to codex, openai's command-line coding agent")
     && lower.contains("2. sign in with device code")
     && lower.contains("3. provide your own api key")
     && lower.contains("press enter to continue")

--- a/supacodeTests/ScreenHeuristicsTests.swift
+++ b/supacodeTests/ScreenHeuristicsTests.swift
@@ -574,6 +574,25 @@ struct ScreenHeuristicsTests {
     )
   }
 
+  @Test func codexStaleSignInMenuBeforeCurrentInputIsIdle() {
+    #expect(
+      DetectedAgent.codex.detectState(
+        in: """
+            Welcome to Codex, OpenAI's command-line coding agent
+
+            1. Sign in with ChatGPT
+          > 2. Sign in with Device Code
+            3. Provide your own API key
+
+            Press enter to continue
+
+          › Explain the sign-in menu above without acting on it.
+          gpt-5.6-terra xhigh · Context 5% used
+          """
+      ) == .idle
+    )
+  }
+
   @Test func codexTranscriptConfirmationVocabularyDoesNotOverrideLiveState() {
     #expect(
       DetectedAgent.codex.detectState(

--- a/supacodeTests/ScreenHeuristicsTests.swift
+++ b/supacodeTests/ScreenHeuristicsTests.swift
@@ -130,6 +130,36 @@ struct ScreenHeuristicsTests {
     )
   }
 
+  @Test func claudeCurrentTrustAndSubagentScreensRemainClassified() {
+    #expect(
+      DetectedAgent.claude.detectState(
+        in: """
+          Accessing workspace:
+
+          Quick safety check: Is this a project you created or one you trust?
+          Claude Code'll be able to read, edit, and execute files here.
+
+          ❯ 1. Yes, I trust this folder
+            2. No, exit
+
+          Enter to confirm · Esc to cancel
+          """
+      ) == .blocked
+    )
+    #expect(
+      DetectedAgent.claude.detectState(
+        in: """
+          ✢ Manifesting… (5s · ↓ 180 tokens · thought for 1s)
+          ─────────
+          ❯
+          ─────────
+            ⏺ main
+            ◯ general-purpose  Answer a simple question  0s
+          """
+      ) == .working
+    )
+  }
+
   @Test func claudeIgnoresStalePermissionPromptNearCurrentIdlePrompt() {
     #expect(
       DetectedAgent.claude.detectState(
@@ -456,6 +486,92 @@ struct ScreenHeuristicsTests {
     )
     #expect(DetectedAgent.codex.detectState(in: "• Working (12s • esc to interrupt)") == .working)
     #expect(DetectedAgent.codex.detectState(in: "Ready for input") == .idle)
+  }
+
+  @Test func codexCurrentPreSessionBlockersAreBlocked() {
+    #expect(
+      DetectedAgent.codex.detectState(
+        in: """
+          > You are in /tmp/detection-workspace
+
+            Do you trust the contents of this directory? Working with untrusted contents comes with higher risk of
+            prompt injection. Trusting the directory allows project-local config, hooks, and exec policies to load.
+
+          › 1. Yes, continue
+            2. No, quit
+
+            Press enter to continue
+          """
+      ) == .blocked
+    )
+    #expect(
+      DetectedAgent.codex.detectState(
+        in: """
+            Hooks need review
+            1 hook is new or changed.
+            Hooks can run outside the sandbox after you trust them.
+
+          › 1. Review hooks
+            2. Trust all and continue
+            3. Continue without trusting (hooks won't run)
+
+            Press enter to confirm or esc to go back
+          """
+      ) == .blocked
+    )
+    #expect(
+      DetectedAgent.codex.detectState(
+        in: """
+            Welcome to Codex, OpenAI's command-line coding agent
+
+            Sign in with ChatGPT to use Codex as part of your paid plan
+            or connect an API key for usage-based billing
+
+          > 1. Sign in with ChatGPT
+              Usage included with Plus, Pro, Business, and Enterprise plans
+
+            2. Sign in with Device Code
+              Sign in from another device with a one-time code
+
+            3. Provide your own API key
+              Pay for what you use
+
+            Press enter to continue
+          """
+      ) == .blocked
+    )
+  }
+
+  @Test func codexSignInAlternativeSelectedChoiceIsBlocked() {
+    #expect(
+      DetectedAgent.codex.detectState(
+        in: """
+            Welcome to Codex, OpenAI's command-line coding agent
+
+            1. Sign in with ChatGPT
+          > 2. Sign in with Device Code
+            3. Provide your own API key
+
+            Press enter to continue
+          """
+      ) == .blocked
+    )
+  }
+
+  @Test func codexStalePreSessionPromptBeforeCurrentInputIsIdle() {
+    #expect(
+      DetectedAgent.codex.detectState(
+        in: """
+            Do you trust the contents of this directory?
+          › 1. Yes, continue
+            2. No, quit
+            Press enter to continue
+
+          › Explain the prompt above without opening it.
+          gpt-5.6-terra xhigh · Context 5% used
+          """
+      ) == .idle
+    )
   }
 
   @Test func codexTranscriptConfirmationVocabularyDoesNotOverrideLiveState() {


### PR DESCRIPTION
## Summary

- classify Codex directory-trust, hook-review, and first-run sign-in menus as blocked
- anchor the sign-in rule to the last `›`/`>` selection-marker line so a stale or quoted menu above a newer input prompt stays idle
- add live CLI transcript regressions and stale-transcript protection
- document the screen-only decision and current recognized menus

## Validation

- `xcodebuild test -project supacode.xcodeproj -scheme supacode -destination 'platform=macOS' -only-testing:supacodeTests/ScreenHeuristicsTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY='' -skipMacroValidation` — 42 tests passed. (An earlier revision of this body listed the suite as `ScreenHeuristicsTests()`; the trailing parentheses silently match zero tests, so that command validated nothing.)
- `make check`
- `make build-app`

Validated against Claude Code 2.1.223 and Codex CLI 0.146.1.
