### PR TITLE
Add dedicated Ghostty config override

### DIFF
--- a/docs/components/settings.md
+++ b/docs/components/settings.md
@@ -25,7 +25,7 @@ opens that section's root.
 
 | Section | Controls |
 |-----|----------|
-| **General** | Appearance (system/light/dark), default app for opening worktrees, diff tool, confirm-before-quit, default view mode, window chrome tint, automatic repository icon detection, toolbar buttons (Run / Open-in-editor), dim unfocused splits, Active Agents panel auto-show & terminal titles. |
+| **General** | Appearance (system/light/dark), optional dedicated Ghostty config, default app for opening worktrees, diff tool, confirm-before-quit, default view mode, window chrome tint, automatic repository icon detection, toolbar buttons (Run / Open-in-editor), dim unfocused splits, Active Agents panel auto-show & terminal titles. |
 | **Notifications** | In-app alerts, notification sound picker (Never / system sounds / Prowl Classic), macOS system notifications, move-notified-to-top, command-finished notification + threshold, Dock badge & bounce. → [notifications](notifications.md) |
 | **Shortcuts** | Remap app keyboard shortcuts; view defaults; resolve conflicts. → [keyboard-shortcuts](../reference/keyboard-shortcuts.md) |
 | **Worktree** | Worktree creation/deletion defaults: prompt on create, fetch before create, base directory, copy ignored/untracked files, automatic local-branch cleanup, merged-worktree action, archived auto-delete period. |

--- a/docs/components/terminal.md
+++ b/docs/components/terminal.md
@@ -148,12 +148,14 @@ Selection for Find** (`search_selection`). These are Ghostty-managed.
 
 Scrollback, wide/CJK character rendering, and copy/paste are handled by Ghostty
 with its defaults — Prowl doesn't override them. Customize terminal behavior in
-your Ghostty config at `~/.config/ghostty/config`.
+your Ghostty config at `~/.config/ghostty/config`, or choose a dedicated config
+for Prowl under **Settings → General → Appearance**. A dedicated config replaces
+the global Ghostty config until **Use Default** is selected again.
 
 ## Color scheme
 
 The terminal theme automatically follows the macOS light/dark appearance. There's
-no in-app Ghostty theme picker; change Ghostty colors via its config file.
+no in-app Ghostty theme picker; change Ghostty colors via the active config file.
 
 ## Layout persistence
 

--- a/docs/reference/settings-fields.md
+++ b/docs/reference/settings-fields.md
@@ -49,6 +49,7 @@ JSON is pretty-printed with sorted keys. Legacy `~/.supacode` is migrated to
 | `pullRequestMergeStrategy` | enum (`merge`/`squash`/`rebase`) | `merge` | Default PR merge strategy. |
 | `restoreTerminalLayoutOnLaunch` | Bool | `false` | Restore tabs/splits on launch. |
 | `terminalFontSize` | Float32? | `nil` | Remembered terminal font size. |
+| `ghosttyConfigPath` | String? | `nil` | Dedicated Ghostty configuration file used only by Prowl; `nil` loads Ghostty's default configuration files. |
 | `archivedAutoDeletePeriod` | enum? (days) | `nil` | Auto-delete archived worktrees after N days; `nil` = never. |
 | `keybindingUserOverrides` | object | empty | User keyboard-shortcut remappings. |
 | `defaultViewMode` | enum (`normal`/`shelf`/`canvas`) | `normal` | View mode on launch. |

--- a/supacode.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/supacode.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -78,8 +78,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-composable-architecture",
       "state" : {
-        "revision" : "df934d9c5a274a6f6a7bdcec73fbcb330149ff8b",
-        "version" : "1.23.2"
+        "revision" : "ead11e04e5011c437722c1990d22f80d87056978",
+        "version" : "1.26.1"
       }
     },
     {
@@ -123,8 +123,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-navigation",
       "state" : {
-        "revision" : "e7441dc4dfec6a4ae929e614e3c1e67c6639d164",
-        "version" : "2.7.0"
+        "revision" : "32f35241b8be0719c4c7f00eb27713b1cadb6248",
+        "version" : "2.8.0"
       }
     },
     {
@@ -141,8 +141,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-sharing",
       "state" : {
-        "revision" : "3bfc408cc2d0bee2287c174da6b1c76768377818",
-        "version" : "2.7.4"
+        "revision" : "c525e53936c878c102421eee241d82711eb38104",
+        "version" : "2.8.1"
       }
     },
     {

--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -71,13 +71,15 @@ final class SupacodeAppDelegate: NSObject, NSApplicationDelegate {
   }
 
   func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
-    WindowLifecycleDiagnostics.logWithWindows("applicationShouldHandleReopen hasVisibleWindows=\(flag)")
+    WindowLifecycleDiagnostics.logWithWindows(
+      "applicationShouldHandleReopen hasVisibleWindows=\(flag)")
     if flag, MainWindowSurface.hasVisibleMainWindow(in: sender.windows) {
       WindowLifecycleDiagnostics.noteMainWindowAppeared()
       return true
     }
     let surfaced = sender.surfaceMainWindow()
-    WindowLifecycleDiagnostics.log("applicationShouldHandleReopen surfaced=\(surfaced) -> handled=\(!surfaced)")
+    WindowLifecycleDiagnostics.log(
+      "applicationShouldHandleReopen surfaced=\(surfaced) -> handled=\(!surfaced)")
     return !surfaced
   }
 
