### PR TITLE
Add detector-faithful CLI screen capture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,9 @@ build/
 # Prowl-generated handoff artifacts can include terminal/session excerpts.
 .prowl/handoff/
 
+# Private, unredacted agent-screen captures staged before fixture sanitization.
+.local/agent-screen-captures/
+
 # Release-only credentials (analytics, crash reporting)
 Config/Secrets.env
 .build-benchmark/

--- a/ProwlCLI/CLIRunner.swift
+++ b/ProwlCLI/CLIRunner.swift
@@ -7,7 +7,8 @@ import ProwlCLIShared
 
 enum CLIRunner {
   /// Execute a command envelope by sending it to the running app
-  /// and rendering the response.
+  /// and rendering the response. A response validator must throw `ExitError`
+  /// so contract failures retain the command's error code instead of becoming transport failures.
   static func execute(
     _ envelope: CommandEnvelope,
     validateResponse: ((CommandResponse) throws -> Void)? = nil

--- a/ProwlCLI/CLIRunner.swift
+++ b/ProwlCLI/CLIRunner.swift
@@ -8,11 +8,17 @@ import ProwlCLIShared
 enum CLIRunner {
   /// Execute a command envelope by sending it to the running app
   /// and rendering the response.
-  static func execute(_ envelope: CommandEnvelope) throws {
+  static func execute(
+    _ envelope: CommandEnvelope,
+    validateResponse: ((CommandResponse) throws -> Void)? = nil
+  ) throws {
     do {
       let responseData = try SocketTransportClient.send(envelope)
       let decoder = JSONDecoder()
       let response = try decoder.decode(CommandResponse.self, from: responseData)
+      if response.ok {
+        try validateResponse?(response)
+      }
       switch envelope.output {
       case .json:
         renderJSONData(responseData)

--- a/ProwlCLI/Commands/ReadCommand.swift
+++ b/ProwlCLI/Commands/ReadCommand.swift
@@ -70,19 +70,38 @@ struct ReadCommand: ParsableCommand {
 
       try validateStabilityOptions()
 
+      let requestedSource = source.inputSource
       let envelope = CommandEnvelope(
         output: options.outputMode,
         command: .read(ReadInput(
           selector: sel,
           last: last,
-          source: source.inputSource,
+          source: requestedSource,
           waitStable: waitStable,
           stableIntervalMs: stableInterval,
           stablePeriodMs: stablePeriod,
           waitTimeoutSeconds: waitTimeout
         ))
       )
-      try CLIRunner.execute(envelope)
+      try CLIRunner.execute(envelope) { response in
+        try Self.validate(response: response, requestedSource: requestedSource)
+      }
+    }
+  }
+
+  private static func validate(
+    response: CommandResponse,
+    requestedSource: ReadInputSource
+  ) throws {
+    guard requestedSource == .detection else { return }
+    guard let data = response.data,
+      let payload = try? data.decode(as: ReadCommandPayload.self),
+      payload.source == .detection
+    else {
+      throw ExitError(
+        code: CLIErrorCode.readFailed,
+        message: "The running Prowl app did not honor --source detection. Update or restart Prowl, then retry."
+      )
     }
   }
 

--- a/ProwlCLI/Commands/ReadCommand.swift
+++ b/ProwlCLI/Commands/ReadCommand.swift
@@ -3,6 +3,18 @@
 import ArgumentParser
 import ProwlCLIShared
 
+private enum ReadSourceOption: String, ExpressibleByArgument {
+  case viewport
+  case detection
+
+  var inputSource: ReadInputSource {
+    switch self {
+    case .viewport: .viewport
+    case .detection: .detection
+    }
+  }
+}
+
 struct ReadCommand: ParsableCommand {
   static let configuration = CommandConfiguration(
     commandName: "read",
@@ -14,6 +26,12 @@ struct ReadCommand: ParsableCommand {
 
   @Option(name: .long, help: "Number of recent lines to read (omit for snapshot).")
   var last: Int?
+
+  @Option(
+    name: .long,
+    help: "Content source: viewport, or detection for the exact active-screen agent detector input."
+  )
+  private var source: ReadSourceOption = .viewport
 
   @Flag(name: .long, help: "Re-read the pane until its output stops changing before returning (good for live TUIs).")
   var waitStable = false
@@ -57,6 +75,7 @@ struct ReadCommand: ParsableCommand {
         command: .read(ReadInput(
           selector: sel,
           last: last,
+          source: source.inputSource,
           waitStable: waitStable,
           stableIntervalMs: stableInterval,
           stablePeriodMs: stablePeriod,

--- a/ProwlCLITests/ProwlCLIIntegrationTests.swift
+++ b/ProwlCLITests/ProwlCLIIntegrationTests.swift
@@ -1448,6 +1448,47 @@ final class ProwlCLIIntegrationTests: XCTestCase {
     XCTAssertEqual(data["source"] as? String, "detection")
   }
 
+  func testReadDetectionSourceRejectsUnhonoredSource() throws {
+    let socketPath = temporarySocketPath(suffix: "read-detection-unhonored")
+    let response = try CommandResponse(
+      ok: true,
+      command: "read",
+      schemaVersion: "prowl.cli.read.v1",
+      data: RawJSON(encoding: ReadResponseData(
+        target: ReadResponseTarget(
+          worktree: ListWorktree(
+            id: "Prowl:/Projects/Prowl",
+            name: "Prowl",
+            path: "/Projects/Prowl",
+            rootPath: "/Projects/Prowl",
+            kind: "git"
+          ),
+          tab: ReadResponseTab(id: "tab-1", title: "Prowl 1", selected: true),
+          pane: ReadResponsePane(id: "pane-1", title: "zsh", cwd: "/Projects/Prowl", focused: true)
+        ),
+        mode: "snapshot",
+        last: nil,
+        source: "screen",
+        truncated: false,
+        lineCount: 1,
+        text: "viewport"
+      ))
+    )
+
+    let (_, result) = try runWithMockServer(
+      socketPath: socketPath,
+      response: response,
+      args: ["read", "--source", "detection", "--json"]
+    )
+
+    XCTAssertNotEqual(result.exitCode, 0)
+    let payload = try jsonObject(from: result.stdout)
+    XCTAssertEqual(payload["ok"] as? Bool, false)
+    let error = try XCTUnwrap(payload["error"] as? [String: Any])
+    XCTAssertEqual(error["code"] as? String, CLIErrorCode.readFailed)
+    XCTAssertTrue((error["message"] as? String)?.contains("did not honor") == true)
+  }
+
   func testReadWithoutLastDefaultsToSnapshot() throws {
     let socketPath = temporarySocketPath(suffix: "read-snapshot")
     let response = CommandResponse(

--- a/ProwlCLITests/ProwlCLIIntegrationTests.swift
+++ b/ProwlCLITests/ProwlCLIIntegrationTests.swift
@@ -1489,6 +1489,46 @@ final class ProwlCLIIntegrationTests: XCTestCase {
     XCTAssertTrue((error["message"] as? String)?.contains("did not honor") == true)
   }
 
+  func testReadDetectionSourceRejectsUnhonoredSourceInTextModeWithoutLeakingText() throws {
+    let socketPath = temporarySocketPath(suffix: "read-detection-unhonored-text")
+    let response = try CommandResponse(
+      ok: true,
+      command: "read",
+      schemaVersion: "prowl.cli.read.v1",
+      data: RawJSON(encoding: ReadResponseData(
+        target: ReadResponseTarget(
+          worktree: ListWorktree(
+            id: "Prowl:/Projects/Prowl",
+            name: "Prowl",
+            path: "/Projects/Prowl",
+            rootPath: "/Projects/Prowl",
+            kind: "git"
+          ),
+          tab: ReadResponseTab(id: "tab-1", title: "Prowl 1", selected: true),
+          pane: ReadResponsePane(id: "pane-1", title: "zsh", cwd: "/Projects/Prowl", focused: true)
+        ),
+        mode: "snapshot",
+        last: nil,
+        source: "screen",
+        truncated: false,
+        lineCount: 1,
+        text: "private viewport text"
+      ))
+    )
+
+    let (_, result) = try runWithMockServer(
+      socketPath: socketPath,
+      response: response,
+      args: ["read", "--source", "detection"]
+    )
+
+    XCTAssertNotEqual(result.exitCode, 0)
+    XCTAssertEqual(result.stdout, "")
+    XCTAssertTrue(result.stderr.contains("error [READ_FAILED]"))
+    XCTAssertFalse(result.stderr.contains("private viewport text"))
+    XCTAssertEqual(result.stderr.components(separatedBy: "READ_FAILED").count - 1, 1)
+  }
+
   func testReadWithoutLastDefaultsToSnapshot() throws {
     let socketPath = temporarySocketPath(suffix: "read-snapshot")
     let response = CommandResponse(

--- a/ProwlCLITests/ProwlCLIIntegrationTests.swift
+++ b/ProwlCLITests/ProwlCLIIntegrationTests.swift
@@ -1391,6 +1391,7 @@ final class ProwlCLIIntegrationTests: XCTestCase {
     if case .read(let input) = envelope.command {
       XCTAssertEqual(input.selector, .pane("pane-123"))
       XCTAssertEqual(input.last, 5)
+      XCTAssertEqual(input.source, .viewport)
     } else {
       XCTFail("Expected read command envelope")
     }
@@ -1399,6 +1400,52 @@ final class ProwlCLIIntegrationTests: XCTestCase {
     XCTAssertEqual(payload["ok"] as? Bool, true)
     XCTAssertEqual(payload["command"] as? String, "read")
     XCTAssertEqual(payload["schema_version"] as? String, "prowl.cli.read.v1")
+  }
+
+  func testReadDetectionSourcePassesExactSourceToApp() throws {
+    let socketPath = temporarySocketPath(suffix: "read-detection")
+    let response = try CommandResponse(
+      ok: true,
+      command: "read",
+      schemaVersion: "prowl.cli.read.v1",
+      data: RawJSON(encoding: ReadResponseData(
+        target: ReadResponseTarget(
+          worktree: ListWorktree(
+            id: "Prowl:/Projects/Prowl",
+            name: "Prowl",
+            path: "/Projects/Prowl",
+            rootPath: "/Projects/Prowl",
+            kind: "git"
+          ),
+          tab: ReadResponseTab(id: "tab-1", title: "Prowl 1", selected: true),
+          pane: ReadResponsePane(id: "pane-1", title: "zsh", cwd: "/Projects/Prowl", focused: true)
+        ),
+        mode: "snapshot",
+        last: nil,
+        source: "detection",
+        truncated: false,
+        lineCount: 2,
+        text: "active-line-1\nactive-line-2"
+      ))
+    )
+
+    let (requestData, result) = try runWithMockServer(
+      socketPath: socketPath,
+      response: response,
+      args: ["read", "--source", "detection", "--json"]
+    )
+
+    XCTAssertEqual(result.exitCode, 0)
+    let envelope = try JSONDecoder().decode(CommandEnvelope.self, from: requestData)
+    if case .read(let input) = envelope.command {
+      XCTAssertEqual(input.source, .detection)
+    } else {
+      XCTFail("Expected read command envelope")
+    }
+
+    let payload = try jsonObject(from: result.stdout)
+    let data = try XCTUnwrap(payload["data"] as? [String: Any])
+    XCTAssertEqual(data["source"] as? String, "detection")
   }
 
   func testReadWithoutLastDefaultsToSnapshot() throws {

--- a/docs-ai/030-agent-status-detection/000-plan.md
+++ b/docs-ai/030-agent-status-detection/000-plan.md
@@ -122,3 +122,6 @@ the failed attempt to extend the first signal to plain commands is
 - Updated 2026-08-06: current Codex pre-session directory trust, hook review, and sign-in
   dialogs are covered with screen-only rules — see
   [006-current-cli-pre-session-blockers.md](006-current-cli-pre-session-blockers.md)
+- Updated 2026-08-06: a staged migration to typed Claude/Codex profiles, detector-faithful
+  captures, versioned fixtures, and explainable reasons is proposed — see
+  [007-screen-profile-migration-plan.md](007-screen-profile-migration-plan.md)

--- a/docs-ai/030-agent-status-detection/000-plan.md
+++ b/docs-ai/030-agent-status-detection/000-plan.md
@@ -125,3 +125,6 @@ the failed attempt to extend the first signal to plain commands is
 - Updated 2026-08-06: a staged migration to typed Claude/Codex profiles, detector-faithful
   captures, versioned fixtures, and explainable reasons is proposed — see
   [007-screen-profile-migration-plan.md](007-screen-profile-migration-plan.md)
+- Updated 2026-08-06: `prowl read --source detection` now captures the exact active-screen
+  buffer used by production state detection — see
+  [008-detector-faithful-cli-capture.md](008-detector-faithful-cli-capture.md)

--- a/docs-ai/030-agent-status-detection/007-screen-profile-migration-plan.md
+++ b/docs-ai/030-agent-status-detection/007-screen-profile-migration-plan.md
@@ -1,0 +1,265 @@
+# 030.007 — Screen Detection Profiles and Captured Fixture Corpus: Plan
+
+| | |
+| --- | --- |
+| **Status** | Approved — implementation in progress |
+| **Anchor date** | 2026-08-06 |
+| **Primary PRs** | TBD; one independently reviewable PR per phase below |
+| **Sources** | Issue #676, PRs #674/#683, herdr `fae0b236` (v0.8.0-era) |
+| **Related** | [000-plan.md](000-plan.md), [004-live-region-evidence.md](004-live-region-evidence.md), [005-confirmation-live-structure.md](005-confirmation-live-structure.md), [006-current-cli-pre-session-blockers.md](006-current-cli-pre-session-blockers.md), `docs/components/agent-detection.md` |
+
+## Background
+
+Issue #676 identified a maintenance failure rather than only six stale strings: a known
+agent whose current UI no longer matches Prowl silently falls back to `idle`. PRs #674 and
+#683 repaired the currently reproduced Claude/Codex states, but capture provenance and
+rule ownership remain implicit.
+
+Current `main` has an 883-line `ScreenHeuristics.swift`: 15 detector functions, 48 other
+private helpers, and roughly 155 string-containment checks. Its 1,164-line test file has
+42 test methods and about 70 multiline screen literals. The implementation is still a
+pure `String -> AgentRawState` classifier over the last 24 non-empty lines, cached by the
+exact detected agent and active-screen text.
+
+The direction remains **screen-only state detection**. Process inspection continues to
+own agent identity/liveness; it is not state evidence. The existing 3-second working
+hold, `.unknown` viewer semantics, polling schedule, and scan cache are retained.
+
+## Goals
+
+- Give each migrated Claude/Codex result a stable rule ID or explicit no-match reason.
+- Make live UI regions and rule precedence reviewable within a runtime-owned Swift file.
+- Test capture-derived, versioned detector inputs independently from constructed predicate
+  and boundary microtests.
+- Migrate one runtime at a time with reproducible behavior-parity evidence.
+- Keep runtime cost and public state behavior unchanged.
+
+## Non-goals
+
+- No hooks, sockets, process liveness, OSC title/progress, or other agent-side state
+  authority.
+- No TOML/JSON rule DSL, generic `all`/`any`/`not` interpreter, numeric priorities,
+  remote updates, or user rule overrides.
+- No replacement of stabilization, polling, identity detection, or display-state logic.
+- No scheduled authenticated recapture in this migration.
+- No obligation to migrate all supported runtimes.
+
+This work does **not** automatically discover a vendor UI shape never captured before.
+It makes known shapes regression-testable and live results explainable; proactive latest-CLI
+recapture remains a possible later project.
+
+## herdr findings and boundary
+
+The current herdr implementation was reviewed at `fae0b236` (latest release v0.8.0).
+
+| Adopt | Do not port |
+| --- | --- |
+| Stable rule IDs and explicit known-agent fallback | ~1,500-line generic manifest evaluator and nested matcher DSL |
+| Runtime-specific screen regions | TOML manifests, engine versions, validation limits, overrides, remote updates |
+| Deterministic precedence and explain output | Hook authority arbitration and visible-idle transition state machine |
+| Capture metadata and detector-input source distinction | OSC title/progress rules as state evidence |
+
+herdr's manifest engine improves distribution and reviewability but has not eliminated
+runtime-specific drift; its current history still contains Claude, Codex, Cursor, Kiro,
+and Grok rule fixes. Its Claude/Codex profiles also lean on OSC regions that Prowl has
+explicitly deferred, so Prowl's screen structure must carry more of the classification
+load. The transferable value is therefore the **profile/region/reason/capture model**, not
+the engine.
+
+## Proposed design
+
+### Detection result
+
+Add an internal result while preserving `detectState(in:)` as the compatibility projection:
+
+```swift
+struct AgentScreenDetection: Equatable, Sendable {
+  let state: AgentRawState
+  let reason: AgentScreenDetectionReason
+}
+
+enum AgentScreenDetectionReason: Equatable, Sendable {
+  case matched(AgentScreenRuleID)
+  case noRuleMatched
+  case legacyDetector
+}
+```
+
+`AgentScreenRuleID` is a small string-backed value. Constants stay beside their owning
+profile (`CodexScreenProfile.RuleID.directoryTrust == "codex.directoryTrust"`) rather
+than in one global enum. Profiles expose their IDs for a uniqueness/prefix test.
+
+`detectState(in:)` returns `detectScreen(in:).state`; unmigrated detectors retain their
+existing state and report `.legacyDetector`. A positive legacy result is not mislabeled as
+a fallback.
+
+Known-agent no-match remains `.idle`. `.unknown` is reserved for a screen that carries no
+usable signal, such as a viewer overlay: the stabilizer preserves the previous state on
+`.unknown`, so using it for ordinary no-match could freeze `working` indefinitely.
+
+`AgentScreenScan` caches the complete result instead of only the state. Existing diagnostics
+may log the stable reason string, never screen text. Phase 3 also adds an optional,
+Release-visible `detection_reason` field to `prowl agents --json` while leaving text output
+and UI unchanged.
+
+### Snapshot, regions, and profiles
+
+`AgentScreenSnapshot` has a deliberately small contract:
+
+- constructed after the existing 24-non-empty-line truncation;
+- retains canonical text and a split-once line representation;
+- may cache mechanical per-line normalization;
+- never owns named runtime regions or rule semantics.
+
+`CodexScreenRegions` and `ClaudeScreenRegions` own prompt/menu/footer boundaries. Each
+profile uses ordinary Swift predicates and early returns; source order is precedence.
+There is no profile protocol or generic rule array initially.
+
+Existing cross-runtime predicates keep one shared owner. Profiles may call shared
+mechanical predicates such as spinner/numbered-choice checks; a predicate becomes private
+only when its last other caller is removed. Region extraction and rule ordering remain
+profile-owned. This avoids copying shared glyph tables into independently drifting files.
+
+### Captured fixture corpus
+
+Normal fixture path:
+
+```text
+supacodeTests/Fixtures/AgentScreenDetection/
+  <runtime>/<cli-version>/<expected-raw-state>/<scenario>.txt
+```
+
+`done` is never a fixture state because it is derived from `idle + unseen`. Each `.txt`
+has same-basename metadata recording capture timestamp, exact CLI version, terminal
+geometry, capture source, and redaction summary. Reconstructed or synthetic screens remain
+inline tests and are never presented as captured/version-stamped evidence.
+
+A corpus fixture is the plain-text, active-screen input the detector actually receives,
+normalized to the canonical 24-non-empty-line tail. It is not an arbitrary matched-region
+snippet. Account, path, repository, prompt, and model-output data are redacted without
+changing runtime chrome, ordering, marker positions, wrapping, or blank-line boundaries.
+Raw captures go to an ignored private staging directory and are never committed.
+
+The harness enumerates files relative to `#filePath`, validates path/metadata/state/runtime,
+asserts at least one fixture ran, and reports the relative path on failure. Corpus tests
+assert end-to-end state; focused inline tests assert rule IDs, precedence, and parser
+boundaries. Existing constructed tests are not mechanically moved into files.
+
+If a fresh capture exposes a current bug, it is not omitted. It enters a machine-checked
+quarantine path containing expected state, current observed state, and linked issue. The
+quarantine test asserts current behavior, then fails when a later fix makes promotion to
+the normal corpus necessary.
+
+Retain the newest verified capture for each scenario/UI shape. Keep an older version only
+when its distinct shape remains intentionally supported; prune byte-equivalent history.
+
+## Phased migration
+
+### Phase 1 — detector-faithful capture seam
+
+- Add an explicit way to read the exact `readActiveText()` / `GHOSTTY_POINT_ACTIVE` input
+  used by production detection; current `prowl read` uses the viewport and is not equivalent
+  when scrolled.
+- Prove capture bytes and production detector input share the same source/normalization.
+- Establish ignored, private raw-capture staging.
+
+Implementation decision: ship an explicit read-only `prowl read` detection source in normal
+builds, documented and tested. Its default remains the existing viewport behavior.
+
+Exit: a live pane can be captured reproducibly without instrumenting or patching the app
+locally.
+
+### Phase 2 — corpus harness and fresh baseline
+
+- Add the loader, metadata validator, policy README, and quarantine convention.
+- Run fresh manual sessions against installed Claude and Codex versions.
+- Seed Codex directory trust, hook review, sign-in, permission, working footer, idle, and
+  stale/quoted negatives.
+- Seed Claude trust, permission, foreground spinner/elapsed work, viewer/no-signal, idle,
+  and reproducible background/subagent forms. Do not invent a subagent-wait fixture.
+
+Exit: every freshly captured current shape is either green in the normal corpus or visible
+in quarantine; zero captured failures are silently dropped.
+
+### Phase 3 — explainable result plumbing
+
+- Add `AgentScreenDetection`, profile-owned rule IDs, and reasons.
+- Keep `detectState(in:)` as a state-only projection and wrap unmigrated detectors as legacy.
+- Cache the complete result and include reason IDs in existing transition diagnostics.
+- Add an optional `detection_reason` to `prowl agents --json`; text output and UI remain
+  unchanged.
+
+Exit: all raw/stabilized states are unchanged; cache tests cover reason reuse and invalidation.
+
+### Phase 4 — Codex profile
+
+- Move Codex region extraction, predicates, and ordered decisions into its profile.
+- Preserve #674/#683 anchors and blocker-over-working precedence.
+- Add positive live-idle recognition only where current chrome is structurally reliable;
+  otherwise retain `.idle + noRuleMatched`.
+- Use two reviewable commits: profile + temporary legacy-parity test, then legacy removal.
+  No dual production classifier ships.
+
+Exit: parity over all existing Codex tests and corpus fixtures, except separately reviewed
+capture-backed behavior fixes; stable rule IDs cover every matched profile path.
+
+### Phase 5 — Claude profile
+
+- Move viewer, current-selection blocker, live status, elapsed status, background-work,
+  and reliable idle regions into its profile.
+- Preserve `.unknown` viewer behavior and the 3-second hold.
+- Use the same two-commit parity protocol as Codex.
+- Add no subagent-wait rule without a captured failing screen.
+
+Exit: parity over all existing Claude tests and corpus fixtures, except separately reviewed
+capture-backed behavior fixes; stable rule IDs cover every matched profile path.
+
+### Adoption gate
+
+After both profiles ship, measure readability, corpus upkeep, changed-frame detection cost,
+and the usefulness of reasons. A third runtime migrates only with fresh fixture provenance
+and demonstrated maintenance pressure. Shared abstractions are extracted only from proven
+duplication; leaving legacy detectors in place is an acceptable steady state.
+
+## Validation and invariants
+
+Every implementation PR preserves:
+
+- screen-only state authority and last-24-non-empty-lines semantics;
+- exact `(agent, active-screen text)` cache identity;
+- existing state precedence, `.unknown` behavior, and 3-second hold;
+- no raw screen content in logs, analytics, or agent-status payloads;
+- focused tests, complete detection/cache tests, `make check`, full tests as required, and
+  `make build-app`;
+- non-zero Swift Testing execution counts (suite/method selectors must not silently match
+  zero tests).
+
+Record an opt-in Release median over the corpus before and after each profile migration;
+do not add an absolute CI timing gate. Snapshot splitting and region normalization should
+occur once per changed screen.
+
+## Risks and controls
+
+| Risk | Control |
+| --- | --- |
+| Infrastructure outgrows the heuristic code | No DSL, profile protocol, numeric priority, remote update, or generic region registry |
+| Migration changes correct behavior | One runtime per phase; reproducible parity commit; intentional differences require fresh captures |
+| Strict rules create false idle | Explicit no-match reason, positive idle tripwire where reliable, quarantine for discovered failures |
+| Broad rules match transcript prose | Runtime-owned live regions plus mandatory stale/quoted negative fixtures |
+| Shared helpers drift after copying | Single shared owner; last-user-takes-private rule |
+| Corpus becomes an archive | Newest-per-shape retention and deliberate pruning |
+| Captures leak private data | Private ignored raw staging, required metadata/redaction review, no automatic commit |
+| Metadata causes UI churn | Cache/diagnostics only; optional additive JSON field, no view state |
+| Changed-frame CPU regresses | Parse once, preserve memoization, compare Release corpus medians |
+| Partial migration creates two frameworks | Explicit legacy path; no production dual-run; no ritual migration target |
+
+## Aligned decisions
+
+- The detector-faithful capture seam ships as an explicit, documented, read-only
+  `prowl read` source in normal builds rather than a Debug-only facility.
+- Phase 3 adds optional `detection_reason` to `prowl agents --json`; it contains only a
+  stable rule/fallback/legacy identifier and never raw screen text. Text output and UI do
+  not change.
+- Manual fixture refresh remains the initial policy. Even with positive idle rules and a
+  Release-visible reason, Prowl will not proactively alert on unknown vendor UI drift; that
+  limitation is explicitly accepted unless a later recapture/telemetry design is approved.

--- a/docs-ai/030-agent-status-detection/008-detector-faithful-cli-capture.md
+++ b/docs-ai/030-agent-status-detection/008-detector-faithful-cli-capture.md
@@ -27,8 +27,9 @@ prowl read --pane "$pane" --source detection --json
 - `viewport` is the default and preserves all existing snapshot/scrollback behavior.
 - `detection` reads `GhosttySurfaceView.readActiveContentsForCLI()`, the same method
   reached by production `readActiveText()`.
-- The success payload reports `source: "detection"`; fixture tooling must verify this
-  value before accepting text.
+- The success payload reports `source: "detection"`; the CLI rejects a successful
+  response that does not honor the requested source (for example, from an older running
+  app), and fixture tooling must still verify the value before accepting text.
 - Omitting `--last` returns the complete active buffer unchanged. `--last` remains a
   supported line projection but is not used for detector fixture capture.
 - `--wait-stable` polls only the requested source. Normal reads do not pay for an extra
@@ -40,8 +41,9 @@ a mismatched provider result. The response schema remains `prowl.cli.read.v1`; t
 source value appears only when explicitly requested.
 
 Raw screen content is returned only to the explicit `read` caller. It is not logged,
-added to status payloads, or committed automatically. CLI/component/skill documentation
-requires private staging, source verification, and redaction before a fixture is added.
+added to status payloads, or committed automatically. `.local/agent-screen-captures/` is
+the canonical ignored private staging directory; CLI/component/skill documentation
+requires source verification and redaction before a fixture is added.
 
 ## Validation
 
@@ -50,8 +52,8 @@ implementation:
 
 - `CLIReadCommandHandlerTests`: 18 passed, including exact trailing-newline preservation,
   detection-only `--last`, mismatched-source rejection, and legacy request decoding.
-- SwiftPM: 75 passed.
-- CLI integration filter: 65 passed.
+- SwiftPM: 76 passed.
+- CLI integration filter: 66 passed.
 - Full app suite: xcsift reported 2,272 passed; the xcresult backstop independently
   verified 2,275 tests and zero failures.
 - `make test-cli-smoke`, `make build-cli`, `make test-cli-integration`, `make check`, and

--- a/docs-ai/030-agent-status-detection/008-detector-faithful-cli-capture.md
+++ b/docs-ai/030-agent-status-detection/008-detector-faithful-cli-capture.md
@@ -52,8 +52,9 @@ implementation:
 
 - `CLIReadCommandHandlerTests`: 18 passed, including exact trailing-newline preservation,
   detection-only `--last`, mismatched-source rejection, and legacy request decoding.
-- SwiftPM: 76 passed.
-- CLI integration filter: 66 passed.
+- SwiftPM: 77 passed.
+- CLI integration filter: 67 passed, including JSON/text stale-app rejection without
+  returning viewport text.
 - Full app suite: xcsift reported 2,272 passed; the xcresult backstop independently
   verified 2,275 tests and zero failures.
 - `make test-cli-smoke`, `make build-cli`, `make test-cli-integration`, `make check`, and

--- a/docs-ai/030-agent-status-detection/008-detector-faithful-cli-capture.md
+++ b/docs-ai/030-agent-status-detection/008-detector-faithful-cli-capture.md
@@ -1,0 +1,76 @@
+# 030.008 — Detector-Faithful CLI Capture Source
+
+| | |
+| --- | --- |
+| **Status** | Implemented |
+| **Anchor date** | 2026-08-06 |
+| **Primary PR** | TBD |
+| **Plan** | [007-screen-profile-migration-plan.md](007-screen-profile-migration-plan.md), Phase 1 |
+| **Related** | `docs/components/cli.md`, `docs/components/agent-detection.md` |
+
+## Context
+
+The production state detector reads `GHOSTTY_POINT_ACTIVE` through
+`GhosttySurfaceBridge.readActiveText()`. Before this change, `prowl read` used
+`GHOSTTY_POINT_VIEWPORT`; a scrolled pane could therefore produce a capture different
+from the detector's actual input. A versioned fixture corpus built from that command
+would have false provenance.
+
+## Change
+
+`prowl read` now accepts an explicit source:
+
+```bash
+prowl read --pane "$pane" --source detection --json
+```
+
+- `viewport` is the default and preserves all existing snapshot/scrollback behavior.
+- `detection` reads `GhosttySurfaceView.readActiveContentsForCLI()`, the same method
+  reached by production `readActiveText()`.
+- The success payload reports `source: "detection"`; fixture tooling must verify this
+  value before accepting text.
+- Omitting `--last` returns the complete active buffer unchanged. `--last` remains a
+  supported line projection but is not used for detector fixture capture.
+- `--wait-stable` polls only the requested source. Normal reads do not pay for an extra
+  Ghostty text read.
+
+The read request source decodes to `viewport` when absent, preserving requests from an
+older CLI. The app's capture provider carries the requested source explicitly and rejects
+a mismatched provider result. The response schema remains `prowl.cli.read.v1`; the new
+source value appears only when explicitly requested.
+
+Raw screen content is returned only to the explicit `read` caller. It is not logged,
+added to status payloads, or committed automatically. CLI/component/skill documentation
+requires private staging, source verification, and redaction before a fixture is added.
+
+## Validation
+
+Test-first failures established the missing parser and handler contracts. After the
+implementation:
+
+- `CLIReadCommandHandlerTests`: 18 passed, including exact trailing-newline preservation,
+  detection-only `--last`, mismatched-source rejection, and legacy request decoding.
+- SwiftPM: 75 passed.
+- CLI integration filter: 65 passed.
+- Full app suite: xcsift reported 2,272 passed; the xcresult backstop independently
+  verified 2,275 tests and zero failures.
+- `make test-cli-smoke`, `make build-cli`, `make test-cli-integration`, `make check`, and
+  `make build-app` passed.
+
+A second Debug app was launched against an isolated Unix socket and temporary plain
+workspace. After printing 120 synthetic sentinel lines and scrolling its real Ghostty
+viewport with an AppKit/CGEvent input path:
+
+- default read returned `source: "screen"`;
+- detection read returned `source: "detection"`;
+- viewport and active-buffer SHA-256 values differed;
+- the detection capture retained the newest sentinel while the scrolled viewport did not.
+
+No raw user or agent content was used in this live verification.
+
+## Result
+
+Phase 1's exit condition is met: a live pane's exact detector input can be captured
+reproducibly without a local patch or Debug-only app facility. Fixture loading,
+provenance metadata, redaction policy enforcement, and fresh Claude/Codex captures remain
+Phase 2 work.

--- a/docs-ai/030-agent-status-detection/008-detector-faithful-cli-capture.md
+++ b/docs-ai/030-agent-status-detection/008-detector-faithful-cli-capture.md
@@ -4,7 +4,7 @@
 | --- | --- |
 | **Status** | Implemented |
 | **Anchor date** | 2026-08-06 |
-| **Primary PR** | TBD |
+| **Primary PR** | [#684](https://github.com/onevcat/Prowl/pull/684) |
 | **Plan** | [007-screen-profile-migration-plan.md](007-screen-profile-migration-plan.md), Phase 1 |
 | **Related** | `docs/components/cli.md`, `docs/components/agent-detection.md` |
 

--- a/docs/components/agent-detection.md
+++ b/docs/components/agent-detection.md
@@ -53,6 +53,11 @@ at a `~/.grok/` install (so Cursor's own `agent` entrypoint stays Cursor).
    ended; Prowl reads that footer as **Working**, so a churning workflow isn't
    mistaken for idle.
 
+For diagnostics and sanitized regression captures, `prowl read --source detection`
+returns the exact active-screen buffer used by stage 2. It is explicitly requested
+because it can differ from the visible viewport when a pane is scrolled; the default
+`prowl read` behavior is unchanged.
+
 To avoid flicker, detection **stabilizes**: it tolerates several consecutive
 misses before declaring an agent gone, and a working agent gets a short (~3s)
 hold so brief pauses between thinking and output don't drop it out of

--- a/docs/components/cli.md
+++ b/docs/components/cli.md
@@ -173,9 +173,11 @@ For detector regression captures, omit `--last`, require the returned source, an
 extract the JSON string without adding a newline:
 
 ```bash
+mkdir -p .local/agent-screen-captures
 capture="$(prowl read --pane "$pane" --source detection --json)"
 printf '%s\n' "$capture" | jq -e '.data.source == "detection"' >/dev/null
-printf '%s\n' "$capture" | jq -j '.data.text' > /path/to/private/raw-capture.txt
+printf '%s\n' "$capture" | jq -j '.data.text' \
+  > .local/agent-screen-captures/raw-capture.txt
 ```
 
 This is a diagnostic/capture source, not a more complete terminal-history read;

--- a/docs/components/cli.md
+++ b/docs/components/cli.md
@@ -153,6 +153,9 @@ It prints a pane handle such as `p7` for each agent; use it as
 Read a pane's content.
 
 - `--last <n>` — last N lines (scrollback + screen); omit for a full snapshot.
+- `--source <viewport|detection>` — `viewport` preserves the normal read behavior
+  (default); `detection` reads the exact active-screen buffer used by agent-state
+  detection, which can differ from the viewport when a pane is scrolled.
 - `--wait-stable` — re-read until the screen stops changing (best for live TUIs).
 - `--stable-interval <50–5000ms>` (default 200), `--stable-period <100–60000ms>`
   (default 800), `--wait-timeout <1–300s>` (default 10) — tune the stable wait.
@@ -160,11 +163,23 @@ Read a pane's content.
 ```bash
 prowl read --pane "$pane" --last 200 --wait-stable --json
 ```
-Response includes `mode` (snapshot|last), `source` (screen|scrollback|mixed),
-`truncated`, `line_count`, `text`, and (when waiting) `stabilized`, `waited_ms`,
-`samples`. **`truncated: false` with fewer lines than `--last` just means the pane
-has less history — don't retry.** `truncated: true` flags a possibly-incomplete
-read.
+Response includes `mode` (snapshot|last), `source`
+(screen|scrollback|mixed|detection), `truncated`, `line_count`, `text`, and (when
+waiting) `stabilized`, `waited_ms`, `samples`. **`truncated: false` with fewer
+lines than `--last` just means the pane has less history — don't retry.**
+`truncated: true` flags a possibly-incomplete read.
+
+For detector regression captures, omit `--last`, require the returned source, and
+extract the JSON string without adding a newline:
+
+```bash
+capture="$(prowl read --pane "$pane" --source detection --json)"
+printf '%s\n' "$capture" | jq -e '.data.source == "detection"' >/dev/null
+printf '%s\n' "$capture" | jq -j '.data.text' > /path/to/private/raw-capture.txt
+```
+
+This is a diagnostic/capture source, not a more complete terminal-history read;
+normal pane inspection should keep the default viewport source.
 
 ### `prowl send [target] [text]`
 Type into a pane, optionally wait for completion and capture output.

--- a/docs/components/cli.md
+++ b/docs/components/cli.md
@@ -155,7 +155,9 @@ Read a pane's content.
 - `--last <n>` — last N lines (scrollback + screen); omit for a full snapshot.
 - `--source <viewport|detection>` — `viewport` preserves the normal read behavior
   (default); `detection` reads the exact active-screen buffer used by agent-state
-  detection, which can differ from the viewport when a pane is scrolled.
+  detection, which can differ from the viewport when a pane is scrolled. If the
+  running app is too old to honor `detection`, the CLI fails with `READ_FAILED`
+  instead of returning viewport text; update or restart Prowl and retry.
 - `--wait-stable` — re-read until the screen stops changing (best for live TUIs).
 - `--stable-interval <50–5000ms>` (default 200), `--stable-period <100–60000ms>`
   (default 800), `--wait-timeout <1–300s>` (default 10) — tune the stable wait.
@@ -173,11 +175,14 @@ For detector regression captures, omit `--last`, require the returned source, an
 extract the JSON string without adding a newline:
 
 ```bash
-mkdir -p .local/agent-screen-captures
+# Run from the Prowl source checkout so the private staging path is ignored.
+repo_root="$(git rev-parse --show-toplevel)"
+test -f "$repo_root/supacode.xcodeproj/project.pbxproj"
+staging="$repo_root/.local/agent-screen-captures"
+mkdir -p "$staging"
 capture="$(prowl read --pane "$pane" --source detection --json)"
 printf '%s\n' "$capture" | jq -e '.data.source == "detection"' >/dev/null
-printf '%s\n' "$capture" | jq -j '.data.text' \
-  > .local/agent-screen-captures/raw-capture.txt
+printf '%s\n' "$capture" | jq -j '.data.text' > "$staging/raw-capture.txt"
 ```
 
 This is a diagnostic/capture source, not a more complete terminal-history read;

--- a/skills/prowl-cli/SKILL.md
+++ b/skills/prowl-cli/SKILL.md
@@ -157,14 +157,18 @@ done
 prowl read --pane "$pane" --last 200 --wait-stable --json
 ```
 
-The default read source follows the viewport. Only when diagnosing agent-state detection or collecting a sanitized detector fixture, request the exact active-screen detector input and verify the returned source before trusting it:
+The default read source follows the viewport. Only when diagnosing agent-state detection or collecting a sanitized detector fixture, request the exact active-screen detector input and verify the returned source before trusting it. An older running app that does not honor `detection` fails with `READ_FAILED`; update or restart Prowl rather than accepting viewport text.
+
+Run the capture from the Prowl source checkout so its canonical private staging path is covered by `.gitignore`:
 
 ```bash
-mkdir -p .local/agent-screen-captures
+repo_root="$(git rev-parse --show-toplevel)"
+test -f "$repo_root/supacode.xcodeproj/project.pbxproj"
+staging="$repo_root/.local/agent-screen-captures"
+mkdir -p "$staging"
 capture="$(prowl read --pane "$pane" --source detection --json)"
 printf '%s\n' "$capture" | jq -e '.data.source == "detection"' >/dev/null
-printf '%s\n' "$capture" | jq -j '.data.text' \
-  > .local/agent-screen-captures/raw-capture.txt
+printf '%s\n' "$capture" | jq -j '.data.text' > "$staging/raw-capture.txt"
 ```
 
 Omit `--last` for detector captures. A scrolled pane's detection source can differ from its viewport. Treat the raw capture as private and redact it before committing any fixture.

--- a/skills/prowl-cli/SKILL.md
+++ b/skills/prowl-cli/SKILL.md
@@ -160,9 +160,11 @@ prowl read --pane "$pane" --last 200 --wait-stable --json
 The default read source follows the viewport. Only when diagnosing agent-state detection or collecting a sanitized detector fixture, request the exact active-screen detector input and verify the returned source before trusting it:
 
 ```bash
+mkdir -p .local/agent-screen-captures
 capture="$(prowl read --pane "$pane" --source detection --json)"
 printf '%s\n' "$capture" | jq -e '.data.source == "detection"' >/dev/null
-printf '%s\n' "$capture" | jq -j '.data.text' > /path/to/private/raw-capture.txt
+printf '%s\n' "$capture" | jq -j '.data.text' \
+  > .local/agent-screen-captures/raw-capture.txt
 ```
 
 Omit `--last` for detector captures. A scrolled pane's detection source can differ from its viewport. Treat the raw capture as private and redact it before committing any fixture.

--- a/skills/prowl-cli/SKILL.md
+++ b/skills/prowl-cli/SKILL.md
@@ -131,7 +131,7 @@ prowl list --json | jq -e '.ok == true' >/dev/null || echo "command failed"
 
 Key fields by command (see `docs/components/cli.md` for the full contract):
 
-- `read` → `.data.text`, `.data.line_count`, `.data.truncated`, `.data.mode` (`snapshot`|`last`), `.data.source` (`screen`|`scrollback`|`mixed`), plus `.data.stabilized` / `.data.waited_ms` / `.data.samples` when `--wait-stable`.
+- `read` → `.data.text`, `.data.line_count`, `.data.truncated`, `.data.mode` (`snapshot`|`last`), `.data.source` (`screen`|`scrollback`|`mixed`|`detection`), plus `.data.stabilized` / `.data.waited_ms` / `.data.samples` when `--wait-stable`.
 - `send` → `.data.input` (source/characters/bytes/trailing_enter_sent); `.data.wait.exit_code` and `.data.wait.duration_ms` when waiting; `.data.capture.text` / `.data.capture.line_count` / `.data.capture.truncated` when `--capture`.
 - `list` / `agents` → `.data.items[]` / `.data.agents[]`, each with `.pane.id`, `.tab.id`, `.worktree.{id,name,path}`, `.task.status`.
 - `tab create` / `open` → `.data.target.{pane,tab,worktree}`.
@@ -156,6 +156,16 @@ for i in 1 2 3 4 5 6; do
 done
 prowl read --pane "$pane" --last 200 --wait-stable --json
 ```
+
+The default read source follows the viewport. Only when diagnosing agent-state detection or collecting a sanitized detector fixture, request the exact active-screen detector input and verify the returned source before trusting it:
+
+```bash
+capture="$(prowl read --pane "$pane" --source detection --json)"
+printf '%s\n' "$capture" | jq -e '.data.source == "detection"' >/dev/null
+printf '%s\n' "$capture" | jq -j '.data.text' > /path/to/private/raw-capture.txt
+```
+
+Omit `--last` for detector captures. A scrolled pane's detection source can differ from its viewport. Treat the raw capture as private and redact it before committing any fixture.
 
 When you need complete output from an agent, prefer writing or redirecting to a file over reading rendered TUI output. Screen capture can be truncated or miss folded content.
 

--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -526,6 +526,30 @@ struct SupacodeApp: App {
     }
   }
 
+  private static func makeReadCapture(
+    request: ReadCaptureRequest,
+    terminalManager: WorktreeTerminalManager
+  ) -> ReadCaptureInput? {
+    let target = request.target
+    guard let state = terminalManager.stateIfExists(for: target.worktreeID),
+      let surface = state.surfaceView(for: target.paneID)
+    else {
+      return nil
+    }
+
+    switch request.source {
+    case .viewport:
+      guard let viewportText = surface.readViewportContentsForCLI() else { return nil }
+      return ReadCaptureInput(
+        viewportText: viewportText,
+        screenText: surface.readScreenContentsForCLI()
+      )
+    case .detection:
+      guard let detectionText = surface.readActiveContentsForCLI() else { return nil }
+      return ReadCaptureInput(detectionText: detectionText)
+    }
+  }
+
   // swiftlint:disable:next function_body_length
   static func makeCLICommandRouter(
     appStore: StoreOf<AppFeature>,
@@ -630,17 +654,8 @@ struct SupacodeApp: App {
         }
         return resolver.resolve(selector).map { ReadResolvedTarget(from: $0) }
       },
-      captureProvider: { target in
-        guard let state = terminalManager.stateIfExists(for: target.worktreeID),
-          let surface = state.surfaceView(for: target.paneID),
-          let viewportText = surface.readViewportContentsForCLI()
-        else {
-          return nil
-        }
-        return ReadCaptureInput(
-          viewportText: viewportText,
-          screenText: surface.readScreenContentsForCLI()
-        )
+      captureProvider: { request in
+        Self.makeReadCapture(request: request, terminalManager: terminalManager)
       }
     )
     let keyHandler = KeyCommandHandler(

--- a/supacode/CLIService/ReadCommandHandler.swift
+++ b/supacode/CLIService/ReadCommandHandler.swift
@@ -9,9 +9,39 @@ private struct ReadCapture {
   let truncated: Bool
 }
 
+struct ReadCaptureRequest: Sendable {
+  let target: ReadResolvedTarget
+  let source: ReadInputSource
+}
+
 struct ReadCaptureInput: Sendable {
-  let viewportText: String
-  let screenText: String?
+  enum Content: Sendable {
+    case viewport(text: String, screenText: String?)
+    case detection(text: String)
+  }
+
+  let content: Content
+
+  var viewportText: String {
+    switch content {
+    case .viewport(let text, _), .detection(let text): text
+    }
+  }
+
+  var screenText: String? {
+    switch content {
+    case .viewport(_, let screenText): screenText
+    case .detection: nil
+    }
+  }
+
+  init(viewportText: String, screenText: String?) {
+    self.content = .viewport(text: viewportText, screenText: screenText)
+  }
+
+  init(detectionText: String) {
+    self.content = .detection(text: detectionText)
+  }
 }
 
 /// Resolved target metadata for read payload construction.
@@ -50,7 +80,7 @@ extension ReadResolvedTarget {
 @MainActor
 final class ReadCommandHandler: CommandHandler {
   typealias ResolveProvider = @MainActor (TargetSelector) -> Result<ReadResolvedTarget, TargetResolverError>
-  typealias CaptureProvider = @MainActor (ReadResolvedTarget) -> ReadCaptureInput?
+  typealias CaptureProvider = @MainActor (ReadCaptureRequest) -> ReadCaptureInput?
 
   private let resolveProvider: ResolveProvider
   private let captureProvider: CaptureProvider
@@ -92,7 +122,7 @@ final class ReadCommandHandler: CommandHandler {
       waitedMs = result.waitedMs
       samples = result.samples
     } else {
-      guard let single = makeCapture(target: target, last: input.last) else {
+      guard let single = makeCapture(target: target, input: input) else {
         return errorResponse(code: CLIErrorCode.readFailed, message: "Failed to read terminal text.")
       }
       capture = single
@@ -140,21 +170,42 @@ final class ReadCommandHandler: CommandHandler {
     static let timeoutSeconds = 10
   }
 
-  /// Capture the pane's current content, applying `--last` line selection when requested.
-  private func makeCapture(target: ReadResolvedTarget, last: Int?) -> ReadCapture? {
-    guard let captureInput = captureProvider(target) else { return nil }
-    if let last {
-      return captureLast(
-        requestedLineCount: last,
-        viewportText: captureInput.viewportText,
-        screenText: captureInput.screenText
+  /// Capture the requested terminal source, applying `--last` line selection when requested.
+  private func makeCapture(target: ReadResolvedTarget, input: ReadInput) -> ReadCapture? {
+    let request = ReadCaptureRequest(target: target, source: input.source)
+    guard let captureInput = captureProvider(request) else { return nil }
+
+    switch (input.source, captureInput.content) {
+    case (.viewport, .viewport(let viewportText, let screenText)):
+      if let last = input.last {
+        return captureLast(
+          requestedLineCount: last,
+          viewportText: viewportText,
+          screenText: screenText
+        )
+      }
+      return ReadCapture(
+        text: viewportText,
+        source: .screen,
+        truncated: false
       )
+
+    case (.detection, .detection(let text)):
+      let output: String
+      if let last = input.last {
+        output = joinLines(splitLines(text).suffix(last))
+      } else {
+        output = text
+      }
+      return ReadCapture(
+        text: output,
+        source: .detection,
+        truncated: false
+      )
+
+    default:
+      return nil
     }
-    return ReadCapture(
-      text: captureInput.viewportText,
-      source: .screen,
-      truncated: false
-    )
   }
 
   /// Re-read the pane on a fixed interval until its content stops changing for a streak of
@@ -170,7 +221,7 @@ final class ReadCommandHandler: CommandHandler {
     let requiredStreak = max(1, Int((Double(periodMs) / Double(intervalMs)).rounded(.up)))
     let maxSleeps = max(1, Int((Double(timeoutMs) / Double(intervalMs)).rounded(.up)))
 
-    guard var current = makeCapture(target: target, last: input.last) else { return nil }
+    guard var current = makeCapture(target: target, input: input) else { return nil }
     var streak = 0
     var samples = 1
     var sleeps = 0
@@ -191,7 +242,7 @@ final class ReadCommandHandler: CommandHandler {
         break  // Cancelled: return the best capture so far.
       }
       sleeps += 1
-      guard let next = makeCapture(target: target, last: input.last) else {
+      guard let next = makeCapture(target: target, input: input) else {
         break  // Capture became unavailable mid-poll (e.g. pane closed): stop with what we have.
       }
       samples += 1

--- a/supacode/CLIService/Shared/InputModels.swift
+++ b/supacode/CLIService/Shared/InputModels.swift
@@ -109,9 +109,16 @@ public struct KeyInput: Codable, Sendable {
   }
 }
 
+public enum ReadInputSource: String, Codable, Sendable {
+  case viewport
+  case detection
+}
+
 public struct ReadInput: Codable, Sendable {
   public let selector: TargetSelector
   public let last: Int?
+  /// The terminal buffer requested by the caller.
+  public let source: ReadInputSource
   /// When true, the app re-reads the pane until its output stops changing before responding.
   public let waitStable: Bool
   /// Sampling interval in milliseconds while waiting for stable output (nil → app default).
@@ -121,9 +128,20 @@ public struct ReadInput: Codable, Sendable {
   /// Maximum seconds to keep waiting for stable output before returning the latest snapshot (nil → app default).
   public let waitTimeoutSeconds: Int?
 
+  enum CodingKeys: String, CodingKey {
+    case selector
+    case last
+    case source
+    case waitStable
+    case stableIntervalMs
+    case stablePeriodMs
+    case waitTimeoutSeconds
+  }
+
   public init(
     selector: TargetSelector = .none,
     last: Int? = nil,
+    source: ReadInputSource = .viewport,
     waitStable: Bool = false,
     stableIntervalMs: Int? = nil,
     stablePeriodMs: Int? = nil,
@@ -131,10 +149,33 @@ public struct ReadInput: Codable, Sendable {
   ) {
     self.selector = selector
     self.last = last
+    self.source = source
     self.waitStable = waitStable
     self.stableIntervalMs = stableIntervalMs
     self.stablePeriodMs = stablePeriodMs
     self.waitTimeoutSeconds = waitTimeoutSeconds
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    self.selector = try container.decodeIfPresent(TargetSelector.self, forKey: .selector) ?? .none
+    self.last = try container.decodeIfPresent(Int.self, forKey: .last)
+    self.source = try container.decodeIfPresent(ReadInputSource.self, forKey: .source) ?? .viewport
+    self.waitStable = try container.decodeIfPresent(Bool.self, forKey: .waitStable) ?? false
+    self.stableIntervalMs = try container.decodeIfPresent(Int.self, forKey: .stableIntervalMs)
+    self.stablePeriodMs = try container.decodeIfPresent(Int.self, forKey: .stablePeriodMs)
+    self.waitTimeoutSeconds = try container.decodeIfPresent(Int.self, forKey: .waitTimeoutSeconds)
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(selector, forKey: .selector)
+    try container.encodeIfPresent(last, forKey: .last)
+    try container.encode(source, forKey: .source)
+    try container.encode(waitStable, forKey: .waitStable)
+    try container.encodeIfPresent(stableIntervalMs, forKey: .stableIntervalMs)
+    try container.encodeIfPresent(stablePeriodMs, forKey: .stablePeriodMs)
+    try container.encodeIfPresent(waitTimeoutSeconds, forKey: .waitTimeoutSeconds)
   }
 }
 

--- a/supacode/CLIService/Shared/ReadCommandPayload.swift
+++ b/supacode/CLIService/Shared/ReadCommandPayload.swift
@@ -65,6 +65,7 @@ public enum ReadSource: String, Codable, Sendable {
   case screen
   case scrollback
   case mixed
+  case detection
 }
 
 public struct ReadTarget: Codable, Sendable, Equatable {

--- a/supacodeTests/CLIReadCommandHandlerTests.swift
+++ b/supacodeTests/CLIReadCommandHandlerTests.swift
@@ -26,10 +26,13 @@ struct CLIReadCommandHandlerTests {
     )
   }
 
-  private static func makeEnvelope(last: Int? = nil) -> CommandEnvelope {
+  private static func makeEnvelope(
+    last: Int? = nil,
+    source: ReadInputSource = .viewport
+  ) -> CommandEnvelope {
     CommandEnvelope(
       output: .json,
-      command: .read(ReadInput(selector: .none, last: last))
+      command: .read(ReadInput(selector: .none, last: last, source: source))
     )
   }
 
@@ -56,6 +59,66 @@ struct CLIReadCommandHandlerTests {
     #expect(payload.truncated == false)
     #expect(payload.lineCount == 2)
     #expect(payload.text == "line-1\nline-2")
+  }
+
+  @Test func detectionSnapshotUsesExactDetectorInput() async throws {
+    let handler = ReadCommandHandler(
+      resolveProvider: { _ in .success(Self.makeTarget()) },
+      captureProvider: { request in
+        #expect(request.source == .detection)
+        return ReadCaptureInput(detectionText: "active-line-1\nactive-line-2\n")
+      }
+    )
+
+    let response = await handler.handle(envelope: Self.makeEnvelope(source: .detection))
+
+    #expect(response.ok)
+    let payload = try #require(try response.data?.decode(as: ReadCommandPayload.self))
+    #expect(payload.mode == .snapshot)
+    #expect(payload.source == .detection)
+    #expect(payload.truncated == false)
+    #expect(payload.lineCount == 3)
+    #expect(payload.text == "active-line-1\nactive-line-2\n")
+  }
+
+  @Test func detectionLastUsesOnlyDetectorInput() async throws {
+    let handler = ReadCommandHandler(
+      resolveProvider: { _ in .success(Self.makeTarget()) },
+      captureProvider: { _ in ReadCaptureInput(detectionText: "one\ntwo\nthree") }
+    )
+
+    let response = await handler.handle(envelope: Self.makeEnvelope(last: 2, source: .detection))
+
+    #expect(response.ok)
+    let payload = try #require(try response.data?.decode(as: ReadCommandPayload.self))
+    #expect(payload.mode == .last)
+    #expect(payload.source == .detection)
+    #expect(payload.truncated == false)
+    #expect(payload.lineCount == 2)
+    #expect(payload.text == "two\nthree")
+  }
+
+  @Test func detectionRejectsMismatchedCaptureSource() async {
+    let handler = ReadCommandHandler(
+      resolveProvider: { _ in .success(Self.makeTarget()) },
+      captureProvider: { _ in ReadCaptureInput(viewportText: "viewport", screenText: nil) }
+    )
+
+    let response = await handler.handle(envelope: Self.makeEnvelope(source: .detection))
+
+    #expect(response.ok == false)
+    #expect(response.error?.code == CLIErrorCode.readFailed)
+  }
+
+  @Test func readInputWithoutSourceDecodesAsViewport() throws {
+    let encoded = try JSONEncoder().encode(ReadInput())
+    var object = try #require(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+    object.removeValue(forKey: "source")
+    let legacyData = try JSONSerialization.data(withJSONObject: object)
+
+    let input = try JSONDecoder().decode(ReadInput.self, from: legacyData)
+
+    #expect(input.source == .viewport)
   }
 
   @Test func snapshotSucceedsWhenScreenCaptureUnavailable() async throws {


### PR DESCRIPTION
## Summary

- document the staged screen-detection profile and fixture migration
- add `prowl read --source detection` backed by the same active Ghostty buffer as production state detection
- preserve viewport defaults and legacy request decoding
- reject stale running apps that do not honor the requested detection source
- establish an ignored private raw-capture staging path and document source verification/redaction

## Validation

- `make check`
- `make build-app`
- `make build-cli`
- `make test-cli-smoke`
- `make test-cli-integration` (67 tests)
- `swift test` (77 tests)
- full app suite (2,275 tests verified from xcresult)
- isolated live Debug-app verification with a scrolled viewport; viewport and detection captures diverged as expected while detection retained the newest synthetic sentinel