@@ -133,10 +135,14 @@ struct SupacodeApp: App {
   private static func bootstrapTelemetry(initialSettings: GlobalSettings) {
     #if !DEBUG
       let infoDictionary = Bundle.main.infoDictionary ?? [:]
-      let releaseName = (infoDictionary["CFBundleShortVersionString"] as? String).map { "prowl@\($0)" }
+      let releaseName = (infoDictionary["CFBundleShortVersionString"] as? String).map {
+        "prowl@\($0)"
+      }
       let environment = "production"
 
-      if initialSettings.crashReportsEnabled, let dsn = infoPlistSecret(infoDictionary, key: "ProwlSentryDSN") {
+      if initialSettings.crashReportsEnabled,
+        let dsn = infoPlistSecret(infoDictionary, key: "ProwlSentryDSN")
+      {
         SentrySDK.start { options in
           options.dsn = dsn
           options.environment = environment
@@ -190,7 +196,10 @@ struct SupacodeApp: App {
         preconditionFailure("ghostty_init failed")
       }
     }
-    let runtime = GhosttyRuntime(initialColorScheme: initialSettings.appearanceMode.colorScheme)
+    let runtime = GhosttyRuntime(
+      initialColorScheme: initialSettings.appearanceMode.colorScheme,
+      configPath: initialSettings.ghosttyConfigPath
+    )
     _ghostty = State(initialValue: runtime)
     let shortcuts = GhosttyShortcutManager(runtime: runtime)
     _ghosttyShortcuts = State(initialValue: shortcuts)
@@ -208,7 +217,8 @@ struct SupacodeApp: App {
     _pullRequestRefreshCoordinator = State(initialValue: coordinator)
     let keyObserver = CommandKeyObserver()
     _commandKeyObserver = State(initialValue: keyObserver)
-    var initialAppState = AppFeature.State(settings: SettingsFeature.State(settings: initialSettings))
+    var initialAppState = AppFeature.State(
+      settings: SettingsFeature.State(settings: initialSettings))
     if let cliOpenPath = Self.cliLaunchOpenPath() {
       initialAppState.launchRestoreMode = .cliOpenPath(cliOpenPath)
     }
@@ -281,7 +291,8 @@ struct SupacodeApp: App {
   ) -> OutgoingChangesClient {
     .live(
       pullRequestInfo: { worktreeID in
-        storeBox.store?.withState { $0.repositories.worktreeInfo(for: worktreeID)?.pullRequest } ?? nil
+        storeBox.store?.withState { $0.repositories.worktreeInfo(for: worktreeID)?.pullRequest }
+          ?? nil
       }
     )
   }
@@ -507,7 +518,8 @@ struct SupacodeApp: App {
       sessionID: nativeSession?.id,
       paneID: paneID.uuidString,
       paneTitle: title.isEmpty ? nil : title,
-      source: nativeSession?.source.rawValue ?? (screenText == nil ? "terminal-unavailable" : "terminal-scrollback"),
+      source: nativeSession?.source.rawValue
+        ?? (screenText == nil ? "terminal-unavailable" : "terminal-scrollback"),
       confidence: nativeSession?.confidence.rawValue ?? "fallback",
       transcriptPath: nativeSession?.transcriptPath?.path(percentEncoded: false),
       excerptText: screenText
@@ -690,7 +702,10 @@ struct SupacodeApp: App {
       },
       createTab: { target, path in
         let repositories = Array(appStore.state.repositories.repositories)
-        guard let worktree = resolveCLITerminalWorktree(id: target.worktreeID, repositories: repositories) else {
+        guard
+          let worktree = resolveCLITerminalWorktree(
+            id: target.worktreeID, repositories: repositories)
+        else {
           return nil
         }
         selectCLIWorktreeContext(
@@ -839,10 +854,14 @@ struct SupacodeApp: App {
     terminalManager: WorktreeTerminalManager
   ) -> HandoffLaunchedPane? {
     let repositories = Array(appStore.state.repositories.repositories)
-    guard let worktree = resolveCLITerminalWorktree(id: target.worktreeID, repositories: repositories) else {
+    guard
+      let worktree = resolveCLITerminalWorktree(id: target.worktreeID, repositories: repositories)
+    else {
       return nil
     }
-    guard let initialInput = try? AgentRuntimeAdapterRegistry.makeStartInvocation(request).terminalInput else {
+    guard
+      let initialInput = try? AgentRuntimeAdapterRegistry.makeStartInvocation(request).terminalInput
+    else {
       return nil
     }
     let state = terminalManager.state(for: worktree)
@@ -939,7 +958,8 @@ struct SupacodeApp: App {
       },
       createTabAtPath: { worktreeID, path in
         let repositories = Array(appStore.state.repositories.repositories)
-        guard let worktree = resolveCLITerminalWorktree(id: worktreeID, repositories: repositories) else {
+        guard let worktree = resolveCLITerminalWorktree(id: worktreeID, repositories: repositories)
+        else {
           return
         }
         terminalManager.handleCommand(
@@ -947,7 +967,9 @@ struct SupacodeApp: App {
         )
       },
       resolveTarget: { selector in
-        switch makeTargetResolver(appStore: appStore, terminalManager: terminalManager).resolve(selector) {
+        let result = makeTargetResolver(appStore: appStore, terminalManager: terminalManager).resolve(
+          selector)
+        switch result {
         case .success(let target):
           return OpenResolvedTarget(
             worktreeID: target.worktreeID,

--- a/supacode/Clients/Terminal/TerminalClient.swift
+++ b/supacode/Clients/Terminal/TerminalClient.swift
@@ -66,6 +66,7 @@ struct TerminalClient {
     case prune(Set<Worktree.ID>)
     case setNotificationsEnabled(Bool)
     case setCommandFinishedNotification(enabled: Bool, threshold: Int)
+    case setGhosttyConfigPath(String?)
     case setCanvasMode(Bool)
     case setSelectedWorktreeID(Worktree.ID?)
     case saveLayoutSnapshot
@@ -75,7 +76,8 @@ struct TerminalClient {
 
   enum Event: Equatable {
     case customCommandSucceeded(worktreeID: Worktree.ID, name: String, durationMs: Int)
-    case notificationReceived(worktreeID: Worktree.ID, surfaceID: UUID, title: String, body: String, isViewed: Bool)
+    case notificationReceived(
+      worktreeID: Worktree.ID, surfaceID: UUID, title: String, body: String, isViewed: Bool)
     case notificationIndicatorChanged(count: Int)
     case tabCreated(worktreeID: Worktree.ID)
     case tabClosed(worktreeID: Worktree.ID, remainingTabs: Int)
@@ -100,7 +102,8 @@ struct TerminalClient {
 extension TerminalClient: DependencyKey {
   static let liveValue = TerminalClient(
     send: { _ in fatalError("TerminalClient.send not configured") },
-    createTabInDirectory: { _, _ in fatalError("TerminalClient.createTabInDirectory not configured") },
+    createTabInDirectory: { _, _ in fatalError("TerminalClient.createTabInDirectory not configured")
+    },
     events: { fatalError("TerminalClient.events not configured") },
     canvasFocusedWorktreeID: { nil },
     selectedSurfaceID: { _ in nil },

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -42,7 +42,8 @@ struct AppFeature {
       self.repositories = repositories
       self.settings = settings
       lastKnownSystemNotificationsEnabled = settings.systemNotificationsEnabled
-      launchRestoreMode = settings.restoreTerminalLayoutOnLaunch ? .restoreLayout : .lastFocusedWorktree
+      launchRestoreMode =
+        settings.restoreTerminalLayoutOnLaunch ? .restoreLayout : .lastFocusedWorktree
     }
   }
 
@@ -120,7 +121,9 @@ struct AppFeature {
       switch action {
       case .appLaunched:
         try? SupacodePaths.migrateLegacyCacheFilesIfNeeded()
-        appLogger.info("[LayoutRestore] appLaunched: launchRestoreMode=\(String(describing: state.launchRestoreMode))")
+        appLogger.info(
+          "[LayoutRestore] appLaunched: launchRestoreMode=\(String(describing: state.launchRestoreMode))"
+        )
         state.launchedAt = now
         state.repositories.launchRestoreMode = state.launchRestoreMode
         analyticsClient.capture("app_launched", nil)
@@ -166,7 +169,8 @@ struct AppFeature {
             !state.suppressLayoutSaveUntilRelaunch,
             state.launchRestoreMode != .restoreLayout
           {
-            appLogger.info("[LayoutRestore] scenePhase=\(String(describing: phase)), saving layout snapshot")
+            appLogger.info(
+              "[LayoutRestore] scenePhase=\(String(describing: phase)), saving layout snapshot")
             effects.append(.run { _ in await terminalClient.send(.saveLayoutSnapshot) })
           }
           return .merge(effects)
@@ -241,7 +245,8 @@ struct AppFeature {
         )
         effects.append(
           .run { _ in
-            await worktreeInfoWatcher.send(.setSelectedWorktreeID(isPlainFolderSelection ? nil : worktree.id))
+            await worktreeInfoWatcher.send(
+              .setSelectedWorktreeID(isPlainFolderSelection ? nil : worktree.id))
           }
         )
         effects.append(
@@ -293,7 +298,9 @@ struct AppFeature {
           state.launchRestoreMode = .lastFocusedWorktree
           state.repositories.selection = nil
         }
-        state.runScriptStatusByWorktreeID = state.runScriptStatusByWorktreeID.filter { ids.contains($0.key) }
+        state.runScriptStatusByWorktreeID = state.runScriptStatusByWorktreeID.filter {
+          ids.contains($0.key)
+        }
         let restorableWorktrees = makeTerminalRestorableWorktrees(from: Array(repositories))
         appLogger.info("[LayoutRestore] restorableWorktrees count=\(restorableWorktrees.count)")
         var allEffects: [Effect<Action>] = []
@@ -400,8 +407,10 @@ struct AppFeature {
             appearance: repositoryAppearances[repository.id] ?? .empty
           )
           repoSettingsState.workspace = repository.workspace
-          repoSettingsState.globalCopyIgnoredOnWorktreeCreate = state.settings.copyIgnoredOnWorktreeCreate
-          repoSettingsState.globalCopyUntrackedOnWorktreeCreate = state.settings.copyUntrackedOnWorktreeCreate
+          repoSettingsState.globalCopyIgnoredOnWorktreeCreate =
+            state.settings.copyIgnoredOnWorktreeCreate
+          repoSettingsState.globalCopyUntrackedOnWorktreeCreate =
+            state.settings.copyUntrackedOnWorktreeCreate
           repoSettingsState.globalPullRequestMergeStrategy = state.settings.pullRequestMergeStrategy
           state.settings.repositorySettings = repoSettingsState
           state.settings.globalCustomCommands = nil
@@ -452,7 +461,9 @@ struct AppFeature {
           : .send(.repositories(.repositoryManagement(.cancelPendingIconDetections)))
         return .merge(
           cancelIconDetections,
-          .send(.repositories(.githubIntegration(.setGithubIntegrationEnabled(settings.githubIntegrationEnabled)))),
+          .send(
+            .repositories(
+              .githubIntegration(.setGithubIntegrationEnabled(settings.githubIntegrationEnabled)))),
           .send(
             .repositories(
               .githubIntegration(
@@ -515,7 +526,9 @@ struct AppFeature {
                 )
               }
             case .denied:
-              await send(.systemNotificationsPermissionFailed(errorMessage: "Authorization status is denied."))
+              await send(
+                .systemNotificationsPermissionFailed(
+                  errorMessage: "Authorization status is denied."))
             }
           },
           .run { _ in
@@ -525,6 +538,11 @@ struct AppFeature {
 
       case .settings(.delegate(.terminalFontSizeChanged)):
         return .none
+
+      case .settings(.delegate(.ghosttyConfigPathChanged(let path))):
+        return .run { _ in
+          await terminalClient.send(.setGhosttyConfigPath(path))
+        }
 
       case .settings(.delegate(.cliInstallCompleted(let result))):
         switch result {
@@ -584,7 +602,8 @@ struct AppFeature {
         return .send(.openSelectedWorktree)
 
       case .openSelectedWorktree:
-        return .send(.openWorktree(OpenWorktreeAction.availableSelection(state.openActionSelection)))
+        return .send(
+          .openWorktree(OpenWorktreeAction.availableSelection(state.openActionSelection)))
 
       case .showSelectedWorktreeDiff:
         return openSelectedWorktreeDiffEffect(state: state)
@@ -656,7 +675,8 @@ struct AppFeature {
           return .none
         }
         analyticsClient.capture("terminal_tab_created", nil)
-        let shouldRunSetupScript = state.repositories.pendingSetupScriptWorktreeIDs.contains(worktree.id)
+        let shouldRunSetupScript = state.repositories.pendingSetupScriptWorktreeIDs.contains(
+          worktree.id)
         return .run { _ in
           await terminalClient.send(.createTab(worktree, runSetupScriptIfNew: shouldRunSetupScript))
         }
@@ -667,7 +687,8 @@ struct AppFeature {
           return .none
         }
         guard state.repositories.worktree(for: location.worktreeID) != nil else {
-          notificationJumpLogger.warning("Unread notification worktree vanished: \(location.worktreeID)")
+          notificationJumpLogger.warning(
+            "Unread notification worktree vanished: \(location.worktreeID)")
           return .none
         }
         analyticsClient.capture("notifications_jump_to_latest_unread", nil)
@@ -680,7 +701,8 @@ struct AppFeature {
         )
 
       case .toggleLeftSidebar:
-        state.leftSidebarVisibility = state.leftSidebarVisibility == .detailOnly ? .all : .detailOnly
+        state.leftSidebarVisibility =
+          state.leftSidebarVisibility == .detailOnly ? .all : .detailOnly
         return .none
 
       case .showLeftSidebar:
@@ -720,7 +742,9 @@ struct AppFeature {
         guard let worktree = actionTargetWorktree(repositories: state.repositories) else {
           return .none
         }
-        guard let effectiveCommand = state.selectedCustomCommands.first(where: { $0.id == commandID }) else {
+        guard
+          let effectiveCommand = state.selectedCustomCommands.first(where: { $0.id == commandID })
+        else {
           return .none
         }
         let customCommand = effectiveCommand.command

--- a/supacode/Features/Settings/Models/GlobalSettings.swift
+++ b/supacode/Features/Settings/Models/GlobalSettings.swift
@@ -24,6 +24,7 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
   var pullRequestMergeStrategy: PullRequestMergeStrategy
   var restoreTerminalLayoutOnLaunch: Bool
   var terminalFontSize: Float32?
+  var ghosttyConfigPath: String?
   var archivedAutoDeletePeriod: AutoDeletePeriod?
   var keybindingUserOverrides: KeybindingUserOverrideStore
   var defaultViewMode: DefaultViewMode
@@ -71,6 +72,7 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     restoreTerminalLayoutOnLaunch: false,
     archivedAutoDeletePeriod: nil,
     terminalFontSize: nil,
+    ghosttyConfigPath: nil,
     keybindingUserOverrides: .empty,
     defaultViewMode: .normal,
     canvasDefaultLayout: .tile,
@@ -115,6 +117,7 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     restoreTerminalLayoutOnLaunch: Bool = false,
     archivedAutoDeletePeriod: AutoDeletePeriod? = nil,
     terminalFontSize: Float32? = nil,
+    ghosttyConfigPath: String? = nil,
     keybindingUserOverrides: KeybindingUserOverrideStore = .empty,
     defaultViewMode: DefaultViewMode = .normal,
     canvasDefaultLayout: CanvasDefaultLayout = .tile,
@@ -157,6 +160,7 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     self.restoreTerminalLayoutOnLaunch = restoreTerminalLayoutOnLaunch
     self.archivedAutoDeletePeriod = archivedAutoDeletePeriod
     self.terminalFontSize = terminalFontSize
+    self.ghosttyConfigPath = ghosttyConfigPath
     self.keybindingUserOverrides = keybindingUserOverrides
     self.defaultViewMode = defaultViewMode
     self.canvasDefaultLayout = canvasDefaultLayout
@@ -179,29 +183,38 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     try container.encode(appearanceMode, forKey: .appearanceMode)
     try container.encode(defaultEditorID, forKey: .defaultEditorID)
     try container.encode(confirmBeforeQuit, forKey: .confirmBeforeQuit)
-    try container.encode(updatesAutomaticallyCheckForUpdates, forKey: .updatesAutomaticallyCheckForUpdates)
-    try container.encode(updatesAutomaticallyDownloadUpdates, forKey: .updatesAutomaticallyDownloadUpdates)
+    try container.encode(
+      updatesAutomaticallyCheckForUpdates, forKey: .updatesAutomaticallyCheckForUpdates)
+    try container.encode(
+      updatesAutomaticallyDownloadUpdates, forKey: .updatesAutomaticallyDownloadUpdates)
     try container.encode(inAppNotificationsEnabled, forKey: .inAppNotificationsEnabled)
     try container.encode(notificationSound, forKey: .notificationSound)
     try container.encode(systemNotificationsEnabled, forKey: .systemNotificationsEnabled)
-    try container.encode(muteNotificationsForActiveSurface, forKey: .muteNotificationsForActiveSurface)
+    try container.encode(
+      muteNotificationsForActiveSurface, forKey: .muteNotificationsForActiveSurface)
     try container.encode(moveNotifiedWorktreeToTop, forKey: .moveNotifiedWorktreeToTop)
-    try container.encode(commandFinishedNotificationEnabled, forKey: .commandFinishedNotificationEnabled)
-    try container.encode(commandFinishedNotificationThreshold, forKey: .commandFinishedNotificationThreshold)
+    try container.encode(
+      commandFinishedNotificationEnabled, forKey: .commandFinishedNotificationEnabled)
+    try container.encode(
+      commandFinishedNotificationThreshold, forKey: .commandFinishedNotificationThreshold)
     try container.encode(analyticsEnabled, forKey: .analyticsEnabled)
     try container.encode(crashReportsEnabled, forKey: .crashReportsEnabled)
     try container.encode(githubIntegrationEnabled, forKey: .githubIntegrationEnabled)
     try container.encode(deleteBranchOnAutomaticCleanup, forKey: .deleteBranchOnAutomaticCleanup)
     try container.encodeIfPresent(mergedWorktreeAction, forKey: .mergedWorktreeAction)
     try container.encode(promptForWorktreeCreation, forKey: .promptForWorktreeCreation)
-    try container.encode(fetchOriginBeforeWorktreeCreation, forKey: .fetchOriginBeforeWorktreeCreation)
-    try container.encodeIfPresent(defaultWorktreeBaseDirectoryPath, forKey: .defaultWorktreeBaseDirectoryPath)
+    try container.encode(
+      fetchOriginBeforeWorktreeCreation, forKey: .fetchOriginBeforeWorktreeCreation)
+    try container.encodeIfPresent(
+      defaultWorktreeBaseDirectoryPath, forKey: .defaultWorktreeBaseDirectoryPath)
     try container.encode(copyIgnoredOnWorktreeCreate, forKey: .copyIgnoredOnWorktreeCreate)
     try container.encode(copyUntrackedOnWorktreeCreate, forKey: .copyUntrackedOnWorktreeCreate)
     try container.encode(pullRequestMergeStrategy, forKey: .pullRequestMergeStrategy)
     try container.encode(restoreTerminalLayoutOnLaunch, forKey: .restoreTerminalLayoutOnLaunch)
-    try container.encodeIfPresent(archivedAutoDeletePeriod?.rawValue, forKey: .archivedAutoDeletePeriod)
+    try container.encodeIfPresent(
+      archivedAutoDeletePeriod?.rawValue, forKey: .archivedAutoDeletePeriod)
     try container.encodeIfPresent(terminalFontSize, forKey: .terminalFontSize)
+    try container.encodeIfPresent(ghosttyConfigPath, forKey: .ghosttyConfigPath)
     try container.encode(keybindingUserOverrides, forKey: .keybindingUserOverrides)
     try container.encode(defaultViewMode, forKey: .defaultViewMode)
     try container.encode(canvasDefaultLayout, forKey: .canvasDefaultLayout)
@@ -216,10 +229,12 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     try container.encode(dockBounceMode, forKey: .dockBounceMode)
     try container.encode(showNotificationDotOnDock, forKey: .showNotificationDotOnDock)
     try container.encode(shelfSpineTintFallback, forKey: .shelfSpineTintFallback)
-    try container.encode(shelfSpineTintFollowsRepositoryColor, forKey: .shelfSpineTintFollowsRepositoryColor)
+    try container.encode(
+      shelfSpineTintFollowsRepositoryColor, forKey: .shelfSpineTintFollowsRepositoryColor)
     try container.encode(externalDiffToolID, forKey: .externalDiffToolID)
     try container.encode(externalDiffCustomCommand, forKey: .externalDiffCustomCommand)
-    try container.encode(detectRepositoryIconsAutomatically, forKey: .detectRepositoryIconsAutomatically)
+    try container.encode(
+      detectRepositoryIconsAutomatically, forKey: .detectRepositoryIconsAutomatically)
   }
 
   private enum CodingKeys: String, CodingKey {
@@ -249,6 +264,7 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     case restoreTerminalLayoutOnLaunch
     case archivedAutoDeletePeriod
     case terminalFontSize
+    case ghosttyConfigPath
     case keybindingUserOverrides
     case defaultViewMode
     case canvasDefaultLayout
@@ -282,8 +298,10 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     confirmBeforeQuit =
       try container.decodeIfPresent(Bool.self, forKey: .confirmBeforeQuit)
       ?? Self.default.confirmBeforeQuit
-    updatesAutomaticallyCheckForUpdates = try container.decode(Bool.self, forKey: .updatesAutomaticallyCheckForUpdates)
-    updatesAutomaticallyDownloadUpdates = try container.decode(Bool.self, forKey: .updatesAutomaticallyDownloadUpdates)
+    updatesAutomaticallyCheckForUpdates = try container.decode(
+      Bool.self, forKey: .updatesAutomaticallyCheckForUpdates)
+    updatesAutomaticallyDownloadUpdates = try container.decode(
+      Bool.self, forKey: .updatesAutomaticallyDownloadUpdates)
     inAppNotificationsEnabled =
       try container.decodeIfPresent(Bool.self, forKey: .inAppNotificationsEnabled)
       ?? Self.default.inAppNotificationsEnabled
@@ -330,21 +348,17 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
       try container.decodeIfPresent(Bool.self, forKey: .copyUntrackedOnWorktreeCreate)
       ?? Self.default.copyUntrackedOnWorktreeCreate
     pullRequestMergeStrategy =
-      try container.decodeIfPresent(PullRequestMergeStrategy.self, forKey: .pullRequestMergeStrategy)
+      try container.decodeIfPresent(
+        PullRequestMergeStrategy.self, forKey: .pullRequestMergeStrategy)
       ?? Self.default.pullRequestMergeStrategy
-    restoreTerminalLayoutOnLaunch =
-      try container.decodeIfPresent(Bool.self, forKey: .restoreTerminalLayoutOnLaunch)
-      ?? Self.default.restoreTerminalLayoutOnLaunch
-    if let rawAutoDelete = try container.decodeIfPresent(Int.self, forKey: .archivedAutoDeletePeriod) {
-      archivedAutoDeletePeriod = AutoDeletePeriod(rawValue: rawAutoDelete)
-    } else {
-      archivedAutoDeletePeriod = Self.default.archivedAutoDeletePeriod
-    }
-    terminalFontSize =
-      try container.decodeIfPresent(Float32.self, forKey: .terminalFontSize)
-      ?? Self.default.terminalFontSize
+    let terminalSettings = try Self.decodeTerminalSettings(from: container)
+    restoreTerminalLayoutOnLaunch = terminalSettings.restoresLayout
+    archivedAutoDeletePeriod = terminalSettings.autoDeletePeriod
+    terminalFontSize = terminalSettings.fontSize
+    ghosttyConfigPath = terminalSettings.configPath
     keybindingUserOverrides =
-      try container.decodeIfPresent(KeybindingUserOverrideStore.self, forKey: .keybindingUserOverrides)
+      try container.decodeIfPresent(
+        KeybindingUserOverrideStore.self, forKey: .keybindingUserOverrides)
       ?? Self.default.keybindingUserOverrides
     (defaultViewMode, canvasDefaultLayout) = try Self.decodeViewSettings(from: container)
     dimUnfocusedSplits =
@@ -360,8 +374,10 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
       try container.decodeIfPresent(Bool.self, forKey: .showActiveAgentStatusInShelf)
       ?? Self.default.showActiveAgentStatusInShelf
     (windowTintMode, windowTintCustomColor) = try Self.decodeWindowTint(from: container)
-    (shelfSpineTintFallback, shelfSpineTintFollowsRepositoryColor) = try Self.decodeShelfSpineTint(from: container)
-    (externalDiffToolID, externalDiffCustomCommand) = try Self.decodeExternalDiffSettings(from: container)
+    (shelfSpineTintFallback, shelfSpineTintFollowsRepositoryColor) = try Self.decodeShelfSpineTint(
+      from: container)
+    (externalDiffToolID, externalDiffCustomCommand) = try Self.decodeExternalDiffSettings(
+      from: container)
     detectRepositoryIconsAutomatically =
       try container.decodeIfPresent(Bool.self, forKey: .detectRepositoryIconsAutomatically)
       ?? true
@@ -382,6 +398,35 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
       try container.decodeIfPresent(CanvasDefaultLayout.self, forKey: .canvasDefaultLayout)
       ?? Self.default.canvasDefaultLayout
     return (mode, layout)
+  }
+
+  private struct DecodedTerminalSettings {
+    var restoresLayout: Bool
+    var autoDeletePeriod: AutoDeletePeriod?
+    var fontSize: Float32?
+    var configPath: String?
+  }
+
+  private static func decodeTerminalSettings(
+    from container: KeyedDecodingContainer<CodingKeys>
+  ) throws -> DecodedTerminalSettings {
+    let restoreLayout =
+      try container.decodeIfPresent(Bool.self, forKey: .restoreTerminalLayoutOnLaunch)
+      ?? Self.default.restoreTerminalLayoutOnLaunch
+    let autoDeletePeriod =
+      try container.decodeIfPresent(Int.self, forKey: .archivedAutoDeletePeriod)
+      .flatMap(AutoDeletePeriod.init(rawValue:))
+      ?? Self.default.archivedAutoDeletePeriod
+    let fontSize =
+      try container.decodeIfPresent(Float32.self, forKey: .terminalFontSize)
+      ?? Self.default.terminalFontSize
+    let configPath = try container.decodeIfPresent(String.self, forKey: .ghosttyConfigPath)
+    return DecodedTerminalSettings(
+      restoresLayout: restoreLayout,
+      autoDeletePeriod: autoDeletePeriod,
+      fontSize: fontSize,
+      configPath: configPath
+    )
   }
 
   private static func decodeWindowTint(
@@ -412,7 +457,8 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     from container: KeyedDecodingContainer<CodingKeys>
   ) throws -> (String, String) {
     let toolID =
-      ExternalDiffTool.normalizedSettingsID(try container.decodeIfPresent(String.self, forKey: .externalDiffToolID))
+      ExternalDiffTool.normalizedSettingsID(
+        try container.decodeIfPresent(String.self, forKey: .externalDiffToolID))
     let customCommand =
       try container.decodeIfPresent(String.self, forKey: .externalDiffCustomCommand)
       ?? Self.default.externalDiffCustomCommand
@@ -427,10 +473,14 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
   private static func decodeNotificationSound(
     from container: KeyedDecodingContainer<CodingKeys>
   ) throws -> NotificationSound {
-    if let sound = try? container.decodeIfPresent(NotificationSound.self, forKey: .notificationSound) {
+    if let sound = try? container.decodeIfPresent(
+      NotificationSound.self, forKey: .notificationSound)
+    {
       return sound
     }
-    if let legacyEnabled = try container.decodeIfPresent(Bool.self, forKey: .notificationSoundEnabled) {
+    if let legacyEnabled = try container.decodeIfPresent(
+      Bool.self, forKey: .notificationSoundEnabled)
+    {
       return legacyEnabled ? Self.default.notificationSound : .never
     }
     return Self.default.notificationSound
@@ -454,10 +504,14 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
   private static func decodeMergedWorktreeAction(
     from container: KeyedDecodingContainer<CodingKeys>
   ) throws -> MergedWorktreeAction? {
-    if let decoded = try container.decodeIfPresent(MergedWorktreeAction.self, forKey: .mergedWorktreeAction) {
+    if let decoded = try container.decodeIfPresent(
+      MergedWorktreeAction.self, forKey: .mergedWorktreeAction)
+    {
       return decoded
     }
-    if let legacyBool = try container.decodeIfPresent(Bool.self, forKey: .automaticallyArchiveMergedWorktrees) {
+    if let legacyBool = try container.decodeIfPresent(
+      Bool.self, forKey: .automaticallyArchiveMergedWorktrees)
+    {
       return legacyBool ? .archive : nil
     }
     return Self.default.mergedWorktreeAction
@@ -478,11 +532,13 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     try ToolbarAndDockSettings(
       showRunButtonInToolbar: container.decodeIfPresent(Bool.self, forKey: .showRunButtonInToolbar)
         ?? Self.default.showRunButtonInToolbar,
-      showDefaultEditorInToolbar: container.decodeIfPresent(Bool.self, forKey: .showDefaultEditorInToolbar)
+      showDefaultEditorInToolbar: container.decodeIfPresent(
+        Bool.self, forKey: .showDefaultEditorInToolbar)
         ?? Self.default.showDefaultEditorInToolbar,
       dockBounceMode: container.decodeIfPresent(DockBounceMode.self, forKey: .dockBounceMode)
         ?? Self.default.dockBounceMode,
-      showNotificationDotOnDock: container.decodeIfPresent(Bool.self, forKey: .showNotificationDotOnDock)
+      showNotificationDotOnDock: container.decodeIfPresent(
+        Bool.self, forKey: .showNotificationDotOnDock)
         ?? Self.default.showNotificationDotOnDock
     )
   }

--- a/supacode/Features/Settings/Reducer/SettingsFeature.swift
+++ b/supacode/Features/Settings/Reducer/SettingsFeature.swift
@@ -32,6 +32,7 @@ struct SettingsFeature {
     var pullRequestMergeStrategy: PullRequestMergeStrategy
     var restoreTerminalLayoutOnLaunch: Bool
     var terminalFontSize: Float32?
+    var ghosttyConfigPath: String?
     var keybindingUserOverrides: KeybindingUserOverrideStore
     var defaultViewMode: DefaultViewMode
     var canvasDefaultLayout: CanvasDefaultLayout
@@ -66,7 +67,8 @@ struct SettingsFeature {
     @Presents var alert: AlertState<Alert>?
 
     init(settings: GlobalSettings = .default) {
-      let normalizedDefaultEditorID = OpenWorktreeAction.normalizedDefaultEditorID(settings.defaultEditorID)
+      let normalizedDefaultEditorID = OpenWorktreeAction.normalizedDefaultEditorID(
+        settings.defaultEditorID)
       appearanceMode = settings.appearanceMode
       defaultEditorID = normalizedDefaultEditorID
       confirmBeforeQuit = settings.confirmBeforeQuit
@@ -88,12 +90,14 @@ struct SettingsFeature {
       promptForWorktreeCreation = settings.promptForWorktreeCreation
       fetchRemoteBeforeWorktreeCreation = settings.fetchOriginBeforeWorktreeCreation
       defaultWorktreeBaseDirectoryPath =
-        SupacodePaths.normalizedWorktreeBaseDirectoryPath(settings.defaultWorktreeBaseDirectoryPath) ?? ""
+        SupacodePaths.normalizedWorktreeBaseDirectoryPath(settings.defaultWorktreeBaseDirectoryPath)
+        ?? ""
       copyIgnoredOnWorktreeCreate = settings.copyIgnoredOnWorktreeCreate
       copyUntrackedOnWorktreeCreate = settings.copyUntrackedOnWorktreeCreate
       pullRequestMergeStrategy = settings.pullRequestMergeStrategy
       restoreTerminalLayoutOnLaunch = settings.restoreTerminalLayoutOnLaunch
       terminalFontSize = settings.terminalFontSize
+      ghosttyConfigPath = settings.ghosttyConfigPath
       keybindingUserOverrides = settings.keybindingUserOverrides
       defaultViewMode = settings.defaultViewMode
       canvasDefaultLayout = settings.canvasDefaultLayout
@@ -144,6 +148,7 @@ struct SettingsFeature {
         restoreTerminalLayoutOnLaunch: restoreTerminalLayoutOnLaunch,
         archivedAutoDeletePeriod: archivedAutoDeletePeriod,
         terminalFontSize: terminalFontSize,
+        ghosttyConfigPath: ghosttyConfigPath,
         keybindingUserOverrides: keybindingUserOverrides,
         defaultViewMode: defaultViewMode,
         canvasDefaultLayout: canvasDefaultLayout,
@@ -174,6 +179,7 @@ struct SettingsFeature {
     case setSystemNotificationsEnabled(Bool)
     case setCommandFinishedNotificationThreshold(String)
     case setTerminalFontSize(Float32?)
+    case setGhosttyConfigPath(String?)
     case clearShortcutButtonTapped(commandID: String)
     case clearTerminalLayoutSnapshotButtonTapped
     case installCLIButtonTapped(showAlert: Bool = true)
@@ -206,6 +212,7 @@ struct SettingsFeature {
   enum Delegate: Equatable {
     case settingsChanged(GlobalSettings)
     case terminalFontSizeChanged(Float32?)
+    case ghosttyConfigPathChanged(String?)
     case terminalLayoutSnapshotCleared(success: Bool)
     case cliInstallCompleted(CLIInstallResultMessage)
   }
@@ -225,9 +232,11 @@ struct SettingsFeature {
         return .send(.settingsLoaded(settingsFile.global))
 
       case .settingsLoaded(let settings):
-        let normalizedDefaultEditorID = OpenWorktreeAction.normalizedDefaultEditorID(settings.defaultEditorID)
+        let normalizedDefaultEditorID = OpenWorktreeAction.normalizedDefaultEditorID(
+          settings.defaultEditorID)
         let normalizedWorktreeBaseDirPath =
-          SupacodePaths.normalizedWorktreeBaseDirectoryPath(settings.defaultWorktreeBaseDirectoryPath)
+          SupacodePaths.normalizedWorktreeBaseDirectoryPath(
+            settings.defaultWorktreeBaseDirectoryPath)
         let normalizedSettings: GlobalSettings
         if normalizedDefaultEditorID == settings.defaultEditorID,
           normalizedWorktreeBaseDirPath == settings.defaultWorktreeBaseDirectoryPath
@@ -244,15 +253,20 @@ struct SettingsFeature {
         state.appearanceMode = normalizedSettings.appearanceMode
         state.defaultEditorID = normalizedSettings.defaultEditorID
         state.confirmBeforeQuit = normalizedSettings.confirmBeforeQuit
-        state.updatesAutomaticallyCheckForUpdates = normalizedSettings.updatesAutomaticallyCheckForUpdates
-        state.updatesAutomaticallyDownloadUpdates = normalizedSettings.updatesAutomaticallyDownloadUpdates
+        state.updatesAutomaticallyCheckForUpdates =
+          normalizedSettings.updatesAutomaticallyCheckForUpdates
+        state.updatesAutomaticallyDownloadUpdates =
+          normalizedSettings.updatesAutomaticallyDownloadUpdates
         state.inAppNotificationsEnabled = normalizedSettings.inAppNotificationsEnabled
         state.notificationSound = normalizedSettings.notificationSound
         state.systemNotificationsEnabled = normalizedSettings.systemNotificationsEnabled
-        state.muteNotificationsForActiveSurface = normalizedSettings.muteNotificationsForActiveSurface
+        state.muteNotificationsForActiveSurface =
+          normalizedSettings.muteNotificationsForActiveSurface
         state.moveNotifiedWorktreeToTop = normalizedSettings.moveNotifiedWorktreeToTop
-        state.commandFinishedNotificationEnabled = normalizedSettings.commandFinishedNotificationEnabled
-        state.commandFinishedNotificationThreshold = normalizedSettings.commandFinishedNotificationThreshold
+        state.commandFinishedNotificationEnabled =
+          normalizedSettings.commandFinishedNotificationEnabled
+        state.commandFinishedNotificationThreshold =
+          normalizedSettings.commandFinishedNotificationThreshold
         state.analyticsEnabled = normalizedSettings.analyticsEnabled
         state.crashReportsEnabled = normalizedSettings.crashReportsEnabled
         state.githubIntegrationEnabled = normalizedSettings.githubIntegrationEnabled
@@ -260,13 +274,16 @@ struct SettingsFeature {
         state.mergedWorktreeAction = normalizedSettings.mergedWorktreeAction
         state.archivedAutoDeletePeriod = normalizedSettings.archivedAutoDeletePeriod
         state.promptForWorktreeCreation = normalizedSettings.promptForWorktreeCreation
-        state.fetchRemoteBeforeWorktreeCreation = normalizedSettings.fetchOriginBeforeWorktreeCreation
-        state.defaultWorktreeBaseDirectoryPath = normalizedSettings.defaultWorktreeBaseDirectoryPath ?? ""
+        state.fetchRemoteBeforeWorktreeCreation =
+          normalizedSettings.fetchOriginBeforeWorktreeCreation
+        state.defaultWorktreeBaseDirectoryPath =
+          normalizedSettings.defaultWorktreeBaseDirectoryPath ?? ""
         state.copyIgnoredOnWorktreeCreate = normalizedSettings.copyIgnoredOnWorktreeCreate
         state.copyUntrackedOnWorktreeCreate = normalizedSettings.copyUntrackedOnWorktreeCreate
         state.pullRequestMergeStrategy = normalizedSettings.pullRequestMergeStrategy
         state.restoreTerminalLayoutOnLaunch = normalizedSettings.restoreTerminalLayoutOnLaunch
         state.terminalFontSize = normalizedSettings.terminalFontSize
+        state.ghosttyConfigPath = normalizedSettings.ghosttyConfigPath
         state.keybindingUserOverrides = normalizedSettings.keybindingUserOverrides
         state.defaultViewMode = normalizedSettings.defaultViewMode
         state.dimUnfocusedSplits = normalizedSettings.dimUnfocusedSplits
@@ -275,7 +292,8 @@ struct SettingsFeature {
         state.showActiveAgentStatusInShelf = normalizedSettings.showActiveAgentStatusInShelf
         state.windowTintMode = normalizedSettings.windowTintMode
         state.shelfSpineTintFallback = normalizedSettings.shelfSpineTintFallback
-        state.shelfSpineTintFollowsRepositoryColor = normalizedSettings.shelfSpineTintFollowsRepositoryColor
+        state.shelfSpineTintFollowsRepositoryColor =
+          normalizedSettings.shelfSpineTintFollowsRepositoryColor
         state.windowTintCustomColor = normalizedSettings.windowTintCustomColor.color
         state.showRunButtonInToolbar = normalizedSettings.showRunButtonInToolbar
         state.showDefaultEditorInToolbar = normalizedSettings.showDefaultEditorInToolbar
@@ -284,7 +302,8 @@ struct SettingsFeature {
         state.externalDiffToolID = normalizedSettings.externalDiffToolID
         state.externalDiffCustomCommand = normalizedSettings.externalDiffCustomCommand
         state.canvasDefaultLayout = normalizedSettings.canvasDefaultLayout
-        state.detectRepositoryIconsAutomatically = normalizedSettings.detectRepositoryIconsAutomatically
+        state.detectRepositoryIconsAutomatically =
+          normalizedSettings.detectRepositoryIconsAutomatically
         state.syncGlobalDefaults(from: normalizedSettings)
         return .send(.delegate(.settingsChanged(normalizedSettings)))
 
@@ -301,7 +320,8 @@ struct SettingsFeature {
         )
 
       case .binding:
-        state.commandFinishedNotificationThreshold = min(max(state.commandFinishedNotificationThreshold, 0), 600)
+        state.commandFinishedNotificationThreshold = min(
+          max(state.commandFinishedNotificationThreshold, 0), 600)
         state.syncGlobalDefaults(from: state.globalSettings)
         return persist(state)
 
@@ -326,9 +346,21 @@ struct SettingsFeature {
           .send(.delegate(.terminalFontSizeChanged(fontSize)))
         )
 
+      case .setGhosttyConfigPath(let path):
+        let trimmed = path?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let normalizedPath = trimmed.flatMap { $0.isEmpty ? nil : $0 }
+        guard state.ghosttyConfigPath != normalizedPath else { return .none }
+        state.ghosttyConfigPath = normalizedPath
+        return .merge(
+          persist(state, emitSettingsChanged: false),
+          .send(.delegate(.ghosttyConfigPathChanged(normalizedPath)))
+        )
+
       case .clearShortcutButtonTapped(let commandID):
         guard
-          let command = KeybindingSchemaDocument.appDefaultsV1.commands.first(where: { $0.id == commandID }),
+          let command = KeybindingSchemaDocument.appDefaultsV1.commands.first(where: {
+            $0.id == commandID
+          }),
           command.allowUserOverride
         else {
           return .none
@@ -360,7 +392,8 @@ struct SettingsFeature {
           } catch let error as CLIInstallError {
             await send(.cliInstallCompleted(.failure(error)))
           } catch {
-            await send(.cliInstallCompleted(.failure(CLIInstallError(message: error.localizedDescription))))
+            await send(
+              .cliInstallCompleted(.failure(CLIInstallError(message: error.localizedDescription))))
           }
         }
 
@@ -378,7 +411,8 @@ struct SettingsFeature {
           } catch let error as CLIInstallError {
             await send(.cliInstallCompleted(.failure(error)))
           } catch {
-            await send(.cliInstallCompleted(.failure(CLIInstallError(message: error.localizedDescription))))
+            await send(
+              .cliInstallCompleted(.failure(CLIInstallError(message: error.localizedDescription))))
           }
         }
 
@@ -425,7 +459,8 @@ struct SettingsFeature {
 
       case .refreshDockBadgeAuthorization:
         return .run { send in
-          await send(.dockBadgeAuthorizationResponse(systemNotificationClient.dockBadgeAuthorization()))
+          await send(
+            .dockBadgeAuthorizationResponse(systemNotificationClient.dockBadgeAuthorization()))
         }
 
       case .dockBadgeAuthorizationResponse(let authorization):

--- a/supacode/Features/Settings/Views/AppearanceSettingsView.swift
+++ b/supacode/Features/Settings/Views/AppearanceSettingsView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import ComposableArchitecture
 import SwiftUI
 
@@ -11,7 +12,7 @@ struct AppearanceSettingsView: View {
       Form {
         Section("Appearance") {
           HStack {
-            let appearanceMode = $store.appearanceMode
+            let appearanceMode: Binding<AppearanceMode> = $store.appearanceMode
             ForEach(AppearanceMode.allCases) { mode in
               AppearanceOptionCardView(
                 mode: mode,
@@ -22,6 +23,29 @@ struct AppearanceSettingsView: View {
             }
           }
           VStack(alignment: .leading, spacing: 6) {
+            Text("Ghostty Configuration")
+              .font(.headline)
+              .foregroundStyle(.primary)
+            Text(store.ghosttyConfigPath ?? "Using Ghostty's default configuration")
+              .monospaced()
+              .lineLimit(1)
+              .truncationMode(.middle)
+              .textSelection(.enabled)
+              .help(
+                store.ghosttyConfigPath ?? "Prowl follows Ghostty's default configuration files.")
+            HStack(spacing: 8) {
+              Button("Choose Config…") {
+                presentGhosttyConfigPicker()
+              }
+              .help("Choose a dedicated Ghostty configuration file for Prowl.")
+              Button("Use Default") {
+                store.send(.setGhosttyConfigPath(nil))
+              }
+              .disabled(store.ghosttyConfigPath == nil)
+              .help("Stop using the override and return to Ghostty's default configuration.")
+            }
+            .controlSize(.small)
+            Text("An override replaces the global Ghostty configuration while it is selected.")
             Text(
               """
               Terminal theming follows your Ghostty configuration. \
@@ -34,9 +58,13 @@ struct AppearanceSettingsView: View {
               .textSelection(.enabled)
             HStack(spacing: 8) {
               Button("Open Config") {
-                GhosttyRuntime.openGhosttyConfig()
+                if let runtime = GhosttyRuntime.shared {
+                  runtime.openAppConfig()
+                } else {
+                  GhosttyRuntime.openGhosttyConfig(at: store.ghosttyConfigPath)
+                }
               }
-              .help("Open your Ghostty config file in the default text editor.")
+              .help("Open the active Ghostty config file in the default text editor.")
               Button("Reload") {
                 GhosttyRuntime.shared?.reloadAppConfig()
               }
@@ -60,7 +88,8 @@ struct AppearanceSettingsView: View {
               selection: $store.windowTintCustomColor,
               supportsOpacity: false
             )
-            .help("Tint the nav and toolbar with this color in every view, ignoring repository colors.")
+            .help(
+              "Tint the nav and toolbar with this color in every view, ignoring repository colors.")
           }
           Text(tintFootnote)
             .font(.callout)
@@ -71,7 +100,9 @@ struct AppearanceSettingsView: View {
               Text(fallback.title).tag(fallback)
             }
           }
-          .help("Spine style for repositories without a color, or for every spine when Follow Repo Color is off.")
+          .help(
+            "Spine style for repositories without a color, or for every spine when Follow Repo Color is off."
+          )
           Toggle(
             "Follow Repo Color Setting",
             isOn: $store.shelfSpineTintFollowsRepositoryColor
@@ -114,7 +145,8 @@ struct AppearanceSettingsView: View {
             "Show terminal titles in agent rows",
             isOn: $store.showActiveAgentTabTitles
           )
-          .help("Display each agent's own terminal title in the row and show the branch name on hover.")
+          .help(
+            "Display each agent's own terminal title in the row and show the branch name on hover.")
           Toggle(
             "Show agent status in Shelf tabs",
             isOn: $store.showActiveAgentStatusInShelf
@@ -127,7 +159,9 @@ struct AppearanceSettingsView: View {
               Text(mode.title).tag(mode)
             }
           }
-          .help("View Prowl starts in on launch. Shelf and Canvas require at least one worktree or folder.")
+          .help(
+            "View Prowl starts in on launch. Shelf and Canvas require at least one worktree or folder."
+          )
 
           Picker("Canvas layout", selection: $store.canvasDefaultLayout) {
             ForEach(CanvasDefaultLayout.allCases) { layout in
@@ -207,6 +241,22 @@ struct AppearanceSettingsView: View {
       .formStyle(.grouped)
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+  }
+
+  private func presentGhosttyConfigPicker() {
+    let panel = NSOpenPanel()
+    panel.canChooseDirectories = false
+    panel.canChooseFiles = true
+    panel.allowsMultipleSelection = false
+    panel.prompt = "Use Config"
+    panel.message = "Choose the Ghostty configuration file Prowl should use."
+    if let path = store.ghosttyConfigPath {
+      panel.directoryURL = URL(fileURLWithPath: path).deletingLastPathComponent()
+    }
+    panel.begin { response in
+      guard response == .OK, let url = panel.url else { return }
+      store.send(.setGhosttyConfigPath(url.path(percentEncoded: false)))
+    }
   }
 
   private var tintFootnote: String {

--- a/supacode/Features/Settings/Views/RepositorySettingsView.swift
+++ b/supacode/Features/Settings/Views/RepositorySettingsView.swift
@@ -13,7 +13,7 @@ struct RepositorySettingsView: View {
   var body: some View {
     let baseRefOptions =
       store.branchOptions.isEmpty ? [store.defaultWorktreeBaseRef] : store.branchOptions
-    let settings = $store.settings
+    let settings: Binding<RepositorySettings> = $store.settings
     let worktreeBaseDirectoryPath = Binding(
       get: { settings.worktreeBaseDirectoryPath.wrappedValue ?? "" },
       set: { settings.worktreeBaseDirectoryPath.wrappedValue = $0 },

--- a/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
+++ b/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
@@ -76,7 +76,8 @@ final class WorktreeTerminalManager {
     case .createTab(let worktree, let runSetupScriptIfNew):
       Task { createTabAsync(in: worktree, runSetupScriptIfNew: runSetupScriptIfNew) }
     case .createTabWithInput(
-      let worktree, let input, let workingDirectory, let runSetupScriptIfNew, let autoCloseOnSuccess,
+      let worktree, let input, let workingDirectory, let runSetupScriptIfNew,
+      let autoCloseOnSuccess,
       let customCommandName, let customCommandIcon):
       Task {
         createTabAsync(
@@ -90,7 +91,8 @@ final class WorktreeTerminalManager {
         )
       }
     case .createSplitWithInput(
-      let worktree, let direction, let input, let autoCloseOnSuccess, let customCommandName, let customCommandIcon):
+      let worktree, let direction, let input, let autoCloseOnSuccess, let customCommandName,
+      let customCommandIcon):
       Task {
         createSplitAsync(
           in: worktree,
@@ -177,9 +179,12 @@ final class WorktreeTerminalManager {
       setNotificationsEnabled(enabled)
     case .setCommandFinishedNotification(let enabled, let threshold):
       setCommandFinishedNotification(enabled: enabled, threshold: threshold)
+    case .setGhosttyConfigPath(let path):
+      runtime?.setConfigPath(path)
     case .setCanvasMode(let enabled):
       if enabled {
-        terminalLogger.info("[CanvasExit] enteringCanvas previousSelectedWorktree=\(selectedWorktreeID ?? "nil")")
+        terminalLogger.info(
+          "[CanvasExit] enteringCanvas previousSelectedWorktree=\(selectedWorktreeID ?? "nil")")
         selectedWorktreeID = nil
       }
     case .setSelectedWorktreeID(let id):
@@ -205,7 +210,8 @@ final class WorktreeTerminalManager {
       terminalLogger.info("[LayoutRestore] received saveLayoutSnapshot command")
       Task { await persistLayoutSnapshot() }
     case .restoreLayoutSnapshot(let worktrees):
-      terminalLogger.info("[LayoutRestore] received restoreLayoutSnapshot command, worktrees=\(worktrees.count)")
+      terminalLogger.info(
+        "[LayoutRestore] received restoreLayoutSnapshot command, worktrees=\(worktrees.count)")
       Task { await restoreLayoutSnapshot(from: worktrees) }
     case .presentTabIconPicker(let worktree):
       state(for: worktree).presentIconPickerForFocusedTab()
@@ -313,7 +319,8 @@ final class WorktreeTerminalManager {
       self?.syncPreferredFontSize(from: worktree.id)
     }
     state.onCustomCommandSucceeded = { [weak self] name, durationMs in
-      self?.emit(.customCommandSucceeded(worktreeID: worktree.id, name: name, durationMs: durationMs))
+      self?.emit(
+        .customCommandSucceeded(worktreeID: worktree.id, name: name, durationMs: durationMs))
     }
     states[worktree.id] = state
     terminalLogger.info("Created terminal state for worktree \(worktree.id)")
@@ -613,10 +620,12 @@ final class WorktreeTerminalManager {
   func persistLayoutSnapshotSync() {
     guard let payload = makeLayoutSnapshotPayload() else {
       terminalLogger.info("[LayoutRestore] persistSync: no active states, clearing snapshot")
-      discardTerminalLayoutSnapshot(at: SupacodePaths.terminalLayoutSnapshotURL, fileManager: .default)
+      discardTerminalLayoutSnapshot(
+        at: SupacodePaths.terminalLayoutSnapshotURL, fileManager: .default)
       return
     }
-    terminalLogger.info("[LayoutRestore] persistSync: saving \(payload.worktrees.count) worktree(s)")
+    terminalLogger.info(
+      "[LayoutRestore] persistSync: saving \(payload.worktrees.count) worktree(s)")
     let saved = saveTerminalLayoutSnapshot(
       payload,
       at: SupacodePaths.terminalLayoutSnapshotURL,
@@ -644,7 +653,8 @@ final class WorktreeTerminalManager {
       )
     }
     for (index, worktree) in worktrees.enumerated() {
-      terminalLogger.info("[LayoutRestore] restore: available[\(index)] id=\(worktree.id) name=\(worktree.name)")
+      terminalLogger.info(
+        "[LayoutRestore] restore: available[\(index)] id=\(worktree.id) name=\(worktree.name)")
     }
     let didRestore = applyLayoutSnapshotPayload(payload, availableWorktrees: worktrees)
     terminalLogger.info("[LayoutRestore] restore: applyResult=\(didRestore)")
@@ -654,7 +664,8 @@ final class WorktreeTerminalManager {
       )
       emit(.layoutRestored(selectedWorktreeID: payload.selectedWorktreeID))
     } else {
-      terminalLogger.warning("[LayoutRestore] restore: clearing invalid snapshot and emitting failure toast")
+      terminalLogger.warning(
+        "[LayoutRestore] restore: clearing invalid snapshot and emitting failure toast")
       _ = await layoutPersistence.clearSnapshot()
       emit(.layoutRestoreFailed(message: layoutRestoreFailureMessage))
     }
@@ -711,7 +722,8 @@ final class WorktreeTerminalManager {
       terminalLogger.info("[LayoutRestore] apply: restoring worktree \(worktree.id)")
       let state = state(for: worktree)
       guard state.applyLayoutSnapshot(snapshot) else {
-        terminalLogger.warning("[LayoutRestore] apply: applyLayoutSnapshot failed for \(worktree.id)")
+        terminalLogger.warning(
+          "[LayoutRestore] apply: applyLayoutSnapshot failed for \(worktree.id)")
         state.closeAllSurfaces()
         for restored in restoredStates {
           restored.closeAllSurfaces()
@@ -721,7 +733,8 @@ final class WorktreeTerminalManager {
       restoredStates.append(state)
     }
 
-    terminalLogger.info("[LayoutRestore] apply: successfully restored \(restoredStates.count) worktree(s)")
+    terminalLogger.info(
+      "[LayoutRestore] apply: successfully restored \(restoredStates.count) worktree(s)")
     return true
   }
 

--- a/supacode/Features/Terminal/Views/GhosttySurfaceSearchOverlay.swift
+++ b/supacode/Features/Terminal/Views/GhosttySurfaceSearchOverlay.swift
@@ -264,7 +264,7 @@ private enum GhosttySearchCorner {
 }
 
 private struct GhosttySearchOverlayShape: Shape {
-  func path(in rect: CGRect) -> Path {
+  nonisolated func path(in rect: CGRect) -> Path {
     ConcentricRectangle(corners: .concentric(minimum: 8), isUniform: true).path(in: rect)
   }
 }

--- a/supacode/Infrastructure/Ghostty/GhosttyRuntime+Callbacks.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttyRuntime+Callbacks.swift
@@ -196,7 +196,11 @@ extension GhosttyRuntime {
       }
     }
     if action.tag == GHOSTTY_ACTION_OPEN_CONFIG, target.tag == GHOSTTY_TARGET_APP {
-      openGhosttyConfig()
+      if let runtime = runtime(fromApp: app) {
+        runtime.openAppConfig()
+      } else {
+        openGhosttyConfig()
+      }
       return true
     }
     if action.tag == GHOSTTY_ACTION_QUIT {
@@ -226,12 +230,24 @@ extension GhosttyRuntime {
     }
   }
 
-  static func openGhosttyConfig() {
+  func openAppConfig() {
+    Self.openGhosttyConfig(at: configPath)
+  }
+
+  static func openGhosttyConfig(at overridePath: String? = nil) {
+    if let overridePath = normalizedConfigPath(overridePath) {
+      openConfigFile(at: overridePath)
+      return
+    }
     let configStr = ghostty_config_open_path()
     defer { ghostty_string_free(configStr) }
     guard let ptr = configStr.ptr else { return }
     let path = String(data: Data(bytes: ptr, count: Int(configStr.len)), encoding: .utf8) ?? ""
     guard !path.isEmpty else { return }
+    openConfigFile(at: path)
+  }
+
+  private static func openConfigFile(at path: String) {
     let process = Process()
     process.executableURL = URL(fileURLWithPath: "/usr/bin/open")
     process.arguments = ["-t", path]

--- a/supacode/Infrastructure/Ghostty/GhosttyRuntime+ThemeFallback.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttyRuntime+ThemeFallback.swift
@@ -4,6 +4,12 @@ import SwiftUI
 
 extension GhosttyRuntime {
   func reconcileThemeFallback(for scheme: ColorScheme) {
+    // A dedicated config is intentionally isolated from the user's global
+    // Ghostty config, including Prowl's automatic single-theme fallback.
+    guard configPath == nil else {
+      setThemeFallbackOverride("")
+      return
+    }
     // Subprocess discovery of the user's Ghostty CLI can block the main
     // thread (and in XCTest host bringup it has timed out the test runner
     // preparation phase). Short-circuit under test, and dispatch the
@@ -15,7 +21,8 @@ extension GhosttyRuntime {
     Task { [weak self] in
       let snapshot = await Self.probeUserConfigSnapshot()
       let pair: GhosttyThemePair? =
-        snapshot?.themeMode.allowsMismatchFallback == true ? await Self.probeFallbackThemePair() : nil
+        snapshot?.themeMode.allowsMismatchFallback == true
+        ? await Self.probeFallbackThemePair() : nil
       self?.applyResolvedThemeFallback(for: scheme, snapshot: snapshot, pair: pair)
     }
   }
@@ -72,7 +79,8 @@ extension GhosttyRuntime {
   func applyRuntimeOverridesIfNeeded() {
     guard let app else { return }
 
-    let nextSignature = [appKeybindOverrideContents, themeFallbackOverrideContents].joined(separator: "\n---\n")
+    let nextSignature = [appKeybindOverrideContents, themeFallbackOverrideContents].joined(
+      separator: "\n---\n")
     guard nextSignature != runtimeOverrideSignature else { return }
 
     var overrideURLs: [URL] = []
@@ -83,7 +91,8 @@ extension GhosttyRuntime {
         try appKeybindOverrideContents.write(to: url, atomically: true, encoding: .utf8)
         overrideURLs.append(url)
       } catch {
-        ghosttyLogger.warning("Failed to write ghostty keybind override file: \(error.localizedDescription)")
+        ghosttyLogger.warning(
+          "Failed to write ghostty keybind override file: \(error.localizedDescription)")
         return
       }
     }
@@ -95,22 +104,15 @@ extension GhosttyRuntime {
         try themeFallbackOverrideContents.write(to: url, atomically: true, encoding: .utf8)
         overrideURLs.append(url)
       } catch {
-        ghosttyLogger.warning("Failed to write ghostty theme override file: \(error.localizedDescription)")
+        ghosttyLogger.warning(
+          "Failed to write ghostty theme override file: \(error.localizedDescription)")
         return
       }
     }
 
-    guard let updated = ghostty_config_new() else { return }
-    ghostty_config_load_default_files(updated)
-    ghostty_config_load_recursive_files(updated)
-    ghostty_config_load_cli_args(updated)
-    Self.loadTerminalProgramOverrides(into: updated)
-    for url in overrideURLs {
-      url.path.withCString { path in
-        ghostty_config_load_file(updated, path)
-      }
+    guard let updated = Self.loadConfig(at: configPath, additionalFiles: overrideURLs) else {
+      return
     }
-    ghostty_config_finalize(updated)
     ghostty_app_update_config(app, updated)
     if let clone = ghostty_config_clone(updated) {
       setConfig(clone)
@@ -225,7 +227,8 @@ extension GhosttyRuntime {
     ghosttyCLICacheLock.unlock()
 
     var resolvedPath: String?
-    for candidate in ghosttyExecutableCandidates where FileManager.default.isExecutableFile(atPath: candidate) {
+    for candidate in ghosttyExecutableCandidates
+    where FileManager.default.isExecutableFile(atPath: candidate) {
       resolvedPath = candidate
       break
     }

--- a/supacode/Infrastructure/Ghostty/GhosttyRuntime.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttyRuntime.swift
@@ -42,6 +42,7 @@ final class GhosttyRuntime {
   }
 
   var config: ghostty_config_t?
+  private(set) var configPath: String?
   private(set) var app: ghostty_app_t?
   var observers: [NSObjectProtocol] = []
   var surfaceRefs: [SurfaceReference] = []
@@ -54,10 +55,12 @@ final class GhosttyRuntime {
   var onConfigChange: (() -> Void)?
   var onQuit: (() -> Void)?
 
-  init(initialColorScheme: ColorScheme? = nil) {
-    guard let config = Self.loadConfig() else {
+  init(initialColorScheme: ColorScheme? = nil, configPath: String? = nil) {
+    let configPath = Self.normalizedConfigPath(configPath)
+    guard let config = Self.loadConfig(at: configPath) else {
       preconditionFailure("ghostty_config_new failed")
     }
+    self.configPath = configPath
     self.config = config
 
     var runtimeConfig = ghostty_runtime_config_s(
@@ -249,7 +252,7 @@ final class GhosttyRuntime {
       ghostty_config_free(clone)
       return
     }
-    guard let config = Self.loadConfig() else { return }
+    guard let config = Self.loadConfig(at: configPath) else { return }
     applyConfig(config, target: target, app: app)
     ghostty_config_free(config)
   }
@@ -262,6 +265,17 @@ final class GhosttyRuntime {
     // config to ghostty, regardless of whether our override contents changed.
     runtimeOverrideSignature = ""
     applyRuntimeOverridesIfNeeded()
+  }
+
+  func setConfigPath(_ path: String?) {
+    let normalizedPath = Self.normalizedConfigPath(path)
+    guard configPath != normalizedPath else { return }
+    configPath = normalizedPath
+    themeFallbackOverrideContents = ""
+    reloadAppConfig()
+    if let currentColorScheme {
+      reconcileThemeFallback(for: currentColorScheme)
+    }
   }
 
   func applyConfig(
@@ -338,12 +352,24 @@ final class GhosttyRuntime {
     return trigger.isEmpty ? nil : trigger
   }
 
-  static func loadConfig() -> ghostty_config_t? {
+  nonisolated static func normalizedConfigPath(_ path: String?) -> String? {
+    let trimmed = path?.trimmingCharacters(in: .whitespacesAndNewlines)
+    return trimmed.flatMap { $0.isEmpty ? nil : $0 }
+  }
+
+  static func loadConfig(at path: String?, additionalFiles: [URL] = []) -> ghostty_config_t? {
     guard let config = ghostty_config_new() else { return nil }
-    ghostty_config_load_default_files(config)
+    if let path {
+      path.withCString { ghostty_config_load_file(config, $0) }
+    } else {
+      ghostty_config_load_default_files(config)
+    }
     ghostty_config_load_recursive_files(config)
     ghostty_config_load_cli_args(config)
     loadTerminalProgramOverrides(into: config)
+    for url in additionalFiles {
+      url.path.withCString { ghostty_config_load_file(config, $0) }
+    }
     ghostty_config_finalize(config)
     return config
   }
@@ -373,9 +399,11 @@ final class GhosttyRuntime {
     let url = URL(fileURLWithPath: NSTemporaryDirectory())
       .appendingPathComponent("prowl-ghostty-term-program.conf")
     do {
-      try terminalProgramOverrides(version: appVersion).write(to: url, atomically: true, encoding: .utf8)
+      try terminalProgramOverrides(version: appVersion).write(
+        to: url, atomically: true, encoding: .utf8)
     } catch {
-      ghosttyLogger.warning("Failed to write TERM_PROGRAM override file: \(error.localizedDescription)")
+      ghosttyLogger.warning(
+        "Failed to write TERM_PROGRAM override file: \(error.localizedDescription)")
       return
     }
     url.path.withCString { path in
@@ -455,7 +483,9 @@ final class GhosttyRuntime {
       return Color(nsColor: NSColor(ghostty: color))
     }
     let backgroundKey = "background"
-    if ghostty_config_get(config, &color, backgroundKey, UInt(backgroundKey.lengthOfBytes(using: .utf8))) {
+    if ghostty_config_get(
+      config, &color, backgroundKey, UInt(backgroundKey.lengthOfBytes(using: .utf8)))
+    {
       return Color(nsColor: NSColor(ghostty: color))
     }
     ghosttyLogger.warning(

--- a/supacodeTests/AppFeatureSettingsChangedTests.swift
+++ b/supacodeTests/AppFeatureSettingsChangedTests.swift
@@ -79,6 +79,22 @@ struct AppFeatureSettingsChangedTests {
     #expect(watcherCommands.value.isEmpty)
   }
 
+  @Test(.dependencies) func ghosttyConfigPathChangeUpdatesTerminalRuntime() async {
+    let sentTerminalCommands = LockIsolated<[TerminalClient.Command]>([])
+    let store = TestStore(initialState: AppFeature.State()) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in
+        sentTerminalCommands.withValue { $0.append(command) }
+      }
+    }
+
+    await store.send(.settings(.delegate(.ghosttyConfigPathChanged("/tmp/prowl.ghostty"))))
+    await store.finish()
+
+    #expect(sentTerminalCommands.value == [.setGhosttyConfigPath("/tmp/prowl.ghostty")])
+  }
+
   @Test(.dependencies) func agentEntryAutoShowsActiveAgentsPanelWhenEnabled() async {
     var settings = SettingsFeature.State()
     settings.autoShowActiveAgentsPanel = true

--- a/supacodeTests/GhosttyRuntimeConfigPathTests.swift
+++ b/supacodeTests/GhosttyRuntimeConfigPathTests.swift
@@ -1,0 +1,35 @@
+import Foundation
+import Testing
+
+@testable import supacode
+
+@MainActor
+struct GhosttyRuntimeConfigPathTests {
+  @Test func loadsAndSwitchesDedicatedConfigFiles() throws {
+    let directory = FileManager.default.temporaryDirectory.appending(
+      path: "prowl-ghostty-config-tests-\(UUID().uuidString)",
+      directoryHint: .isDirectory
+    )
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: directory) }
+
+    let firstConfig = directory.appending(path: "first-config")
+    let secondConfig = directory.appending(path: "second-config")
+    try "focus-follows-mouse = true".write(to: firstConfig, atomically: true, encoding: .utf8)
+    try "background-opacity = 0.42".write(to: secondConfig, atomically: true, encoding: .utf8)
+
+    let runtime = GhosttyRuntime(configPath: firstConfig.path(percentEncoded: false))
+    #expect(runtime.configPath == firstConfig.path(percentEncoded: false))
+    #expect(runtime.focusFollowsMouse())
+
+    runtime.setConfigPath(secondConfig.path(percentEncoded: false))
+    #expect(runtime.configPath == secondConfig.path(percentEncoded: false))
+    #expect(!runtime.focusFollowsMouse())
+    #expect(abs(runtime.backgroundOpacity() - 0.42) < 0.001)
+  }
+
+  @Test func blankConfigPathUsesDefaultSelection() {
+    let runtime = GhosttyRuntime(configPath: "   ")
+    #expect(runtime.configPath == nil)
+  }
+}

--- a/supacodeTests/SettingsFeatureTests.swift
+++ b/supacodeTests/SettingsFeatureTests.swift
@@ -292,7 +292,9 @@ struct SettingsFeatureTests {
     #expect(store.state.defaultWorktreeBaseDirectoryPath == expectedPath)
   }
 
-  @Test(.dependencies) func changingDefaultWorktreeBaseDirectoryUpdatesRepositorySettingsState() async {
+  @Test(.dependencies) func changingDefaultWorktreeBaseDirectoryUpdatesRepositorySettingsState()
+    async
+  {
     let rootURL = URL(fileURLWithPath: "/tmp/repo")
     let expectedPath = SupacodePaths.normalizedWorktreeBaseDirectoryPath(" ~/worktrees ")!
     @Shared(.settingsFile) var settingsFile
@@ -420,6 +422,40 @@ struct SettingsFeatureTests {
 
     #expect(settingsFile.global.terminalFontSize == 18)
     #expect(capturedEvents.value.isEmpty)
+  }
+
+  @Test(.dependencies) func setGhosttyConfigPathPersistsAndEmitsFocusedDelegate() async {
+    @Shared(.settingsFile) var settingsFile
+    $settingsFile.withLock { $0.global = .default }
+    let store = TestStore(initialState: SettingsFeature.State()) {
+      SettingsFeature()
+    }
+
+    await store.send(.setGhosttyConfigPath("  /tmp/prowl.ghostty  ")) {
+      $0.ghosttyConfigPath = "/tmp/prowl.ghostty"
+    }
+    await store.receive(\.delegate.ghosttyConfigPathChanged)
+    await store.finish()
+
+    #expect(settingsFile.global.ghosttyConfigPath == "/tmp/prowl.ghostty")
+  }
+
+  @Test(.dependencies) func clearingGhosttyConfigPathRestoresDefaultSelection() async {
+    var initialSettings = GlobalSettings.default
+    initialSettings.ghosttyConfigPath = "/tmp/prowl.ghostty"
+    @Shared(.settingsFile) var settingsFile
+    $settingsFile.withLock { $0.global = initialSettings }
+    let store = TestStore(initialState: SettingsFeature.State(settings: initialSettings)) {
+      SettingsFeature()
+    }
+
+    await store.send(.setGhosttyConfigPath(nil)) {
+      $0.ghosttyConfigPath = nil
+    }
+    await store.receive(\.delegate.ghosttyConfigPathChanged)
+    await store.finish()
+
+    #expect(settingsFile.global.ghosttyConfigPath == nil)
   }
 
   @Test(.dependencies) func keybindingOverridesPersistAndFanOut() async {

--- a/supacodeTests/SettingsFilePersistenceTests.swift
+++ b/supacodeTests/SettingsFilePersistenceTests.swift
@@ -181,7 +181,8 @@ struct SettingsFilePersistenceTests {
     #expect(settings.pinnedWorktreeIDs.isEmpty)
   }
 
-  @Test(.dependencies) func legacyAutomaticallyArchiveMergedWorktreesMigratesToMergedWorktreeAction() throws {
+  @Test(.dependencies)
+  func legacyAutomaticallyArchiveMergedWorktreesMigratesToMergedWorktreeAction() throws {
     let legacy = LegacyAutoArchiveSettingsFile(
       global: LegacyAutoArchiveGlobalSettings(
         appearanceMode: .dark,
@@ -234,7 +235,9 @@ struct SettingsFilePersistenceTests {
     var globalDict = try #require(try JSONSerialization.jsonObject(with: encoded) as? [String: Any])
     globalDict.removeValue(forKey: "deleteBranchOnAutomaticCleanup")
     globalDict["deleteBranchOnDeleteWorktree"] = true
-    let data = try JSONSerialization.data(withJSONObject: ["global": globalDict, "repositories": [:]])
+    let data = try JSONSerialization.data(withJSONObject: [
+      "global": globalDict, "repositories": [:],
+    ])
     let storage = MutableTestStorage(initialData: data)
 
     let settings: SettingsFile = withDependencies {
@@ -252,7 +255,9 @@ struct SettingsFilePersistenceTests {
     var globalDict = try #require(try JSONSerialization.jsonObject(with: encoded) as? [String: Any])
     globalDict["deleteBranchOnAutomaticCleanup"] = false
     globalDict["deleteBranchOnDeleteWorktree"] = true
-    let data = try JSONSerialization.data(withJSONObject: ["global": globalDict, "repositories": [:]])
+    let data = try JSONSerialization.data(withJSONObject: [
+      "global": globalDict, "repositories": [:],
+    ])
     let storage = MutableTestStorage(initialData: data)
 
     let settings: SettingsFile = withDependencies {
@@ -274,6 +279,16 @@ struct SettingsFilePersistenceTests {
 
     #expect(globalDict["deleteBranchOnAutomaticCleanup"] as? Bool == true)
     #expect(globalDict["deleteBranchOnDeleteWorktree"] == nil)
+  }
+
+  @Test func roundTripsGhosttyConfigPath() throws {
+    var settings = GlobalSettings.default
+    settings.ghosttyConfigPath = "/tmp/prowl.ghostty"
+
+    let encoded = try JSONEncoder().encode(settings)
+    let decoded = try JSONDecoder().decode(GlobalSettings.self, from: encoded)
+
+    #expect(decoded.ghosttyConfigPath == "/tmp/prowl.ghostty")
   }
 
   @Test(.dependencies) func roundTripsExplicitNotificationSound() throws {
@@ -347,7 +362,9 @@ struct SettingsFilePersistenceTests {
     #expect(settings.global.notificationSound == .supacodeClassic)
   }
 
-  @Test(.dependencies) func decodesUnrecognizedNotificationSoundAsDefaultWithoutResettingSiblings() throws {
+  @Test(.dependencies) func decodesUnrecognizedNotificationSoundAsDefaultWithoutResettingSiblings()
+    throws
+  {
     // A hand-edited or downgraded file carrying a sound case this build doesn't
     // know yet. The `try?` must isolate the fallback to this one field.
     var global = GlobalSettings.default
@@ -358,7 +375,9 @@ struct SettingsFilePersistenceTests {
     let encoded = try JSONEncoder().encode(global)
     var globalDict = try #require(try JSONSerialization.jsonObject(with: encoded) as? [String: Any])
     globalDict["notificationSound"] = "futureSoundFromNewerBuild"
-    let data = try JSONSerialization.data(withJSONObject: ["global": globalDict, "repositories": [:]])
+    let data = try JSONSerialization.data(withJSONObject: [
+      "global": globalDict, "repositories": [:],
+    ])
     let storage = MutableTestStorage(initialData: data)
 
     let settings: SettingsFile = withDependencies {


### PR DESCRIPTION
## Summary

- add an optional dedicated Ghostty config path under Settings → General → Appearance
- load, reload, and open the selected file without layering the user's global Ghostty config
- persist the override and apply changes live through the existing Settings → TerminalClient flow
- document the setting and cover persistence, reducer routing, and real Ghostty config switching
- update Point-Free dependencies and narrow isolation annotations required to build with Xcode 27

Closes #693.

## User impact

Prowl can now use a Ghostty configuration that is isolated from standalone Ghostty. Choosing **Use Default** restores the existing global-config behavior.

## Validation

- `make check`
- 6 focused Swift Testing tests (6 passed)
- `make build-app`